### PR TITLE
Fixed issue #20332 Changed sort order of country

### DIFF
--- a/app/code/Magento/Checkout/Block/Checkout/LayoutProcessor.php
+++ b/app/code/Magento/Checkout/Block/Checkout/LayoutProcessor.php
@@ -298,10 +298,16 @@ class LayoutProcessor implements \Magento\Checkout\Block\Checkout\LayoutProcesso
                         'billingAddress' . $paymentCode,
                         [
                             'country_id' => [
-                                'sortOrder' => 115,
+                                'sortOrder' => 80,
                             ],
                             'region' => [
                                 'visible' => false,
+                            ],
+                            'city' => [
+                                 'sortOrder' => 100,
+                                 'validation' => [
+                                    'required-entry' => true,
+                                ],
                             ],
                             'region_id' => [
                                 'component' => 'Magento_Ui/js/form/element/region',

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_index_index.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_index_index.xml
@@ -222,6 +222,12 @@
                                                                             <item name="min_text_length" xsi:type="number">0</item>
                                                                         </item>
                                                                     </item>
+                                                                    <item name="city" xsi:type="array">
+                                                                        <item name="sortOrder" xsi:type="string">110</item>
+                                                                        <item name="validation" xsi:type="array">
+                                                                            <item name="required-entry" xsi:type="boolean">true</item>
+                                                                        </item>
+                                                                    </item>
                                                                     <item name="country_id" xsi:type="array">
                                                                         <item name="sortOrder" xsi:type="string">80</item>
                                                                     </item>

--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_index_index.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_index_index.xml
@@ -223,7 +223,7 @@
                                                                         </item>
                                                                     </item>
                                                                     <item name="country_id" xsi:type="array">
-                                                                        <item name="sortOrder" xsi:type="string">115</item>
+                                                                        <item name="sortOrder" xsi:type="string">80</item>
                                                                     </item>
                                                                     <item name="telephone" xsi:type="array">
                                                                         <item name="config" xsi:type="array">

--- a/app/code/Magento/Customer/Setup/CustomerSetup.php
+++ b/app/code/Magento/Customer/Setup/CustomerSetup.php
@@ -417,7 +417,7 @@ class CustomerSetup extends EavSetup
                         'type' => 'static',
                         'label' => 'City',
                         'input' => 'text',
-                        'sort_order' => 80,
+                        'sort_order' => 110,
                         'validate_rules' => '{"max_text_length":255,"min_text_length":1}',
                         'position' => 80,
                     ],

--- a/app/code/Magento/Customer/view/adminhtml/ui_component/customer_address_form.xml
+++ b/app/code/Magento/Customer/view/adminhtml/ui_component/customer_address_form.xml
@@ -174,7 +174,7 @@
                 <label translate="true">Company</label>
             </settings>
         </field>
-        <field name="city" sortOrder="80" formElement="input">
+        <field name="city" sortOrder="100" formElement="input">
             <settings>
                 <dataType>text</dataType>
                 <label translate="true">City</label>

--- a/app/code/Magento/Customer/view/frontend/templates/address/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/address/edit.phtml
@@ -70,7 +70,6 @@
                 </div>
             </div>
         </div>
-
         <?php if ($this->helper('Magento\Customer\Helper\Address')->isVatAttributeVisible()) : ?>
             <div class="field taxvat">
                 <label class="label" for="vat_id">
@@ -86,15 +85,10 @@
                 </div>
             </div>
         <?php endif; ?>
-        <div class="field city required">
-            <label class="label" for="city"><span><?= /* @noEscape */ $block->getAttributeData()->getFrontendLabel('city') ?></span></label>
+        <div class="field country required">
+            <label class="label" for="country"><span><?= /* @noEscape */ $block->getAttributeData()->getFrontendLabel('country_id') ?></span></label>
             <div class="control">
-                <input type="text"
-                       name="city"
-                       value="<?= $block->escapeHtmlAttr($block->getAddress()->getCity()) ?>"
-                       title="<?= $block->escapeHtmlAttr(__('City')) ?>"
-                       class="input-text <?= $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('city')) ?>"
-                       id="city">
+                <?= $block->getCountryHtmlSelect() ?>
             </div>
         </div>
         <div class="field region required">
@@ -104,7 +98,7 @@
             <div class="control">
                 <select id="region_id" name="region_id"
                         title="<?= /* @noEscape */ $block->getAttributeData()->getFrontendLabel('region') ?>"
-                        class="validate-select region_id" <?= /* @noEscape */ !$block->getConfig('general/region/display_all') ? ' disabled="disabled"' : '' ?>>
+                        class="validate-select" <?= /* @noEscape */ !$block->getConfig('general/region/display_all') ? ' disabled="disabled"' : '' ?>>
                     <option value=""><?= $block->escapeHtml(__('Please select a region, state or province.')) ?></option>
                 </select>
                 <input type="text"
@@ -113,6 +107,17 @@
                        value="<?= $block->escapeHtmlAttr($block->getRegion()) ?>"
                        title="<?= /* @noEscape */ $block->getAttributeData()->getFrontendLabel('region') ?>"
                        class="input-text validate-not-number-first <?= $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('region')) ?>"<?= !$block->getConfig('general/region/display_all') ? ' disabled="disabled"' : '' ?>/>
+            </div>
+        </div>
+        <div class="field city required">
+            <label class="label" for="city"><span><?= /* @noEscape */ $block->getAttributeData()->getFrontendLabel('city') ?></span></label>
+            <div class="control">
+                <input type="text"
+                       name="city"
+                       value="<?= $block->escapeHtmlAttr($block->getAddress()->getCity()) ?>"
+                       title="<?= $block->escapeHtmlAttr(__('City')) ?>"
+                       class="input-text <?= $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('city')) ?>"
+                       id="city">
             </div>
         </div>
         <div class="field zip required">
@@ -128,13 +133,7 @@
                        class="input-text validate-zip-international <?= $block->escapeHtmlAttr($this->helper('Magento\Customer\Helper\Address')->getAttributeValidationClass('postcode')) ?>">
             </div>
         </div>
-        <div class="field country required">
-            <label class="label" for="country"><span><?= /* @noEscape */ $block->getAttributeData()->getFrontendLabel('country_id') ?></span></label>
-            <div class="control">
-                <?= $block->getCountryHtmlSelect() ?>
-            </div>
-        </div>
-
+        
         <?php if ($block->isDefaultBilling()): ?>
             <div class="message info">
                 <span><?= $block->escapeHtml(__("It's a default billing address.")) ?></span>


### PR DESCRIPTION
### Description (*)
Fixed issue #20332 Shipping address form City, State/Province, Zip/Postal Code, Country not in right Order in checkout

### Fixed Issues (if relevant)

1. magento/magento2 #20332: Issue title:Shipping address form City, State/Province, Zip/Postal Code, Country not in right Order in checkout


### Manual testing scenarios (*)

Step 1: Open frontend
Step 2: Add any product in cart
Step 3: Go to checkout and and see shipping address form

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
