### PR TITLE
issue fixed #20124 Sort By label is hidden by Shop By Menu on listing…

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_toolbar.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_toolbar.less
@@ -84,7 +84,7 @@
 
         .page-products & {
             position: absolute;
-            right: @indent__s;
+            right: 0;
             top: 0;
             z-index: 1;
         }

--- a/app/design/frontend/Magento/luma/Magento_LayeredNavigation/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_LayeredNavigation/web/css/source/_module.less
@@ -364,10 +364,10 @@
                 content: '';
                 display: block;
                 height: 40px;
-                left: -15px;
+                left: 0;
                 margin-top: -60px;
                 position: relative;
-                width: 100px;
+                width: 75px;
                 z-index: 99;
             }
         }


### PR DESCRIPTION
Sort By label is hidden by Shop By Menu on listing page in iphone5 device

issue fixed magento/magento2#20124 Sort By label is hidden by Shop By Menu on listing page in iphone5 device


### Description (*)

issue fixed magento/magento2#20124 Sort By label is hidden by Shop By Menu on listing…

### Manual testing scenarios (*)

1. Go to listing page on iphone5 device you can see that Shop By menu is overlapping sort by option
2.  you can see that Shop By menu is overlapping Sort By Label

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
