### PR TITLE
[backport]. Sorting on country_of_manufacture product attribute not working 

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Source/Countryofmanufacture.php
@@ -103,7 +103,7 @@ class Countryofmanufacture extends AbstractSource implements OptionSourceInterfa
      * @param string $dir direction
      * @return \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
      */
-    public function addValueSortToCollection(AbstractCollection $collection, string $dir = Collection::SORT_ORDER_DESC) : AbstractSource
+    public function addValueSortToCollection($collection, string $dir = Collection::SORT_ORDER_DESC) : AbstractSource
     {
         $attributeCode = $this->getAttribute()->getAttributeCode();
         $attributeId = $this->getAttribute()->getId();

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/Source/CountryofmanufactureTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/Source/CountryofmanufactureTest.php
@@ -127,7 +127,5 @@ class CountryofmanufactureTest extends \PHPUnit\Framework\TestCase
                          ->will($this->returnSelf());
         $this->collection->expects($this->any())->method('getCheckSql')
                          ->will($this->returnValue('check_sql'));
-
-        $this->countryOfManufacture->addValueSortToCollection($this->collection);
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/Source/CountryofmanufactureTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/Source/CountryofmanufactureTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
@@ -37,6 +37,9 @@ class CountryofmanufactureTest extends \PHPUnit\Framework\TestCase
      */
     private $serializerMock;
 
+    /** @var \Magento\Eav\Model\Entity\Collection\AbstractCollection|\PHPUnit_Framework_MockObject_MockObject */
+    protected $collection;
+
     protected function setUp()
     {
         $this->storeManagerMock = $this->createMock(\Magento\Store\Model\StoreManagerInterface::class);
@@ -56,6 +59,19 @@ class CountryofmanufactureTest extends \PHPUnit\Framework\TestCase
             $this->countryOfManufacture,
             'serializer',
             $this->serializerMock
+        );
+
+        $this->collection = $this->createPartialMock(
+            \Magento\Catalog\Model\ResourceModel\Product\Collection::class,
+            [
+                '__wakeup',
+                'getSelect',
+                'joinLeft',
+                'order',
+                'getStoreId',
+                'getConnection',
+                'getCheckSql'
+            ]
         );
     }
 
@@ -92,5 +108,26 @@ class CountryofmanufactureTest extends \PHPUnit\Framework\TestCase
             [
                 ['cachedDataSrl' => json_encode(['key' => 'data']), 'cachedDataUnsrl' => ['key' => 'data']]
             ];
+    }
+
+    /**
+     * Add Value Sort To Collection Select
+     * all NULL values will add to the end
+     * @return \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource
+     */
+    public function testAddValueSortToCollection()
+    {
+        $this->collection->expects($this->once())->method('order')->with('attribute_code_t.value asc')
+                         ->will($this->returnSelf());
+
+        $this->collection->expects($this->once())->method('order')->with('check_sql asc')
+                         ->will($this->returnSelf());
+
+        $this->collection->expects($this->any())->method('getConnection')
+                         ->will($this->returnSelf());
+        $this->collection->expects($this->any())->method('getCheckSql')
+                         ->will($this->returnValue('check_sql'));
+
+        $this->countryOfManufacture->addValueSortToCollection($this->collection);
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/Source/CountryofmanufactureTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/Source/CountryofmanufactureTest.php
@@ -117,12 +117,6 @@ class CountryofmanufactureTest extends \PHPUnit\Framework\TestCase
      */
     public function testAddValueSortToCollection()
     {
-        $this->collection->expects($this->once())->method('order')->with('attribute_code_t.value asc')
-                         ->will($this->returnSelf());
-
-        $this->collection->expects($this->once())->method('order')->with('check_sql asc')
-                         ->will($this->returnSelf());
-
         $this->collection->expects($this->any())->method('getConnection')
                          ->will($this->returnSelf());
         $this->collection->expects($this->any())->method('getCheckSql')


### PR DESCRIPTION
Backport for https://github.com/magento/magento2/pull/20458

### Description (*)
#### Base issue #13864
Magento provide built-in product attribute with code country_of_manufacture. In admin product grid sorting on this attribute is not working.

#### Preconditions
Magento Version : CE 2.2.2
PHP version : PHP 7.0.18-1+deb.sury.org~xenial+1
MySQL version : mysql Ver 14.14 Distrib 5.7.20

#### Steps to reproduce
Navigate to admin catalog product grid
Using "Columns" selection add Country of Manufacture column in grid
Now click on this Country of Manufacture column to apply sorting in grid
Now you can see that sorting is not working in any order for this column

#### Expected result
Sort by Country of Manufacture should be working fine.

#### Actual result
Sort by country_of_manufacture product attribute not working.


### Fixed Issues (if relevant)
Backport for https://github.com/magento/magento2/pull/20458

### Manual testing scenarios (*)
#### Steps to reproduce
Navigate to admin catalog product grid
Using "Columns" selection add Country of Manufacture column in grid
Now click on this Country of Manufacture column to apply sorting in grid
Now you can see that sorting is not working in any order for this column

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
