### PR TITLE
#19623 :: Error message for the website admin when trying to add a re…

### DIFF
--- a/app/code/Magento/Review/Controller/Adminhtml/Product/JsonProductInfo.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/JsonProductInfo.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Review\Controller\Adminhtml\Product;
 
-use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Review\Controller\Adminhtml\Product as ProductController;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Registry;
@@ -18,7 +18,7 @@ use Magento\Framework\Controller\ResultFactory;
 /**
  * Represents product info in json
  */
-class JsonProductInfo extends ProductController implements HttpGetActionInterface
+class JsonProductInfo extends ProductController implements HttpPostActionInterface
 {
     /**
      * @var \Magento\Catalog\Api\ProductRepositoryInterface


### PR DESCRIPTION

### Description (*)
1. Magento 2.3 admin receives an error message when trying to add a review and the stars rating is unavailable. I have fixed this issue, now review is getting added properly from the megento admin.

### Fixed Issues (if relevant)

1. magento/magento2 #19623: Error message for the website admin when trying to add a review Magento 2.3


### Manual testing scenarios (*)

1. Sign in to Magento backend.
2. Marketing > Reviews > New Review
3. Select a product to review
4. Add review details and click 'Save Review' button


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
