### PR TITLE
issue fixed #20367 In Compare Products page showing horizontal scroll…

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
@@ -981,7 +981,8 @@
                 &.main {
                     flex-basis: inherit;
                 }
-        }   }
+            }
+        }
     }
 }
 

--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
@@ -975,6 +975,14 @@
     [class*='block-compare'] {
         display: none;
     }
+    .catalog-product_compare-index {
+        .columns {
+            .column {
+                &.main {
+                    flex-basis: inherit;
+                }
+        }   }
+    }
 }
 
 //


### PR DESCRIPTION
…bar In body But It should appear in **table-wrapper comparison** div For mobile device

issue fixed #20367 In Compare Products page showing horizontal scrollbar In body But It should appear in **table-wrapper comparison** div For mobile device

### Manual testing scenarios (*)

Step 1: Open frontend 
Step 2: Add two any product to Compare and open Compare Products page in mobile 
Step 3: Here will be horizontal scroll in body (Ref screenshot)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
