### PR TITLE
issue fixed #20337 Option Title breaking in two line because applying…

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -531,7 +531,6 @@
     & > .admin__field {
         &:first-child {
             position: static;
-            width: 100%;
             & > .admin__field-label {
                 #mix-grid .column(@field-label-grid__column, @field-grid__columns);
                 cursor: pointer;
@@ -685,6 +684,7 @@
                 margin: 0;
                 opacity: 1;
                 position: static;
+                width: 100%;
             }
         }
         & > .admin__field-label { 

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -531,7 +531,7 @@
     & > .admin__field {
         &:first-child {
             position: static;
-
+            width: 100%;
             & > .admin__field-label {
                 #mix-grid .column(@field-label-grid__column, @field-grid__columns);
                 cursor: pointer;


### PR DESCRIPTION
… wrong css for manage width

issue fixed #20337 Option Title breaking in two line because applying wrong css for manage width

### Description (*)
issue fixed #20337 Option Title breaking in two line because applying wrong css for manage width

### Manual testing scenarios (*)

1. Login to admin panel
2. Go in Catalog > product section
3. Create new product and go to tab Customizable Options and click on Add option button
    and see first label Option Title (See screenshot shown)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
