### PR TITLE
Backport.  Success message is not showing when creating invoice & shipment simultaniously #

### DIFF
--- a/app/code/Magento/Sales/view/frontend/email/shipment_new.html
+++ b/app/code/Magento/Sales/view/frontend/email/shipment_new.html
@@ -53,7 +53,7 @@
                 </tr>
             </table>
             {{/depend}}
-            {{block class='Magento\\Framework\\View\\Element\\Template' area='frontend' template='Magento_Sales::email/shipment/track.phtml' shipment=$shipment order=$order}}
+            {{layout handle="sales_email_order_shipment_track" shipment=$shipment order=$order}}
             <table class="order-details">
                 <tr>
                     <td class="address-details">

--- a/app/code/Magento/Sales/view/frontend/email/shipment_new_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/shipment_new_guest.html
@@ -51,7 +51,7 @@
                 </tr>
             </table>
             {{/depend}}
-            {{block class='Magento\\Framework\\View\\Element\\Template' area='frontend' template='Magento_Sales::email/shipment/track.phtml' shipment=$shipment order=$order}}
+            {{layout handle="sales_email_order_shipment_track" shipment=$shipment order=$order}}
             <table class="order-details">
                 <tr>
                     <td class="address-details">

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_shipment_track.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_shipment_track.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="sales_email_order_shipment_renderers"/>
+    <body>
+        <block class="Magento\Framework\View\Element\Template" name="sales.order.email.shipment.track" template="Magento_Sales::email/shipment/track.phtml"/>
+    </body>
+</page>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_new.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_new.html
@@ -51,7 +51,7 @@
                 </tr>
             </table>
             {{/depend}}
-            {{block class='Magento\\Framework\\View\\Element\\Template' area='frontend' template='Magento_Sales::email/shipment/track.phtml' shipment=$shipment order=$order}}
+            {{layout handle="sales_email_order_shipment_track" shipment=$shipment order=$order}}
             <table class="order-details">
                 <tr>
                     <td class="address-details">

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_new_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_new_guest.html
@@ -49,7 +49,7 @@
                 </tr>
             </table>
             {{/depend}}
-            {{block class='Magento\\Framework\\View\\Element\\Template' area='frontend' template='Magento_Sales::email/shipment/track.phtml' shipment=$shipment order=$order}}
+            {{layout handle="sales_email_order_shipment_track" shipment=$shipment order=$order}}
             <table class="order-details">
                 <tr>
                     <td class="address-details">


### PR DESCRIPTION
#### Backport

### Description (*)
### Preconditions (*)
Magento 2.3
PHP 7.1.3
#### Steps to reproduce (*)
Create order from admin panel.
View order at admin panel and Click "create invoice".
Check the checkbox "create shipment" and "Email copy of invoice" while generating invoice. and click submit invoice button.
#### Expected result (*)
Success message should show as "You created the invoice and shipment."
#### Actual result (*)
Invoice has been created but no success message is appearing.

### Fixed Issues (if relevant)
Backport for https://github.com/magento/magento2/pull/20391
### Manual testing scenarios (*)
Create order from admin panel.
View order at admin panel and Click "create invoice".
Check the checkbox "create shipment" and "Email copy of invoice" while generating invoice. and click submit invoice button.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
