### PR TITLE
Fixed issue #20113  Widget option labels are misalinged

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/styles-old.less
+++ b/app/design/adminhtml/Magento/backend/web/css/styles-old.less
@@ -2739,6 +2739,7 @@
 
     #widget_instace_tabs_properties_section_content .widget-option-label {
         margin-top: 6px;
+        display: inline-block;
     }
 
     //

--- a/app/design/adminhtml/Magento/backend/web/css/styles-old.less
+++ b/app/design/adminhtml/Magento/backend/web/css/styles-old.less
@@ -2738,7 +2738,7 @@
     //  ---------------------------------------------
 
     #widget_instace_tabs_properties_section_content .widget-option-label {
-        margin-top: 6px;
+        margin-top: 7px;
         display: inline-block;
     }
 


### PR DESCRIPTION
Fixed issue #20113  Widget option labels are misalinged

### Description (*)

Fixed issue #20113  Widget option labels are misalinged

### Fixed Issues (if relevant)

1. magento/magento2#20113: Widget option labels are misalinged


### Manual testing scenarios (*)

1. In admin content >> Widgets >> Edit widget >> widget options
2. Add New Widget

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
