### PR TITLE
Fixed issue #20154 Multiple Store Views 2.3 not allowing unique descriptions per store view fields disabled

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
@@ -55,6 +55,8 @@ define([
             varienGlobalEvents.attachEventHandler('wysiwygEditorInitialized', function () {
                 if (this.disabled()) {
                     this.setDisabled(true);
+                }else{
+                   this.setDisabled(false);
                 }
             }.bind(this));
 

--- a/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
@@ -51,15 +51,6 @@ define([
                     this.$wysiwygEditorButton.add($(element)) : $(element);
             }.bind(this));
 
-            // disable editor completely after initialization is field is disabled
-            varienGlobalEvents.attachEventHandler('wysiwygEditorInitialized', function () {
-                if (this.disabled()) {
-                    this.setDisabled(true);
-                } else {
-                    this.setDisabled(false);
-                }
-            }.bind(this));
-
             return this;
         },
 

--- a/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
@@ -55,7 +55,7 @@ define([
             varienGlobalEvents.attachEventHandler('wysiwygEditorInitialized', function () {
                 if (this.disabled()) {
                     this.setDisabled(true);
-                }else{
+                } else {
                    this.setDisabled(false);
                 }
             }.bind(this));

--- a/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/wysiwyg.js
@@ -56,7 +56,7 @@ define([
                 if (this.disabled()) {
                     this.setDisabled(true);
                 } else {
-                   this.setDisabled(false);
+                    this.setDisabled(false);
                 }
             }.bind(this));
 


### PR DESCRIPTION

### Description (*)
Fixed issue #20154 Multiple Store Views 2.3 not allowing unique descriptions per store view fields disabled

### Fixed Issues (if relevant)

1. magento/magento2 #20154: Multiple Store Views 2.3 not allowing unique descriptions per store view fields disabled


### Manual testing scenarios (*)

    1.Install Magento 2.3 via command line composer
    2.Run command line install
    3.Added 3 websites, 1 store and 1 store view each
    4.Add a sku to 1 store view. Title, price, description, url and save.
    5.Add that sku to another store view by checking the box in product editor.
    5.copy the data from 1 store view or default.
    6.try editing the sku from each store view.
    7.Description & short Description boxes are disabled even if you have use default is unchecked. but .


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
