### PR TITLE
magento/magento2#12549: Payment method option is not showing under shopping cart rules condition tab.

### DIFF
--- a/app/code/Magento/SalesRule/Model/Rule/Condition/Address.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Condition/Address.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\SalesRule\Model\Rule\Condition;
 
+/**
+ * Address rule condition data model.
+ */
 class Address extends \Magento\Rule\Model\Condition\AbstractCondition
 {
     /**
@@ -61,6 +64,7 @@ class Address extends \Magento\Rule\Model\Condition\AbstractCondition
             'base_subtotal' => __('Subtotal'),
             'total_qty' => __('Total Items Quantity'),
             'weight' => __('Total Weight'),
+            'payment_method' => __('Payment Method'),
             'shipping_method' => __('Shipping Method'),
             'postcode' => __('Shipping Postcode'),
             'region' => __('Shipping Region'),


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#12549

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Marketing > Promotions > Cart Price Rules
2. Add New Rule
3. Open Conditions tab.
4. Payment Method option should be available as well as the Shipping Method etc.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
