### PR TITLE
[Backport] Fixed The ui-component field validation error not opening accordion tab that owns the field (field does not get focused)

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/components/fieldset.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/components/fieldset.js
@@ -162,6 +162,10 @@ define([
             }
 
             this.error(hasErrors || message);
+
+            if (hasErrors || message) {
+                this.open();
+            }
         },
 
         /**

--- a/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js
@@ -408,6 +408,7 @@ define([
                 isValid = this.disabled() || !this.visible() || result.passed;
 
             this.error(message);
+            this.error.valueHasMutated();
             this.bubble('error', message);
 
             //TODO: Implement proper result propagation for form


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19812
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed The ui-component field validation error not opening accordion tab that owns the field (field does not get focused)

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17926: The ui-component field validation error not opening accordion tab that owns the field (field does not get focused)

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. N/A
### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
