### PR TITLE
[Backport] Fix issue 20232 : Backend order credit card detail check box misaligned

### DIFF
--- a/app/code/Magento/Braintree/view/adminhtml/templates/form/cc.phtml
+++ b/app/code/Magento/Braintree/view/adminhtml/templates/form/cc.phtml
@@ -83,7 +83,7 @@ $ccType = $block->getInfoData('cc_type');
                    id="<?= /* @noEscape */ $code ?>_vault"
                    name="payment[is_active_payment_token_enabler]"
                    class="admin__control-checkbox"/>
-            <label class="label" for="<?= /* @noEscape */ $code ?>_vault">
+            <label class="label admin__field-label" for="<?= /* @noEscape */ $code ?>_vault">
                 <span><?= $block->escapeHtml(__('Save for later use.')) ?></span>
             </label>
         </div>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20233
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
 Backend order credit card detail check box misaligned
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20232:  Backend order credit card detail check box misaligned


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.Backend -> sale -> order -> create new order/reorder(Perticular order)
2.Under payment method -> credit card -> check save for later checkbox alignment

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
