### PR TITLE
20434 consider url rewrite when change product visibility attribute

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Observer/ProcessUrlRewriteOnChangeProductVisibilityObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/ProcessUrlRewriteOnChangeProductVisibilityObserver.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogUrlRewrite\Observer;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\CatalogUrlRewrite\Model\ProductUrlPathGenerator;
+use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
+use Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException;
+use Magento\UrlRewrite\Model\UrlPersistInterface;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Search\Adapter\Mysql\Filter\Builder\Term;
+
+/**
+ * Class ProductProcessUrlRewriteSavingObserver
+ */
+class ProcessUrlRewriteOnChangeProductVisibilityObserver implements ObserverInterface
+{
+    /**
+     * @var CollectionFactory
+     */
+    private $productCollectionFactory;
+
+    /**
+     * @var ProductUrlRewriteGenerator
+     */
+    private $productUrlRewriteGenerator;
+
+    /**
+     * @var UrlPersistInterface
+     */
+    private $urlPersist;
+
+    /**
+     * @var ProductUrlPathGenerator
+     */
+    private $productUrlPathGenerator;
+
+    /**
+     * @param CollectionFactory $collectionFactory
+     * @param ProductUrlRewriteGenerator $productUrlRewriteGenerator
+     * @param UrlPersistInterface $urlPersist
+     * @param ProductUrlPathGenerator|null $productUrlPathGenerator
+     */
+    public function __construct(
+        CollectionFactory $collectionFactory,
+        ProductUrlRewriteGenerator $productUrlRewriteGenerator,
+        UrlPersistInterface $urlPersist,
+        ProductUrlPathGenerator $productUrlPathGenerator
+    ) {
+        $this->productCollectionFactory = $collectionFactory;
+        $this->productUrlRewriteGenerator = $productUrlRewriteGenerator;
+        $this->urlPersist = $urlPersist;
+        $this->productUrlPathGenerator = $productUrlPathGenerator;
+    }
+
+    /**
+     * Generate urls for UrlRewrites and save it in storage
+     *
+     * @param Observer $observer
+     * @return array
+     * @throws UrlAlreadyExistsException
+     */
+    public function execute(Observer $observer)
+    {
+        $event = $observer->getEvent();
+        $attrData = $event->getAttributesData();
+        $productIds = $event->getProductIds();
+        $storeId = $event->getStoreId();
+
+        $visibility = $attrData[ProductInterface::VISIBILITY] ?? null;
+
+        if (!$visibility) {
+            return [$attrData, $productIds, $storeId];
+        }
+
+        $productCollection = $this->productCollectionFactory->create();
+        $productCollection->addAttributeToSelect(ProductInterface::VISIBILITY);
+        $productCollection->addAttributeToSelect('url_key');
+        $productCollection->addFieldToFilter(
+            'entity_id',
+            [Term::CONDITION_OPERATOR_IN => array_unique($productIds)]
+        );
+
+        foreach ($productCollection as $product) {
+            if ($visibility == Visibility::VISIBILITY_NOT_VISIBLE) {
+                $this->urlPersist->deleteByData(
+                    [
+                        UrlRewrite::ENTITY_ID => $product->getId(),
+                        UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
+                    ]
+                );
+            } elseif ($visibility !== Visibility::VISIBILITY_NOT_VISIBLE) {
+                $product->setVisibility($visibility);
+                $productUrlPathGenerator = $this->productUrlPathGenerator->getUrlPath($product);
+                $productUrlRewriteGenerator = $this->productUrlRewriteGenerator->generate($product);
+                $product->unsUrlPath();
+                $product->setUrlPath($productUrlPathGenerator);
+                $this->urlPersist->replace($productUrlRewriteGenerator);
+            }
+        }
+
+        return [$attrData, $productIds, $storeId];
+    }
+}

--- a/app/code/Magento/CatalogUrlRewrite/Observer/ProcessUrlRewriteOnChangeProductVisibilityObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/ProcessUrlRewriteOnChangeProductVisibilityObserver.php
@@ -32,7 +32,7 @@ class ProcessUrlRewriteOnChangeProductVisibilityObserver implements ObserverInte
     /**
      * @var ProductUrlRewriteGenerator
      */
-    private $productUrlRewriteGenerator;
+    private $urlRewriteGenerator;
 
     /**
      * @var UrlPersistInterface
@@ -42,24 +42,24 @@ class ProcessUrlRewriteOnChangeProductVisibilityObserver implements ObserverInte
     /**
      * @var ProductUrlPathGenerator
      */
