### PR TITLE
Sorting on country_of_manufacture product atrtibute not working

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
@@ -13,7 +13,6 @@ namespace Magento\Catalog\Model\Product\Attribute\Source;
 
 use Magento\Eav\Model\Entity\Attribute\Source\AbstractSource;
 use Magento\Framework\Data\OptionSourceInterface;
-use \Magento\Eav\Model\Entity\Collection\AbstractCollection;
 use \Magento\Framework\Data\Collection;
 
 class Countryofmanufacture extends AbstractSource implements OptionSourceInterface
@@ -100,8 +99,10 @@ class Countryofmanufacture extends AbstractSource implements OptionSourceInterfa
      * all NULL values will add to the end
      *
      * @param \Magento\Eav\Model\Entity\Collection\AbstractCollection $collection
-     * @param string $dir direction
+     * @param string $dir
+     *
      * @return \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function addValueSortToCollection($collection, $dir = Collection::SORT_ORDER_DESC) : AbstractSource
     {

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
@@ -147,7 +147,10 @@ class Countryofmanufacture extends AbstractSource implements OptionSourceInterfa
                 []
             );
 
-            $valueExpr = $tableName . '.value';
+            $valueExpr = $collection->getConnection()->getCheckSql(
+                $tableName2 . '.value',
+                $tableName . '.value'
+            );
             $collection->getSelect()->order(
                 [
                     "ISNULL($valueExpr)",

--- a/app/code/Magento/Catalog/Test/Mftf/Data/ProductData.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Data/ProductData.xml
@@ -720,6 +720,18 @@
         <data key="status">1</data>
         <requiredEntity type="product_extension_attribute">EavStock100</requiredEntity>
     </entity>
+    <entity name="nameAndAttributeSkuMaskSimpleProductCM" type="product">
+        <data key="urlKey" unique="suffix">simple-product-cm</data>
+        <data key="name" unique="suffix">SimpleProductCM</data>
+        <data key="price">10000.00</data>
+        <data key="quantity">657</data>
+        <data key="weight">50</data>
+        <data key="country_of_manufacture">CM</data>
+        <data key="country_of_manufacture_label">Cameroon</data>
+        <data key="type_id">simple</data>
+        <data key="status">1</data>
+        <requiredEntity type="product_extension_attribute">EavStock100</requiredEntity>
+    </entity>
     <entity name="ProductShortDescription" type="ProductAttribute">
         <data key="attribute_code">short_description</data>
     </entity>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminSortingByCountryOfManufactureAttributeTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminSortingByCountryOfManufactureAttributeTest.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminSortingByCountryOfManufactureAttributeTest">
+        <annotations>
+            <stories value="View sorting by country of manufacture"/>
+            <title value="Sorting by country of manufacture in Admin"/>
+            <description value="Sorting by country of manufacture in Admin"/>
+            <group value="catalog"/>
+        </annotations>
+        <before>
+            <magentoCLI stepKey="setCountryOfManufacture" command="config:set catalog/fields_masks/sku" arguments="{{name}}-{{country_of_manufacture}}"/>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <magentoCLI stepKey="setName" command="config:set catalog/fields_masks/sku" arguments="{{name}}"/>
+            <actionGroup ref="deleteProductBySku" stepKey="deleteCreatedProduct">
+                <argument name="sku" value="{{nameAndAttributeSkuMaskSimpleProduct.name}}" />
+                <argument name="sku" value="{{nameAndAttributeSkuMaskSimpleProductCM.name}}" />
+            </actionGroup>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+
+        <amOnPage url="{{ProductCatalogPage.url}}" stepKey="openProductCatalogPage"/>
+        <waitForPageLoad stepKey="waitForProductCatalogPage"/>
+        <click selector="{{AdminProductGridActionSection.addProductToggle}}" stepKey="clickAddProductToggle"/>
+        <waitForPageLoad stepKey="waitForProductToggleToSelectSimpleProduct"/>
+        <click selector="{{AdminProductGridActionSection.addSimpleProduct}}" stepKey="clickSimpleProductFromDropDownList"/>
+
+        <!-- Create simple product with country of manufacture attribute -->
+        <fillField selector="{{AdminProductFormSection.productName}}" userInput="{{nameAndAttributeSkuMaskSimpleProduct.name}}" stepKey="fillSimpleProductName"/>
+        <selectOption selector="{{AdminProductFormSection.countryOfManufacture}}" userInput="{{nameAndAttributeSkuMaskSimpleProduct.country_of_manufacture_label}}" stepKey="selectCountryOfManufacture"/>
+        <fillField selector="{{AdminProductFormSection.productPrice}}" userInput="{{nameAndAttributeSkuMaskSimpleProduct.price}}" stepKey="fillSimpleProductPrice"/>
+        <fillField selector="{{AdminProductFormSection.productWeight}}" userInput="{{nameAndAttributeSkuMaskSimpleProduct.weight}}" stepKey="fillSimpleProductWeight"/>
+        <fillField selector="{{AdminProductFormSection.productQuantity}}" userInput="{{nameAndAttributeSkuMaskSimpleProduct.quantity}}" stepKey="fillSimpleProductQuantity"/>
+        <click selector="{{AdminProductFormSection.save}}" stepKey="clickSaveButton"/>
+        <waitForPageLoad stepKey="waitForSimpleProductToSave"/>
+        <!-- Verify customer see success message -->
+        <see selector="{{AdminProductFormSection.successMessage}}" userInput="You saved the product." stepKey="seeAssertSimpleProductSaveSuccessMessage"/>
+
+        <!-- Search created simple product(from above step) in the grid page to verify sku masked as name and country of manufacture -->
+        <amOnPage url="{{ProductCatalogPage.url}}" stepKey="OpenProductCatalogPageToSearchCreatedSimpleProduct"/>
+        <waitForPageLoad stepKey="waitForProductCatalogPageToLoad"/>
+
+        <click selector="{{AdminProductGridActionSection.addProductToggle}}" stepKey="clickAddProductToggleCM"/>
+        <waitForPageLoad stepKey="waitForProductToggleToSelectSimpleProductCM"/>
+        <click selector="{{AdminProductGridActionSection.addSimpleProduct}}" stepKey="clickSimpleProductFromDropDownListCM"/>
+
+        <fillField selector="{{AdminProductFormSection.productName}}" userInput="{{nameAndAttributeSkuMaskSimpleProductCM.name}}" stepKey="fillSimpleProductNameCM"/>
+        <selectOption selector="{{AdminProductFormSection.countryOfManufacture}}" userInput="{{nameAndAttributeSkuMaskSimpleProductCM.country_of_manufacture_label}}" stepKey="selectCountryOfManufactureCM"/>
+        <fillField selector="{{AdminProductFormSection.productPrice}}" userInput="{{nameAndAttributeSkuMaskSimpleProductCM.price}}" stepKey="fillSimpleProductPriceCM"/>
+        <fillField selector="{{AdminProductFormSection.productWeight}}" userInput="{{nameAndAttributeSkuMaskSimpleProductCM.weight}}" stepKey="fillSimpleProductWeightCM"/>
+        <fillField selector="{{AdminProductFormSection.productQuantity}}" userInput="{{nameAndAttributeSkuMaskSimpleProductCM.quantity}}" stepKey="fillSimpleProductQuantityCM"/>
+        <click selector="{{AdminProductFormSection.save}}" stepKey="clickSaveButtonCM"/>
+        <waitForPageLoad stepKey="waitForSimpleProductToSaveCM"/>
+        <!-- Verify customer see success message -->
+        <see selector="{{AdminProductFormSection.successMessage}}" userInput="You saved the product." stepKey="seeAssertSimpleProductSaveSuccessMessageCM"/>
+
+        <!-- Search created simple product(from above step) in the grid page to verify sku masked as name and country of manufacture -->
+        <amOnPage url="{{AdminProductIndexPage.url}}" stepKey="navigateToCatalogProductGrid"/>
+        <waitForPageLoad stepKey="waitForCatalogProductGrid"/>
+
+        <!--&lt;!&ndash;Sort Ascending&ndash;&gt;-->
+        <actionGroup ref="resetProductGridToDefaultView" stepKey="setProductGridToDefaultSortingWebsites"/>
+        <click selector="{{AdminProductGridSection.columnHeader('Country of Manufacture')}}" stepKey="clickCountryOfManufactureHeaderToSortAsc"/>
+        <see selector="{{AdminProductGridSection.productGridContentsOnRow('1')}}" userInput="Ukraine" stepKey="checkIfCountryOfManufacture1Asc"/>
+        <see selector="{{AdminProductGridSection.productGridContentsOnRow('2')}}" userInput="Cameroon" stepKey="checkIfCountryOfManufactureAsc"/>
+
+        <!--Sort Descending-->
+        <click selector="{{AdminProductGridSection.columnHeader('Country of Manufacture')}}" stepKey="clickCountryOfManufactureHeaderToSortDesc"/>
+        <see selector="{{AdminProductGridSection.productGridContentsOnRow('1')}}" userInput="Cameroon" stepKey="checkIfCountryOfManufacture1Desc"/>
+        <see selector="{{AdminProductGridSection.productGridContentsOnRow('2')}}" userInput="Ukraine" stepKey="checkIfCountryOfManufactureDesc"/>
+    </test>
+</tests>

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/Source/CountryofmanufactureTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/Source/CountryofmanufactureTest.php
@@ -38,10 +38,10 @@ class CountryofmanufactureTest extends \PHPUnit\Framework\TestCase
     private $serializerMock;
 
     /** @var \Magento\Eav\Model\Entity\Collection\AbstractCollection|\PHPUnit_Framework_MockObject_MockObject */
-    protected $collection;
+    private $collection;
 
     /** @var \Magento\Directory\Model\CountryFactory|\PHPUnit_Framework_MockObject_MockObject */
-    protected $countryFactory;
+    private $countryFactory;
 
     /**
      * @var AbstractAttribute | \PHPUnit_Framework_MockObject_MockObject
@@ -114,7 +114,7 @@ class CountryofmanufactureTest extends \PHPUnit\Framework\TestCase
     {
         return
             [
-                ['cachedDataSrl' =>  json_encode(['key' => 'data']), 'cachedDataUnsrl' => ['key' => 'data']]
+                ['cachedDataSrl' => json_encode(['key' => 'data']), 'cachedDataUnsrl' => ['key' => 'data']]
             ];
     }
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/Source/CountryofmanufactureTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/Source/CountryofmanufactureTest.php
@@ -37,15 +37,29 @@ class CountryofmanufactureTest extends \PHPUnit\Framework\TestCase
      */
     private $serializerMock;
 
+    /** @var \Magento\Eav\Model\Entity\Collection\AbstractCollection|\PHPUnit_Framework_MockObject_MockObject */
+    protected $collection;
+
+    /** @var \Magento\Directory\Model\CountryFactory|\PHPUnit_Framework_MockObject_MockObject */
+    protected $countryFactory;
+
+    /**
+     * @var AbstractAttribute | \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $abstractAttributeMock;
+
     protected function setUp()
     {
         $this->storeManagerMock = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
         $this->storeMock = $this->createMock(\Magento\Store\Model\Store::class);
         $this->cacheConfig = $this->createMock(\Magento\Framework\App\Cache\Type\Config::class);
+        $this->countryFactory = $this->createMock(\Magento\Directory\Model\CountryFactory::class);
+
         $this->objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->countryOfManufacture = $this->objectManagerHelper->getObject(
             \Magento\Catalog\Model\Product\Attribute\Source\Countryofmanufacture::class,
             [
+                'countryFactory' => $this->countryFactory,
                 'storeManager' => $this->storeManagerMock,
                 'configCacheType' => $this->cacheConfig,
             ]
@@ -57,6 +71,16 @@ class CountryofmanufactureTest extends \PHPUnit\Framework\TestCase
             'serializer',
             $this->serializerMock
         );
+        $this->abstractAttributeMock = $this->getMockBuilder(\Magento\Eav\Model\Entity\Attribute\AbstractAttribute::class)
+                                            ->setMethods(
+                                                [
+                                                    'getFrontend', 'getAttribute', 'getAttributeCode', 'isScopeGlobal', '__wakeup', 'getStoreId',
+                                                    'getId', 'getIsRequired', 'getEntity', 'getBackend'
+                                                ]
+                                            )
+                                            ->disableOriginalConstructor()
+                                            ->getMockForAbstractClass();
+        $this->countryOfManufacture->setAttribute($this->abstractAttributeMock);
     }
 
     /**
@@ -90,7 +114,75 @@ class CountryofmanufactureTest extends \PHPUnit\Framework\TestCase
     {
         return
             [
-                ['cachedDataSrl' => json_encode(['key' => 'data']), 'cachedDataUnsrl' => ['key' => 'data']]
+                ['cachedDataSrl' =>  json_encode(['key' => 'data']), 'cachedDataUnsrl' => ['key' => 'data']]
             ];
+    }
+
+    /**
+     * Add Value Sort To Collection Select
+     * all NULL values will add to the end
+     * @dataProvider addValueSortToCollectionDataProvider
+     * @param string $direction
+     * @param bool $isScopeGlobal
+     */
+    public function testAddValueSortToCollection(
+        $direction,
+        $isScopeGlobal
+    ) {
+        $this->getMockBuilder(\Magento\Catalog\Model\Product\Attribute\Source\Countryofmanufacture::class)
+             ->setMethods(
+                 [
+                     'addValueSortToCollection'
+                 ]
+             )
+             ->disableOriginalConstructor()
+             ->getMockForAbstractClass();
+
+        $attributeCode = 'country_of_manufacture';
+        $collection = $this->getMockBuilder(\Magento\Eav\Model\Entity\Collection\AbstractCollection::class)
+                           ->setMethods([ 'getSelect', 'getStoreId'])
+                           ->disableOriginalConstructor()
+                           ->getMockForAbstractClass();
+
+        $this->abstractAttributeMock->expects($this->any())->method('getAttributeCode')->willReturn($attributeCode);
+
+        $entity = $this->getMockBuilder(\Magento\Eav\Model\Entity\AbstractEntity::class)
+                       ->setMethods(['getLinkField'])
+                       ->disableOriginalConstructor()
+                       ->getMockForAbstractClass();
+        $this->abstractAttributeMock->expects($this->once())->method('getEntity')->willReturn($entity);
+        $this->abstractAttributeMock->expects($this->any())->method('isScopeGlobal')->will($this->returnValue($isScopeGlobal));
+        $entity->expects($this->once())->method('getLinkField')->willReturn('entity_id');
+        $select = $this->getMockBuilder(\Magento\Framework\DB\Select::class)
+                       ->setMethods(['joinLeft', 'getConnection', 'order'])
+                       ->disableOriginalConstructor()
+                       ->getMock();
+        $collection->expects($this->any())->method('getSelect')->willReturn($select);
+        $select->expects($this->any())->method('joinLeft')->willReturnSelf();
+        $backend = $this->getMockBuilder(\Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend::class)
+                        ->setMethods(['getTable'])
+                        ->disableOriginalConstructor()
+                        ->getMockForAbstractClass();
+        $this->abstractAttributeMock->expects($this->any())->method('getBackend')->willReturn($backend);
+        $backend->expects($this->any())->method('getTable')->willReturn('table_name');
+        $this->abstractAttributeMock->expects($this->any())->method('getId')->willReturn(1);
+        $collection->expects($this->any())->method('getStoreId')->willReturn(1);
+        $connection = $this->getMockBuilder(\Magento\Framework\DB\Adapter\AdapterInterface::class)
+                           ->disableOriginalConstructor()
+                           ->getMock();
+        $select->expects($this->any())->method('getConnection')->willReturn($connection);
+
+        $select->expects($this->any())->method('order')->with(['ISNULL(country_of_manufacture_t.value)', "{$attributeCode}_t.value {$direction}"]);
+        $this->assertEquals($this->countryOfManufacture, $this->countryOfManufacture->addValueSortToCollection($collection, $direction));
+    }
+
+    public function addValueSortToCollectionDataProvider()
+    {
+        return [
+            ['direction' => \Magento\Framework\DB\Select::SQL_ASC, 'isScopeGlobal' => false],
+            ['direction' => \Magento\Framework\DB\Select::SQL_DESC, 'isScopeGlobal' => false],
+            ['direction' => \Magento\Framework\DB\Select::SQL_ASC, 'isScopeGlobal' => true],
+            ['direction' => \Magento\Framework\DB\Select::SQL_DESC, 'isScopeGlobal' => true]
+        ];
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Source/CountryofmanufactureTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Source/CountryofmanufactureTest.php
@@ -6,18 +6,29 @@
 namespace Magento\Catalog\Model\Product\Attribute\Source;
 
 use Magento\TestFramework\Helper\CacheCleaner;
+use \Magento\Framework\Data\Collection;
 
 class CountryofmanufactureTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * code of attribute for test
+     */
+    const ATTRIBUTE_CODE = 'country_of_manufacture';
+
     /**
      * @var \Magento\Catalog\Model\Product\Attribute\Source\Countryofmanufacture
      */
     private $model;
 
+    /**
+     * @var
+     */
+    private $objectManager;
+
     protected function setUp()
     {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $this->model = $objectManager->create(
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->model = $this->objectManager->create(
             \Magento\Catalog\Model\Product\Attribute\Source\Countryofmanufacture::class
         );
     }
@@ -28,5 +39,24 @@ class CountryofmanufactureTest extends \PHPUnit\Framework\TestCase
         $allOptions = $this->model->getAllOptions();
         $cachedAllOptions = $this->model->getAllOptions();
         $this->assertEquals($allOptions, $cachedAllOptions);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/products_simple_with_country_of_manufacture.php
+     */
+    public function testAddValueSortToCollection()
+    {
+        /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $collection */
+        $collection = $this->objectManager->create(\Magento\Catalog\Model\ResourceModel\Product\Collection::class);
+        $attr = $this->objectManager->get(\Magento\Eav\Model\Config::class)
+                                                       ->getAttribute('catalog_product', self::ATTRIBUTE_CODE);
+        $this->model->setAttribute($attr);
+        $this->model->addValueSortToCollection($collection, Collection::SORT_ORDER_ASC);
+        $collection->addAttributeToSelect(self::ATTRIBUTE_CODE);
+        $countries = [];
+        foreach ($collection->getItems() as $item) {
+            $countries[] = $item->getData(self::ATTRIBUTE_CODE);
+        }
+        $this->assertEquals(['CM', 'UA'], $countries);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/products_simple_with_country_of_manufacture.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/products_simple_with_country_of_manufacture.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+$product = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+                                                  ->create(\Magento\Catalog\Model\Product::class);
+$product
+    ->setTypeId('simple')
+    ->setAttributeSetId(4)
+    ->setWebsiteIds([1])
+    ->setName('First Simple Product')
+    ->setSku('simple-249')
+    ->setPrice(249.9)
+    ->setSpecialPrice(153)
+    ->setWeight(10)
+    ->setMetaTitle('meta title')
+    ->setMetaKeyword('meta keyword')
+    ->setMetaDescription('meta description')
+    ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+    ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
+    ->setStockData(['use_config_manage_stock' => 1, 'qty' => 22, 'is_in_stock' => 1])
+    ->setQty(22)
+    ->setCustomAttribute('country_of_manufacture', 'UA')
+    ->save();
+
+$product = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+                                                  ->create(\Magento\Catalog\Model\Product::class);
+$product
+    ->setTypeId('simple')
+    ->setAttributeSetId(4)
+    ->setWebsiteIds([1])
+    ->setWeight(10)
+    ->setName('Second Simple Product')
+    ->setSku('simple-156')
+    ->setPrice(156)
+    ->setSpecialPrice(156)
+    ->setMetaTitle('meta title')
+    ->setMetaKeyword('meta keyword')
+    ->setMetaDescription('meta description')
+    ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+    ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
+    ->setStockData(['use_config_manage_stock' => 1, 'qty' => 22, 'is_in_stock' => 1])
+    ->setQty(22)
+    ->setCustomAttribute('country_of_manufacture', 'CM')
+    ->save();

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/products_simple_with_country_of_manufacture_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/products_simple_with_country_of_manufacture_rollback.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+/** @var \Magento\Framework\Registry $registry */
+$registry = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Framework\Registry::class);
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+
+/**
+ * @var Magento\Catalog\Api\ProductRepositoryInterface $productRepository
+ */
+$productRepository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+                                                            ->get(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+
+try {
+    $customDesignProduct = $productRepository->get('simple-156', false, null, true);
+    $productRepository->delete($customDesignProduct);
+} catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+    //Product already removed
+}
+
+try {
+    $customDesignProduct = $productRepository->get('simple-249', false, null, true);
+    $productRepository->delete($customDesignProduct);
+} catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+    //Product already removed
+}
+
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', false);


### PR DESCRIPTION

### Description (*)
Base issue https://github.com/magento/magento2/issues/13864
Magento provide built-in product attribute with code country_of_manufacture. In admin product grid sorting on this attribute is not working.

#### Preconditions
Magento Version : CE 2.2.2
PHP version : PHP 7.0.18-1+deb.sury.org~xenial+1
MySQL version : mysql Ver 14.14 Distrib 5.7.20

#### Steps to reproduce
Navigate to admin catalog product grid
Using "Columns" selection add Country of Manufacture column in grid
Now click on this Country of Manufacture column to apply sorting in grid
Now you can see that sorting is not working in any order for this column
#### Expected result
Sort by Country of Manufacture should be working fine.

#### Actual result
Sort by country_of_manufacture product attribute not working.

### Fixed Issues (if relevant)
Implement sort functionlity. All Null values will be added to the end of collection

### Manual testing scenarios (*)
#### Steps to reproduce
Navigate to admin catalog product grid
Using "Columns" selection add Country of Manufacture column in grid
Now click on this Country of Manufacture column to apply sorting in grid
Now you can see that sorting is not working in any order for this column

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
