### PR TITLE
PHP unit dedicate assert

### DIFF
--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionRefundTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionRefundTest.php
@@ -121,7 +121,7 @@ class TransactionRefundTest extends \PHPUnit\Framework\TestCase
 
         $actualResult = $this->client->placeRequest($this->getTransferObjectMock());
 
-        $this->assertTrue(is_object($actualResult['object']));
+        $this->assertInternalType('object', $actualResult['object']);
         $this->assertEquals(['object' => $response], $actualResult);
     }
 

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionSaleTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionSaleTest.php
@@ -112,7 +112,7 @@ class TransactionSaleTest extends \PHPUnit\Framework\TestCase
 
         $actualResult = $this->model->placeRequest($this->getTransferObjectMock());
 
-        $this->assertTrue(is_object($actualResult['object']));
+        $this->assertInternalType('object', $actualResult['object']);
         $this->assertEquals(['object' => $response], $actualResult);
     }
 

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionSubmitForSettlementTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionSubmitForSettlementTest.php
@@ -91,7 +91,7 @@ class TransactionSubmitForSettlementTest extends \PHPUnit\Framework\TestCase
         /** @var TransferInterface|MockObject $transferObject */
         $transferObject = $this->getTransferObjectMock();
         $response = $this->client->placeRequest($transferObject);
-        static::assertTrue(is_object($response['object']));
+        static::assertInternalType('object', $response['object']);
         static::assertEquals(['object' => $data], $response);
     }
 

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionVoidTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionVoidTest.php
@@ -115,7 +115,7 @@ class TransactionVoidTest extends \PHPUnit\Framework\TestCase
 
         $actualResult = $this->client->placeRequest($this->getTransferObjectMock());
 
-        $this->assertTrue(is_object($actualResult['object']));
+        $this->assertInternalType('object', $actualResult['object']);
         $this->assertEquals(['object' => $response], $actualResult);
     }
 

--- a/app/code/Magento/Braintree/Test/Unit/Model/Report/TransactionsCollectionTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/Report/TransactionsCollectionTest.php
@@ -100,7 +100,7 @@ class TransactionsCollectionTest extends \PHPUnit\Framework\TestCase
 
         $collection->addFieldToFilter('orderId', ['like' => '0']);
         $items = $collection->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertInstanceOf(DocumentInterface::class, $items[1]);
     }
 
@@ -129,7 +129,7 @@ class TransactionsCollectionTest extends \PHPUnit\Framework\TestCase
 
         $collection->addFieldToFilter('orderId', ['like' => '0']);
         $items = $collection->getItems();
-        $this->assertEquals(0, count($items));
+        $this->assertCount(0, $items);
     }
 
     /**

--- a/app/code/Magento/Braintree/Test/Unit/Ui/Component/Report/Listing/Column/CheckColumnOptionSourceTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Ui/Component/Report/Listing/Column/CheckColumnOptionSourceTest.php
@@ -19,7 +19,7 @@ class CheckColumnOptionSourceTest extends \PHPUnit\Framework\TestCase
         $source = new PaymentType();
         $options = $source->toOptionArray();
 
-        static::assertEquals(6, count($options));
+        static::assertCount(6, $options);
     }
 
     public function testStatusSource()
@@ -27,7 +27,7 @@ class CheckColumnOptionSourceTest extends \PHPUnit\Framework\TestCase
         $source = new Status();
         $options = $source->toOptionArray();
 
-        static::assertEquals(14, count($options));
+        static::assertCount(14, $options);
     }
 
     public function testTransactionTypeSource()
@@ -35,6 +35,6 @@ class CheckColumnOptionSourceTest extends \PHPUnit\Framework\TestCase
         $source = new TransactionType();
         $options = $source->toOptionArray();
 
-        static::assertEquals(2, count($options));
+        static::assertCount(2, $options);
     }
 }

--- a/app/code/Magento/Bundle/Test/Unit/Model/ProductOptionProcessorTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/ProductOptionProcessorTest.php
@@ -184,7 +184,7 @@ class ProductOptionProcessorTest extends \PHPUnit\Framework\TestCase
 
         if (!empty($expected)) {
             $this->assertArrayHasKey($expected, $result);
-            $this->assertTrue(is_array($result[$expected]));
+            $this->assertInternalType('array', $result[$expected]);
         } else {
             $this->assertEmpty($result);
         }

--- a/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/InventoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/InventoryTest.php
@@ -111,7 +111,7 @@ class InventoryTest extends \PHPUnit\Framework\TestCase
             ->with('store')
             ->will($this->returnValue('125'));
 
-        $this->assertTrue(is_integer($this->inventory->getStoreId()));
+        $this->assertInternalType('integer', $this->inventory->getStoreId());
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Rss/NotifyStockTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Rss/NotifyStockTest.php
@@ -98,9 +98,9 @@ class NotifyStockTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue('http://magento.com/catalog/product/edit/id/1'));
 
         $data = $this->block->getRssData();
-        $this->assertTrue(is_string($data['title']));
-        $this->assertTrue(is_string($data['description']));
-        $this->assertTrue(is_string($data['entries'][0]['description']));
+        $this->assertInternalType('string', $data['title']);
+        $this->assertInternalType('string', $data['description']);
+        $this->assertInternalType('string', $data['entries'][0]['description']);
         $this->assertEquals($this->rssFeed, $data);
     }
 

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/View/AttributesTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/View/AttributesTest.php
@@ -134,7 +134,7 @@ class AttributesTest extends TestCase
             ->method('getValue')
             ->willReturn($this->phrase);
         $attributes = $this->attributesBlock->getAdditionalData();
-        $this->assertTrue(empty($attributes['phrase']));
+        $this->assertEmpty($attributes['phrase']);
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Helper/Product/Flat/IndexerTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Helper/Product/Flat/IndexerTest.php
@@ -94,7 +94,7 @@ class IndexerTest extends \PHPUnit\Framework\TestCase
     public function testGetFlatColumnsDdlDefinition()
     {
         foreach ($this->_model->getFlatColumnsDdlDefinition() as $column) {
-            $this->assertTrue(is_array($column), 'Columns must be an array value');
+            $this->assertInternalType('array', $column, 'Columns must be an array value');
             $this->assertArrayHasKey('type', $column, 'Column must have type definition at least');
         }
     }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/DataProviderTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/DataProviderTest.php
@@ -237,7 +237,7 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
         $model = $this->getModel();
         $result = $model->getData();
 
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertArrayHasKey($categoryId, $result);
         $this->assertArrayNotHasKey('image', $result[$categoryId]);
     }
@@ -322,7 +322,7 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
         $model = $this->getModel();
         $result = $model->getData();
 
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertArrayHasKey($categoryId, $result);
         $this->assertArrayHasKey('image', $result[$categoryId]);
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/FileInfoTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/FileInfoTest.php
@@ -125,7 +125,7 @@ class FileInfoTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->model->getStat($fileName);
 
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('size', $result);
         $this->assertEquals(1, $result['size']);
     }

--- a/app/code/Magento/Catalog/Test/Unit/Model/CategoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CategoryTest.php
@@ -468,7 +468,7 @@ class CategoryTest extends \PHPUnit\Framework\TestCase
         $attributeValue2 = new \Magento\Framework\Api\AttributeValue();
         $this->attributeValueFactory->expects($this->exactly(2))->method('create')
             ->willReturnOnConsecutiveCalls($attributeValue, $attributeValue2);
-        $this->assertEquals(1, count($this->category->getCustomAttributes()));
+        $this->assertCount(1, $this->category->getCustomAttributes());
         $this->assertNotNull($this->category->getCustomAttribute($customAttributeCode));
         $this->assertEquals(
             $initialCustomAttributeValue,
@@ -477,7 +477,7 @@ class CategoryTest extends \PHPUnit\Framework\TestCase
 
         //Change the attribute value, should reflect in getCustomAttribute
         $this->category->setCustomAttribute($customAttributeCode, $newCustomAttributeValue);
-        $this->assertEquals(1, count($this->category->getCustomAttributes()));
+        $this->assertCount(1, $this->category->getCustomAttributes());
         $this->assertNotNull($this->category->getCustomAttribute($customAttributeCode));
         $this->assertEquals(
             $newCustomAttributeValue,

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/ImageTest.php
@@ -453,6 +453,6 @@ class ImageTest extends \PHPUnit\Framework\TestCase
         $this->imageAsset->expects($this->any())->method('getPath')->willReturn($absolutePath);
         $this->cacheManager->expects($this->once())->method('load')->willReturn(false);
         $this->cacheManager->expects($this->once())->method('save');
-        $this->assertTrue(is_array($this->image->getResizedImageInfo()));
+        $this->assertInternalType('array', $this->image->getResizedImageInfo());
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Price/TierPriceStorageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Price/TierPriceStorageTest.php
@@ -149,7 +149,7 @@ class TierPriceStorageTest extends \PHPUnit\Framework\TestCase
         $this->tierPriceFactory->expects($this->atLeastOnce())->method('create')->willReturn($price);
         $prices = $this->tierPriceStorage->get($skus);
         $this->assertNotEmpty($prices);
-        $this->assertEquals(2, count($prices));
+        $this->assertCount(2, $prices);
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Type/PriceTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Type/PriceTest.php
@@ -197,7 +197,7 @@ class PriceTest extends \PHPUnit\Framework\TestCase
         // test the data actually set on the product
         $tpArray = $this->product->getData($this::KEY_TIER_PRICE);
         $this->assertNotNull($tpArray);
-        $this->assertTrue(is_array($tpArray));
+        $this->assertInternalType('array', $tpArray);
         $this->assertEquals(sizeof($tps), sizeof($tpArray));
 
         for ($i = 0; $i < sizeof($tps); $i++) {
@@ -225,7 +225,7 @@ class PriceTest extends \PHPUnit\Framework\TestCase
         // test with the data retrieved as a REST object
         $tpRests = $this->model->getTierPrices($this->product);
         $this->assertNotNull($tpRests);
-        $this->assertTrue(is_array($tpRests));
+        $this->assertInternalType('array', $tpRests);
         $this->assertEquals(sizeof($tps), sizeof($tpRests));
         foreach ($tpRests as $tpRest) {
             $this->assertEquals(50, $tpRest->getExtensionAttributes()->getPercentageValue());

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/VisibilityTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/VisibilityTest.php
@@ -33,7 +33,7 @@ class VisibilityTest extends \PHPUnit\Framework\TestCase
 
         $flatColumns = $this->_model->getFlatColumns();
 
-        $this->assertTrue(is_array($flatColumns), 'FlatColumns must be an array value');
+        $this->assertInternalType('array', $flatColumns, 'FlatColumns must be an array value');
         $this->assertTrue(!empty($flatColumns), 'FlatColumns must be not empty');
         foreach ($flatColumns as $result) {
             $this->assertArrayHasKey('unsigned', $result, 'FlatColumns must have "unsigned" column');

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductOptionProcessorTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductOptionProcessorTest.php
@@ -188,7 +188,7 @@ class ProductOptionProcessorTest extends \PHPUnit\Framework\TestCase
 
         if (!empty($expected)) {
             $this->assertArrayHasKey($expected, $result);
-            $this->assertTrue(is_array($result));
+            $this->assertInternalType('array', $result);
             $this->assertSame($this->customOption, $result['custom_options'][0]);
         } else {
             $this->assertEmpty($result);

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductTest.php
@@ -1311,7 +1311,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
         $attributeValue2 = new \Magento\Framework\Api\AttributeValue();
         $this->attributeValueFactory->expects($this->exactly(2))->method('create')
             ->willReturnOnConsecutiveCalls($attributeValue, $attributeValue2);
-        $this->assertEquals(1, count($this->model->getCustomAttributes()));
+        $this->assertCount(1, $this->model->getCustomAttributes());
         $this->assertNotNull($this->model->getCustomAttribute($customAttributeCode));
         $this->assertEquals(
             $initialCustomAttributeValue,
@@ -1320,7 +1320,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
 
         //Change the attribute value, should reflect in getCustomAttribute
         $this->model->setCustomAttribute($customAttributeCode, $newCustomAttributeValue);
-        $this->assertEquals(1, count($this->model->getCustomAttributes()));
+        $this->assertCount(1, $this->model->getCustomAttributes());
         $this->assertNotNull($this->model->getCustomAttribute($customAttributeCode));
         $this->assertEquals(
             $newCustomAttributeValue,

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ProductOptionProcessorTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ProductOptionProcessorTest.php
@@ -171,7 +171,7 @@ class ProductOptionProcessorTest extends \PHPUnit\Framework\TestCase
 
         if (!empty($expected)) {
             $this->assertArrayHasKey($expected, $result);
-            $this->assertTrue(is_array($result[$expected]));
+            $this->assertInternalType('array', $result[$expected]);
         } else {
             $this->assertEmpty($result);
         }

--- a/app/code/Magento/Contact/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Contact/Test/Unit/Helper/DataTest.php
@@ -62,7 +62,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
             ->method('getValue')
             ->willReturn('1');
 
-        $this->assertTrue(is_string($this->helper->isEnabled()));
+        $this->assertInternalType('string', $this->helper->isEnabled());
     }
 
     public function testIsNotEnabled()

--- a/app/code/Magento/Contact/Test/Unit/Model/System/Config/Backend/LinksTest.php
+++ b/app/code/Magento/Contact/Test/Unit/Model/System/Config/Backend/LinksTest.php
@@ -23,6 +23,6 @@ class LinksTest extends \PHPUnit\Framework\TestCase
 
     public function testGetIdentities()
     {
-        $this->assertTrue(is_array($this->_model->getIdentities()));
+        $this->assertInternalType('array', $this->_model->getIdentities());
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Model/FileProcessorTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/FileProcessorTest.php
@@ -102,7 +102,7 @@ class FileProcessorTest extends \PHPUnit\Framework\TestCase
         $model = $this->getModel(CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER);
         $result = $model->getStat($fileName);
 
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('size', $result);
         $this->assertEquals(1, $result['size']);
     }

--- a/app/code/Magento/Customer/Test/Unit/Ui/Component/DataProviderTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Ui/Component/DataProviderTest.php
@@ -138,11 +138,11 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->model->getData();
 
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('totalRecords', $result);
         $this->assertEquals(1, $result['totalRecords']);
         $this->assertArrayHasKey('items', $result);
-        $this->assertTrue(is_array($result['items']));
+        $this->assertInternalType('array', $result['items']);
         $this->assertEquals($result['items'], $expected);
     }
 

--- a/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
@@ -119,7 +119,7 @@ class FixerIoTest extends \PHPUnit\Framework\TestCase
 
         $messages = $this->model->getMessages();
         self::assertNotEmpty($messages);
-        self::assertTrue(is_array($messages));
+        self::assertInternalType('array', $messages);
         self::assertEquals($message, (string)$messages[0]);
     }
 }

--- a/app/code/Magento/Directory/Test/Unit/Model/CurrencyInformationAcquirerTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/CurrencyInformationAcquirerTest.php
@@ -107,7 +107,7 @@ class CurrencyInformationAcquirerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('USD', $result->getDefaultDisplayCurrencyCode());
         $this->assertEquals('$', $result->getDefaultDisplayCurrencySymbol());
         $this->assertEquals(['AUD'], $result->getAvailableCurrencyCodes());
-        $this->assertTrue(is_array($result->getExchangeRates()));
+        $this->assertInternalType('array', $result->getExchangeRates());
         $this->assertEquals([$exchangeRate], $result->getExchangeRates());
         $this->assertEquals('0.80', $result->getExchangeRates()[0]->getRate());
         $this->assertEquals('AUD', $result->getExchangeRates()[0]->getCurrencyTo());

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Source/BooleanTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Source/BooleanTest.php
@@ -35,7 +35,7 @@ class BooleanTest extends \PHPUnit\Framework\TestCase
 
         $flatColumns = $this->_model->getFlatColumns();
 
-        $this->assertTrue(is_array($flatColumns), 'FlatColumns must be an array value');
+        $this->assertInternalType('array', $flatColumns, 'FlatColumns must be an array value');
         $this->assertTrue(!empty($flatColumns), 'FlatColumns must be not empty');
         foreach ($flatColumns as $result) {
             $this->assertArrayHasKey('unsigned', $result, 'FlatColumns must have "unsigned" column');

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Source/TableTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Source/TableTest.php
@@ -127,7 +127,7 @@ class TableTest extends \PHPUnit\Framework\TestCase
 
         $flatColumns = $this->model->getFlatColumns();
 
-        $this->assertTrue(is_array($flatColumns), 'FlatColumns must be an array value');
+        $this->assertInternalType('array', $flatColumns, 'FlatColumns must be an array value');
         $this->assertTrue(!empty($flatColumns), 'FlatColumns must be not empty');
 
         foreach ($flatColumns as $result) {

--- a/app/code/Magento/Fedex/Test/Unit/Model/CarrierTest.php
+++ b/app/code/Magento/Fedex/Test/Unit/Model/CarrierTest.php
@@ -409,7 +409,7 @@ class CarrierTest extends \PHPUnit\Framework\TestCase
         $this->carrier->getTracking($tracking);
         $tracks = $this->carrier->getResult()->getAllTrackings();
 
-        $this->assertEquals(1, count($tracks));
+        $this->assertCount(1, $tracks);
 
         /** @var Error $current */
         $current = $tracks[0];
