### PR TITLE
php unit construct

### DIFF
--- a/app/code/Magento/Authorizenet/Test/Unit/Model/DirectpostTest.php
+++ b/app/code/Magento/Authorizenet/Test/Unit/Model/DirectpostTest.php
@@ -249,7 +249,7 @@ class DirectpostTest extends \PHPUnit\Framework\TestCase
     public function testValidateResponseSuccess()
     {
         $this->prepareTestValidateResponse('some_md5', 'login', true);
-        $this->assertEquals(true, $this->directpost->validateResponse());
+        $this->assertTrue($this->directpost->validateResponse());
     }
 
     /**
@@ -288,7 +288,7 @@ class DirectpostTest extends \PHPUnit\Framework\TestCase
             ->method('getXTransId')
             ->willReturn('111');
 
-        $this->assertEquals(true, $this->directpost->checkTransId());
+        $this->assertTrue($this->directpost->checkTransId());
     }
 
     /**
@@ -314,7 +314,7 @@ class DirectpostTest extends \PHPUnit\Framework\TestCase
             ->method('getXResponseCode')
             ->willReturn($responseCode);
 
-        $this->assertEquals(true, $this->directpost->checkResponseCode());
+        $this->assertTrue($this->directpost->checkResponseCode());
     }
 
     /**

--- a/app/code/Magento/Backend/Test/Unit/App/Router/NoRouteHandlerTest.php
+++ b/app/code/Magento/Backend/Test/Unit/App/Router/NoRouteHandlerTest.php
@@ -82,7 +82,7 @@ class NoRouteHandlerTest extends \PHPUnit\Framework\TestCase
             $this->returnValue($this->_requestMock)
         );
 
-        $this->assertEquals(true, $this->_model->process($this->_requestMock));
+        $this->assertTrue($this->_model->process($this->_requestMock));
     }
 
     /**
@@ -104,6 +104,6 @@ class NoRouteHandlerTest extends \PHPUnit\Framework\TestCase
 
         $this->_requestMock->expects($this->never())->method('setActionName');
 
-        $this->assertEquals(false, $this->_model->process($this->_requestMock));
+        $this->assertFalse($this->_model->process($this->_requestMock));
     }
 }

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Button/SplitTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Button/SplitTest.php
@@ -12,10 +12,10 @@ class SplitTest extends \PHPUnit\Framework\TestCase
         $objectManagerHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         /** @var \Magento\Backend\Block\Widget\Button\SplitButton $block */
         $block = $objectManagerHelper->getObject(\Magento\Backend\Block\Widget\Button\SplitButton::class);
-        $this->assertSame(true, $block->hasSplit());
+        $this->assertTrue($block->hasSplit());
         $block->setData('has_split', false);
-        $this->assertSame(false, $block->hasSplit());
+        $this->assertFalse($block->hasSplit());
         $block->setData('has_split', true);
-        $this->assertSame(true, $block->hasSplit());
+        $this->assertTrue($block->hasSplit());
     }
 }

--- a/app/code/Magento/Backend/Test/Unit/Model/Menu/Config/SchemaLocatorTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Model/Menu/Config/SchemaLocatorTest.php
@@ -40,6 +40,6 @@ class SchemaLocatorTest extends \PHPUnit\Framework\TestCase
 
     public function testGetPerFileSchema()
     {
-        $this->assertEquals(null, $this->_model->getPerFileSchema());
+        $this->assertNull($this->_model->getPerFileSchema());
     }
 }

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Config/ConfigTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Config/ConfigTest.php
@@ -206,7 +206,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             ->with($this->getPath(Config::KEY_USE_CVV), ScopeInterface::SCOPE_STORE, null)
             ->willReturn(1);
 
-        static::assertEquals(true, $this->model->isCvvEnabled());
+        static::assertTrue($this->model->isCvvEnabled());
     }
 
     /**

--- a/app/code/Magento/Braintree/Test/Unit/Model/Report/FilterMapperTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/Report/FilterMapperTest.php
@@ -110,6 +110,6 @@ class FilterMapperTest extends \PHPUnit\Framework\TestCase
 
         $mapper = new FilterMapper($this->appliersPoolMock, $this->braintreeSearchAdapterMock);
         $result = $mapper->getFilter('orderId', []);
-        $this->assertEquals(null, $result);
+        $this->assertNull($result);
     }
 }

--- a/app/code/Magento/Bundle/Test/Unit/Block/Adminhtml/Sales/Order/Items/RendererTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Block/Adminhtml/Sales/Order/Items/RendererTest.php
@@ -43,7 +43,7 @@ class RendererTest extends \PHPUnit\Framework\TestCase
         $item->expects($this->once())->method('getOrderItem')->will($this->returnValue($this->orderItem));
         $this->orderItem->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $this->assertSame(null, $this->model->getChildren($item));
+        $this->assertNull($this->model->getChildren($item));
     }
 
     /**

--- a/app/code/Magento/Bundle/Test/Unit/Block/Sales/Order/Items/RendererTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Block/Sales/Order/Items/RendererTest.php
@@ -44,7 +44,7 @@ class RendererTest extends \PHPUnit\Framework\TestCase
         $item->expects($this->once())->method('getOrderItem')->will($this->returnValue($this->orderItem));
         $this->orderItem->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $this->assertSame(null, $this->model->getChildren($item));
+        $this->assertNull($this->model->getChildren($item));
     }
 
     /**

--- a/app/code/Magento/Bundle/Test/Unit/Model/Product/CatalogPriceTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/Product/CatalogPriceTest.php
@@ -125,6 +125,6 @@ class CatalogPriceTest extends \PHPUnit\Framework\TestCase
 
     public function testGetCatalogRegularPrice()
     {
-        $this->assertEquals(null, $this->catalogPrice->getCatalogRegularPrice($this->productMock));
+        $this->assertNull($this->catalogPrice->getCatalogRegularPrice($this->productMock));
     }
 }

--- a/app/code/Magento/Bundle/Test/Unit/Model/Sales/Order/Pdf/Items/AbstractItemsTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/Sales/Order/Pdf/Items/AbstractItemsTest.php
@@ -46,7 +46,7 @@ class AbstractItemsTest extends \PHPUnit\Framework\TestCase
         $item->expects($this->once())->method('getOrderItem')->will($this->returnValue($this->orderItem));
         $this->orderItem->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $this->assertSame(null, $this->model->getChildren($item));
+        $this->assertNull($this->model->getChildren($item));
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/InventoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/InventoryTest.php
@@ -202,6 +202,6 @@ class InventoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testIsEnabled()
     {
-        $this->assertEquals(true, $this->inventory->isAvailable('field'));
+        $this->assertTrue($this->inventory->isAvailable('field'));
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Rss/Grid/LinkTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Rss/Grid/LinkTest.php
@@ -55,6 +55,6 @@ class LinkTest extends \PHPUnit\Framework\TestCase
 
     public function testIsRssAllowed()
     {
-        $this->assertEquals(true, $this->link->isRssAllowed());
+        $this->assertTrue($this->link->isRssAllowed());
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/View/GalleryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/View/GalleryTest.php
@@ -101,7 +101,7 @@ class GalleryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('product_page_image_large_url', $decodedJson[0]['full']);
         $this->assertEquals('test_label', $decodedJson[0]['caption']);
         $this->assertEquals('2', $decodedJson[0]['position']);
-        $this->assertEquals(false, $decodedJson[0]['isMain']);
+        $this->assertFalse($decodedJson[0]['isMain']);
         $this->assertEquals('test_media_type', $decodedJson[0]['type']);
         $this->assertEquals('test_video_url', $decodedJson[0]['videoUrl']);
     }

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/ViewTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/ViewTest.php
@@ -58,7 +58,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
         )->will(
             $this->returnValue(true)
         );
-        $this->assertEquals(false, $this->view->shouldRenderQuantity());
+        $this->assertFalse($this->view->shouldRenderQuantity());
     }
 
     public function testGetIdentities()

--- a/app/code/Magento/Catalog/Test/Unit/Block/Rss/CategoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Rss/CategoryTest.php
@@ -199,7 +199,7 @@ class CategoryTest extends \PHPUnit\Framework\TestCase
         $this->scopeConfig->expects($this->once())->method('isSetFlag')
             ->with('rss/catalog/category', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
             ->will($this->returnValue(true));
-        $this->assertEquals(true, $this->block->isAllowed());
+        $this->assertTrue($this->block->isAllowed());
     }
 
     public function testGetFeeds()

--- a/app/code/Magento/Catalog/Test/Unit/Block/Rss/Product/SpecialTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Rss/Product/SpecialTest.php
@@ -206,7 +206,7 @@ class SpecialTest extends \PHPUnit\Framework\TestCase
         $this->scopeConfig->expects($this->once())->method('isSetFlag')
             ->with('rss/catalog/special', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
             ->will($this->returnValue(true));
-        $this->assertEquals(true, $this->block->isAllowed());
+        $this->assertTrue($this->block->isAllowed());
     }
 
     public function testGetCacheLifetime()

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/ReloadTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/ReloadTest.php
@@ -147,7 +147,7 @@ class ReloadTest extends \PHPUnit\Framework\TestCase
             ->with('noroute')
             ->willReturn(true);
 
-        $this->assertSame(true, $this->model->execute());
+        $this->assertTrue($this->model->execute());
     }
 
     public function testExecute()

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/ImageTest.php
@@ -101,7 +101,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
 
         $model->beforeSave($object);
 
-        $this->assertEquals(null, $object->getTestAttribute());
+        $this->assertNull($object->getTestAttribute());
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/CategoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CategoryTest.php
@@ -271,7 +271,7 @@ class CategoryTest extends \PHPUnit\Framework\TestCase
 
     public function testGetUseFlatResourceFalse()
     {
-        $this->assertEquals(false, $this->category->getUseFlatResource());
+        $this->assertFalse($this->category->getUseFlatResource());
     }
 
     public function testGetUseFlatResourceTrue()
@@ -281,7 +281,7 @@ class CategoryTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue(true));
 
         $category = $this->getCategoryModel();
-        $this->assertEquals(true, $category->getUseFlatResource());
+        $this->assertTrue($category->getUseFlatResource());
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/Flat/StateTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/Flat/StateTest.php
@@ -65,7 +65,7 @@ class StateTest extends \PHPUnit\Framework\TestCase
             $this->scopeConfigMock,
             $this->indexerRegistryMock
         );
-        $this->assertEquals(true, $this->model->isFlatEnabled());
+        $this->assertTrue($this->model->isFlatEnabled());
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/RepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/RepositoryTest.php
@@ -157,7 +157,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
         $attributeMock = $this->createMock(\Magento\Catalog\Model\ResourceModel\Eav\Attribute::class);
         $this->attributeResourceMock->expects($this->once())->method('delete')->with($attributeMock);
 
-        $this->assertEquals(true, $this->model->delete($attributeMock));
+        $this->assertTrue($this->model->delete($attributeMock));
     }
 
     /**
@@ -175,7 +175,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
             )->willReturn($attributeMock);
         $this->attributeResourceMock->expects($this->once())->method('delete')->with($attributeMock);
 
-        $this->assertEquals(true, $this->model->deleteById($attributeCode));
+        $this->assertTrue($this->model->deleteById($attributeCode));
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/ImageTest.php
@@ -256,8 +256,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
         $this->imageAsset->expects($this->any())->method('getSourceFile')->willReturn('catalog/product/somefile.png');
         $this->image->setBaseFile('/somefile.png');
         $this->assertEquals('catalog/product/somefile.png', $this->image->getBaseFile());
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $this->image->getNewFile()
         );
     }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Type/FileTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Type/FileTest.php
@@ -404,7 +404,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->will($this->returnValue($itemMock));
 
-        $this->assertEquals(null, $fileObject->parseOptionValue($userInput, []));
+        $this->assertNull($fileObject->parseOptionValue($userInput, []));
     }
 
     public function testParseOptionValueInvalid()
@@ -431,7 +431,7 @@ class FileTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->will($this->returnValue($itemMock));
 
-        $this->assertEquals(null, $fileObject->parseOptionValue($userInput, []));
+        $this->assertNull($fileObject->parseOptionValue($userInput, []));
     }
 
     public function testPrepareOptionValueForRequest()

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/TierPriceManagementTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/TierPriceManagementTest.php
@@ -190,7 +190,7 @@ class TierPriceManagementTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue(0));
         $this->priceModifierMock->expects($this->once())->method('removeTierPrice')->with($this->productMock, 4, 5, 0);
 
-        $this->assertEquals(true, $this->service->remove('product_sku', 4, 5, 0));
+        $this->assertTrue($this->service->remove('product_sku', 4, 5, 0));
     }
 
     /**
@@ -222,7 +222,7 @@ class TierPriceManagementTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue(1));
         $this->priceModifierMock->expects($this->once())->method('removeTierPrice')->with($this->productMock, 4, 5, 1);
 
-        $this->assertEquals(true, $this->service->remove('product_sku', 4, 5, 6));
+        $this->assertTrue($this->service->remove('product_sku', 4, 5, 6));
     }
 
     public function testSetNewPriceWithGlobalPriceScopeAll()

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Type/AbstractTypeTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Type/AbstractTypeTest.php
@@ -63,7 +63,7 @@ class AbstractTypeTest extends \PHPUnit\Framework\TestCase
             $this->returnValue(Status::STATUS_ENABLED)
         );
         $this->product->setData('is_salable', 3);
-        $this->assertEquals(true, $this->model->isSalable($this->product));
+        $this->assertTrue($this->model->isSalable($this->product));
     }
 
     public function testGetAttributeById()
@@ -122,6 +122,6 @@ class AbstractTypeTest extends \PHPUnit\Framework\TestCase
     public function testHasOptions()
     {
         $this->product->expects($this->once())->method('getHasOptions')->will($this->returnValue(true));
-        $this->assertEquals(true, $this->model->hasOptions($this->product));
+        $this->assertTrue($this->model->hasOptions($this->product));
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/ValidatorTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/ValidatorTest.php
@@ -14,6 +14,6 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         $requestMock = $this->createMock(\Magento\Framework\App\RequestInterface::class);
         $responseMock = $this->createMock(\Magento\Framework\DataObject::class);
         $productMock->expects($this->once())->method('validate')->will($this->returnValue(true));
-        $this->assertEquals(true, $validator->validate($productMock, $requestMock, $responseMock));
+        $this->assertTrue($validator->validate($productMock, $requestMock, $responseMock));
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/ConfigTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductTypes/ConfigTest.php
@@ -119,6 +119,6 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
                 'serializer' => $this->serializerMock,
             ]
         );
-        $this->assertEquals(false, $this->config->isProductSet('typeId'));
+        $this->assertFalse($this->config->isProductSet('typeId'));
     }
 }

--- a/app/code/Magento/CatalogInventory/Test/Unit/Api/StockStateTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Api/StockStateTest.php
@@ -115,24 +115,21 @@ class StockStateTest extends \PHPUnit\Framework\TestCase
 
     public function testVerifyStock()
     {
-        $this->assertEquals(
-            true,
+        $this->assertTrue(
             $this->stockState->verifyStock($this->productId, $this->websiteId)
         );
     }
 
     public function testVerifyNotification()
     {
-        $this->assertEquals(
-            true,
+        $this->assertTrue(
             $this->stockState->verifyNotification($this->productId, $this->websiteId)
         );
     }
 
     public function testCheckQty()
     {
-        $this->assertEquals(
-            true,
+        $this->assertTrue(
             $this->stockState->checkQty($this->productId, $this->qty, $this->websiteId)
         );
     }

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/CatalogRuleRepositoryTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/CatalogRuleRepositoryTest.php
@@ -86,7 +86,7 @@ class CatalogRuleRepositoryTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('delete')
             ->with($this->ruleMock);
-        $this->assertEquals(true, $this->repository->delete($this->ruleMock));
+        $this->assertTrue($this->repository->delete($this->ruleMock));
     }
 
     public function testDeleteRuleById()
@@ -101,7 +101,7 @@ class CatalogRuleRepositoryTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('delete')
             ->with($ruleMock);
-        $this->assertEquals(true, $this->repository->deleteById($ruleId));
+        $this->assertTrue($this->repository->deleteById($ruleId));
     }
 
     /**

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/Product/PriceModifierTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/Product/PriceModifierTest.php
@@ -67,6 +67,6 @@ class PriceModifierTest extends \PHPUnit\Framework\TestCase
     public function testModifyPriceIfPriceNotExist()
     {
         $this->ruleFactoryMock->expects($this->never())->method('create');
-        $this->assertEquals(null, $this->priceModifier->modifyPrice(null, $this->productMock));
+        $this->assertNull($this->priceModifier->modifyPrice(null, $this->productMock));
     }
 }

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Indexer/Fulltext/Plugin/AttributeTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Indexer/Fulltext/Plugin/AttributeTest.php
@@ -88,8 +88,7 @@ class AttributeTest extends \PHPUnit\Framework\TestCase
             ->method('dataHasChangedFor')
             ->with('is_searchable')
             ->willReturn(true);
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $this->model->beforeSave($this->subjectMock, $this->attributeMock)
         );
     }
@@ -133,8 +132,7 @@ class AttributeTest extends \PHPUnit\Framework\TestCase
         $this->attributeMock->expects($this->once())
             ->method('getIsSearchable')
             ->willReturn(true);
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $this->model->beforeDelete($this->subjectMock, $this->attributeMock)
         );
     }

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/ObjectRegistryTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/ObjectRegistryTest.php
@@ -32,7 +32,7 @@ class ObjectRegistryTest extends \PHPUnit\Framework\TestCase
 
     public function testGetNotExistObject()
     {
-        $this->assertEquals(null, $this->objectRegistry->get('no-id'));
+        $this->assertNull($this->objectRegistry->get('no-id'));
     }
 
     public function testGetList()

--- a/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/ProductsListTest.php
+++ b/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/ProductsListTest.php
@@ -357,9 +357,9 @@ class ProductsListTest extends \PHPUnit\Framework\TestCase
 
     public function testShowPager()
     {
-        $this->assertEquals(false, $this->productsList->showPager());
+        $this->assertFalse($this->productsList->showPager());
         $this->productsList->setData('show_pager', true);
-        $this->assertEquals(true, $this->productsList->showPager());
+        $this->assertTrue($this->productsList->showPager());
     }
 
     public function testGetIdentities()

--- a/app/code/Magento/Checkout/Test/Unit/Model/AgreementsValidatorTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/AgreementsValidatorTest.php
@@ -19,6 +19,6 @@ class AgreementsValidatorTest extends \PHPUnit\Framework\TestCase
 
     public function testIsValid()
     {
-        $this->assertEquals(true, $this->model->isValid());
+        $this->assertTrue($this->model->isValid());
     }
 }

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Importer/SaveProcessorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Importer/SaveProcessorTest.php
@@ -134,6 +134,6 @@ class SaveProcessorTest extends \PHPUnit\Framework\TestCase
                 ['web/unsecure/base_url', 'http://magento3.local/', 'websites', 'base', $value2]
             ]);
 
-        $this->assertSame(null, $this->model->process($data));
+        $this->assertNull($this->model->process($data));
     }
 }

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Reader/Source/Deployed/DocumentRootTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Reader/Source/Deployed/DocumentRootTest.php
@@ -54,7 +54,7 @@ class DocumentRootTest extends \PHPUnit\Framework\TestCase
     {
         $this->configMockSetForDocumentRootIsPub();
 
-        $this->assertSame(true, $this->documentRoot->isPub());
+        $this->assertTrue($this->documentRoot->isPub());
     }
 
     private function configMockSetForDocumentRootIsPub()

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/CartConfiguration/Plugin/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/CartConfiguration/Plugin/ConfigurableTest.php
@@ -47,8 +47,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
         )->will(
             $this->returnValue(\Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE)
         );
-        $this->assertEquals(
-            true,
+        $this->assertTrue(
             $this->model->aroundIsProductConfigured(
                 $this->subjectMock,
                 $this->closureMock,

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Observer/HideUnsupportedAttributeTypesTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Observer/HideUnsupportedAttributeTypesTest.php
@@ -40,7 +40,7 @@ class HideUnsupportedAttributeTypesTest extends \PHPUnit\Framework\TestCase
     {
         $target = $this->createTarget($this->createRequestMock(false));
         $event = $this->createEventMock();
-        $this->assertEquals(null, $target->execute($event));
+        $this->assertNull($target->execute($event));
     }
 
     /**
@@ -109,7 +109,7 @@ class HideUnsupportedAttributeTypesTest extends \PHPUnit\Framework\TestCase
     {
         $target = $this->createTarget($this->createRequestMock(true), $supportedTypes);
         $event = $this->createEventMock($this->createForm($originalValues, $expectedValues));
-        $this->assertEquals(null, $target->execute($event));
+        $this->assertNull($target->execute($event));
     }
 
     /**

--- a/app/code/Magento/CurrencySymbol/Test/Unit/Model/System/CurrencysymbolTest.php
+++ b/app/code/Magento/CurrencySymbol/Test/Unit/Model/System/CurrencysymbolTest.php
@@ -270,7 +270,7 @@ class CurrencysymbolTest extends \PHPUnit\Framework\TestCase
         $this->serializerMock->expects($this->never())
             ->method('unserialize');
         $currencySymbol = $this->model->getCurrencySymbol('USD');
-        $this->assertEquals(false, $currencySymbol);
+        $this->assertFalse($currencySymbol);
     }
 
     /**

--- a/app/code/Magento/Customer/Test/Unit/Block/Widget/DobTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Widget/DobTest.php
@@ -155,7 +155,7 @@ class DobTest extends \PHPUnit\Framework\TestCase
                     )
                 ))
             );
-        $this->assertSame(false, $this->_block->isEnabled());
+        $this->assertFalse($this->_block->isEnabled());
     }
 
     /**
@@ -182,7 +182,7 @@ class DobTest extends \PHPUnit\Framework\TestCase
                     )
                 ))
             );
-        $this->assertSame(false, $this->_block->isRequired());
+        $this->assertFalse($this->_block->isRequired());
     }
 
     /**

--- a/app/code/Magento/Customer/Test/Unit/Block/Widget/GenderTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Widget/GenderTest.php
@@ -98,7 +98,7 @@ class GenderTest extends \PHPUnit\Framework\TestCase
                 )
             ))
         );
-        $this->assertSame(false, $this->block->isEnabled());
+        $this->assertFalse($this->block->isEnabled());
     }
 
     /**
@@ -139,7 +139,7 @@ class GenderTest extends \PHPUnit\Framework\TestCase
                 )
             ))
         );
-        $this->assertSame(false, $this->block->isRequired());
+        $this->assertFalse($this->block->isRequired());
     }
 
     /**

--- a/app/code/Magento/Customer/Test/Unit/Block/Widget/TaxvatTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Widget/TaxvatTest.php
@@ -85,7 +85,7 @@ class TaxvatTest extends \PHPUnit\Framework\TestCase
                 )
             ))
         );
-        $this->assertSame(false, $this->_block->isEnabled());
+        $this->assertFalse($this->_block->isEnabled());
     }
 
     /**
@@ -123,6 +123,6 @@ class TaxvatTest extends \PHPUnit\Framework\TestCase
                 )
             ))
         );
-        $this->assertSame(false, $this->_block->isRequired());
+        $this->assertFalse($this->_block->isRequired());
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Model/Customer/Attribute/Source/WebsiteTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Customer/Attribute/Source/WebsiteTest.php
@@ -89,6 +89,6 @@ class WebsiteTest extends \PHPUnit\Framework\TestCase
     {
         $this->mockOptions();
 
-        $this->assertEquals(false, $this->model->getOptionText('value'));
+        $this->assertFalse($this->model->getOptionText('value'));
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Model/Metadata/Form/AbstractDataTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Metadata/Form/AbstractDataTest.php
@@ -108,7 +108,7 @@ class AbstractDataTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($this->_model, $this->_model->setExtractedData($data));
         $this->assertSame($data, $this->_model->getExtractedData());
         $this->assertSame('VALUE', $this->_model->getExtractedData('KEY'));
-        $this->assertSame(null, $this->_model->getExtractedData('BAD_KEY'));
+        $this->assertNull($this->_model->getExtractedData('BAD_KEY'));
     }
 
     /**

--- a/app/code/Magento/Customer/Test/Unit/Model/Metadata/Form/DateTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Metadata/Form/DateTest.php
@@ -202,7 +202,7 @@ class DateTest extends AbstractFormTestCase
      */
     public function testOutputValue()
     {
-        $this->assertEquals(null, $this->date->outputValue());
+        $this->assertNull($this->date->outputValue());
         $date = new \Magento\Customer\Model\Metadata\Form\Date(
             $this->localeMock,
             $this->loggerMock,

--- a/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/Db/VersionControl/AddressSnapshotTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/Db/VersionControl/AddressSnapshotTest.php
@@ -124,6 +124,6 @@ class AddressSnapshotTest extends \PHPUnit\Framework\TestCase
 
         $this->model->registerSnapshot($dataObjectMock);
 
-        $this->assertEquals(true, $this->model->isModified($dataObjectMock));
+        $this->assertTrue($this->model->isModified($dataObjectMock));
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Ui/Component/Form/AddressFieldsetTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Ui/Component/Form/AddressFieldsetTest.php
@@ -64,6 +64,6 @@ class AddressFieldsetTest extends \PHPUnit\Framework\TestCase
     {
         $this->context->expects($this->atLeastOnce())->method('getRequestParam')->with('id')
             ->willReturn(null);
-        $this->assertEquals(false, $this->fieldset->isComponentVisible());
+        $this->assertFalse($this->fieldset->isComponentVisible());
     }
 }

--- a/app/code/Magento/Deploy/Test/Unit/Model/ModeTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Model/ModeTest.php
@@ -139,7 +139,7 @@ class ModeTest extends \PHPUnit\Framework\TestCase
                 [State::PARAM_MODE => State::MODE_DEVELOPER]
             );
 
