### PR TITLE
[Backport] issue fixed #20259 Store switcher not sliding up and down, only dropd…

### DIFF
--- a/app/design/frontend/Magento/blank/web/css/source/_navigation.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_navigation.less
@@ -131,15 +131,14 @@
                 );
             }
         }
-
         .switcher-dropdown {
             .lib-list-reset-styles();
             padding: @indent__s 0;
             display: none;
         }
-        .switcher-options{
-            &.active{
-                .switcher-dropdown{
+        .switcher-options {
+            &.active {
+                .switcher-dropdown {
                     display: block;
                 }
             }

--- a/app/design/frontend/Magento/blank/web/css/source/_navigation.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_navigation.less
@@ -133,8 +133,8 @@
         }
         .switcher-dropdown {
             .lib-list-reset-styles();
-            padding: @indent__s 0;
             display: none;
+            padding: @indent__s 0;
         }
         .switcher-options {
             &.active {
@@ -213,7 +213,7 @@
         }
 
         .nav-toggle {
-            &:after{
+            &:after {
                 background: rgba(0, 0, 0, @overlay__opacity);
                 content: '';
                 display: block;

--- a/app/design/frontend/Magento/blank/web/css/source/_navigation.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_navigation.less
@@ -135,8 +135,15 @@
         .switcher-dropdown {
             .lib-list-reset-styles();
             padding: @indent__s 0;
+            display: none;
         }
-
+        .switcher-options{
+            &.active{
+                .switcher-dropdown{
+                    display: block;
+                }
+            }
+        } 
         .header.links {
             .lib-list-reset-styles();
             border-bottom: 1px solid @color-gray82;


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20260

issue fixed #20259 Store switcher not sliding up and down, only dropdown arrow working


### Description (*)
Store switcher not sliding up and down, only dropdown arrow working 

Step 1: Go to frontend in mobile device
Step 2: click on toggle in left top corner
Step 3: Go to setting tab and see store switcher and clcik on label (Ref screenshot)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
