### PR TITLE
fix-issue-19786 Can only export default store view items when upgrade to 2.3.0

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Export/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Export/Product.php
@@ -948,8 +948,8 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
             foreach ($collection as $itemId => $item) {
                 $data[$itemId][$storeId] = $item;
             }
+            $collection->clear();
         }
-        $collection->clear();
 
         return $data;
     }


### PR DESCRIPTION

### Description (*)
Even if i upload CSV file, having each of the positions having row for each store view (default (pln), eur, usd and gbp in my case), then after clicking System > Data Transfer > Export > Products then i get just the CSV with my products for the default store view, loosing all the rows for other store views

### Fixed Issues (if relevant)

1. magento/magento2#19786: Issue title
2. ...

### Manual testing scenarios (*)
1.Clean install Magento 2.2.6 without any unnecessary module.
2.Creat a new Website with a new store and a new store view "storeview2".
3.Upload a item with different price in different store view. Now the product export file is correct with 2 rows.
4.Upgrade to 2.3.0, now the exported file have only 1 row and do not have the price information of "storeview2"

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
