### PR TITLE
[Backport] Use the new json serializer which throws an error when failing

### DIFF
--- a/app/code/Magento/Checkout/Block/Onepage.php
+++ b/app/code/Magento/Checkout/Block/Onepage.php
@@ -38,7 +38,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
     protected $layoutProcessors;
 
     /**
-     * @var \Magento\Framework\Serialize\Serializer\Json
+     * @var \Magento\Framework\Serialize\SerializerInterface
      */
     private $serializer;
 
@@ -48,8 +48,8 @@ class Onepage extends \Magento\Framework\View\Element\Template
      * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider
      * @param array $layoutProcessors
      * @param array $data
-     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
-     * @throws \RuntimeException
+     * @param \Magento\Framework\Serialize\Serializer\Json $serializer
+     * @param \Magento\Framework\Serialize\SerializerInterface $serializerInterface
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
@@ -57,7 +57,8 @@ class Onepage extends \Magento\Framework\View\Element\Template
         \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
         array $layoutProcessors = [],
         array $data = [],
-        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null,
+        \Magento\Framework\Serialize\SerializerInterface $serializerInterface = null
     ) {
         parent::__construct($context, $data);
         $this->formKey = $formKey;
@@ -65,8 +66,8 @@ class Onepage extends \Magento\Framework\View\Element\Template
         $this->jsLayout = isset($data['jsLayout']) && is_array($data['jsLayout']) ? $data['jsLayout'] : [];
         $this->configProvider = $configProvider;
         $this->layoutProcessors = $layoutProcessors;
-        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
+        $this->serializer = $serializerInterface ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\JsonHexTag::class);
     }
 
     /**
@@ -78,7 +79,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
             $this->jsLayout = $processor->process($this->jsLayout);
         }
 
-        return json_encode($this->jsLayout, JSON_HEX_TAG);
+        return $this->serializer->serialize($this->jsLayout);
     }
 
     /**
@@ -120,6 +121,6 @@ class Onepage extends \Magento\Framework\View\Element\Template
      */
     public function getSerializedCheckoutConfig()
     {
-        return json_encode($this->getCheckoutConfig(), JSON_HEX_TAG);
+        return  $this->serializer->serialize($this->getCheckoutConfig());
     }
 }

--- a/app/code/Magento/Checkout/Block/Onepage.php
+++ b/app/code/Magento/Checkout/Block/Onepage.php
@@ -50,6 +50,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
      * @param array $data
      * @param \Magento\Framework\Serialize\Serializer\Json $serializer
      * @param \Magento\Framework\Serialize\SerializerInterface $serializerInterface
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
@@ -71,7 +72,7 @@ class Onepage extends \Magento\Framework\View\Element\Template
     }
 
     /**
-     * @return string
+     * @inheritdoc
      */
     public function getJsLayout()
     {
@@ -116,6 +117,8 @@ class Onepage extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Retrieve serialized checkout config.
+     *
      * @return bool|string
      * @since 100.2.0
      */

--- a/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/OnepageTest.php
@@ -35,7 +35,7 @@ class OnepageTest extends \PHPUnit\Framework\TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
-    private $serializer;
+    private $serializerMock;
 
     protected function setUp()
     {
@@ -49,7 +49,7 @@ class OnepageTest extends \PHPUnit\Framework\TestCase
             \Magento\Checkout\Block\Checkout\LayoutProcessorInterface::class
         );
 
-        $this->serializer = $this->createMock(\Magento\Framework\Serialize\Serializer\Json::class);
+        $this->serializerMock = $this->createMock(\Magento\Framework\Serialize\Serializer\JsonHexTag::class);
 
         $this->model = new \Magento\Checkout\Block\Onepage(
             $contextMock,
@@ -57,7 +57,8 @@ class OnepageTest extends \PHPUnit\Framework\TestCase
             $this->configProviderMock,
             [$this->layoutProcessorMock],
             [],
-            $this->serializer
+            $this->serializerMock,
+            $this->serializerMock
         );
     }
 
@@ -93,6 +94,7 @@ class OnepageTest extends \PHPUnit\Framework\TestCase
         $processedLayout = ['layout' => ['processed' => true]];
         $jsonLayout = '{"layout":{"processed":true}}';
         $this->layoutProcessorMock->expects($this->once())->method('process')->with([])->willReturn($processedLayout);
+        $this->serializerMock->expects($this->once())->method('serialize')->willReturn($jsonLayout);
 
         $this->assertEquals($jsonLayout, $this->model->getJsLayout());
     }
@@ -101,6 +103,7 @@ class OnepageTest extends \PHPUnit\Framework\TestCase
     {
         $checkoutConfig = ['checkout', 'config'];
         $this->configProviderMock->expects($this->once())->method('getConfig')->willReturn($checkoutConfig);
+        $this->serializerMock->expects($this->once())->method('serialize')->willReturn(json_encode($checkoutConfig));
 
         $this->assertEquals(json_encode($checkoutConfig), $this->model->getSerializedCheckoutConfig());
     }

