### PR TITLE
Multiline whitespace before semicolons

### DIFF
--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/AbstractTestCase.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Dashboard/AbstractTestCase.php
@@ -21,8 +21,7 @@ class AbstractTestCase extends \PHPUnit\Framework\TestCase
     {
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $outPut = "data";
-        $resultRawMock = $this->createPartialMock(\Magento\Framework\Controller\Result\Raw::class, ['setContents'])
-        ;
+        $resultRawMock = $this->createPartialMock(\Magento\Framework\Controller\Result\Raw::class, ['setContents']);
         $resultRawFactoryMock =
             $this->createPartialMock(\Magento\Framework\Controller\Result\RawFactory::class, ['create']);
         $layoutFactoryMock = $this->createPartialMock(\Magento\Framework\View\LayoutFactory::class, ['create']);

--- a/app/code/Magento/Config/Console/Command/ConfigSet/ProcessorFacade.php
+++ b/app/code/Magento/Config/Console/Command/ConfigSet/ProcessorFacade.php
@@ -141,8 +141,7 @@ class ProcessorFacade
                     ? $this->configSetProcessorFactory->create(ConfigSetProcessorFactory::TYPE_LOCK_ENV)
                     : $this->configSetProcessorFactory->create(ConfigSetProcessorFactory::TYPE_LOCK_CONFIG)
                 )
-                : $this->configSetProcessorFactory->create(ConfigSetProcessorFactory::TYPE_DEFAULT)
-            ;
+                : $this->configSetProcessorFactory->create(ConfigSetProcessorFactory::TYPE_DEFAULT);
 
         $message =
             $lock

--- a/app/code/Magento/PageCache/Model/Cache/Server.php
+++ b/app/code/Magento/PageCache/Model/Cache/Server.php
@@ -62,8 +62,7 @@ class Server
             foreach ($configuredHosts as $host) {
                 $servers[] = UriFactory::factory('')
                     ->setHost($host['host'])
-                    ->setPort(isset($host['port']) ? $host['port'] : self::DEFAULT_PORT)
-                ;
+                    ->setPort(isset($host['port']) ? $host['port'] : self::DEFAULT_PORT);
             }
         } elseif ($this->request->getHttpHost()) {
             $servers[] = UriFactory::factory('')->setHost($this->request->getHttpHost())->setPort(self::DEFAULT_PORT);

--- a/app/code/Magento/Search/Test/Unit/Model/SynonymAnalyzerTest.php
+++ b/app/code/Magento/Search/Test/Unit/Model/SynonymAnalyzerTest.php
@@ -59,15 +59,13 @@ class SynonymAnalyzerTest extends \PHPUnit\Framework\TestCase
         $this->synReaderModel->expects($this->once())
             ->method('loadByPhrase')
             ->with($phrase)
-            ->willReturnSelf()
-        ;
+            ->willReturnSelf();
         $this->synReaderModel->expects($this->once())
             ->method('getData')
             ->willReturn([
                 ['synonyms' => 'british,english'],
                 ['synonyms' => 'queen,monarch'],
-            ])
-        ;
+            ]);
 
         $actual = $this->synonymAnalyzer->getSynonymsForPhrase($phrase);
         $this->assertEquals($expected, $actual);

--- a/app/code/Magento/Store/Model/ResourceModel/Website/Collection.php
+++ b/app/code/Magento/Store/Model/ResourceModel/Website/Collection.php
@@ -151,7 +151,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
                 ) // view is admin
                 ->addOrder('store_table.sort_order', \Magento\Framework\DB\Select::SQL_ASC) // view sort order
                 ->addOrder('store_table.name', \Magento\Framework\DB\Select::SQL_ASC)       // view name
-            ;
+;
         }
         return $this;
     }

--- a/app/code/Magento/Theme/Ui/Component/Theme/DataProvider/SearchResult.php
+++ b/app/code/Magento/Theme/Ui/Component/Theme/DataProvider/SearchResult.php
@@ -39,8 +39,7 @@ class SearchResult extends \Magento\Framework\View\Element\UiComponent\DataProvi
             ->addFieldToFilter('main_table.type', ['in' => [
                 \Magento\Framework\View\Design\ThemeInterface::TYPE_PHYSICAL,
                 \Magento\Framework\View\Design\ThemeInterface::TYPE_VIRTUAL,
-            ]])
-        ;
+            ]]);
 
         $this->getSelect()->joinLeft(
             ['parent' => $this->getMainTable()],

--- a/lib/internal/Magento/Framework/App/Test/Unit/Router/ActionListTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Router/ActionListTest.php
@@ -65,8 +65,7 @@ class ActionListTest extends \PHPUnit\Framework\TestCase
             ->method('save');
         $this->readerMock->expects($this->once())
             ->method('getActionFiles')
-            ->willReturn('data')
-        ;
+            ->willReturn('data');
         $this->createActionListInstance();
     }
 

--- a/lib/internal/Magento/Framework/View/Test/Unit/Layout/Generator/BlockTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Layout/Generator/BlockTest.php
@@ -136,8 +136,7 @@ class BlockTest extends \PHPUnit\Framework\TestCase
                 ->with($testArgumentData['argument'])
                 ->willReturn($argumentData['argument']);
         } else {
-            $argumentInterpreter->expects($this->never())->method('evaluate')
-            ;
+            $argumentInterpreter->expects($this->never())->method('evaluate');
         }
 
         /** @var \Magento\Framework\View\Element\BlockFactory|\PHPUnit_Framework_MockObject_MockObject $blockFactory */

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/DiCompileCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/DiCompileCommandTest.php
@@ -161,8 +161,7 @@ class DiCompileCommandTest extends \PHPUnit\Framework\TestCase
                 [OperationFactory::INTERCEPTION, $this->anything()],
                 [OperationFactory::AREA_CONFIG_GENERATOR, $this->anything()],
                 [OperationFactory::INTERCEPTION_CACHE, $this->anything()]
-            )
-        ;
+            );
 
         $this->managerMock->expects($this->once())->method('process');
         $tester = new CommandTester($this->command);


### PR DESCRIPTION
Forbid multi-line whitespace before the closing semicolon or move the semicolon to the new line for chained calls.