### PR TITLE
Missing method setIsAnchor() in \Magento\Catalog\Api\Data\CategoryInterface

### DIFF
--- a/app/code/Magento/Catalog/Api/Data/CategoryInterface.php
+++ b/app/code/Magento/Catalog/Api/Data/CategoryInterface.php
@@ -20,6 +20,7 @@ interface CategoryInterface extends \Magento\Framework\Api\CustomAttributesDataI
     const KEY_PARENT_ID = 'parent_id';
     const KEY_NAME = 'name';
     const KEY_IS_ACTIVE = 'is_active';
+    const KEY_IS_ANCHOR = 'is_anchor';
     const KEY_POSITION = 'position';
     const KEY_LEVEL = 'level';
     const KEY_UPDATED_AT = 'updated_at';
@@ -35,6 +36,7 @@ interface CategoryInterface extends \Magento\Framework\Api\CustomAttributesDataI
         self::KEY_PARENT_ID,
         self::KEY_NAME,
         self::KEY_IS_ACTIVE,
+        self::KEY_IS_ANCHOR,
         self::KEY_POSITION,
         self::KEY_LEVEL,
         self::KEY_UPDATED_AT,
@@ -100,6 +102,21 @@ interface CategoryInterface extends \Magento\Framework\Api\CustomAttributesDataI
      * @return $this
      */
     public function setIsActive($isActive);
+
+    /**
+     * Check whether category is anchor
+     *
+     * @return bool|null
+     */
+    public function getIsAnchor();
+
+    /**
+     * Set whether category is anchor
+     *
+     * @param bool $isAnchor
+     * @return $this
+     */
+    public function setIsAnchor($isAnchor);
 
     /**
      * Get category position

--- a/app/code/Magento/Catalog/Model/Category.php
+++ b/app/code/Magento/Catalog/Model/Category.php
@@ -1224,6 +1224,17 @@ class Category extends \Magento\Catalog\Model\AbstractModel implements
     }
 
     /**
+     * Returns is anchor
+     *
+     * @return bool
+     * @SuppressWarnings(PHPMD.BooleanGetMethodName)
+     */
+    public function getIsAnchor()
+    {
+        return $this->getData(self::KEY_IS_ANCHOR);
+    }
+
+    /**
      * Returns category id
      *
      * @return int|null
@@ -1356,6 +1367,17 @@ class Category extends \Magento\Catalog\Model\AbstractModel implements
     public function setIsActive($isActive)
     {
         return $this->setData(self::KEY_IS_ACTIVE, $isActive);
+    }
+
+    /**
+     * Set whether category is anchor
+     *
+     * @param bool $isAnchor
+     * @return $this
+     */
+    public function setIsAnchor($isAnchor)
+    {
+        return $this->setData(self::KEY_IS_ANCHOR, $isAnchor);
     }
 
     /**


### PR DESCRIPTION
### Description (*)
Add missed methods for category api data
Method \Magento\Catalog\Api\Data\CategoryInterface::setIsAnchor(bool) exists.
Method \Magento\Catalog\Api\Data\CategoryInterface::getIsAnchor() exists.

### Manual testing scenarios (*)
No steps, it's a missing piece in the code.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
