### PR TITLE
patch-14492 : Fixed Create Customer without password is direct confirmed.

### DIFF
--- a/app/code/Magento/Customer/Model/ResourceModel/Customer.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/Customer.php
@@ -141,7 +141,7 @@ class Customer extends \Magento\Eav\Model\Entity\VersionControl\AbstractEntity
         }
 
         // set confirmation key logic
-        if ($customer->getForceConfirmed() || $customer->getPasswordHash() == '') {
+        if ($customer->getForceConfirmed() || $customer->getPasswordHash() === '') {
             $customer->setConfirmation(null);
         } elseif (!$customer->getId() && $customer->isConfirmationRequired()) {
             $customer->setConfirmation($customer->getRandomConfirmationKey());

--- a/app/code/Magento/Customer/Model/ResourceModel/Customer.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/Customer.php
@@ -141,7 +141,7 @@ class Customer extends \Magento\Eav\Model\Entity\VersionControl\AbstractEntity
         }
 
         // set confirmation key logic
-        if ($customer->getForceConfirmed() || $customer->getPasswordHash() === '') {
+        if ($customer->getForceConfirmed()) {
             $customer->setConfirmation(null);
         } elseif (!$customer->getId() && $customer->isConfirmationRequired()) {
             $customer->setConfirmation($customer->getRandomConfirmationKey());


### PR DESCRIPTION
Creating Customer without password is directly confirmed #14492

### Description (*)
Fixed issue when Creating Customer without password is directly confirmed #14492


### Fixed Issues (if relevant)
1. magento/magento2#14492: Creating Customer without password is directly confirmed #14492


### Manual testing scenarios (*)

1. Set Customer Account Confirmation Required from admin
2. Create customer programatically without password using AccountManagementInterface
3. Go to Admin and open Customer from admin (Customer -> All customer), Newly created customer account is confirmed directly.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
