### PR TITLE
[Backport] Adjusted documentation for ReadInterface to reflect Exception

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Directory/ReadInterface.php
+++ b/lib/internal/Magento/Framework/Filesystem/Directory/ReadInterface.php
@@ -89,6 +89,7 @@ interface ReadInterface
      *
      * @param string $path
      * @return \Magento\Framework\Filesystem\File\ReadInterface
+     * @throws \Magento\Framework\Exception\FileSystemException
      */
     public function openFile($path);
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20283
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
`openFile` ends up calling `magento/framework/Filesystem/DriverInterface.php` -> `fileOpen` which can throw a `Magento\Framework\Exception\FileSystemException`. My proposed change adds the exception to the documentation for the method.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Not relevant.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Not relevant for this code change, as it involves only documentation.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