@@ -466,7 +466,7 @@ class CarrierTest extends \PHPUnit\Framework\TestCase
             ->willReturn($status);
 
         $tracks = $this->carrier->getTracking($tracking)->getAllTrackings();
-        $this->assertEquals(1, count($tracks));
+        $this->assertCount(1, $tracks);
 
         $current = $tracks[0];
         $fields = [
@@ -590,11 +590,11 @@ class CarrierTest extends \PHPUnit\Framework\TestCase
 
         $this->carrier->getTracking($tracking);
         $tracks = $this->carrier->getResult()->getAllTrackings();
-        $this->assertEquals(1, count($tracks));
+        $this->assertCount(1, $tracks);
 
         $current = $tracks[0];
         $this->assertNotEmpty($current['progressdetail']);
-        $this->assertEquals(1, count($current['progressdetail']));
+        $this->assertCount(1, $current['progressdetail']);
 
         $event = $current['progressdetail'][0];
         $fields = ['activity', 'deliverylocation'];

--- a/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerReindexCommandTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerReindexCommandTest.php
@@ -85,7 +85,7 @@ class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
         $this->stateMock->expects($this->never())->method('setAreaCode');
         $this->command = new IndexerReindexCommand($this->objectManagerFactory);
         $optionsList = $this->command->getInputList();
-        $this->assertSame(1, sizeof($optionsList));
+        $this->assertCount(1, $optionsList);
         $this->assertSame('index', $optionsList[0]->getName());
     }
 

--- a/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerSetModeCommandTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerSetModeCommandTest.php
@@ -26,7 +26,7 @@ class IndexerSetModeCommandTest extends AbstractIndexerCommandCommonSetup
         $this->stateMock->expects($this->never())->method('setAreaCode')->with(FrontNameResolver::AREA_CODE);
         $this->command = new IndexerSetModeCommand($this->objectManagerFactory);
         $optionsList = $this->command->getInputList();
-        $this->assertSame(2, sizeof($optionsList));
+        $this->assertCount(2, $optionsList);
         $this->assertSame('mode', $optionsList[0]->getName());
         $this->assertSame('index', $optionsList[1]->getName());
     }

--- a/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerShowModeCommandTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerShowModeCommandTest.php
@@ -23,7 +23,7 @@ class IndexerShowModeCommandTest extends AbstractIndexerCommandCommonSetup
         $this->stateMock->expects($this->never())->method('setAreaCode')->with(FrontNameResolver::AREA_CODE);
         $this->command = new IndexerShowModeCommand($this->objectManagerFactory);
         $optionsList = $this->command->getInputList();
-        $this->assertSame(1, sizeof($optionsList));
+        $this->assertCount(1, $optionsList);
         $this->assertSame('index', $optionsList[0]->getName());
     }
 

--- a/app/code/Magento/Msrp/Test/Unit/Model/Product/Attribute/Source/Type/PriceTest.php
+++ b/app/code/Magento/Msrp/Test/Unit/Model/Product/Attribute/Source/Type/PriceTest.php
@@ -33,7 +33,7 @@ class PriceTest extends \PHPUnit\Framework\TestCase
 
         $flatColumns = $this->_model->getFlatColumns();
 
-        $this->assertTrue(is_array($flatColumns), 'FlatColumns must be an array value');
+        $this->assertInternalType('array', $flatColumns, 'FlatColumns must be an array value');
         $this->assertTrue(!empty($flatColumns), 'FlatColumns must be not empty');
         foreach ($flatColumns as $result) {
             $this->assertArrayHasKey('unsigned', $result, 'FlatColumns must have "unsigned" column');

--- a/app/code/Magento/OfflineShipping/Test/Unit/Model/ResourceModel/Carrier/Tablerate/CSV/RowParserTest.php
+++ b/app/code/Magento/OfflineShipping/Test/Unit/Model/ResourceModel/Carrier/Tablerate/CSV/RowParserTest.php
@@ -54,7 +54,7 @@ class RowParserTest extends \PHPUnit\Framework\TestCase
     public function testGetColumns()
     {
         $columns = $this->rowParser->getColumns();
-        $this->assertTrue(is_array($columns), 'Columns should be array, ' . gettype($columns) . ' given');
+        $this->assertInternalType('array', $columns, 'Columns should be array, ' . gettype($columns) . ' given');
         $this->assertNotEmpty($columns);
     }
 

--- a/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Order/CollectionTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Order/CollectionTest.php
@@ -281,7 +281,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
             ->willReturn(1);
 
         $result = $this->collection->getDateRange($range, $customStart, $customEnd);
-        $this->assertEquals(3, count($result));
+        $this->assertCount(3, $result);
     }
 
     /**
@@ -289,8 +289,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetDateRangeWithReturnObject()
     {
-        $this->assertEquals(2, count($this->collection->getDateRange('7d', '', '', true)));
-        $this->assertEquals(3, count($this->collection->getDateRange('7d', '', '', false)));
+        $this->assertCount(2, $this->collection->getDateRange('7d', '', '', true));
+        $this->assertCount(3, $this->collection->getDateRange('7d', '', '', false));
     }
 
     /**

--- a/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Report/CollectionTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Report/CollectionTest.php
@@ -119,7 +119,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         foreach ($reports as $report) {
             $this->assertInstanceOf(\Magento\Framework\DataObject::class, $report);
             $reportData = $report->getData();
-            $this->assertTrue(empty($reportData['children']));
+            $this->assertEmpty($reportData['children']);
             $this->assertTrue($reportData['is_empty']);
         }
         $this->assertEquals($size, count($reports));

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ShipmentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ShipmentTest.php
@@ -88,7 +88,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
 
         $actual = $this->shipmentModel->getCommentsCollection();
 
-        self::assertTrue(is_object($actual));
+        self::assertInternalType('object', $actual);
         self::assertEquals($this->commentCollection, $actual);
     }
 
@@ -126,7 +126,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
             ->willReturn($collection);
 
         $actual = $this->shipmentModel->getComments();
-        self::assertTrue(is_array($actual));
+        self::assertInternalType('array', $actual);
         self::assertEquals($collection, $actual);
     }
 

--- a/app/code/Magento/Store/Test/Unit/Model/Service/StoreConfigManagerTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/Service/StoreConfigManagerTest.php
@@ -180,7 +180,7 @@ class StoreConfigManagerTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->model->getStoreConfigs([$code]);
 
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         $this->assertEquals($id, $result[0]->getId());
         $this->assertEquals($code, $result[0]->getCode());
         $this->assertEquals($weightUnit, $result[0]->getWeightUnit());

--- a/app/code/Magento/Tax/Test/Unit/Model/Calculation/Rate/ConverterTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/Calculation/Rate/ConverterTest.php
@@ -96,7 +96,7 @@ class ConverterTest extends \PHPUnit\Framework\TestCase
 
         $this->assertArrayHasKey('title[1]', $this->converter->createArrayFromServiceObject($taxRateMock, true));
         $this->assertArrayHasKey('title', $this->converter->createArrayFromServiceObject($taxRateMock));
-        $this->assertTrue(is_array($this->converter->createArrayFromServiceObject($taxRateMock)));
+        $this->assertInternalType('array', $this->converter->createArrayFromServiceObject($taxRateMock));
     }
 
     public function testPopulateTaxRateData()

--- a/app/code/Magento/Tax/Test/Unit/Model/TaxClass/Source/ProductTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/TaxClass/Source/ProductTest.php
@@ -82,7 +82,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
 
         $flatColumns = $this->product->getFlatColumns();
 
-        $this->assertTrue(is_array($flatColumns), 'FlatColumns must be an array value');
+        $this->assertInternalType('array', $flatColumns, 'FlatColumns must be an array value');
         $this->assertTrue(!empty($flatColumns), 'FlatColumns must be not empty');
         foreach ($flatColumns as $result) {
             $this->assertArrayHasKey('unsigned', $result, 'FlatColumns must have "unsigned" column');

--- a/app/code/Magento/Tax/Test/Unit/Plugin/Checkout/CustomerData/CartTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Plugin/Checkout/CustomerData/CartTest.php
@@ -104,8 +104,8 @@ class CartTest extends TestCase
         self::assertArrayHasKey('subtotal_incl_tax', $result);
         self::assertArrayHasKey('subtotal_excl_tax', $result);
         self::assertArrayHasKey('items', $result);
-        self::assertTrue(is_array($result['items']));
-        self::assertEquals(2, count($result['items']));
+        self::assertInternalType('array', $result['items']);
+        self::assertCount(2, $result['items']);
         self::assertEquals(1, $result['items'][0]['product_price']);
         self::assertEquals(1, $result['items'][1]['product_price']);
     }

--- a/app/code/Magento/Theme/Test/Unit/Block/Adminhtml/Design/Config/Edit/SaveButtonTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Block/Adminhtml/Design/Config/Edit/SaveButtonTest.php
@@ -34,7 +34,7 @@ class SaveButtonTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('label', $result);
         $this->assertEquals($result['label'], __('Save Configuration'));
         $this->assertArrayHasKey('data_attribute', $result);
-        $this->assertTrue(is_array($result['data_attribute']));
+        $this->assertInternalType('array', $result['data_attribute']);
     }
 
     protected function initContext()

--- a/app/code/Magento/Theme/Test/Unit/Model/Design/Config/DataProvider/DataLoaderTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Design/Config/DataProvider/DataLoaderTest.php
@@ -108,11 +108,11 @@ class DataLoaderTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->model->getData();
 
-        $this->assertTrue(is_array($result));
-        $this->assertTrue(array_key_exists($scope, $result));
-        $this->assertTrue(is_array($result[$scope]));
-        $this->assertTrue(array_key_exists('scope', $result[$scope]));
-        $this->assertTrue(array_key_exists('scope_id', $result[$scope]));
+        $this->assertInternalType('array', $result);
+        $this->assertArrayHasKey($scope, $result);
+        $this->assertInternalType('array', $result[$scope]);
+        $this->assertArrayHasKey('scope', $result[$scope]);
+        $this->assertArrayHasKey('scope_id', $result[$scope]);
         $this->assertEquals($scope, $result[$scope]['scope']);
         $this->assertEquals($scopeId, $result[$scope]['scope_id']);
     }

--- a/app/code/Magento/Ui/Test/Unit/Component/Form/Element/DataType/DateTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/Form/Element/DataType/DateTest.php
@@ -65,7 +65,7 @@ class DateTest extends \PHPUnit\Framework\TestCase
         $this->date->prepare();
 
         $config = $this->date->getConfig();
-        $this->assertTrue(is_array($config));
+        $this->assertInternalType('array', $config);
 
         $this->assertArrayHasKey('options', $config);
         $this->assertArrayHasKey('dateFormat', $config['options']);
@@ -103,7 +103,7 @@ class DateTest extends \PHPUnit\Framework\TestCase
         $this->date->prepare();
 
         $config = $this->date->getConfig();
-        $this->assertTrue(is_array($config));
+        $this->assertInternalType('array', $config);
 
         $this->assertArrayHasKey('options', $config);
         $this->assertArrayHasKey('dateFormat', $config['options']);

--- a/app/code/Magento/Ui/Test/Unit/Model/Export/ConvertToCsvTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Model/Export/ConvertToCsvTest.php
@@ -139,7 +139,7 @@ class ConvertToCsvTest extends \PHPUnit\Framework\TestCase
             ->with($document, $componentName);
 
         $result = $this->model->getCsvFile();
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('type', $result);
         $this->assertArrayHasKey('value', $result);
         $this->assertArrayHasKey('rm', $result);

--- a/app/code/Magento/Ui/Test/Unit/Model/Export/ConvertToXmlTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Model/Export/ConvertToXmlTest.php
@@ -173,7 +173,7 @@ class ConvertToXmlTest extends \PHPUnit\Framework\TestCase
             ->with($document, $componentName);
 
         $result = $this->model->getXmlFile();
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('type', $result);
         $this->assertArrayHasKey('value', $result);
         $this->assertArrayHasKey('rm', $result);

--- a/app/code/Magento/Ui/Test/Unit/Model/Export/MetadataProviderTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Model/Export/MetadataProviderTest.php
@@ -86,7 +86,7 @@ class MetadataProviderTest extends \PHPUnit\Framework\TestCase
 
         $component = $this->prepareColumns($componentName, $columnName, $columnLabels[0]);
         $result = $this->model->getHeaders($component);
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
         $this->assertEquals($expected, $result);
     }
@@ -115,7 +115,7 @@ class MetadataProviderTest extends \PHPUnit\Framework\TestCase
         $component = $this->prepareColumns($componentName, $columnName, $columnLabel);
 
         $result = $this->model->getFields($component);
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
         $this->assertEquals($columnName, $result[0]);
     }
@@ -217,7 +217,7 @@ class MetadataProviderTest extends \PHPUnit\Framework\TestCase
             ->willReturn($key);
 
         $result = $this->model->getRowData($document, $fields, $options);
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
         $this->assertEquals($expected, $result);
     }
@@ -310,7 +310,7 @@ class MetadataProviderTest extends \PHPUnit\Framework\TestCase
             ->willReturn($options);
 
         $result = $this->model->getOptions();
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
         $this->assertEquals($expected, $result);
     }

--- a/app/code/Magento/Weee/Test/Unit/Model/TaxTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Model/TaxTest.php
@@ -252,7 +252,7 @@ class TaxTest extends \PHPUnit\Framework\TestCase
             ]);
 
         $result = $this->model->getProductWeeeAttributes($product, null, null, $websitePassed, true);
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertArrayHasKey(0, $result);
         $obj = $result[0];
         $this->assertEquals(1, $obj->getAmount());

--- a/app/code/Magento/Wishlist/Test/Unit/Model/ItemTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/ItemTest.php
@@ -141,7 +141,7 @@ class ItemTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($optionMock);
         $this->model->addOption($option);
-        $this->assertEquals(1, count($this->model->getOptions()));
+        $this->assertCount(1, $this->model->getOptions());
     }
 
     /**
@@ -165,7 +165,7 @@ class ItemTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($optionMock);
         $this->model->addOption($option);
-        $this->assertEquals(1, count($this->model->getOptions()));
+        $this->assertCount(1, $this->model->getOptions());
         $this->model->removeOption($code);
         $actualOptions = $this->model->getOptions();
         $actualOption = array_pop($actualOptions);

--- a/dev/tests/api-functional/testsuite/Magento/Analytics/Api/LinkProviderTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Analytics/Api/LinkProviderTest.php
@@ -76,7 +76,7 @@ class LinkProviderTest extends WebapiAbstract
             $this->fail("Exception 'Operation allowed only in HTTPS' should be thrown");
         } else {
             $response = $this->_webApiCall($serviceInfo);
-            $this->assertEquals(2, count($response));
+            $this->assertCount(2, $response);
             $this->assertEquals(
                 base64_encode($fileInfo->getInitializationVector()),
                 $response['initialization_vector']

--- a/dev/tests/api-functional/testsuite/Magento/AsynchronousOperations/Api/OperationRepositoryInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/AsynchronousOperations/Api/OperationRepositoryInterfaceTest.php
@@ -58,7 +58,7 @@ class OperationRepositoryInterfaceTest extends WebapiAbstract
 
         $this->assertEquals($searchCriteria['searchCriteria'], $response['search_criteria']);
         $this->assertEquals(3, $response['total_count']);
-        $this->assertEquals(3, count($response['items']));
+        $this->assertCount(3, $response['items']);
 
         foreach ($response['items'] as $item) {
             $this->assertEquals('bulk-uuid-searchable-6', $item['bulk_uuid']);
@@ -115,7 +115,7 @@ class OperationRepositoryInterfaceTest extends WebapiAbstract
 
         $this->assertEquals($searchCriteria['searchCriteria'], $response['search_criteria']);
         $this->assertEquals(1, $response['total_count']);
-        $this->assertEquals(1, count($response['items']));
+        $this->assertCount(1, $response['items']);
 
         foreach ($response['items'] as $item) {
             $this->assertEquals('bulk-uuid-searchable-6', $item['bulk_uuid']);

--- a/dev/tests/api-functional/testsuite/Magento/Bundle/Api/CartItemRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Bundle/Api/CartItemRepositoryTest.php
@@ -47,7 +47,7 @@ class CartItemRepositoryTest extends WebapiAbstract
             ],
         ];
         $response = $this->_webApiCall($serviceInfo, ['cartId' => $quoteId]);
-        $this->assertEquals(1, count($response));
+        $this->assertCount(1, $response);
         $response = $response[0];
         $bundleOption = $quote->getItemById($response['item_id'])->getBuyRequest()->getBundleOption();
         $bundleOptionQty = $quote->getItemById($response['item_id'])->getBuyRequest()->getBundleOptionQty();
@@ -192,7 +192,7 @@ class CartItemRepositoryTest extends WebapiAbstract
         $cartItems = $quoteUpdated->getAllVisibleItems();
         $buyRequest = $cartItems[0]->getBuyRequest()->toArray();
 
-        $this->assertEquals(1, count($cartItems));
+        $this->assertCount(1, $cartItems);
         $this->assertEquals(count($buyRequest['bundle_option']), count($bundleOptions));
         foreach ($bundleOptions as $option) {
             $optionId = $option['option_id'];

--- a/dev/tests/api-functional/testsuite/Magento/Bundle/Api/OrderItemRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Bundle/Api/OrderItemRepositoryTest.php
@@ -50,7 +50,7 @@ class OrderItemRepositoryTest extends WebapiAbstract
 
         $response = $this->_webApiCall($serviceInfo, ['id' => $orderItem->getId()]);
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertOrderItem($orderItem, $response);
     }
 
@@ -92,10 +92,10 @@ class OrderItemRepositoryTest extends WebapiAbstract
 
         $response = $this->_webApiCall($serviceInfo, $requestData);
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertArrayHasKey('items', $response);
         $this->assertCount(1, $response['items']);
-        $this->assertTrue(is_array($response['items'][0]));
+        $this->assertInternalType('array', $response['items'][0]);
         $this->assertOrderItem(current($order->getItems()), $response['items'][0]);
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CartItemRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CartItemRepositoryTest.php
@@ -53,7 +53,7 @@ class CartItemRepositoryTest extends WebapiAbstract
         ];
         $response = $this->_webApiCall($serviceInfo, $this->getRequestData($cartId));
         $this->assertTrue($quote->hasProductId($product->getId()));
-        $this->assertEquals(1, count($quote->getAllItems()));
+        $this->assertCount(1, $quote->getAllItems());
         /** @var \Magento\Quote\Api\Data\CartItemInterface $item */
         $item = $quote->getAllItems()[0];
         $this->assertEquals(

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CategoryAttributeOptionManagementInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CategoryAttributeOptionManagementInterfaceTest.php
@@ -42,7 +42,7 @@ class CategoryAttributeOptionManagementInterfaceTest extends WebapiAbstract
 
         $response = $this->_webApiCall($serviceInfo, ['attributeCode' => $testAttributeCode]);
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertEquals($expectedOptions, $response);
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CategoryAttributeRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CategoryAttributeRepositoryTest.php
@@ -20,7 +20,7 @@ class CategoryAttributeRepositoryTest extends \Magento\TestFramework\TestCase\We
         $attributeCode = 'test_attribute_code_666';
         $attribute = $this->getAttribute($attributeCode);
 
-        $this->assertTrue(is_array($attribute));
+        $this->assertInternalType('array', $attribute);
         $this->assertArrayHasKey('attribute_id', $attribute);
         $this->assertArrayHasKey('attribute_code', $attribute);
         $this->assertEquals($attributeCode, $attribute['attribute_code']);

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/OrderItemRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/OrderItemRepositoryTest.php
@@ -50,7 +50,7 @@ class OrderItemRepositoryTest extends WebapiAbstract
 
         $response = $this->_webApiCall($serviceInfo, ['id' => $orderItem->getId()]);
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertOrderItem($orderItem, $response);
     }
 
