### PR TITLE
Gift-option-message-overlap-edit-and-remove-button ::Gift option mess…

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_GiftMessage/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_GiftMessage/web/css/source/_module.less
@@ -246,6 +246,9 @@
     .gift-messages-order {
         margin-bottom: @indent__m;
     }
+    .gift-message-summary {
+        padding-right: 7rem;
+    }
 }
 
 //
@@ -280,10 +283,6 @@
             padding-left: 1.5rem;
             padding-right: 1.5rem;
         }
-    }
-
-    .gift-message-summary {
-        padding-right: 7rem;
     }
 
     //


### PR DESCRIPTION
…age overlap edit and remove button.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2 #20604: Gift option massage overlap edit and remove button


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login Admin
2. Go to Store >> Configuration >> sales >> sales >>gift option>> enable both settings
3. add product to cart.
4. add gift option massage.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
