### PR TITLE
Fix clean_cache plugin flush mode

### DIFF
--- a/lib/internal/Magento/Framework/App/Cache/FlushCacheByTags.php
+++ b/lib/internal/Magento/Framework/App/Cache/FlushCacheByTags.php
@@ -1,10 +1,16 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Framework\App\Cache;
+
+use Magento\Framework\App\Cache\Tag\Resolver;
+use Magento\Framework\App\Cache\Type\FrontendPool;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
 
 /**
  * Automatic cache cleaner plugin
@@ -12,7 +18,7 @@ namespace Magento\Framework\App\Cache;
 class FlushCacheByTags
 {
     /**
-     * @var Type\FrontendPool
+     * @var \Magento\Framework\App\Cache\Type\FrontendPool
      */
     private $cachePool;
 
@@ -22,28 +28,26 @@ class FlushCacheByTags
     private $cacheList;
 
     /**
-     * @var StateInterface
+     * @var \Magento\Framework\App\Cache\StateInterface
      */
     private $cacheState;
 
     /**
-     * @var Tag\Resolver
+     * @var \Magento\Framework\App\Cache\Tag\Resolver
      */
     private $tagResolver;
 
     /**
-     * FlushCacheByTags constructor.
-     *
-     * @param Type\FrontendPool $cachePool
-     * @param StateInterface $cacheState
-     * @param array $cacheList
-     * @param Tag\Resolver $tagResolver
+     * @param \Magento\Framework\App\Cache\Type\FrontendPool $cachePool
+     * @param \Magento\Framework\App\Cache\StateInterface $cacheState
+     * @param string[] $cacheList
+     * @param \Magento\Framework\App\Cache\Tag\Resolver $tagResolver
      */
     public function __construct(
-        \Magento\Framework\App\Cache\Type\FrontendPool $cachePool,
-        \Magento\Framework\App\Cache\StateInterface $cacheState,
+        FrontendPool $cachePool,
+        StateInterface $cacheState,
         array $cacheList,
-        \Magento\Framework\App\Cache\Tag\Resolver $tagResolver
+        Resolver $tagResolver
     ) {
         $this->cachePool = $cachePool;
         $this->cacheState = $cacheState;
@@ -60,11 +64,8 @@ class FlushCacheByTags
      * @return \Magento\Framework\Model\ResourceModel\AbstractResource
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundSave(
-        \Magento\Framework\Model\ResourceModel\AbstractResource $subject,
-        \Closure $proceed,
-        \Magento\Framework\Model\AbstractModel $object
-    ) {
+    public function aroundSave(AbstractResource $subject, \Closure $proceed, AbstractModel $object): AbstractResource
+    {
         $result = $proceed($object);
         $tags = $this->tagResolver->getTags($object);
         $this->cleanCacheByTags($tags);
@@ -81,33 +82,31 @@ class FlushCacheByTags
      * @return \Magento\Framework\Model\ResourceModel\AbstractResource
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundDelete(
-        \Magento\Framework\Model\ResourceModel\AbstractResource $subject,
-        \Closure $proceed,
-        \Magento\Framework\Model\AbstractModel $object
-    ) {
+    public function aroundDelete(AbstractResource $subject, \Closure $proceed, AbstractModel $object): AbstractResource
+    {
         $tags = $this->tagResolver->getTags($object);
         $result = $proceed($object);
         $this->cleanCacheByTags($tags);
+
         return $result;
     }
 
     /**
      * Clean cache by tags
      *
-     * @param  string[] $tags
+     * @param string[] $tags
      * @return void
      */
-    private function cleanCacheByTags($tags)
+    private function cleanCacheByTags(array $tags): void
     {
-        if (empty($tags)) {
+        if (!$tags) {
             return;
         }
         foreach ($this->cacheList as $cacheType) {
             if ($this->cacheState->isEnabled($cacheType)) {
                 $this->cachePool->get($cacheType)->clean(
-                    \Zend_Cache::CLEANING_MODE_MATCHING_TAG,
-                    array_unique($tags)
+                    \Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG,
+                    \array_unique($tags)
                 );
             }
         }

--- a/lib/internal/Magento/Framework/App/Test/Unit/Cache/FlushCacheByTagsTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Cache/FlushCacheByTagsTest.php
@@ -3,9 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Framework\App\Test\Unit\Cache;
 
+use Magento\Framework\App\Cache\FlushCacheByTags;
+use Magento\Framework\App\Cache\StateInterface;
+use Magento\Framework\App\Cache\Tag\Resolver;
+use Magento\Framework\App\Cache\Type\FrontendPool;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+
+/**
+ * Unit tests for the \Magento\Framework\App\Cache\FlushCacheByTags class.
+ */
 class FlushCacheByTagsTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -28,13 +39,16 @@ class FlushCacheByTagsTest extends \PHPUnit\Framework\TestCase
      */
     private $plugin;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp()
     {
-        $this->cacheState = $this->getMockForAbstractClass(\Magento\Framework\App\Cache\StateInterface::class);
-        $this->frontendPool = $this->createMock(\Magento\Framework\App\Cache\Type\FrontendPool::class);
-        $this->tagResolver = $this->createMock(\Magento\Framework\App\Cache\Tag\Resolver::class);
+        $this->cacheState = $this->getMockForAbstractClass(StateInterface::class);
+        $this->frontendPool = $this->createMock(FrontendPool::class);
+        $this->tagResolver = $this->createMock(Resolver::class);
 
-        $this->plugin = new \Magento\Framework\App\Cache\FlushCacheByTags(
+        $this->plugin = new FlushCacheByTags(
             $this->frontendPool,
             $this->cacheState,
             ['test'],
@@ -42,14 +56,19 @@ class FlushCacheByTagsTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testAroundSave()
+    /**
+     * @return void
+     */
+    public function testAroundSave(): void
     {
-        $resource = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\AbstractResource::class)
+        $resource = $this->getMockBuilder(AbstractResource::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-        $model = $this->getMockBuilder(\Magento\Framework\Model\AbstractModel::class)
+        $model = $this->getMockBuilder(AbstractModel::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
+        $this->tagResolver->expects($this->atLeastOnce())->method('getTags')->with($model)->willReturn([]);
+
         $result = $this->plugin->aroundSave(
             $resource,
             function () use ($resource) {
@@ -57,17 +76,23 @@ class FlushCacheByTagsTest extends \PHPUnit\Framework\TestCase
             },
             $model
         );
+
         $this->assertSame($resource, $result);
     }
 
-    public function testAroundDelete()
+    /**
+     * @return void
+     */
+    public function testAroundDelete(): void
     {
-        $resource = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\AbstractResource::class)
+        $resource = $this->getMockBuilder(AbstractResource::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-        $model = $this->getMockBuilder(\Magento\Framework\Model\AbstractModel::class)
+        $model = $this->getMockBuilder(AbstractModel::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
+        $this->tagResolver->expects($this->atLeastOnce())->method('getTags')->with($model)->willReturn([]);
+
         $result = $this->plugin->aroundDelete(
             $resource,
             function () use ($resource) {
@@ -75,25 +100,7 @@ class FlushCacheByTagsTest extends \PHPUnit\Framework\TestCase
             },
             $model
         );
-        $this->assertSame($resource, $result);
-    }
 
-    public function testAroundSaveWithInterface()
-    {
-        $resource = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\AbstractResource::class)
-
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
-        $model = $this->getMockBuilder(\Magento\Framework\Model\AbstractModel::class)
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
-        $result = $this->plugin->aroundSave(
-            $resource,
-            function () use ($resource) {
-                return $resource;
-            },
-            $model
-        );
         $this->assertSame($resource, $result);
     }
 }


### PR DESCRIPTION
The following plugin is used to clean the "block_html" and "collections" cache types by tags.
This plugin is not really used in the native Magento app, so I guess no one didn't really had issue with it (unless for eav resource models).

The `\Zend_Cache::CLEANING_MODE_MATCHING_TAG` is too restrictive as all entity tags must match with the stored data tags.

### Description (*)
- introduce strict types
- fix clean cache mode to match any tags

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