--- a/app/code/Magento/Checkout/etc/frontend/di.xml
+++ b/app/code/Magento/Checkout/etc/frontend/di.xml
@@ -59,6 +59,7 @@
                 <item name="totalsSortOrder" xsi:type="object">Magento\Checkout\Block\Checkout\TotalsProcessor</item>
                 <item name="directoryData" xsi:type="object">Magento\Checkout\Block\Checkout\DirectoryDataProcessor</item>
             </argument>
+            <argument name="serializer" xsi:type="object">Magento\Framework\Serialize\Serializer\JsonHexTag</argument>
         </arguments>
     </type>
     <type name="Magento\Checkout\Block\Cart\Totals">

--- a/app/code/Magento/Ui/TemplateEngine/Xhtml/Result.php
+++ b/app/code/Magento/Ui/TemplateEngine/Xhtml/Result.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Ui\TemplateEngine\Xhtml;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Serialize\Serializer\JsonHexTag;
 use Magento\Framework\View\Layout\Generator\Structure;
 use Magento\Framework\View\Element\UiComponentInterface;
 use Magento\Framework\View\TemplateEngine\Xhtml\Template;
@@ -43,24 +45,32 @@ class Result implements ResultInterface
     protected $logger;
 
     /**
+     * @var JsonHexTag
+     */
+    private $jsonSerializer;
+
+    /**
      * @param Template $template
      * @param CompilerInterface $compiler
      * @param UiComponentInterface $component
      * @param Structure $structure
      * @param LoggerInterface $logger
+     * @param JsonHexTag $jsonSerializer
      */
     public function __construct(
         Template $template,
         CompilerInterface $compiler,
         UiComponentInterface $component,
         Structure $structure,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        JsonHexTag $jsonSerializer = null
     ) {
         $this->template = $template;
         $this->compiler = $compiler;
         $this->component = $component;
         $this->structure = $structure;
         $this->logger = $logger;
+        $this->jsonSerializer = $jsonSerializer ?? ObjectManager::getInstance()->get(JsonHexTag::class);
     }
 
     /**
@@ -81,7 +91,7 @@ class Result implements ResultInterface
     public function appendLayoutConfiguration()
     {
         $layoutConfiguration = $this->wrapContent(
-            json_encode($this->structure->generate($this->component), JSON_HEX_TAG)
+            $this->jsonSerializer->serialize($this->structure->generate($this->component))
         );
         $this->template->append($layoutConfiguration);
     }

--- a/app/code/Magento/Ui/Test/Unit/TemplateEngine/Xhtml/ResultTest.php
+++ b/app/code/Magento/Ui/Test/Unit/TemplateEngine/Xhtml/ResultTest.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Ui\Test\Unit\TemplateEngine\Xhtml;
 
+use Magento\Framework\Serialize\Serializer\JsonHexTag;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\View\Layout\Generator\Structure;
 use Magento\Framework\View\Element\UiComponentInterface;
@@ -58,6 +59,11 @@ class ResultTest extends \PHPUnit\Framework\TestCase
      */
     private $objectManager;
 
+    /**
+     * @var JsonHexTag|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $serializer;
+
     protected function setUp()
     {
         $this->template = $this->createPartialMock(Template::class, ['append']);
@@ -65,6 +71,9 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $this->component = $this->createMock(UiComponentInterface::class);
         $this->structure = $this->createPartialMock(Structure::class, ['generate']);
         $this->logger = $this->createMock(LoggerInterface::class);
+        $this->serializer = $this->getMockBuilder(JsonHexTag::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->objectManager = new ObjectManager($this);
         $this->testModel = $this->objectManager->getObject(Result::class, [
@@ -73,6 +82,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
             'component' => $this->component,
             'structure' => $this->structure,
             'logger' => $this->logger,
+            'jsonSerializer' => $this->serializer
         ]);
     }
 
@@ -82,6 +92,10 @@ class ResultTest extends \PHPUnit\Framework\TestCase
     public function testAppendLayoutConfiguration()
     {
         $configWithCdata = 'text before <![CDATA[cdata text]]>';
+        $this->serializer->expects($this->once())
+            ->method('serialize')
+            ->with([$configWithCdata])
+            ->willReturn('["text before \u003C![CDATA[cdata text]]\u003E"]');
         $this->structure->expects($this->once())
             ->method('generate')
             ->with($this->component)

--- a/lib/internal/Magento/Framework/Serialize/README.md
+++ b/lib/internal/Magento/Framework/Serialize/README.md
@@ -3,6 +3,7 @@
 **Serialize** library provides interface *SerializerInterface* and multiple implementations:
 
  * *Json* - default implementation. Uses PHP native json_encode/json_decode functions;
+ * *JsonHexTag* - default implementation. Uses PHP native json_encode/json_decode functions with `JSON_HEX_TAG` option enabled;
  * *Serialize* - less secure than *Json*, but gives higher performance on big arrays. Uses PHP native serialize/unserialize functions, does not unserialize objects on PHP 7.
  
 Using *Serialize* implementation directly is discouraged, always use *SerializerInterface*, using *Serialize* implementation may lead to security vulnerabilities.

--- a/lib/internal/Magento/Framework/Serialize/Serializer/JsonHexTag.php
+++ b/lib/internal/Magento/Framework/Serialize/Serializer/JsonHexTag.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Framework\Serialize\Serializer;
+
+use Magento\Framework\Serialize\SerializerInterface;
+
+/**
+ * Serialize data to JSON with the JSON_HEX_TAG option enabled
+ * (All < and > are converted to \u003C and \u003E),
+ * unserialize JSON encoded data
+ *
+ * @api
+ * @since 100.2.0
+ */
+class JsonHexTag extends Json implements SerializerInterface
+{
+    /**
+     * @inheritDoc
+     * @since 100.2.0
+     */
+    public function serialize($data): string
+    {
+        $result = json_encode($data, JSON_HEX_TAG);
+        if (false === $result) {
+            throw new \InvalidArgumentException('Unable to serialize value.');
+        }
+        return $result;
+    }
+}

