### PR TITLE
[Backport] Floating point overflows in checkout totals fixed

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Address/Total.php
+++ b/app/code/Magento/Quote/Model/Quote/Address/Total.php
@@ -54,6 +54,9 @@ class Total extends \Magento\Framework\DataObject
      */
     public function setTotalAmount($code, $amount)
     {
+        /* (Fixes issue #18027) Round the total amount to 4 decimal places, to avoid floating point overflows */
+        $amount = number_format($amount, 4);
+
         $this->totalAmounts[$code] = $amount;
         if ($code != 'subtotal') {
             $code = $code . '_amount';

--- a/app/code/Magento/Quote/Model/Quote/Address/Total.php
+++ b/app/code/Magento/Quote/Model/Quote/Address/Total.php
@@ -56,7 +56,7 @@ class Total extends \Magento\Framework\DataObject
     public function setTotalAmount($code, $amount)
     {
         /* (Fixes issue #18027) Round the total amount to 4 decimal places, to avoid floating point overflows */
-        $amount = is_float($amount) ? (float)number_format($amount, 4, ".", "") : $amount;
+        $amount = is_float($amount) ? round($amount, 4) : $amount;
 
         $this->totalAmounts[$code] = $amount;
         if ($code != 'subtotal') {
@@ -77,7 +77,7 @@ class Total extends \Magento\Framework\DataObject
     public function setBaseTotalAmount($code, $amount)
     {
         /* (Fixes issue #18027) Round the total amount to 4 decimal places, to avoid floating point overflows */
-        $amount = is_float($amount) ? (float)number_format($amount, 4, ".", "") : $amount;
+        $amount = is_float($amount) ? round($amount, 4) : $amount;
 
         $this->baseTotalAmounts[$code] = $amount;
         if ($code != 'subtotal') {

--- a/app/code/Magento/Quote/Model/Quote/Address/Total.php
+++ b/app/code/Magento/Quote/Model/Quote/Address/Total.php
@@ -56,7 +56,7 @@ class Total extends \Magento\Framework\DataObject
     public function setTotalAmount($code, $amount)
     {
         /* (Fixes issue #18027) Round the total amount to 4 decimal places, to avoid floating point overflows */
-        $amount = is_float($amount) ? (float)number_format($amount, 4) : $amount;
+        $amount = is_float($amount) ? (float)number_format($amount, 4, ".", "") : $amount;
 
         $this->totalAmounts[$code] = $amount;
         if ($code != 'subtotal') {
@@ -77,7 +77,7 @@ class Total extends \Magento\Framework\DataObject
     public function setBaseTotalAmount($code, $amount)
     {
         /* (Fixes issue #18027) Round the total amount to 4 decimal places, to avoid floating point overflows */
-        $amount = is_float($amount) ? (float)number_format($amount, 4) : $amount;
+        $amount = is_float($amount) ? (float)number_format($amount, 4, ".", "") : $amount;
 
         $this->baseTotalAmounts[$code] = $amount;
         if ($code != 'subtotal') {
@@ -173,7 +173,8 @@ class Total extends \Magento\Framework\DataObject
     //@codeCoverageIgnoreEnd
 
     /**
-     * Set the full info, which is used to capture tax related information. If a string is used, it is assumed to be serialized.
+     * Set the full info, which is used to capture tax related information.
+     * If a string is used, it is assumed to be serialized.
      *
      * @param array|string $info
      * @return $this

--- a/app/code/Magento/Quote/Model/Quote/Address/Total.php
+++ b/app/code/Magento/Quote/Model/Quote/Address/Total.php
@@ -6,6 +6,7 @@
 namespace Magento\Quote\Model\Quote\Address;
 
 /**
+ * Class Total
  * @method string getCode()
  *
  * @api
@@ -75,6 +76,9 @@ class Total extends \Magento\Framework\DataObject
      */
     public function setBaseTotalAmount($code, $amount)
     {
+        /* (Fixes issue #18027) Round the total amount to 4 decimal places, to avoid floating point overflows */
+        $amount = is_float($amount) ? number_format($amount, 4) : $amount;
+
         $this->baseTotalAmounts[$code] = $amount;
         if ($code != 'subtotal') {
             $code = $code . '_amount';
@@ -170,6 +174,7 @@ class Total extends \Magento\Framework\DataObject
 
     /**
      * Set the full info, which is used to capture tax related information.
+     *
      * If a string is used, it is assumed to be serialized.
      *
      * @param array|string $info

--- a/app/code/Magento/Quote/Model/Quote/Address/Total.php
+++ b/app/code/Magento/Quote/Model/Quote/Address/Total.php
@@ -55,7 +55,7 @@ class Total extends \Magento\Framework\DataObject
     public function setTotalAmount($code, $amount)
     {
         /* (Fixes issue #18027) Round the total amount to 4 decimal places, to avoid floating point overflows */
-        $amount = number_format($amount, 4);
+        $amount = is_float($amount) ? number_format($amount, 4) : $amount;
 
         $this->totalAmounts[$code] = $amount;
         if ($code != 'subtotal') {

--- a/app/code/Magento/Quote/Model/Quote/Address/Total.php
+++ b/app/code/Magento/Quote/Model/Quote/Address/Total.php
@@ -56,7 +56,7 @@ class Total extends \Magento\Framework\DataObject
     public function setTotalAmount($code, $amount)
     {
         /* (Fixes issue #18027) Round the total amount to 4 decimal places, to avoid floating point overflows */
-        $amount = is_float($amount) ? number_format($amount, 4) : $amount;
+        $amount = is_float($amount) ? (float)number_format($amount, 4) : $amount;
 
         $this->totalAmounts[$code] = $amount;
         if ($code != 'subtotal') {
@@ -77,7 +77,7 @@ class Total extends \Magento\Framework\DataObject
     public function setBaseTotalAmount($code, $amount)
     {
         /* (Fixes issue #18027) Round the total amount to 4 decimal places, to avoid floating point overflows */
-        $amount = is_float($amount) ? number_format($amount, 4) : $amount;
+        $amount = is_float($amount) ? (float)number_format($amount, 4) : $amount;
 
         $this->baseTotalAmounts[$code] = $amount;
         if ($code != 'subtotal') {
@@ -173,9 +173,7 @@ class Total extends \Magento\Framework\DataObject
     //@codeCoverageIgnoreEnd
 
     /**
-     * Set the full info, which is used to capture tax related information.
-     *
-     * If a string is used, it is assumed to be serialized.
+     * Set the full info, which is used to capture tax related information. If a string is used, it is assumed to be serialized.
      *
      * @param array|string $info
      * @return $this

--- a/app/code/Magento/Quote/Model/Quote/Address/Total.php
+++ b/app/code/Magento/Quote/Model/Quote/Address/Total.php
@@ -55,7 +55,6 @@ class Total extends \Magento\Framework\DataObject
      */
     public function setTotalAmount($code, $amount)
     {
-        /* (Fixes issue #18027) Round the total amount to 4 decimal places, to avoid floating point overflows */
         $amount = is_float($amount) ? round($amount, 4) : $amount;
 
         $this->totalAmounts[$code] = $amount;
@@ -76,7 +75,6 @@ class Total extends \Magento\Framework\DataObject
      */
     public function setBaseTotalAmount($code, $amount)
     {
-        /* (Fixes issue #18027) Round the total amount to 4 decimal places, to avoid floating point overflows */
         $amount = is_float($amount) ? round($amount, 4) : $amount;
 
         $this->baseTotalAmounts[$code] = $amount;

--- a/app/code/Magento/Quote/Model/Quote/Address/Total.php
+++ b/app/code/Magento/Quote/Model/Quote/Address/Total.php
@@ -7,6 +7,7 @@ namespace Magento\Quote\Model\Quote\Address;
 
 /**
  * Class Total
+ *
  * @method string getCode()
  *
  * @api
@@ -172,6 +173,7 @@ class Total extends \Magento\Framework\DataObject
 
     /**
      * Set the full info, which is used to capture tax related information.
+     *
      * If a string is used, it is assumed to be serialized.
      *
      * @param array|string $info


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18185
### Description
Round the total amount to 4 decimal places in `\Magento\Quote\Model\Quote\Address\Total::setTotalAmount`, to avoid floating point overflows

### Fixed Issues (if relevant)
1. magento/magento2#18027: Cart Total is NaN in some circumstances
2. ...

### Manual testing scenarios
1. Put two items in the cart, in our case this is one product at 59,80€ incl. Tax and one product at 9,49€ incl. Tax, Shipping is free
2. Apply a coupon code (cart price rule) with 100% discount
3. This usually results in a floating point overflow and the grand total coming as __1.4210854715202e-14__ instead of 0
4. After this fix, the grand total should come 0