@@ -92,10 +92,10 @@ class OrderItemRepositoryTest extends WebapiAbstract
 
         $response = $this->_webApiCall($serviceInfo, $requestData);
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertArrayHasKey('items', $response);
         $this->assertCount(1, $response['items']);
-        $this->assertTrue(is_array($response['items'][0]));
+        $this->assertInternalType('array', $response['items'][0]);
         $this->assertOrderItem(current($order->getItems()), $response['items'][0]);
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductAttributeOptionManagementInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductAttributeOptionManagementInterfaceTest.php
@@ -43,7 +43,7 @@ class ProductAttributeOptionManagementInterfaceTest extends WebapiAbstract
 
         $response = $this->_webApiCall($serviceInfo, ['attributeCode' => $testAttributeCode]);
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertEquals($expectedOptions, $response);
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductAttributeRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductAttributeRepositoryTest.php
@@ -30,7 +30,7 @@ class ProductAttributeRepositoryTest extends \Magento\TestFramework\TestCase\Web
         $attributeCode = 'test_attribute_code_333';
         $attribute = $this->getAttribute($attributeCode);
 
-        $this->assertTrue(is_array($attribute));
+        $this->assertInternalType('array', $attribute);
         $this->assertArrayHasKey('attribute_id', $attribute);
         $this->assertArrayHasKey('attribute_code', $attribute);
         $this->assertEquals($attributeCode, $attribute['attribute_code']);
@@ -307,7 +307,7 @@ class ProductAttributeRepositoryTest extends \Magento\TestFramework\TestCase\Web
         ];
 
         $output = $this->updateAttribute($attributeCode, $attributeData);
-        $this->assertEquals(4, count($output['options']));
+        $this->assertCount(4, $output['options']);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductCustomOptionRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductCustomOptionRepositoryTest.php
@@ -61,7 +61,7 @@ class ProductCustomOptionRepositoryTest extends WebapiAbstract
         /** @var  \Magento\Catalog\Model\Product $product */
         $product = $productRepository->get($sku, false, null, true);
         $this->assertNull($product->getOptionById($optionId));
-        $this->assertEquals(9, count($product->getOptions()));
+        $this->assertCount(9, $product->getOptions());
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductRepositoryInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductRepositoryInterfaceTest.php
@@ -451,7 +451,7 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
 
         $this->assertArrayHasKey('product_links', $response);
         $links = $response['product_links'];
-        $this->assertEquals(1, count($links));
+        $this->assertCount(1, $links);
         $this->assertEquals($productLinkData, $links[0]);
 
         // update link information
@@ -478,7 +478,7 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
 
         $this->assertArrayHasKey('product_links', $response);
         $links = $response['product_links'];
-        $this->assertEquals(1, count($links));
+        $this->assertCount(1, $links);
         $this->assertEquals($productLinkData, $links[0]);
 
         // Remove link
@@ -554,9 +554,9 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
 
         $this->assertArrayHasKey('options', $response);
         $options = $response['options'];
-        $this->assertEquals(2, count($options));
-        $this->assertEquals(1, count($options[0]['values']));
-        $this->assertEquals(1, count($options[1]['values']));
+        $this->assertCount(2, $options);
+        $this->assertCount(1, $options[0]['values']);
+        $this->assertCount(1, $options[1]['values']);
 
         //update the product options, adding a value to option 1, delete an option and create a new option
         $options[0]['values'][] = [
@@ -584,9 +584,9 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
         $response = $this->updateProduct($response);
         $this->assertArrayHasKey('options', $response);
         $options = $response['options'];
-        $this->assertEquals(2, count($options));
-        $this->assertEquals(2, count($options[0]['values']));
-        $this->assertEquals(1, count($options[1]['values']));
+        $this->assertCount(2, $options);
+        $this->assertCount(2, $options[0]['values']);
+        $this->assertCount(1, $options[1]['values']);
 
         //update product without setting options field, option should not be changed
         unset($response['options']);
@@ -594,7 +594,7 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
         $response = $this->getProduct($productData[ProductInterface::SKU]);
         $this->assertArrayHasKey('options', $response);
         $options = $response['options'];
-        $this->assertEquals(2, count($options));
+        $this->assertCount(2, $options);
 
         //update product with empty options, options should be removed
         $response['options'] = [];
@@ -616,7 +616,7 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
         $response = $this->saveProduct($productData);
         $this->assertArrayHasKey('media_gallery_entries', $response);
         $mediaGalleryEntries = $response['media_gallery_entries'];
-        $this->assertEquals(2, count($mediaGalleryEntries));
+        $this->assertCount(2, $mediaGalleryEntries);
         $id = $mediaGalleryEntries[0]['id'];
         foreach ($mediaGalleryEntries as &$entry) {
             unset($entry['id']);
@@ -654,7 +654,7 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
         ];
         $response = $this->updateProduct($response);
         $mediaGalleryEntries = $response['media_gallery_entries'];
-        $this->assertEquals(1, count($mediaGalleryEntries));
+        $this->assertCount(1, $mediaGalleryEntries);
         unset($mediaGalleryEntries[0]['id']);
         $expectedValue = [
             [
@@ -671,7 +671,7 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
         unset($response['media_gallery_entries']);
         $response = $this->updateProduct($response);
         $mediaGalleryEntries = $response['media_gallery_entries'];
-        $this->assertEquals(1, count($mediaGalleryEntries));
+        $this->assertCount(1, $mediaGalleryEntries);
         unset($mediaGalleryEntries[0]['id']);
         $this->assertEquals($expectedValue, $mediaGalleryEntries);
         //pass empty array, delete all existing media gallery entries
@@ -1058,7 +1058,7 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
         $searchResult = $this->_webApiCall($serviceInfo, $requestData);
 
         $this->assertEquals(3, $searchResult['total_count']);
-        $this->assertEquals(1, count($searchResult['items']));
+        $this->assertCount(1, $searchResult['items']);
         $this->assertEquals('search_product_4', $searchResult['items'][0][ProductInterface::SKU]);
         $this->assertNotNull(
             $searchResult['items'][0][ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]['website_ids']
@@ -1435,8 +1435,8 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
         $missingAttributes = ['news_from_date', 'custom_design_from'];
         $expectedAttribute = ['special_price', 'special_from_date'];
         $attributeCodes = array_column($customAttributes, 'attribute_code');
-        $this->assertEquals(0, count(array_intersect($attributeCodes, $missingAttributes)));
-        $this->assertEquals(2, count(array_intersect($attributeCodes, $expectedAttribute)));
+        $this->assertCount(0, array_intersect($attributeCodes, $missingAttributes));
+        $this->assertCount(2, array_intersect($attributeCodes, $expectedAttribute));
     }
 
     /**
@@ -1468,7 +1468,7 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
         $this->saveProduct($productData);
         $response = $this->getProduct($productData[ProductInterface::SKU]);
         $customAttributes = array_column($response['custom_attributes'], 'value', 'attribute_code');
-        $this->assertFalse(array_key_exists(self::KEY_SPECIAL_PRICE, $customAttributes));
+        $this->assertArrayNotHasKey(self::KEY_SPECIAL_PRICE, $customAttributes);
     }
 
     public function testUpdateStatus()

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/TierPriceStorageTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/TierPriceStorageTest.php
@@ -238,7 +238,7 @@ class TierPriceStorageTest extends WebapiAbstract
         $tierPrices = $productRepository->get(self::SIMPLE_PRODUCT_SKU)->getTierPrices();
         $tierPrice = $tierPrices[0];
         $this->assertEmpty($response);
-        $this->assertEquals(1, count($tierPrices));
+        $this->assertCount(1, $tierPrices);
         $this->assertEquals($pricesToStore, $tierPrice);
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/CheckoutAgreements/Api/CheckoutAgreementsListTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/CheckoutAgreements/Api/CheckoutAgreementsListTest.php
@@ -26,7 +26,7 @@ class CheckoutAgreementsListTest extends WebapiAbstract
 
         // Checkout agreements are disabled by default
         $agreements = $this->_webApiCall($this->getServiceInfo($requestData), $requestData);
-        $this->assertEquals(2, count($agreements));
+        $this->assertCount(2, $agreements);
     }
 
     /**
@@ -47,7 +47,7 @@ class CheckoutAgreementsListTest extends WebapiAbstract
 
         $agreements = $this->_webApiCall($this->getServiceInfo($requestData), $requestData);
 
-        $this->assertEquals(1, count($agreements));
+        $this->assertCount(1, $agreements);
         $this->assertEquals(1, $agreements[0]['is_active']);
         $this->assertEquals('Checkout Agreement (active)', $agreements[0]['name']);
     }

--- a/dev/tests/api-functional/testsuite/Magento/Cms/Api/BlockRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Cms/Api/BlockRepositoryTest.php
@@ -276,7 +276,7 @@ class BlockRepositoryTest extends WebapiAbstract
 
         $searchResult = $this->_webApiCall($serviceInfo, $requestData);
         $this->assertEquals(2, $searchResult['total_count']);
-        $this->assertEquals(1, count($searchResult['items']));
+        $this->assertCount(1, $searchResult['items']);
         $this->assertEquals(
             $searchResult['items'][0][BlockInterface::IDENTIFIER],
             $cmsBlocks['third']->getIdentifier()

--- a/dev/tests/api-functional/testsuite/Magento/Cms/Api/PageRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Cms/Api/PageRepositoryTest.php
@@ -277,7 +277,7 @@ class PageRepositoryTest extends WebapiAbstract
 
         $searchResult = $this->_webApiCall($serviceInfo, $requestData);
         $this->assertEquals(2, $searchResult['total_count']);
-        $this->assertEquals(1, count($searchResult['items']));
+        $this->assertCount(1, $searchResult['items']);
         $this->assertEquals(
             $searchResult['items'][0][PageInterface::IDENTIFIER],
             $cmsPages['third']->getIdentifier()

--- a/dev/tests/api-functional/testsuite/Magento/ConfigurableProduct/Api/OptionRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/ConfigurableProduct/Api/OptionRepositoryTest.php
@@ -24,14 +24,14 @@ class OptionRepositoryTest extends \Magento\TestFramework\TestCase\WebapiAbstrac
         $productSku = 'configurable';
 
         $options = $this->getList($productSku);
-        $this->assertTrue(is_array($options));
+        $this->assertInternalType('array', $options);
         $this->assertNotEmpty($options);
 
         foreach ($options as $option) {
             /** @var array $result */
             $result = $this->get($productSku, $option['id']);
 
-            $this->assertTrue(is_array($result));
+            $this->assertInternalType('array', $result);
             $this->assertNotEmpty($result);
 
             $this->assertArrayHasKey('id', $result);
@@ -44,7 +44,7 @@ class OptionRepositoryTest extends \Magento\TestFramework\TestCase\WebapiAbstrac
             $this->assertEquals($option['label'], $result['label']);
 
             $this->assertArrayHasKey('values', $result);
-            $this->assertTrue(is_array($result['values']));
+            $this->assertInternalType('array', $result['values']);
             $this->assertEquals($option['values'], $result['values']);
         }
     }
@@ -60,26 +60,26 @@ class OptionRepositoryTest extends \Magento\TestFramework\TestCase\WebapiAbstrac
         $result = $this->getList($productSku);
 
         $this->assertNotEmpty($result);
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertArrayHasKey(0, $result);
 
         $option = $result[0];
 
         $this->assertNotEmpty($option);
-        $this->assertTrue(is_array($option));
+        $this->assertInternalType('array', $option);
 
         $this->assertArrayHasKey('id', $option);
         $this->assertArrayHasKey('label', $option);
         $this->assertEquals($option['label'], 'Test Configurable');
 
         $this->assertArrayHasKey('values', $option);
-        $this->assertTrue(is_array($option));
+        $this->assertInternalType('array', $option);
         $this->assertNotEmpty($option);
 
         $this->assertCount(2, $option['values']);
 
         foreach ($option['values'] as $value) {
-            $this->assertTrue(is_array($value));
+            $this->assertInternalType('array', $value);
             $this->assertNotEmpty($value);
 
             $this->assertArrayHasKey('value_index', $value);

--- a/dev/tests/api-functional/testsuite/Magento/ConfigurableProduct/Api/OrderItemRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/ConfigurableProduct/Api/OrderItemRepositoryTest.php
@@ -50,7 +50,7 @@ class OrderItemRepositoryTest extends WebapiAbstract
 
         $response = $this->_webApiCall($serviceInfo, ['id' => $orderItem->getId()]);
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertOrderItem($orderItem, $response);
     }
 
@@ -92,10 +92,10 @@ class OrderItemRepositoryTest extends WebapiAbstract
 
         $response = $this->_webApiCall($serviceInfo, $requestData);
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertArrayHasKey('items', $response);
         $this->assertCount(1, $response['items']);
-        $this->assertTrue(is_array($response['items'][0]));
+        $this->assertInternalType('array', $response['items'][0]);
         $this->assertOrderItem(current($order->getItems()), $response['items'][0]);
     }
 
@@ -114,8 +114,8 @@ class OrderItemRepositoryTest extends WebapiAbstract
 
         $actualOptions = $response['product_option']['extension_attributes']['configurable_item_options'];
 
-        $this->assertTrue(is_array($actualOptions));
-        $this->assertTrue(is_array($actualOptions[0]));
+        $this->assertInternalType('array', $actualOptions);
+        $this->assertInternalType('array', $actualOptions[0]);
         $this->assertArrayHasKey('option_id', $actualOptions[0]);
         $this->assertArrayHasKey('option_value', $actualOptions[0]);
 

