### PR TITLE
[Forwardport]Fixed bug, when exception occurred on order with coupons cancel, made by guest after creating of customer account.

### DIFF
--- a/app/code/Magento/Sales/Model/Order/CustomerAssignment.php
+++ b/app/code/Magento/Sales/Model/Order/CustomerAssignment.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Model\Order;
+
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Framework\Event\ManagerInterface;
+
+class CustomerAssignment
+{
+    /**
+     * @var ManagerInterface
+     */
+    private $eventManager;
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * CustomerAssignment constructor.
+     *
+     * @param ManagerInterface $eventManager
+     * @param OrderRepositoryInterface $orderRepository
+     */
+    public function __construct(
+        ManagerInterface $eventManager,
+        OrderRepositoryInterface $orderRepository
+    ) {
+        $this->eventManager = $eventManager;
+        $this->orderRepository = $orderRepository;
+    }
+
+    /**
+     * @param OrderInterface $order
+     * @param CustomerInterface $customer
+     */
+    public function execute(OrderInterface $order, CustomerInterface $customer)/*: void*/
+    {
+        $order->setCustomerId($customer->getId());
+        $order->setCustomerIsGuest(false);
+        $this->orderRepository->save($order);
+
+        $this->eventManager->dispatch(
+            'sales_order_customer_assign_after', [
+                'order'     => $order,
+                'customer'  => $customer
+            ]
+        );
+    }
+}

--- a/app/code/Magento/Sales/Observer/AssignOrderToCustomerObserver.php
+++ b/app/code/Magento/Sales/Observer/AssignOrderToCustomerObserver.php
@@ -11,6 +11,7 @@ use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order\CustomerAssignment;
 
 /**
  * Assign order to customer created after issuing guest order.
@@ -23,11 +24,22 @@ class AssignOrderToCustomerObserver implements ObserverInterface
     private $orderRepository;
 
     /**
-     * @param OrderRepositoryInterface $orderRepository
+     * @var CustomerAssignment
      */
-    public function __construct(OrderRepositoryInterface $orderRepository)
-    {
+    private $assignmentService;
+
+    /**
+     * AssignOrderToCustomerObserver constructor.
+     *
+     * @param OrderRepositoryInterface $orderRepository
+     * @param CustomerAssignment $assignmentService
+     */
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        CustomerAssignment $assignmentService
+    ) {
         $this->orderRepository = $orderRepository;
+        $this->assignmentService = $assignmentService;
     }
 
     /**
@@ -43,11 +55,8 @@ class AssignOrderToCustomerObserver implements ObserverInterface
         if (array_key_exists('__sales_assign_order_id', $delegateData)) {
             $orderId = $delegateData['__sales_assign_order_id'];
             $order = $this->orderRepository->get($orderId);
-            if (!$order->getCustomerId()) {
-                //if customer ID wasn't already assigned then assigning.
-                $order->setCustomerId($customer->getId());
-                $order->setCustomerIsGuest(0);
-                $this->orderRepository->save($order);
+            if (!$order->getCustomerId() && $customer->getId()) {
+                $this->assignmentService->execute($order, $customer);
             }
         }
     }

--- a/app/code/Magento/Sales/Test/Unit/Observer/AssignOrderToCustomerObserverTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Observer/AssignOrderToCustomerObserverTest.php
@@ -12,6 +12,7 @@ use Magento\Framework\Event;
 use Magento\Framework\Event\Observer;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order\CustomerAssignment;
 use Magento\Sales\Observer\AssignOrderToCustomerObserver;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
@@ -27,6 +28,9 @@ class AssignOrderToCustomerObserverTest extends TestCase
     /** @var OrderRepositoryInterface|PHPUnit_Framework_MockObject_MockObject */
     protected $orderRepositoryMock;
 
+    /** @var CustomerAssignment | PHPUnit_Framework_MockObject_MockObject */
+    protected $assignmentMock;
+
     /**
      * Set Up
      */