-        $this->assertSame(null, $this->model->getMode());
+        $this->assertNull($this->model->getMode());
         $this->assertSame(State::MODE_DEVELOPER, $this->model->getMode());
     }
 

--- a/app/code/Magento/Deploy/Test/Unit/Process/QueueTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Process/QueueTest.php
@@ -93,7 +93,7 @@ class QueueTest extends \PHPUnit\Framework\TestCase
         $package = $this->createMock(Package::class);
         $package->expects($this->once())->method('getPath')->willReturn('path');
 
-        $this->assertEquals(true, $this->queue->add($package));
+        $this->assertTrue($this->queue->add($package));
         $packages = $this->queue->getPackages();
         $this->assertEquals(
             $package,

--- a/app/code/Magento/Deploy/Test/Unit/Service/DeployStaticContentTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Service/DeployStaticContentTest.php
@@ -184,7 +184,7 @@ class DeployStaticContentTest extends \PHPUnit\Framework\TestCase
                 ->willReturnOnConsecutiveCalls($minifyTemplates);
         }
 
-        $this->assertEquals(null, $this->service->deploy($options));
+        $this->assertNull($this->service->deploy($options));
     }
 
     /**

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Backend/ArrayBackendTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Backend/ArrayBackendTest.php
@@ -37,7 +37,7 @@ class ArrayBackendTest extends \PHPUnit\Framework\TestCase
         $product = new \Magento\Framework\DataObject(['code' => $data, 'empty' => '']);
         $this->_model->validate($product);
         $this->assertEquals('1,2,3', $product->getCode());
-        $this->assertEquals(null, $product->getEmpty());
+        $this->assertNull($product->getEmpty());
     }
 
     /**

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Collection/VersionControl/AbstractCollectionTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Collection/VersionControl/AbstractCollectionTest.php
@@ -60,7 +60,7 @@ class AbstractCollectionTest extends \Magento\Eav\Test\Unit\Model\Entity\Collect
         if (!$data) {
             $this->entitySnapshot->expects($this->never())->method('registerSnapshot');
 
-            $this->assertEquals(false, $this->subject->fetchItem());
+            $this->assertFalse($this->subject->fetchItem());
         } else {
             $this->entitySnapshot->expects($this->once())->method('registerSnapshot')->with($item);
 

--- a/app/code/Magento/Elasticsearch/Test/Unit/Elasticsearch5/Model/Client/ElasticsearchTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/Elasticsearch5/Model/Client/ElasticsearchTest.php
@@ -118,7 +118,7 @@ class ElasticsearchTest extends \PHPUnit\Framework\TestCase
     public function testPing()
     {
         $this->elasticsearchClientMock->expects($this->once())->method('ping')->willReturn(true);
-        $this->assertEquals(true, $this->model->ping());
+        $this->assertTrue($this->model->ping());
     }
 
     /**
@@ -127,7 +127,7 @@ class ElasticsearchTest extends \PHPUnit\Framework\TestCase
     public function testTestConnection()
     {
         $this->elasticsearchClientMock->expects($this->once())->method('ping')->willReturn(true);
-        $this->assertEquals(true, $this->model->testConnection());
+        $this->assertTrue($this->model->testConnection());
     }
 
     /**
@@ -136,7 +136,7 @@ class ElasticsearchTest extends \PHPUnit\Framework\TestCase
     public function testTestConnectionFalse()
     {
         $this->elasticsearchClientMock->expects($this->once())->method('ping')->willReturn(false);
-        $this->assertEquals(true, $this->model->testConnection());
+        $this->assertTrue($this->model->testConnection());
     }
 
     /**
@@ -153,7 +153,7 @@ class ElasticsearchTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->model->ping();
-        $this->assertEquals(true, $this->model->testConnection());
+        $this->assertTrue($this->model->testConnection());
     }
 
     /**

--- a/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/Container/AttributeTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/Container/AttributeTest.php
@@ -153,7 +153,7 @@ class AttributeTest extends \PHPUnit\Framework\TestCase
             $this->createAttributeMock(120, 'attribute_code')
         ];
         $this->mockAttributes($attributes);
-        $this->assertEquals(null, $this->attribute->getAttribute($attributeCode));
+        $this->assertNull($this->attribute->getAttribute($attributeCode));
     }
 
     /**

--- a/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/ElasticsearchTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/ElasticsearchTest.php
@@ -186,7 +186,7 @@ class ElasticsearchTest extends \PHPUnit\Framework\TestCase
         $this->client->expects($this->once())
             ->method('ping')
             ->willReturn(true);
-        $this->assertEquals(true, $this->model->ping());
+        $this->assertTrue($this->model->ping());
     }
 
     /**

--- a/app/code/Magento/Elasticsearch/Test/Unit/Model/ResourceModel/EngineTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/Model/ResourceModel/EngineTest.php
@@ -90,7 +90,7 @@ class EngineTest extends \PHPUnit\Framework\TestCase
      */
     public function testAllowAdvancedIndex()
     {
-        $this->assertEquals(false, $this->model->allowAdvancedIndex());
+        $this->assertFalse($this->model->allowAdvancedIndex());
     }
 
     /**
@@ -98,7 +98,7 @@ class EngineTest extends \PHPUnit\Framework\TestCase
      */
     public function testIsAvailable()
     {
-        $this->assertEquals(true, $this->model->isAvailable());
+        $this->assertTrue($this->model->isAvailable());
     }
 
     /**

--- a/app/code/Magento/Email/Test/Unit/Model/TemplateTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/TemplateTest.php
@@ -181,10 +181,10 @@ class TemplateTest extends \PHPUnit\Framework\TestCase
     {
         $model = $this->getModelMock();
         $model->setIsChildTemplate(true);
-        $this->assertSame(true, $model->isChildTemplate());
+        $this->assertTrue($model->isChildTemplate());
 
         $model->setIsChildTemplate(false);
-        $this->assertSame(false, $model->isChildTemplate());
+        $this->assertFalse($model->isChildTemplate());
     }
 
     public function testSetAndGetTemplateFilter()

--- a/app/code/Magento/GroupedProduct/Test/Unit/Block/Adminhtml/Order/Create/SidebarTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Block/Adminhtml/Order/Create/SidebarTest.php
@@ -70,8 +70,7 @@ class SidebarTest extends \PHPUnit\Framework\TestCase
 
     public function testAroundIsConfigurationRequiredWhenProductGrouped()
     {
-        $this->assertEquals(
-            true,
+        $this->assertTrue(
             $this->sidebarMock->aroundIsConfigurationRequired(
                 $this->subjectMock,
                 $this->closureMock,

--- a/app/code/Magento/GroupedProduct/Test/Unit/Block/Adminhtml/Product/Composite/Fieldset/GroupedTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Block/Adminhtml/Product/Composite/Fieldset/GroupedTest.php
@@ -187,7 +187,7 @@ class GroupedTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetCanShowProductPrice()
     {
-        $this->assertEquals(true, $this->block->getCanShowProductPrice($this->productMock));
+        $this->assertTrue($this->block->getCanShowProductPrice($this->productMock));
     }
 
     /**
@@ -199,7 +199,7 @@ class GroupedTest extends \PHPUnit\Framework\TestCase
 
         $this->productMock->expects($this->never())->method('getOptions');
 
-        $this->assertEquals(true, $this->block->getIsLastFieldset());
+        $this->assertTrue($this->block->getIsLastFieldset());
     }
 
     /**

--- a/app/code/Magento/GroupedProduct/Test/Unit/Model/Product/Cart/Configuration/Plugin/GroupedTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Model/Product/Cart/Configuration/Plugin/GroupedTest.php
@@ -47,8 +47,7 @@ class GroupedTest extends \PHPUnit\Framework\TestCase
         )->will(
             $this->returnValue(\Magento\GroupedProduct\Model\Product\Type\Grouped::TYPE_CODE)
         );
-        $this->assertEquals(
-            true,
+        $this->assertTrue(
             $this->groupedPlugin->aroundIsProductConfigured(
                 $this->subjectMock,
                 $this->closureMock,

--- a/app/code/Magento/GroupedProduct/Test/Unit/Model/Product/CatalogPriceTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Model/Product/CatalogPriceTest.php
@@ -82,7 +82,7 @@ class CatalogPriceTest extends \PHPUnit\Framework\TestCase
         );
         $this->storeManagerMock->expects($this->never())->method('getStore');
         $this->storeManagerMock->expects($this->never())->method('setCurrentStore');
-        $this->assertEquals(null, $this->catalogPrice->getCatalogPrice($this->productMock));
+        $this->assertNull($this->catalogPrice->getCatalogPrice($this->productMock));
     }
 
     public function testGetCatalogPriceWithDefaultStoreAndSubProductIsNotSalable()
@@ -125,7 +125,7 @@ class CatalogPriceTest extends \PHPUnit\Framework\TestCase
         $this->productMock->expects($this->never())->method('setTaxClassId');
         $this->storeManagerMock->expects($this->never())->method('getStore');
         $this->storeManagerMock->expects($this->never())->method('setCurrentStore');
-        $this->assertEquals(null, $this->catalogPrice->getCatalogPrice($this->productMock));
+        $this->assertNull($this->catalogPrice->getCatalogPrice($this->productMock));
     }
 
     public function testGetCatalogPriceWithCustomStoreAndSubProductIsSalable()
@@ -197,6 +197,6 @@ class CatalogPriceTest extends \PHPUnit\Framework\TestCase
 
     public function testGetCatalogRegularPrice()
     {
-        $this->assertEquals(null, $this->catalogPrice->getCatalogRegularPrice($this->productMock));
+        $this->assertNull($this->catalogPrice->getCatalogRegularPrice($this->productMock));
     }
 }

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Import/Entity/AbstractTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Import/Entity/AbstractTest.php
@@ -143,7 +143,7 @@ class AbstractTest extends \Magento\ImportExport\Test\Unit\Model\Import\Abstract
      */
     public function testIsNeedToLogInHistory()
     {
-        $this->assertEquals(false, $this->_model->isNeedToLogInHistory());
+        $this->assertFalse($this->_model->isNeedToLogInHistory());
     }
 
     /**

--- a/app/code/Magento/ImportExport/Test/Unit/Model/ImportTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/ImportTest.php
@@ -280,7 +280,7 @@ class ImportTest extends \Magento\ImportExport\Test\Unit\Model\Import\AbstractIm
             $this->import->expects($this->once())->method($method)->will($this->returnValue(null));
         }
 
-        $this->assertEquals(true, $this->import->importSource());
+        $this->assertTrue($this->import->importSource());
     }
 
     /**

--- a/app/code/Magento/Indexer/Test/Unit/Model/Indexer/AbstractProcessorTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Model/Indexer/AbstractProcessorTest.php
@@ -73,14 +73,14 @@ class AbstractProcessorTest extends \PHPUnit\Framework\TestCase
                 self::INDEXER_ID
             )->willReturnSelf();
             $this->_indexerRegistryMock->expects($this->once())->method('isScheduled')->willReturn($scheduled);
-            $this->assertEquals(null, $this->model->reindexRow($id));
+            $this->assertNull($this->model->reindexRow($id));
         } else {
             $this->_indexerRegistryMock->expects($this->exactly(2))->method('get')->with(
                 self::INDEXER_ID
             )->willReturnSelf();
             $this->_indexerRegistryMock->expects($this->once())->method('isScheduled')->willReturn($scheduled);
             $this->_indexerRegistryMock->expects($this->once())->method('reindexRow')->with($id)->willReturnSelf();
-            $this->assertEquals(null, $this->model->reindexRow($id));
+            $this->assertNull($this->model->reindexRow($id));
         }
     }
 
@@ -96,14 +96,14 @@ class AbstractProcessorTest extends \PHPUnit\Framework\TestCase
                 self::INDEXER_ID
             )->willReturnSelf();
             $this->_indexerRegistryMock->expects($this->once())->method('isScheduled')->willReturn($scheduled);
-            $this->assertEquals(null, $this->model->reindexList($ids));
+            $this->assertNull($this->model->reindexList($ids));
         } else {
             $this->_indexerRegistryMock->expects($this->exactly(2))->method('get')->with(
                 self::INDEXER_ID
             )->willReturnSelf();
             $this->_indexerRegistryMock->expects($this->once())->method('isScheduled')->willReturn($scheduled);
             $this->_indexerRegistryMock->expects($this->once())->method('reindexList')->with($ids)->willReturnSelf();
-            $this->assertEquals(null, $this->model->reindexList($ids));
+            $this->assertNull($this->model->reindexList($ids));
         }
     }
 

--- a/app/code/Magento/Indexer/Test/Unit/Model/Indexer/StateTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Model/Indexer/StateTest.php
@@ -61,7 +61,7 @@ class StateTest extends \PHPUnit\Framework\TestCase
 
     public function testBeforeSave()
     {
-        $this->assertEquals(null, $this->model->getUpdated());
+        $this->assertNull($this->model->getUpdated());
         $this->model->beforeSave();
         $this->assertTrue(($this->model->getUpdated() != null));
     }

--- a/app/code/Magento/Indexer/Test/Unit/Model/IndexerTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Model/IndexerTest.php
@@ -435,7 +435,7 @@ class IndexerTest extends \PHPUnit\Framework\TestCase
 
         $this->stateFactoryMock->expects($this->once())->method('create')->will($this->returnValue($stateMock));
         $stateMock->expects($this->once())->method('getStatus')->will($this->returnValue($status));
-        $this->assertEquals(true, $this->model->$method());
+        $this->assertTrue($this->model->$method());
     }
 
     /**

--- a/app/code/Magento/Indexer/Test/Unit/Model/Mview/View/StateTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Model/Mview/View/StateTest.php
@@ -62,7 +62,7 @@ class StateTest extends \PHPUnit\Framework\TestCase
 
     public function testBeforeSave()
     {
-        $this->assertEquals(null, $this->model->getUpdated());
+        $this->assertNull($this->model->getUpdated());
         $this->model->beforeSave();
         $this->assertTrue(($this->model->getUpdated() != null));
     }

--- a/app/code/Magento/Integration/Test/Unit/Model/Oauth/Token/ProviderTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/Oauth/Token/ProviderTest.php
@@ -117,7 +117,7 @@ class ProviderTest extends \PHPUnit\Framework\TestCase
     public function testValidateConsumer()
     {
         $this->consumerMock->expects($this->once())->method('isValidForTokenExchange')->willReturn(true);
-        $this->assertEquals(true, $this->tokenProvider->validateConsumer($this->consumerMock));
+        $this->assertTrue($this->tokenProvider->validateConsumer($this->consumerMock));
     }
 
     /**

--- a/app/code/Magento/Marketplace/Test/Unit/Helper/CacheTest.php
+++ b/app/code/Magento/Marketplace/Test/Unit/Helper/CacheTest.php
@@ -64,7 +64,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->serializer->expects($this->never())
             ->method('unserialize');
 
-        $this->assertSame(false, $this->cacheHelper->loadPartnersFromCache());
+        $this->assertFalse($this->cacheHelper->loadPartnersFromCache());
     }
 
     public function testSavePartnersToCache()

--- a/app/code/Magento/MysqlMq/Test/Unit/Model/ConnectionTypeResolverTest.php
+++ b/app/code/Magento/MysqlMq/Test/Unit/Model/ConnectionTypeResolverTest.php
@@ -16,7 +16,7 @@ class ConnectionTypeResolverTest extends \PHPUnit\Framework\TestCase
     {
         $model = new ConnectionTypeResolver();
         $this->assertEquals('db', $model->getConnectionType('db'));
-        $this->assertEquals(null, $model->getConnectionType('non-db'));
+        $this->assertNull($model->getConnectionType('non-db'));
     }
 
     public function testGetConnectionTypeWithCustomValues()

--- a/app/code/Magento/Newsletter/Test/Unit/Model/Plugin/CustomerPluginTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Model/Plugin/CustomerPluginTest.php
@@ -182,7 +182,7 @@ class CustomerPluginTest extends \PHPUnit\Framework\TestCase
         $this->subscriber->expects($this->once())->method('getId')->willReturn(1);
         $this->subscriber->expects($this->once())->method('delete')->willReturnSelf();
 
-        $this->assertEquals(true, $this->plugin->afterDelete($subject, true, $customer));
+        $this->assertTrue($this->plugin->afterDelete($subject, true, $customer));
     }
 
     public function testAroundDeleteById()
@@ -199,7 +199,7 @@ class CustomerPluginTest extends \PHPUnit\Framework\TestCase
         $this->subscriber->expects($this->once())->method('getId')->willReturn(1);
         $this->subscriber->expects($this->once())->method('delete')->willReturnSelf();
 
-        $this->assertEquals(true, $this->plugin->aroundDeleteById($subject, $deleteCustomerById, $customerId));
+        $this->assertTrue($this->plugin->aroundDeleteById($subject, $deleteCustomerById, $customerId));
     }
 
     /**

--- a/app/code/Magento/Payment/Test/Unit/Gateway/Data/Order/OrderAdapterTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Gateway/Data/Order/OrderAdapterTest.php
@@ -67,7 +67,7 @@ class OrderAdapterTest extends \PHPUnit\Framework\TestCase
     {
         $this->orderMock->expects($this->once())->method('getBillingAddress')->willReturn(null);
 
-        $this->assertSame(null, $this->model->getBillingAddress());
+        $this->assertNull($this->model->getBillingAddress());
     }
 
     public function testGetBillingAddress()
@@ -91,7 +91,7 @@ class OrderAdapterTest extends \PHPUnit\Framework\TestCase
     {
         $this->orderMock->expects($this->once())->method('getShippingAddress')->willReturn(null);
 
-        $this->assertSame(null, $this->model->getShippingAddress());
+        $this->assertNull($this->model->getShippingAddress());
     }
 
     public function testGetShippingAddress()

--- a/app/code/Magento/Payment/Test/Unit/Gateway/Data/Quote/QuoteAdapterTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Gateway/Data/Quote/QuoteAdapterTest.php
@@ -75,7 +75,7 @@ class QuoteAdapterTest extends \PHPUnit\Framework\TestCase
     {
         $this->quoteMock->expects($this->once())->method('getBillingAddress')->willReturn(null);
 
-        $this->assertSame(null, $this->model->getBillingAddress());
+        $this->assertNull($this->model->getBillingAddress());
     }
 
     public function testGetBillingAddress()
@@ -99,7 +99,7 @@ class QuoteAdapterTest extends \PHPUnit\Framework\TestCase
     {
         $this->quoteMock->expects($this->once())->method('getShippingAddress')->willReturn(null);
 
-        $this->assertSame(null, $this->model->getShippingAddress());
+        $this->assertNull($this->model->getShippingAddress());
     }
 
     public function testGetShippingAddress()

--- a/app/code/Magento/Payment/Test/Unit/Model/CcConfigTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Model/CcConfigTest.php
@@ -76,7 +76,7 @@ class CcConfigTest extends \PHPUnit\Framework\TestCase
 
     public function testHasVerification()
     {
-        $this->assertEquals(true, $this->model->hasVerification());
+        $this->assertTrue($this->model->hasVerification());
     }
 
     public function testGetCvvImageUrl()

--- a/app/code/Magento/Paypal/Test/Unit/Model/Config/StructurePluginTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/Config/StructurePluginTest.php
@@ -132,8 +132,7 @@ class StructurePluginTest extends \PHPUnit\Framework\TestCase
             ->method('getConfigurationCountryCode')
             ->willReturn($countryCode);
 
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $this->plugin->aroundGetElementByPathParts($this->configStructureMock, $proceed, $pathParts)
         );
     }

--- a/app/code/Magento/Paypal/Test/Unit/Model/PayflowExpressTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/PayflowExpressTest.php
@@ -119,11 +119,11 @@ class PayflowExpressTest extends \PHPUnit\Framework\TestCase
 
     public function testCanFetchTransactionInfo()
     {
-        $this->assertEquals(false, $this->_model->canFetchTransactionInfo());
+        $this->assertFalse($this->_model->canFetchTransactionInfo());
     }
 
     public function testCanReviewPayment()
     {
-        $this->assertEquals(false, $this->_model->canReviewPayment());
+        $this->assertFalse($this->_model->canReviewPayment());
     }
 }

--- a/app/code/Magento/Quote/Test/Unit/Model/GuestCart/GuestCartManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/GuestCart/GuestCartManagementTest.php
@@ -113,7 +113,7 @@ class GuestCartManagementTest extends \PHPUnit\Framework\TestCase
         $this->quoteIdMaskFactoryMock->expects($this->once())->method('create')->willReturn($this->quoteIdMaskMock);
         $this->quoteManagementMock->expects($this->once())->method('assignCustomer')->willReturn(true);
 
-        $this->assertEquals(true, $this->guestCartManagement->assignCustomer($cartId, $customerId, $storeId));
+        $this->assertTrue($this->guestCartManagement->assignCustomer($cartId, $customerId, $storeId));
     }
 
     public function testPlaceOrder()

--- a/app/code/Magento/ReleaseNotification/Test/Unit/Model/Condition/CanViewNotificationTest.php
+++ b/app/code/Magento/ReleaseNotification/Test/Unit/Model/Condition/CanViewNotificationTest.php
@@ -73,7 +73,7 @@ class CanViewNotificationTest extends \PHPUnit\Framework\TestCase
             ->method('load')
             ->with('release-notification-popup-1')
             ->willReturn("0");
-        $this->assertEquals(false, $this->canViewNotification->isVisible([]));
+        $this->assertFalse($this->canViewNotification->isVisible([]));
     }
 
     /**

--- a/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Report/CollectionTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Report/CollectionTest.php
@@ -72,7 +72,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     public function testGetStoreIds()
     {
         $storeIds = [1];
-        $this->assertEquals(null, $this->collection->getStoreIds());
+        $this->assertNull($this->collection->getStoreIds());
         $this->collection->setStoreIds($storeIds);
         $this->assertEquals($storeIds, $this->collection->getStoreIds());
     }
@@ -98,7 +98,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     public function testGetPageSize()
     {
         $pageSize = 1;
-        $this->assertEquals(null, $this->collection->getPageSize());
+        $this->assertNull($this->collection->getPageSize());
         $this->collection->setPageSize($pageSize);
         $this->assertEquals($pageSize, $this->collection->getPageSize());
     }

--- a/app/code/Magento/Review/Test/Unit/Block/Adminhtml/Rss/Grid/LinkTest.php
+++ b/app/code/Magento/Review/Test/Unit/Block/Adminhtml/Rss/Grid/LinkTest.php
@@ -55,6 +55,6 @@ class LinkTest extends \PHPUnit\Framework\TestCase
 
     public function testIsRssAllowed()
     {
-        $this->assertEquals(true, $this->link->isRssAllowed());
+        $this->assertTrue($this->link->isRssAllowed());
     }
 }

--- a/app/code/Magento/Review/Test/Unit/Block/Adminhtml/RssTest.php
+++ b/app/code/Magento/Review/Test/Unit/Block/Adminhtml/RssTest.php
@@ -125,7 +125,7 @@ class RssTest extends \PHPUnit\Framework\TestCase
 
     public function testIsAllowed()
     {
-        $this->assertEquals(true, $this->block->isAllowed());
+        $this->assertTrue($this->block->isAllowed());
     }
 
     public function testGetFeeds()

--- a/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/Items/GridTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/Items/GridTest.php
@@ -265,7 +265,7 @@ class GridTest extends \PHPUnit\Framework\TestCase
         $items = $this->block->setLayout($layoutMock)->getItems();
 
         $this->assertEquals('Message', $items[0]->getMessage());
-        $this->assertEquals(true, $this->block->getQuote()->getIsSuperMode());
+        $this->assertTrue($this->block->getQuote()->getIsSuperMode());
     }
 
     /**

--- a/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/Sidebar/AbstractSidebarTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/Sidebar/AbstractSidebarTest.php
@@ -50,6 +50,6 @@ class AbstractSidebarTest extends \PHPUnit\Framework\TestCase
     public function testIsConfigurationRequired()
     {
         $productTypeMock = $this->createMock(\Magento\Catalog\Model\Product\Type::class);
-        $this->assertEquals(false, $this->abstractSidebar->isConfigurationRequired($productTypeMock));
+        $this->assertFalse($this->abstractSidebar->isConfigurationRequired($productTypeMock));
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Block/Reorder/SidebarTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Reorder/SidebarTest.php
@@ -265,6 +265,6 @@ class SidebarTest extends \PHPUnit\Framework\TestCase
             ->method('getProduct')
             ->willThrowException(new \Magento\Framework\Exception\NoSuchEntityException());
         $this->createBlockObject();
-        $this->assertSame(false, $this->block->isItemAvailableForReorder($orderItem));
+        $this->assertFalse($this->block->isItemAvailableForReorder($orderItem));
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Address/RendererTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Address/RendererTest.php
@@ -119,7 +119,7 @@ class RendererTest extends \PHPUnit\Framework\TestCase
         $this->eventManagerMock->expects(static::never())
             ->method('dispatch');
 
-        $this->assertEquals(null, $this->orderAddressRenderer->format($this->orderAddressMock, $type));
+        $this->assertNull($this->orderAddressRenderer->format($this->orderAddressMock, $type));
     }
 
     /**

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/AddressTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/AddressTest.php
@@ -127,7 +127,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
             ->willReturn(2);
         $this->regionMock->expects($this->never())
             ->method('getCode');
-        $this->assertEquals(null, $this->address->getRegionCode());
+        $this->assertNull($this->address->getRegionCode());
     }
 
     public function testGetName()

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/Transaction/RepositoryTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/Transaction/RepositoryTest.php
@@ -287,8 +287,7 @@ class RepositoryTest extends \PHPUnit\Framework\TestCase
             $transactionId
         )->willReturn(false);
         $transaction->expects($this->once())->method('getId')->willReturn(false);
-        $this->assertEquals(
-            false,
+        $this->assertFalse(
             $this->repository->getByTransactionId($transactionId, $paymentId, $orderId)
         );
     }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/TransactionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/TransactionTest.php
@@ -63,6 +63,6 @@ class TransactionTest extends \PHPUnit\Framework\TestCase
         $this->transaction->setData('txn_id', 'test');
 
         $this->assertEquals('test', $this->transaction->getHtmlTxnId());
-        $this->assertEquals(null, $this->transaction->getData('html_txn_id'));
+        $this->assertNull($this->transaction->getData('html_txn_id'));
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Status/HistoryTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Status/HistoryTest.php
@@ -62,7 +62,7 @@ class HistoryTest extends \PHPUnit\Framework\TestCase
     public function testSetIsCustomerNotified()
     {
         $this->model->setIsCustomerNotified(true);
-        $this->assertEquals(true, $this->model->getIsCustomerNotified());
+        $this->assertTrue($this->model->getIsCustomerNotified());
     }
 
     public function testSetIsCustomerNotifiedNotApplicable()

--- a/app/code/Magento/Sales/Test/Unit/Model/OrderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/OrderTest.php
@@ -176,7 +176,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->assertEquals($orderItem, $this->order->getItemById($realOrderItemId));
-        $this->assertEquals(null, $this->order->getItemById($fakeOrderItemId));
+        $this->assertNull($this->order->getItemById($fakeOrderItemId));
     }
 
     /**
@@ -1050,7 +1050,7 @@ class OrderTest extends \PHPUnit\Framework\TestCase
 
     public function testSetPaymentNull()
     {
-        $this->assertEquals(null, $this->order->setPayment(null));
+        $this->assertNull($this->order->setPayment(null));
 
         $this->assertEquals(
             $this->order->getData(

--- a/app/code/Magento/Search/Test/Unit/Model/SearchEngine/ConfigTest.php
+++ b/app/code/Magento/Search/Test/Unit/Model/SearchEngine/ConfigTest.php
@@ -36,6 +36,6 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             ['dataStorage' => $this->dataStorage]
         );
         $this->dataStorage->expects($this->once())->method('get')->with('mysql')->willReturn(['synonyms']);
-        $this->assertEquals(true, $config->isFeatureSupported('synonyms', 'mysql'));
+        $this->assertTrue($config->isFeatureSupported('synonyms', 'mysql'));
     }
 }

--- a/app/code/Magento/Security/Test/Unit/Model/AdminSessionInfoTest.php
+++ b/app/code/Magento/Security/Test/Unit/Model/AdminSessionInfoTest.php
@@ -68,7 +68,7 @@ class AdminSessionInfoTest extends \PHPUnit\Framework\TestCase
         $this->dateTimeMock->expects($this->once())
             ->method('gmtTimestamp')
             ->willReturn(1000);
-        $this->assertEquals(true, $this->model->isLoggedInStatus());
+        $this->assertTrue($this->model->isLoggedInStatus());
     }
 
     /**
@@ -82,7 +82,7 @@ class AdminSessionInfoTest extends \PHPUnit\Framework\TestCase
         $this->dateTimeMock->expects($this->once())
             ->method('gmtTimestamp')
             ->willReturn(1000);
-        $this->assertEquals(false, $this->model->isLoggedInStatus());
+        $this->assertFalse($this->model->isLoggedInStatus());
         $this->assertEquals(\Magento\Security\Model\AdminSessionInfo::LOGGED_OUT, $this->model->getStatus());
     }
 
@@ -137,7 +137,7 @@ class AdminSessionInfoTest extends \PHPUnit\Framework\TestCase
      */
     public function testIsOtherSessionsTerminated()
     {
-        $this->assertEquals(false, $this->model->isOtherSessionsTerminated());
+        $this->assertFalse($this->model->isOtherSessionsTerminated());
     }
 
     /**

--- a/app/code/Magento/Shipping/Test/Unit/Helper/CarrierTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Helper/CarrierTest.php
@@ -101,7 +101,7 @@ class CarrierTest extends \PHPUnit\Framework\TestCase
             $this->returnValue("GB")
         );
 
-        $this->assertEquals(true, $this->helper->isCountryInEU("GB"));
-        $this->assertEquals(false, $this->helper->isCountryInEU("US"));
+        $this->assertTrue($this->helper->isCountryInEU("GB"));
+        $this->assertFalse($this->helper->isCountryInEU("US"));
     }
 }

--- a/app/code/Magento/Signifyd/Test/Unit/Model/Guarantee/CreationServiceTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/Guarantee/CreationServiceTest.php
@@ -151,8 +151,7 @@ class CreationServiceTest extends TestCase
             ->method('update');
 
         $result = $this->service->createForOrder($dummyOrderId);
-        $this->assertEquals(
-            false,
+        $this->assertFalse(
             $result,
             'Service should return false in case of gateway failure'
         );
@@ -196,8 +195,7 @@ class CreationServiceTest extends TestCase
         $this->withGatewaySuccess($dummyGuaranteeDisposition);
 
         $result = $this->service->createForOrder($dummyOrderId);
-        $this->assertEquals(
-            true,
+        $this->assertTrue(
             $result,
             'Service should return true in case if case update service is called'
         );

--- a/app/code/Magento/Swatches/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Helper/DataTest.php
@@ -806,6 +806,6 @@ class DataTest extends \PHPUnit\Framework\TestCase
     {
         $this->getSwatchAttributes();
         $result = $this->swatchHelperObject->isProductHasSwatch($this->productMock);
-        $this->assertEquals(true, $result);
+        $this->assertTrue($result);
     }
 }

--- a/app/code/Magento/Swatches/Test/Unit/Model/SwatchAttributeTypeTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Model/SwatchAttributeTypeTest.php
@@ -147,8 +147,8 @@ class SwatchAttributeTypeTest extends \PHPUnit\Framework\TestCase
                 ]
             );
 
-        $this->assertEquals(true, $this->swatchType->isTextSwatch($attributeMock));
-        $this->assertEquals(false, $this->swatchType->isVisualSwatch($attributeMock));
+        $this->assertTrue($this->swatchType->isTextSwatch($attributeMock));
+        $this->assertFalse($this->swatchType->isVisualSwatch($attributeMock));
     }
 
     /**

--- a/app/code/Magento/Theme/Test/Unit/Model/Config/CustomizationTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Config/CustomizationTest.php
@@ -153,7 +153,7 @@ class CustomizationTest extends \PHPUnit\Framework\TestCase
             ->willReturn([$this->getAssignedTheme(), $this->getUnassignedTheme()]);
 
         $themeAssigned = $this->model->isThemeAssignedToStore($this->getAssignedTheme());
-        $this->assertEquals(true, $themeAssigned);
+        $this->assertTrue($themeAssigned);
     }
 
     /**
@@ -167,7 +167,7 @@ class CustomizationTest extends \PHPUnit\Framework\TestCase
             ->willReturn($this->getAssignedTheme()->getId());
 
         $themeUnassigned = $this->model->isThemeAssignedToStore($this->getUnassignedTheme(), $this->getStore());
-        $this->assertEquals(false, $themeUnassigned);
+        $this->assertFalse($themeUnassigned);
     }
 
     /**

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/Domain/VirtualTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/Domain/VirtualTest.php
@@ -136,7 +136,7 @@ class VirtualTest extends \PHPUnit\Framework\TestCase
         );
         /** @var $model \Magento\Theme\Model\Theme\Domain\Virtual */
         $model = $objectManagerHelper->getObject(\Magento\Theme\Model\Theme\Domain\Virtual::class, $constructArguments);
