### PR TITLE
Fixed #20282 Module Catalog Url Rewrite: Permanent Redirect for old URL is missed when product was imported

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
@@ -200,6 +200,7 @@ class AfterImportDataObserver implements ObserverInterface
 
     /**
      * Action after data import.
+     *
      * Save new url rewrites and remove old if exist.
      *
      * @param Observer $observer
@@ -268,6 +269,8 @@ class AfterImportDataObserver implements ObserverInterface
     }
 
     /**
+     * Add store id to product data.
+     *
      * @param \Magento\Catalog\Model\Product $product
      * @param array $rowData
      * @return void
@@ -437,6 +440,8 @@ class AfterImportDataObserver implements ObserverInterface
     }
 
     /**
+     * Generate url-rewrite for outogenerated url-rewirte.
+     *
      * @param UrlRewrite $url
      * @param Category $category
      * @return array
@@ -471,6 +476,8 @@ class AfterImportDataObserver implements ObserverInterface
     }
 
     /**
+     * Generate url-rewrite for custom url-rewirte.
+     *
      * @param UrlRewrite $url
      * @param Category $category
      * @return array
@@ -504,6 +511,8 @@ class AfterImportDataObserver implements ObserverInterface
     }
 
     /**
+     * Retrieve category from url metadata.
+     *
      * @param UrlRewrite $url
      * @return Category|null|bool
      */
@@ -518,6 +527,8 @@ class AfterImportDataObserver implements ObserverInterface
     }
 
     /**
+     * Check, category suited for url-rewrite generation.
+     *
      * @param \Magento\Catalog\Model\Category $category
      * @param int $storeId
      * @return bool

--- a/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
@@ -135,6 +135,7 @@ class AfterImportDataObserver implements ObserverInterface
         'url_path',
         'name',
         'visibility',
+        'save_rewrites_history'
     ];
 
     /**


### PR DESCRIPTION
Fixed ##20282 Module Catalog Url Rewrite: Permanent Redirect for old URL is missed when product was imported

You have to add one more column in you csv file named  'save_rewrites_history' set it to 1 or 0 based on your requirement. Set it to 1 if you want permanent redirect for old URL of your product.

**Preconditions (*)**

    Magento 2.2.7


**Steps to reproduce (*)**

    Export some visible product via System-> Data Transfer-> Export.
    Change 'url-key' for this product in CSV file.
    Import this product via System-> Data Transfer-> Import.

**Expected result (*)**

    When you try to open the changed product by the old URL key you are redirected to the new URL.

Actual result (*)

    When you try to open the changed product by the old URL key you receive 404-page.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)