@@ -35,7 +39,12 @@ class AssignOrderToCustomerObserverTest extends TestCase
         $this->orderRepositoryMock = $this->getMockBuilder(OrderRepositoryInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->sut = new AssignOrderToCustomerObserver($this->orderRepositoryMock);
+
+        $this->assignmentMock =  $this->getMockBuilder(CustomerAssignment::class)
+        ->disableOriginalConstructor()
+        ->getMock();
+
+        $this->sut = new AssignOrderToCustomerObserver($this->orderRepositoryMock, $this->assignmentMock);
     }
 
     /**
@@ -69,13 +78,14 @@ class AssignOrderToCustomerObserverTest extends TestCase
         $orderMock->expects($this->once())->method('getCustomerId')->willReturn($customerId);
         $this->orderRepositoryMock->expects($this->once())->method('get')->with($orderId)
             ->willReturn($orderMock);
-        if (!$customerId) {
-            $this->orderRepositoryMock->expects($this->once())->method('save')->with($orderMock);
+
+        if ($customerId) {
+            $this->assignmentMock->expects($this->once())->method('execute')->with($orderMock, $customerMock);
             $this->sut->execute($observerMock);
-            return ;
+            return;
         }
 
-        $this->orderRepositoryMock->expects($this->never())->method('save')->with($orderMock);
+        $this->assignmentMock->expects($this->never())->method('execute');
         $this->sut->execute($observerMock);
     }
 

--- a/app/code/Magento/SalesRule/Observer/AssignCouponDataAfterOrderCustomerAssignObserver.php
+++ b/app/code/Magento/SalesRule/Observer/AssignCouponDataAfterOrderCustomerAssignObserver.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\SalesRule\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\SalesRule\Model\Coupon\UpdateCouponUsages;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Framework\Event\ObserverInterface;
+
+class AssignCouponDataAfterOrderCustomerAssignObserver implements ObserverInterface
+{
+    const EVENT_KEY_CUSTOMER = 'customer';
+
+    const EVENT_KEY_ORDER    = 'order';
+
+    /**
+     * @var UpdateCouponUsages
+     */
+    private $updateCouponUsages;
+
+    /**
+     * AssignCouponDataAfterOrderCustomerAssign constructor.
+     *
+     * @param UpdateCouponUsages $updateCouponUsages
+     */
+    public function __construct(
+        UpdateCouponUsages $updateCouponUsages
+    ) {
+        $this->updateCouponUsages = $updateCouponUsages;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Observer $observer)
+    {
+        $event = $observer->getEvent();
+        /** @var OrderInterface $order */
+        $order = $event->getData(self::EVENT_KEY_ORDER);
+
+        if ($order->getCustomerId()) {
+            $this->updateCouponUsages->execute($order, true);
+        }
+    }
+}

--- a/app/code/Magento/SalesRule/etc/events.xml
+++ b/app/code/Magento/SalesRule/etc/events.xml
@@ -27,4 +27,7 @@
     <event name="magento_salesrule_api_data_ruleinterface_load_after">
         <observer name="legacy_model_load" instance="Magento\Framework\EntityManager\Observer\AfterEntityLoad" />
     </event>
+    <event name="sales_order_customer_assign_after">
+        <observer name="sales_order_assign_customer_after" instance="Magento\SalesRule\Observer\AssignCouponDataAfterOrderCustomerAssignObserver" />
+    </event>
 </config>