-    private $productUrlPathGenerator;
+    private $urlPathGenerator;
 
     /**
      * @param CollectionFactory $collectionFactory
-     * @param ProductUrlRewriteGenerator $productUrlRewriteGenerator
+     * @param ProductUrlRewriteGenerator $urlRewriteGenerator
      * @param UrlPersistInterface $urlPersist
-     * @param ProductUrlPathGenerator|null $productUrlPathGenerator
+     * @param ProductUrlPathGenerator|null $urlPathGenerator
      */
     public function __construct(
         CollectionFactory $collectionFactory,
-        ProductUrlRewriteGenerator $productUrlRewriteGenerator,
+        ProductUrlRewriteGenerator $urlRewriteGenerator,
         UrlPersistInterface $urlPersist,
-        ProductUrlPathGenerator $productUrlPathGenerator
+        ProductUrlPathGenerator $urlPathGenerator
     ) {
         $this->productCollectionFactory = $collectionFactory;
-        $this->productUrlRewriteGenerator = $productUrlRewriteGenerator;
+        $this->urlRewriteGenerator = $urlRewriteGenerator;
         $this->urlPersist = $urlPersist;
-        $this->productUrlPathGenerator = $productUrlPathGenerator;
+        $this->urlPathGenerator = $urlPathGenerator;
     }
 
     /**
@@ -100,11 +100,11 @@ class ProcessUrlRewriteOnChangeProductVisibilityObserver implements ObserverInte
                 );
             } elseif ($visibility !== Visibility::VISIBILITY_NOT_VISIBLE) {
                 $product->setVisibility($visibility);
-                $productUrlPathGenerator = $this->productUrlPathGenerator->getUrlPath($product);
-                $productUrlRewriteGenerator = $this->productUrlRewriteGenerator->generate($product);
+                $productUrlPath = $this->urlPathGenerator->getUrlPath($product);
+                $productUrlRewrite = $this->urlRewriteGenerator->generate($product);
                 $product->unsUrlPath();
-                $product->setUrlPath($productUrlPathGenerator);
-                $this->urlPersist->replace($productUrlRewriteGenerator);
+                $product->setUrlPath($productUrlPath);
+                $this->urlPersist->replace($productUrlRewrite);
             }
         }
 

--- a/app/code/Magento/CatalogUrlRewrite/Observer/ProductProcessUrlRewriteSavingObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/ProductProcessUrlRewriteSavingObserver.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\CatalogUrlRewrite\Observer;
 
 use Magento\Catalog\Model\Product;

--- a/app/code/Magento/CatalogUrlRewrite/Observer/ProductProcessUrlRewriteSavingObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/ProductProcessUrlRewriteSavingObserver.php
@@ -40,25 +40,25 @@ class ProductProcessUrlRewriteSavingObserver implements ObserverInterface
     /**
      * @var CollectionFactory
      */
-    private $productCollectionFactory;
+    private $collectionFactory;
 
     /**
      * @param ProductUrlRewriteGenerator $productUrlRewriteGenerator
      * @param UrlPersistInterface $urlPersist
-     * @param ProductUrlPathGenerator|null $productUrlPathGenerator
-     * @param CollectionFactory|null $productCollectionFactory
+     * @param ProductUrlPathGenerator|null $urlPathGenerator
+     * @param CollectionFactory|null $collectionFactory
      */
     public function __construct(
         ProductUrlRewriteGenerator $productUrlRewriteGenerator,
         UrlPersistInterface $urlPersist,
-        ProductUrlPathGenerator $productUrlPathGenerator = null,
-        CollectionFactory $productCollectionFactory = null
+        ProductUrlPathGenerator $urlPathGenerator = null,
+        CollectionFactory $collectionFactory = null
     ) {
         $this->productUrlRewriteGenerator = $productUrlRewriteGenerator;
         $this->urlPersist = $urlPersist;
-        $this->productUrlPathGenerator = $productUrlPathGenerator ?: ObjectManager::getInstance()
+        $this->productUrlPathGenerator = $urlPathGenerator ?: ObjectManager::getInstance()
             ->get(ProductUrlPathGenerator::class);
-        $this->productCollectionFactory = $productCollectionFactory ?: ObjectManager::getInstance()
+        $this->collectionFactory = $collectionFactory ?: ObjectManager::getInstance()
             ->get(CollectionFactory::class);
     }
 