--- a/dev/tests/api-functional/testsuite/Magento/ConfigurableProduct/Api/ProductRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/ConfigurableProduct/Api/ProductRepositoryTest.php
@@ -75,7 +75,7 @@ class ProductRepositoryTest extends WebapiAbstract
         $this->assertNotNull($this->configurableAttribute);
 
         $options = $this->getConfigurableAttributeOptions();
-        $this->assertEquals(2, count($options));
+        $this->assertCount(2, $options);
 
         $configurableProductOptions = [
             [
@@ -131,21 +131,21 @@ class ProductRepositoryTest extends WebapiAbstract
         );
         $resultConfigurableProductOptions
             = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["configurable_product_options"];
-        $this->assertEquals(1, count($resultConfigurableProductOptions));
+        $this->assertCount(1, $resultConfigurableProductOptions);
         $this->assertTrue(isset($resultConfigurableProductOptions[0]['label']));
         $this->assertTrue(isset($resultConfigurableProductOptions[0]['id']));
         $this->assertEquals($label, $resultConfigurableProductOptions[0]['label']);
         $this->assertTrue(
             isset($resultConfigurableProductOptions[0]['values'])
         );
-        $this->assertEquals(2, count($resultConfigurableProductOptions[0]['values']));
+        $this->assertCount(2, $resultConfigurableProductOptions[0]['values']);
 
         $this->assertTrue(
             isset($response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["configurable_product_links"])
         );
         $resultConfigurableProductLinks
             = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["configurable_product_links"];
-        $this->assertEquals(2, count($resultConfigurableProductLinks));
+        $this->assertCount(2, $resultConfigurableProductLinks);
 
         $this->assertEquals([$productId1, $productId2], $resultConfigurableProductLinks);
     }
@@ -167,14 +167,14 @@ class ProductRepositoryTest extends WebapiAbstract
         );
         $resultConfigurableProductOptions
             = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["configurable_product_options"];
-        $this->assertEquals(0, count($resultConfigurableProductOptions));
+        $this->assertCount(0, $resultConfigurableProductOptions);
 
         $this->assertTrue(
             isset($response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["configurable_product_links"])
         );
         $resultConfigurableProductLinks
             = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["configurable_product_links"];
-        $this->assertEquals(0, count($resultConfigurableProductLinks));
+        $this->assertCount(0, $resultConfigurableProductLinks);
 
         $this->assertEquals([], $resultConfigurableProductLinks);
     }
@@ -214,7 +214,7 @@ class ProductRepositoryTest extends WebapiAbstract
         );
         $resultConfigurableProductOptions
             = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["configurable_product_options"];
-        $this->assertEquals(1, count($resultConfigurableProductOptions));
+        $this->assertCount(1, $resultConfigurableProductOptions);
 
         unset($updatedOption['id']);
         unset($resultConfigurableProductOptions[0]['id']);
@@ -241,16 +241,16 @@ class ProductRepositoryTest extends WebapiAbstract
         );
         $resultConfigurableProductOptions
             = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["configurable_product_options"];
-        $this->assertEquals(1, count($resultConfigurableProductOptions));
+        $this->assertCount(1, $resultConfigurableProductOptions);
         //Since one product is removed, the available values for the option is reduced
-        $this->assertEquals(1, count($resultConfigurableProductOptions[0]['values']));
+        $this->assertCount(1, $resultConfigurableProductOptions[0]['values']);
 
         $this->assertTrue(
             isset($response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["configurable_product_links"])
         );
         $resultConfigurableProductLinks
             = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["configurable_product_links"];
-        $this->assertEquals(1, count($resultConfigurableProductLinks));
+        $this->assertCount(1, $resultConfigurableProductLinks);
         $this->assertEquals([$productId1], $resultConfigurableProductLinks);
 
         //adding back the product links, the option value should be restored

--- a/dev/tests/api-functional/testsuite/Magento/Customer/Api/AccountManagementCustomAttributesTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Customer/Api/AccountManagementCustomAttributesTest.php
@@ -271,6 +271,6 @@ class AccountManagementCustomAttributesTest extends WebapiAbstract
         $customerMediaPath = $mediaDirectory->getAbsolutePath(CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER);
         $previousImagePath =
             $previousCustomerData[CustomAttributesDataInterface::CUSTOM_ATTRIBUTES][0][AttributeValue::VALUE];
-        $this->assertFalse(file_exists($customerMediaPath . $previousImagePath));
+        $this->assertFileNotExists($customerMediaPath . $previousImagePath);
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/Downloadable/Api/LinkRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Downloadable/Api/LinkRepositoryTest.php
@@ -910,7 +910,7 @@ class LinkRepositoryTest extends WebapiAbstract
 
         $list = $this->_webApiCall($serviceInfo, $requestData);
 
-        $this->assertEquals(1, count($list));
+        $this->assertCount(1, $list);
 
         $link = reset($list);
         foreach ($expectations['fields'] as $index => $value) {

--- a/dev/tests/api-functional/testsuite/Magento/Downloadable/Api/OrderItemRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Downloadable/Api/OrderItemRepositoryTest.php
@@ -50,7 +50,7 @@ class OrderItemRepositoryTest extends WebapiAbstract
 
         $response = $this->_webApiCall($serviceInfo, ['id' => $orderItem->getId()]);
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertOrderItem($orderItem, $response);
     }
 
@@ -92,10 +92,10 @@ class OrderItemRepositoryTest extends WebapiAbstract
 
         $response = $this->_webApiCall($serviceInfo, $requestData);
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertArrayHasKey('items', $response);
         $this->assertCount(1, $response['items']);
-        $this->assertTrue(is_array($response['items'][0]));
+        $this->assertInternalType('array', $response['items'][0]);
         $this->assertOrderItem(current($order->getItems()), $response['items'][0]);
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/Downloadable/Api/ProductRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Downloadable/Api/ProductRepositoryTest.php
@@ -175,7 +175,7 @@ class ProductRepositoryTest extends WebapiAbstract
         );
         $resultLinks
             = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["downloadable_product_links"];
-        $this->assertEquals(2, count($resultLinks));
+        $this->assertCount(2, $resultLinks);
         $this->assertTrue(isset($resultLinks[0]['id']));
         $this->assertTrue(isset($resultLinks[0]['link_file']));
         $this->assertTrue(isset($resultLinks[0]['sample_file']));
@@ -189,7 +189,7 @@ class ProductRepositoryTest extends WebapiAbstract
         $this->assertEquals($expectedLinkData, $resultLinks);
 
         $resultSamples = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["downloadable_product_samples"];
-        $this->assertEquals(2, count($resultSamples));
+        $this->assertCount(2, $resultSamples);
         $this->assertTrue(isset($resultSamples[0]['id']));
         unset($resultSamples[0]['id']);
         $this->assertTrue(isset($resultSamples[1]['id']));
@@ -239,7 +239,7 @@ class ProductRepositoryTest extends WebapiAbstract
         $resultLinks
             = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["downloadable_product_links"];
 
-        $this->assertEquals(3, count($resultLinks));
+        $this->assertCount(3, $resultLinks);
         $this->assertTrue(isset($resultLinks[0]['id']));
         $this->assertEquals($link1Id, $resultLinks[0]['id']);
         $this->assertTrue(isset($resultLinks[0]['link_file']));
@@ -273,7 +273,7 @@ class ProductRepositoryTest extends WebapiAbstract
         $this->assertEquals($expectedLinkData, $resultLinks);
 
         $resultSamples = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["downloadable_product_samples"];
-        $this->assertEquals(2, count($resultSamples));
+        $this->assertCount(2, $resultSamples);
     }
 
     /**
@@ -341,7 +341,7 @@ class ProductRepositoryTest extends WebapiAbstract
         $resultLinks
             = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["downloadable_product_links"];
 
-        $this->assertEquals(2, count($resultLinks));
+        $this->assertCount(2, $resultLinks);
         $this->assertTrue(isset($resultLinks[0]['id']));
         $this->assertEquals($link1Id, $resultLinks[0]['id']);
         $this->assertTrue(isset($resultLinks[0]['link_file']));
@@ -386,7 +386,7 @@ class ProductRepositoryTest extends WebapiAbstract
         $this->assertEquals($expectedLinkData, $resultLinks);
 
         $resultSamples = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["downloadable_product_samples"];
-        $this->assertEquals(2, count($resultSamples));
+        $this->assertCount(2, $resultSamples);
     }
 
     public function testUpdateDownloadableProductSamples()
@@ -420,10 +420,10 @@ class ProductRepositoryTest extends WebapiAbstract
         $resultLinks
             = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["downloadable_product_links"];
 
-        $this->assertEquals(2, count($resultLinks));
+        $this->assertCount(2, $resultLinks);
 
         $resultSamples = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["downloadable_product_samples"];
-        $this->assertEquals(3, count($resultSamples));
+        $this->assertCount(3, $resultSamples);
         $this->assertTrue(isset($resultSamples[0]['id']));
         $this->assertEquals($sample1Id, $resultSamples[0]['id']);
         unset($resultSamples[0]['id']);
@@ -487,10 +487,10 @@ class ProductRepositoryTest extends WebapiAbstract
         $resultLinks
             = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["downloadable_product_links"];
 
-        $this->assertEquals(2, count($resultLinks));
+        $this->assertCount(2, $resultLinks);
 
         $resultSamples = $response[ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY]["downloadable_product_samples"];
-        $this->assertEquals(2, count($resultSamples));
+        $this->assertCount(2, $resultSamples);
         $this->assertTrue(isset($resultSamples[0]['id']));
         $this->assertEquals($sample1Id, $resultSamples[0]['id']);
         unset($resultSamples[0]['id']);

--- a/dev/tests/api-functional/testsuite/Magento/Downloadable/Api/SampleRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Downloadable/Api/SampleRepositoryTest.php
@@ -544,7 +544,7 @@ class SampleRepositoryTest extends WebapiAbstract
 
         $list = $this->_webApiCall($serviceInfo, $requestData);
 
-        $this->assertEquals(1, count($list));
+        $this->assertCount(1, $list);
 
         $link = reset($list);
         foreach ($expectations['fields'] as $index => $value) {

--- a/dev/tests/api-functional/testsuite/Magento/Eav/Api/AttributeSetRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Eav/Api/AttributeSetRepositoryTest.php
@@ -257,7 +257,7 @@ class AttributeSetRepositoryTest extends WebapiAbstract
         $searchResult = $this->_webApiCall($serviceInfo, $requestData);
 
         $this->assertEquals(2, $searchResult['total_count']);
-        $this->assertEquals(1, count($searchResult['items']));
+        $this->assertCount(1, $searchResult['items']);
         $this->assertEquals(
             $searchResult['items'][0]['attribute_set_name'],
             'attribute_set_3_for_search'

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Bundle/BundleProductViewTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Bundle/BundleProductViewTest.php
@@ -250,7 +250,7 @@ QUERY;
         $childProduct->setId(
             $childProduct->getData($metadataPool->getMetadata(ProductInterface::class)->getLinkField())
         );
-        $this->assertEquals(1, count($options));
+        $this->assertCount(1, $options);
         $this->assertResponseFields(
             $actualResponse['items'][0],
             [

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductSearchTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductSearchTest.php
@@ -157,7 +157,7 @@ QUERY;
     private function assertFilters($response, $expectedFilters, $message = '')
     {
         $this->assertArrayHasKey('filters', $response['products'], 'Product has filters');
-        $this->assertTrue(is_array(($response['products']['filters'])), 'Product filters is array');
+        $this->assertInternalType('array', ($response['products']['filters']), 'Product filters is array');
         $this->assertTrue(count($response['products']['filters']) > 0, 'Product filters is not empty');
         foreach ($expectedFilters as $expectedFilter) {
             $found = false;

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductViewTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductViewTest.php
@@ -252,7 +252,7 @@ QUERY;
         );
         $this->assertArrayHasKey('products', $response);
         $this->assertArrayHasKey('items', $response['products']);
-        $this->assertEquals(1, count($response['products']['items']));
+        $this->assertCount(1, $response['products']['items']);
         $this->assertArrayHasKey(0, $response['products']['items']);
         $this->assertBaseFields($product, $response['products']['items'][0]);
         $this->assertEavAttributes($product, $response['products']['items'][0]);
@@ -483,7 +483,7 @@ QUERY;
         $product = $productRepository->get($productSku, false, null, true);
         $this->assertArrayHasKey('products', $response);
         $this->assertArrayHasKey('items', $response['products']);
-        $this->assertEquals(1, count($response['products']['items']));
+        $this->assertCount(1, $response['products']['items']);
         $this->assertArrayHasKey(0, $response['products']['items']);
         $this->assertMediaGalleryEntries($product, $response['products']['items'][0]);
         $this->assertArrayHasKey('websites', $response['products']['items'][0]);
@@ -516,7 +516,7 @@ QUERY;
 
         $this->assertArrayHasKey('products', $response);
         $this->assertArrayHasKey('items', $response['products']);
-        $this->assertEquals(1, count($response['products']['items']));
+        $this->assertCount(1, $response['products']['items']);
         $this->assertArrayHasKey(0, $response['products']['items']);
         $this->assertCustomAttribute($response['products']['items'][0]);
     }
@@ -658,8 +658,8 @@ QUERY;
     {
         $mediaGalleryEntries = $product->getMediaGalleryEntries();
         $this->assertCount(1, $mediaGalleryEntries, "Precondition failed, incorrect number of media gallery entries.");
-        $this->assertTrue(
-            is_array([$actualResponse['media_gallery_entries']]),
+        $this->assertInternalType(
+            'array', [$actualResponse['media_gallery_entries']],
             "Media galleries field must be of an array type."
         );
         $this->assertCount(1, $actualResponse['media_gallery_entries'], "There must be 1 record in media gallery.");

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/VirtualProductViewTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/VirtualProductViewTest.php
@@ -64,7 +64,7 @@ QUERY;
         );
         $this->assertArrayHasKey('products', $response);
         $this->assertArrayHasKey('items', $response['products']);
-        $this->assertEquals(1, count($response['products']['items']));
+        $this->assertCount(1, $response['products']['items']);
         $this->assertArrayHasKey(0, $response['products']['items']);
         $this->assertBaseFields($product, $response['products']['items'][0]);
         $this->assertArrayNotHasKey(

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/ConfigurableProductViewTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/ConfigurableProductViewTest.php
@@ -210,7 +210,7 @@ QUERY;
 
         $this->assertArrayHasKey('products', $response);
         $this->assertArrayHasKey('items', $response['products']);
-        $this->assertEquals(1, count($response['products']['items']));
+        $this->assertCount(1, $response['products']['items']);
         $this->assertArrayHasKey(0, $response['products']['items']);
         $this->assertBaseFields($product, $response['products']['items'][0]);
         $this->assertConfigurableProductOptions($response['products']['items'][0]);
@@ -327,13 +327,13 @@ QUERY;
                 $mediaGalleryEntries,
                 "Precondition failed since there are incorrect number of media gallery entries"
             );
-            $this->assertTrue(
-                is_array(
+            $this->assertInternalType(
+                'array',
                     $actualResponse['variants']
                     [$variantKey]
                     ['product']
                     ['media_gallery_entries']
-                )
+                
             );
             $this->assertCount(
                 1,

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/CreateCustomerAddressTest.php
@@ -225,7 +225,7 @@ MUTATION;
             ['response_field' => 'default_billing', 'expected_value' => (bool)$address->isDefaultBilling()],
         ];
         $this->assertResponseFields($actualResponse, $assertionMap);
-        $this->assertTrue(is_array([$actualResponse['region']]), "region field must be of an array type.");
+        $this->assertInternalType('array', [$actualResponse['region']], "region field must be of an array type.");
         $assertionRegionMap = [
             ['response_field' => 'region', 'expected_value' => $address->getRegion()->getRegion()],
             ['response_field' => 'region_code', 'expected_value' => $address->getRegion()->getRegionCode()],

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GetAddressesTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/GetAddressesTest.php
@@ -56,8 +56,8 @@ QUERY;
         $response = $this->graphQlQuery($query, [], '', $headerMap);
         $this->assertArrayHasKey('customer', $response);
         $this->assertArrayHasKey('addresses', $response['customer']);
-        $this->assertTrue(
-            is_array([$response['customer']['addresses']]),
+        $this->assertInternalType(
+            'array', [$response['customer']['addresses']],
             " Addresses field must be of an array type."
         );
         self::assertEquals($customer->getId(), $response['customer']['id']);

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/UpdateCustomerAddressTest.php
@@ -217,7 +217,7 @@ MUTATION;
             ['response_field' => 'default_billing', 'expected_value' => (bool)$address->isDefaultBilling()],
         ];
         $this->assertResponseFields($actualResponse, $assertionMap);
-        $this->assertTrue(is_array([$actualResponse['region']]), "region field must be of an array type.");
+        $this->assertInternalType('array', [$actualResponse['region']], "region field must be of an array type.");
         $assertionRegionMap = [
             ['response_field' => 'region', 'expected_value' => $address->getRegion()->getRegion()],
             ['response_field' => 'region_code', 'expected_value' => $address->getRegion()->getRegionCode()],

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/GroupedProduct/GroupedProductViewTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/GroupedProduct/GroupedProductViewTest.php
@@ -62,7 +62,7 @@ QUERY;
             $actualResponse['items'],
             "Precondition failed: 'grouped product items' must not be empty"
         );
-        $this->assertEquals(2, count($actualResponse['items']));
+        $this->assertCount(2, $actualResponse['items']);
         $groupedProductLinks = $product->getProductLinks();
         foreach ($actualResponse['items'] as $itemIndex => $bundleItems) {
             $this->assertNotEmpty($bundleItems);

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Swatches/ProductSearchTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Swatches/ProductSearchTest.php
@@ -156,7 +156,7 @@ QUERY;
     private function assertFilters($response, $expectedFilters, $message = '')
     {
         $this->assertArrayHasKey('filters', $response['products'], 'Product has filters');
-        $this->assertTrue(is_array(($response['products']['filters'])), 'Product filters is array');
+        $this->assertInternalType('array', ($response['products']['filters']), 'Product filters is array');
         $this->assertTrue(count($response['products']['filters']) > 0, 'Product filters is not empty');
         foreach ($expectedFilters as $expectedFilter) {
             $found = false;

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Tax/ProductViewTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Tax/ProductViewTest.php
@@ -199,7 +199,7 @@ QUERY;
         );
         $this->assertArrayHasKey('products', $response);
         $this->assertArrayHasKey('items', $response['products']);
-        $this->assertEquals(1, count($response['products']['items']));
+        $this->assertCount(1, $response['products']['items']);
         $this->assertArrayHasKey(0, $response['products']['items']);
         $this->assertBaseFields($product, $response['products']['items'][0]);
     }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/VariablesSupportQueryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/VariablesSupportQueryTest.php
@@ -70,7 +70,7 @@ QUERY;
 
         self::assertArrayHasKey('products', $response);
         self::assertArrayHasKey('items', $response['products']);
-        self::assertEquals(1, count($response['products']['items']));
+        self::assertCount(1, $response['products']['items']);
         self::assertArrayHasKey(0, $response['products']['items']);
         self::assertEquals($product->getSku(), $response['products']['items'][0]['sku']);
         self::assertEquals(

--- a/dev/tests/api-functional/testsuite/Magento/GroupedProduct/Api/ProductRepositoryInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GroupedProduct/Api/ProductRepositoryInterfaceTest.php
@@ -153,7 +153,7 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
         $response = $this->getProduct("group_product_500");
         $this->assertArrayHasKey('product_links', $response);
         $links = $response['product_links'];
-        $this->assertEquals(1, count($links));
+        $this->assertCount(1, $links);
         $this->assertEquals($productLinkData, $links[0]);
 
         // update link information for Group Product
@@ -179,7 +179,7 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
 
         $this->assertArrayHasKey('product_links', $response);
         $links = $response['product_links'];
-        $this->assertEquals(2, count($links));
+        $this->assertCount(2, $links);
         $this->assertEquals($productLinkData1, $links[1]);
         $this->assertEquals($productLinkData2, $links[0]);
 

--- a/dev/tests/api-functional/testsuite/Magento/Quote/Api/GuestShipmentEstimationTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Quote/Api/GuestShipmentEstimationTest.php
@@ -100,7 +100,7 @@ class GuestShipmentEstimationTest extends WebapiAbstract
 
         $result = $this->_webApiCall($serviceInfo, $requestData);
         $this->assertNotEmpty($result);
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         foreach ($result as $rate) {
             $this->assertEquals("flatrate", $rate['carrier_code']);
             $this->assertEquals(0, $rate['amount']);

--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderItemGetListTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderItemGetListTest.php
@@ -78,10 +78,10 @@ class OrderItemGetListTest extends WebapiAbstract
 
         $response = $this->_webApiCall($serviceInfo, $requestData);
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertArrayHasKey('items', $response);
         $this->assertCount(3, $response['items']);
-        $this->assertTrue(is_array($response['items'][0]));
+        $this->assertInternalType('array', $response['items'][0]);
         $rowTotals = [];
 
         foreach ($response['items'] as $item) {

--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderItemGetTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderItemGetTest.php
@@ -51,7 +51,7 @@ class OrderItemGetTest extends WebapiAbstract
 
         $response = $this->_webApiCall($serviceInfo, ['id' => $orderItem->getId()]);
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertOrderItem($orderItem, $response);
 
         //check that nullable fields were marked as optional and were not sent
@@ -103,7 +103,7 @@ class OrderItemGetTest extends WebapiAbstract
 
         $response = $this->_webApiCall($serviceInfo, ['id' => $orderItem->getId()]);
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertEquals(8.00, $response['row_total']);
         $this->assertEquals(8.00, $response['base_row_total']);
         $this->assertEquals(9.00, $response['row_total_incl_tax']);

--- a/dev/tests/api-functional/testsuite/Magento/SalesRule/Api/CouponManagementTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/SalesRule/Api/CouponManagementTest.php
@@ -37,7 +37,7 @@ class CouponManagementTest extends WebapiAbstract
         $ruleId = $salesRule->getRuleId();
 
         $result = $this->generate($ruleId, $count, $length, $format);
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertTrue(count($result) == $count);
         foreach ($result as $code) {
             $this->assertRegExp($regex, $code);

--- a/dev/tests/api-functional/testsuite/Magento/Search/Api/SearchTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Search/Api/SearchTest.php
@@ -63,7 +63,7 @@ class SearchTest extends WebapiAbstract
 
         self::assertArrayHasKey('search_criteria', $response);
         self::assertArrayHasKey('items', $response);
-        self::assertEquals(0, count($response['items']));
+        self::assertCount(0, $response['items']);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/Store/Api/StoreConfigManagerTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Store/Api/StoreConfigManagerTest.php
@@ -39,7 +39,7 @@ class StoreConfigManagerTest extends WebapiAbstract
         ];
         $storeConfigs = $this->_webApiCall($serviceInfo, $requestData);
         $this->assertNotNull($storeConfigs);
-        $this->assertEquals(1, count($storeConfigs));
+        $this->assertCount(1, $storeConfigs);
         $expectedKeys = [
             'id',
             'code',

--- a/dev/tests/api-functional/testsuite/Magento/Webapi/JsonGenerationFromDataObjectTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Webapi/JsonGenerationFromDataObjectTest.php
@@ -121,7 +121,7 @@ class JsonGenerationFromDataObjectTest extends \Magento\TestFramework\TestCase\W
         foreach ($expected as $expKey => $expVal) {
             $this->assertArrayHasKey($expKey, $actual, 'Schema does not contain \'' . $expKey . '\' section.');
             if (is_array($expVal)) {
-                $this->assertTrue(is_array($actual[$expKey]));
+                $this->assertInternalType('array', $actual[$expKey]);
                 $this->assertRecursiveArray($expVal, $actual[$expKey], $checkVal);
             } elseif ($checkVal) {
                 $this->assertEquals($expVal, $actual[$expKey], '\'' . $expKey . '\' section content is invalid.');

--- a/dev/tests/integration/testsuite/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricingTest.php
+++ b/dev/tests/integration/testsuite/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricingTest.php
@@ -139,7 +139,7 @@ class AdvancedPricingTest extends \PHPUnit\Framework\TestCase
         foreach ($productIdList as $sku => $productId) {
             $product->load($productId);
             $tierPriceCollection = $product->getTierPrices();
-            $this->assertEquals(4, count($tierPriceCollection));
+            $this->assertCount(4, $tierPriceCollection);
             $index = 0;
             /** @var \Magento\Catalog\Model\Product\TierPrice $tierPrice */
             foreach ($tierPriceCollection as $tierPrice) {
@@ -237,7 +237,7 @@ class AdvancedPricingTest extends \PHPUnit\Framework\TestCase
             $newPricingData = $this->objectManager->create(\Magento\Catalog\Model\Product::class)
                 ->load($ids[$index])
                 ->getTierPrices();
-            $this->assertEquals(0, count($newPricingData));
+            $this->assertCount(0, $newPricingData);
         }
     }
 
