### PR TITLE
[Backport] Fix issue causing attribute not loading when using getList

### DIFF
--- a/app/code/Magento/Backend/Model/Search/Customer.php
+++ b/app/code/Magento/Backend/Model/Search/Customer.php
@@ -89,7 +89,7 @@ class Customer extends \Magento\Framework\DataObject
 
         $this->searchCriteriaBuilder->setCurrentPage($this->getStart());
         $this->searchCriteriaBuilder->setPageSize($this->getLimit());
-        $searchFields = ['firstname', 'lastname', 'company'];
+        $searchFields = ['firstname', 'lastname', 'billing_company'];
         $filters = [];
         foreach ($searchFields as $field) {
             $filters[] = $this->filterBuilder

--- a/app/code/Magento/Customer/Model/ResourceModel/CustomerRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/CustomerRepository.php
@@ -365,7 +365,7 @@ class CustomerRepository implements CustomerRepositoryInterface
             ->joinAttribute('billing_telephone', 'customer_address/telephone', 'default_billing', null, 'left')
             ->joinAttribute('billing_region', 'customer_address/region', 'default_billing', null, 'left')
             ->joinAttribute('billing_country_id', 'customer_address/country_id', 'default_billing', null, 'left')
-            ->joinAttribute('company', 'customer_address/company', 'default_billing', null, 'left');
+            ->joinAttribute('billing_company', 'customer_address/company', 'default_billing', null, 'left');
 
         $this->collectionProcessor->process($searchCriteria, $collection);
 

--- a/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/CustomerRepositoryTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/CustomerRepositoryTest.php
@@ -740,7 +740,7 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
             ->willReturnSelf();
         $collection->expects($this->at(7))
             ->method('joinAttribute')
-            ->with('company', 'customer_address/company', 'default_billing', null, 'left')
+            ->with('billing_company', 'customer_address/company', 'default_billing', null, 'left')
             ->willReturnSelf();
         $this->collectionProcessorMock->expects($this->once())
             ->method('process')


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19620
### Description (*)
As specified in issue #17759, `CustomerRepository::getList()` is unexpectedly returning `NULL`, when `CustomerRepository::get()` is correctly returning the value. Specifying the attribute as `billing_company` instead of `company` removes the conflict.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17759: M2.2.5 : CustomerRepository::getList() does not load custom attribute if the name is "company" 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create/Install two custom `varchar` customer attributes, one with the code `company`.
2. Log the data when loading with `getbyId()`:
    `$customerById = $customerRepository->getbyId(x);`
3. Log the data when loading with `getList()`:
    `$customerByList = $customerRepository->getList($searchCriteria->addFilter('x, y')->create());`

Previously, under custom attributes, both attributes were loading correctly for `getbyId()`, but `company` would pull `NULL` when using `getList()`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
