### PR TITLE
[Backport ]issue fixed #20337 Option Title breaking in two line because applying…

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -519,7 +519,7 @@
     & > .admin__field {
         &:first-child {
             position: static;
-
+            width: 100%;
             & > .admin__field-label {
                 #mix-grid .column(@field-label-grid__column, @field-grid__columns);
                 background: @color-white;


### PR DESCRIPTION
… wrong css for manage width

issue fixed #20337 Option Title breaking in two line because applying wrong css for manage width

### Description (*)
issue fixed #20337 Option Title breaking in two line because applying wrong css for manage width

**Original PR**: https://github.com/magento/magento2/pull/20339

### Manual testing scenarios (*)

1. Login to admin panel
2. Go in Catalog > product section
3. Create new product and go to tab Customizable Options and click on Add option button
    and see first label Option Title (See screenshot shown)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
