### PR TITLE
[Backport] Fixed Issue #20121 Cancel order increases stock although "Set Items' Status to be In Stock When Order is Cancelled" is set to No

### DIFF
--- a/app/code/Magento/CatalogInventory/Observer/CancelOrderItemObserver.php
+++ b/app/code/Magento/CatalogInventory/Observer/CancelOrderItemObserver.php
@@ -6,10 +6,10 @@
 
 namespace Magento\CatalogInventory\Observer;
 
-use Magento\CatalogInventory\Model\Configuration;
-use Magento\Framework\Event\ObserverInterface;
 use Magento\CatalogInventory\Api\StockManagementInterface;
+use Magento\CatalogInventory\Model\Configuration;
 use Magento\Framework\Event\Observer as EventObserver;
+use Magento\Framework\Event\ObserverInterface;
 
 /**
  * Catalog inventory module observer
@@ -32,6 +32,7 @@ class CancelOrderItemObserver implements ObserverInterface
     protected $priceIndexer;
 
     /**
+     * @param Configuration $configuration
      * @param StockManagementInterface $stockManagement
      * @param \Magento\Catalog\Model\Indexer\Product\Price\Processor $priceIndexer
      */


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20252
Fixed Issue #20121 Cancel order increases stock although "Set Items' Status to be In Stock When Order is Cancelled" is set to No

### Preconditions
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento 2.2.6 Community
2. Reproduced on PHP 7.1.18 and 7.1.25
3. MariaDB 10.1.26 and 10.3.11
4. Go to Stores -> Configuration -> Catalog -> Inventory and make sure the following options are set as per below:
 * **Decrease Stock When Order is Placed** to **Yes**
 * **Set Items' Status to be In Stock When Order is Cancelled** to **No**
 * **Manage Stock** to **Yes**
 * **Automatically Return Credit Memo Item to Stock** to **No**
(see screenshot below)
![image](https://user-images.githubusercontent.com/12296157/50830354-3d674400-1350-11e9-9278-81b92aef7761.png)

### Steps to reproduce
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Place an order with 1 item of product (i.e. qty = 1)
2. Cancel order

### Expected result
<!--- Tell us what do you expect to happen. -->
1. Product quantity in product catalog is decreased by 1 after order is created
2. Product quantity remains the same (i.e. does not increase) after order is canceled

### Actual result
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Product quantity in product catalog is decreased by 1 after order is created
2. Product quantity is increased by 1 immediately after order is canceled


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
