### PR TITLE
[Backport]#20222 Canary islands in ups carrier 2.2

### DIFF
--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrierOnline.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrierOnline.php
@@ -28,6 +28,14 @@ abstract class AbstractCarrierOnline extends AbstractCarrier
 
     const GUAM_REGION_CODE = 'GU';
 
+    const SPAIN_COUNTRY_ID = 'ES';
+
+    const CANARY_ISLANDS_COUNTRY_ID = 'IC';
+
+    const SANTA_CRUZ_DE_TENERIFE_REGION_ID = 'Santa Cruz de Tenerife';
+
+    const LAS_PALMAS_REGION_ID = 'Las Palmas';
+
     /**
      * Array of quotes
      *

--- a/app/code/Magento/Ups/Model/Carrier.php
+++ b/app/code/Magento/Ups/Model/Carrier.php
@@ -334,6 +334,14 @@ class Carrier extends AbstractCarrierOnline implements CarrierInterface
             $destCountry = self::GUAM_COUNTRY_ID;
         }
 
+        // For UPS, Las Palmas and Santa Cruz de Tenerife will be represented by Canary Islands country
+        if (
+            $destCountry == self::SPAIN_COUNTRY_ID &&
+            ($request->getDestRegionCode() == self::LAS_PALMAS_REGION_ID || $request->getDestRegionCode() == self::SANTA_CRUZ_DE_TENERIFE_REGION_ID)
+        ) {
+            $destCountry = self::CANARY_ISLANDS_COUNTRY_ID;
+        }
+
         $country = $this->_countryFactory->create()->load($destCountry);
         $rowRequest->setDestCountry($country->getData('iso2_code') ?: $destCountry);
 


### PR DESCRIPTION
### For UPS, Las Palmas and Santa Cruz de Tenerife will be represented by Canary Islands country

### Description
Backport  #20222: For Puerto Rico and Guam the country id was already changed but not for countries part of the Canary Islands. 

This PR changes the country id necessary for the UPS request to 'IC' instead of 'ES'

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add Product to cart
2. Go to cart or checkout page
3. Change Country to Spain
4. Change region to either Las Palmas or Santa Cruz de Tenerife
5. Shipping rate will be calculated with country id 'IC' (Canary Islands) instead of Spain
 
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