@@ -281,7 +281,7 @@ class AdvancedPricingTest extends \PHPUnit\Framework\TestCase
         foreach ($productIdList as $sku => $productId) {
             $product->load($productId);
             $tierPriceCollection = $product->getTierPrices();
-            $this->assertEquals(4, count($tierPriceCollection));
+            $this->assertCount(4, $tierPriceCollection);
             $index = 0;
             /** @var \Magento\Catalog\Model\Product\TierPrice $tierPrice */
             foreach ($tierPriceCollection as $tierPrice) {

--- a/dev/tests/integration/testsuite/Magento/AsynchronousOperations/Model/BulkStatusTest.php
+++ b/dev/tests/integration/testsuite/Magento/AsynchronousOperations/Model/BulkStatusTest.php
@@ -41,7 +41,7 @@ class BulkStatusTest extends \PHPUnit\Framework\TestCase
         /** @var \Magento\AsynchronousOperations\Model\BulkSummary[] $bulks */
         $bulksUuidArray = ['bulk-uuid-1', 'bulk-uuid-2', 'bulk-uuid-3', 'bulk-uuid-4', 'bulk-uuid-5'];
         $bulks =  $this->model->getBulksByUser(1);
-        $this->assertEquals(5, count($bulks));
+        $this->assertCount(5, $bulks);
         foreach ($bulks as $bulk) {
             $this->assertTrue(in_array($bulk->getBulkId(), $bulksUuidArray));
         }

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/Widget/FormTest.php
@@ -39,7 +39,7 @@ class FormTest extends \PHPUnit\Framework\TestCase
         $method->invoke($formBlock, $attributes, $fieldSet);
         $fields = $fieldSet->getElements();
 
-        $this->assertEquals(1, count($fields));
+        $this->assertCount(1, $fields);
         $this->assertInstanceOf(\Magento\Framework\Data\Form\Element\Date::class, $fields[0]);
         $this->assertNotEmpty($fields[0]->getDateFormat());
     }

--- a/dev/tests/integration/testsuite/Magento/Bundle/Model/Product/OptionListTest.php
+++ b/dev/tests/integration/testsuite/Magento/Bundle/Model/Product/OptionListTest.php
@@ -43,7 +43,7 @@ class OptionListTest extends \PHPUnit\Framework\TestCase
          */
         $optionList = $this->objectManager->create(\Magento\Bundle\Model\Product\OptionList::class);
         $options = $optionList->getItems($this->product);
-        $this->assertEquals(1, count($options));
+        $this->assertCount(1, $options);
         $this->assertEquals('Bundle Product Items', $options[0]->getTitle());
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Bundle/Model/Product/SaveHandlerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Bundle/Model/Product/SaveHandlerTest.php
@@ -80,7 +80,7 @@ class SaveHandlerTest extends \PHPUnit\Framework\TestCase
 
         $product = $this->productRepository->get('bundle-product', false, $secondStoreId, true);
         $options = $optionList->getItems($product);
-        $this->assertEquals(1, count($options));
+        $this->assertCount(1, $options);
         $this->assertEquals(
             $title . ' ' . $this->store->load('fixture_second_store')->getCode(),
             $options[0]->getTitle()

--- a/dev/tests/integration/testsuite/Magento/BundleImportExport/Model/Import/Product/Type/BundleTest.php
+++ b/dev/tests/integration/testsuite/Magento/BundleImportExport/Model/Import/Product/Type/BundleTest.php
@@ -95,7 +95,7 @@ class BundleTest extends \Magento\TestFramework\Indexer\TestCase
 
         $resource = $this->objectManager->get(\Magento\Catalog\Model\ResourceModel\Product::class);
         $productId = $resource->getIdBySku(self::TEST_PRODUCT_NAME);
-        $this->assertTrue(is_numeric($productId));
+        $this->assertInternalType('numeric', $productId);
         /** @var \Magento\Catalog\Model\Product $product */
         $product = $this->objectManager->create(\Magento\Catalog\Model\Product::class);
         $product->load($productId);
@@ -107,7 +107,7 @@ class BundleTest extends \Magento\TestFramework\Indexer\TestCase
 
         $optionIdList = $resource->getProductsIdsBySkus($this->optionSkuList);
         $bundleOptionCollection = $product->getExtensionAttributes()->getBundleProductOptions();
-        $this->assertEquals(2, count($bundleOptionCollection));
+        $this->assertCount(2, $bundleOptionCollection);
         foreach ($bundleOptionCollection as $optionKey => $option) {
             $this->assertEquals('checkbox', $option->getData('type'));
             $this->assertEquals('Option ' . ($optionKey + 1), $option->getData('title'));
@@ -163,7 +163,7 @@ class BundleTest extends \Magento\TestFramework\Indexer\TestCase
         $this->model->importData();
         $resource = $this->objectManager->get(\Magento\Catalog\Model\ResourceModel\Product::class);
         $productId = $resource->getIdBySku(self::TEST_PRODUCT_NAME);
-        $this->assertTrue(is_numeric($productId));
+        $this->assertInternalType('numeric', $productId);
         /** @var \Magento\Catalog\Model\Product $product */
         $product = $this->objectManager->create(\Magento\Catalog\Model\Product::class);
         $product->load($productId);

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryTreeTest.php
@@ -180,28 +180,28 @@ class CategoryTreeTest extends \PHPUnit\Framework\TestCase
     {
         $this->_model->load(5);
         $parents = $this->_model->getParentCategories();
-        $this->assertEquals(3, count($parents));
+        $this->assertCount(3, $parents);
     }
 
     public function testGetParentCategoriesEmpty()
     {
         $this->_model->load(1);
         $parents = $this->_model->getParentCategories();
-        $this->assertEquals(0, count($parents));
+        $this->assertCount(0, $parents);
     }
 
     public function testGetChildrenCategories()
     {
         $this->_model->load(3);
         $children = $this->_model->getChildrenCategories();
-        $this->assertEquals(2, count($children));
+        $this->assertCount(2, $children);
     }
 
     public function testGetChildrenCategoriesEmpty()
     {
         $this->_model->load(5);
         $children = $this->_model->getChildrenCategories();
-        $this->assertEquals(0, count($children));
+        $this->assertCount(0, $children);
     }
 
     public function testGetParentDesignCategory()

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Indexer/FlatTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Indexer/FlatTest.php
@@ -76,7 +76,7 @@ class FlatTest extends \Magento\TestFramework\Indexer\TestCase
         $category = $this->instantiateCategoryModel();
         $result = $category->getCollection()->getAllIds();
         $this->assertNotEmpty($result);
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
     }
 
     /**
@@ -128,7 +128,7 @@ class FlatTest extends \Magento\TestFramework\Indexer\TestCase
         $this->createSubCategoriesInDefaultCategory();
 
         $result = $this->getLoadedDefaultCategory()->getCollection()->getItems();
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
 
         $this->assertEquals(self::$defaultCategoryId, $result[self::$categoryOne]->getParentId());
         $this->assertEquals(self::$categoryOne, $result[self::$categoryTwo]->getParentId());
@@ -236,7 +236,7 @@ class FlatTest extends \Magento\TestFramework\Indexer\TestCase
         $category = $this->instantiateCategoryModel();
         $result = $category->getCollection()->getAllIds();
         $this->assertNotEmpty($result);
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertCount($countBeforeModification, $result);
     }
 

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/CategoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/CategoryTest.php
@@ -39,7 +39,7 @@ class CategoryTest extends \PHPUnit\Framework\TestCase
         $collection = $this->_model->getProductCollection();
         $this->assertInstanceOf(\Magento\Catalog\Model\ResourceModel\Product\Collection::class, $collection);
         $ids = $collection->getAllIds();
-        $this->assertEquals(2, count($ids));
+        $this->assertCount(2, $ids);
         $this->assertSame($collection, $this->_model->getProductCollection());
     }
 

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/AttributeTest.php
@@ -92,7 +92,7 @@ class AttributeTest extends \PHPUnit\Framework\TestCase
         $items = $this->_model->getItems();
 
         $this->assertInternalType('array', $items);
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
 
         /** @var $item \Magento\Catalog\Model\Layer\Filter\Item */
         $item = $items[0];

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/CategoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Layer/Filter/CategoryTest.php
@@ -136,7 +136,7 @@ class CategoryTest extends \PHPUnit\Framework\TestCase
         $items = $model->getItems();
 
         $this->assertInternalType('array', $items);
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
 
         /** @var $item \Magento\Catalog\Model\Layer\Filter\Item */
         $item = $items[0];

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/TierpriceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/TierpriceTest.php
@@ -155,7 +155,7 @@ class TierpriceTest extends \PHPUnit\Framework\TestCase
         ];
 
         $newData = $this->_model->preparePriceData($data, \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE, 1);
-        $this->assertEquals(4, count($newData));
+        $this->assertCount(4, $newData);
         $this->assertArrayHasKey('1-2', $newData);
         $this->assertArrayHasKey('1-5', $newData);
         $this->assertArrayHasKey('1-5.3', $newData);
@@ -175,7 +175,7 @@ class TierpriceTest extends \PHPUnit\Framework\TestCase
         $this->_model->afterLoad($product);
         $price = $product->getTierPrice();
         $this->assertNotEmpty($price);
-        $this->assertEquals(5, count($price));
+        $this->assertCount(5, $price);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductExternalTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductExternalTest.php
@@ -319,7 +319,7 @@ class ProductExternalTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->_model->hasCustomOptions());
 
         $this->_model->setCustomOptions(['test']);
