### PR TITLE
[Backport] Fix issue with file uploading if an upload field is disabled 

### DIFF
--- a/app/code/Magento/Ui/i18n/en_US.csv
+++ b/app/code/Magento/Ui/i18n/en_US.csv
@@ -202,3 +202,4 @@ CSV,CSV
 "Please enter at least {0} characters.","Please enter at least {0} characters."
 "Please enter a value between {0} and {1} characters long.","Please enter a value between {0} and {1} characters long."
 "Please enter a value between {0} and {1}.","Please enter a value between {0} and {1}."
+"The file upload field is disabled.","The file upload field is disabled."

--- a/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js
@@ -13,8 +13,9 @@ define([
     'Magento_Ui/js/modal/alert',
     'Magento_Ui/js/lib/validation/validator',
     'Magento_Ui/js/form/element/abstract',
+    'mage/translate',
     'jquery/file-uploader'
-], function ($, _, utils, uiAlert, validator, Element) {
+], function ($, _, utils, uiAlert, validator, Element, $t) {
     'use strict';
 
     return Element.extend({

--- a/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js
@@ -328,6 +328,12 @@ define([
                 allowed  = this.isFileAllowed(file),
                 target   = $(e.target);
 
+            if (this.disabled()) {
+                this.notifyError($t('The file upload field is disabled.'));
+
+                return;
+            }
+
             if (allowed.passed) {
                 target.on('fileuploadsend', function (event, postData) {
                     postData.data.append('param_name', this.paramName);


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/20461

### Description (*)
Fixed the issue with file uploading if an upload field is disabled.

### Fixed Issues (if relevant)

1. https://github.com/magento/magento2/issues/20376: Image gets uploaded if a field is disabled in Category

### Manual testing scenarios (*)
1. Login to admin panel
2. Goto Catalog present on left
3. Then goto Categories
4. Select Dafault category
5. Change Store View to Default Store view
6. Now click to content tab
7. then click Browse to find or drag image here, it will not work untill we don't remove the tick from the Use Default Value
8. But when we simply drags a image on it, then image gets added successfully.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
