### PR TITLE
Optimize snail_case replacement to PascalCase

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/GridOnly.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/GridOnly.php
@@ -1,12 +1,16 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Catalog\Controller\Adminhtml\Product;
 
-class GridOnly extends \Magento\Catalog\Controller\Adminhtml\Product
+use Magento\Framework\App\Action\HttpGetActionInterface;
+
+/**
+ * Get specified tab grid controller.
+ */
+class GridOnly extends \Magento\Catalog\Controller\Adminhtml\Product implements HttpGetActionInterface
 {
     /**
      * @var \Magento\Framework\Controller\Result\RawFactory

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/GridOnly.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/GridOnly.php
@@ -47,7 +47,7 @@ class GridOnly extends \Magento\Catalog\Controller\Adminhtml\Product
         $this->productBuilder->build($this->getRequest());
 
         $block = $this->getRequest()->getParam('gridOnlyBlock');
-        $blockClassSuffix = str_replace(' ', '_', ucwords(str_replace('_', ' ', $block)));
+        $blockClassSuffix = ucwords($block, '_');
 
         /** @var \Magento\Framework\Controller\Result\Raw $resultRaw */
         $resultRaw = $this->resultRawFactory->create();

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/CurrentUrlRewritesRegeneratorTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/CurrentUrlRewritesRegeneratorTest.php
@@ -252,7 +252,7 @@ class CurrentUrlRewritesRegeneratorTest extends \PHPUnit\Framework\TestCase
                 ->disableOriginalConstructor()->getMock();
             foreach ($urlRewrite as $key => $value) {
                 $url->expects($this->any())
-                    ->method('get' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key))))
+                    ->method('get' . str_replace('_', '', ucwords($key, '_')))
                     ->will($this->returnValue($value));
             }
             $rewrites[] = $url;

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Product/CurrentUrlRewritesRegeneratorTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Product/CurrentUrlRewritesRegeneratorTest.php
@@ -294,7 +294,7 @@ class CurrentUrlRewritesRegeneratorTest extends \PHPUnit\Framework\TestCase
                 ->disableOriginalConstructor()->getMock();
             foreach ($urlRewrite as $key => $value) {
                 $url->expects($this->any())
-                    ->method('get' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key))))
+                    ->method('get' . str_replace('_', '', ucwords($key, '_')))
                     ->will($this->returnValue($value));
             }
             $rewrites[] = $url;

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/AfterImportDataObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/AfterImportDataObserverTest.php
@@ -694,7 +694,7 @@ class AfterImportDataObserverTest extends \PHPUnit\Framework\TestCase
                 ->disableOriginalConstructor()->getMock();
             foreach ($urlRewrite as $key => $value) {
                 $url->expects($this->any())
-                    ->method('get' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key))))
+                    ->method('get' . str_replace('_', '', ucwords($key, '_')))
                     ->will($this->returnValue($value));
             }
             $rewrites[] = $url;

--- a/app/code/Magento/Tax/Test/Unit/Model/Calculation/RateRepositoryTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/Calculation/RateRepositoryTest.php
@@ -252,7 +252,7 @@ class RateRepositoryTest extends \PHPUnit\Framework\TestCase
         foreach ($taxRateData as $key => $value) {
             // convert key from snake case to upper case
             $taxRateMock->expects($this->any())
-                ->method('get' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key))))
+                ->method('get' . str_replace('_', '', ucwords($key, '_')))
                 ->will($this->returnValue($value));
         }
 

--- a/app/code/Magento/Tax/Test/Unit/Model/Sales/Total/Quote/ShippingTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/Sales/Total/Quote/ShippingTest.php
@@ -133,7 +133,7 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
         $getterValueMap = [];
         $methods = ['__wakeup'];
         foreach ($objectState as $key => $value) {
-            $getterName = 'get' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key)));
+            $getterName = 'get' . str_replace('_', '', ucwords($key, '_'));
             $getterValueMap[$getterName] = $value;
             $methods[] = $getterName;
         }

