### PR TITLE
Fixed Incorrect position of grid header Design Configuration Grid #20024

### DIFF
--- a/app/code/Magento/Backend/etc/module.xml
+++ b/app/code/Magento/Backend/etc/module.xml
@@ -9,6 +9,7 @@
     <module name="Magento_Backend">
         <sequence>
             <module name="Magento_Directory"/>
+            <module name="Magento_Theme"/>
         </sequence>
     </module>
 </config>

--- a/app/code/Magento/Backend/view/adminhtml/ui_component/design_config_listing.xml
+++ b/app/code/Magento/Backend/view/adminhtml/ui_component/design_config_listing.xml
@@ -6,6 +6,7 @@
  */
 -->
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <listingToolbar name="listing_top" />
     <columns name="design_config_columns">
         <column name="theme_theme_id" component="Magento_Ui/js/grid/columns/select" sortOrder="40">
             <settings>


### PR DESCRIPTION
Fixed Incorrect position of grid header Design Configuration Grid #20024

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento 2.3

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Open the Design Configuration Grid: *Content -> Design -> Configuration*

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. The grid header is displayed above the grid.
![screen shot 2018-12-31 at 10 18 51 am](https://user-images.githubusercontent.com/32304009/50556868-4b311f80-0ce7-11e9-848c-00b9ac6978bf.png)

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. The grid header is displayed below the grid.
![screen shot 2018-12-31 at 10 17 12 am](https://user-images.githubusercontent.com/32304009/50556872-52f0c400-0ce7-11e9-850d-e8f5fba0ad99.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
