### PR TITLE
3846: Table sales_order field store_name has 32 bytes

### DIFF
--- a/app/code/Magento/Sales/etc/db_schema.xml
+++ b/app/code/Magento/Sales/etc/db_schema.xml
@@ -219,7 +219,7 @@
         <column xsi:type="varchar" name="remote_ip" nullable="true" length="45" comment="Remote Ip"/>
         <column xsi:type="varchar" name="shipping_method" nullable="true" length="120"/>
         <column xsi:type="varchar" name="store_currency_code" nullable="true" length="3" comment="Store Currency Code"/>
-        <column xsi:type="varchar" name="store_name" nullable="true" length="32" comment="Store Name"/>
+        <column xsi:type="varchar" name="store_name" nullable="true" length="255" comment="Store Name"/>
         <column xsi:type="varchar" name="x_forwarded_for" nullable="true" length="32" comment="X Forwarded For"/>
         <column xsi:type="text" name="customer_note" nullable="true" comment="Customer Note"/>
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP"


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento-engcom/magento2ce/pull/1113

### Description
Increase store_name length in sales_order, in order to be able to include full information about store e.g:
Main Website
Main Website Store
Default Store View
and not just:
Main Website
Main Website Store
as it is currently.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#3846: Table sales_order field store_name has 32 bytes

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create order from storefront or backend.
2. Observe sales_order.store_name
3. Check, it includes full store information like:
WebsiteName
StoreGroupName
StoreName

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
