### PR TITLE
Fixed issue #20317 : Magento_CheckoutAgreement wysiwyg: true not working

### DIFF
--- a/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
+++ b/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
@@ -22,6 +22,16 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
      */
     protected $_wysiwygConfig;
     
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * Editor config path
+     */
+   const XML_PATH_SHOW_EDITOR = 'checkout/options/enable_agreements';
+    
 
     /**
      * @param \Magento\Backend\Block\Template\Context $context
@@ -30,6 +40,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
      * @param \Magento\Store\Model\System\Store $systemStore
      * @param \Magento\CheckoutAgreements\Model\AgreementModeOptions $agreementModeOptions
      * @param \Magento\Cms\Model\Wysiwyg\Config $wysiwygConfig
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param array $data
      * @codeCoverageIgnore
      */
@@ -40,11 +51,13 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         \Magento\Store\Model\System\Store $systemStore,
         \Magento\CheckoutAgreements\Model\AgreementModeOptions $agreementModeOptions,
         \Magento\Cms\Model\Wysiwyg\Config $wysiwygConfig,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         array $data = []
     ) {
         $this->_systemStore = $systemStore;
         $this->agreementModeOptions = $agreementModeOptions;
         $this->_wysiwygConfig = $wysiwygConfig;
+        $this->scopeConfig = $scopeConfig;
         parent::__construct($context, $registry, $formFactory, $data);
     }
 
