### PR TITLE
aclResource for UIComponent buttons

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml
@@ -17,6 +17,7 @@
                 <url path="sales/order_create/start"/>
                 <class>primary</class>
                 <label translate="true">Create New Order</label>
+                <aclResource>Magento_Sales::create</aclResource>
             </button>
         </buttons>
         <spinner>sales_order_columns</spinner>

--- a/app/code/Magento/Ui/view/base/ui_component/etc/definition/ui_settings.xsd
+++ b/app/code/Magento/Ui/view/base/ui_component/etc/definition/ui_settings.xsd
@@ -476,6 +476,13 @@
                                     </xs:documentation>
                                 </xs:annotation>
                             </xs:element>
+                            <xs:element name="aclResource" type="xs:string" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        ACL Resource used to validate access to UI Component data
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
                             <xs:element ref="param"/>
                         </xs:choice>
                         <xs:attribute name="name" type="xs:string" use="required">

--- a/lib/internal/Magento/Framework/View/Element/UiComponent/Context.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponent/Context.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Framework\View\Element\UiComponent;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\AuthorizationInterface;
 use Magento\Framework\UrlInterface;

--- a/lib/internal/Magento/Framework/View/Element/UiComponent/Context.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponent/Context.php
@@ -98,7 +98,7 @@ class Context implements ContextInterface
     /**
      * @var AuthorizationInterface
      */
-    protected $authorization;
+    private $authorization;
 
     /**
      * @param PageLayoutInterface $pageLayout
@@ -123,9 +123,9 @@ class Context implements ContextInterface
         UrlInterface $urlBuilder,
         Processor $processor,
         UiComponentFactory $uiComponentFactory,
-        AuthorizationInterface $authorization,
         DataProviderInterface $dataProvider = null,
-        $namespace = null
+        $namespace = null,
+        AuthorizationInterface $authorization = null
     ) {
         $this->namespace = $namespace;
         $this->request = $request;
@@ -137,7 +137,9 @@ class Context implements ContextInterface
         $this->urlBuilder = $urlBuilder;
         $this->processor = $processor;
         $this->uiComponentFactory = $uiComponentFactory;
-        $this->authorization = $authorization;
+        $this->authorization = $authorization ?: ObjectManager::getInstance()->get(
+            AuthorizationInterface::class
+        );
         $this->setAcceptType();
     }
 

--- a/lib/internal/Magento/Framework/View/Element/UiComponent/Context.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponent/Context.php
@@ -6,6 +6,7 @@
 namespace Magento\Framework\View\Element\UiComponent;
 
 use Magento\Framework\App\RequestInterface;
+use Magento\Framework\AuthorizationInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\UiComponent\ContentType\ContentTypeFactory;
 use Magento\Framework\View\Element\UiComponent\Control\ActionPoolFactory;
@@ -95,6 +96,11 @@ class Context implements ContextInterface
     protected $uiComponentFactory;
 
     /**
+     * @var AuthorizationInterface
+     */
+    protected $authorization;
+
+    /**
      * @param PageLayoutInterface $pageLayout
      * @param RequestInterface $request
      * @param ButtonProviderFactory $buttonProviderFactory
@@ -103,6 +109,7 @@ class Context implements ContextInterface
      * @param UrlInterface $urlBuilder
      * @param Processor $processor
      * @param UiComponentFactory $uiComponentFactory
+     * @param AuthorizationInterface $authorization
      * @param DataProviderInterface|null $dataProvider
      * @param string|null $namespace
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -116,6 +123,7 @@ class Context implements ContextInterface
         UrlInterface $urlBuilder,
         Processor $processor,
         UiComponentFactory $uiComponentFactory,
+        AuthorizationInterface $authorization,
         DataProviderInterface $dataProvider = null,
         $namespace = null
     ) {
@@ -129,6 +137,7 @@ class Context implements ContextInterface
         $this->urlBuilder = $urlBuilder;
         $this->processor = $processor;
         $this->uiComponentFactory = $uiComponentFactory;
+        $this->authorization = $authorization;
         $this->setAcceptType();
     }
 
@@ -280,6 +289,9 @@ class Context implements ContextInterface
             uasort($buttons, [$this, 'sortButtons']);
 
             foreach ($buttons as $buttonId => $buttonData) {
+                if (isset($buttonData['aclResource']) && !$this->authorization->isAllowed($buttonData['aclResource'])) {
+                    continue;
+                }
                 if (isset($buttonData['url'])) {
                     $buttonData['url'] = $this->getUrl($buttonData['url']);
                 }

--- a/lib/internal/Magento/Framework/View/Element/UiComponent/Context.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponent/Context.php
@@ -110,9 +110,9 @@ class Context implements ContextInterface
      * @param UrlInterface $urlBuilder
      * @param Processor $processor
      * @param UiComponentFactory $uiComponentFactory
-     * @param AuthorizationInterface $authorization
      * @param DataProviderInterface|null $dataProvider
-     * @param string|null $namespace
+     * @param string $namespace
+     * @param AuthorizationInterface|null $authorization
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/UiComponent/ContextTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/UiComponent/ContextTest.php
@@ -11,7 +11,11 @@ namespace Magento\Framework\View\Test\Unit\Element\UiComponent;
 
 use Magento\Framework\View\Element\UiComponent\Context;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\Framework\View\Element\UiComponent\Control\ActionPoolInterface;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class ContextTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -20,7 +24,7 @@ class ContextTest extends \PHPUnit\Framework\TestCase
     protected $context;
 
     /**
-     * @var \Magento\Framework\View\Element\UiComponent\Control\ActionPoolInterface
+     * @var ActionPoolInterface
      */
     private $actionPool;
 
@@ -43,7 +47,7 @@ class ContextTest extends \PHPUnit\Framework\TestCase
             $this->getMockBuilder(\Magento\Framework\View\Element\UiComponent\Control\ActionPoolFactory::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-        $this->actionPool = $this->getMockBuilder(\Magento\Framework\View\Element\UiComponent\Control\ActionPoolInterface::class)
+        $this->actionPool = $this->getMockBuilder(ActionPoolInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $actionPoolFactory->method('create')->willReturn($this->actionPool);


### PR DESCRIPTION
### Description

Currently is not possible to hide buttons based on the user role in the admin panel. As the example from this Pull Request, the `Create new Order` button is always shown, even when the user does not have the permission for it. Clicking on the button gives a permission denied page, as expected.

This PR introduces the possibility of defining an `aclResource` for UIComponents buttons, the same way that a [dataSource](https://github.com/magento/magento2/blob/e5c1527902e1cb69ef4da0e4ff50b25355068813/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_grid.xml#L31) can have.

### Manual testing scenarios

1. Create an admin role without the `Magento_Sales::create` permission;
2. Assign the created role to a new (or existing) user;
3. Login on admin panel with the previous user;
4. Access the sales order grid on admin;
5. The `Create New order` button should not be available;

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
