### PR TITLE
fixes-customer-information-wishlist-bundle-product-options-alignment

### DIFF
--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/radio.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/radio.phtml
@@ -19,11 +19,13 @@
     <div class="control admin__field-control">
         <div class="nested<?php if ($_option->getDecoratedIsLast()):?> last<?php endif; ?>">
         <?php if ($block->showSingle()): ?>
-            <?= /* @escapeNotVerified */ $block->getSelectionTitlePrice($_selections[0]) ?>
-            <input type="hidden"
-                   name="bundle_option[<?= /* @escapeNotVerified */ $_option->getId() ?>]"
-                   value="<?= /* @escapeNotVerified */ $_selections[0]->getSelectionId() ?>"
-                   price="<?= /* @escapeNotVerified */ $block->getSelectionPrice($_selections[0]) ?>" />
+            <div class="field choice admin__field admin__field-option">
+                <?= /* @escapeNotVerified */ $block->getSelectionTitlePrice($_selections[0]) ?>
+                <input type="hidden"
+                       name="bundle_option[<?= /* @escapeNotVerified */ $_option->getId() ?>]"
+                       value="<?= /* @escapeNotVerified */ $_selections[0]->getSelectionId() ?>"
+                       price="<?= /* @escapeNotVerified */ $block->getSelectionPrice($_selections[0]) ?>" />
+            </div>
         <?php else:?>
             <?php if (!$_option->getRequired()): ?>
                 <div class="field choice admin__field admin__field-option">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
admin customer information wishlist bundle product options alignment issue while editing
Magento 2.3.0



### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to admin
2. In Customers >>All customers>> edit customer>>click on wishlist
3. Action Configure for bundle product added into wishlist

### Expected result (*)
![2019-01-24_15-52_p d - customers - customers](https://user-images.githubusercontent.com/18118695/51672726-3304a580-1ff2-11e9-84de-1484f56f7c0f.jpg)

### Actual result (*)
![2019-01-24_15-53_p d - customers - customers](https://user-images.githubusercontent.com/18118695/51672765-4879cf80-1ff2-11e9-92f3-adf80a21a43b.jpg)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
