### PR TITLE
[Backport] issue fixed #20304 No space between step title and saved address in c…

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_checkout.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_checkout.less
@@ -48,6 +48,7 @@
         .step-title {
             &:extend(.abs-checkout-title all);
             .lib-css(border-bottom, @checkout-step-title__border);
+            margin-bottom: 15px;
         }
 
         .step-content {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20306
…heckout

issue fixed #20304 No space between step title and saved address in checkout

### Manual testing scenarios (*)

Step 1: Open frontend 
Step 2: Add any product in cart 
Step 3: Go to checkout and login as existing customer 

Note: Address should saved already

Step 4: Goto checkout in step 1(Shipping adress)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
