### PR TITLE
Fix URL rewrite match search when switching store

### DIFF
--- a/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
+++ b/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
@@ -66,16 +66,16 @@ class RewriteUrl implements StoreSwitcherInterface
             UrlRewrite::STORE_ID => $oldStoreId,
         ]);
         if ($oldRewrite) {
+            $targetUrl = $targetStore->getBaseUrl();
+
             // look for url rewrite match on the target store
             $currentRewrite = $this->urlFinder->findOneByData([
                 UrlRewrite::TARGET_PATH => $oldRewrite->getTargetPath(),
                 UrlRewrite::STORE_ID => $targetStore->getId(),
             ]);
+
             if ($currentRewrite) {
                 $targetUrl = $targetStore->getUrl($currentRewrite->getRequestPath());
-            } else {
-                /** @var \Magento\Framework\App\Response\Http $response */
-                $targetUrl = $targetStore->getBaseUrl();
             }
         }
 

--- a/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
+++ b/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
@@ -68,10 +68,12 @@ class RewriteUrl implements StoreSwitcherInterface
         if ($oldRewrite) {
             // look for url rewrite match on the target store
             $currentRewrite = $this->urlFinder->findOneByData([
-                UrlRewrite::REQUEST_PATH => $urlPath,
+                UrlRewrite::TARGET_PATH => $oldRewrite->getTargetPath(),
                 UrlRewrite::STORE_ID => $targetStore->getId(),
             ]);
-            if (null === $currentRewrite) {
+            if ($currentRewrite) {
+                $targetUrl = $targetStore->getUrl($currentRewrite->getRequestPath());
+            } else {
                 /** @var \Magento\Framework\App\Response\Http $response */
                 $targetUrl = $targetStore->getBaseUrl();
             }

--- a/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
+++ b/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
@@ -75,7 +75,7 @@ class RewriteUrl implements StoreSwitcherInterface
             ]);
 
             if ($currentRewrite) {
-                $targetUrl = $targetStore->getUrl($currentRewrite->getRequestPath());
+                $targetUrl .= $currentRewrite->getRequestPath();
             }
         }
 

--- a/dev/tests/integration/testsuite/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrlTest.php
+++ b/dev/tests/integration/testsuite/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrlTest.php
@@ -92,7 +92,8 @@ class RewriteUrlTest extends \PHPUnit\Framework\TestCase
         $storeRepository = $this->objectManager->create(\Magento\Store\Api\StoreRepositoryInterface::class);
         $toStore = $storeRepository->get($toStoreCode);
 
-        $redirectUrl = $expectedUrl = "http://localhost/index.php/page-c/";
+        $redirectUrl = "http://localhost/index.php/page-c/";
+        $expectedUrl = "http://localhost/index.php/page-c-on-2nd-store";
 
         $this->assertEquals($expectedUrl, $this->storeSwitcher->switch($fromStore, $toStore, $redirectUrl));
     }

--- a/dev/tests/integration/testsuite/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrlTest.php
+++ b/dev/tests/integration/testsuite/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrlTest.php
@@ -92,7 +92,7 @@ class RewriteUrlTest extends \PHPUnit\Framework\TestCase
         $storeRepository = $this->objectManager->create(\Magento\Store\Api\StoreRepositoryInterface::class);
         $toStore = $storeRepository->get($toStoreCode);
 
-        $redirectUrl = $expectedUrl = "http://localhost/index.php/page-c";
+        $redirectUrl = $expectedUrl = "http://localhost/index.php/page-c/";
 
         $this->assertEquals($expectedUrl, $this->storeSwitcher->switch($fromStore, $toStore, $redirectUrl));
     }

--- a/dev/tests/integration/testsuite/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrlTest.php
+++ b/dev/tests/integration/testsuite/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrlTest.php
@@ -92,7 +92,7 @@ class RewriteUrlTest extends \PHPUnit\Framework\TestCase
         $storeRepository = $this->objectManager->create(\Magento\Store\Api\StoreRepositoryInterface::class);
         $toStore = $storeRepository->get($toStoreCode);
 
-        $redirectUrl = $expectedUrl = "http://localhost/page-c";
+        $redirectUrl = $expectedUrl = "http://localhost/index.php/page-c";
 
         $this->assertEquals($expectedUrl, $this->storeSwitcher->switch($fromStore, $toStore, $redirectUrl));
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When "Use Store Code in URLs" is enabled, Magento 2 currently redirects to the homepage if changing the store from a product, category or CMS page. So basically any page which uses URL rewrites. There has been some work done on this by Magento (see issue #2786), but there's no definitive solution yet. This PR aims to fix the issues with the following changes:

- Uses target path to match URL rewrites between
  stores. Request path (used previously) can be
  different between stores.
- Changes the target URL if matching
  URL rewrite is found. Previously it just
  redirected to the homepage in case the rewrite
  wasn't found, and did nothing if found.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#2786: Store View Switching

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Start with a clean Magento installation.
2. Create a new store view called "Test store" with the code "test" in the "Main Website" website.
3. Enable "Use Store Code in URLs" globally.
4. Create a product with a URL key "product-1" in the "Default Store View" scope.
5. Change the scope to "Test store" in the product editor.
6. Set the product URL key as "product-1-test-store" in the "Test store" scope. Save the product.
7. Navigate to the frontend http://<your-store.com>/default/product-1 (eg. in the default store)
8. Change the store through the store switcher to "Test store". This should go through the stores/store/redirect controller. **Magento will redirect you http://<your-store.com>/test, aka the homepage for "Test store"**. This PR will change it so that the user remains on the product page, eg. http://<your-store.com>/test/product-1-test-store.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