@@ -69,6 +82,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     {
         $model = $this->_coreRegistry->registry('checkout_agreement');
         $wysiwygConfig = $this->_wysiwygConfig->getConfig();
+        $showEditor = $this->scopeConfig->getValue(self::XML_PATH_SHOW_EDITOR);
         /** @var \Magento\Framework\Data\Form $form */
         $form = $this->_formFactory->create(
             ['data' => ['id' => 'edit_form', 'action' => $this->getData('action'), 'method' => 'post']]
@@ -156,20 +170,19 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
 
         $fieldset->addField(
             'checkbox_text',
-            'editor',
+            'textarea',
             [
                 'name' => 'checkbox_text',
                 'label' => __('Checkbox Text'),
                 'title' => __('Checkbox Text'),
                 'rows' => '5',
                 'cols' => '30',
-                'wysiwyg' => false,
-                'config' =>$wysiwygConfig,
                 'required' => true
             ]
         );
 
-        $fieldset->addField(
+        if($showEditor){
+           $fieldset->addField(
             'content',
             'editor',
             [
@@ -177,11 +190,24 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'label' => __('Content'),
                 'title' => __('Content'),
                 'style' => 'height:24em;',
-                'wysiwyg' => false,
-                'config' =>$wysiwygConfig,
-                'required' => true
+                'required' => true,
+                'wysiwyg' => true,
+                'config' =>$wysiwygConfig
             ]
+        ); 
+       }else{
+        $fieldset->addField(
+            'content',
+            'textarea',
+            [
+                'name' => 'content',
+                'label' => __('Content'),
+                'title' => __('Content'),
+                'style' => 'height:24em;',
+                'required' => true,
+             ]
         );
+       }
 
         $fieldset->addField(
             'content_height',

--- a/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
+++ b/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\CheckoutAgreements\Block\Adminhtml\Agreement\Edit;
 
-use \Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Class Form
@@ -21,12 +21,12 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
      * @var \Magento\CheckoutAgreements\Model\AgreementModeOptions
      */
     protected $agreementModeOptions;
-    
+
     /**
      * @var \Magento\Cms\Model\Wysiwyg\Config
      */
     private $wysiwygConfig;
-    
+
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
@@ -35,8 +35,8 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     /**
      * Editor config path
      */
-   const XML_PATH_SHOW_EDITOR = 'checkout/options/enable_wysiwyg_editor';
-    
+    const XML_PATH_SHOW_EDITOR = 'checkout/options/enable_wysiwyg_editor';
+
     /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Framework\Registry $registry
@@ -64,7 +64,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             ->get(\Magento\Cms\Model\Wysiwyg\Config::class);
         $this->scopeConfig = $scopeConfig ?: ObjectManager::getInstance()
             ->get(\Magento\Framework\App\Config\ScopeConfigInterface::class);
-       parent::__construct($context, $registry, $formFactory, $data);
+        parent::__construct($context, $registry, $formFactory, $data);
     }
 
     /**
@@ -89,7 +89,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     protected function _prepareForm()
     {
         $model = $this->_coreRegistry->registry('checkout_agreement');
-       
+
         /** @var \Magento\Framework\Data\Form $form */
         $form = $this->_formFactory->create(
             ['data' => ['id' => 'edit_form', 'action' => $this->getData('action'), 'method' => 'post']]
@@ -188,33 +188,33 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             ]
         );
 
-        if($this->scopeConfig->getValue(self::XML_PATH_SHOW_EDITOR)){
-           $fieldset->addField(
-            'content',
-            'editor',
-            [
-                'name' => 'content',
-                'label' => __('Content'),
-                'title' => __('Content'),
-                'style' => 'height:24em;',
-                'required' => true,
-                'wysiwyg' => true,
-                'config' =>$this->wysiwygConfig->getConfig()
-            ]
-        ); 
-       } else {
-        $fieldset->addField(
-            'content',
-            'textarea',
-            [
-                'name' => 'content',
-                'label' => __('Content'),
-                'title' => __('Content'),
-                'style' => 'height:24em;',
-                'required' => true,
-             ]
-        );
-       }
+        if ($this->scopeConfig->getValue(self::XML_PATH_SHOW_EDITOR)) {
+            $fieldset->addField(
+                'content',
+                'editor',
+                [
+                    'name' => 'content',
+                    'label' => __('Content'),
+                    'title' => __('Content'),
+                    'style' => 'height:24em;',
+                    'required' => true,
+                    'wysiwyg' => true,
+                    'config' =>$this->wysiwygConfig->getConfig()
+                ]
+            );
+        } else {
+            $fieldset->addField(
+                'content',
+                'textarea',
+                [
+                    'name' => 'content',
+                    'label' => __('Content'),
+                    'title' => __('Content'),
+                    'style' => 'height:24em;',
+                    'required' => true,
+                 ]
+            );
+        }
 
         $fieldset->addField(
             'content_height',

--- a/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
+++ b/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
@@ -52,7 +52,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         \Magento\Framework\Data\FormFactory $formFactory,
         \Magento\Store\Model\System\Store $systemStore,
         \Magento\CheckoutAgreements\Model\AgreementModeOptions $agreementModeOptions,
-         array $data = [],
+        array $data = [],
         \Magento\Cms\Model\Wysiwyg\Config $wysiwygConfig = null,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig = null,
     ) {

--- a/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
+++ b/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
@@ -7,6 +7,9 @@ namespace Magento\CheckoutAgreements\Block\Adminhtml\Agreement\Edit;
 
 use \Magento\Framework\App\ObjectManager;
 
+/**
+ * Class Form
+ */
 class Form extends \Magento\Backend\Block\Widget\Form\Generic
 {
     /**
@@ -34,7 +37,6 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
      */
    const XML_PATH_SHOW_EDITOR = 'checkout/options/enable_wysiwyg_editor';
     
-
     /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Framework\Registry $registry
@@ -59,9 +61,9 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         $this->_systemStore = $systemStore;
         $this->agreementModeOptions = $agreementModeOptions;
         $this->wysiwygConfig = $wysiwygConfig ?: ObjectManager::getInstance()
-                ->get(\Magento\Cms\Model\Wysiwyg\Config::class);
+            ->get(\Magento\Cms\Model\Wysiwyg\Config::class);
         $this->scopeConfig = $scopeConfig ?: ObjectManager::getInstance()
-                ->get(\Magento\Framework\App\Config\ScopeConfigInterface::class);
+            ->get(\Magento\Framework\App\Config\ScopeConfigInterface::class);
        parent::__construct($context, $registry, $formFactory, $data);
     }
 
@@ -79,6 +81,8 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     }
 
     /**
+     * Prepare form
+     *
      * @return $this
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */

--- a/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
+++ b/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
@@ -53,7 +53,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         \Magento\Store\Model\System\Store $systemStore,
         \Magento\CheckoutAgreements\Model\AgreementModeOptions $agreementModeOptions,
          array $data = [],
-         \Magento\Cms\Model\Wysiwyg\Config $wysiwygConfig = null,
+        \Magento\Cms\Model\Wysiwyg\Config $wysiwygConfig = null,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig = null,
     ) {
         $this->_systemStore = $systemStore;

--- a/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
+++ b/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
@@ -198,7 +198,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'config' =>$this->wysiwygConfig->getConfig()
             ]
         ); 
