### PR TITLE
magento:magento2.2: Layered Navigation shows no products when apply f…

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/CustomAttributeFilter.php
+++ b/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/CustomAttributeFilter.php
@@ -141,7 +141,6 @@ class CustomAttributeFilter
     {
         return [
             sprintf('`%s`.`entity_id` = `%s`.`entity_id`', $mainTable, $joinTable),
-            sprintf('`%s`.`source_id` = `%s`.`source_id`', $mainTable, $joinTable),
             $this->conditionManager->generateCondition(
                 sprintf('%s.attribute_id', $joinTable),
                 '=',


### PR DESCRIPTION
…ilters with configurable attribute and non-configurable #12240

### Description (*)
#### Preconditions
Magento 2.2.1
mysql Ver 14.14 Distrib 5.7.20, for Linux (x86_64)
PHP 7.0.25-1+ubuntu16.04.1+deb.sury.org+1
Server version: Apache/2.4.18 (Ubuntu)
#### Steps to reproduce
Find category with layered navigation and configurable products. In case of Magento Sample data it can be Women - Tops.
Apply filter for non-configurable attribute (for example 'style general' - 'jacket' ) - https://prnt.sc/haasfk
Apply filter for configurable attribute (from screenshot above 'color' - 'blue')
#### Expected result
Get at least three products "Olivia 1/4 Zip Light Jacket", "Juno Jacket" and "Neve Studio Dance Jacket"
#### Actual result
Message "We can't find products matching the selection." Check screenshot -- https://prnt.sc/haawr6
Additional info
Layered Navigation can not find product only when customer use mix of configurable and non-configurable attributes to filter products. In other cases everything works as it should.
Same issue exists on Magento 2.2.0 

### Fixed Issues (if relevant)
This issue was fixed in 2.3

### Manual testing scenarios (*)
Use sample data
Find category with layered navigation and configurable products. In case of Magento Sample data it can be Women - Tops.
Apply filter for non-configurable attribute (for example 'style general' - 'jacket' ) - https://prnt.sc/haasfk
Apply filter for configurable attribute (from screenshot above 'color' - 'blue')
Expected result
Get at least three products "Olivia 1/4 Zip Light Jacket", "Juno Jacket" and "Neve Studio Dance Jacket"

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
