### PR TITLE
[Backport] issue #18349 Fixed for 2.3: Incorrect quote_item_id saved on order items during multiple address checkout

### DIFF
--- a/app/code/Magento/Multishipping/Model/Checkout/Type/Multishipping.php
+++ b/app/code/Magento/Multishipping/Model/Checkout/Type/Multishipping.php
@@ -1168,7 +1168,7 @@ class Multishipping extends \Magento\Framework\DataObject
     {
         foreach ($shippingAddresses as $address) {
             foreach ($address->getAllItems() as $addressItem) {
-                if (in_array($addressItem->getId(), $placedAddressItems)) {
+                if (in_array($addressItem->getQuoteItemId(), $placedAddressItems)) {
                     if ($addressItem->getProduct()->getIsVirtual()) {
                         $addressItem->isDeleted(true);
                     } else {
@@ -1218,7 +1218,7 @@ class Multishipping extends \Magento\Framework\DataObject
         $item = array_pop($items);
         foreach ($addresses as $address) {
             foreach ($address->getAllItems() as $addressItem) {
-                if ($addressItem->getId() == $item->getQuoteItemId()) {
+                if ($addressItem->getQuoteItemId() == $item->getQuoteItemId()) {
                     return (int)$address->getId();
                 }
             }

--- a/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
@@ -64,15 +64,15 @@ class ToOrderItem
             $item
         );
         if ($item instanceof \Magento\Quote\Model\Quote\Address\Item) {
-            $data = array_merge(
-                $data,
-                $this->objectCopyService->getDataFromFieldset(
-                    'quote_convert_item',
-                    'to_order_item_id',
-                    $item
-                )
-            );
-        }
+            $orderItemData= array_merge(
+                $orderItemData,
+               $this->objectCopyService->getDataFromFieldset(
+                   'quote_convert_address_item',
+                   'to_order_item',
+                   $item
+               )
+           );
+       }
         if (!$item->getNoDiscount()) {
             $data = array_merge(
                 $data,

--- a/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
@@ -63,6 +63,9 @@ class ToOrderItem
             'to_order_item',
             $item
         );
+        if ($item instanceof \Magento\Quote\Model\Quote\Address\Item) {
+            $orderItemData['quote_item_id'] = $item->getQuoteItemId();
+        }
         if (!$item->getNoDiscount()) {
             $data = array_merge(
                 $data,

--- a/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
@@ -64,7 +64,14 @@ class ToOrderItem
             $item
         );
         if ($item instanceof \Magento\Quote\Model\Quote\Address\Item) {
-            $orderItemData['quote_item_id'] = $item->getQuoteItemId();
+            $data = array_merge(
+                $data,
+                $this->objectCopyService->getDataFromFieldset(
+                    'quote_convert_item',
+                    'to_order_item_id',
+                    $item
+                )
+            );
         }
         if (!$item->getNoDiscount()) {
             $data = array_merge(

--- a/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
@@ -64,7 +64,7 @@ class ToOrderItem
             $item
         );
         if ($item instanceof \Magento\Quote\Model\Quote\Address\Item) {
-            $orderItemData= array_merge(
+            $orderItemData = array_merge(
                 $orderItemData,
                $this->objectCopyService->getDataFromFieldset(
                    'quote_convert_address_item',

--- a/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
@@ -48,6 +48,8 @@ class ToOrderItem
     }
 
     /**
+     * Convert quote item(quote address item) into order item.
+     *
      * @param Item|AddressItem $item
      * @param array $data
      * @return OrderItemInterface
@@ -66,13 +68,13 @@ class ToOrderItem
         if ($item instanceof \Magento\Quote\Model\Quote\Address\Item) {
             $orderItemData = array_merge(
                 $orderItemData,
-               $this->objectCopyService->getDataFromFieldset(
-                   'quote_convert_address_item',
-                   'to_order_item',
-                   $item
-               )
-           );
-       }
+                $this->objectCopyService->getDataFromFieldset(
+                    'quote_convert_address_item',
+                    'to_order_item',
+                    $item
+                )
+            );
+        }
         if (!$item->getNoDiscount()) {
             $data = array_merge(
                 $data,

--- a/app/code/Magento/Quote/etc/fieldset.xml
+++ b/app/code/Magento/Quote/etc/fieldset.xml
@@ -205,6 +205,9 @@
             <field name="qty">
                 <aspect name="to_order_item" targetField="qty_ordered" />
             </field>
+            <field name="quote_item_id">
+                <aspect name="to_order_item_id" targetField="quote_item_id" />
+            </field>
             <field name="id">
                 <aspect name="to_order_item" targetField="quote_item_id" />
             </field>

--- a/app/code/Magento/Quote/etc/fieldset.xml
+++ b/app/code/Magento/Quote/etc/fieldset.xml
@@ -186,6 +186,11 @@
                 <aspect name="to_order_address" />
             </field>
         </fieldset>
+        <fieldset id="quote_convert_address_item">
+            <field name="quote_item_id">
+                <aspect name="to_order_item" />
+            </field>
+        </fieldset>
         <fieldset id="quote_convert_item">
             <field name="sku">
                 <aspect name="to_order_item" />
@@ -204,9 +209,6 @@
             </field>
             <field name="qty">
                 <aspect name="to_order_item" targetField="qty_ordered" />
-            </field>
-            <field name="quote_item_id">
-                <aspect name="to_order_item_id" targetField="quote_item_id" />
             </field>
             <field name="id">
                 <aspect name="to_order_item" targetField="quote_item_id" />


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19192
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

Incorrect quote_item_id saved on order items during multiple address checkout issue fixed.

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When order placed using Multiple address checkout then there were incorrect **quote_item_id**  in 
sales_order_item table.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #18349 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Placed and Order with Multi address checkout, now **quote_item_id** is correct.
2. Placed an order with Onestep checkout **quote_item_id** is correct as well.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