-       }else{
+       } else {
         $fieldset->addField(
             'content',
             'textarea',

--- a/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
+++ b/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
@@ -16,6 +16,12 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
      * @var \Magento\CheckoutAgreements\Model\AgreementModeOptions
      */
     protected $agreementModeOptions;
+    
+    /**
+     * @var \Magento\Cms\Model\Wysiwyg\Config
+     */
+    protected $_wysiwygConfig;
+    
 
     /**
      * @param \Magento\Backend\Block\Template\Context $context
@@ -23,6 +29,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
      * @param \Magento\Framework\Data\FormFactory $formFactory
      * @param \Magento\Store\Model\System\Store $systemStore
      * @param \Magento\CheckoutAgreements\Model\AgreementModeOptions $agreementModeOptions
+     * @param \Magento\Cms\Model\Wysiwyg\Config $wysiwygConfig
      * @param array $data
      * @codeCoverageIgnore
      */
@@ -32,10 +39,12 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         \Magento\Framework\Data\FormFactory $formFactory,
         \Magento\Store\Model\System\Store $systemStore,
         \Magento\CheckoutAgreements\Model\AgreementModeOptions $agreementModeOptions,
+        \Magento\Cms\Model\Wysiwyg\Config $wysiwygConfig,
         array $data = []
     ) {
         $this->_systemStore = $systemStore;
         $this->agreementModeOptions = $agreementModeOptions;
+        $this->_wysiwygConfig = $wysiwygConfig;
         parent::__construct($context, $registry, $formFactory, $data);
     }
 
@@ -59,6 +68,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     protected function _prepareForm()
     {
         $model = $this->_coreRegistry->registry('checkout_agreement');
+        $wysiwygConfig = $this->_wysiwygConfig->getConfig();
         /** @var \Magento\Framework\Data\Form $form */
         $form = $this->_formFactory->create(
             ['data' => ['id' => 'edit_form', 'action' => $this->getData('action'), 'method' => 'post']]
@@ -154,6 +164,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'rows' => '5',
                 'cols' => '30',
                 'wysiwyg' => false,
+                'config' =>$wysiwygConfig,
                 'required' => true
             ]
         );
@@ -167,6 +178,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'title' => __('Content'),
                 'style' => 'height:24em;',
                 'wysiwyg' => false,
+                'config' =>$wysiwygConfig,
                 'required' => true
             ]
         );

--- a/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
+++ b/app/code/Magento/CheckoutAgreements/Block/Adminhtml/Agreement/Edit/Form.php
@@ -54,14 +54,14 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         \Magento\CheckoutAgreements\Model\AgreementModeOptions $agreementModeOptions,
         array $data = [],
         \Magento\Cms\Model\Wysiwyg\Config $wysiwygConfig = null,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig = null,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig = null
     ) {
         $this->_systemStore = $systemStore;
         $this->agreementModeOptions = $agreementModeOptions;
         $this->wysiwygConfig = $wysiwygConfig ?: ObjectManager::getInstance()
-                ->get(Config::class);
+                ->get(\Magento\Cms\Model\Wysiwyg\Config::class);
         $this->scopeConfig = $scopeConfig ?: ObjectManager::getInstance()
-                ->get(ScopeConfigInterface::class);
+                ->get(\Magento\Framework\App\Config\ScopeConfigInterface::class);
        parent::__construct($context, $registry, $formFactory, $data);
     }
 

--- a/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
+++ b/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
@@ -29,7 +29,6 @@ class AgreementsConfigProvider implements ConfigProviderInterface
      * @var \Magento\Framework\Escaper
      */
     protected $escaper;
-    
     /**
      * @var \Magento\CheckoutAgreements\Api\CheckoutAgreementsListInterface
      */

--- a/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
+++ b/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
@@ -29,6 +29,11 @@ class AgreementsConfigProvider implements ConfigProviderInterface
      * @var \Magento\Framework\Escaper
      */
     protected $escaper;
