### PR TITLE
[Backport] Fix: Attribute Option with zero at the beginning does not work if there is already option with the same number without the zero [REST API]

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/OptionManagement.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/OptionManagement.php
@@ -47,7 +47,7 @@ class OptionManagement implements \Magento\Catalog\Api\ProductAttributeOptionMan
                 /** @var \Magento\Eav\Api\Data\AttributeOptionInterface $attributeOption */
                     $attributeOption = $attributeOption->getLabel();
             });
-            if (in_array($option->getLabel(), $currentOptions)) {
+            if (in_array($option->getLabel(), $currentOptions, true)) {
                 return false;
             }
         }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19451
### Description
Fix: Attribute Option with zero at the beginning does not work if there is already option with the same number without the zero

### Fixed Issues
1. magento/magento2#19436: Attribute Option with zero at the bigining does not work if there is already option with the same number without the zero (REST API)

### Manual testing scenarios
1. Create an attribute (select or multiselect) from the backend (example: attribute_code = brand_number)
2. add new Option to this attribute from the backend (12345)
3. Add new Option to this attribute by the REST API (endpoint : /V1/products/attributes/brand_number/options), json = {"option":{"label":"012345"}}
4. expected result to have two options (12345 and 012345).

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
