### PR TITLE
Fixed issue #20305 Update button on payment checkout is not proper alligned

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
@@ -63,10 +63,13 @@
                     }
                 }
             }
-            
+            /**
+             * @codingStandardsIgnoreStart
+             */
             #po_number {
                 margin-bottom: 20px;
             }
+            //  @codingStandardsIgnoreEnd
         }
 
         .payment-method-title {
@@ -116,9 +119,9 @@
             margin: 0 0 @indent__base;
 
             .primary {
-                .action-update {
-                    margin-right: 0;
+                .action-update {                    
                     margin-bottom: 20px;
+                    margin-right: 0;
                 }
             }
 

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
@@ -118,6 +118,7 @@
             .primary {
                 .action-update {
                     margin-right: 0;
+                    margin-bottom:20px;
                 }
             }
 

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
@@ -118,7 +118,7 @@
             .primary {
                 .action-update {
                     margin-right: 0;
-                    margin-bottom:20px;
+                    margin-bottom: 20px;
                 }
             }
 


### PR DESCRIPTION

### Description (*)
Fixed issue #20305 Update button on payment checkout is not proper alligned

### Fixed Issues (if relevant)

1. magento/magento2 #20305: Update button on payment checkout is not proper alligned
2. ...

### Manual testing scenarios (*)

   1. Go to frontend
    2.Add product to cart
    3.Goto Checkout
    4.On Payment Information uncheck the box of My billing and shipping address are the same
    5.Go down and check update button


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
