### PR TITLE
Fix: #20379 Calendar icon not aligned inside the textbox in Add Design Change page

### DIFF
--- a/app/code/Magento/Theme/view/adminhtml/page_layout/admin-2columns-left.xml
+++ b/app/code/Magento/Theme/view/adminhtml/page_layout/admin-2columns-left.xml
@@ -31,7 +31,7 @@
                     </container>
                     <container name="page.main.container" as="page_main_container" htmlId="page:main-container" htmlTag="div" htmlClass="page-columns">
                         <container name="main.col" as="main-col" htmlId="container" htmlTag="div" htmlClass="main-col">
-                            <container name="admin.scope.col.wrap" as="admin-scope-col-wrap" htmlTag="div" htmlClass="admin__scope-old"> <!-- ToDo UI: remove this wrapper remove with old styles removal -->
+                            <container name="admin.scope.col.wrap" as="admin-scope-col-wrap" htmlTag="div" htmlClass="form-inline"> <!-- ToDo UI: remove this wrapper remove with old styles removal -->
                                 <container name="content" as="content"/>
                             </container>
                         </container>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Changed class `admin__scope-old` to `form-inline`.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20379: Issue title:calendar icon not aligned inside the textbox in Add Design Change page

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
