### PR TITLE
[Backport] REST API - Attribute option creation -> no ID returned

### DIFF
--- a/app/code/Magento/Catalog/Api/ProductAttributeOptionManagementInterface.php
+++ b/app/code/Magento/Catalog/Api/ProductAttributeOptionManagementInterface.php
@@ -29,7 +29,7 @@ interface ProductAttributeOptionManagementInterface
      * @param \Magento\Eav\Api\Data\AttributeOptionInterface $option
      * @throws \Magento\Framework\Exception\StateException
      * @throws \Magento\Framework\Exception\InputException
-     * @return bool
+     * @return \Magento\Eav\Api\Data\AttributeOptionInterface
      */
     public function add($attributeCode, $option);
 

--- a/app/code/Magento/Catalog/Api/ProductAttributeOptionManagementInterface.php
+++ b/app/code/Magento/Catalog/Api/ProductAttributeOptionManagementInterface.php
@@ -29,7 +29,7 @@ interface ProductAttributeOptionManagementInterface
      * @param \Magento\Eav\Api\Data\AttributeOptionInterface $option
      * @throws \Magento\Framework\Exception\StateException
      * @throws \Magento\Framework\Exception\InputException
-     * @return \Magento\Eav\Api\Data\AttributeOptionInterface
+     * @return string
      */
     public function add($attributeCode, $option);
 

--- a/app/code/Magento/Eav/Api/AttributeOptionManagementInterface.php
+++ b/app/code/Magento/Eav/Api/AttributeOptionManagementInterface.php
@@ -20,7 +20,7 @@ interface AttributeOptionManagementInterface
      * @param \Magento\Eav\Api\Data\AttributeOptionInterface $option
      * @throws \Magento\Framework\Exception\StateException
      * @throws \Magento\Framework\Exception\InputException
-     * @return bool
+     * @return \Magento\Eav\Api\Data\AttributeOptionInterface
      */
     public function add($entityType, $attributeCode, $option);
 

--- a/app/code/Magento/Eav/Api/AttributeOptionManagementInterface.php
+++ b/app/code/Magento/Eav/Api/AttributeOptionManagementInterface.php
@@ -20,7 +20,7 @@ interface AttributeOptionManagementInterface
      * @param \Magento\Eav\Api\Data\AttributeOptionInterface $option
      * @throws \Magento\Framework\Exception\StateException
      * @throws \Magento\Framework\Exception\InputException
-     * @return \Magento\Eav\Api\Data\AttributeOptionInterface
+     * @return string
      */
     public function add($entityType, $attributeCode, $option);
 

--- a/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
@@ -158,17 +158,16 @@ class OptionManagement implements \Magento\Eav\Api\AttributeOptionManagementInte
      * @param string $optionLabel
      * @return void
      */