-        $this->assertEquals(true, $model->isAssigned());
+        $this->assertTrue($model->isAssigned());
     }
 
     /**

--- a/app/code/Magento/Ui/Test/Unit/Component/AbstractComponentTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/AbstractComponentTest.php
@@ -133,7 +133,7 @@ class AbstractComponentTest extends \PHPUnit\Framework\TestCase
      */
     public function testRenderChildComponentNotExists()
     {
-        $this->assertEquals(null, $this->abstractComponent->renderChildComponent('someComponent'));
+        $this->assertNull($this->abstractComponent->renderChildComponent('someComponent'));
     }
 
     /**

--- a/app/code/Magento/Ui/Test/Unit/Component/Form/Element/AbstractElementTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/Form/Element/AbstractElementTest.php
@@ -72,21 +72,21 @@ abstract class AbstractElementTest extends \PHPUnit\Framework\TestCase
 
     public function testGetValue()
     {
-        $this->assertSame(null, $this->getModel()->getValue());
+        $this->assertNull($this->getModel()->getValue());
     }
 
     public function testGetFormInputName()
     {
-        $this->assertSame(null, $this->getModel()->getFormInputName());
+        $this->assertNull($this->getModel()->getFormInputName());
     }
 
     public function testIsReadonly()
     {
-        $this->assertSame(false, $this->getModel()->isReadonly());
+        $this->assertFalse($this->getModel()->isReadonly());
     }
 
     public function testGetCssClasses()
     {
-        $this->assertSame(null, $this->getModel()->getCssClasses());
+        $this->assertNull($this->getModel()->getCssClasses());
     }
 }

--- a/app/code/Magento/Ui/Test/Unit/Component/Form/Element/CheckboxSetTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/Form/Element/CheckboxSetTest.php
@@ -29,6 +29,6 @@ class CheckboxSetTest extends AbstractElementTest
 
     public function testGetIsSelected()
     {
-        $this->assertSame(false, $this->getModel()->getIsSelected(''));
+        $this->assertFalse($this->getModel()->getIsSelected(''));
     }
 }

--- a/app/code/Magento/Vault/Test/Unit/Model/PaymentTokenManagementTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Model/PaymentTokenManagementTest.php
@@ -208,7 +208,7 @@ class PaymentTokenManagementTest extends \PHPUnit\Framework\TestCase
         $this->paymentTokenFactory->expects(self::never())
             ->method('create');
 
-        self::assertEquals(null, $this->paymentTokenManagement->getByPaymentId(1));
+        self::assertNull($this->paymentTokenManagement->getByPaymentId(1));
     }
 
     /**
@@ -246,7 +246,7 @@ class PaymentTokenManagementTest extends \PHPUnit\Framework\TestCase
         $this->paymentTokenFactory->expects(self::never())
             ->method('create');
 
-        self::assertEquals(null, $this->paymentTokenManagement->getByGatewayToken('some-not-exists-token', 1, 1));
+        self::assertNull($this->paymentTokenManagement->getByGatewayToken('some-not-exists-token', 1, 1));
     }
 
     /**
@@ -262,7 +262,7 @@ class PaymentTokenManagementTest extends \PHPUnit\Framework\TestCase
         $this->paymentTokenFactory->expects(self::never())
             ->method('create');
 
-        self::assertEquals(null, $this->paymentTokenManagement->getByPublicHash('some-not-exists-token', 1));
+        self::assertNull($this->paymentTokenManagement->getByPublicHash('some-not-exists-token', 1));
     }
 
     /**

--- a/app/code/Magento/Webapi/Test/Unit/Model/Authorization/GuestUserContextTest.php
+++ b/app/code/Magento/Webapi/Test/Unit/Model/Authorization/GuestUserContextTest.php
@@ -34,7 +34,7 @@ class GuestUserContextTest extends \PHPUnit\Framework\TestCase
 
     public function testGetUserId()
     {
-        $this->assertEquals(null, $this->guestUserContext->getUserId());
+        $this->assertNull($this->guestUserContext->getUserId());
     }
 
     public function testGetUserType()

--- a/app/code/Magento/Webapi/Test/Unit/Model/Authorization/OauthUserContextTest.php
+++ b/app/code/Magento/Webapi/Test/Unit/Model/Authorization/OauthUserContextTest.php
@@ -118,7 +118,7 @@ class OauthUserContextTest extends \PHPUnit\Framework\TestCase
 
         $this->setupUserId($integrationId, []);
 
-        $this->assertEquals(null, $this->oauthUserContext->getUserId());
+        $this->assertNull($this->oauthUserContext->getUserId());
     }
 
     /**

--- a/app/code/Magento/WebapiAsync/Test/Unit/Model/ServiceConfig/SchemaLocatorTest.php
+++ b/app/code/Magento/WebapiAsync/Test/Unit/Model/ServiceConfig/SchemaLocatorTest.php
@@ -47,6 +47,6 @@ class SchemaLocatorTest extends \PHPUnit\Framework\TestCase
 
     public function testGetPerFileSchema()
     {
-        $this->assertEquals(null, $this->model->getPerFileSchema());
+        $this->assertNull($this->model->getPerFileSchema());
     }
 }

--- a/app/code/Magento/Weee/Test/Unit/Ui/DataProvider/Product/Form/Modifier/Manager/WebsiteTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Ui/DataProvider/Product/Form/Modifier/Manager/WebsiteTest.php
@@ -103,6 +103,6 @@ class WebsiteTest extends \PHPUnit\Framework\TestCase
             ->method('hasSingleStore')
             ->willReturn(true);
 
-        $this->assertSame(false, $this->model->isMultiWebsites());
+        $this->assertFalse($this->model->isMultiWebsites());
     }
 }

--- a/app/code/Magento/Wishlist/Test/Unit/Block/Rss/LinkTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Block/Rss/LinkTest.php
@@ -88,6 +88,6 @@ class LinkTest extends \PHPUnit\Framework\TestCase
             ->method('isSetFlag')
             ->with('rss/wishlist/active', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
             ->will($this->returnValue(true));
-        $this->assertEquals(true, $this->link->isRssAllowed());
+        $this->assertTrue($this->link->isRssAllowed());
     }
 }

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/WishlistProviderTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/WishlistProviderTest.php
@@ -155,6 +155,6 @@ class WishlistProviderTest extends \PHPUnit\Framework\TestCase
             ->method('getParam')
             ->will($this->returnValue(1));
 
-        $this->assertEquals(false, $this->wishlistProvider->getWishlist());
+        $this->assertFalse($this->wishlistProvider->getWishlist());
     }
 }

--- a/app/code/Magento/Wishlist/Test/Unit/Model/Rss/WishlistTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/Rss/WishlistTest.php
@@ -303,7 +303,7 @@ class WishlistTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue('somesharingcode'));
         $this->wishlistHelperMock->expects($this->any())->method('getWishlist')
             ->will($this->returnValue($wishlist));
-        $this->assertEquals(false, $this->model->isAuthRequired());
+        $this->assertFalse($this->model->isAuthRequired());
     }
 
     public function testGetProductPriceHtmlBlockDoesntExists()

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductAttributeRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductAttributeRepositoryTest.php
@@ -198,7 +198,7 @@ class ProductAttributeRepositoryTest extends \Magento\TestFramework\TestCase\Web
         $result = $this->updateAttribute($attributeCode, $attributeData);
 
         $this->assertEquals($attribute['attribute_id'], $result['attribute_id']);
-        $this->assertEquals(true, $result['is_used_in_grid']);
+        $this->assertTrue($result['is_used_in_grid']);
         $this->assertEquals($attributeCode, $result['attribute_code']);
         $this->assertEquals('default_label_new', $result['default_frontend_label']);
         $this->assertEquals('front_lbl_store1_new', $result['frontend_labels'][0]['label']);
@@ -234,7 +234,7 @@ class ProductAttributeRepositoryTest extends \Magento\TestFramework\TestCase\Web
         $result = $this->updateAttribute($attributeCode, $attributeData);
 
         $this->assertEquals($attribute['attribute_id'], $result['attribute_id']);
-        $this->assertEquals(true, $result['is_used_in_grid']);
+        $this->assertTrue($result['is_used_in_grid']);
         $this->assertEquals($attributeCode, $result['attribute_code']);
         $this->assertEquals('front_lbl_store0_new', $result['default_frontend_label']);
         $this->assertEquals('front_lbl_store1_new', $result['frontend_labels'][0]['label']);
@@ -266,7 +266,7 @@ class ProductAttributeRepositoryTest extends \Magento\TestFramework\TestCase\Web
         $result = $this->updateAttribute($attributeCode, $attributeData);
 
         $this->assertEquals($attribute['attribute_id'], $result['attribute_id']);
-        $this->assertEquals(true, $result['is_used_in_grid']);
+        $this->assertTrue($result['is_used_in_grid']);
         $this->assertEquals($attributeCode, $result['attribute_code']);
         $this->assertEquals('default_label', $result['default_frontend_label']);
         $this->assertEquals('front_lbl_store1_new', $result['frontend_labels'][0]['label']);

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductRepositoryInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductRepositoryInterfaceTest.php
@@ -677,7 +677,7 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
         //pass empty array, delete all existing media gallery entries
         $response['media_gallery_entries'] = [];
         $response = $this->updateProduct($response);
-        $this->assertEquals(true, empty($response['media_gallery_entries']));
+        $this->assertTrue(empty($response['media_gallery_entries']));
         $this->deleteProduct($productData[ProductInterface::SKU]);
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/CatalogInventory/Api/ProductRepositoryInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/CatalogInventory/Api/ProductRepositoryInterfaceTest.php
@@ -172,7 +172,7 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
         $stockItemData = $response[self::KEY_EXTENSION_ATTRIBUTES][self::KEY_STOCK_ITEM];
 
         $this->assertEquals($qty, $stockItemData[self::KEY_QTY]);
-        $this->assertEquals(false, $stockItemData[self::KEY_IS_IN_STOCK]);
+        $this->assertFalse($stockItemData[self::KEY_IS_IN_STOCK]);
 
         // update a created product with catalog inventory
         $qty = 1;

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/DeleteCustomerAddressTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Customer/DeleteCustomerAddressTest.php
@@ -57,7 +57,7 @@ mutation {
 MUTATION;
         $response = $this->graphQlQuery($mutation, [], '', $this->getCustomerAuthHeaders($userName, $password));
         $this->assertArrayHasKey('deleteCustomerAddress', $response);
-        $this->assertEquals(true, $response['deleteCustomerAddress']);
+        $this->assertTrue($response['deleteCustomerAddress']);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartManagementTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartManagementTest.php
@@ -455,7 +455,7 @@ class CartManagementTest extends WebapiAbstract
         $this->assertEquals($cart->getItemsQty(), $cartData['items_qty']);
 
         $this->assertContains('customer', $cartData);
-        $this->assertEquals(false, $cartData['customer_is_guest']);
+        $this->assertFalse($cartData['customer_is_guest']);
         $this->assertContains('currency', $cartData);
         $this->assertEquals($cart->getGlobalCurrencyCode(), $cartData['currency']['global_currency_code']);
         $this->assertEquals($cart->getBaseCurrencyCode(), $cartData['currency']['base_currency_code']);

--- a/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartRepositoryTest.php
@@ -117,7 +117,7 @@ class CartRepositoryTest extends WebapiAbstract
         $this->assertEquals($cart->getItemsQty(), $cartData['items_qty']);
         //following checks will be uncommented when all cart related services are ready
         $this->assertContains('customer', $cartData);
-        $this->assertEquals(true, $cartData['customer_is_guest']);
+        $this->assertTrue($cartData['customer_is_guest']);
         $this->assertContains('currency', $cartData);
         $this->assertEquals($cart->getGlobalCurrencyCode(), $cartData['currency']['global_currency_code']);
         $this->assertEquals($cart->getBaseCurrencyCode(), $cartData['currency']['base_currency_code']);

--- a/dev/tests/api-functional/testsuite/Magento/Quote/Api/GuestCartRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Quote/Api/GuestCartRepositoryTest.php
@@ -92,7 +92,7 @@ class GuestCartRepositoryTest extends WebapiAbstract
         $this->assertEquals($cart->getItemsQty(), $cartData['items_qty']);
         //following checks will be uncommented when all cart related services are ready
         $this->assertContains('customer', $cartData);
-        $this->assertEquals(true, $cartData['customer_is_guest']);
+        $this->assertTrue($cartData['customer_is_guest']);
         $this->assertContains('currency', $cartData);
         $this->assertEquals($cart->getGlobalCurrencyCode(), $cartData['currency']['global_currency_code']);
         $this->assertEquals($cart->getBaseCurrencyCode(), $cartData['currency']['base_currency_code']);

--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderGetTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderGetTest.php
@@ -132,7 +132,7 @@ class OrderGetTest extends WebapiAbstract
         $appliedTaxes = $result['extension_attributes']['item_applied_taxes'];
         self::assertEquals($expectedTax['type'], $appliedTaxes[0]['type']);
         self::assertNotEmpty($appliedTaxes[0]['applied_taxes']);
-        self::assertEquals(true, $result['extension_attributes']['converting_from_quote']);
+        self::assertTrue($result['extension_attributes']['converting_from_quote']);
         self::assertArrayHasKey('payment_additional_info', $result['extension_attributes']);
         self::assertNotEmpty($result['extension_attributes']['payment_additional_info']);
     }

--- a/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderListTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Sales/Service/V1/OrderListTest.php
@@ -89,7 +89,7 @@ class OrderListTest extends WebapiAbstract
         $appliedTaxes = $result['items'][0]['extension_attributes']['item_applied_taxes'];
         $this->assertEquals($expectedTax['type'], $appliedTaxes[0]['type']);
         $this->assertNotEmpty($appliedTaxes[0]['applied_taxes']);
-        $this->assertEquals(true, $result['items'][0]['extension_attributes']['converting_from_quote']);
+        $this->assertTrue($result['items'][0]['extension_attributes']['converting_from_quote']);
         $this->assertArrayHasKey('payment_additional_info', $result['items'][0]['extension_attributes']);
         $this->assertNotEmpty($result['items'][0]['extension_attributes']['payment_additional_info']);
     }

--- a/dev/tests/api-functional/testsuite/Magento/SalesRule/Api/CouponRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/SalesRule/Api/CouponRepositoryTest.php
@@ -80,7 +80,7 @@ class CouponRepositoryTest extends WebapiAbstract
         $this->assertEquals($inputData, $result);
 
         //test delete
-        $this->assertEquals(true, $this->deleteCoupon($couponId));
+        $this->assertTrue($this->deleteCoupon($couponId));
     }
 
     // verify (and remove) the fields that are set by the Sales Rule

--- a/dev/tests/api-functional/testsuite/Magento/SalesRule/Api/RuleRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/SalesRule/Api/RuleRepositoryTest.php
@@ -124,7 +124,7 @@ class RuleRepositoryTest extends WebapiAbstract
         $this->assertEquals($inputData, $result);
 
         //test delete
-        $this->assertEquals(true, $this->deleteRule($ruleId));
+        $this->assertTrue($this->deleteRule($ruleId));
     }
 
     public function verifyGetList($ruleId)

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/RequestTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/RequestTest.php
@@ -41,8 +41,8 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertSame(['test' => 'value', 'null' => null], $this->_model->getServer()->toArray());
         $this->assertEquals('value', $this->_model->getServer('test'));
-        $this->assertSame(null, $this->_model->getServer('non-existing'));
+        $this->assertNull($this->_model->getServer('non-existing'));
         $this->assertSame('default', $this->_model->getServer('non-existing', 'default'));
-        $this->assertSame(null, $this->_model->getServer('null'));
+        $this->assertNull($this->_model->getServer('null'));
     }
 }

--- a/dev/tests/integration/testsuite/Magento/AsynchronousOperations/Model/OperationManagementTest.php
+++ b/dev/tests/integration/testsuite/Magento/AsynchronousOperations/Model/OperationManagementTest.php
@@ -68,7 +68,7 @@ class OperationManagementTest extends \PHPUnit\Framework\TestCase
         $updatedOperation = $this->operationFactory->create();
         $this->entityManager->load($updatedOperation, $operationId);
         $this->assertEquals(OperationInterface::STATUS_TYPE_OPEN, $updatedOperation->getStatus());
-        $this->assertEquals(null, $updatedOperation->getResultMessage());
-        $this->assertEquals(null, $updatedOperation->getSerializedData());
+        $this->assertNull($updatedOperation->getResultMessage());
+        $this->assertNull($updatedOperation->getSerializedData());
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductTest.php
@@ -605,7 +605,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
     {
         $product = $this->productRepository->get('simple-out-of-stock', true, null, true);
         $stockItem = $product->getExtensionAttributes()->getStockItem();
-        $this->assertEquals(false, $stockItem->getIsInStock());
+        $this->assertFalse($stockItem->getIsInStock());
         $stockData = [
             'backorders' => 1,
             'qty' => $qty,

--- a/dev/tests/integration/testsuite/Magento/CatalogInventory/Model/Stock/ItemTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogInventory/Model/Stock/ItemTest.php
@@ -55,7 +55,7 @@ class ItemTest extends \PHPUnit\Framework\TestCase
         $savedStockItem->setQty(null);
         $savedStockItem->save();
 
-        $this->assertEquals(null, $savedStockItem->load($savedStockItemId)->getQty());
+        $this->assertNull($savedStockItem->load($savedStockItemId)->getQty());
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Config/Console/Command/ConfigSetCommandTest.php
+++ b/dev/tests/integration/testsuite/Magento/Config/Console/Command/ConfigSetCommandTest.php
@@ -232,7 +232,7 @@ class ConfigSetCommandTest extends \PHPUnit\Framework\TestCase
             $value,
             $this->scopeConfig->getValue($path, $scope, $scopeCode)
         );
-        $this->assertSame(null, $this->arrayManager->get($configPath, $this->loadConfig()));
+        $this->assertNull($this->arrayManager->get($configPath, $this->loadConfig()));
 
         $this->runCommand($arguments, $optionsLock, '<info>Value was saved in app/etc/env.php and locked.</info>');
         $this->runCommand($arguments, $optionsLock, '<info>Value was saved in app/etc/env.php and locked.</info>');

--- a/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/GroupTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/GroupTest.php
@@ -249,7 +249,7 @@ class GroupTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
             MessageInterface::TYPE_ERROR
         );
         $this->assertRedirect($this->stringStartsWith(self::BASE_CONTROLLER_URL . 'edit/'));
-        $this->assertEquals(null, $this->session->getCustomerGroupData());
+        $this->assertNull($this->session->getCustomerGroupData());
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/AddressTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/AddressTest.php
@@ -88,7 +88,7 @@ class AddressTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('CityZ', $updatedAddressData->getCity());
         $this->assertEquals('CompanyZ', $updatedAddressData->getCompany());
         $this->assertEquals('99999', $updatedAddressData->getPostcode());
-        $this->assertEquals(true, $updatedAddressData->isDefaultBilling());
-        $this->assertEquals(true, $updatedAddressData->isDefaultShipping());
+        $this->assertTrue($updatedAddressData->isDefaultBilling());
+        $this->assertTrue($updatedAddressData->isDefaultShipping());
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Customer/Model/GroupManagementTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/GroupManagementTest.php
@@ -74,7 +74,7 @@ class GroupManagementTest extends \PHPUnit\Framework\TestCase
     public function testIsReadonlyWithGroupId()
     {
         $testGroup = ['id' => 3, 'code' => 'General', 'tax_class_id' => 3, 'tax_class_name' => 'Retail Customer'];
-        $this->assertEquals(false, $this->groupManagement->isReadonly($testGroup['id']));
+        $this->assertFalse($this->groupManagement->isReadonly($testGroup['id']));
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Deploy/Console/Command/App/ConfigImportCommandTest.php
+++ b/dev/tests/integration/testsuite/Magento/Deploy/Console/Command/App/ConfigImportCommandTest.php
@@ -221,9 +221,9 @@ class ConfigImportCommandTest extends \PHPUnit\Framework\TestCase
         $website = $websiteFactory->create();
         $website->getResource()->load($website, 'test_website', 'code');
 
-        $this->assertSame(null, $store->getId());
-        $this->assertSame(null, $website->getId());
-        $this->assertSame(null, $group->getId());
+        $this->assertNull($store->getId());
+        $this->assertNull($website->getId());
+        $this->assertNull($group->getId());
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Framework/HTTP/HeaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/HTTP/HeaderTest.php
@@ -28,10 +28,10 @@ class HeaderTest extends \PHPUnit\Framework\TestCase
     {
         $host = 'localhost';
         $this->assertEquals($host, $this->_header->getHttpHost());
-        $this->assertEquals(false, $this->_header->getHttpUserAgent());
-        $this->assertEquals(false, $this->_header->getHttpAcceptLanguage());
-        $this->assertEquals(false, $this->_header->getHttpAcceptCharset());
-        $this->assertEquals(false, $this->_header->getHttpReferer());
+        $this->assertFalse($this->_header->getHttpUserAgent());
+        $this->assertFalse($this->_header->getHttpAcceptLanguage());
+        $this->assertFalse($this->_header->getHttpAcceptCharset());
+        $this->assertFalse($this->_header->getHttpReferer());
     }
 
     public function testGetRequestUri()

--- a/dev/tests/integration/testsuite/Magento/Framework/HTTP/PhpEnvironment/RemoteAddressTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/HTTP/PhpEnvironment/RemoteAddressTest.php
@@ -20,6 +20,6 @@ class RemoteAddressTest extends \PHPUnit\Framework\TestCase
 
     public function testGetRemoteAddress()
     {
-        $this->assertEquals(false, $this->_helper->getRemoteAddress());
+        $this->assertFalse($this->_helper->getRemoteAddress());
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Framework/HTTP/PhpEnvironment/ServerAddressTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/HTTP/PhpEnvironment/ServerAddressTest.php
@@ -20,6 +20,6 @@ class ServerAddressTest extends \PHPUnit\Framework\TestCase
 
     public function testGetServerAddress()
     {
-        $this->assertEquals(false, $this->_helper->getServerAddress());
+        $this->assertFalse($this->_helper->getServerAddress());
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/Consumer/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/Consumer/ConfigTest.php
@@ -61,7 +61,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('queue5', $consumer->getQueue());
         $this->assertEquals('amqp', $consumer->getConnection());
         $this->assertEquals(\Magento\Framework\MessageQueue\ConsumerInterface::class, $consumer->getConsumerInstance());
-        $this->assertEquals(null, $consumer->getMaxMessages());
+        $this->assertNull($consumer->getMaxMessages());
         $handlers = $consumer->getHandlers();
         $this->assertInstanceOf(HandlerIterator::class, $handlers);
         $this->assertCount(0, $handlers);

--- a/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/Consumer/DeprecatedConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/Consumer/DeprecatedConfigTest.php
@@ -34,7 +34,7 @@ class DeprecatedConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('deprecated.config.queue.2', $consumer->getQueue());
         $this->assertEquals('db', $consumer->getConnection());
         $this->assertEquals(\Magento\Framework\MessageQueue\ConsumerInterface::class, $consumer->getConsumerInstance());
-        $this->assertEquals(null, $consumer->getMaxMessages());
+        $this->assertNull($consumer->getMaxMessages());
 
         $handlers = $consumer->getHandlers();
         $this->assertInstanceOf(HandlerIterator::class, $handlers);
@@ -55,7 +55,7 @@ class DeprecatedConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('deprecated.config.queue.3', $consumer->getQueue());
         $this->assertEquals('amqp', $consumer->getConnection());
         $this->assertEquals(\Magento\Framework\MessageQueue\ConsumerInterface::class, $consumer->getConsumerInstance());
-        $this->assertEquals(null, $consumer->getMaxMessages());
+        $this->assertNull($consumer->getMaxMessages());
 
         $handlers = $consumer->getHandlers();
         $this->assertInstanceOf(HandlerIterator::class, $handlers);
@@ -74,7 +74,7 @@ class DeprecatedConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('deprecated.config.queue.4', $consumer->getQueue());
         $this->assertEquals('amqp', $consumer->getConnection());
         $this->assertEquals(\Magento\Framework\MessageQueue\ConsumerInterface::class, $consumer->getConsumerInstance());
-        $this->assertEquals(null, $consumer->getMaxMessages());
+        $this->assertNull($consumer->getMaxMessages());
 
         $handlers = $consumer->getHandlers();
         $this->assertInstanceOf(HandlerIterator::class, $handlers);
@@ -110,7 +110,7 @@ class DeprecatedConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('consumer.config.queue', $consumer->getQueue());
         $this->assertEquals('amqp', $consumer->getConnection());
         $this->assertEquals(\Magento\Framework\MessageQueue\ConsumerInterface::class, $consumer->getConsumerInstance());
-        $this->assertEquals(null, $consumer->getMaxMessages());
+        $this->assertNull($consumer->getMaxMessages());
 
         $handlers = $consumer->getHandlers();
         $this->assertInstanceOf(HandlerIterator::class, $handlers);

--- a/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/MessageEncoderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/MessageEncoderTest.php
@@ -96,7 +96,7 @@ class MessageEncoderTest extends \PHPUnit\Framework\TestCase
             $addresses[0]
         );
         $this->assertEquals('3468676', $addresses[0]->getTelephone());
-        $this->assertEquals(true, $addresses[0]->isDefaultBilling());
+        $this->assertTrue($addresses[0]->isDefaultBilling());
 
         $this->assertInstanceOf(
             \Magento\Customer\Api\Data\RegionInterface::class,

--- a/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/Publisher/DeprecatedConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/Publisher/DeprecatedConfigTest.php
@@ -30,12 +30,12 @@ class DeprecatedConfigTest extends \PHPUnit\Framework\TestCase
         $config = $this->objectManager->create(\Magento\Framework\MessageQueue\Publisher\ConfigInterface::class);
         $publisher = $config->getPublisher('deprecated.config.async.string.topic');
         $this->assertEquals('deprecated.config.async.string.topic', $publisher->getTopic());
-        $this->assertEquals(false, $publisher->isDisabled());
+        $this->assertFalse($publisher->isDisabled());
 
         $connection = $publisher->getConnection();
         $this->assertEquals('amqp', $connection->getName());
         $this->assertEquals('magento', $connection->getExchange());
-        $this->assertEquals(false, $connection->isDisabled());
+        $this->assertFalse($connection->isDisabled());
     }
 
     public function testGetPublisherCustomConnection()
@@ -44,12 +44,12 @@ class DeprecatedConfigTest extends \PHPUnit\Framework\TestCase
         $config = $this->objectManager->create(\Magento\Framework\MessageQueue\Publisher\ConfigInterface::class);
         $publisher = $config->getPublisher('deprecated.config.sync.bool.topic');
         $this->assertEquals('deprecated.config.sync.bool.topic', $publisher->getTopic());
-        $this->assertEquals(false, $publisher->isDisabled());
+        $this->assertFalse($publisher->isDisabled());
 
         $connection = $publisher->getConnection();
         $this->assertEquals('amqp', $connection->getName());
         $this->assertEquals('customExchange', $connection->getExchange());
-        $this->assertEquals(false, $connection->isDisabled());
+        $this->assertFalse($connection->isDisabled());
     }
 
     public function testGetOverlapWithQueueConfig()
@@ -58,11 +58,11 @@ class DeprecatedConfigTest extends \PHPUnit\Framework\TestCase
         $config = $this->objectManager->create(\Magento\Framework\MessageQueue\Publisher\ConfigInterface::class);
         $publisher = $config->getPublisher('overlapping.topic.declaration');
         $this->assertEquals('overlapping.topic.declaration', $publisher->getTopic());
-        $this->assertEquals(false, $publisher->isDisabled());
+        $this->assertFalse($publisher->isDisabled());
 
         $connection = $publisher->getConnection();
         $this->assertEquals('amqp', $connection->getName());
         $this->assertEquals('magento', $connection->getExchange());
-        $this->assertEquals(false, $connection->isDisabled());
+        $this->assertFalse($connection->isDisabled());
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/Topology/DeprecatedConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/MessageQueue/Topology/DeprecatedConfigTest.php
@@ -32,9 +32,9 @@ class DeprecatedConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('deprecatedExchange', $topology->getName());
         $this->assertEquals('topic', $topology->getType());
         $this->assertEquals('db', $topology->getConnection());
-        $this->assertEquals(true, $topology->isDurable());
-        $this->assertEquals(false, $topology->isAutoDelete());
-        $this->assertEquals(false, $topology->isInternal());
+        $this->assertTrue($topology->isDurable());
+        $this->assertFalse($topology->isAutoDelete());
+        $this->assertFalse($topology->isInternal());
 
         $arguments = $topology->getArguments();
         $this->assertInternalType('array', $arguments);
@@ -51,7 +51,7 @@ class DeprecatedConfigTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('queue', $binding->getDestinationType());
         $this->assertEquals('deprecated.config.queue.2', $binding->getDestination());
-        $this->assertEquals(false, $binding->isDisabled());
+        $this->assertFalse($binding->isDisabled());
         $this->assertEquals('deprecated.config.async.bool.topic', $binding->getTopic());
         $arguments = $binding->getArguments();
         $this->assertInternalType('array', $arguments);
@@ -66,9 +66,9 @@ class DeprecatedConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('overlappingDeprecatedExchange', $topology->getName());
         $this->assertEquals('topic', $topology->getType());
         $this->assertEquals('amqp', $topology->getConnection());
-        $this->assertEquals(true, $topology->isDurable());
-        $this->assertEquals(false, $topology->isAutoDelete());
-        $this->assertEquals(false, $topology->isInternal());
+        $this->assertTrue($topology->isDurable());
+        $this->assertFalse($topology->isAutoDelete());
+        $this->assertFalse($topology->isInternal());
 
         $arguments = $topology->getArguments();
         $this->assertInternalType('array', $arguments);
@@ -86,7 +86,7 @@ class DeprecatedConfigTest extends \PHPUnit\Framework\TestCase
         $binding = $bindings[$bindingId];
         $this->assertEquals('queue', $binding->getDestinationType());
         $this->assertEquals('consumer.config.queue', $binding->getDestination());
-        $this->assertEquals(false, $binding->isDisabled());
+        $this->assertFalse($binding->isDisabled());
         $this->assertEquals('overlapping.topic.declaration', $binding->getTopic());
         $arguments = $binding->getArguments();
         $this->assertInternalType('array', $arguments);
@@ -97,7 +97,7 @@ class DeprecatedConfigTest extends \PHPUnit\Framework\TestCase
         $binding = $bindings[$bindingId];
         $this->assertEquals('queue', $binding->getDestinationType());
         $this->assertEquals('topology.config.queue', $binding->getDestination());
-        $this->assertEquals(false, $binding->isDisabled());
+        $this->assertFalse($binding->isDisabled());
         $this->assertEquals('overlapping.topic.declaration', $binding->getTopic());
         $arguments = $binding->getArguments();
         $this->assertInternalType('array', $arguments);
@@ -108,7 +108,7 @@ class DeprecatedConfigTest extends \PHPUnit\Framework\TestCase
         $binding = $bindings[$bindingId];
         $this->assertEquals('queue', $binding->getDestinationType());
         $this->assertEquals('topology.config.queue', $binding->getDestination());
-        $this->assertEquals(false, $binding->isDisabled());
+        $this->assertFalse($binding->isDisabled());
         $this->assertEquals('deprecated.config.async.string.topic', $binding->getTopic());
         $arguments = $binding->getArguments();
         $this->assertInternalType('array', $arguments);

--- a/dev/tests/integration/testsuite/Magento/Framework/Session/ConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Session/ConfigTest.php
@@ -101,8 +101,8 @@ namespace Magento\Framework\Session {
             $this->assertEquals($this->_cacheLimiter, $model->getCacheLimiter());
             $this->assertEquals('/', $model->getCookiePath());
             $this->assertEquals('localhost', $model->getCookieDomain());
-            $this->assertEquals(false, $model->getCookieSecure());
-            $this->assertEquals(true, $model->getCookieHttpOnly());
+            $this->assertFalse($model->getCookieSecure());
+            $this->assertTrue($model->getCookieHttpOnly());
             $this->assertEquals($model->getSavePath(), $model->getOption('save_path'));
         }
 

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Design/Theme/ValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Design/Theme/ValidatorTest.php
@@ -24,7 +24,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         $themeModel = $this->_getThemeModel();
         $themeModel->setData($this->_getThemeValidData());
 
-        $this->assertEquals(true, $validator->validate($themeModel));
+        $this->assertTrue($validator->validate($themeModel));
     }
 
     /**
@@ -40,7 +40,7 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         $themeModel = $this->_getThemeModel();
         $themeModel->setData($this->_getThemeInvalidData());
 
-        $this->assertEquals(false, $validator->validate($themeModel));
+        $this->assertFalse($validator->validate($themeModel));
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Integration/Model/ConfigBasedIntegrationManagerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Integration/Model/ConfigBasedIntegrationManagerTest.php
@@ -78,7 +78,7 @@ class ConfigBasedIntegrationManagerTest extends \PHPUnit\Framework\TestCase
         // Check that the integrations do not exist already
         foreach ($newIntegrations as $integrationName => $integrationData) {
             $integration = $this->integrationService->findByName($integrationName);
-            $this->assertEquals(null, $integration->getId(), 'Integration already exists');
+            $this->assertNull($integration->getId(), 'Integration already exists');
         }
 
         // Create new integrations

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/AbstractCollectorPositionsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/AbstractCollectorPositionsTest.php
@@ -24,7 +24,7 @@ abstract class AbstractCollectorPositionsTest extends \PHPUnit\Framework\TestCas
         $allCollectors = self::_getConfigCollectors($configType);
         $collectorCodes = array_keys($allCollectors);
         $collectorPos = array_search($collectorCode, $collectorCodes);
-        $this->assertNotSame(false, $collectorPos, "'{$collectorCode}' total collector is not found");
+        $this->assertNotFalse($collectorPos, "'{$collectorCode}' total collector is not found");
 
         foreach ($before as $compareWithCode) {
             $compareWithPos = array_search($compareWithCode, $collectorCodes);

--- a/dev/tests/integration/testsuite/Magento/SalesRule/Model/Rule/Condition/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/Model/Rule/Condition/ProductTest.php
@@ -84,7 +84,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
         $rule = $this->objectManager->get(\Magento\Framework\Registry::class)
             ->registry('_fixture/Magento_SalesRule_Sku_Exclude');
 
-        $this->assertEquals(false, $rule->validate($quote));
+        $this->assertFalse($rule->validate($quote));
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Search/Model/SynonymGroupRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Search/Model/SynonymGroupRepositoryTest.php
@@ -170,11 +170,11 @@ class SynonymGroupRepositoryTest extends \PHPUnit\Framework\TestCase
         // merged rows should be deleted
         $synonymGroupModel = $this->objectManager->create(\Magento\Search\Model\SynonymGroup::class);
         $synonymGroupModel->load($id1);
-        $this->assertEquals(null, $synonymGroupModel->getSynonyms());
+        $this->assertNull($synonymGroupModel->getSynonyms());
 
         $synonymGroupModel = $this->objectManager->create(\Magento\Search\Model\SynonymGroup::class);
         $synonymGroupModel->load($id2);
-        $this->assertEquals(null, $synonymGroupModel->getSynonyms());
+        $this->assertNull($synonymGroupModel->getSynonyms());
     }
 
     public function testSaveUpdateMerge()
@@ -231,11 +231,11 @@ class SynonymGroupRepositoryTest extends \PHPUnit\Framework\TestCase
         // merged rows are deleted
         $synonymGroupModel = $this->objectManager->create(\Magento\Search\Model\SynonymGroup::class);
         $synonymGroupModel->load($id2);
-        $this->assertEquals(null, $synonymGroupModel->getSynonyms());
+        $this->assertNull($synonymGroupModel->getSynonyms());
 
         $synonymGroupModel = $this->objectManager->create(\Magento\Search\Model\SynonymGroup::class);
         $synonymGroupModel->load($id3);
-        $this->assertEquals(null, $synonymGroupModel->getSynonyms());
+        $this->assertNull($synonymGroupModel->getSynonyms());
     }
 
     public function testDelete()

--- a/dev/tests/integration/testsuite/Magento/Signifyd/Controller/Webhooks/HandlerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Signifyd/Controller/Webhooks/HandlerTest.php
@@ -49,7 +49,7 @@ class HandlerTest extends AbstractController
         self::assertEquals('2017-01-06 12:47:03', $caseEntity->getCreatedAt());
         self::assertEquals('2017-01-06 12:47:03', $caseEntity->getUpdatedAt());
         self::assertEquals('Magento', $caseEntity->getAssociatedTeam()['teamName']);
-        self::assertEquals(true, $caseEntity->isGuaranteeEligible());
+        self::assertTrue($caseEntity->isGuaranteeEligible());
         self::assertEquals(CaseInterface::STATUS_OPEN, $caseEntity->getStatus());
         self::assertEquals($orderEntityId, $caseEntity->getOrderId());
 

--- a/dev/tests/integration/testsuite/Magento/Signifyd/Model/CaseServices/UpdatingServiceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Signifyd/Model/CaseServices/UpdatingServiceTest.php
@@ -87,7 +87,7 @@ class UpdatingServiceTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('2017-01-05 22:23:26', $caseEntity->getCreatedAt());
         self::assertEquals(CaseInterface::GUARANTEE_APPROVED, $caseEntity->getGuaranteeDisposition());
         self::assertEquals('AnyTeam', $caseEntity->getAssociatedTeam()['teamName']);
-        self::assertEquals(true, $caseEntity->isGuaranteeEligible());
+        self::assertTrue($caseEntity->isGuaranteeEligible());
         self::assertEquals(CaseInterface::STATUS_PROCESSING, $caseEntity->getStatus());
         self::assertEquals($orderEntityId, $caseEntity->getOrderId());
         self::assertEquals(

--- a/dev/tests/integration/testsuite/Magento/Store/App/Request/PathInfoProcessorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Store/App/Request/PathInfoProcessorTest.php
@@ -177,6 +177,6 @@ class PathInfoProcessorTest extends \PHPUnit\Framework\TestCase
         $config->setValue(Store::XML_PATH_STORE_IN_URL, false);
         $pathInfo = sprintf('/%s/m/c/a', 'whatever');
         $this->assertEquals($pathInfo, $this->pathProcessor->process($request, $pathInfo));
-        $this->assertEquals(null, $request->getActionName());
+        $this->assertNull($request->getActionName());
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/TaxClass/ManagementTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/TaxClass/ManagementTest.php
@@ -87,8 +87,7 @@ class ManagementTest extends \PHPUnit\Framework\TestCase
             $this->taxClassManagement->getTaxClassId($taxClassKeyTypeId, TaxClassManagementInterface::TYPE_CUSTOMER)
         );
         $this->assertNull($this->taxClassManagement->getTaxClassId(null));
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $this->taxClassManagement->getTaxClassId($taxClassKeyTypeName, TaxClassManagementInterface::TYPE_PRODUCT)
         );
     }

--- a/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Catalog/Category/TreeTest.php
+++ b/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Catalog/Category/TreeTest.php
@@ -40,9 +40,9 @@ class TreeTest extends \PHPUnit\Framework\TestCase
     public function testGetTreeArray()
     {
         $tree = $this->_treeBlock->getTreeArray();
-        $this->assertEquals(false, $tree['is_active']);
+        $this->assertFalse($tree['is_active']);
         $this->assertEquals('Root', (string)$tree['name']);
-        $this->assertEquals(true, $tree['expanded']);
+        $this->assertTrue($tree['expanded']);
         $this->assertCount(1, $tree['children']);
     }
 

--- a/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/User/InvalidateTokenTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/User/InvalidateTokenTest.php
@@ -37,7 +37,7 @@ class InvalidateTokenTest extends \Magento\TestFramework\TestCase\AbstractBacken
         $this->getRequest()->setParam('user_id', $adminUserId);
         $this->dispatch('backend/admin/user/invalidateToken');
         $token = $tokenModel->loadByAdminId($adminUserId);
-        $this->assertEquals(null, $token->getId());
+        $this->assertNull($token->getId());
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Test/Unit/ActionFlagTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/ActionFlagTest.php
@@ -85,6 +85,6 @@ class ActionFlagTest extends \PHPUnit\Framework\TestCase
         )->will(
             $this->returnValue('controller')
         );
-        $this->assertEquals(false, $this->_actionFlag->get('action', 'flag'));
+        $this->assertFalse($this->_actionFlag->get('action', 'flag'));
     }
 }

--- a/lib/internal/Magento/Framework/App/Test/Unit/Console/MaintenanceModeEnablerTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Console/MaintenanceModeEnablerTest.php
@@ -54,8 +54,7 @@ class MaintenanceModeEnablerTest extends TestCase
                 true
             );
         } catch (\Exception $e) {
-            $this->assertEquals(
-                true,
+            $this->assertTrue(
                 $maintenanceMode->isOn(),
                 'Maintenance mode is not active after failure'
             );

--- a/lib/internal/Magento/Framework/App/Test/Unit/PageCache/KernelTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/PageCache/KernelTest.php
@@ -175,7 +175,7 @@ class KernelTest extends \PHPUnit\Framework\TestCase
             $this->returnValue(json_encode($cache))
         );
         $this->identifierMock->expects($this->any())->method('getValue')->will($this->returnValue($id));
-        $this->assertEquals(false, $this->kernel->load());
+        $this->assertFalse($this->kernel->load());
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Test/Unit/Request/HttpTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Request/HttpTest.php
@@ -380,7 +380,7 @@ class HttpTest extends \PHPUnit\Framework\TestCase
     {
         $this->model = $this->getModel();
         $_SERVER['REQUEST_METHOD'] = $httpMethod;
-        $this->assertEquals(true, $this->model->isSafeMethod());
+        $this->assertTrue($this->model->isSafeMethod());
     }
 
     /**
@@ -392,7 +392,7 @@ class HttpTest extends \PHPUnit\Framework\TestCase
     {
         $this->model = $this->getModel();
         $_SERVER['REQUEST_METHOD'] = $httpMethod;
-        $this->assertEquals(false, $this->model->isSafeMethod());
+        $this->assertFalse($this->model->isSafeMethod());
     }
 
     /**

--- a/lib/internal/Magento/Framework/Cache/Test/Unit/Backend/RemoteSynchronizedCacheTest.php
+++ b/lib/internal/Magento/Framework/Cache/Test/Unit/Backend/RemoteSynchronizedCacheTest.php
@@ -223,7 +223,7 @@ class RemoteSynchronizedCacheTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        $this->assertEquals(true, $database->remove(5));
+        $this->assertTrue($database->remove(5));
     }
 
     public function testClean()
@@ -255,6 +255,6 @@ class RemoteSynchronizedCacheTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        $this->assertEquals(true, $database->clean());
+        $this->assertTrue($database->clean());
     }
 }

--- a/lib/internal/Magento/Framework/Cache/Test/Unit/Config/SchemaLocatorTest.php
+++ b/lib/internal/Magento/Framework/Cache/Test/Unit/Config/SchemaLocatorTest.php
@@ -40,6 +40,6 @@ class SchemaLocatorTest extends \PHPUnit\Framework\TestCase
 
     public function testGetPerFileSchema()
     {
-        $this->assertEquals(null, $this->schemaLocator->getPerFileSchema());
+        $this->assertNull($this->schemaLocator->getPerFileSchema());
     }
 }

--- a/lib/internal/Magento/Framework/Code/Test/Unit/Validator/ConstructorIntegrityTest.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/Validator/ConstructorIntegrityTest.php
@@ -26,17 +26,17 @@ class ConstructorIntegrityTest extends \PHPUnit\Framework\TestCase
 
     public function testValidateIfParentClassExist()
     {
-        $this->assertEquals(true, $this->_model->validate(\Magento\SomeModule\Model\One\Test::class));
+        $this->assertTrue($this->_model->validate(\Magento\SomeModule\Model\One\Test::class));
     }
 
     public function testValidateIfClassHasParentConstructCall()
     {
-        $this->assertEquals(true, $this->_model->validate(\Magento\SomeModule\Model\Two\Test::class));
+        $this->assertTrue($this->_model->validate(\Magento\SomeModule\Model\Two\Test::class));
     }
 
     public function testValidateIfClassHasArgumentsQtyEqualToParentClass()
     {
-        $this->assertEquals(true, $this->_model->validate(\Magento\SomeModule\Model\Three\Test::class));
+        $this->assertTrue($this->_model->validate(\Magento\SomeModule\Model\Three\Test::class));
     }
 
     public function testValidateIfClassHasExtraArgumentInTheParentConstructor()

--- a/lib/internal/Magento/Framework/Config/Test/Unit/DataTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/DataTest.php
@@ -51,7 +51,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertEquals($data, $config->get());
         $this->assertEquals('b', $config->get('a'));
-        $this->assertEquals(null, $config->get('a/b'));
+        $this->assertNull($config->get('a/b'));
         $this->assertEquals(33, $config->get('a/b', 33));
     }
 

--- a/lib/internal/Magento/Framework/DB/Test/Unit/ProfilerTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/ProfilerTest.php
@@ -38,7 +38,7 @@ class ProfilerTest extends \PHPUnit\Framework\TestCase
     public function testQueryStart()
     {
         $lastQueryId = $this->_profiler->queryStart('SELECT * FROM table');
-        $this->assertEquals(null, $lastQueryId);
+        $this->assertNull($lastQueryId);
     }
 
     public function testQueryEnd()

--- a/lib/internal/Magento/Framework/Data/Test/Unit/CollectionTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/CollectionTest.php
@@ -213,7 +213,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals([$secondItemMock], $this->_model->getItemsByColumnValue('colName', 'second_value'));
         $this->assertEquals($firstItemMock, $this->_model->getItemByColumnValue('colName', 'second_value'));
         $this->assertEquals([], $this->_model->getItemsByColumnValue('colName', 'non_existing_value'));
-        $this->assertEquals(null, $this->_model->getItemByColumnValue('colName', 'non_existing_value'));
+        $this->assertNull($this->_model->getItemByColumnValue('colName', 'non_existing_value'));
 
         /** get items */
         $this->assertEquals(['item_id', 0], $this->_model->getAllIds());