+    
+    /**
+     * @var \Magento\Widget\Model\Template\Filter
+     */
+    protected $templateProcessor;
 
     /**
      * @var \Magento\CheckoutAgreements\Api\CheckoutAgreementsListInterface
@@ -44,6 +49,7 @@ class AgreementsConfigProvider implements ConfigProviderInterface
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfiguration
      * @param \Magento\CheckoutAgreements\Api\CheckoutAgreementsRepositoryInterface $checkoutAgreementsRepository
      * @param \Magento\Framework\Escaper $escaper
+     * @param \Magento\Widget\Model\Template\Filter $templateProcessor
      * @param \Magento\CheckoutAgreements\Api\CheckoutAgreementsListInterface|null $checkoutAgreementsList
      * @param ActiveStoreAgreementsFilter|null $activeStoreAgreementsFilter
      * @codeCoverageIgnore
@@ -52,12 +58,14 @@ class AgreementsConfigProvider implements ConfigProviderInterface
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfiguration,
         \Magento\CheckoutAgreements\Api\CheckoutAgreementsRepositoryInterface $checkoutAgreementsRepository,
         \Magento\Framework\Escaper $escaper,
+        \Magento\Widget\Model\Template\Filter $templateProcessor, 
         \Magento\CheckoutAgreements\Api\CheckoutAgreementsListInterface $checkoutAgreementsList = null,
         ActiveStoreAgreementsFilter $activeStoreAgreementsFilter = null
     ) {
         $this->scopeConfiguration = $scopeConfiguration;
         $this->checkoutAgreementsRepository = $checkoutAgreementsRepository;
         $this->escaper = $escaper;
+        $this->templateProcessor = $templateProcessor;
         $this->checkoutAgreementsList = $checkoutAgreementsList ?: ObjectManager::getInstance()->get(
             \Magento\CheckoutAgreements\Api\CheckoutAgreementsListInterface::class
         );
@@ -97,7 +105,7 @@ class AgreementsConfigProvider implements ConfigProviderInterface
         foreach ($agreementsList as $agreement) {
             $agreementConfiguration['agreements'][] = [
                 'content' => $agreement->getIsHtml()
-                    ? $agreement->getContent()
+                    ? $this->templateProcessor->filter($agreement->getContent())
                     : nl2br($this->escaper->escapeHtml($agreement->getContent())),
                 'checkboxText' => $agreement->getCheckboxText(),
                 'mode' => $agreement->getMode(),

--- a/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
+++ b/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
@@ -60,7 +60,7 @@ class AgreementsConfigProvider implements ConfigProviderInterface
         \Magento\Framework\Escaper $escaper,
         \Magento\CheckoutAgreements\Api\CheckoutAgreementsListInterface $checkoutAgreementsList = null,
         ActiveStoreAgreementsFilter $activeStoreAgreementsFilter = null,
-        \Magento\Widget\Model\Template\Filter $templateProcessor = null,
+        \Magento\Widget\Model\Template\Filter $templateProcessor = null
     ) {
         $this->scopeConfiguration = $scopeConfiguration;
         $this->checkoutAgreementsRepository = $checkoutAgreementsRepository;

--- a/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
+++ b/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
@@ -9,6 +9,7 @@ use Magento\Checkout\Model\ConfigProviderInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Store\Model\ScopeInterface;
 use Magento\CheckoutAgreements\Model\Api\SearchCriteria\ActiveStoreAgreementsFilter;
+use Magento\Widget\Model\Template\Filter;
 
 /**
  * Configuration provider for GiftMessage rendering on "Shipping Method" step of checkout.
@@ -40,7 +41,7 @@ class AgreementsConfigProvider implements ConfigProviderInterface
     private $activeStoreAgreementsFilter;
 
     /**
-     * @var \Magento\Widget\Model\Template\Filter
+     * @var Filter
      */
     private $templateProcessor;
 
@@ -50,7 +51,7 @@ class AgreementsConfigProvider implements ConfigProviderInterface
      * @param \Magento\Framework\Escaper $escaper
      * @param \Magento\CheckoutAgreements\Api\CheckoutAgreementsListInterface|null $checkoutAgreementsList
      * @param ActiveStoreAgreementsFilter|null $activeStoreAgreementsFilter
