### PR TITLE
[TASK] Remove translation of attribute store label in getAdditionalData

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Attributes.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Attributes.php
@@ -90,7 +90,7 @@ class Attributes extends \Magento\Framework\View\Element\Template
 
                 if (is_string($value) && strlen($value)) {
                     $data[$attribute->getAttributeCode()] = [
-                        'label' => __($attribute->getStoreLabel()),
+                        'label' => $attribute->getStoreLabel(),
                         'value' => $value,
                         'code' => $attribute->getAttributeCode(),
                     ];


### PR DESCRIPTION
Attribute labels should be translated in magento admin setting correct translation for stores

Magento offers the possibility to set different labels for attributes in magento admin.
This commit solves the issue that some attribute-labels might get translated even if they are already translated, by setting correct value in magento admin.

### Description (*)

In \Magento\Catalog\Block\Product\View\Attributes::getAdditionalData an array of attributes will be returned.
Each array element contains 'code', 'value' and 'label'. 
Following the admin field in "stores -> attribtues -> products" select any attribute and there in "manage labels" tab
you are supposed to translate the attribute label for the specific languages / store-views in there.
But since the attribute-label will be translated again you might not get the result you set in magento admin, depending if you have a translation for the label you have chosen

### Manual testing scenarios (*)
Steps to reproduce
1. create a store-view using german as locale
2. create a translation file containing a translation for e.g. "Display","Anzeigen"
3. create a attribute with "Display" as a specific label for the store-view using german as locale
4. ensure the new attribute is shown in frontend ( on detail page)
5. check the detail-page while on the store-view ( with german as locale)
6. expected result would be "Display" as attribute label shown in frontend, current result will be "Anzeigen" because the label will be translated using the csv.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
