### PR TITLE
[Backport] Fixed  Incorrect class name on Orders and returns page.

### DIFF
--- a/app/code/Magento/Sales/view/frontend/templates/guest/form.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/guest/form.phtml
@@ -10,7 +10,7 @@
 <form class="form form-orders-search" id="oar-widget-orders-and-returns-form" data-mage-init='{"ordersReturns":{}, "validation":{}}' action="<?= /* @escapeNotVerified */ $block->getActionUrl() ?>"
       method="post" name="guest_post">
     <fieldset class="fieldset">
-        <legend class="admin__legend"><span><?= /* @escapeNotVerified */ __('Order Information') ?></span></legend>
+        <legend class="legend"><span><?= /* @escapeNotVerified */ __('Order Information') ?></span></legend>
         <br>
 
         <div class="field id required">


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19784
Fixed #19780
Incorrect class name on Orders and returns page.

**Summary (*)**

On 'Orders and returns' page legend tag has class admin__legend as on admin area.
**Examples (*)**

app/code/Magento/Sales/view/frontend/templates/guest/form.phtml
<legend class="admin__legend"><span><?= /* @escapeNotVerified */ __('Order Information') ?></span></legend>

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
