### PR TITLE
[Backport] Fixed-View-and-Edit-Cart-link-not-aligned-in-middle

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/minicart/content.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/minicart/content.html
@@ -97,7 +97,7 @@
         </div>
     </div>
 
-    <div id="minicart-widgets" class="minicart-widgets">
+    <div id="minicart-widgets" class="minicart-widgets" if="getRegion('promotion').length">
         <each args="getRegion('promotion')" render=""/>
     </div>
 </div>

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
@@ -211,7 +211,7 @@
         }
 
         .minicart-widgets {
-            margin-top: 15px;
+            margin-top: 0px;
         }
     }
 

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
@@ -211,7 +211,7 @@
         }
 
         .minicart-widgets {
-            margin-top: 0px;
+            margin-top: 15px;
         }
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Original PR: https://github.com/magento/magento2/pull/20383

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20382: View and Edit Cart link not aligned in middle
2. Magento 2.2

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open frontend
2. Add any product in cart and go to minicart and see View and Edit Cart Link
3. You will see extra space bellow the link 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
