### PR TITLE
Correct interface used in JsonProductInfo

### DIFF
--- a/app/code/Magento/Review/Controller/Adminhtml/Product/JsonProductInfo.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/JsonProductInfo.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Review\Controller\Adminhtml\Product;
 
-use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Review\Controller\Adminhtml\Product as ProductController;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Registry;
@@ -18,7 +18,7 @@ use Magento\Framework\Controller\ResultFactory;
 /**
  * Represents product info in json
  */
-class JsonProductInfo extends ProductController implements HttpGetActionInterface
+class JsonProductInfo extends ProductController implements HttpPostActionInterface
 {
     /**
      * @var \Magento\Catalog\Api\ProductRepositoryInterface


### PR DESCRIPTION
### Description (*)
This controller is accessed from the admin panel via a `POST` request. This
caused the `HttpMethodValidator` to reject the request because the controller
class did not implement `HttpPostActionInterface`

### Fixed Issues (if relevant)
1. magento/magento2#20385: product name not found while add new review

### Manual testing scenarios (*)
1. Login to Admin Dashboard
2. From Menu, Marketing under user Content Review
3. Add Review
4. Select Product
5. Complete required fields
6. Save review

<img width="1246" alt="screen shot 2019-01-17 at 9 10 14 pm" src="https://user-images.githubusercontent.com/12674247/51361078-51bbe700-1a9c-11e9-9b8c-655fd9a0799e.png">

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
