### PR TITLE
Use correct base path to check if setup folder exists

### DIFF
--- a/lib/internal/Magento/Framework/App/DocRootLocator.php
+++ b/lib/internal/Magento/Framework/App/DocRootLocator.php
@@ -3,10 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Framework\App;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\ReadFactory;
 
 /**
@@ -20,18 +22,26 @@ class DocRootLocator
     private $request;
 
     /**
+     * @deprecated
      * @var ReadFactory
      */
     private $readFactory;
 
     /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
      * @param RequestInterface $request
      * @param ReadFactory $readFactory
+     * @param Filesystem|null $filesystem
      */
-    public function __construct(RequestInterface $request, ReadFactory $readFactory)
+    public function __construct(RequestInterface $request, ReadFactory $readFactory, Filesystem $filesystem = null)
     {
         $this->request = $request;
         $this->readFactory = $readFactory;
+        $this->filesystem = $filesystem ?: ObjectManager::getInstance()->get(Filesystem::class);
     }
 
     /**
@@ -42,7 +52,8 @@ class DocRootLocator
     public function isPub()
     {
         $rootBasePath = $this->request->getServer('DOCUMENT_ROOT');
-        $readDirectory = $this->readFactory->create(DirectoryList::ROOT);
-        return (substr($rootBasePath, -strlen('/pub')) === '/pub') && !$readDirectory->isExist($rootBasePath . 'setup');
+        $readDirectory = $this->filesystem->getDirectoryRead(DirectoryList::ROOT);
+
+        return (substr($rootBasePath, -\strlen('/pub')) === '/pub') && ! $readDirectory->isExist('setup');
     }
 }

--- a/lib/internal/Magento/Framework/App/Test/Unit/DocRootLocatorTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DocRootLocatorTest.php
@@ -8,6 +8,9 @@ namespace Magento\Framework\App\Test\Unit;
 
 use Magento\Framework\App\DocRootLocator;
 
+/**
+ * Test for Magento\Framework\App\DocRootLocator class.
+ */
 class DocRootLocatorTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/lib/internal/Magento/Framework/App/Test/Unit/DocRootLocatorTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DocRootLocatorTest.php
@@ -21,11 +21,15 @@ class DocRootLocatorTest extends \PHPUnit\Framework\TestCase
     {
         $request = $this->createMock(\Magento\Framework\App\Request\Http::class);
         $request->expects($this->once())->method('getServer')->willReturn($path);
-        $reader = $this->createMock(\Magento\Framework\Filesystem\Directory\Read::class);
-        $reader->expects($this->any())->method('isExist')->willReturn($isExist);
+
         $readFactory = $this->createMock(\Magento\Framework\Filesystem\Directory\ReadFactory::class);
-        $readFactory->expects($this->once())->method('create')->willReturn($reader);
-        $model = new DocRootLocator($request, $readFactory);
+
+        $reader = $this->createMock(\Magento\Framework\Filesystem\Directory\Read::class);
+        $filesystem = $this->createMock(\Magento\Framework\Filesystem::class);
+        $filesystem->expects($this->once())->method('getDirectoryRead')->willReturn($reader);
+        $reader->expects($this->any())->method('isExist')->willReturn($isExist);
+
+        $model = new DocRootLocator($request, $readFactory, $filesystem);
         $this->assertSame($result, $model->isPub());
     }
 


### PR DESCRIPTION
### Description (*)
Current implementation checks the path `base/data/web/magento2/pubsetup` which is incorrect. It should be `/data/web/magento2/pub/setup`.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/11892
2. https://github.com/magento/magento2/issues/7623

### Manual testing scenarios (*)
1. Install Magento and set doc root is `pub/`.
2. Symlink `setup` folder to `pub`.
3. `Web Setup Wizard` should be visible under **System > Web Setup Wizard** but it's not.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
