### PR TITLE
Fixed issue-  Customer non-default addresses' post codes do not change on leading zero

### DIFF
--- a/lib/internal/Magento/Framework/Model/ResourceModel/Db/VersionControl/Snapshot.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Db/VersionControl/Snapshot.php
@@ -65,7 +65,7 @@ class Snapshot
             return true;
         }
         foreach ($this->snapshotData[$entityClass][$entity->getId()] as $field => $value) {
-            if ($entity->getDataByKey($field) != $value) {
+            if ($entity->getDataByKey($field) !== $value) {
                 return true;
             }
         }


### PR DESCRIPTION
Fixed issue #20100 and #17452

### Preconditions
<!---
    Please provide as detailed information about your environment as possible.
    For example Magento version, tag, HEAD, PHP & MySQL version, etc..
-->
1. Magento 2.2.4
2. Create a customer with at least 3 addresses.  The non-default address should have a post code that is only 4 numbers.

### Steps to reproduce
<!---
    It is important to provide a set of clear steps to reproduce this bug.
    If relevant please include code samples
-->
1. Edit the customer addresses in the admin panel, and add a leading zero to the post code of the address that is not a default billing or shipping address.
2. Save the customer.
3. Look at the address to confirm the post code did not change.

### Expected result
<!--- Tell us what should happen -->
1. Post code should change to whatever was entered.

### Actual result
<!--- Tell us what happens instead -->
1. Post code does not change.

I tested and this works the opposite way as well:  If the post code has a leading zero and you remove it and save, it retains the leading zero.  So, it seems to be equating 01111 = 1111 and ignoring it, regardless of which side of the equation it's on.  You can also change it to an entirely different value (e.g. 22222) and that works as expected.  The issue is just changing it from a leading zero or to a leading zero, and only on non-default addresses.