-        $this->assertTrue(is_array($this->_model->getCustomOptions()));
+        $this->assertInternalType('array', $this->_model->getCustomOptions());
     }
 
     public function testCanBeShowInCategory()

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Webapi/Product/Option/Type/File/ProcessorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Webapi/Product/Option/Type/File/ProcessorTest.php
@@ -35,17 +35,17 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
         $result = $model->processFileContent($imageContent);
 
         $this->assertArrayHasKey('fullpath', $result);
-        $this->assertTrue(file_exists($result['fullpath']));
+        $this->assertFileExists($result['fullpath']);
 
         /** @var  $filesystem \Magento\Framework\Filesystem */
         $filesystem = $this->objectManager->get(\Magento\Framework\Filesystem::class);
         $this->assertArrayHasKey('quote_path', $result);
         $filePath = $filesystem->getDirectoryRead(DirectoryList::MEDIA)->getAbsolutePath($result['quote_path']);
-        $this->assertTrue(file_exists($filePath));
+        $this->assertFileExists($filePath);
 
         $this->assertArrayHasKey('order_path', $result);
         $filePath = $filesystem->getDirectoryRead(DirectoryList::MEDIA)->getAbsolutePath($result['order_path']);
-        $this->assertTrue(file_exists($filePath));
+        $this->assertFileExists($filePath);
     }
 
     public function pathConfigDataProvider()

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
@@ -1201,7 +1201,7 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
         $resource = $objectManager->get(\Magento\Catalog\Model\ResourceModel\Product::class);
         $productId = $resource->getIdBySku('simple1');
-        $this->assertTrue(is_numeric($productId));
+        $this->assertInternalType('numeric', $productId);
         /** @var \Magento\Catalog\Model\Product $product */
         $product = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
             \Magento\Catalog\Model\Product::class
@@ -2167,9 +2167,9 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
 
         $this->_model->importData();
 
-        $this->assertEquals(
+        $this->assertCount(
             3,
-            count($productRepository->getList($searchCriteria)->getItems())
+            $productRepository->getList($searchCriteria)->getItems()
         );
         foreach ($importedPrices as $sku => $expectedPrice) {
             $this->assertEquals($expectedPrice, $productRepository->get($sku)->getPrice());
@@ -2193,9 +2193,9 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
 
         $this->_model->importData();
 
-        $this->assertEquals(
+        $this->assertCount(
             3,
-            count($productRepository->getList($searchCriteria)->getItems()),
+            $productRepository->getList($searchCriteria)->getItems(),
             'Ensures that new products were not created'
         );
         foreach ($updatedPrices as $sku => $expectedPrice) {

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Model/Layer/Filter/CategoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Model/Layer/Filter/CategoryTest.php
@@ -119,7 +119,7 @@ class CategoryTest extends \PHPUnit\Framework\TestCase
         $items = $this->_model->getItems();
 
         $this->assertInternalType('array', $items);
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
 
         /** @var $item \Magento\Catalog\Model\Layer\Filter\Item */
         $item = $items[0];

--- a/dev/tests/integration/testsuite/Magento/Checkout/Controller/CartTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Controller/CartTest.php
@@ -334,7 +334,7 @@ class CartTest extends \Magento\TestFramework\TestCase\AbstractController
 
         $this->assertContains(json_encode([]), $this->getResponse()->getBody());
         $items = $quote->getItems()->getItems();
-        $this->assertTrue(is_array($items), 'Quote doesn\'t have any items');
+        $this->assertInternalType('array', $items, 'Quote doesn\'t have any items');
         $this->assertCount(1, $items, 'Expected quote items not equal to 1');
         $item = reset($items);
         $this->assertEquals(1, $item->getProductId(), 'Quote has more than one product');

--- a/dev/tests/integration/testsuite/Magento/ConfigurableImportExport/Model/Import/Product/Type/ConfigurableTest.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableImportExport/Model/Import/Product/Type/ConfigurableTest.php
@@ -97,7 +97,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
         /** @var \Magento\Catalog\Model\ResourceModel\Product $resource */
         $resource = $this->objectManager->get(\Magento\Catalog\Model\ResourceModel\Product::class);
         $productId = $resource->getIdBySku($productName);
-        $this->assertTrue(is_numeric($productId));
+        $this->assertInternalType('numeric', $productId);
         /** @var \Magento\Catalog\Model\Product $product */
         $product = $this->objectManager->get(ProductRepositoryInterface::class)->getById($productId);
 
@@ -118,7 +118,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
         }
 
         $configurableOptionCollection = $product->getExtensionAttributes()->getConfigurableProductOptions();
-        $this->assertEquals(1, count($configurableOptionCollection));
+        $this->assertCount(1, $configurableOptionCollection);
         foreach ($configurableOptionCollection as $option) {
             $optionData = $option->getData();
             $this->assertArrayHasKey('product_super_attribute_id', $optionData);
@@ -147,7 +147,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
             $this->assertEquals('Option 2', $optionData['options'][1]['store_label']);
             $this->assertArrayHasKey('values', $optionData);
             $valuesData = $optionData['values'];
-            $this->assertEquals(2, count($valuesData));
+            $this->assertCount(2, $valuesData);
         }
     }
 

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/VariationHandlerTest.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/VariationHandlerTest.php
@@ -49,7 +49,7 @@ class VariationHandlerTest extends \PHPUnit\Framework\TestCase
         $this->_product->setNewVariationsAttributeSetId(4);
         // Default attribute set id
         $generatedProducts = $this->_model->generateSimpleProducts($this->_product, $productsData);
-        $this->assertEquals(3, count($generatedProducts));
+        $this->assertCount(3, $generatedProducts);
         foreach ($generatedProducts as $productId) {
             $stockItem = $this->stockRegistry->getStockItem($productId);
             /** @var $product \Magento\Catalog\Model\Product */

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/ResourceModel/AddressRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/ResourceModel/AddressRepositoryTest.php
@@ -386,7 +386,7 @@ class AddressRepositoryTest extends \PHPUnit\Framework\TestCase
         $items = array_values($searchResults->getItems());
 
         $this->assertEquals(count($expectedResult), $searchResults->getTotalCount());
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
 
         $expectedResultIndex = count($expectedResult) - 1;
 

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/ResourceModel/CustomerRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/ResourceModel/CustomerRepositoryTest.php
@@ -273,7 +273,7 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
             ->setAddresses([$newAddressDataObject, $addresses[1]]);
         $this->customerRepository->save($newCustomerEntity);
         $newCustomer = $this->customerRepository->get($email);
-        $this->assertEquals(2, count($newCustomer->getAddresses()));
+        $this->assertCount(2, $newCustomer->getAddresses());
 
         foreach ($newCustomer->getAddresses() as $newAddress) {
             if ($newAddress->getId() == $addressId) {
@@ -306,7 +306,7 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
 
         $newCustomerDetails = $this->customerRepository->getById($customerId);
         //Verify that old addresses are still present
-        $this->assertEquals(2, count($newCustomerDetails->getAddresses()));
+        $this->assertCount(2, $newCustomerDetails->getAddresses());
     }
 
     /**
@@ -333,7 +333,7 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
 
         $newCustomerDetails = $this->customerRepository->getById($customerId);
         //Verify that old addresses are removed
-        $this->assertEquals(0, count($newCustomerDetails->getAddresses()));
+        $this->assertCount(0, $newCustomerDetails->getAddresses());
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/ResourceModel/Group/Grid/ServiceCollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/ResourceModel/Group/Grid/ServiceCollectionTest.php
@@ -25,7 +25,7 @@ class ServiceCollectionTest extends \PHPUnit\Framework\TestCase
         $this->collection->setOrder('code', \Magento\Framework\Data\Collection::SORT_ORDER_ASC);
         $this->collection->loadData();
         $items = $this->collection->getItems();
-        $this->assertEquals(4, count($items));
+        $this->assertCount(4, $items);
 
         $this->assertEquals('General', $items[0]->getCode());
         $this->assertEquals('1', $items[0]->getId());
@@ -49,7 +49,7 @@ class ServiceCollectionTest extends \PHPUnit\Framework\TestCase
         $this->collection->addFieldToFilter(['code'], [['NOT LOGGED IN']]);
         $this->collection->loadData();
         $items = $this->collection->getItems();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
 
         $this->assertEquals('NOT LOGGED IN', $items[0]->getCode());
         $this->assertEquals('0', $items[0]->getId());
@@ -61,7 +61,7 @@ class ServiceCollectionTest extends \PHPUnit\Framework\TestCase
         $this->collection->addFieldToFilter(['code', 'code'], ['General', 'Retailer']);
         $this->collection->loadData();
         $items = $this->collection->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
 
         $this->assertEquals('General', $items[0]->getCode());
         $this->assertEquals('1', $items[0]->getId());
@@ -77,7 +77,7 @@ class ServiceCollectionTest extends \PHPUnit\Framework\TestCase
         $this->collection->addFieldToFilter('code', 'NOT LOGGED IN');
         $this->collection->loadData();
         $items = $this->collection->getItems();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
 
         $this->assertEquals('NOT LOGGED IN', $items[0]->getCode());
         $this->assertEquals('0', $items[0]->getId());
@@ -89,7 +89,7 @@ class ServiceCollectionTest extends \PHPUnit\Framework\TestCase
         $this->collection->addFieldToFilter('code', ['like' => 'NOT%']);
         $this->collection->loadData();
         $items = $this->collection->getItems();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
 
         $this->assertEquals('NOT LOGGED IN', $items[0]->getCode());
         $this->assertEquals('0', $items[0]->getId());

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/ResourceModel/GroupRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/ResourceModel/GroupRepositoryTest.php
@@ -186,7 +186,7 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
         $searchResults = $this->groupRepository->getList($this->searchCriteriaBuilder->create());
         /** @var GroupInterface[] $results */
         $results = $searchResults->getItems();
-        $this->assertEquals(4, count($results));
+        $this->assertCount(4, $results);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Model/Product/TypeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Model/Product/TypeTest.php
@@ -213,7 +213,7 @@ class TypeTest extends \PHPUnit\Framework\TestCase
         $samples = $product->getExtensionAttributes()->getDownloadableProductSamples();
         $sample = reset($samples);
         $this->assertNotEmpty($sample->getData());
-        $this->assertEquals(1, count($samples));
+        $this->assertCount(1, $samples);
         /** @var \Magento\Downloadable\Model\Sample $sample */
         $sample = $sample->getData();
         /** @var \Magento\User\Api\Data\UserInterface $testAttribute */

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Model/ResourceModel/Indexer/PriceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Model/ResourceModel/Indexer/PriceTest.php
@@ -68,7 +68,7 @@ class PriceTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($specialPrice, $product->getMinimalPrice());
 
         $resultTiers = $product->getTierPrices();
-        $this->assertTrue(is_array($resultTiers), 'Tiers not found');
+        $this->assertInternalType('array', $resultTiers, 'Tiers not found');
         $this->assertEquals(count($tierData), count($resultTiers), 'Incorrect number of result tiers');
 
         for ($i = 0; $i < count($tierData); $i++) {

--- a/dev/tests/integration/testsuite/Magento/DownloadableImportExport/Model/Import/Product/Type/DownloadableTest.php
+++ b/dev/tests/integration/testsuite/Magento/DownloadableImportExport/Model/Import/Product/Type/DownloadableTest.php
@@ -95,7 +95,7 @@ class DownloadableTest extends \PHPUnit\Framework\TestCase
 
         $resource = $this->objectManager->get(\Magento\Catalog\Model\ResourceModel\Product::class);
         $productId = $resource->getIdBySku(self::TEST_PRODUCT_NAME);
-        $this->assertTrue(is_numeric($productId));
+        $this->assertInternalType('numeric', $productId);
         /** @var \Magento\Catalog\Model\Product $product */
         $product = $this->objectManager->create(
             \Magento\Catalog\Model\Product::class

--- a/dev/tests/integration/testsuite/Magento/Eav/Model/Attribute/GroupRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Eav/Model/Attribute/GroupRepositoryTest.php
@@ -79,7 +79,7 @@ class GroupRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(2, $searchResult->getTotalCount());
 
         $items = array_values($searchResult->getItems());
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('attribute_group_3_for_search', $items[0]['attribute_group_code']);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Eav/Model/AttributeRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Eav/Model/AttributeRepositoryTest.php
@@ -68,7 +68,7 @@ class AttributeRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(3, $searchResult->getTotalCount());
 
         $items = array_values($searchResult->getItems());
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('attribute_for_search_3', $items[0]['attribute_code']);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Eav/Model/Entity/AttributeLoaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Eav/Model/Entity/AttributeLoaderTest.php
@@ -62,8 +62,8 @@ class AttributeLoaderTest extends \PHPUnit\Framework\TestCase
         // Before load all attributes
         $attributesByCode = $this->resource->getAttributesByCode();
         $attributesByTable = $this->resource->getAttributesByTable();
-        $this->assertEquals(0, count($attributesByCode));
-        $this->assertEquals(0, count($attributesByTable));
+        $this->assertCount(0, $attributesByCode);
+        $this->assertCount(0, $attributesByTable);
 
         // Load all attributes
         $resource2 = $this->attributeLoader->loadAllAttributes(

--- a/dev/tests/integration/testsuite/Magento/Framework/Backup/FilesystemTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Backup/FilesystemTest.php
@@ -45,6 +45,6 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
             ->setBackupExtension('tgz');
 
         $this->assertTrue($this->filesystem->rollback());
-        $this->assertTrue(file_exists($rootDir . '/' . $fileName));
+        $this->assertFileExists($rootDir . '/' . $fileName);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Framework/Encryption/ModelTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Encryption/ModelTest.php
@@ -59,7 +59,7 @@ class ModelTest extends \PHPUnit\Framework\TestCase
         $password = uniqid();
         $hash = $this->_model->getHash($password, true);
 
-        $this->assertTrue(is_string($hash));
+        $this->assertInternalType('string', $hash);
         $this->assertTrue($this->_model->validateHash($password, $hash));
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Framework/Filesystem/Directory/ReadTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Filesystem/Directory/ReadTest.php
@@ -274,7 +274,7 @@ class ReadTest extends \PHPUnit\Framework\TestCase
         ];
         $result = $dir->stat($path);
         foreach ($expectedInfo as $key) {
-            $this->assertTrue(array_key_exists($key, $result));
+            $this->assertArrayHasKey($key, $result);
         }
     }
 

--- a/dev/tests/integration/testsuite/Magento/Framework/Filesystem/File/ReadTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Filesystem/File/ReadTest.php
@@ -151,7 +151,7 @@ class ReadTest extends \PHPUnit\Framework\TestCase
         ];
         $result = $file->stat();
         foreach ($expectedInfo as $key) {
-            $this->assertTrue(array_key_exists($key, $result));
+            $this->assertArrayHasKey($key, $result);
         }
     }
 

--- a/dev/tests/integration/testsuite/Magento/Framework/GraphQl/Config/GraphQlReaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/GraphQl/Config/GraphQlReaderTest.php
@@ -207,32 +207,32 @@ QUERY;
             );
         }
         //Checks to make sure that the given description exists in the expectedOutput array
-        $this->assertTrue(
-            array_key_exists(
+        $this->assertArrayHasKey(
+            
                 array_search(
                     'Comment for empty PhysicalProductInterface',
                     array_column($expectedOutput, 'description')
                 ),
                 $expectedOutput
-            )
+            
         );
-        $this->assertTrue(
-            array_key_exists(
+        $this->assertArrayHasKey(
+            
                 array_search(
                     'Comment for empty Enum',
                     array_column($expectedOutput, 'description')
                 ),
                 $expectedOutput
-            )
+            
         );
-        $this->assertTrue(
-            array_key_exists(
+        $this->assertArrayHasKey(
+            
                 array_search(
                     'Comment for SearchResultPageInfo',
                     array_column($expectedOutput, 'description')
                 ),
                 $expectedOutput
-            )
+            
         );
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/UseCase/WildcardTopicTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/UseCase/WildcardTopicTest.php
@@ -33,7 +33,7 @@ class WildcardTopicTest extends QueueTestCaseAbstract
 
         $this->waitForAsynchronousResult(count($matchingQueues), $this->logFilePath);
 
-        $this->assertTrue(file_exists($this->logFilePath), "No handlers invoked (log file was not created).");
+        $this->assertFileExists($this->logFilePath, "No handlers invoked (log file was not created).");
         foreach ($nonMatchingQueues as $queueName) {
             $this->assertNotContains($queueName, file_get_contents($this->logFilePath));
         }
@@ -63,7 +63,7 @@ class WildcardTopicTest extends QueueTestCaseAbstract
         $testObject = $this->generateTestObject();
         $this->publisher->publish('not.matching.wildcard.topic', $testObject);
         sleep(2);
-        $this->assertFalse(file_exists($this->logFilePath), "No log file must be created for non-matching topic.");
+        $this->assertFileNotExists($this->logFilePath, "No log file must be created for non-matching topic.");
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Framework/Mview/View/ChangelogTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Mview/View/ChangelogTest.php
@@ -137,11 +137,11 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
             $this->connection->insert($changelogName, $data);
         }
         $this->assertEquals(5, $this->model->getVersion());
-        $this->assertEquals(3, count($this->model->getList(0, 5)));//distinct entity_ids
-        $this->assertEquals(3, count($this->model->getList(2, 5)));//distinct entity_ids
-        $this->assertEquals(2, count($this->model->getList(0, 3)));//distinct entity_ids
-        $this->assertEquals(1, count($this->model->getList(0, 2)));//distinct entity_ids
-        $this->assertEquals(1, count($this->model->getList(2, 3)));//distinct entity_ids
-        $this->assertEquals(0, count($this->model->getList(4, 3)));//because fromVersionId > toVersionId
+        $this->assertCount(3, $this->model->getList(0, 5));//distinct entity_ids
+        $this->assertCount(3, $this->model->getList(2, 5));//distinct entity_ids
+        $this->assertCount(2, $this->model->getList(0, 3));//distinct entity_ids
+        $this->assertCount(1, $this->model->getList(0, 2));//distinct entity_ids
+        $this->assertCount(1, $this->model->getList(2, 3));//distinct entity_ids
+        $this->assertCount(0, $this->model->getList(4, 3));//because fromVersionId > toVersionId
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Framework/Search/Request/MapperTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Search/Request/MapperTest.php
@@ -40,7 +40,7 @@ class MapperTest extends \PHPUnit\Framework\TestCase
     public function testGetBuckets()
     {
         $buckets = $this->mapper->getBuckets();
-        $this->assertEquals(2, count($buckets));
+        $this->assertCount(2, $buckets);
 
         $this->assertInstanceOf(\Magento\Framework\Search\Request\Aggregation\TermBucket::class, $buckets[0]);
         $this->assertEquals('category_bucket', $buckets[0]->getName());

--- a/dev/tests/integration/testsuite/Magento/GroupedImportExport/Model/Import/Product/Type/GroupedTest.php
+++ b/dev/tests/integration/testsuite/Magento/GroupedImportExport/Model/Import/Product/Type/GroupedTest.php
@@ -76,7 +76,7 @@ class GroupedTest extends \PHPUnit\Framework\TestCase
 
         $resource = $this->objectManager->get(\Magento\Catalog\Model\ResourceModel\Product::class);
         $productId = $resource->getIdBySku('Test Grouped');
-        $this->assertTrue(is_numeric($productId));
+        $this->assertInternalType('numeric', $productId);
         /** @var \Magento\Catalog\Model\Product $product */
         $product = $this->objectManager->create(\Magento\Catalog\Model\Product::class);
         $product->load($productId);

--- a/dev/tests/integration/testsuite/Magento/Integration/Block/Adminhtml/Integration/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/Integration/Block/Adminhtml/Integration/EditTest.php
@@ -107,7 +107,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
 
         // Assert that 'save' button is removed for integration of config type
         foreach ($buttonList as $button) {
-            $this->assertFalse(array_key_exists('save', $button));
+            $this->assertArrayNotHasKey('save', $button);
         }
 
         // Tear down

--- a/dev/tests/integration/testsuite/Magento/MessageQueue/Model/Cron/ConsumersRunnerTest.php
+++ b/dev/tests/integration/testsuite/Magento/MessageQueue/Model/Cron/ConsumersRunnerTest.php
@@ -159,9 +159,9 @@ class ConsumersRunnerTest extends \PHPUnit\Framework\TestCase
             $pidFileFullPath = $this->getPidFileFullPath($consumerName);
 
             if ($consumerName === $specificConsumer) {
-                $this->assertTrue(file_exists($pidFileFullPath));
+                $this->assertFileExists($pidFileFullPath);
             } else {
-                $this->assertFalse(file_exists($pidFileFullPath));
+                $this->assertFileNotExists($pidFileFullPath);
             }
         }
     }
@@ -184,7 +184,7 @@ class ConsumersRunnerTest extends \PHPUnit\Framework\TestCase
 
         foreach ($this->consumerConfig->getConsumers() as $consumer) {
             $pidFileFullPath = $this->getPidFileFullPath($consumer->getName());
-            $this->assertFalse(file_exists($pidFileFullPath));
+            $this->assertFileNotExists($pidFileFullPath);
         }
     }
 

--- a/dev/tests/integration/testsuite/Magento/MysqlMq/Model/QueueManagementTest.php
+++ b/dev/tests/integration/testsuite/Magento/MysqlMq/Model/QueueManagementTest.php
@@ -50,9 +50,9 @@ class QueueManagementTest extends \PHPUnit\Framework\TestCase
             QueueManagement::MESSAGE_STATUS_IN_PROGRESS,
             $firstMessage[QueueManagement::MESSAGE_STATUS]
         );
