### PR TITLE
Granular Magento_Customer ACL

### DIFF
--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/DeleteButton.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/DeleteButton.php
@@ -10,6 +10,7 @@ use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
 
 /**
  * Class DeleteButton
+ *
  * @package Magento\Customer\Block\Adminhtml\Edit
  */
 class DeleteButton extends GenericButton implements ButtonProviderInterface
@@ -36,6 +37,8 @@ class DeleteButton extends GenericButton implements ButtonProviderInterface
     }
 
     /**
+     * Get button data.
+     *
      * @return array
      */
     public function getButtonData()
@@ -60,6 +63,8 @@ class DeleteButton extends GenericButton implements ButtonProviderInterface
     }
 
     /**
+     * Get delete url.
+     *
      * @return string
      */
     public function getDeleteUrl()

--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/DeleteButton.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/DeleteButton.php
@@ -53,6 +53,7 @@ class DeleteButton extends GenericButton implements ButtonProviderInterface
                 ],
                 'on_click' => '',
                 'sort_order' => 20,
+                'aclResource' => 'Magento_Customer::delete',
             ];
         }
         return $data;

--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/InvalidateTokenButton.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/InvalidateTokenButton.php
@@ -9,11 +9,14 @@ use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
 
 /**
  * Class InvalidateTokenButton
+ *
  * @package Magento\Customer\Block\Adminhtml\Edit
  */
 class InvalidateTokenButton extends GenericButton implements ButtonProviderInterface
 {
     /**
+     * Get button data.
+     *
      * @return array
      */
     public function getButtonData()
@@ -34,6 +37,8 @@ class InvalidateTokenButton extends GenericButton implements ButtonProviderInter
     }
 
     /**
+     * Get invalidate token url.
+     *
      * @return string
      */
     public function getInvalidateTokenUrl()

--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/InvalidateTokenButton.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/InvalidateTokenButton.php
@@ -27,6 +27,7 @@ class InvalidateTokenButton extends GenericButton implements ButtonProviderInter
                 'class' => 'invalidate-token',
                 'on_click' => 'deleteConfirm("' . $deleteConfirmMsg . '", "' . $this->getInvalidateTokenUrl() . '")',
                 'sort_order' => 65,
+                'aclResource' => 'Magento_Customer::invalidate_tokens',
             ];
         }
         return $data;

--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/ResetPasswordButton.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/ResetPasswordButton.php
@@ -27,6 +27,7 @@ class ResetPasswordButton extends GenericButton implements ButtonProviderInterfa
                 'class' => 'reset reset-password',
                 'on_click' => sprintf("location.href = '%s';", $this->getResetPasswordUrl()),
                 'sort_order' => 60,
+                'aclResource' => 'Magento_Customer::reset_password',
             ];
         }
         return $data;

--- a/app/code/Magento/Customer/Controller/Adminhtml/Customer/InvalidateToken.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Customer/InvalidateToken.php
@@ -28,6 +28,13 @@ use Magento\Framework\Api\DataObjectHelper;
 class InvalidateToken extends \Magento\Customer\Controller\Adminhtml\Index
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Customer::invalidate_tokens';
+
+    /**
      * @var CustomerTokenServiceInterface
      */
     protected $tokenService;

--- a/app/code/Magento/Customer/Controller/Adminhtml/Customer/InvalidateToken.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Customer/InvalidateToken.php
@@ -7,6 +7,7 @@
 
 namespace Magento\Customer\Controller\Adminhtml\Customer;
 
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Integration\Api\CustomerTokenServiceInterface;
 use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\AddressRepositoryInterface;
