### PR TITLE
Fixed #18812  Unable to update simple product custom option in cart when quantity is 1

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator/Initializer/StockItem.php
+++ b/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator/Initializer/StockItem.php
@@ -95,7 +95,7 @@ class StockItem
         } else {
             $increaseQty = $quoteItem->getQtyToAdd() ? $quoteItem->getQtyToAdd() : $qty;
             $rowQty = $qty;
-            $origIdquoteItemId = 0;
+            $origquoteItemId = 0;
             if($this->_coreRegistry->registry('configure_item')){
                 $origquoteItemId = $this->request->getParam('id'); 
             }

--- a/app/code/Magento/Checkout/Controller/Cart/UpdateItemOptions.php
+++ b/app/code/Magento/Checkout/Controller/Cart/UpdateItemOptions.php
@@ -8,9 +8,52 @@
 namespace Magento\Checkout\Controller\Cart;
 
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
+use Magento\Framework;
+use Magento\Framework\Controller\ResultFactory;
 
 class UpdateItemOptions extends \Magento\Checkout\Controller\Cart implements HttpPostActionInterface
 {
+    
+    /**
+     * Core registry
+     *
+     * @var \Magento\Framework\Registry
+     */
+    protected $_coreRegistry;
+
+    /**
+     * @param \Magento\Framework\App\Action\Context $context
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Magento\Checkout\Model\Session $checkoutSession
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Framework\Data\Form\FormKey\Validator $formKeyValidator
+     * @param \Magento\Checkout\Model\Cart $cart
+     * @param \Magento\Framework\Registry $coreRegistry
+     * @codeCoverageIgnore
+     */
+    public function __construct(
+        Framework\App\Action\Context $context,
+        Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Checkout\Model\Session $checkoutSession,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Framework\Data\Form\FormKey\Validator $formKeyValidator,
+        \Magento\Checkout\Model\Cart $cart,
+        \Magento\Framework\Registry $coreRegistry = null
+    ) {
+
+        parent::__construct(
+            $context,
+            $scopeConfig,
+            $checkoutSession,
+            $storeManager,
+            $formKeyValidator,
+            $cart
+        );
+         $this->_coreRegistry = $coreRegistry ?: \Magento\Framework\App\ObjectManager::getInstance()
+                              ->get(\Magento\Framework\Registry::class);
+         $this->_coreRegistry->register('configure_item',true);
+    }
+    
     /**
      * Update product configuration for a cart item
      *


### PR DESCRIPTION
Fixed #18812  Unable to update simple product custom option in cart when quantity is 1

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento CE 2.2.5
2. Although reproduced in 2.2.2-2.2.4
3. Backorders disabled, minimum order qty is 1.
4. A simple product with at least one custom option, e.g. size - 1,2,3; price type fixed.

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Go to product page and select options and click add to cart. 
2. Go to cart and select "Edit/Update Item"
3. Select different option from original and click update.

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. Redirected back to cart
2. Product custom option updated.

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Error message on product page.
![image](https://user-images.githubusercontent.com/1066322/47514211-bbe73600-d877-11e8-963e-1d429115c4ee.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
