### PR TITLE
Secure errors directory

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -159,6 +159,11 @@ location /media/downloadable/ {
 location /media/import/ {
     deny all;
 }
+location /errors/ {
+    location ~* \.xml$ {
+        deny all;
+    }
+}
 
 # PHP entry point for main application
 location ~ ^/(index|get|static|errors/report|errors/404|errors/503|health_check)\.php$ {
@@ -198,6 +203,6 @@ gzip_types
 gzip_vary on;
 
 # Banned locations (only reached if the earlier PHP entry point regexes don't match)
-location ~* (\.php$|\.htaccess$|\.git) {
+location ~* (\.php$|\.phtml$|\.htaccess$|\.git) {
     deny all;
 }

--- a/pub/errors/.htaccess
+++ b/pub/errors/.htaccess
@@ -1,4 +1,7 @@
 Options None
+<FilesMatch "\.(xml|phtml)$">
+    Deny from all
+</FilesMatch>
 <IfModule mod_rewrite.c>
     RewriteEngine Off
 </IfModule>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

**For Apache:** deny access to XML and PHTML files within errors directory (pub/errors/.htaccess)
**For Nginx:** deny access to PHTML files in general and XML files within errors directory (nginx.conf.sample)

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20209: errors/local.xml and error page templates are publicly accessible

### Manual testing scenarios (*)

See issue #20209 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
