### PR TITLE
[Backport]  Product image failure when importing through CSV #20098

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
@@ -191,9 +191,9 @@ class Uploader extends \Magento\MediaStorage\Model\File\Uploader
             }
 
             $fileName = preg_replace('/[^a-z0-9\._-]+/i', '', $fileName);
-            $filePath = $this->_directory->getRelativePath($filePath . $fileName);
+            $relativePath = $this->_directory->getRelativePath($filePath . $fileName);
             $this->_directory->writeFile(
-                $filePath,
+                $relativePath,
                 $read->readAll()
             );
         }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20127
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Remote image file import by csv , it was failed because `$filePath` variable was overridden incorrectly in  `Uploader.php` `public function move($fileName, $renameFileOff = false)`.
Updated `$filePath` to `$relativePath` in case of remote URL image.   

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20098: Issue Product image failure when importing through CSV #20098

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