--- a/lib/internal/Magento/Framework/DataObject/Test/Unit/CacheTest.php
+++ b/lib/internal/Magento/Framework/DataObject/Test/Unit/CacheTest.php
@@ -20,7 +20,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
 
     public function testSaveWhenArgumentIsNotObject()
     {
-        $this->assertEquals(false, $this->cache->save('string'));
+        $this->assertFalse($this->cache->save('string'));
     }
 
     /**
@@ -65,7 +65,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
 
     public function testReferenceWhenReferenceEmpty()
     {
-        $this->assertEquals(null, $this->cache->reference([], 'idx'));
+        $this->assertNull($this->cache->reference([], 'idx'));
     }
 
     public function testLoadWhenReferenceAndObjectAlreadyExists()
@@ -74,10 +74,10 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->cache->reference('refName', $idx);
         $object = new \stdClass();
         $hash = spl_object_hash($object);
-        $this->assertEquals(null, $this->cache->findByHash($hash));
+        $this->assertNull($this->cache->findByHash($hash));
         $this->cache->save($object, $idx);
         $this->assertEquals($object, $this->cache->load($idx));
-        $this->assertEquals(true, $this->cache->has($idx));
+        $this->assertTrue($this->cache->has($idx));
         $this->assertEquals($object, $this->cache->findByHash($hash));
         $this->assertEquals(['refName' => 'idx'], $this->cache->getAllReferences());
     }

--- a/lib/internal/Magento/Framework/DataObject/Test/Unit/Copy/ConfigTest.php
+++ b/lib/internal/Magento/Framework/DataObject/Test/Unit/Copy/ConfigTest.php
@@ -54,6 +54,6 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $this->_storageMock->expects($this->once())->method('get')
             ->will($this->returnValue([]));
         $result = $this->_model->getFieldset('test');
-        $this->assertEquals(null, $result);
+        $this->assertNull($result);
     }
 }

--- a/lib/internal/Magento/Framework/DataObject/Test/Unit/CopyTest.php
+++ b/lib/internal/Magento/Framework/DataObject/Test/Unit/CopyTest.php
@@ -56,8 +56,7 @@ class CopyTest extends \PHPUnit\Framework\TestCase
     public function testCopyFieldsetToTargetWhenFieldsetInputInvalid()
     {
         $this->fieldsetConfigMock->expects($this->never())->method('getFieldset');
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $this->copy->copyFieldsetToTarget('fieldset', 'aspect', [], 'target')
         );
     }

--- a/lib/internal/Magento/Framework/Indexer/Test/Unit/StrategyTest.php
+++ b/lib/internal/Magento/Framework/Indexer/Test/Unit/StrategyTest.php
@@ -43,13 +43,13 @@ class StrategyTest extends \PHPUnit\Framework\TestCase
      */
     public function testUseIdxTable()
     {
-        $this->assertEquals(false, $this->_model->getUseIdxTable());
+        $this->assertFalse($this->_model->getUseIdxTable());
         $this->_model->setUseIdxTable(false);
-        $this->assertEquals(false, $this->_model->getUseIdxTable());
+        $this->assertFalse($this->_model->getUseIdxTable());
         $this->_model->setUseIdxTable(true);
-        $this->assertEquals(true, $this->_model->getUseIdxTable());
+        $this->assertTrue($this->_model->getUseIdxTable());
         $this->_model->setUseIdxTable();
-        $this->assertEquals(false, $this->_model->getUseIdxTable());
+        $this->assertFalse($this->_model->getUseIdxTable());
     }
 
     /**

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/PluginList/PluginListTest.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/PluginList/PluginListTest.php
@@ -256,7 +256,7 @@ class PluginListTest extends \PHPUnit\Framework\TestCase
         $this->cacheMock->expects($this->once())
             ->method('save');
 
-        $this->assertEquals(null, $this->object->getNext('Type', 'method'));
+        $this->assertNull($this->object->getNext('Type', 'method'));
     }
 
     /**
@@ -298,7 +298,7 @@ class PluginListTest extends \PHPUnit\Framework\TestCase
             ->with('global|scope|interception')
             ->willReturn($serializedData);
 
-        $this->assertEquals(null, $this->object->getNext('Type', 'method'));
+        $this->assertNull($this->object->getNext('Type', 'method'));
     }
 
     /**

--- a/lib/internal/Magento/Framework/Model/Test/Unit/AbstractExtensibleModelTest.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/AbstractExtensibleModelTest.php
@@ -129,8 +129,7 @@ class AbstractExtensibleModelTest extends \PHPUnit\Framework\TestCase
             $this->model->getCustomAttributes(),
             "Empty array is expected as a result of getCustomAttributes() when custom attributes are not set."
         );
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $this->model->getCustomAttribute('not_existing_custom_attribute'),
             "Null is expected as a result of getCustomAttribute(\$code) when custom attribute is not set."
         );

--- a/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/AbstractDbTest.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/AbstractDbTest.php
@@ -200,7 +200,7 @@ class AbstractDbTest extends \PHPUnit\Framework\TestCase
 
     public function testGetChecksumNegative()
     {
-        $this->assertEquals(false, $this->_model->getChecksum(null));
+        $this->assertFalse($this->_model->getChecksum(null));
     }
 
     /**

--- a/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/Collection/AbstractCollectionTest.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/Collection/AbstractCollectionTest.php
@@ -128,7 +128,7 @@ class AbstractCollectionTest extends \PHPUnit\Framework\TestCase
         $this->uut = $this->getUut();
 
         $this->assertTrue($this->uut->setMainTable('') instanceof Uut);
-        $this->assertEquals(null, $this->uut->getMainTable());
+        $this->assertNull($this->uut->getMainTable());
     }
 
     public function testSetMainTableFirst()

--- a/lib/internal/Magento/Framework/Module/Test/Unit/Plugin/DbStatusValidatorTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/Plugin/DbStatusValidatorTest.php
@@ -81,8 +81,7 @@ class DbStatusValidatorTest extends \PHPUnit\Framework\TestCase
             ->method('isDbDataUpToDate')
             ->will($this->returnValueMap($returnMap));
 
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $this->_model->beforeDispatch($this->subjectMock, $this->requestMock)
         );
     }
@@ -97,8 +96,7 @@ class DbStatusValidatorTest extends \PHPUnit\Framework\TestCase
             ->method('isDbSchemaUpToDate');
         $this->moduleManager->expects($this->never())
             ->method('isDbDataUpToDate');
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $this->_model->beforeDispatch($this->subjectMock, $this->requestMock)
         );
     }

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/CompiledTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/CompiledTest.php
@@ -163,7 +163,7 @@ class CompiledTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetArgumentsNotDefined()
     {
-        $this->assertSame(null, $this->compiled->getArguments('class_not_stored_in_config'));
+        $this->assertNull($this->compiled->getArguments('class_not_stored_in_config'));
     }
 
     /**

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/SchemaLocatorTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/SchemaLocatorTest.php
@@ -44,8 +44,7 @@ class SchemaLocatorTest extends \PHPUnit\Framework\TestCase
 
     public function testGetPerFileSchema()
     {
-        $this->assertEquals(
-            null,
+        $this->assertNull(
             $this->model->getPerFileSchema()
         );
     }

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/CompiledTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/CompiledTest.php
@@ -202,7 +202,7 @@ class CompiledTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf($nonSharedType, $result->getNonSharedDependency());
         $this->assertEquals('value', $result->getValue());
         $this->assertEquals(['default_value1', 'default_value2'], $result->getValueArray());
-        $this->assertEquals(null, $result->getGlobalValue());
+        $this->assertNull($result->getGlobalValue());
         $this->assertNull($result->getNullValue());
     }
 

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/Patch/PatchRegirtryTest.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/Patch/PatchRegirtryTest.php
@@ -70,7 +70,7 @@ class PatchRegirtryTest extends \PHPUnit\Framework\TestCase
             ->with(\SomeDataPatch::class)
             ->willReturn(true);
 
-        $this->assertEquals(false, $this->patchRegistry->registerPatch(\SomeDataPatch::class));
+        $this->assertFalse($this->patchRegistry->registerPatch(\SomeDataPatch::class));
     }
 
     public function testGetIterator()

--- a/lib/internal/Magento/Framework/Test/Unit/DataObjectTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/DataObjectTest.php
@@ -180,8 +180,8 @@ string',
 
         $this->dataObject->setData('key2', 'value2');
         $this->assertEquals('value2', $this->dataObject->getData('key2'));
-        $this->assertEquals(null, $this->dataObject->getKey2());
-        $this->assertEquals(null, $this->dataObject->getDataUsingMethod('key2'));
+        $this->assertNull($this->dataObject->getKey2());
+        $this->assertNull($this->dataObject->getDataUsingMethod('key2'));
     }
 
     /**

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/CurrencyTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/CurrencyTest.php
@@ -23,6 +23,6 @@ class CurrencyTest extends \PHPUnit\Framework\TestCase
         $lists = $this->createMock(\Magento\Framework\Setup\Lists::class);
         $lists->expects($this->any())->method('getCurrencyList')->will($this->returnValue($this->expectedCurrencies));
         $currency = new \Magento\Framework\Validator\Currency($lists);
-        $this->assertEquals(true, $currency->isValid('EUR'));
+        $this->assertTrue($currency->isValid('EUR'));
     }
 }

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/LocaleTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/LocaleTest.php
@@ -23,6 +23,6 @@ class LocaleTest extends \PHPUnit\Framework\TestCase
         $lists = $this->createMock(\Magento\Framework\Setup\Lists::class);
         $lists->expects($this->any())->method('getLocaleList')->will($this->returnValue($this->expectedLocales));
         $locale = new \Magento\Framework\Validator\Locale($lists);
-        $this->assertEquals(true, $locale->isValid('en_US'));
+        $this->assertTrue($locale->isValid('en_US'));
     }
 }

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/TimezoneTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/TimezoneTest.php
@@ -23,6 +23,6 @@ class TimezoneTest extends \PHPUnit\Framework\TestCase
         $lists = $this->createMock(\Magento\Framework\Setup\Lists::class);
         $lists->expects($this->any())->method('getTimezoneList')->will($this->returnValue($this->expectedTimezones));
         $timezone = new \Magento\Framework\Validator\Timezone($lists);
-        $this->assertEquals(true, $timezone->isValid('America/Los_Angeles'));
+        $this->assertTrue($timezone->isValid('America/Los_Angeles'));
     }
 }

--- a/lib/internal/Magento/Framework/View/Test/Unit/PageLayout/ConfigTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/PageLayout/ConfigTest.php
@@ -64,8 +64,8 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
 
     public function testHasPageLayout()
     {
-        $this->assertEquals(true, $this->config->hasPageLayout('one'));
-        $this->assertEquals(false, $this->config->hasPageLayout('three'));
+        $this->assertTrue($this->config->hasPageLayout('one'));
+        $this->assertFalse($this->config->hasPageLayout('three'));
     }
 
     public function testGetOptions()

--- a/setup/src/Magento/Setup/Test/Unit/Controller/BackupActionItemsTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Controller/BackupActionItemsTest.php
@@ -94,7 +94,7 @@ class BackupActionItemsTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('responseType', $variables);
         $this->assertEquals(ResponseTypeInterface::RESPONSE_TYPE_SUCCESS, $variables['responseType']);
         $this->assertArrayHasKey('size', $variables);
-        $this->assertEquals(true, $variables['size']);
+        $this->assertTrue($variables['size']);
     }
 
     public function testCheckActionWithError()

--- a/setup/src/Magento/Setup/Test/Unit/Fixtures/FixtureConfigTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Fixtures/FixtureConfigTest.php
@@ -56,7 +56,7 @@ class FixtureConfigTest extends \PHPUnit\Framework\TestCase
 
     public function testGetValue()
     {
-        $this->assertSame(null, $this->model->getValue('null_key'));
+        $this->assertNull($this->model->getValue('null_key'));
     }
 }
 

--- a/setup/src/Magento/Setup/Test/Unit/Model/ModuleStatusTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ModuleStatusTest.php
@@ -91,10 +91,10 @@ class ModuleStatusTest extends \PHPUnit\Framework\TestCase
 
         $moduleStatus = new ModuleStatus($this->moduleLoader, $this->deploymentConfig, $this->objectManagerProvider);
         $allModules = $moduleStatus->getAllModules(['module1', 'module2']);
-        $this->assertSame(true, $allModules['module1']['selected']);
-        $this->assertSame(true, $allModules['module2']['selected']);
-        $this->assertSame(false, $allModules['module3']['selected']);
-        $this->assertSame(false, $allModules['module4']['selected']);
+        $this->assertTrue($allModules['module1']['selected']);
+        $this->assertTrue($allModules['module2']['selected']);
+        $this->assertFalse($allModules['module3']['selected']);
+        $this->assertFalse($allModules['module4']['selected']);
     }
 
     /**
@@ -116,7 +116,7 @@ class ModuleStatusTest extends \PHPUnit\Framework\TestCase
         $moduleStatus = new ModuleStatus($this->moduleLoader, $this->deploymentConfig, $this->objectManagerProvider);
         $moduleStatus->setIsEnabled(false, 'module1');
         $allModules = $moduleStatus->getAllModules();
-        $this->assertSame(false, $allModules['module1']['selected']);
+        $this->assertFalse($allModules['module1']['selected']);
         $this->assertSame($expectedResult[1], $allModules['module2']['selected']);
         $this->assertSame($expectedResult[2], $allModules['module3']['selected']);
         $this->assertSame($expectedResult[3], $allModules['module4']['selected']);

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/Php/TokenizerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/Php/TokenizerTest.php
@@ -39,20 +39,20 @@ class TokenizerTest extends \PHPUnit\Framework\TestCase
     {
         $class = 'Phrase';
         $this->parseFile();
-        $this->assertEquals(false, $this->tokenizer->isMatchingClass($class)); // new
-        $this->assertEquals(true, $this->tokenizer->isMatchingClass($class)); // \Magento\Framework\Phrase(
-        $this->assertEquals(false, $this->tokenizer->isMatchingClass($class)); // 'Testing'
-        $this->assertEquals(false, $this->tokenizer->isMatchingClass($class)); // )
-        $this->assertEquals(false, $this->tokenizer->isMatchingClass($class)); // ;
-        $this->assertEquals(false, $this->tokenizer->isMatchingClass($class)); // new
-        $this->assertEquals(true, $this->tokenizer->isMatchingClass($class)); // Phrase(
-        $this->assertEquals(false, $this->tokenizer->isMatchingClass($class)); // 'More testing'
-        $this->assertEquals(false, $this->tokenizer->isMatchingClass($class)); // )
-        $this->assertEquals(false, $this->tokenizer->isMatchingClass($class)); // ;
-        $this->assertEquals(false, $this->tokenizer->isMatchingClass($class)); // new
-        $this->assertEquals(false, $this->tokenizer->isMatchingClass($class)); // \Magento\Framework\DataObject(
-        $this->assertEquals(false, $this->tokenizer->isMatchingClass($class)); // )
-        $this->assertEquals(false, $this->tokenizer->isMatchingClass($class)); // ;
+        $this->assertFalse($this->tokenizer->isMatchingClass($class)); // new
+        $this->assertTrue($this->tokenizer->isMatchingClass($class)); // \Magento\Framework\Phrase(
+        $this->assertFalse($this->tokenizer->isMatchingClass($class)); // 'Testing'
+        $this->assertFalse($this->tokenizer->isMatchingClass($class)); // )
+        $this->assertFalse($this->tokenizer->isMatchingClass($class)); // ;
+        $this->assertFalse($this->tokenizer->isMatchingClass($class)); // new
+        $this->assertTrue($this->tokenizer->isMatchingClass($class)); // Phrase(
+        $this->assertFalse($this->tokenizer->isMatchingClass($class)); // 'More testing'
+        $this->assertFalse($this->tokenizer->isMatchingClass($class)); // )
+        $this->assertFalse($this->tokenizer->isMatchingClass($class)); // ;
+        $this->assertFalse($this->tokenizer->isMatchingClass($class)); // new
+        $this->assertFalse($this->tokenizer->isMatchingClass($class)); // \Magento\Framework\DataObject(
+        $this->assertFalse($this->tokenizer->isMatchingClass($class)); // )
+        $this->assertFalse($this->tokenizer->isMatchingClass($class)); // ;
     }
 
     /**

--- a/setup/src/Magento/Setup/Test/Unit/Validator/DbValidatorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Validator/DbValidatorTest.php
@@ -76,8 +76,8 @@ class DbValidatorTest extends \PHPUnit\Framework\TestCase
                     [\PDO::FETCH_NUM, null, $listOfPrivileges]
                 ]
             );
-        $this->assertEquals(true, $this->dbValidator->checkDatabaseConnection('name', 'host', 'user', 'password'));
-        $this->assertEquals(true, $this->dbValidator->checkDatabaseConnection('name', 'host:3339', 'user', 'password'));
+        $this->assertTrue($this->dbValidator->checkDatabaseConnection('name', 'host', 'user', 'password'));
+        $this->assertTrue($this->dbValidator->checkDatabaseConnection('name', 'host:3339', 'user', 'password'));
     }
 
     /**
@@ -136,7 +136,7 @@ class DbValidatorTest extends \PHPUnit\Framework\TestCase
 
     public function testCheckDatabaseTablePrefix()
     {
-        $this->assertEquals(true, $this->dbValidator->checkDatabaseTablePrefix('test'));
+        $this->assertTrue($this->dbValidator->checkDatabaseTablePrefix('test'));
     }
 
     /**
@@ -145,7 +145,7 @@ class DbValidatorTest extends \PHPUnit\Framework\TestCase
      */
     public function testCheckDatabaseTablePrefixWrongFormat()
     {
-        $this->assertEquals(true, $this->dbValidator->checkDatabaseTablePrefix('_wrong_format'));
+        $this->assertTrue($this->dbValidator->checkDatabaseTablePrefix('_wrong_format'));
     }
 
     /**
@@ -154,8 +154,7 @@ class DbValidatorTest extends \PHPUnit\Framework\TestCase
      */
     public function testCheckDatabaseTablePrefixWrongLength()
     {
-        $this->assertEquals(
-            true,
+        $this->assertTrue(
             $this->dbValidator->checkDatabaseTablePrefix('mvbXzXzItSIr0wrZW3gqgV2UKrWiK1Mj7bkBlW72rZW3gqgV2UKrWiK1M')
         );
     }


### PR DESCRIPTION
PHPUnit assertion method calls like ->assertSame(true, $foo) should be written with dedicated method like ->assertTrue($foo)