-        $this->assertTrue(is_numeric($firstMessage[QueueManagement::MESSAGE_QUEUE_ID]));
-        $this->assertTrue(is_numeric($firstMessage[QueueManagement::MESSAGE_ID]));
-        $this->assertTrue(is_numeric($firstMessage[QueueManagement::MESSAGE_QUEUE_RELATION_ID]));
+        $this->assertInternalType('numeric', $firstMessage[QueueManagement::MESSAGE_QUEUE_ID]);
+        $this->assertInternalType('numeric', $firstMessage[QueueManagement::MESSAGE_ID]);
+        $this->assertInternalType('numeric', $firstMessage[QueueManagement::MESSAGE_QUEUE_RELATION_ID]);
         $this->assertEquals(0, $firstMessage[QueueManagement::MESSAGE_NUMBER_OF_TRIALS]);
         $this->assertCount(12, date_parse($firstMessage[QueueManagement::MESSAGE_UPDATED_AT]));
 
@@ -64,9 +64,9 @@ class QueueManagementTest extends \PHPUnit\Framework\TestCase
             QueueManagement::MESSAGE_STATUS_IN_PROGRESS,
             $secondMessage[QueueManagement::MESSAGE_STATUS]
         );
-        $this->assertTrue(is_numeric($secondMessage[QueueManagement::MESSAGE_QUEUE_ID]));
-        $this->assertTrue(is_numeric($secondMessage[QueueManagement::MESSAGE_ID]));
-        $this->assertTrue(is_numeric($secondMessage[QueueManagement::MESSAGE_QUEUE_RELATION_ID]));
+        $this->assertInternalType('numeric', $secondMessage[QueueManagement::MESSAGE_QUEUE_ID]);
+        $this->assertInternalType('numeric', $secondMessage[QueueManagement::MESSAGE_ID]);
+        $this->assertInternalType('numeric', $secondMessage[QueueManagement::MESSAGE_QUEUE_RELATION_ID]);
         $this->assertEquals(0, $secondMessage[QueueManagement::MESSAGE_NUMBER_OF_TRIALS]);
         $this->assertCount(12, date_parse($secondMessage[QueueManagement::MESSAGE_UPDATED_AT]));
 

--- a/dev/tests/integration/testsuite/Magento/Paypal/Block/Payment/Form/Billing/AgreementTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Block/Payment/Form/Billing/AgreementTest.php
@@ -43,7 +43,7 @@ class AgreementTest extends \PHPUnit\Framework\TestCase
     public function testGetBillingAgreements()
     {
         $billingAgreements = $this->_block->getBillingAgreements();
-        $this->assertEquals(1, count($billingAgreements));
+        $this->assertCount(1, $billingAgreements);
         $this->assertEquals('REF-ID-TEST-678', array_shift($billingAgreements));
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Paypal/Model/Express/CheckoutTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Model/Express/CheckoutTest.php
@@ -172,7 +172,7 @@ class CheckoutTest extends \PHPUnit\Framework\TestCase
         $customer = $customerService->getById($quote->getCustomerId());
 
         $this->assertEquals(1, $quote->getCustomerId());
-        $this->assertEquals(2, count($customer->getAddresses()));
+        $this->assertCount(2, $customer->getAddresses());
 
         $this->assertEquals(1, $quote->getBillingAddress()->getCustomerAddressId());
         $this->assertEquals(2, $quote->getShippingAddress()->getCustomerAddressId());

--- a/dev/tests/integration/testsuite/Magento/Paypal/Model/IpnTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Model/IpnTest.php
@@ -65,7 +65,7 @@ class IpnTest extends \PHPUnit\Framework\TestCase
         $creditmemo = current($creditmemoItems);
 
         $this->assertEquals(Order::STATE_CLOSED, $order->getState()) ;
-        $this->assertEquals(1, count($creditmemoItems));
+        $this->assertCount(1, $creditmemoItems);
         $this->assertEquals(Creditmemo::STATE_REFUNDED, $creditmemo->getState());
         $this->assertEquals(10, $order->getSubtotalRefunded());
         $this->assertEquals(10, $order->getBaseSubtotalRefunded());
@@ -116,7 +116,7 @@ class IpnTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(Order::STATE_PROCESSING, $order->getState()) ;
         $this->assertEmpty(count($creditmemoItems));
-        $this->assertEquals(1, count($comments));
+        $this->assertCount(1, $comments);
         $this->assertEquals($commentOrigin, $commentData->getComment());
     }
 
@@ -147,7 +147,7 @@ class IpnTest extends \PHPUnit\Framework\TestCase
         $creditmemoItems = $order->getCreditmemosCollection()->getItems();
 
         $this->assertEquals(Order::STATE_CLOSED, $order->getState()) ;
-        $this->assertEquals(1, count($creditmemoItems));
+        $this->assertCount(1, $creditmemoItems);
         $this->assertEquals(10, $order->getSubtotalRefunded());
         $this->assertEquals(10, $order->getBaseSubtotalRefunded());
         $this->assertEquals(20, $order->getShippingRefunded());

--- a/dev/tests/integration/testsuite/Magento/Sales/Api/CreditmemoCommentRepositoryInterfaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Api/CreditmemoCommentRepositoryInterfaceTest.php
@@ -71,7 +71,7 @@ class CreditmemoCommentRepositoryInterfaceTest extends \PHPUnit\Framework\TestCa
         $searchResult = $this->repository->getList($searchCriteria);
 
         $items = array_values($searchResult->getItems());
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('comment 2', $items[0][CreditmemoCommentInterface::COMMENT]);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/Api/CreditmemoItemRepositoryInterfaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Api/CreditmemoItemRepositoryInterfaceTest.php
@@ -72,7 +72,7 @@ class CreditmemoItemRepositoryInterfaceTest extends \PHPUnit\Framework\TestCase
         $searchResult = $this->repository->getList($searchCriteria);
 
         $items = array_values($searchResult->getItems());
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('item 2', $items[0][CreditmemoItemInterface::NAME]);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/Api/InvoiceCommentRepositoryInterfaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Api/InvoiceCommentRepositoryInterfaceTest.php
@@ -71,7 +71,7 @@ class InvoiceCommentRepositoryInterfaceTest extends \PHPUnit\Framework\TestCase
         $searchResult = $this->repository->getList($searchCriteria);
 
         $items = array_values($searchResult->getItems());
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('comment 2', $items[0][InvoiceCommentInterface::COMMENT]);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/Api/InvoiceItemRepositoryInterfaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Api/InvoiceItemRepositoryInterfaceTest.php
@@ -72,7 +72,7 @@ class InvoiceItemRepositoryInterfaceTest extends \PHPUnit\Framework\TestCase
         $searchResult = $this->repository->getList($searchCriteria);
 
         $items = array_values($searchResult->getItems());
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('item 2', $items[0][InvoiceItemInterface::NAME]);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/Api/OrderStatusHistoryRepositoryInterfaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Api/OrderStatusHistoryRepositoryInterfaceTest.php
@@ -71,7 +71,7 @@ class OrderStatusHistoryRepositoryInterfaceTest extends \PHPUnit\Framework\TestC
         $searchResult = $this->repository->getList($searchCriteria);
 
         $items = array_values($searchResult->getItems());
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('comment 2', $items[0][OrderStatusHistoryInterface::COMMENT]);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/Api/ShipmentCommentRepositoryInterfaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Api/ShipmentCommentRepositoryInterfaceTest.php
@@ -71,7 +71,7 @@ class ShipmentCommentRepositoryInterfaceTest extends \PHPUnit\Framework\TestCase
         $searchResult = $this->repository->getList($searchCriteria);
 
         $items = array_values($searchResult->getItems());
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('comment 2', $items[0][ShipmentCommentInterface::COMMENT]);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/Api/ShipmentItemRepositoryInterfaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Api/ShipmentItemRepositoryInterfaceTest.php
@@ -72,7 +72,7 @@ class ShipmentItemRepositoryInterfaceTest extends \PHPUnit\Framework\TestCase
         $searchResult = $this->repository->getList($searchCriteria);
 
         $items = array_values($searchResult->getItems());
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('item 2', $items[0][ShipmentItemInterface::NAME]);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/Api/ShipmentTrackRepositoryInterfaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Api/ShipmentTrackRepositoryInterfaceTest.php
@@ -76,7 +76,7 @@ class ShipmentTrackRepositoryInterfaceTest extends \PHPUnit\Framework\TestCase
         $searchResult = $this->repository->getList($searchCriteria);
 
         $items = array_values($searchResult->getItems());
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('title 2', $items[0][ShipmentTrackInterface::TITLE]);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/ShipmentTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/ShipmentTest.php
@@ -120,7 +120,7 @@ class ShipmentTest extends \PHPUnit\Framework\TestCase
         $actual = array_map(function (CommentInterface $comment) {
             return $comment->getComment();
         }, $comments);
-        self::assertEquals(2, count($actual));
+        self::assertCount(2, $actual);
         self::assertEquals([$message1, $message2], $actual);
     }
 

--- a/dev/tests/integration/testsuite/Magento/SalesRule/Model/ResourceModel/Rule/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/Model/ResourceModel/Rule/CollectionTest.php
@@ -167,7 +167,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
                 $quote->getShippingAddress()
             )->getItems()
         );
-        $this->assertEquals(3, count($appliedRulesArray));
+        $this->assertCount(3, $appliedRulesArray);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Store/Model/ResourceModel/Store/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Store/Model/ResourceModel/Store/CollectionTest.php
@@ -80,10 +80,10 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 
     public function testToOptionArrayHash()
     {
-        $this->assertTrue(is_array($this->_collection->toOptionArray()));
+        $this->assertInternalType('array', $this->_collection->toOptionArray());
         $this->assertNotEmpty($this->_collection->toOptionArray());
 
-        $this->assertTrue(is_array($this->_collection->toOptionHash()));
+        $this->assertInternalType('array', $this->_collection->toOptionHash());
         $this->assertNotEmpty($this->_collection->toOptionHash());
     }
 

--- a/dev/tests/integration/testsuite/Magento/Store/Model/WebsiteTest.php
+++ b/dev/tests/integration/testsuite/Magento/Store/Model/WebsiteTest.php
@@ -184,6 +184,6 @@ class WebsiteTest extends \PHPUnit\Framework\TestCase
     public function testCollection()
     {
         $collection = $this->_model->getCollection()->joinGroupAndStore()->addIdFilter(1);
-        $this->assertEquals(1, count($collection->getItems()));
+        $this->assertCount(1, $collection->getItems());
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Tax/Controller/Adminhtml/RateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Controller/Adminhtml/RateTest.php
@@ -240,11 +240,11 @@ class RateTest extends \Magento\TestFramework\TestCase\AbstractBackendController
             $jsonBody
         );
 
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('success', $result);
         $this->assertTrue($result['success'] == true);
         $this->assertArrayHasKey('result', $result);
-        $this->assertTrue(is_array($result['result']));
+        $this->assertInternalType('array', $result['result']);
         $this->assertEquals($result['result']['tax_country_id'], $class->getTaxCountryId());
         $this->assertEquals($result['result']['tax_region_id'], $class->getTaxRegionId());
         $this->assertEquals($result['result']['tax_postcode'], $class->getTaxPostcode());
@@ -276,7 +276,7 @@ class RateTest extends \Magento\TestFramework\TestCase\AbstractBackendController
             $jsonBody
         );
 
