### PR TITLE
issue fixed #20293 Main website label and main website store label no…

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/_store-scope.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/_store-scope.less
@@ -22,7 +22,23 @@
             text-align: left;
         }
     }
-
+    
+    [class*='field-w']{
+        .admin__field-label {
+            span {
+                margin-left: 30px;
+            }
+        }
+    }
+    
+    [class*='field-sg']{
+        .admin__field-label {
+            span {
+                margin-left: 60px;
+            }
+        }
+    }
+    
     [class*='field-website_label'] {
         .admin__field-label {
             text-align: right;


### PR DESCRIPTION
…t alignd proper overlapping in left navigation in admin panel during create New Cart Price Rule

issue fixed #20293 Main website label and main website store label not alignd proper overlapping in left navigation in admin panel during create New Cart Price Rule

### Manual testing scenarios (*)

Steps to reproduce
Step 1: Login to admin panel
Step 2: Go to marketing link from left navigation 
     2.a: Click on cart price rules link
     2.b: click on add new rule
     2.c: Go to Labels tab (Ref screenshot)
 
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