--- a/dev/tests/integration/testsuite/Magento/SalesRule/Model/Observer/AssignCouponDataAfterOrderCustomerAssignTest.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/Model/Observer/AssignCouponDataAfterOrderCustomerAssignTest.php
@@ -1,0 +1,269 @@
+<?php
+
+use Magento\Sales\Model\Order;
+
+use Magento\Customer\Model\GroupManagement;
+use Magento\SalesRule\Api\CouponRepositoryInterface;
+use Magento\SalesRule\Model\Coupon;
+use Magento\SalesRule\Model\Rule;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Customer\Model\Data\Customer;
+
+
+class AssignCouponDataAfterOrderCustomerAssignTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Quote\Api\GuestCartManagementInterface
+     */
+    private $assignCouponToCustomerObserver;
+
+    /**
+     * @var Magento\Sales\Model\OrderRepository
+     */
+    private $orderRepository;
+
+    /**
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var \Magento\Framework\Event\ManagerInterface
+     */
+    protected $eventManager;
+
+    /**
+     * @var Magento\Customer\Api\CustomerRepositoryInterface
+     */
+    private $customerRepository;
+
+    /**
+     * @var Order\OrderCustomerDelegate
+     */
+    private $delegateCustomerService;
+
+    /**
+     * @var Magento\SalesRule\Model\Rule\CustomerFactory
+     */
+    private $ruleCustomerFactory;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->eventManager = $this->createMock(\Magento\Framework\Event\ManagerInterface::class);
+        $this->orderRepository = $this->objectManager->get(Magento\Sales\Model\OrderRepository::class);
+        $this->delegateCustomerService = $this->objectManager->get(Order\OrderCustomerDelegate::class);
+        $this->customerRepository = $this->objectManager->get(\Magento\Customer\Api\CustomerRepositoryInterface::class);
+        $this->ruleCustomerFactory =  $this->objectManager->get(Magento\SalesRule\Model\Rule\CustomerFactory::class);;
+        $this->assignCouponToCustomerObserver = $this->objectManager->get(
+            Magento\SalesRule\Observer\AssignCouponDataAfterOrderCustomerAssignObserver::class
+        );
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testCouponDataHasBeenAssignedTest()
+    {
+        $rule = $this->prepareSalesRule();
+        $coupon = $this->attachSalesruleCoupon($rule);
+
+        $order  = $this->makeOrderWithCouponAsGuest($coupon);
+        $this->delegateOrderToBeAssigned($order);
+
+        $customer = $this->registerNewCustomer();
+        $ruleCustomer = $this->getSalesruleCustomerUsage($customer, $rule);
+
+        // Assert, that rule customer model has been created for specific customer
+        $this->assertEquals(
+            $ruleCustomer->getCustomerId(),
+            $customer->getId()
+        );
+
+        // Assert, that customer has increased coupon usage of specific rule
+        $this->assertEquals(
+            1,
+            $ruleCustomer->getTimesUsed()
+        );
+    }
+
+    /**
+     * @magentoAppIsolation enabled
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testOrderCancelingDecreasesCouponUsages()
+    {
+        $rule = $this->prepareSalesRule();
+        $coupon = $this->attachSalesruleCoupon($rule);
+
+        $order  = $this->makeOrderWithCouponAsGuest($coupon);
+        $this->delegateOrderToBeAssigned($order);
+
+        $customer = $this->registerNewCustomer();
+
+        $order->setCustomerId($customer->getId());
+        $this->processOrder($order);
+
+        // Should not throw exception as bux is fixed now
+        $this->cancelOrder($order);
+        $ruleCustomer = $this->getSalesruleCustomerUsage($customer, $rule);
+
+        // Assert, that rule customer model has been created for specific customer
+        $this->assertEquals(
+            $ruleCustomer->getCustomerId(),
+            $customer->getId()
+        );
+
+        // Assert, that customer has increased coupon usage of specific rule
+        $this->assertEquals(
+            0,
+            $ruleCustomer->getTimesUsed()
+        );
+
+    }
+
+    /**
+     * @param Order $order
+     * @return \Magento\Sales\Api\Data\OrderInterface
+     */
+    private function processOrder(Order $order)
+    {
+        $order->setState(\Magento\Sales\Model\Order::STATE_PROCESSING);
+        $order->setStatus(\Magento\Sales\Model\Order::STATE_PROCESSING);
+        return $this->orderRepository->save($order);
+    }
+
+    /**
+     * @param Order $order
+     */
+    private function cancelOrder(Order $order)
+    {
+        $order->cancel();
+    }
+
+    /**
+     * @param Customer $customer
+     * @param Rule $rule
+     * @return Rule\Customer
+     */
+    private function getSalesruleCustomerUsage(Customer $customer, Rule $rule) : Magento\SalesRule\Model\Rule\Customer
+    {
+        $ruleCustomer = $this->ruleCustomerFactory->create();
+        return $ruleCustomer->loadByCustomerRule($customer->getId(), $rule->getRuleId());
+    }
+
+    /**
+     * @return Rule
+     */
+    private function prepareSalesRule() : Rule
+    {
+        /** @var Rule $salesRule */
+        $salesRule = $this->objectManager->create(Rule::class);
+        $salesRule->setData(
+            [
+                'name' => '15$ fixed discount on whole cart',
+                'is_active' => 1,
+                'customer_group_ids' => [GroupManagement::NOT_LOGGED_IN_ID],
+                'coupon_type' => Rule::COUPON_TYPE_SPECIFIC,
+                'conditions' => [
+                    [
+                        'type' => \Magento\SalesRule\Model\Rule\Condition\Address::class,
+                        'attribute' => 'base_subtotal',
+                        'operator' => '>',
+                        'value' => 45,
+                    ],
+                ],
+                'simple_action' => Rule::CART_FIXED_ACTION,
+                'discount_amount' => 15,
+                'discount_step' => 0,
+                'stop_rules_processing' => 1,
+                'website_ids' => [
+                    $this->objectManager->get(StoreManagerInterface::class)->getWebsite()->getId(),
+                ],
+            ]
+        );
+        $this->objectManager->get(
+            \Magento\SalesRule\Model\ResourceModel\Rule::class
+        )->save($salesRule);
+
+        return $salesRule;
+    }
+
+    /**
+     * @param Rule $salesRule
+     * @return Coupon
+     */
+    private function attachSalesruleCoupon(Rule $salesRule) : Coupon
+    {
+        $coupon = $this->objectManager->create(Coupon::class);
+        $coupon->setRuleId($salesRule->getId())
+            ->setCode('CART_FIXED_DISCOUNT_15')
+            ->setType(0);
+
+        $this->objectManager->get(CouponRepositoryInterface::class)->save($coupon);
+
+        return $coupon;
+    }
+
+    /**
+     * @param Coupon $coupon
+     * @return Order
+     */
+    private function makeOrderWithCouponAsGuest(Coupon $coupon) : Order
+    {
+        $order = $this->objectManager->create(\Magento\Sales\Model\Order::class);
+        $order->loadByIncrementId('100000001')
+            ->setCustomerIsGuest(true)
+            ->setCouponCode($coupon->getCode())
+            ->setCreatedAt('2014-10-25 10:10:10')
+            ->setAppliedRuleIds($coupon->getRuleId())
+            ->save();
+
+        return $order;
+    }
+
+    /**
+     * @param Order $order
+     */
+    private function delegateOrderToBeAssigned(Order $order)
+    {
+        $this->delegateCustomerService->delegateNew($order->getId());
+    }
+
+    /**
+     * @return Customer
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\State\InputMismatchException
+     */
+    private function registerNewCustomer() : Customer
+    {
+        $customer = $this->objectManager->create(
+            \Magento\Customer\Api\Data\CustomerInterface::class
+        );
+
+        /** @var Magento\Customer\Api\Data\CustomerInterface $customer */
+        $customer->setWebsiteId(1)
+            ->setEmail('customer@example.com')
+            ->setGroupId(1)
+            ->setStoreId(1)
+            ->setPrefix('Mr.')
+            ->setFirstname('John')
+            ->setMiddlename('A')
+            ->setLastname('Smith')
+            ->setSuffix('Esq.')
+            ->setDefaultBilling(1)
+            ->setDefaultShipping(1)
+            ->setTaxvat('12')
+            ->setGender(0);
+
+        $customer = $this->customerRepository->save($customer, 'password');
+
+        return $customer;
+    }
+}
+


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/19423

