### PR TITLE
Fixed blank amdin page after install magento 2.3.0 in Windows 10

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
+++ b/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
@@ -137,7 +137,7 @@ class Validator
         }
         $realPath = $this->fileDriver->getRealPath($path);
         foreach ($directories as $directory) {
-            if (0 === strpos($realPath, $directory)) {
+            if (0 === strpos($realPath, $directory) || 0 === strpos($path, $directory)) {
                 return true;
             }
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed blank amdin page after install magento 2.3.0 in Windows 10

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20084: Blank admin page after install magento 2.3.0 on Windows 10


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. I go to folder \lib\internal\Magento\Framework\View\Element\Template\File\Validator.php
2. Change code in line 140
```bash
if (0 === strpos($realPath, $directory)) {
    return true;
}
```
To
```bash
if (0 === strpos($realPath, $directory) || 0 === strpos($path, $directory)) {
    return true;
}
```

### Result
I ran successfully on windows
![screenshot_5](https://user-images.githubusercontent.com/11944757/50723269-f0942b00-110d-11e9-80cc-37a9d335caeb.png)
![screenshot_6](https://user-images.githubusercontent.com/11944757/50723271-f1c55800-110d-11e9-9d1f-1b20c6afe9c6.png)

Maybe this is the solution you need 💯 
