### PR TITLE
Fixed Issue #20631 Console error on checkout after changing the allowed countries from admin

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/post-code.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/post-code.js
@@ -33,11 +33,8 @@ define([
             }
 
             option = options[value];
-            if (!option) {
-                return;
-            }
             
-            if (option['is_zipcode_optional']) {
+            if (option && option['is_zipcode_optional']) {
                 this.error(false);
                 this.validation = _.omit(this.validation, 'required-entry');
             } else {

--- a/app/code/Magento/Ui/view/base/web/js/form/element/post-code.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/post-code.js
@@ -34,7 +34,11 @@ define([
 
             option = options[value];
             
-            if (option && option['is_zipcode_optional']) {
+            if (!option) {
+                return;
+            }
+            
+            if (option['is_zipcode_optional']) {
                 this.error(false);
                 this.validation = _.omit(this.validation, 'required-entry');
             } else {

--- a/app/code/Magento/Ui/view/base/web/js/form/element/post-code.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/post-code.js
@@ -26,14 +26,17 @@ define([
         update: function (value) {
             var country = registry.get(this.parentName + '.' + 'country_id'),
                 options = country.indexedOptions,
-                option;
+                option = null;
 
             if (!value) {
                 return;
             }
 
             option = options[value];
-
+            if (!option) {
+                return;
+            }
+            
             if (option['is_zipcode_optional']) {
                 this.error(false);
                 this.validation = _.omit(this.validation, 'required-entry');


### PR DESCRIPTION
### Description (*)
Fixed Issue #20631 Console error on checkout after changing the allowed countries from admin

### Fixed Issues (if relevant)

1. magento/magento2#20631: Console error on checkout after changing the allowed countries from admin

### Manual testing scenarios (*)

    1. Add a product to cart as guest.
   2. Fill the shipping address and reload the page now shipping address must be filled already.
   3. Go to Admin->Stores->configuration->General, Change allowed countries single one that is not  filled    on checkout. like i have filled United State at checkout and change allowed countries to Libya.
    4.Now reload the checkout shipping page again.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