-        $this->assertTrue(is_array($result));
+        $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('success', $result);
         $this->assertTrue($result['success'] == false);
         $this->assertTrue(!array_key_exists('result', $result));

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/Calculation/RateRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/Calculation/RateRepositoryTest.php
@@ -178,14 +178,14 @@ class RateRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull($taxRateServiceData->getId());
 
         $titles = $taxRateServiceData->getTitles();
-        $this->assertEquals(1, count($titles));
+        $this->assertCount(1, $titles);
         $this->assertEquals($store->getId(), $titles[0]->getStoreId());
         $this->assertEquals($taxData['titles'][0]['value'], $titles[0]->getValue());
 
         $taxRateServiceData = $this->rateRepository->get($taxRateServiceData->getId());
 
         $titles = $taxRateServiceData->getTitles();
-        $this->assertEquals(1, count($titles));
+        $this->assertCount(1, $titles);
         $this->assertEquals($store->getId(), $titles[0]->getStoreId());
         $this->assertEquals($taxData['titles'][0]['value'], $titles[0]->getValue());
     }

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/DesignTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/DesignTest.php
@@ -146,7 +146,7 @@ class DesignTest extends \PHPUnit\Framework\TestCase
 
         $cachedDesign = $serializer->unserialize($cachedDesign);
 
-        $this->assertTrue(is_array($cachedDesign));
+        $this->assertInternalType('array', $cachedDesign);
         $this->assertEquals($cachedDesign['design'], $design->getDesign());
     }
 

--- a/dev/tests/integration/testsuite/Magento/User/Model/UserTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Model/UserTest.php
@@ -132,11 +132,11 @@ class UserTest extends \PHPUnit\Framework\TestCase
     {
         $this->_model->loadByUsername(\Magento\TestFramework\Bootstrap::ADMIN_NAME);
         $roles = $this->_model->getRoles();
-        $this->assertEquals(1, count($roles));
+        $this->assertCount(1, $roles);
         $this->assertEquals(\Magento\TestFramework\Bootstrap::ADMIN_ROLE_NAME, $this->_model->getRole()->getRoleName());
         $this->_model->setRoleId(self::$_newRole->getId())->save();
         $roles = $this->_model->getRoles();
-        $this->assertEquals(1, count($roles));
+        $this->assertCount(1, $roles);
         $this->assertEquals(self::$_newRole->getId(), $roles[0]);
     }
 
@@ -307,7 +307,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     {
         $this->_model->loadByUsername(\Magento\TestFramework\Bootstrap::ADMIN_NAME);
         $role = $this->_model->hasAssigned2Role($this->_model);
-        $this->assertEquals(1, count($role));
+        $this->assertCount(1, $role);
         $this->assertArrayHasKey('role_id', $role[0]);
         $roles = $this->_model->getRoles();
         $this->_model->setRoleId(reset($roles))->deleteFromRole();

--- a/dev/tests/integration/testsuite/Magento/Weee/Model/TaxTest.php
+++ b/dev/tests/integration/testsuite/Magento/Weee/Model/TaxTest.php
@@ -92,7 +92,7 @@ class TaxTest extends \PHPUnit\Framework\TestCase
         $product = $productRepository->get('simple-with-ftp');
 
         $amount = $this->_model->getProductWeeeAttributes($product, $shipping, null, null, true);
-        $this->assertTrue(is_array($amount));
+        $this->assertInternalType('array', $amount);
         $this->assertArrayHasKey(0, $amount);
         $this->assertEquals(12.70, $amount[0]->getAmount());
     }

--- a/dev/tests/integration/testsuite/Magento/Widget/Model/Widget/InstanceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Model/Widget/InstanceTest.php
@@ -45,7 +45,7 @@ class InstanceTest extends \PHPUnit\Framework\TestCase
     {
         $config = $this->_model->setType(\Magento\Catalog\Block\Product\Widget\NewWidget::class)
             ->getWidgetConfigAsArray();
-        $this->assertTrue(is_array($config));
+        $this->assertInternalType('array', $config);
         $element = null;
         if (isset(
             $config['parameters']

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Xml/SchemaTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Xml/SchemaTest.php
@@ -27,9 +27,9 @@ class SchemaTest extends \PHPUnit\Framework\TestCase
 
                 $schemaLocations = [];
                 preg_match('/xsi:noNamespaceSchemaLocation=\s*"(urn:[^"]+)"/s', $xmlFile, $schemaLocations);
-                $this->assertEquals(
+                $this->assertCount(
                     2,
-                    count($schemaLocations),
+                    $schemaLocations,
                     'The XML file at ' . $filename . ' does not have a schema properly defined.  It should '
                     . 'have a xsi:noNamespaceSchemaLocation attribute defined with a URN path.  E.g. '
                     . 'xsi:noNamespaceSchemaLocation="urn:magento:framework:Relative_Path/something.xsd"'

--- a/dev/tests/static/testsuite/Magento/Test/Php/LiveCodeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Php/LiveCodeTest.php
@@ -368,9 +368,9 @@ class LiveCodeTest extends \PHPUnit\Framework\TestCase
             }
         }
 
-        $this->assertEquals(
+        $this->assertCount(
             0,
-            count($filesMissingStrictTyping),
+            $filesMissingStrictTyping,
             "Following files are missing strict type declaration:"
             . PHP_EOL
             . implode(PHP_EOL, $filesMissingStrictTyping)

--- a/lib/internal/Magento/Framework/App/Test/Unit/Console/CommandListTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Console/CommandListTest.php
@@ -35,6 +35,6 @@ class CommandListTest extends \PHPUnit\Framework\TestCase
     {
         $commands = $this->commandList->getCommands();
         $this->assertSame([$this->testCommand], $commands);
-        $this->assertEquals(1, count($commands));
+        $this->assertCount(1, $commands);
     }
 }

--- a/lib/internal/Magento/Framework/DataObject/Test/Unit/CacheTest.php
+++ b/lib/internal/Magento/Framework/DataObject/Test/Unit/CacheTest.php
@@ -119,7 +119,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $newIdx = 'idx' . $hash;
         $this->assertEquals($newIdx, $this->cache->save($object, 'idx{hash}'));
         $this->cache->debug($newIdx);
-        $this->assertTrue(array_key_exists($newIdx, $this->cache->debugByIds($newIdx)));
+        $this->assertArrayHasKey($newIdx, $this->cache->debugByIds($newIdx));
     }
 
     public function testGetAndDeleteTags()

--- a/lib/internal/Magento/Framework/Filter/Test/Unit/AbstractFactoryTest.php
+++ b/lib/internal/Magento/Framework/Filter/Test/Unit/AbstractFactoryTest.php
@@ -117,7 +117,7 @@ class AbstractFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($filterMock, $this->_factory->createFilter($alias, $arguments));
         if ($isShared) {
             $sharedList = $property->getValue($this->_factory);
-            $this->assertTrue(array_key_exists($alias, $sharedList));
+            $this->assertArrayHasKey($alias, $sharedList);
             $this->assertEquals($filterMock, $sharedList[$alias]);
         } else {
             $this->assertEmpty($property->getValue($this->_factory));

--- a/lib/internal/Magento/Framework/Math/Test/Unit/RandomTest.php
+++ b/lib/internal/Magento/Framework/Math/Test/Unit/RandomTest.php
@@ -51,8 +51,8 @@ class RandomTest extends \PHPUnit\Framework\TestCase
         $mathRandom = new \Magento\Framework\Math\Random();
         $hashOne = $mathRandom->getUniqueHash();
         $hashTwo = $mathRandom->getUniqueHash();
-        $this->assertTrue(is_string($hashOne));
-        $this->assertTrue(is_string($hashTwo));
+        $this->assertInternalType('string', $hashOne);
+        $this->assertInternalType('string', $hashTwo);
         $this->assertNotEquals($hashOne, $hashTwo);
     }
 

--- a/lib/internal/Magento/Framework/Message/Test/Unit/CollectionTest.php
+++ b/lib/internal/Magento/Framework/Message/Test/Unit/CollectionTest.php
@@ -137,7 +137,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         }
 
         $this->assertEquals($this->model->getItemsByType(MessageInterface::TYPE_ERROR), $this->model->getErrors());
-        $this->assertEquals(4, count($this->model->getErrors()));
+        $this->assertCount(4, $this->model->getErrors());
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Test/Unit/Design/Theme/LabelTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Design/Theme/LabelTest.php
@@ -43,8 +43,8 @@ class LabelTest extends \PHPUnit\Framework\TestCase
             ->willReturn([$data]);
 
         $result = $this->model->toOptionArray();
-        $this->assertTrue(is_array($result));
-        $this->assertEquals(2, count($result));
+        $this->assertInternalType('array', $result);
+        $this->assertCount(2, $result);
         $this->assertEquals($defaultLabel, $result[0]['label']);
         $this->assertEquals($data['label'], $result[1]['label']);
     }
@@ -62,8 +62,8 @@ class LabelTest extends \PHPUnit\Framework\TestCase
             ->willReturn([$data]);
 
         $result = $this->model->getLabelsCollectionForSystemConfiguration();
-        $this->assertTrue(is_array($result));
-        $this->assertEquals(2, count($result));
+        $this->assertInternalType('array', $result);
+        $this->assertCount(2, $result);
         $this->assertEquals($defaultLabel, $result[0]['label']);
         $this->assertEquals($data['label'], $result[1]['label']);
     }

--- a/lib/internal/Magento/Framework/Webapi/Test/Unit/ServiceInputProcessorTest.php
+++ b/lib/internal/Magento/Framework/Webapi/Test/Unit/ServiceInputProcessorTest.php
@@ -190,7 +190,7 @@ class ServiceInputProcessorTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull($result);
         $this->assertTrue($result[0] instanceof Nested);
         /** @var array $result */
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         $this->assertNotEmpty($result[0]);
         /** @var NestedData $arg */
         $arg = $result[0];
@@ -229,11 +229,11 @@ class ServiceInputProcessorTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertNotNull($result);
         /** @var array $result */
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         /** @var array $ids */
         $ids = $result[0];
         $this->assertNotNull($ids);
-        $this->assertEquals(4, count($ids));
+        $this->assertCount(4, $ids);
         $this->assertEquals($data['ids'], $ids);
     }
 
@@ -247,7 +247,7 @@ class ServiceInputProcessorTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertNotNull($result);
         /** @var array $result */
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         /** @var array $associativeArray */
         $associativeArray = $result[0];
         $this->assertNotNull($associativeArray);
@@ -265,7 +265,7 @@ class ServiceInputProcessorTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertNotNull($result);
         /** @var array $result */
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         /** @var array $associativeArray */
         $associativeArray = $result[0];
         $this->assertNotNull($associativeArray);
@@ -282,7 +282,7 @@ class ServiceInputProcessorTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertNotNull($result);
         /** @var array $result */
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         /** @var array $associativeArray */
         $array = $result[0];
         $this->assertNotNull($array);
@@ -305,10 +305,10 @@ class ServiceInputProcessorTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertNotNull($result);
         /** @var array $result */
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         /** @var array $dataObjects */
         $dataObjects = $result[0];
-        $this->assertEquals(2, count($dataObjects));
+        $this->assertCount(2, $dataObjects);
         /** @var SimpleData $first */
         $first = $dataObjects[0];
         /** @var SimpleData $second */
@@ -331,14 +331,14 @@ class ServiceInputProcessorTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertNotNull($result);
         /** @var array $result */
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         /** @var SimpleArrayData $dataObject */
         $dataObject = $result[0];
         $this->assertTrue($dataObject instanceof SimpleArray);
         /** @var array $ids */
         $ids = $dataObject->getIds();
         $this->assertNotNull($ids);
-        $this->assertEquals(4, count($ids));
+        $this->assertCount(4, $ids);
         $this->assertEquals($data['arrayData']['ids'], $ids);
     }
 
@@ -354,7 +354,7 @@ class ServiceInputProcessorTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertNotNull($result);
         /** @var array $result */
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         /** @var \Magento\Framework\Webapi\Test\Unit\ServiceInputProcessor\AssociativeArray $dataObject */
         $dataObject = $result[0];
         $this->assertTrue($dataObject instanceof AssociativeArray);
@@ -379,13 +379,13 @@ class ServiceInputProcessorTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertNotNull($result);
         /** @var array $result */
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         /** @var DataArrayData $dataObjects */
         $dataObjects = $result[0];
         $this->assertTrue($dataObjects instanceof DataArray);
         /** @var array $items */
         $items = $dataObjects->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         /** @var SimpleData $first */
         $first = $items[0];
         /** @var SimpleData $second */

--- a/setup/src/Magento/Setup/Test/Unit/Model/Address/AddressDataGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/Address/AddressDataGeneratorTest.php
@@ -40,7 +40,7 @@ class AddressDataGeneratorTest extends \PHPUnit\Framework\TestCase
         $address = $this->addressGenerator->generateAddress();
 
         foreach ($this->addressStructure as $addressField) {
-            $this->assertTrue(array_key_exists($addressField, $address));
+            $this->assertArrayHasKey($addressField, $address);
         }
     }
 }

--- a/setup/src/Magento/Setup/Test/Unit/Model/Customer/CustomerDataGeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/Customer/CustomerDataGeneratorTest.php
@@ -88,7 +88,7 @@ class CustomerDataGeneratorTest extends \PHPUnit\Framework\TestCase
         $customer = $this->customerGenerator->generate(42);
 
         foreach ($this->customerStructure as $customerField) {
-            $this->assertTrue(array_key_exists($customerField, $customer));
+            $this->assertArrayHasKey($customerField, $customer);
         }
     }
 }

--- a/setup/src/Magento/Setup/Test/Unit/Model/PackagesDataTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/PackagesDataTest.php
@@ -224,10 +224,10 @@ class PackagesDataTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('date', $latestData['lastSyncDate']);
         $this->assertArrayHasKey('time', $latestData['lastSyncDate']);
         $this->assertArrayHasKey('packages', $latestData);
-        $this->assertSame(3, count($latestData['packages']));
+        $this->assertCount(3, $latestData['packages']);
         $this->assertSame(3, $latestData['countOfUpdate']);
         $this->assertArrayHasKey('installPackages', $latestData);
-        $this->assertSame(1, count($latestData['installPackages']));
+        $this->assertCount(1, $latestData['installPackages']);
         $this->assertSame(1, $latestData['countOfInstall']);
     }
 
@@ -260,7 +260,7 @@ class PackagesDataTest extends \PHPUnit\Framework\TestCase
             ->willReturn('repo1');
         $this->createPackagesData();
         $packages = $this->packagesData->getPackagesForUpdate();
-        $this->assertEquals(2, count($packages));
+        $this->assertCount(2, $packages);
         $this->assertArrayHasKey('magento/package-1', $packages);
         $this->assertArrayHasKey('partner/package-3', $packages);
         $firstPackage = array_values($packages)[0];
@@ -271,7 +271,7 @@ class PackagesDataTest extends \PHPUnit\Framework\TestCase
     public function testGetPackagesForUpdate()
     {
         $packages = $this->packagesData->getPackagesForUpdate();
-        $this->assertEquals(3, count($packages));
+        $this->assertCount(3, $packages);
         $this->assertArrayHasKey('magento/package-1', $packages);
         $this->assertArrayHasKey('magento/package-2', $packages);
         $this->assertArrayHasKey('partner/package-3', $packages);
@@ -283,7 +283,7 @@ class PackagesDataTest extends \PHPUnit\Framework\TestCase
     public function testGetInstalledPackages()
     {
         $installedPackages = $this->packagesData->getInstalledPackages();
-        $this->assertEquals(3, count($installedPackages));
+        $this->assertCount(3, $installedPackages);
         $this->assertArrayHasKey('magento/package-1', $installedPackages);
         $this->assertArrayHasKey('magento/package-2', $installedPackages);
         $this->assertArrayHasKey('partner/package-3', $installedPackages);

--- a/setup/src/Magento/Setup/Test/Unit/Model/PhpInformationTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/PhpInformationTest.php
@@ -26,7 +26,7 @@ class PhpInformationTest extends \PHPUnit\Framework\TestCase
         // Class variable 'current' should be empty the first time
         $this->assertAttributeEmpty('current', $phpInformation);
         $actualExtensions = $phpInformation->getCurrent();
-        $this->assertTrue(is_array($actualExtensions));
+        $this->assertInternalType('array', $actualExtensions);
 
         // Calling second type should cause class variable to be used
         $this->assertSame($actualExtensions, $phpInformation->getCurrent());

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Reader/ClassesScannerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Reader/ClassesScannerTest.php
@@ -36,7 +36,7 @@ class ClassesScannerTest extends \PHPUnit\Framework\TestCase
     {
         $pathToScan = str_replace('\\', '/', realpath(__DIR__ . '/../../') . '/_files/app/code/Magento/SomeModule');
         $actual = $this->model->getList($pathToScan);
-        $this->assertTrue(is_array($actual));
+        $this->assertInternalType('array', $actual);
         $this->assertCount(5, $actual);
     }
 }


### PR DESCRIPTION
PHPUnit assertions like assertInternalType, assertFileExists, should be used over assertTrue. 