-     * @param \Magento\Widget\Model\Template\Filter $templateProcessor
+     * @param Filter $templateProcessor
      * @codeCoverageIgnore
      */
     public function __construct(
@@ -59,7 +60,7 @@ class AgreementsConfigProvider implements ConfigProviderInterface
         \Magento\Framework\Escaper $escaper,
         \Magento\CheckoutAgreements\Api\CheckoutAgreementsListInterface $checkoutAgreementsList = null,
         ActiveStoreAgreementsFilter $activeStoreAgreementsFilter = null,
-        \Magento\Widget\Model\Template\Filter $templateProcessor = null
+        Filter $templateProcessor = null
     ) {
         $this->scopeConfiguration = $scopeConfiguration;
         $this->checkoutAgreementsRepository = $checkoutAgreementsRepository;
@@ -70,11 +71,11 @@ class AgreementsConfigProvider implements ConfigProviderInterface
         $this->activeStoreAgreementsFilter = $activeStoreAgreementsFilter ?: ObjectManager::getInstance()->get(
             ActiveStoreAgreementsFilter::class
         );
-         $this->templateProcessor = $templateProcessor ?: ObjectManager::getInstance()->get(\Magento\Widget\Model\Template\Filter::class);
+         $this->templateProcessor = $templateProcessor ?: ObjectManager::getInstance()->get(Filter::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getConfig()
     {

--- a/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
+++ b/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
@@ -70,7 +70,7 @@ class AgreementsConfigProvider implements ConfigProviderInterface
         $this->activeStoreAgreementsFilter = $activeStoreAgreementsFilter ?: ObjectManager::getInstance()->get(
             ActiveStoreAgreementsFilter::class
         );
-         $this->templateProcessor = $templateProcessor ?: ObjectManager::getInstance()->get(Filter::class);
+         $this->templateProcessor = $templateProcessor ?: ObjectManager::getInstance()->get(\Magento\Widget\Model\Template\Filter::class);
     }
 
     /**

--- a/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
+++ b/app/code/Magento/CheckoutAgreements/Model/AgreementsConfigProvider.php
@@ -31,11 +31,6 @@ class AgreementsConfigProvider implements ConfigProviderInterface
     protected $escaper;
     
     /**
-     * @var \Magento\Widget\Model\Template\Filter
-     */
-    protected $templateProcessor;
-
-    /**
      * @var \Magento\CheckoutAgreements\Api\CheckoutAgreementsListInterface
      */
     private $checkoutAgreementsList;
@@ -46,32 +41,37 @@ class AgreementsConfigProvider implements ConfigProviderInterface
     private $activeStoreAgreementsFilter;
 
     /**
+     * @var \Magento\Widget\Model\Template\Filter
+     */
+    private $templateProcessor;
+
+    /**
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfiguration
      * @param \Magento\CheckoutAgreements\Api\CheckoutAgreementsRepositoryInterface $checkoutAgreementsRepository
      * @param \Magento\Framework\Escaper $escaper
-     * @param \Magento\Widget\Model\Template\Filter $templateProcessor
      * @param \Magento\CheckoutAgreements\Api\CheckoutAgreementsListInterface|null $checkoutAgreementsList
      * @param ActiveStoreAgreementsFilter|null $activeStoreAgreementsFilter
+     * @param \Magento\Widget\Model\Template\Filter $templateProcessor
      * @codeCoverageIgnore
      */
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfiguration,
         \Magento\CheckoutAgreements\Api\CheckoutAgreementsRepositoryInterface $checkoutAgreementsRepository,
         \Magento\Framework\Escaper $escaper,
-        \Magento\Widget\Model\Template\Filter $templateProcessor, 
         \Magento\CheckoutAgreements\Api\CheckoutAgreementsListInterface $checkoutAgreementsList = null,
-        ActiveStoreAgreementsFilter $activeStoreAgreementsFilter = null
+        ActiveStoreAgreementsFilter $activeStoreAgreementsFilter = null,
+        \Magento\Widget\Model\Template\Filter $templateProcessor = null,
     ) {
         $this->scopeConfiguration = $scopeConfiguration;
         $this->checkoutAgreementsRepository = $checkoutAgreementsRepository;
         $this->escaper = $escaper;
-        $this->templateProcessor = $templateProcessor;
         $this->checkoutAgreementsList = $checkoutAgreementsList ?: ObjectManager::getInstance()->get(
             \Magento\CheckoutAgreements\Api\CheckoutAgreementsListInterface::class
         );
         $this->activeStoreAgreementsFilter = $activeStoreAgreementsFilter ?: ObjectManager::getInstance()->get(
             ActiveStoreAgreementsFilter::class
         );
+         $this->templateProcessor = $templateProcessor ?: ObjectManager::getInstance()->get(Filter::class);
     }
 
     /**

--- a/app/code/Magento/CheckoutAgreements/composer.json
+++ b/app/code/Magento/CheckoutAgreements/composer.json
@@ -10,7 +10,8 @@
         "magento/module-backend": "*",
         "magento/module-checkout": "*",
         "magento/module-quote": "*",
-        "magento/module-store": "*"
+        "magento/module-store": "*",
+        "magento/module-cms": "*",
     },
     "type": "magento2-module",
     "license": [

--- a/app/code/Magento/CheckoutAgreements/composer.json
+++ b/app/code/Magento/CheckoutAgreements/composer.json
@@ -11,7 +11,8 @@
         "magento/module-checkout": "*",
         "magento/module-quote": "*",
         "magento/module-store": "*",
-        "magento/module-cms": "*"
+        "magento/module-cms": "*",
+        "magento/module-widget": "*"
     },
     "type": "magento2-module",
     "license": [

--- a/app/code/Magento/CheckoutAgreements/composer.json
+++ b/app/code/Magento/CheckoutAgreements/composer.json
@@ -11,7 +11,7 @@
         "magento/module-checkout": "*",
         "magento/module-quote": "*",
         "magento/module-store": "*",
-        "magento/module-cms": "*",
+        "magento/module-cms": "*"
     },
     "type": "magento2-module",
     "license": [

--- a/app/code/Magento/CheckoutAgreements/etc/adminhtml/system.xml
+++ b/app/code/Magento/CheckoutAgreements/etc/adminhtml/system.xml
@@ -13,8 +13,8 @@
                     <label>Enable Terms and Conditions</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="enable_editor" translate="label" type="select" sortOrder="25" showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Enable Editor on Terms and Conditions Content</label>
+                <field id="enable_wysiwyg_editor" translate="label" type="select" sortOrder="25" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Enable WYSIWYG Editor on Terms and Conditions Content</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>

--- a/app/code/Magento/CheckoutAgreements/etc/adminhtml/system.xml
+++ b/app/code/Magento/CheckoutAgreements/etc/adminhtml/system.xml
@@ -13,6 +13,10 @@
                     <label>Enable Terms and Conditions</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="enable_editor" translate="label" type="select" sortOrder="25" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Enable Editor on Terms and Conditions Content</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
     </system>

--- a/app/code/Magento/CheckoutAgreements/etc/config.xml
+++ b/app/code/Magento/CheckoutAgreements/etc/config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <checkout>
+            <options>
+                <enable_wysiwyg_editor>0</enable_wysiwyg_editor>
+            </options>
+        </checkout>
+    </default>
+</config>

--- a/app/code/Magento/CheckoutAgreements/etc/module.xml
+++ b/app/code/Magento/CheckoutAgreements/etc/module.xml
@@ -8,6 +8,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Magento_CheckoutAgreements" >
         <sequence>
+             <module name="Magento_Cms"/>
             <module name="Magento_Store"/>
             <module name="Magento_Checkout"/>
         </sequence>


### PR DESCRIPTION
Fixed issue #20317 : Magento_CheckoutAgreement wysiwyg: true not working

### Preconditions (*)
1. 2.3
3. OS is Manjaro Linux

### Steps to reproduce (*)
1. Edit Magento\CheckoutAgreements\Block\Adminhtml\Agreement\Edit\Form.php _prepareForm() method
2. Change 'content' field to have a true value on 'wysiwyg' key

### Expected result (*)
1. Expected checkout agreements content field to be displayed using the wysywig

### Actual result (*)
1. No changes.
2.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
