### PR TITLE
Fixed VAT Number verification error message should be in red color #20311

### DIFF
--- a/app/code/Magento/Customer/view/adminhtml/templates/system/config/validatevat.phtml
+++ b/app/code/Magento/Customer/view/adminhtml/templates/system/config/validatevat.phtml
@@ -35,7 +35,7 @@ require(['prototype'], function(){
                         validationMessage.removeClassName('hidden').addClassName('error')
                     }
                 } catch (e) {
-                    validationMessage.removeClassName('hidden').addClassName('error')
+                    validationMessage.removeClassName('hidden').addClassName('error-message error')
                 }
                 validationMessage.update(result);
             }

--- a/app/code/Magento/Customer/view/adminhtml/templates/system/config/validatevat.phtml
+++ b/app/code/Magento/Customer/view/adminhtml/templates/system/config/validatevat.phtml
@@ -32,7 +32,7 @@ require(['prototype'], function(){
                     if (response.valid == 1) {
                         validationMessage.removeClassName('hidden').addClassName('success')
                     } else {
-                        validationMessage.removeClassName('hidden').addClassName('error')
+                        validationMessage.removeClassName('hidden').addClassName('error-message error')
                     }
                 } catch (e) {
                     validationMessage.removeClassName('hidden').addClassName('error-message error')


### PR DESCRIPTION

### Description (*)
Fixed VAT Number verification error message should be in red color #20311

### Manual testing scenarios (*)
1. Goto admin >> stores >> configuration >> general >> store information >> click on "Validate VAT Number"
 2. Showing error message like "Error during VAT Number verification."

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
