### PR TITLE
Import external Images fix for products

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
@@ -185,9 +185,10 @@ class Uploader extends \Magento\MediaStorage\Model\File\Uploader
                 $filePath,
                 $read->readAll()
             );
+        } else {
+            $filePath = $this->_directory->getRelativePath($filePath . $fileName);
         }
 
-        $filePath = $this->_directory->getRelativePath($filePath . $fileName);
         $this->_setUploadFile($filePath);
         $destDir = $this->_directory->getAbsolutePath($this->getDestDir());
         $result = $this->save($destDir);


### PR DESCRIPTION
### Description (*)
During the import of products which images come from an external source, like s3, the import will fail due to double assignment on file path variable. 
Issue replicated in: 2.3 - 2.2.7 

### Manual testing scenarios (*)
1. Create a CSV for product input that tries to import files from S3 or any other media storage/website/external source
2.Try to import the csv with the magento standard tools
3. An error will appear due to the inhability to import the file (Actually the file will be downloaded, but will be impossible to move it from tmp dir to the catalog/product media dir)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)


@magento-engcom-team give me test instance
@magento-engcom-team give me 2.3-develop instance