### Description (*)
When customer do checkout as a guest using a valid coupon, he makes a new customer account.
During trying to cancel this order, admin does receive SQL exception:
`SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`mage`.`salesrule_customer`, ...`

Issue related to changes made: https://github.com/magento/magento2/issues/19230

### Fixed Issues (if relevant)

1. magento/magento2#19230 : I Can't Cancel Order

## Scenario
Actual problem exist in scenarious when sales rule, used by guest user (using coupon code), it doesn't trigger its coupon usage per customer update, because there is no customer.
After creating of new customer (using of _AccountDelegation_ action), Magento _AssignOrderToCustomerObserver_ using _customer_save_after_data_object_ event tries to assign to this customer order, that has been made previously. 
As a result, this _Magento\SalesRule\Model\Rule\Customer_ wasn't created for newly created customer, but normally it should. Furthermore, it should increase `time_used` attribute for new customer.
As a result, during trying to cancel this type of orders, sales rule plugin is trying to decrease amount of usages for given customer. Actually, method which is responsible for it is not good enough, so it allows to save empty data (empty instert), which provokes cascade adding by foreign keys. As result, admin cannot cancel this order and get SQL error.

## Fixing
So, obviously we have to create this entity on customer registration, when Magento assigns order to related new customer.

As you can see, all data we need is set inside of _AssignOrderToCustomerObserver_ and we cannot subscribe on same event, because only this observer (Sales) knows about order and customer, that its going to be assigned.
So, not to mixing contexts (Sales and SalesRule, because assigning of coupon and sales usages happens using _Magento\SalesRule\Model\Coupon\UpdateCouponUsages_), I decided to make few extending/improvements:
1) Remove business logic from observer to related service, which will be responsible for delegating orders to customers.
2) Fire up event event `sales_order_customer_assign_after` to let another module knows about certain customer has been attached to order.
3) Catch in SalesRule module to create related `salerule_customer` model and increase usage `time_used` value to 1.
4) Write functional testing, that represent all the flow.

So, this PR not only fixes exception on canceling orders, that has been made by guest before registering new account. But also fixes bug, when sales rule usage has not been increased on the same scenario.


### Manual testing scenarios (*)
Checkout as a guest using a valid coupon
After placing the order, register an account using the create account button on the order confirmation page.
Login to the admin
Make sure to get the order to a processing state.
Try to cancel the order
Order is canceled correctly
Sales rule usage for newly created customer is made and set as 1

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
