### PR TITLE
Fixed issue #19942 Success message is not showing when creating invoice & shipment simultaniously 

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
@@ -194,12 +194,6 @@ class Save extends \Magento\Backend\App\Action implements HttpPostActionInterfac
             }
             $transactionSave->save();
 
-            if (!empty($data['do_shipment'])) {
-                $this->messageManager->addSuccessMessage(__('You created the invoice and shipment.'));
-            } else {
-                $this->messageManager->addSuccessMessage(__('The invoice has been created.'));
-            }
-
             // send invoice/shipment emails
             try {
                 if (!empty($data['send_email'])) {
@@ -218,6 +212,11 @@ class Save extends \Magento\Backend\App\Action implements HttpPostActionInterfac
                     $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
                     $this->messageManager->addErrorMessage(__('We can\'t send the shipment right now.'));
                 }
+            }
+            if (!empty($data['do_shipment'])) {
+                $this->messageManager->addSuccessMessage(__('You created the invoice and shipment.'));
+            } else {
+                $this->messageManager->addSuccessMessage(__('The invoice has been created.'));
             }
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->getCommentText(true);
             return $resultRedirect->setPath('sales/order/view', ['order_id' => $orderId]);

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
@@ -18,6 +18,8 @@ use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\Service\InvoiceService;
 
 /**
+ * Save invoice controller.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class Save extends \Magento\Backend\App\Action implements HttpPostActionInterface
@@ -103,6 +105,7 @@ class Save extends \Magento\Backend\App\Action implements HttpPostActionInterfac
 
     /**
      * Save invoice
+     *
      * We can save only new invoice. Existing invoices are not editable
      *
      * @return \Magento\Framework\Controller\ResultInterface


### PR DESCRIPTION

### Description (*)

Fixed issue #19942 Success message is not showing when creating invoice & shipment simultaniously 

### Fixed Issues (if relevant)

1. magento/magento2#19942: Success message is not showing when creating invoice & shipment simultaniously

### Manual testing scenarios (*)

1.Create order from admin panel.
2.View order at admin panel and Click "create invoice".
3.Check the checkbox "create shipment" and "Email copy of invoice" while generating invoice. and click submit invoice button.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