@@ -25,7 +26,7 @@ use Magento\Framework\Api\DataObjectHelper;
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-class InvalidateToken extends \Magento\Customer\Controller\Adminhtml\Index
+class InvalidateToken extends \Magento\Customer\Controller\Adminhtml\Index implements HttpGetActionInterface
 {
     /**
      * Authorization level of a basic admin session

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Delete.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Delete.php
@@ -8,6 +8,9 @@ namespace Magento\Customer\Controller\Adminhtml\Index;
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
 use Magento\Framework\Controller\ResultFactory;
 
+/**
+ * Delete customer action.
+ */
 class Delete extends \Magento\Customer\Controller\Adminhtml\Index implements HttpPostActionInterface
 {
     /**

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Delete.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Delete.php
@@ -11,6 +11,13 @@ use Magento\Framework\Controller\ResultFactory;
 class Delete extends \Magento\Customer\Controller\Adminhtml\Index implements HttpPostActionInterface
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Customer::delete';
+
+    /**
      * Delete customer action
      *
      * @return \Magento\Backend\Model\View\Result\Redirect

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/MassDelete.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/MassDelete.php
@@ -47,8 +47,7 @@ class MassDelete extends AbstractMassAction implements HttpPostActionInterface
     }
 
     /**
-     * @param AbstractCollection $collection
-     * @return \Magento\Backend\Model\View\Result\Redirect
+     * @inheritdoc
      */
     protected function massAction(AbstractCollection $collection)
     {

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/MassDelete.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/MassDelete.php
@@ -19,6 +19,13 @@ use Magento\Framework\Controller\ResultFactory;
 class MassDelete extends AbstractMassAction implements HttpPostActionInterface
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Customer::delete';
+
+    /**
      * @var CustomerRepositoryInterface
      */
     protected $customerRepository;

--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/ResetPassword.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/ResetPassword.php
@@ -17,6 +17,13 @@ use Magento\Framework\Exception\SecurityViolationException;
 class ResetPassword extends \Magento\Customer\Controller\Adminhtml\Index implements HttpGetActionInterface
 {
     /**
+     * Authorization level of a basic admin session
+     *
+     * @see _isAllowed()
+     */
+    const ADMIN_RESOURCE = 'Magento_Customer::reset_password';
+
+    /**
      * Reset password handler
      *
      * @return \Magento\Backend\Model\View\Result\Redirect

--- a/app/code/Magento/Customer/etc/acl.xml
+++ b/app/code/Magento/Customer/etc/acl.xml
@@ -10,7 +10,11 @@
         <resources>
             <resource id="Magento_Backend::admin">
                 <resource id="Magento_Customer::customer" title="Customers" translate="title" sortOrder="40">
-                    <resource id="Magento_Customer::manage" title="All Customers" translate="title" sortOrder="10" />
+                    <resource id="Magento_Customer::manage" title="All Customers" translate="title" sortOrder="10">
+                        <resource id="Magento_Customer::actions" title="Actions" translate="title" sortOrder="10">
+                            <resource id="Magento_Customer::delete" title="Delete" translate="title" sortOrder="10" />
+                        </resource>
+                    </resource>
                     <resource id="Magento_Customer::online" title="Now Online" translate="title" sortOrder="20" />
                     <resource id="Magento_Customer::group" title="Customer Groups" translate="title" sortOrder="30" />
                 </resource>

--- a/app/code/Magento/Customer/etc/acl.xml
+++ b/app/code/Magento/Customer/etc/acl.xml
@@ -14,6 +14,7 @@
                         <resource id="Magento_Customer::actions" title="Actions" translate="title" sortOrder="10">
                             <resource id="Magento_Customer::delete" title="Delete" translate="title" sortOrder="10" />
                             <resource id="Magento_Customer::reset_password" title="Reset password" translate="title" sortOrder="20" />
+                            <resource id="Magento_Customer::invalidate_tokens" title="Invalidate tokens" translate="title" sortOrder="30" />
                         </resource>
                     </resource>
                     <resource id="Magento_Customer::online" title="Now Online" translate="title" sortOrder="20" />

--- a/app/code/Magento/Customer/etc/acl.xml
+++ b/app/code/Magento/Customer/etc/acl.xml
@@ -13,6 +13,7 @@
                     <resource id="Magento_Customer::manage" title="All Customers" translate="title" sortOrder="10">
                         <resource id="Magento_Customer::actions" title="Actions" translate="title" sortOrder="10">
                             <resource id="Magento_Customer::delete" title="Delete" translate="title" sortOrder="10" />
+                            <resource id="Magento_Customer::reset_password" title="Reset password" translate="title" sortOrder="20" />
                         </resource>
                     </resource>
                     <resource id="Magento_Customer::online" title="Now Online" translate="title" sortOrder="20" />


### PR DESCRIPTION
### Description

Given #20408, increase the granularity of ACLs for the Magento_Customer module, adding roles for the `Delete customer`, `Reset password` and `Force Sign-In` buttons.

### Manual testing scenarios

1. Create an admin role without one of the new roles attached;
2. Assign the created role to a new (or existing) user;
3. Login on admin panel with the previous user;
4. Access the customer edit form on admin;
5. The corresponding button for that role should not be shown;

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

