### PR TITLE
Widget-left-navigation-block

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/_page-nav.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/_page-nav.less
@@ -203,7 +203,7 @@
     font-weight: @font-weight__heavier;
     line-height: @line-height__s;
     margin: 0 0 -1px;
-    padding: @admin__page-nav-link__padding;
+    padding: 2rem 0rem 2rem 1rem;
     transition: @admin__page-nav-transition;
     word-wrap: break-word;
 }


### PR DESCRIPTION
In Admin configuration Widget left navigation block not proper in tablet landscape view #20492

### Description (*)
1.Go to CONTENT->Widget->Add new widget
2.While filling form ,left navigation block have design issue in tablet view

### Fixed Issues (if relevant)
In Admin configuration Widget left navigation block not proper in tablet landscape view #20492

### Manual testing scenarios (*)
![screenshot-i-20487-2-3-develop instances magento-community engineering-2019-01-23-13-57-41](https://user-images.githubusercontent.com/18118638/51594073-a71f4a80-1f19-11e9-8370-517b9b7b76a7.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