--- a/lib/internal/Magento/Framework/Serialize/Test/Unit/Serializer/JsonHexTagTest.php
+++ b/lib/internal/Magento/Framework/Serialize/Test/Unit/Serializer/JsonHexTagTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Framework\Serialize\Test\Unit\Serializer;
+
+use Magento\Framework\DataObject;
+use Magento\Framework\Serialize\Serializer\JsonHexTag;
+
+class JsonHexTagTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $json;
+    
+    protected function setUp()
+    {
+        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $this->json = $objectManager->getObject(JsonHexTag::class);
+    }
+
+    /**
+     * @param string|int|float|bool|array|null $value
+     * @param string $expected
+     * @dataProvider serializeDataProvider
+     */
+    public function testSerialize($value, $expected)
+    {
+        $this->assertEquals(
+            $expected,
+            $this->json->serialize($value)
+        );
+    }
+
+    public function serializeDataProvider()
+    {
+        $dataObject = new DataObject(['something']);
+        return [
+            ['', '""'],
+            ['string', '"string"'],
+            [null, 'null'],
+            [false, 'false'],
+            [['a' => 'b', 'd' => 123], '{"a":"b","d":123}'],
+            [123, '123'],
+            [10.56, '10.56'],
+            [$dataObject, '{}'],
+            ['< >', '"\u003C \u003E"'],
+        ];
+    }
+
+    /**
+     * @param string $value
+     * @param string|int|float|bool|array|null $expected
+     * @dataProvider unserializeDataProvider
+     */
+    public function testUnserialize($value, $expected)
+    {
+        $this->assertEquals(
+            $expected,
+            $this->json->unserialize($value)
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function unserializeDataProvider(): array {
+        return [
+            ['""', ''],
+            ['"string"', 'string'],
+            ['null', null],
+            ['false', false],
+            ['{"a":"b","d":123}', ['a' => 'b', 'd' => 123]],
+            ['123', 123],
+            ['10.56', 10.56],
+            ['{}', []],
+            ['"\u003C \u003E"', '< >'],
+        ];
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unable to serialize value.
+     */
+    public function testSerializeException()
+    {
+        $this->json->serialize(STDOUT);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unable to unserialize value.
+     * @dataProvider unserializeExceptionDataProvider
+     */
+    public function testUnserializeException($value)
+    {
+        $this->json->unserialize($value);
+    }
+
+    /**
+     * @return array
+     */
+    public function unserializeExceptionDataProvider(): array {
+        return [
+            [''],
+            [false],
+            [null],
+            ['{']
+        ];
+    }
+}

--- a/lib/internal/Magento/Framework/Serialize/Test/Unit/Serializer/JsonHexTagTest.php
+++ b/lib/internal/Magento/Framework/Serialize/Test/Unit/Serializer/JsonHexTagTest.php
@@ -69,7 +69,8 @@ class JsonHexTagTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function unserializeDataProvider(): array {
+    public function unserializeDataProvider(): array
+    {
         return [
             ['""', ''],
             ['"string"', 'string'],
@@ -105,7 +106,8 @@ class JsonHexTagTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function unserializeExceptionDataProvider(): array {
+    public function unserializeExceptionDataProvider(): array
+    {
         return [
             [''],
             [false],


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/16154
### Description
Use the new serializer which throws an error when json_encoding fails.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14937: Javascript error thrown from uiComponent 'notification_area' if messages are malformed
2. Perhaps more

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