@@ -96,7 +96,7 @@ class ProductProcessUrlRewriteSavingObserver implements ObserverInterface
      */
     private function validateUrlKey(Product $product)
     {
-        $productCollection = $this->productCollectionFactory->create();
+        $productCollection = $this->collectionFactory->create();
         $productCollection->addFieldToFilter(
             'url_key',
             [Term::CONDITION_OPERATOR_EQUALS => $product->getUrlKey()]

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/ProductProcessUrlRewriteSavingObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/ProductProcessUrlRewriteSavingObserverTest.php
@@ -49,6 +49,21 @@ class ProductProcessUrlRewriteSavingObserverTest extends \PHPUnit\Framework\Test
     protected $objectManager;
 
     /**
+     * @var \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * @var \Magento\Catalog\Model\ResourceModel\Product\Collection
+     */
+    private $productCollection;
+
+    /**
+     * @var \Magento\Framework\DB\Select
+     */
+    private $select;
+
+    /**
      * @var \Magento\CatalogUrlRewrite\Observer\ProductProcessUrlRewriteSavingObserver
      */
     protected $model;
@@ -79,12 +94,28 @@ class ProductProcessUrlRewriteSavingObserverTest extends \PHPUnit\Framework\Test
         $this->productUrlRewriteGenerator->expects($this->any())
             ->method('generate')
             ->will($this->returnValue([3 => 'rewrite']));
+        $this->collectionFactory = $this->createMock(
+            \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory::class
+        );
+        $this->productCollection = $this->createMock(
+            \Magento\Catalog\Model\ResourceModel\Product\Collection::class
+        );
+        $this->select = $this->createMock(
+            \Magento\Framework\DB\Select::class
+        );
+        $this->collectionFactory->expects($this->any())
+            ->method('create')
+            ->will($this->returnValue($this->productCollection));
+        $this->productCollection->expects($this->any())
+            ->method('getSelect')
+            ->will($this->returnValue($this->select));
         $this->objectManager = new ObjectManager($this);
         $this->model = $this->objectManager->getObject(
             \Magento\CatalogUrlRewrite\Observer\ProductProcessUrlRewriteSavingObserver::class,
             [
                 'productUrlRewriteGenerator' => $this->productUrlRewriteGenerator,
-                'urlPersist' => $this->urlPersist
+                'urlPersist' => $this->urlPersist,
+                'collectionFactory' => $this->collectionFactory
             ]
         );
     }

--- a/app/code/Magento/CatalogUrlRewrite/etc/events.xml
+++ b/app/code/Magento/CatalogUrlRewrite/etc/events.xml
@@ -27,6 +27,9 @@
     <event name="catalog_product_save_after">
         <observer name="process_url_rewrite_saving" instance="Magento\CatalogUrlRewrite\Observer\ProductProcessUrlRewriteSavingObserver"/>
     </event>
+    <event name="catalog_product_attribute_update_before">
+        <observer name="process_url_rewrite_on_change_product_visibility" instance="Magento\CatalogUrlRewrite\Observer\ProcessUrlRewriteOnChangeProductVisibilityObserver"/>
+    </event>
     <event name="catalog_category_save_before">
         <observer name="category_url_path_autogeneration" instance="Magento\CatalogUrlRewrite\Observer\CategoryUrlPathAutogeneratorObserver"/>
     </event>

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/_files/product_configurable_not_available.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/_files/product_configurable_not_available.php
@@ -43,7 +43,7 @@ foreach ($options as $option) {
     $productSku = array_shift($productsSku);
     $product->setTypeId(Type::TYPE_SIMPLE)
         ->setAttributeSetId($attributeSetId)
-        ->setName('Configurable Option' . $option->getLabel())
+        ->setName('Configurable Option Not Available' . $option->getLabel())
         ->setSku('simple_not_avalilable_' . $productSku)
         ->setPrice(11)
         ->setTestConfigurable($option->getValue())

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/_files/configurable_products.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/_files/configurable_products.php
@@ -107,7 +107,7 @@ foreach ($options as $option) {
         ->setId($productId)
         ->setAttributeSetId($attributeSetId)
         ->setWebsiteIds([1])
-        ->setName('Configurable Option' . $option->getLabel())
+        ->setName('Configurable Option 12345' . $option->getLabel())
         ->setSku('simple_' . $productId)
         ->setPrice($productId)
         ->setTestConfigurable($option->getValue())


### PR DESCRIPTION
### Description (*)
Has been implemented observing the saving attribute via mass action, creating/deleting URL rewrites appropriately on the product visibility attribute change. Also, has been added URL key validation for the invisible product in ProductProcessUrlRewriteSavingObserver in order to avoid saving not unique URL key.
For more details see the issue (magento/magento2#20434).

### Fixed Issues (if relevant)
1. magento/magento2#20434: Product URL duplicate M2.2.6

### Manual testing scenarios (*)
Step 1. Create a product with the following URL (or any of your choice): « mon-produit-de-test » - Visible product (catalog, search)
Step 2. Create a second one with the same values but invisible individually then URL « mon-produit-de-test »

The Url Key exist exception should be thrown.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [] All new or changed code is covered with unit/integration tests (if applicable)
 - [] All automated tests passed successfully (all builds on Travis CI are green)