--- a/dev/tests/functional/tests/app/Magento/CatalogSearch/Test/Fixture/CatalogSearchQuery/QueryText.php
+++ b/dev/tests/functional/tests/app/Magento/CatalogSearch/Test/Fixture/CatalogSearchQuery/QueryText.php
@@ -61,7 +61,7 @@ class QueryText extends DataSource
                 $searchValue = isset($productData[2]) ? $productData[2] : $productData[1];
                 if ($this->data === null) {
                     if ($product->hasData($searchValue)) {
-                        $getProperty = 'get' . str_replace(' ', '', ucwords(str_replace('_', ' ', $searchValue)));
+                        $getProperty = 'get' . str_replace('_', '', ucwords($searchValue, '_'));
                         $this->data = $product->$getProperty();
                     } else {
                         $this->data = $searchValue;

--- a/dev/tests/functional/tests/app/Magento/Widget/Test/Handler/Widget/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Widget/Test/Handler/Widget/Curl.php
@@ -172,7 +172,7 @@ class Curl extends AbstractCurl
         $widgetInstances = [];
         foreach ($data['widget_instance'] as $key => $widgetInstance) {
             $pageGroup = $widgetInstance['page_group'];
-            $method = 'prepare' . str_replace(' ', '', ucwords(str_replace('_', ' ', $pageGroup))) . 'Group';
+            $method = 'prepare' . str_replace('_', '', ucwords($pageGroup, '_')) . 'Group';
             if (!method_exists(__CLASS__, $method)) {
                 throw new \Exception('Method for prepare page group "' . $method . '" is not exist.');
             }

--- a/lib/internal/Magento/Framework/Api/SimpleDataObjectConverter.php
+++ b/lib/internal/Magento/Framework/Api/SimpleDataObjectConverter.php
@@ -58,7 +58,7 @@ class SimpleDataObjectConverter
             if (is_array($fieldValue) && !$this->_isSimpleSequentialArray($fieldValue)) {
                 $fieldValue = $this->convertKeysToCamelCase($fieldValue);
             }
-            $fieldName = lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $fieldName))));
+            $fieldName = lcfirst(str_replace('_', '', ucwords($fieldName, '_')));
             $response[$fieldName] = $fieldValue;
         }
         return $response;
@@ -148,7 +148,7 @@ class SimpleDataObjectConverter
      */
     public static function snakeCaseToUpperCamelCase($input)
     {
-        return str_replace(' ', '', ucwords(str_replace('_', ' ', $input)));
+        return str_replace('_', '', ucwords($input, '_'));
     }
 
     /**

--- a/lib/internal/Magento/Framework/Code/NameBuilder.php
+++ b/lib/internal/Magento/Framework/Code/NameBuilder.php
@@ -23,7 +23,7 @@ class NameBuilder
         $separator = '\\';
         $string = join($separator, $parts);
         $string = str_replace('_', $separator, $string);
-        $className = str_replace(' ', $separator, ucwords(str_replace($separator, ' ', $string)));
+        $className = ucwords($string, $separator);
         return $className;
     }
 }

--- a/lib/internal/Magento/Framework/DataObject.php
+++ b/lib/internal/Magento/Framework/DataObject.php
@@ -64,8 +64,8 @@ class DataObject implements \ArrayAccess
      *
      * If $key is an array, it will overwrite all the data in the object.
      *
-     * @param string|array  $key
-     * @param mixed         $value
+     * @param string|array $key
+     * @param mixed $value
      * @return $this
      */
     public function setData($key, $value = null)
@@ -111,7 +111,7 @@ class DataObject implements \ArrayAccess
      * and retrieve corresponding member. If data is the string - it will be explode
      * by new line character and converted to array.
      *
-     * @param string     $key
+     * @param string $key
      * @param string|int $index
      * @return mixed
      */
