### PR TITLE
Fixes incorrect where condition when deleting swatch option, it delet…

### DIFF
--- a/app/code/Magento/Swatches/Model/ResourceModel/Swatch.php
+++ b/app/code/Magento/Swatches/Model/ResourceModel/Swatch.php
@@ -7,8 +7,9 @@
 namespace Magento\Swatches\Model\ResourceModel;
 
 /**
- * @codeCoverageIgnore
  * Swatch Resource Model
+ *
+ * @codeCoverageIgnore
  * @api
  * @since 100.0.2
  */
@@ -25,8 +26,10 @@ class Swatch extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     }
 
     /**
-     * @param string $defaultValue
+     * Update default swatch option value.
+     *
      * @param integer $id
+     * @param string $defaultValue
      * @return void
      */
     public function saveDefaultSwatchOption($id, $defaultValue)

--- a/app/code/Magento/Swatches/Model/ResourceModel/Swatch.php
+++ b/app/code/Magento/Swatches/Model/ResourceModel/Swatch.php
@@ -49,7 +49,7 @@ class Swatch extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     {
         if (count($optionIDs)) {
             foreach ($optionIDs as $optionId) {
-                $where = ['option_id' => $optionId];
+                $where = ['option_id = ?' => $optionId];
                 if ($type !== null) {
                     $where['type = ?'] = $type;
                 }


### PR DESCRIPTION
…ed all options instead of a specific one.

### Description (*)
This fixes an incorrect where condition in the SQL query which should delete a specific swatch option.
It changes the SQL query from (which deletes all options):
```
DELETE FROM `eav_attribute_option_swatch` WHERE (option_id)
```

to (9 is an example here):
```
DELETE FROM `eav_attribute_option_swatch` WHERE (option_id = 9)
```


### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/20396: Changing attribute from swatch to dropdown deletes swatch options for all attributes


### Manual testing scenarios (*)
See description in https://github.com/magento/magento2/issues/20396
You don't need products, just create 2 swatch attributes, and change one of them to dropdown to reproduce the problem.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
