### PR TITLE
change directory for generated minified phtml files to generated directory

### DIFF
--- a/lib/internal/Magento/Framework/App/Filesystem/DirectoryList.php
+++ b/lib/internal/Magento/Framework/App/Filesystem/DirectoryList.php
@@ -136,6 +136,11 @@ class DirectoryList extends \Magento\Framework\Filesystem\DirectoryList
     const GENERATED_METADATA = 'metadata';
 
     /**
+     * Relative directory key for generated minified phtml sources
+     */
+    const GENERATED_MINIFIEDPHTML = 'minified_phtml';
+
+    /**
      * {@inheritdoc}
      */
     public static function getDefaultConfig()
@@ -164,6 +169,7 @@ class DirectoryList extends \Magento\Framework\Filesystem\DirectoryList
             self::GENERATED => [parent::PATH => 'generated'],
             self::GENERATED_CODE => [parent::PATH => Io::DEFAULT_DIRECTORY],
             self::GENERATED_METADATA => [parent::PATH => 'generated/metadata'],
+            self::GENERATED_MINIFIEDPHTML => [parent::PATH => 'generated/minified_phtml']
         ];
         return parent::getDefaultConfig() + $result;
     }

--- a/lib/internal/Magento/Framework/View/Template/Html/Minifier.php
+++ b/lib/internal/Magento/Framework/View/Template/Html/Minifier.php
@@ -74,7 +74,7 @@ class Minifier implements MinifierInterface
         Filesystem\Directory\ReadFactory $readFactory
     ) {
         $this->filesystem = $filesystem;
-        $this->htmlDirectory = $filesystem->getDirectoryWrite(DirectoryList::TMP_MATERIALIZATION_DIR);
+        $this->htmlDirectory = $filesystem->getDirectoryWrite(DirectoryList::GENERATED_MINIFIEDPHTML);
         $this->readFactory = $readFactory;
     }
 

--- a/lib/internal/Magento/Framework/View/Test/Unit/Template/Html/MinifierTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Template/Html/MinifierTest.php
@@ -64,7 +64,7 @@ class MinifierTest extends \PHPUnit\Framework\TestCase
 
         $this->filesystemMock->expects($this->once())
             ->method('getDirectoryWrite')
-            ->with(DirectoryList::TMP_MATERIALIZATION_DIR)
+            ->with(DirectoryList::GENERATED_MINIFIEDPHTML)
             ->willReturn($this->htmlDirectoryMock);
         $this->filesystemMock->expects($this->any())
             ->method('getDirectoryRead')


### PR DESCRIPTION
* add new constant for directory list
* use new constant for minifier in order to have pregenerated minified phtmls (from static content deploy) not in var/view_preprocessed folder which is not synchronized within deployment as they are not temporary materialization files

### Description (*)
The issue came up when applying optimizations to our current customers server environment. On activation of the minify_html option via env.conf the shop was not able to load any minimized phtml files as they would reside within var/view_preprocessed/pub/....
The whole var folder excluded from the deployment as it is environmentspecific and there are normally no needed files from the build.
The setting static_content_on_demand_in_production is not activated as this would cost additional computation time and the minified phtmls are generated anyway on static content deploy.

The solution is to change the folder of the generated minified phtmls to the generated folder.

### Manual testing scenarios (*)
precondition: setting minify_html ('system' =>  'default' =>  'dev' => 'template' =>  'minify_html' => '1')

1. run static content deploy
2. check if the minified templates are created in the folder generated/minified_phtml

1. setup store in production mode
2. set configuration static_content_on_demand_in_production
3. remove the folder generated/minified_phtml if existing
4. call any shop page
5. check if the minified templates are created

1. setup store not in production mode
2. remove the folder generated/minified_phtml if existing 
4. call any shop page
5. check if the minified templates are created

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
