### PR TITLE
Add getZendMessage() to Mail\Message model

### DIFF
--- a/lib/internal/Magento/Framework/Mail/Message.php
+++ b/lib/internal/Magento/Framework/Mail/Message.php
@@ -189,4 +189,12 @@ class Message implements MailMessageInterface
         $this->setMessageType(self::TYPE_TEXT);
         return $this->setBody($text);
     }
+
+    /**
+     * @return \Zend\Mail\Message
+     */
+    public function getZendMessage(): \Zend\Mail\Message
+    {
+        return $this->zendMessage;
+    }
 }


### PR DESCRIPTION
### Description (*)
In ZF2 it became impossible to update the headers of a `\Zend\Mail\Message` in the implementation `\Magento\Framework\Mail\Message` unless creating you own using concrete ZF classes (our use case to update the content-type to multipart/related).

This is a quick win to fetch the current zend message so it can be edited. I'm open to other suggestions.

### Fixed Issues (if relevant)
1. magento/magento2#19876: \Magento\Mail\Message is to closed in 2.3

### Manual testing scenarios (*)
1. Try to programmatically update headers of a `\Magento\Framework\Mail\Message`.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
