### PR TITLE
Add missing throws to PHPDoc

### DIFF
--- a/app/code/Magento/Catalog/Api/CategoryLinkRepositoryInterface.php
+++ b/app/code/Magento/Catalog/Api/CategoryLinkRepositoryInterface.php
@@ -39,7 +39,7 @@ interface CategoryLinkRepositoryInterface
     /**
      * Remove the product assignment from the category by category id and sku
      *
-     * @param string $sku
+     * @param string $categoryId
      * @param string $sku
      * @return bool will returned True if products successfully deleted
      *

--- a/app/code/Magento/Catalog/Api/CategoryLinkRepositoryInterface.php
+++ b/app/code/Magento/Catalog/Api/CategoryLinkRepositoryInterface.php
@@ -32,6 +32,7 @@ interface CategoryLinkRepositoryInterface
      *
      * @throws \Magento\Framework\Exception\CouldNotSaveException
      * @throws \Magento\Framework\Exception\StateException
+     * @throws \Magento\Framework\Exception\InputException
      */
     public function delete(\Magento\Catalog\Api\Data\CategoryProductLinkInterface $productLink);
 
@@ -44,6 +45,7 @@ interface CategoryLinkRepositoryInterface
      *
      * @throws \Magento\Framework\Exception\CouldNotSaveException
      * @throws \Magento\Framework\Exception\StateException
+     * @throws \Magento\Framework\Exception\InputException
      */
     public function deleteByIds($categoryId, $sku);
 }


### PR DESCRIPTION
### Description (*)
Document the `InputException` thrown https://github.com/magento/magento2/blob/2.3.0/app/code/Magento/Catalog/Model/CategoryLinkRepository.php#L81

### Fixed Issues (if relevant)
1. magento/magento2#20037: CategoryLinkReposity does not list all possible exceptions

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
