### PR TITLE
[Backport] Fixed-Configurable-product-options-are-misaligned-2.2

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/composite/fieldset/configurable.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/composite/fieldset/configurable.phtml
@@ -17,7 +17,7 @@
     <legend class="legend admin__legend">
         <span><?= /* @escapeNotVerified */ __('Associated Products') ?></span>
     </legend>
-    <div class="product-options">
+    <div class="product-options fieldset admin__fieldset">
         <div class="field admin__field _required required">
             <?php foreach ($_attributes as $_attribute): ?>
                 <label class="label admin__field-label"><?php


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20521: Configurable product options are misaligned
2. Magento 2.2-develop

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Go to admin area
2. Go to Sales -> Orders
3. Press create a new order button
4. Press Add Products button
5. From the list, choose a configurable product and press "Configure"

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
