### PR TITLE
Fixed #19258 Incorrect orders updated

### DIFF
--- a/app/code/Magento/Ui/Component/MassAction/Filter.php
+++ b/app/code/Magento/Ui/Component/MassAction/Filter.php
@@ -7,14 +7,16 @@
 namespace Magento\Ui\Component\MassAction;
 
 use Magento\Framework\Api\FilterBuilder;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\Framework\App\RequestInterface;
-use Magento\Framework\View\Element\UiComponentInterface;
 use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use Magento\Framework\View\Element\UiComponentInterface;
 
 /**
+ * Filter component.
+ *
  * @api
  * @since 100.0.2
  */
@@ -99,10 +101,10 @@ class Filter
                 throw new LocalizedException(__('An item needs to be selected. Select and try again.'));
             }
         }
-        
+
         $filterIds = $this->getFilterIds();
-        if(is_array($selected)){
-            $filterIds = array_unique(array_merge($this->getFilterIds(), $selected));
+        if (\is_array($selected)) {
+            $filterIds = array_unique(array_merge($filterIds, $selected));
         }
         $collection->addFieldToFilter(
             $collection->getIdFieldName(),

--- a/app/code/Magento/Ui/Component/MassAction/Filter.php
+++ b/app/code/Magento/Ui/Component/MassAction/Filter.php
@@ -99,10 +99,14 @@ class Filter
                 throw new LocalizedException(__('An item needs to be selected. Select and try again.'));
             }
         }
-
+        
+        $filterIds = $this->getFilterIds();
+        if(is_array($selected)){
+            $filterIds = array_unique(array_merge($this->getFilterIds(), $selected));
+        }
         $collection->addFieldToFilter(
             $collection->getIdFieldName(),
-            ['in' => $this->getFilterIds()]
+            ['in' => $filterIds]
         );
 
         return $collection;


### PR DESCRIPTION
Fixed #19258 Incorrect orders updated
### Preconditions (*)
1. Magento 2.2.5
2. Php 7.0

### Steps to reproduce (*)
1. Open order grid in two tabs.
2. Apply filter of order status in both tabs. Both tabs should show same orders. (ex. pending)
3. Select first order in first tab and change the status of order(ex. change to hold). 
4. Without refresh select same order in second tab and update status(ex. change to cancel)

### Expected result (*)
1. It should show exception message saying "Cant update order" or "No order to update" with id
![image](https://user-images.githubusercontent.com/2101412/48661022-92de4d80-ea91-11e8-9e54-9362d472ad81.png)

### Actual result (*)
1. All orders were updated to cancel status except the one updated in first tab.
![image](https://user-images.githubusercontent.com/2101412/48661008-5ad70a80-ea91-11e8-92f9-3cea6ae5c9f4.png)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
