### PR TITLE
Fixed issue #20030 :Customer EAV Decimal Attribute required allow 0

### DIFF
--- a/app/code/Magento/Eav/Model/Attribute/Data/Text.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/Text.php
@@ -72,7 +72,7 @@ class Text extends \Magento\Eav\Model\Attribute\Data\AbstractData
             return true;
         }
 
-        if (empty($value) && $value !== '0') {
+        if (empty($value) && $value !== '0' && $attribute->getDefaultValue() == NULL) {
             $label = __($attribute->getStoreLabel());
             $errors[] = __('"%1" is a required value.', $label);
         }


### PR DESCRIPTION
Fixed issue  #20030
Customer EAV Decimal Attribute required allow 0

**Preconditions (*)**

    Magento Version 2.2.6

**Steps to reproduce (*)**

    Create a new required customer attribute of type decimal with a default of 0 e.g.

'bal' => [
  'is_used_in_grid' => false,
  'is_visible_in_grid' => false,
  'is_filterable_in_grid' => false,
  'is_searchable_in_grid' => false,
  'type' => 'decimal',
  'label' => 'AR Balance',
  'input' => 'text',
  'required' => true,
  'default' => 0,
  'sort_order' => 202,
  'visible' => true,
  'system' => false,
  'validate_rules' => null,
  'position' => 202,
  'user_defined' => false,
  'frontend_class' => 'validate-number'
],

    Attempt to create a customer on front-end, or attempt to assign the value of 0 through the API.

**Expected result (*)**

    Customer attribute should be set with a 0 value.

**Actual result (*)**

    Both of these fail with [Attribute] is a required value.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
