### PR TITLE
Fixed issue #20187 Downloadble Price duplicate issue

### DIFF
--- a/app/code/Magento/Downloadable/view/frontend/layout/catalog_product_view_type_downloadable.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/catalog_product_view_type_downloadable.xml
@@ -26,17 +26,6 @@
                 </block>
             </block>
         </referenceBlock>
-        <referenceContainer name="product.info.options.wrapper.bottom">
-            <block class="Magento\Catalog\Pricing\Render" name="product.price.final.copy" before="-">
-                <arguments>
-                    <argument name="price_render" xsi:type="string">product.price.render.default</argument>
-                    <argument name="price_type_code" xsi:type="string">final_price</argument>
-                    <argument name="display_msrp_help_message" xsi:type="string">1</argument>
-                    <argument name="zone" xsi:type="string">item_view</argument>
-                    <argument name="id_suffix" xsi:type="string">copy-</argument>
-                </arguments>
-            </block>
-        </referenceContainer>
         <referenceBlock name="head.components">
             <block class="Magento\Framework\View\Element\Js\Components" name="downloadable_page_head_components" template="Magento_Downloadable::js/components.phtml"/>
         </referenceBlock>


### PR DESCRIPTION
Fixed issue #20187 Downloadble Price duplicate issue

### Description (*)
Fixed issue #20187 Downloadble Price duplicate issue

### Fixed Issues (if relevant)

1. magento/magento2#20187: Issue title


### Manual testing scenarios (*)

1.Install one downloadable product and one simple product
2.in frontend open both products in different browser tabs to compare the layout
3.Price is getting duplicated

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