@@ -222,6 +222,7 @@ class DataObject implements \ArrayAccess
 
     /**
      * If $key is empty, checks whether there's any data in the object
+     *
      * Otherwise checks if the specified attribute is set.
      *
      * @param string $key
@@ -272,8 +273,8 @@ class DataObject implements \ArrayAccess
     /**
      * Convert object data into XML string
      *
-     * @param array   $keys array of keys that must be represented
-     * @param string  $rootName root node name
+     * @param array $keys array of keys that must be represented
+     * @param string $rootName root node name
      * @param bool $addOpenTag flag that allow to add initial xml node
      * @param bool $addCdata flag that require wrap all values in CDATA
      * @return string
@@ -436,7 +437,7 @@ class DataObject implements \ArrayAccess
      *
      * Example: key1="value1" key2="value2" ...
      *
-     * @param   array  $keys array of accepted keys
+     * @param   array $keys array of accepted keys
      * @param   string $valueSeparator separator between key and value
      * @param   string $fieldSeparator separator between key/value pairs
      * @param   string $quote quoting sign

--- a/lib/internal/Magento/Framework/DataObject.php
+++ b/lib/internal/Magento/Framework/DataObject.php
@@ -202,7 +202,7 @@ class DataObject implements \ArrayAccess
      */
     public function setDataUsingMethod($key, $args = [])
     {
-        $method = 'set' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key)));
+        $method = 'set' . str_replace('_', '', ucwords($key, '_'));
         $this->{$method}($args);
         return $this;
     }
@@ -216,7 +216,7 @@ class DataObject implements \ArrayAccess
      */
     public function getDataUsingMethod($key, $args = null)
     {
-        $method = 'get' . str_replace(' ', '', ucwords(str_replace('_', ' ', $key)));
+        $method = 'get' . str_replace('_', '', ucwords($key, '_'));
         return $this->{$method}($args);
     }
 

--- a/lib/internal/Magento/Framework/DataObject/Copy.php
+++ b/lib/internal/Magento/Framework/DataObject/Copy.php
@@ -239,7 +239,7 @@ class Copy
      */
     protected function getAttributeValueFromExtensibleDataObject($source, $code)
     {
-        $method = 'get' . str_replace(' ', '', ucwords(str_replace('_', ' ', $code)));
+        $method = 'get' . str_replace('_', '', ucwords($code, '_'));
 
         $methodExists = method_exists($source, $method);
         if ($methodExists == true) {
@@ -273,7 +273,7 @@ class Copy
      */
     protected function setAttributeValueFromExtensibleDataObject($target, $code, $value)
     {
-        $method = 'set' . str_replace(' ', '', ucwords(str_replace('_', ' ', $code)));
+        $method = 'set' . str_replace('_', '', ucwords($code, '_'));
 
         $methodExists = method_exists($target, $method);
         if ($methodExists == true) {

--- a/lib/internal/Magento/Framework/Module/PackageInfo.php
+++ b/lib/internal/Magento/Framework/Module/PackageInfo.php
@@ -8,8 +8,9 @@ namespace Magento\Framework\Module;
 use Magento\Framework\Component\ComponentRegistrar;
 
 /**
- * Provide information of dependencies and conflicts in composer.json files, mapping of package name to module name,
- * and mapping of module name to package version
+ * Provide information of dependencies and conflicts in composer.json files.
+ *
+ * Mapping of package name to module name, and mapping of module name to package version.
  */
 class PackageInfo
 {

--- a/lib/internal/Magento/Framework/Module/PackageInfo.php
+++ b/lib/internal/Magento/Framework/Module/PackageInfo.php
@@ -176,8 +176,7 @@ class PackageInfo
     protected function convertPackageNameToModuleName($packageName)
     {
         $moduleName = str_replace('magento/module-', '', $packageName);
-        $moduleName = str_replace('-', ' ', $moduleName);
-        $moduleName = str_replace(' ', '', ucwords($moduleName));
+        $moduleName = str_replace('-', '', ucwords($moduleName, '-'));
 
         return 'Magento_' . $moduleName;
     }


### PR DESCRIPTION
### Description (*)
I found more efficient way to transform `snail_case` to `PascalCase` with usage of native `ucwords()` second attribute.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
