### PR TITLE
[Backport] Fixed issue - #19346 Import data 2.2.6 Value for 'product_type' attribute contains incorrect value

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -100,7 +100,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
             $attributeCode
         );
 
-        if ($attribute->getId() && !$attributeId) {
+        if ($attribute->getId() && !$attributeId || $attributeCode === 'product_type') {
             $message = strlen($this->getRequest()->getParam('attribute_code'))
                 ? __('An attribute with this code already exists.')
                 : __('An attribute with the same code (%1) already exists.', $attributeCode);


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19408


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fixed issue - #19346
Import data 2.2.6 Value for 'product_type' attribute contains incorrect value

Since 'product_attribute' is reserved attribute,so we can restrict this type of attribute to be created by user.

### Fixed Issues (if relevant)

Fixed issue - #19346
Import data 2.2.6 Value for 'product_type' attribute contains incorrect value

### Manual testing scenarios (*)

   1. create an attribute with code product_type http://i.prntscr.com/AwUJuhizQKatBwNwRa1S7Q.png with type: dropdown scope: global sortable, comparable: no
  2.  add it to a family and create a product.
   3. go to import profiles download sample file then reimport sample file


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
