### PR TITLE
admin-order-info-issue

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/info.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/info.phtml
@@ -104,7 +104,7 @@ $customerUrl = $block->getCustomerViewUrl();
                 <?php if ($order->getBaseCurrencyCode() != $order->getOrderCurrencyCode()): ?>
                     <tr>
                         <th><?= $block->escapeHtml(__('%1 / %2 rate:', $order->getOrderCurrencyCode(), $order->getBaseCurrencyCode())) ?></th>
-                        <th><?= $block->escapeHtml($order->getBaseToOrderRate()) ?></th>
+                        <td><?= $block->escapeHtml($order->getBaseToOrderRate()) ?></td>
                     </tr>
                 <?php endif; ?>
             </table>


### PR DESCRIPTION
Currency rate value not align proper in order information tab when we create creditmemo from admin #20609


### Description (*)
1.In admin configuration create credit memo for any order
2.In Order information tab currency value not align proper

### Fixed Issues (if relevant)
Currency rate value not align proper in order information tab when we create creditmemo from admin #20609


### Manual testing scenarios (*)
![2019-01-25_14-23_new memo - credit memos](https://user-images.githubusercontent.com/18118638/51735474-8982ea00-20ad-11e9-8e54-c66f20434633.jpg)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
