### PR TITLE
[Backport] admin-order-info-issue2.2

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/info.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/info.phtml
@@ -104,7 +104,7 @@ $customerUrl = $block->getCustomerViewUrl();
                 <?php if ($order->getBaseCurrencyCode() != $order->getOrderCurrencyCode()): ?>
                     <tr>
                         <th><?= $block->escapeHtml(__('%1 / %2 rate:', $order->getOrderCurrencyCode(), $order->getBaseCurrencyCode())) ?></th>
-                        <th><?= $block->escapeHtml($order->getBaseToOrderRate()) ?></th>
+                        <td><?= $block->escapeHtml($order->getBaseToOrderRate()) ?></td>
                     </tr>
                 <?php endif; ?>
             </table>


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/20610

Currency rate value not align proper in order information tab when we create creditmemo from admin #20609

<!--- Please provide a general summary of the Pull Request in the Title above -->

1.In admin configuration create credit memo for any order
2.In Order information tab currency value not align proper

### Fixed Issues (if relevant)
Currency rate value not align proper in order information tab when we create creditmemo from admin #20609

### Manual testing scenarios (*)
![2019-01-25_14-23_new memo - credit memos](https://user-images.githubusercontent.com/18118638/51737614-0d8ba080-20b3-11e9-983f-f7074df3b277.jpg)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
