### PR TITLE
Magento widgets source models forced to use deprecated interface #20064

### DIFF
--- a/lib/internal/Magento/Framework/Option/ArrayPool.php
+++ b/lib/internal/Magento/Framework/Option/ArrayPool.php
@@ -34,7 +34,8 @@ class ArrayPool
     {
         $modelInstance = $this->_objectManager->get($model);
         if (false == $modelInstance instanceof \Magento\Framework\Data\OptionSourceInterface) {
-            throw new \InvalidArgumentException($model . 'doesn\'t implement \Magento\Framework\Data\OptionSourceInterface');
+            throw new \InvalidArgumentException($model
+                . 'doesn\'t implement \Magento\Framework\Data\OptionSourceInterface');
         }
         return $modelInstance;
     }

--- a/lib/internal/Magento/Framework/Option/ArrayPool.php
+++ b/lib/internal/Magento/Framework/Option/ArrayPool.php
@@ -28,13 +28,13 @@ class ArrayPool
      *
      * @param string $model
      * @throws \InvalidArgumentException
-     * @return \Magento\Framework\Option\ArrayInterface
+     * @return \Magento\Framework\Data\OptionSourceInterface
      */
     public function get($model)
     {
         $modelInstance = $this->_objectManager->get($model);
-        if (false == $modelInstance instanceof \Magento\Framework\Option\ArrayInterface) {
-            throw new \InvalidArgumentException($model . 'doesn\'t implement \Magento\Framework\Option\ArrayInterface');
+        if (false == $modelInstance instanceof \Magento\Framework\Data\OptionSourceInterface) {
+            throw new \InvalidArgumentException($model . 'doesn\'t implement \Magento\Framework\Data\OptionSourceInterface');
         }
         return $modelInstance;
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20064: Magento widgets source models forced to use deprecated interface 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
? Backward compatibility 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
