### PR TITLE
issue fixed #20563 Go to shipping information, Update qty & Addresses…

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Multishipping/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Multishipping/web/css/source/_module.less
@@ -374,7 +374,7 @@
                 text-align: right;
 
                 .action {
-                    margin-left: @indent__s;
+                    margin-left: 0;
 
                     &.back {
                         display: block;
@@ -494,6 +494,14 @@
 
         .logo {
             margin-left: @indent__xl;
+        }
+    }
+    
+    .multicheckout { 
+        .actions-toolbar {
+            > .primary {
+                margin-right: 0;
+            }
         }
     }
 }


### PR DESCRIPTION
… and Enter a new address button Not aligned from left and right in 767px screen size

issue fixed #20563 Go to shipping information, Update qty & Addresses and Enter a new address button Not aligned from left and right in 767px screen size


### Description (*)
Go to shipping information, Update qty & Addresses and Enter a new address button Not aligned from left and right in 767px screen size 


### Manual testing scenarios (*)
Step 1: Open Frontend
Step 2: Login add existing customer (Should save a shipping address)
Step 2: add to cart any product 
Step 3: go to cart page 
Step 4: Now click on **Check Out with Multiple Addresses** link from bellow corner of page 
Step 5: Now resize page to 767px window size 


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
