### PR TITLE
Fixes incorrect country code being used for Greek VAT numbers, should…

### DIFF
--- a/app/code/Magento/Customer/Model/Vat.php
+++ b/app/code/Magento/Customer/Model/Vat.php
@@ -179,18 +179,21 @@ class Vat
             return $gatewayResponse;
         }
 
+        $countryCodeForVatNumber = $this->getCountryCodeForVatNumber($countryCode);
+        $requesterCountryCodeForVatNumber = $this->getCountryCodeForVatNumber($requesterCountryCode);
+
         try {
             $soapClient = $this->createVatNumberValidationSoapClient();
 
             $requestParams = [];
-            $requestParams['countryCode'] = $countryCode;
+            $requestParams['countryCode'] = $countryCodeForVatNumber;
             $vatNumberSanitized = $this->isCountryInEU($countryCode)
-                ? str_replace([' ', '-', $countryCode], ['', '', ''], $vatNumber)
+                ? str_replace([' ', '-', $countryCodeForVatNumber], ['', '', ''], $vatNumber)
                 : str_replace([' ', '-'], ['', ''], $vatNumber);
             $requestParams['vatNumber'] = $vatNumberSanitized;
-            $requestParams['requesterCountryCode'] = $requesterCountryCode;
+            $requestParams['requesterCountryCode'] = $requesterCountryCodeForVatNumber;
             $reqVatNumSanitized = $this->isCountryInEU($requesterCountryCode)
-                ? str_replace([' ', '-', $requesterCountryCode], ['', '', ''], $requesterVatNumber)
+                ? str_replace([' ', '-', $requesterCountryCodeForVatNumber], ['', '', ''], $requesterVatNumber)
                 : str_replace([' ', '-'], ['', ''], $requesterVatNumber);
             $requestParams['requesterVatNumber'] = $reqVatNumSanitized;
             // Send request to service
@@ -300,5 +303,23 @@ class Vat
             $this->scopeConfig->getValue(self::XML_PATH_EU_COUNTRIES_LIST, ScopeInterface::SCOPE_STORE, $storeId)
         );
         return in_array($countryCode, $euCountries);
+    }
+
+    /**
+     * Returns the country code to use in the VAT number which is not always the same as the normal country code
+     *
+     * @param string $countryCode
+     * @return string
+     */
+    private function getCountryCodeForVatNumber(string $countryCode): string
+    {
+        // Greece uses a different code for VAT numbers then its country code
+        // See: http://ec.europa.eu/taxation_customs/vies/faq.html#item_11
+        // And https://en.wikipedia.org/wiki/VAT_identification_number:
+        // "The full identifier starts with an ISO 3166-1 alpha-2 (2 letters) country code
+        // (except for Greece, which uses the ISO 639-1 language code EL for the Greek language,
+        // instead of its ISO 3166-1 alpha-2 country code GR)"
+
+        return $countryCode === 'GR' ? 'EL' : $countryCode;
     }
 }


### PR DESCRIPTION
… be 'EL' instead of 'GR'.

### Description (*)
Greek VAT numbers use the prefix 'EL' and not the normal country code 'GR'.
This VAT number is send to the [VIES VAT number validation](http://ec.europa.eu/taxation_customs/vies/) and currently in Magento, the validation of Greek VAT numbers just never works. This PR fixes this.

Quoting from [wikipedia](https://en.wikipedia.org/wiki/VAT_identification_number):
> The full identifier starts with an ISO 3166-1 alpha-2 (2 letters) country code (except for Greece, which uses the ISO 639-1 language code EL for the Greek language, instead of its ISO 3166-1 alpha-2 country code GR)

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/6960: Greek vat numbers cannot be validated

### Manual testing scenarios (*)
In admin:
1. In admin, go to Stores > Configuration > General > General > Store Information
2. Make sure you select Greece as country and enter some dummy number "1234"
3. It is expected that the string `EL1234` is send to VIES, right now `GR1234` is getting send

In frontend:
1. First in admin, make sure these configurations are setup in Stores > Configuration > Customers > Customer Configuration > Create New Account Options:
    - Enable Automatic Assignment to Customer Group => Yes
    - Tax Calculation Based On => Yes
    - Group for Valid VAT ID - Domestic => General (doesn't really matter in this case)
    - Group for Valid VAT ID - Intra-Union => General (doesn't really matter in this case)
    - Group for Invalid VAT ID => General (doesn't really matter in this case)
    - Validation Error Group => General (doesn't really matter in this case)
    - Validate on Each Transaction => Yes
    - Show VAT Number on Storefront => Yes
2. Flush caches
3. On frontend, create a new account
4. While logged in, create a new address and select Greece as a country, and enter some dummy VAT number "1234"
5. It is expected that the string `EL1234` is send to VIES, right now `GR1234` is getting send

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
