### PR TITLE
magento/magento2#13227: not correct url in meta data on product view page

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Url.php
+++ b/app/code/Magento/Catalog/Model/Product/Url.php
@@ -162,10 +162,10 @@ class Url extends \Magento\Framework\DataObject
                     \Magento\Store\Model\ScopeInterface::SCOPE_STORE
                 );
 
-                if ($categoryId) {
-                    $filterData[UrlRewrite::METADATA]['category_id'] = $categoryId;
-                } elseif (!$useCategories) {
+                if (!$useCategories) {
                     $filterData[UrlRewrite::METADATA]['category_id'] = '';
+                } elseif ($categoryId) {
+                    $filterData[UrlRewrite::METADATA]['category_id'] = $categoryId;
                 }
 
                 $rewrite = $this->urlFinder->findOneByData($filterData);

--- a/app/code/Magento/Catalog/etc/config.xml
+++ b/app/code/Magento/Catalog/etc/config.xml
@@ -41,7 +41,7 @@
             <seo>
                 <product_url_suffix>.html</product_url_suffix>
                 <category_url_suffix>.html</category_url_suffix>
-                <product_use_categories>0</product_use_categories>
+                <product_use_categories>1</product_use_categories>
                 <save_rewrites_history>1</save_rewrites_history>
                 <title_separator>-</title_separator>
                 <category_canonical_tag>0</category_canonical_tag>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Option  "Use Categories Path for Product URLs" doesn't taken into account in case visiting product view page targeted from category page.
-->
product url in meta data on product view page contains full link including category identifier in case it disabled in back office configs
### Fixed Issues 
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
- magento/magento2#13227: Knockout Recently Viewed contains wrong product url (with category path), also not correct url <meta property="og:url"> on product view page 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. check option back office -> stores -> settings -> configuration -> catalog -> search engine optimization 
-> Use Categories Path for Product URLs  has value 'No'
2. go to category page
3. visit one of products on category page
4. check 'meta og:url' data. 
ER: meta contains short product view url

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
