### PR TITLE
Added original exception as the cause to the new exception on product delete error

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -644,7 +644,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
             unset($this->instancesById[$product->getId()]);
             $this->resourceModel->delete($product);
         } catch (ValidatorException $e) {
-            throw new CouldNotSaveException(__($e->getMessage()));
+            throw new CouldNotSaveException(__($e->getMessage()), $e);
         } catch (\Exception $e) {
             throw new \Magento\Framework\Exception\StateException(
                 __('The "%1" product couldn\'t be removed.', $sku),

--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -647,7 +647,8 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
             throw new CouldNotSaveException(__($e->getMessage()));
         } catch (\Exception $e) {
             throw new \Magento\Framework\Exception\StateException(
-                __('The "%1" product couldn\'t be removed.', $sku)
+                __('The "%1" product couldn\'t be removed.', $sku),
+                $e
             );
         }
         $this->removeProductFromLocalCache($sku);


### PR DESCRIPTION
### Description (*)
When Magento can't delete a product a new exception is thrown, but the original exception is not passed to the new exception as the original "cause"

### Fixed Issues (if relevant)
Just better error handling

### Manual testing scenarios (*)
Just better error handling

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
