### PR TITLE
Review-Details-Detailed-Rating-misaligned

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Review/web/css/source/_module.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Review/web/css/source/_module.less
@@ -34,7 +34,7 @@
         .admin__field-control {
             direction: rtl;
             display: inline-block;
-            margin: -4px 0 0;
+            margin: -1px 0 0;
             unicode-bidi: bidi-override;
             vertical-align: top;
             width: 125px;


### PR DESCRIPTION
### Pull Request to 2.2.x
https://github.com/magento/magento2/pull/20272

### Description (*)

Fixing issue for Rating stars in review tab which was misaligned in admin interface.
Path to check : Marketing >> Reviews >> Review Details >> Detailed Rating

### Fixed Issues (if relevant)

1. magento/magento2 #20120 : Review Details Detailed Rating misaligned


### Manual testing scenarios (*)

1. Go in Admin interface  Marketing >> Reviews >> Review Details >> Detailed Rating 
Rating stars are showing in-front of text
2. ![image](https://user-images.githubusercontent.com/26630846/50883512-4cacc700-140e-11e9-88a4-39d6d7ff1411.png)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