-    public function setOptionValue($option, $attribute, $optionLabel)
+    protected function setOptionValue($option, $attribute, $optionLabel)
     {
-        if ($optionId = $attribute->getSource()->getOptionId($optionLabel)) {
+        $optionId = $attribute->getSource()->getOptionId($optionLabel);
+        if ($optionId) {
             $option->setValue($attribute->getSource()->getOptionId($optionId));
-        } else {
-            if (is_array($option->getStoreLabels())) {
-                foreach ($option->getStoreLabels() as $label) {
-                    if ($optionId = $attribute->getSource()->getOptionId($label->getLabel())) {
-                        $option->setValue($attribute->getSource()->getOptionId($optionId));
-                        break;
-                    }
+        } elseif (is_array($option->getStoreLabels())) {
+            foreach ($option->getStoreLabels() as $label) {
+                if ($optionId = $attribute->getSource()->getOptionId($label->getLabel())) {
+                    $option->setValue($attribute->getSource()->getOptionId($optionId));
+                    break;
                 }
             }
         }

--- a/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
@@ -49,9 +49,10 @@ class OptionManagement implements \Magento\Eav\Api\AttributeOptionManagementInte
             throw new StateException(__('Attribute %1 doesn\'t work with options', $attributeCode));
         }
 
+        $optionLabel = $option->getLabel();
         $optionId = $this->getOptionId($option);
         $options = [];
-        $options['value'][$optionId][0] = $option->getLabel();
+        $options['value'][$optionId][0] = $optionLabel;
         $options['order'][$optionId] = $option->getSortOrder();
 
         if (is_array($option->getStoreLabels())) {
@@ -67,11 +68,14 @@ class OptionManagement implements \Magento\Eav\Api\AttributeOptionManagementInte
         $attribute->setOption($options);
         try {
             $this->resourceModel->save($attribute);
+            if ($optionLabel && $attribute->getAttributeCode()) {
+                $option->setValue($attribute->getSource()->getOptionId($optionLabel));
+            }
         } catch (\Exception $e) {
             throw new StateException(__('Cannot save attribute %1', $attributeCode));
         }
 
-        return true;
+        return $option;
     }
 
     /**

--- a/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
@@ -75,7 +75,7 @@ class OptionManagement implements \Magento\Eav\Api\AttributeOptionManagementInte
             throw new StateException(__('Cannot save attribute %1', $attributeCode));
         }
 
-        return $option;
+        return $this->getOptionId($option);
     }
 
     /**
@@ -147,7 +147,7 @@ class OptionManagement implements \Magento\Eav\Api\AttributeOptionManagementInte
      * @param \Magento\Eav\Api\Data\AttributeOptionInterface $option
      * @return string
      */
-    private function getOptionId($option)
+    private function getOptionId(\Magento\Eav\Api\Data\AttributeOptionInterface $option) : string
     {
         return 'id_' . ($option->getValue() ?: 'new_option');
     }
@@ -158,8 +158,11 @@ class OptionManagement implements \Magento\Eav\Api\AttributeOptionManagementInte
      * @param string $optionLabel
      * @return void
      */
-    protected function setOptionValue($option, $attribute, $optionLabel)
-    {
+    private function setOptionValue(
+        \Magento\Eav\Api\Data\AttributeOptionInterface $option,
+        \Magento\Eav\Api\Data\AttributeInterface $attribute,
+        string $optionLabel
+    ) {
         $optionId = $attribute->getSource()->getOptionId($optionLabel);
         if ($optionId) {
             $option->setValue($attribute->getSource()->getOptionId($optionId));

--- a/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
@@ -69,7 +69,7 @@ class OptionManagement implements \Magento\Eav\Api\AttributeOptionManagementInte
         try {
             $this->resourceModel->save($attribute);
             if ($optionLabel && $attribute->getAttributeCode()) {
-                $option->setValue($attribute->getSource()->getOptionId($optionLabel));
+                $this->setOptionValue($option, $attribute, $optionLabel);
             }
         } catch (\Exception $e) {
             throw new StateException(__('Cannot save attribute %1', $attributeCode));
@@ -150,5 +150,27 @@ class OptionManagement implements \Magento\Eav\Api\AttributeOptionManagementInte
     private function getOptionId($option)
     {
         return 'id_' . ($option->getValue() ?: 'new_option');
+    }
+
+    /**
+     * @param \Magento\Eav\Api\Data\AttributeOptionInterface $option
+     * @param \Magento\Eav\Api\Data\AttributeInterface $attribute
+     * @param string $optionLabel
+     * @return void
+     */
+    public function setOptionValue($option, $attribute, $optionLabel)
+    {
+        if ($optionId = $attribute->getSource()->getOptionId($optionLabel)) {
+            $option->setValue($attribute->getSource()->getOptionId($optionId));
+        } else {
+            if (is_array($option->getStoreLabels())) {
+                foreach ($option->getStoreLabels() as $label) {
+                    if ($optionId = $attribute->getSource()->getOptionId($label->getLabel())) {
+                        $option->setValue($attribute->getSource()->getOptionId($optionId));
+                        break;
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/OptionManagementTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/OptionManagementTest.php
@@ -80,7 +80,7 @@ class OptionManagementTest extends \PHPUnit\Framework\TestCase
         $attributeMock->expects($this->once())->method('setDefault')->with(['id_new_option']);
         $attributeMock->expects($this->once())->method('setOption')->with($option);
         $this->resourceModelMock->expects($this->once())->method('save')->with($attributeMock);
-        $this->assertTrue($this->model->add($entityType, $attributeCode, $optionMock));
+        $this->assertEquals($optionMock, $this->model->add($entityType, $attributeCode, $optionMock));
     }
 
     /**

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/OptionManagementTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/OptionManagementTest.php
@@ -80,7 +80,7 @@ class OptionManagementTest extends \PHPUnit\Framework\TestCase
         $attributeMock->expects($this->once())->method('setDefault')->with(['id_new_option']);
         $attributeMock->expects($this->once())->method('setOption')->with($option);
         $this->resourceModelMock->expects($this->once())->method('save')->with($attributeMock);
-        $this->assertEquals($optionMock, $this->model->add($entityType, $attributeCode, $optionMock));
+        $this->assertEquals('new_option', $this->model->add($entityType, $attributeCode, $optionMock));
     }
 
     /**

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/OptionManagementTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/OptionManagementTest.php
@@ -80,7 +80,7 @@ class OptionManagementTest extends \PHPUnit\Framework\TestCase
         $attributeMock->expects($this->once())->method('setDefault')->with(['id_new_option']);
         $attributeMock->expects($this->once())->method('setOption')->with($option);
         $this->resourceModelMock->expects($this->once())->method('save')->with($attributeMock);
-        $this->assertEquals('new_option', $this->model->add($entityType, $attributeCode, $optionMock));
+        $this->assertEquals('id_new_option', $this->model->add($entityType, $attributeCode, $optionMock));
     }
 
     /**

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/AttributeTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/AttributeTest.php
@@ -119,6 +119,7 @@ class AttributeTest extends \PHPUnit\Framework\TestCase
         $storeLabels = ['test_attribute_store1'];
         $frontendLabelFactory = $this->getMockBuilder(\Magento\Eav\Model\Entity\Attribute\FrontendLabelFactory::class)
             ->setMethods(['create'])
+            ->disableOriginalConstructor()
             ->getMock();
         $resource = $this->getMockBuilder(\Magento\Eav\Model\ResourceModel\Entity\Attribute::class)
             ->setMethods(['getStoreLabelsByAttributeId'])

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductAttributeOptionManagementInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductAttributeOptionManagementInterfaceTest.php
@@ -74,7 +74,7 @@ class ProductAttributeOptionManagementInterfaceTest extends WebapiAbstract
             ]
         );
 
-        $this->assertTrue($response);
+        $this->assertNotNull($response[AttributeOptionInterface::VALUE]);
         $updatedData = $this->getAttributeOptions($testAttributeCode);
         $lastOption = array_pop($updatedData);
         $this->assertEquals(

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductAttributeOptionManagementInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductAttributeOptionManagementInterfaceTest.php
@@ -74,7 +74,7 @@ class ProductAttributeOptionManagementInterfaceTest extends WebapiAbstract
             ]
         );
 
-        $this->assertNotNull($response[AttributeOptionInterface::VALUE]);
+        $this->assertNotNull($response);
         $updatedData = $this->getAttributeOptions($testAttributeCode);
         $lastOption = array_pop($updatedData);
         $this->assertEquals(

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductSwatchAttributeOptionManagementInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductSwatchAttributeOptionManagementInterfaceTest.php
@@ -42,7 +42,7 @@ class ProductSwatchAttributeOptionManagementInterfaceTest extends WebapiAbstract
             ]
         );
 
-        $this->assertTrue($response);
+        $this->assertNotNull($response[AttributeOptionInterface::VALUE]);
         $updatedData = $this->getAttributeOptions($testAttributeCode);
         $lastOption = array_pop($updatedData);
         $this->assertEquals(

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductSwatchAttributeOptionManagementInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductSwatchAttributeOptionManagementInterfaceTest.php
@@ -42,7 +42,7 @@ class ProductSwatchAttributeOptionManagementInterfaceTest extends WebapiAbstract
             ]
         );
 
-        $this->assertNotNull($response[AttributeOptionInterface::VALUE]);
+        $this->assertNotNull($response);
         $updatedData = $this->getAttributeOptions($testAttributeCode);
         $lastOption = array_pop($updatedData);
         $this->assertEquals(


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/12920

<!--- Provide a general summary of the Pull Request in the Title above -->
Set option_id in value field to attributeoptioninterface return type
### Description
<!--- Provide a description of the changes proposed in the pull request -->
I have changed return type of add function and set value to option. So when we do REST or SOAP api then it will return option_id in 'value' field to attributeoptioninterface return type.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#8810: REST API - Attribute option creation -> no ID returned
2. magento/magento2#6300: Successful attribute option POST returns 'true', not the option hash or value

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Fresh install
2. Make following REST request:
`POST /rest/default/V1/products/attributes/manufacturer/options`
with following Body:
`{
  "option": {
    "label": "Manufacturer 1"
  }
}`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
