### PR TITLE
PHP unit namespaced

### DIFF
--- a/app/code/Magento/AdvancedSearch/Test/Unit/Block/SearchDataTest.php
+++ b/app/code/Magento/AdvancedSearch/Test/Unit/Block/SearchDataTest.php
@@ -6,7 +6,7 @@
 
 namespace Magento\AdvancedSearch\Test\Unit\Block;
 
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class SearchDataTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Authorizenet/Test/Unit/Controller/Directpost/Payment/RedirectTest.php
+++ b/app/code/Magento/Authorizenet/Test/Unit/Controller/Directpost/Payment/RedirectTest.php
@@ -11,7 +11,7 @@ use Magento\Framework\App\ViewInterface;
 use Magento\Framework\Registry;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Payment\Block\Transparent\Iframe;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class RedirectTest

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassDisableTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassDisableTest.php
@@ -6,7 +6,7 @@
 
 namespace Magento\Backend\Test\Unit\Controller\Adminhtml\Cache;
 
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Backend\Controller\Adminhtml\Cache\MassDisable;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Framework\App\State;

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassEnableTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/Cache/MassEnableTest.php
@@ -6,7 +6,7 @@
 
 namespace Magento\Backend\Test\Unit\Controller\Adminhtml\Cache;
 
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Backend\Controller\Adminhtml\Cache\MassEnable;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Framework\App\State;

--- a/app/code/Magento/Braintree/Test/Unit/Block/FormTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Block/FormTest.php
@@ -14,7 +14,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Payment\Helper\Data;
 use Magento\Payment\Model\Config;
 use Magento\Vault\Model\VaultPaymentInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Block\Form.

--- a/app/code/Magento/Braintree/Test/Unit/Controller/Adminhtml/Payment/GetClientTokenTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Controller/Adminhtml/Payment/GetClientTokenTest.php
@@ -14,7 +14,7 @@ use Magento\Braintree\Model\Adapter\BraintreeAdapterFactory;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Controller\Adminhtml\Payment\GetClientToken

--- a/app/code/Magento/Braintree/Test/Unit/Controller/Payment/GetNonceTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Controller/Payment/GetNonceTest.php
@@ -15,7 +15,7 @@ use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\Webapi\Exception;
 use Magento\Payment\Gateway\Command\ResultInterface as CommandResultInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Command/CaptureStrategyCommandTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Command/CaptureStrategyCommandTest.php
@@ -21,7 +21,7 @@ use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Sales\Api\TransactionRepositoryInterface;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Sales\Model\ResourceModel\Order\Payment\Transaction\CollectionFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Command\CaptureStrategyCommand.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Command/GetPaymentNonceCommandTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Command/GetPaymentNonceCommandTest.php
@@ -15,7 +15,7 @@ use Magento\Payment\Gateway\Command\Result\ArrayResultFactory;
 use Magento\Payment\Gateway\Validator\ResultInterface;
 use Magento\Vault\Model\PaymentToken;
 use Magento\Vault\Model\PaymentTokenManagement;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class GetPaymentNonceCommandTest

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionRefundTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionRefundTest.php
@@ -10,7 +10,7 @@ use Magento\Braintree\Model\Adapter\BraintreeAdapter;
 use Magento\Braintree\Model\Adapter\BraintreeAdapterFactory;
 use Magento\Payment\Gateway\Http\TransferInterface;
 use Magento\Payment\Model\Method\Logger;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Psr\Log\LoggerInterface;
 use Magento\Braintree\Gateway\Request\PaymentDataBuilder;
 

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionSaleTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionSaleTest.php
@@ -10,7 +10,7 @@ use Magento\Braintree\Model\Adapter\BraintreeAdapter;
 use Magento\Braintree\Model\Adapter\BraintreeAdapterFactory;
 use Magento\Payment\Gateway\Http\TransferInterface;
 use Magento\Payment\Model\Method\Logger;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionSubmitForSettlementTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionSubmitForSettlementTest.php
@@ -11,7 +11,7 @@ use Magento\Braintree\Model\Adapter\BraintreeAdapter;
 use Magento\Braintree\Model\Adapter\BraintreeAdapterFactory;
 use Magento\Payment\Gateway\Http\TransferInterface;
 use Magento\Payment\Model\Method\Logger;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionVoidTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Http/Client/TransactionVoidTest.php
@@ -10,7 +10,7 @@ use Magento\Braintree\Model\Adapter\BraintreeAdapter;
 use Magento\Braintree\Model\Adapter\BraintreeAdapterFactory;
 use Magento\Payment\Gateway\Http\TransferInterface;
 use Magento\Payment\Model\Method\Logger;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Request/AddressDataBuilderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Request/AddressDataBuilderTest.php
@@ -10,7 +10,7 @@ use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\AddressAdapterInterface;
 use Magento\Braintree\Gateway\SubjectReader;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Request\AddressDataBuilder.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Request/CaptureDataBuilderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Request/CaptureDataBuilderTest.php
@@ -9,7 +9,7 @@ use Magento\Braintree\Gateway\Request\CaptureDataBuilder;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Braintree\Gateway\SubjectReader;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Request\CaptureDataBuilder.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Request/ChannelDataBuilderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Request/ChannelDataBuilderTest.php
@@ -8,7 +8,7 @@ namespace Magento\Braintree\Test\Unit\Gateway\Request;
 use Magento\Braintree\Gateway\Request\ChannelDataBuilder;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Payment\Gateway\Config\Config;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class PaymentDataBuilderTest

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Request/CustomerDataBuilderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Request/CustomerDataBuilderTest.php
@@ -10,7 +10,7 @@ use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\AddressAdapterInterface;
 use Magento\Braintree\Gateway\SubjectReader;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Request\CustomerDataBuilder.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Request/DescriptorDataBuilderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Request/DescriptorDataBuilderTest.php
@@ -10,7 +10,7 @@ use Magento\Braintree\Gateway\Request\DescriptorDataBuilder;
 use Magento\Braintree\Gateway\SubjectReader;
 use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class DescriptorDataBuilderTest

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Request/KountPaymentDataBuilderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Request/KountPaymentDataBuilderTest.php
@@ -12,7 +12,7 @@ use Magento\Braintree\Observer\DataAssignObserver;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Braintree\Gateway\Request\KountPaymentDataBuilder;
 use Magento\Braintree\Gateway\SubjectReader;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Request\KountPaymentDataBuilder.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Request/PayPal/DeviceDataBuilderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Request/PayPal/DeviceDataBuilderTest.php
@@ -9,7 +9,7 @@ use Magento\Braintree\Gateway\SubjectReader;
 use Magento\Braintree\Gateway\Request\PayPal\DeviceDataBuilder;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Payment\Model\InfoInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Request\PayPal\DeviceDataBuilder.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Request/PayPal/VaultDataBuilderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Request/PayPal/VaultDataBuilderTest.php
@@ -10,7 +10,7 @@ use Magento\Braintree\Gateway\Request\PayPal\VaultDataBuilder;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Payment\Model\InfoInterface;
 use Magento\Vault\Model\Ui\VaultConfigProvider;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Request\PayPal\VaultDataBuilder.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Request/PaymentDataBuilderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Request/PaymentDataBuilderTest.php
@@ -11,7 +11,7 @@ use Magento\Braintree\Observer\DataAssignObserver;
 use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Sales\Model\Order\Payment;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Braintree\Gateway\Config\Config;
 
 /**

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Request/RefundDataBuilderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Request/RefundDataBuilderTest.php
@@ -11,7 +11,7 @@ use Magento\Braintree\Gateway\SubjectReader;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Sales\Api\Data\TransactionInterface;
 use Magento\Sales\Model\Order\Payment;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Request\RefundDataBuilder.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Request/ThreeDSecureDataBuilderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Request/ThreeDSecureDataBuilderTest.php
@@ -11,7 +11,7 @@ use Magento\Braintree\Gateway\Request\ThreeDSecureDataBuilder;
 use Magento\Payment\Gateway\Data\Order\AddressAdapter;
 use Magento\Payment\Gateway\Data\Order\OrderAdapter;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Request\ThreeDSecureDataBuilder.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Request/VaultCaptureDataBuilderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Request/VaultCaptureDataBuilderTest.php
@@ -13,7 +13,7 @@ use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Sales\Api\Data\OrderPaymentExtension;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Vault\Model\PaymentToken;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Request\VaultCaptureDataBuilder.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Request/VoidDataBuilderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Request/VoidDataBuilderTest.php
@@ -9,7 +9,7 @@ use Magento\Braintree\Gateway\SubjectReader;
 use Magento\Braintree\Gateway\Request\VoidDataBuilder;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Sales\Model\Order\Payment;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Request\VaultCaptureDataBuilder.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Response/CancelDetailsHandlerTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Response/CancelDetailsHandlerTest.php
@@ -13,7 +13,7 @@ use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Sales\Model\Order\Payment;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Response\CancelDetailsHandler.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Response/PayPal/VaultDetailsHandlerTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Response/PayPal/VaultDetailsHandlerTest.php
@@ -20,7 +20,7 @@ use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
 use Magento\Vault\Api\Data\PaymentTokenInterface;
 use Magento\Vault\Model\PaymentToken;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Response\PayPal\VaultDetailsHandler.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Response/PayPalDetailsHandlerTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Response/PayPalDetailsHandlerTest.php
@@ -10,7 +10,7 @@ use Magento\Braintree\Gateway\Response\PayPalDetailsHandler;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Braintree\Gateway\SubjectReader;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class PayPalDetailsHandlerTest

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Response/PaymentDetailsHandlerTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Response/PaymentDetailsHandlerTest.php
@@ -10,7 +10,7 @@ use Magento\Braintree\Gateway\Response\PaymentDetailsHandler;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Braintree\Gateway\SubjectReader;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \\Magento\Braintree\Gateway\Response\PaymentDetailsHandler.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Response/RiskDataHandlerTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Response/RiskDataHandlerTest.php
@@ -10,7 +10,7 @@ use Magento\Braintree\Gateway\SubjectReader;
 use Magento\Braintree\Gateway\Response\RiskDataHandler;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Sales\Model\Order\Payment;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class RiskDataHandlerTest

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Response/ThreeDSecureDetailsHandlerTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Response/ThreeDSecureDetailsHandlerTest.php
@@ -10,7 +10,7 @@ use Magento\Braintree\Gateway\Response\ThreeDSecureDetailsHandler;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Braintree\Gateway\SubjectReader;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ThreeDSecureDetailsHandlerTest

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Response/VaultDetailsHandlerTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Response/VaultDetailsHandlerTest.php
@@ -22,7 +22,7 @@ use Magento\Sales\Model\Order\Payment;
 use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
 use Magento\Vault\Model\PaymentToken;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * VaultDetailsHandler Test

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Validator/CancelResponseValidatorTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Validator/CancelResponseValidatorTest.php
@@ -14,7 +14,7 @@ use Magento\Braintree\Gateway\Validator\GeneralResponseValidator;
 use Magento\Braintree\Gateway\SubjectReader;
 use Magento\Payment\Gateway\Validator\ResultInterface;
 use Magento\Payment\Gateway\Validator\ResultInterfaceFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Gateway\Validator\CancelResponseValidator class.

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Validator/GeneralResponseValidatorTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Validator/GeneralResponseValidatorTest.php
@@ -12,7 +12,7 @@ use Magento\Braintree\Gateway\Validator\GeneralResponseValidator;
 use Magento\Framework\Phrase;
 use Magento\Payment\Gateway\Validator\Result;
 use Magento\Payment\Gateway\Validator\ResultInterfaceFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class GeneralResponseValidatorTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Validator/PaymentNonceResponseValidatorTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Validator/PaymentNonceResponseValidatorTest.php
@@ -10,7 +10,7 @@ use Magento\Braintree\Gateway\Validator\ErrorCodeProvider;
 use Magento\Braintree\Gateway\Validator\PaymentNonceResponseValidator;
 use Magento\Payment\Gateway\Validator\Result;
 use Magento\Payment\Gateway\Validator\ResultInterfaceFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class PaymentNonceResponseValidatorTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Braintree/Test/Unit/Gateway/Validator/ResponseValidatorTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Gateway/Validator/ResponseValidatorTest.php
@@ -14,7 +14,7 @@ use Magento\Framework\Phrase;
 use Magento\Payment\Gateway\Validator\Result;
 use Magento\Payment\Gateway\Validator\ResultInterface;
 use Magento\Payment\Gateway\Validator\ResultInterfaceFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ResponseValidatorTest

--- a/app/code/Magento/Braintree/Test/Unit/Model/AvsEmsCodeMapperTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/AvsEmsCodeMapperTest.php
@@ -8,7 +8,7 @@ namespace Magento\Braintree\Test\Unit\Model;
 use Magento\Braintree\Model\AvsEmsCodeMapper;
 use Magento\Braintree\Model\Ui\ConfigProvider;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class AvsEmsCodeMapperTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Braintree/Test/Unit/Model/CvvEmsCodeMapperTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/CvvEmsCodeMapperTest.php
@@ -8,7 +8,7 @@ namespace Magento\Braintree\Test\Unit\Model;
 use Magento\Braintree\Model\CvvEmsCodeMapper;
 use Magento\Braintree\Model\Ui\ConfigProvider;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class CvvEmsCodeMapperTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Braintree/Test/Unit/Model/InstantPurchase/CreditCard/TokenFormatterTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/InstantPurchase/CreditCard/TokenFormatterTest.php
@@ -10,7 +10,7 @@ namespace Magento\Braintree\Test\Unit\Model\InstantPurchase\CreditCard;
 use Magento\Braintree\Model\InstantPurchase\CreditCard\TokenFormatter as CreditCardTokenFormatter;
 use Magento\Vault\Api\Data\PaymentTokenInterface;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class TokenFormatterTest extends TestCase
 {

--- a/app/code/Magento/Braintree/Test/Unit/Model/Paypal/Helper/QuoteUpdaterTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/Paypal/Helper/QuoteUpdaterTest.php
@@ -16,7 +16,7 @@ use Magento\Quote\Api\Data\CartExtensionInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Address;
 use Magento\Quote\Model\Quote\Payment;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class QuoteUpdaterTest

--- a/app/code/Magento/Braintree/Test/Unit/Model/Paypal/Helper/ShippingMethodUpdaterTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/Paypal/Helper/ShippingMethodUpdaterTest.php
@@ -116,7 +116,7 @@ class ShippingMethodUpdaterTest extends \PHPUnit\Framework\TestCase
     /**
      * @param \PHPUnit_Framework_MockObject_MockObject $quoteMock
      */
-    private function disabledQuoteAddressValidationStep(\PHPUnit_Framework_MockObject_MockObject $quoteMock)
+    private function disabledQuoteAddressValidationStep(\PHPUnit\Framework\MockObject\MockObject $quoteMock)
     {
         $billingAddressMock = $this->getBillingAddressMock($quoteMock);
 
@@ -142,7 +142,7 @@ class ShippingMethodUpdaterTest extends \PHPUnit\Framework\TestCase
      * @param \PHPUnit_Framework_MockObject_MockObject $quoteMock
      * @return Address|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function getBillingAddressMock(\PHPUnit_Framework_MockObject_MockObject $quoteMock)
+    private function getBillingAddressMock(\PHPUnit\Framework\MockObject\MockObject $quoteMock)
     {
         if (!isset($this->billingAddressMock)) {
             $this->billingAddressMock = $this->getMockBuilder(Address::class)

--- a/app/code/Magento/Braintree/Test/Unit/Model/Report/TransactionsCollectionTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/Report/TransactionsCollectionTest.php
@@ -11,7 +11,7 @@ use Magento\Braintree\Model\Report\FilterMapper;
 use Magento\Braintree\Model\Report\TransactionsCollection;
 use Magento\Framework\Api\Search\DocumentInterface;
 use Magento\Framework\Data\Collection\EntityFactoryInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class TransactionsCollectionTest

--- a/app/code/Magento/Braintree/Test/Unit/Model/Ui/Adminhtml/PayPal/TokenUiComponentProviderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/Ui/Adminhtml/PayPal/TokenUiComponentProviderTest.php
@@ -11,7 +11,7 @@ use Magento\Framework\UrlInterface;
 use Magento\Vault\Api\Data\PaymentTokenInterface;
 use Magento\Vault\Model\Ui\TokenUiComponentInterface;
 use Magento\Vault\Model\Ui\TokenUiComponentInterfaceFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Contains methods to test PayPal token Ui component provider

--- a/app/code/Magento/Braintree/Test/Unit/Model/Ui/Adminhtml/TokenUiComponentProviderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/Ui/Adminhtml/TokenUiComponentProviderTest.php
@@ -10,7 +10,7 @@ use Magento\Framework\UrlInterface;
 use Magento\Vault\Api\Data\PaymentTokenInterface;
 use Magento\Vault\Model\Ui\TokenUiComponentInterface;
 use Magento\Vault\Model\Ui\TokenUiComponentInterfaceFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class TokenUiComponentProviderTest

--- a/app/code/Magento/Braintree/Test/Unit/Model/Ui/ConfigProviderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/Ui/ConfigProviderTest.php
@@ -10,7 +10,7 @@ use Magento\Braintree\Model\Adapter\BraintreeAdapter;
 use Magento\Braintree\Model\Adapter\BraintreeAdapterFactory;
 use Magento\Braintree\Model\Ui\ConfigProvider;
 use Magento\Customer\Model\Session;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ConfigProviderTest

--- a/app/code/Magento/Braintree/Test/Unit/Model/Ui/PayPal/ConfigProviderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/Ui/PayPal/ConfigProviderTest.php
@@ -8,7 +8,7 @@ namespace Magento\Braintree\Test\Unit\Model\Ui\PayPal;
 use Magento\Braintree\Gateway\Config\PayPal\Config;
 use Magento\Braintree\Model\Ui\PayPal\ConfigProvider;
 use Magento\Framework\Locale\ResolverInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ConfigProviderTest

--- a/app/code/Magento/Braintree/Test/Unit/Model/Ui/PayPal/TokenUiComponentProviderTest.php
+++ b/app/code/Magento/Braintree/Test/Unit/Model/Ui/PayPal/TokenUiComponentProviderTest.php
@@ -10,7 +10,7 @@ use Magento\Framework\UrlInterface;
 use Magento\Vault\Model\Ui\TokenUiComponentInterfaceFactory;
 use Magento\Vault\Model\Ui\TokenUiComponentInterface;
 use Magento\Vault\Api\Data\PaymentTokenInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class TokenUiComponentProviderTest

--- a/app/code/Magento/Bundle/Test/Unit/Model/Plugin/Frontend/ProductTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/Plugin/Frontend/ProductTest.php
@@ -9,7 +9,7 @@ namespace Magento\Bundle\Test\Unit\Model\Plugin\Frontend;
 use Magento\Bundle\Model\Plugin\Frontend\Product as ProductPlugin;
 use Magento\Bundle\Model\Product\Type;
 use Magento\Catalog\Model\Product;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class ProductTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Bundle/Test/Unit/Model/Plugin/ProductTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/Plugin/ProductTest.php
@@ -8,7 +8,7 @@ namespace Magento\Bundle\Test\Unit\Model\Plugin;
 
 use Magento\Catalog\Model\Product;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class ProductTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Bundle/Test/Unit/Pricing/Price/BundleOptionsTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Pricing/Price/BundleOptionsTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 namespace Magento\Bundle\Test\Unit\Pricing\Price;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Framework\Pricing\Amount\AmountFactory;
 use Magento\Framework\Pricing\Adjustment\Calculator as AdjustmentCalculator;
 use Magento\Framework\Pricing\PriceInfo\Base as BasePriceInfo;

--- a/app/code/Magento/Bundle/Test/Unit/Ui/DataProvider/Product/Form/Modifier/AbstractModifierTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Ui/DataProvider/Product/Form/Modifier/AbstractModifierTest.php
@@ -10,7 +10,7 @@ use Magento\Catalog\Model\Locator\LocatorInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Ui\DataProvider\Modifier\ModifierInterface;
 use Magento\Framework\Stdlib\ArrayManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 abstract class AbstractModifierTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Bundle/Test/Unit/Ui/DataProvider/Product/Form/Modifier/CompositeTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Ui/DataProvider/Product/Form/Modifier/CompositeTest.php
@@ -7,7 +7,7 @@ namespace Magento\Bundle\Test\Unit\Ui\DataProvider\Product\Form\Modifier;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Bundle\Model\Product\Type;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class CompositeTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserLoginBackendObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/CheckUserLoginBackendObserverTest.php
@@ -16,7 +16,7 @@ use Magento\Framework\Event;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Message\ManagerInterface;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class CheckUserLoginBackendObserverTest

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Initialization/Helper/AttributeFilterTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Initialization/Helper/AttributeFilterTest.php
@@ -9,7 +9,7 @@ namespace Magento\Catalog\Test\Unit\Controller\Adminhtml\Product\Initialization\
 use Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper\AttributeFilter;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Eav\Attribute;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class AttributeFilterTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Catalog/Test/Unit/CustomerData/CompareProductsTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/CustomerData/CompareProductsTest.php
@@ -84,7 +84,7 @@ class CompareProductsTest extends \PHPUnit\Framework\TestCase
      * @param array $items
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    private function getItemCollectionMock(array $items) : \PHPUnit_Framework_MockObject_MockObject
+    private function getItemCollectionMock(array $items) : \PHPUnit\Framework\MockObject\MockObject
     {
         $itemCollectionMock = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
@@ -142,7 +142,7 @@ class CompareProductsTest extends \PHPUnit\Framework\TestCase
      * @param array $data
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    private function getProductMock(array $data) : \PHPUnit_Framework_MockObject_MockObject
+    private function getProductMock(array $data) : \PHPUnit\Framework\MockObject\MockObject
     {
         $product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Link/ReadHandlerTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Link/ReadHandlerTest.php
@@ -12,7 +12,7 @@ use Magento\Catalog\Model\Category\Link\ReadHandler;
 use Magento\Catalog\Model\ResourceModel\Product\CategoryLink;
 use Magento\Framework\Api\DataObjectHelper;
 use Magento\Catalog\Model\Product;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ReadHandlerTest

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Link/SaveHandlerTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Link/SaveHandlerTest.php
@@ -12,7 +12,7 @@ use Magento\Framework\EntityManager\HydratorInterface;
 use Magento\Framework\EntityManager\HydratorPool;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\Indexer\IndexerRegistry;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class SaveHandlerTest

--- a/app/code/Magento/Catalog/Test/Unit/Model/Config/Source/CategoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Config/Source/CategoryTest.php
@@ -6,7 +6,7 @@
 namespace Magento\Catalog\Test\Unit\Model\Config\Source;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class CategoryTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Flat/Action/RowTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Flat/Action/RowTest.php
@@ -8,7 +8,7 @@ namespace Magento\Catalog\Test\Unit\Model\Indexer\Product\Flat\Action;
 
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/AttributeTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/AttributeTest.php
@@ -7,7 +7,7 @@
 namespace Magento\Catalog\Test\Unit\Model\Layer\Filter;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/CategoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/CategoryTest.php
@@ -6,7 +6,7 @@
 namespace Magento\Catalog\Test\Unit\Model\Layer\Filter;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Test for \Magento\Catalog\Model\Layer\Filter\Category

--- a/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/DataProvider/CategoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/DataProvider/CategoryTest.php
@@ -7,7 +7,7 @@
 namespace Magento\Catalog\Test\Unit\Model\Layer\Filter\DataProvider;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Test for \Magento\Catalog\Model\Layer\Filter\DataProvider\Category

--- a/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/DataProvider/DecimalTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/DataProvider/DecimalTest.php
@@ -7,7 +7,7 @@
 namespace Magento\Catalog\Test\Unit\Model\Layer\Filter\DataProvider;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Test for \Magento\Catalog\Model\Layer\Filter\DataProvider\Decimal

--- a/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/DataProvider/PriceTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/DataProvider/PriceTest.php
@@ -9,7 +9,7 @@ namespace Magento\Catalog\Test\Unit\Model\Layer\Filter\DataProvider;
 use \Magento\Catalog\Model\Layer\Filter\DataProvider\Price;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Test for \Magento\Catalog\Model\Layer\Filter\DataProvider\Price

--- a/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/PriceTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/PriceTest.php
@@ -7,7 +7,7 @@
 namespace Magento\Catalog\Test\Unit\Model\Layer\Filter;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Test for \Magento\Catalog\Model\Layer\Filter\Price

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/SetRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/SetRepositoryTest.php
@@ -201,7 +201,7 @@ class SetRepositoryTest extends \PHPUnit\Framework\TestCase
      * @param $setEntityTypeId
      */
     protected function setMockForValidation(
-        \PHPUnit_Framework_MockObject_MockObject $attributeSetMock,
+        \PHPUnit\Framework\MockObject\MockObject $attributeSetMock,
         $setEntityTypeId
     ) {
         $typeMock = $this->createMock(\Magento\Eav\Model\Entity\Type::class);

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
@@ -33,7 +33,7 @@ use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ProductRepositoryTest

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/CategoryLinkTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/CategoryLinkTest.php
@@ -7,7 +7,7 @@
 namespace Magento\Catalog\Test\Unit\Model\ResourceModel\Product;
 
 use Magento\Catalog\Model\ResourceModel\Product\CategoryLink;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class CategoryLinkTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
@@ -13,7 +13,7 @@ use Magento\Framework\DB\Query\Generator;
 use Magento\Framework\DB\Select;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Catalog\Model\ResourceModel\Product\Gallery;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Framework\DB\Query\BatchIteratorInterface;
 
 class ImageTest extends \PHPUnit\Framework\TestCase

--- a/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/CatalogEavValidationRulesTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/CatalogEavValidationRulesTest.php
@@ -7,7 +7,7 @@ namespace Magento\Catalog\Test\Unit\Ui\DataProvider;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Catalog\Ui\DataProvider\CatalogEavValidationRules;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class CatalogEavValidationRulesTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Validator/MediaTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Validator/MediaTest.php
@@ -11,7 +11,7 @@ use Magento\CatalogImportExport\Model\Import\Product\Validator\Media;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\ImportExport\Model\Import;
 use Magento\Framework\Url\Validator;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class MediaTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Validator/SuperProductsSkuTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Validator/SuperProductsSkuTest.php
@@ -7,7 +7,7 @@ namespace Magento\CatalogImportExport\Test\Unit\Model\Import\Product\Validator;
 
 use Magento\CatalogImportExport\Model\Import\Product\SkuProcessor;
 use Magento\CatalogImportExport\Model\Import\Product\Validator\SuperProductsSku;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Test for SuperProductsSku

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/Indexer/IndexerTableSwapperTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/Indexer/IndexerTableSwapperTest.php
@@ -11,7 +11,7 @@ use Magento\CatalogRule\Model\Indexer\IndexerTableSwapper;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\DB\Ddl\Table;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Test for Magento\CatalogRule\Model\Indexer\IndexerTableSwapper class.

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Adapter/Mysql/Field/ResolverTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Adapter/Mysql/Field/ResolverTest.php
@@ -68,7 +68,7 @@ class ResolverTest extends \PHPUnit\Framework\TestCase
     public function testResolve(
         array $fields,
         $attributeId,
-        \PHPUnit_Framework_MockObject_MockObject $field,
+        \PHPUnit\Framework\MockObject\MockObject $field,
         array $expectedResult
     ) {
         $item = $this->getMockBuilder(\Magento\Framework\DataObject::class)

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Adapter/Mysql/Filter/PreprocessorTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Adapter/Mysql/Filter/PreprocessorTest.php
@@ -11,7 +11,7 @@ use Magento\Framework\DB\Select;
 use Magento\Framework\EntityManager\EntityMetadata;
 use Magento\Framework\Search\Request\FilterInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/AttributeTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/AttributeTest.php
@@ -8,7 +8,7 @@ namespace Magento\CatalogSearch\Test\Unit\Model\Layer\Filter;
 
 use Magento\Catalog\Model\Layer\Filter\AbstractFilter;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/CategoryTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/CategoryTest.php
@@ -7,7 +7,7 @@
 namespace Magento\CatalogSearch\Test\Unit\Model\Layer\Filter;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Test for \Magento\CatalogSearch\Model\Layer\Filter\Category

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/DecimalTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/DecimalTest.php
@@ -7,7 +7,7 @@
 namespace Magento\CatalogSearch\Test\Unit\Model\Layer\Filter;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Test for \Magento\CatalogSearch\Model\Layer\Filter\Decimal

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/PriceTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/PriceTest.php
@@ -7,7 +7,7 @@
 namespace Magento\CatalogSearch\Test\Unit\Model\Layer\Filter;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Test for \Magento\CatalogSearch\Model\Layer\Filter\Price

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/ResourceModel/Fulltext/CollectionTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/ResourceModel/Fulltext/CollectionTest.php
@@ -7,7 +7,7 @@ namespace Magento\CatalogSearch\Test\Unit\Model\ResourceModel\Fulltext;
 
 use Magento\CatalogSearch\Test\Unit\Model\ResourceModel\BaseCollection;
 use Magento\Framework\Search\Adapter\Mysql\TemporaryStorageFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Catalog\Model\ResourceModel\Product\Collection\ProductLimitationFactory;
 
 /**

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Category/UpdateUrlPathTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Category/UpdateUrlPathTest.php
@@ -13,7 +13,7 @@ use Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGenerator;
 use Magento\CatalogUrlRewrite\Service\V1\StoreViewService;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Catalog\Model\ResourceModel\Category as CategoryResource;
 
 /**

--- a/app/code/Magento/Checkout/Test/Unit/Block/Checkout/LayoutProcessorTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Checkout/LayoutProcessorTest.php
@@ -12,7 +12,7 @@ use Magento\Customer\Model\AttributeMetadataDataProvider;
 use Magento\Customer\Model\Options;
 
 use Magento\Ui\Component\Form\AttributeMapper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * LayoutProcessorTest covers a list of variations for checkout layout processor

--- a/app/code/Magento/Checkout/Test/Unit/Controller/Index/IndexTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Controller/Index/IndexTest.php
@@ -12,7 +12,7 @@ use Magento\Framework\App\Request\Http;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\Builder\InvocationMocker as InvocationMocker;
 use PHPUnit\Framework\MockObject\Matcher\InvokedCount as InvokedCount;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Checkout\Helper\Data;
 use Magento\Quote\Model\Quote;
 use Magento\Framework\View\Result\Page;

--- a/app/code/Magento/Checkout/Test/Unit/Model/Cart/RequestQuantityProcessorTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/Cart/RequestQuantityProcessorTest.php
@@ -9,7 +9,7 @@ namespace Magento\Checkout\Test\Unit\Model\Cart;
 
 use Magento\Checkout\Model\Cart\RequestQuantityProcessor;
 use Magento\Framework\Locale\ResolverInterface;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class RequestQuantityProcessorTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Checkout/Test/Unit/Model/GuestPaymentInformationManagementTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/GuestPaymentInformationManagementTest.php
@@ -273,7 +273,7 @@ class GuestPaymentInformationManagementTest extends \PHPUnit\Framework\TestCase
      */
     private function getMockForAssignBillingAddress(
         int $cartId,
-        \PHPUnit_Framework_MockObject_MockObject  $billingAddressMock
+        \PHPUnit\Framework\MockObject\MockObject  $billingAddressMock
     ) : void {
         $quoteIdMask = $this->createPartialMock(QuoteIdMask::class, ['getQuoteId', 'load']);
         $this->quoteIdMaskFactoryMock->method('create')

--- a/app/code/Magento/Checkout/Test/Unit/Model/Session/SuccessValidatorTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/Session/SuccessValidatorTest.php
@@ -94,7 +94,7 @@ class SuccessValidatorTest extends \PHPUnit\Framework\TestCase
      * @param \PHPUnit_Framework_MockObject_MockObject $checkoutSession
      * @return object
      */
-    protected function createSuccessValidator(\PHPUnit_Framework_MockObject_MockObject $checkoutSession)
+    protected function createSuccessValidator(\PHPUnit\Framework\MockObject\MockObject $checkoutSession)
     {
         return $this->objectManagerHelper->getObject(
             \Magento\Checkout\Model\Session\SuccessValidator::class,

--- a/app/code/Magento/Cms/Test/Unit/Ui/Component/Listing/Column/BlockActionsTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Ui/Component/Listing/Column/BlockActionsTest.php
@@ -11,7 +11,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponent\Processor;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * BlockActionsTest contains unit tests for \Magento\Cms\Ui\Component\Listing\Column\BlockActions class

--- a/app/code/Magento/Config/Test/Unit/App/Config/Source/DumpConfigSourceAggregatedTest.php
+++ b/app/code/Magento/Config/Test/Unit/App/Config/Source/DumpConfigSourceAggregatedTest.php
@@ -10,7 +10,7 @@ use Magento\Config\Model\Config\Export\ExcludeList;
 use Magento\Config\Model\Config\TypePool;
 use Magento\Framework\App\Config\ConfigSourceInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class DumpConfigSourceAggregatedTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Config/Test/Unit/App/Config/Source/InitialSnapshotConfigSourceTest.php
+++ b/app/code/Magento/Config/Test/Unit/App/Config/Source/InitialSnapshotConfigSourceTest.php
@@ -9,7 +9,7 @@ use Magento\Config\App\Config\Source\InitialSnapshotConfigSource;
 use Magento\Framework\DataObject;
 use Magento\Framework\DataObjectFactory;
 use Magento\Framework\FlagManager;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * @inheritdoc

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/ConfigSetProcessorFactoryTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/ConfigSetProcessorFactoryTest.php
@@ -11,7 +11,7 @@ use Magento\Config\Console\Command\ConfigSet\ConfigSetProcessorInterface;
 use Magento\Config\Console\Command\ConfigSet\DefaultProcessor;
 use Magento\Config\Console\Command\ConfigSet\LockProcessor;
 use Magento\Framework\ObjectManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Test for ConfigSetProcessorFactory.

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/DefaultProcessorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/DefaultProcessorTest.php
@@ -16,7 +16,7 @@ use Magento\Store\Model\ScopeInterface;
 use Magento\Config\Model\PreparedValueFactory;
 use Magento\Framework\App\Config\Value;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Test for DefaultProcessor.

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/LockConfigProcessorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/LockConfigProcessorTest.php
@@ -15,7 +15,7 @@ use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Stdlib\ArrayManager;
 use Magento\Store\Model\ScopeInterface;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Test for ShareProcessor.

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/LockEnvProcessorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/LockEnvProcessorTest.php
@@ -15,7 +15,7 @@ use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Stdlib\ArrayManager;
 use Magento\Store\Model\ScopeInterface;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Test for LockProcessor.

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/ProcessorFacadeTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/ProcessorFacadeTest.php
@@ -19,7 +19,7 @@ use Magento\Framework\Exception\ConfigurationMismatchException;
 use Magento\Deploy\Model\DeploymentConfig\Hash;
 use Magento\Config\App\Config\Type\System;
 use Magento\Framework\App\Config;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Test for ProcessorFacade.

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSetCommandTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSetCommandTest.php
@@ -14,7 +14,7 @@ use Magento\Deploy\Model\DeploymentConfig\ChangeDetector;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Console\Cli;
 use Magento\Framework\Exception\ValidatorException;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShowCommandTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShowCommandTest.php
@@ -9,7 +9,7 @@ use Magento\Config\Console\Command\ConfigShowCommand;
 use Magento\Framework\App\Config\ConfigSourceInterface;
 use Magento\Framework\Console\Cli;
 use Magento\Framework\Exception\LocalizedException;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Framework\App\Scope\ValidatorInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Magento\Framework\App\Config\ConfigPathResolver;

--- a/app/code/Magento/Config/Test/Unit/Console/Command/EmulatedAdminhtmlAreaProcessorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/EmulatedAdminhtmlAreaProcessorTest.php
@@ -9,7 +9,7 @@ use Magento\Config\Console\Command\EmulatedAdminhtmlAreaProcessor;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\State;
 use Magento\Framework\Config\ScopeInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class EmulatedAdminhtmlAreaProcessorTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Export/TypePoolTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Export/TypePoolTest.php
@@ -7,7 +7,7 @@ namespace Magento\Config\Test\Unit\Model\Config\Export;
 
 use Magento\Config\Model\Config\Export\ExcludeList;
 use Magento\Config\Model\Config\TypePool;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class TypePoolTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Importer/SaveProcessorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Importer/SaveProcessorTest.php
@@ -12,7 +12,7 @@ use Magento\Config\Model\PreparedValueFactory;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\Value;
 use Magento\Framework\Stdlib\ArrayUtils;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Test for SaveProcessor.

--- a/app/code/Magento/Config/Test/Unit/Model/Config/ImporterTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/ImporterTest.php
@@ -16,7 +16,7 @@ use Magento\Framework\Config\ScopeInterface;
 use Magento\Framework\Flag;
 use Magento\Framework\FlagManager;
 use Magento\Framework\Stdlib\ArrayUtils;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Test for Importer.

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Parser/CommentTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Parser/CommentTest.php
@@ -10,7 +10,7 @@ use Magento\Config\Model\Placeholder\PlaceholderInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\ReadInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class CommentTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Config/Test/Unit/Model/Config/PathValidatorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/PathValidatorTest.php
@@ -8,7 +8,7 @@ namespace Magento\Config\Test\Unit\Model\Config;
 
 use Magento\Config\Model\Config\PathValidator;
 use Magento\Config\Model\Config\Structure;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Test class for PathValidator.

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Processor/EnvironmentPlaceholderTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Processor/EnvironmentPlaceholderTest.php
@@ -9,7 +9,7 @@ use Magento\Config\Model\Config\Processor\EnvironmentPlaceholder;
 use Magento\Config\Model\Placeholder\PlaceholderFactory;
 use Magento\Config\Model\Placeholder\PlaceholderInterface;
 use Magento\Framework\Stdlib\ArrayManager;
-use \PHPUnit_Framework_MockObject_MockObject as Mock;
+use \PHPUnit\Framework\MockObject\MockObject as Mock;
 
 class EnvironmentPlaceholderTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Config/Test/Unit/Model/Config/StructureTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/StructureTest.php
@@ -11,7 +11,7 @@ use Magento\Config\Model\Config\Structure;
 use Magento\Config\Model\Config\Structure\Data;
 use Magento\Config\Model\Config\Structure\Element\FlyweightFactory;
 use Magento\Config\Model\Config\Structure\Element\Iterator\Tab as TabIterator;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Test for Structure.

--- a/app/code/Magento/Config/Test/Unit/Model/Placeholder/EnvironmentTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Placeholder/EnvironmentTest.php
@@ -9,7 +9,7 @@ use Magento\Config\Model\Placeholder\Environment;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Config\ConfigOptionsListConstants;
-use \PHPUnit_Framework_MockObject_MockObject as Mock;
+use \PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Class EnvironmentTest

--- a/app/code/Magento/Config/Test/Unit/Model/PreparedValueFactoryTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/PreparedValueFactoryTest.php
@@ -18,7 +18,7 @@ use Magento\Store\Model\ScopeInterface as StoreScopeInterface;
 use Magento\Framework\App\ScopeResolver;
 use Magento\Framework\App\ScopeResolverPool;
 use Magento\Store\Model\ScopeTypeNormalizer;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * @inheritdoc

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
@@ -408,7 +408,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
      * @param \PHPUnit_Framework_MockObject_MockObject $productMock
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    private function getProductTypeMock(\PHPUnit_Framework_MockObject_MockObject $productMock)
+    private function getProductTypeMock(\PHPUnit\Framework\MockObject\MockObject $productMock)
     {
         $currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
             ->disableOriginalConstructor()
@@ -469,7 +469,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
      * @param float $amount
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    protected function getAmountMock($amount): \PHPUnit_Framework_MockObject_MockObject
+    protected function getAmountMock($amount): \PHPUnit\Framework\MockObject\MockObject
     {
         $amountMock = $this->getMockBuilder(\Magento\Framework\Pricing\Amount\AmountInterface::class)
             ->setMethods([
@@ -495,7 +495,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
      * @param int $percentage
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    protected function getTierPriceMock(\PHPUnit_Framework_MockObject_MockObject $amountMock, $priceQty, $percentage)
+    protected function getTierPriceMock(\PHPUnit\Framework\MockObject\MockObject $amountMock, $priceQty, $percentage)
     {
         $tierPrice = [
             'price_qty' => $priceQty,

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Controller/Adminhtml/Product/Initialization/Helper/Plugin/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Controller/Adminhtml/Product/Initialization/Helper/Plugin/ConfigurableTest.php
@@ -13,7 +13,7 @@ use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableP
 use Magento\ConfigurableProduct\Model\Product\VariationHandler;
 use Magento\ConfigurableProduct\Test\Unit\Model\Product\ProductExtensionAttributes;
 use Magento\Framework\App\Request\Http;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ConfigurableTest

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Helper/Product/Options/FactoryTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Helper/Product/Options/FactoryTest.php
@@ -14,7 +14,7 @@ use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable\AttributeFactory;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class FactoryTest

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Helper/Product/Options/LoaderTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Helper/Product/Options/LoaderTest.php
@@ -13,7 +13,7 @@ use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute;
 use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Attribute\Collection;
 use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class LoaderTest

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Plugin/PriceBackendTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Plugin/PriceBackendTest.php
@@ -12,7 +12,7 @@ use Magento\Catalog\Model\Product\Type;
 use Magento\ConfigurableProduct\Model\Plugin\PriceBackend;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class PriceBackendTest

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Plugin/ProductRepositorySaveTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Plugin/ProductRepositorySaveTest.php
@@ -15,7 +15,7 @@ use Magento\ConfigurableProduct\Model\Plugin\ProductRepositorySave;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\ConfigurableProduct\Test\Unit\Model\Product\ProductExtensionAttributes;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ProductRepositorySaveTest

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/ReadHandlerTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/ReadHandlerTest.php
@@ -9,7 +9,7 @@ use Magento\Catalog\Model\Product;
 use Magento\ConfigurableProduct\Helper\Product\Options\Loader;
 use Magento\ConfigurableProduct\Model\Product\ReadHandler;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ReadHandlerTest

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/SaveHandlerTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/SaveHandlerTest.php
@@ -14,7 +14,7 @@ use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableM
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute;
 use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable;
 use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\ConfigurableFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class SaveHandlerTest
@@ -235,7 +235,7 @@ class SaveHandlerTest extends \PHPUnit\Framework\TestCase
      * @param $id
      * @return void
      */
-    private function processSaveOptions(\PHPUnit_Framework_MockObject_MockObject $attribute, $sku, $id)
+    private function processSaveOptions(\MockObject $attribute, $sku, $id)
     {
         $attribute->expects(static::once())
             ->method('setId')

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Quote/Item/CartItemProcessorTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Quote/Item/CartItemProcessorTest.php
@@ -6,7 +6,7 @@
 namespace Magento\ConfigurableProduct\Test\Unit\Model\Quote\Item;
 
 use Magento\ConfigurableProduct\Test\Unit\Model\Product\ProductOptionExtensionAttributes;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Observer/HideUnsupportedAttributeTypesTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Observer/HideUnsupportedAttributeTypesTest.php
@@ -13,7 +13,7 @@ use Magento\Framework\Event\Observer as EventObserver;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\View\Element\BlockInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Unit test for Magento\ConfigurableProduct\Observer\HideUnsupportedAttributeTypes
@@ -48,7 +48,7 @@ class HideUnsupportedAttributeTypesTest extends \PHPUnit\Framework\TestCase
      * @param array $supportedTypes
      * @return HideUnsupportedAttributeTypes
      */
-    private function createTarget(\PHPUnit_Framework_MockObject_MockObject $request, array $supportedTypes = [])
+    private function createTarget(\MockObject $request, array $supportedTypes = [])
     {
         return $this->objectManager->getObject(
             HideUnsupportedAttributeTypes::class,
@@ -90,7 +90,7 @@ class HideUnsupportedAttributeTypesTest extends \PHPUnit\Framework\TestCase
      * @return EventObserver|\PHPUnit_Framework_MockObject_MockObject
      * @internal param null|MockObject $block
      */
-    private function createEventMock(\PHPUnit_Framework_MockObject_MockObject $form = null)
+    private function createEventMock(\MockObject $form = null)
     {
         $event = $this->getMockBuilder(EventObserver::class)
             ->setMethods(['getForm', 'getBlock'])

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Plugin/SalesRule/Model/Rule/Condition/ProductTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Plugin/SalesRule/Model/Rule/Condition/ProductTest.php
@@ -172,7 +172,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
     /**
      * @return Product|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function createProductMock(): \PHPUnit_Framework_MockObject_MockObject
+    private function createProductMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         $productMock = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
             ->disableOriginalConstructor()

--- a/app/code/Magento/Cron/Test/Unit/Console/Command/CronCommandTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Console/Command/CronCommandTest.php
@@ -8,7 +8,7 @@ namespace Magento\Cron\Test\Unit\Console\Command;
 use Magento\Cron\Console\Command\CronCommand;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\ObjectManagerFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class CronCommandTest extends \PHPUnit\Framework\TestCase

--- a/app/code/Magento/Customer/Test/Unit/Controller/Ajax/LoginTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Ajax/LoginTest.php
@@ -28,7 +28,7 @@ use Magento\Framework\Stdlib\Cookie\CookieMetadata;
 use Magento\Framework\Stdlib\Cookie\CookieMetadataFactory;
 use Magento\Framework\Stdlib\CookieManagerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/Customer/Test/Unit/Controller/Section/LoadTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Section/LoadTest.php
@@ -14,7 +14,7 @@ use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\Escaper;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Framework\App\Request\Http as HttpRequest;
 
 class LoadTest extends \PHPUnit\Framework\TestCase

--- a/app/code/Magento/Customer/Test/Unit/Model/Customer/DataProviderTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Customer/DataProviderTest.php
@@ -335,8 +335,8 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
      * @param array $options
      */
     private function injectVisibilityProps(
-        \PHPUnit_Framework_MockObject_MockObject $attributeMock,
-        \PHPUnit_Framework_MockObject_MockObject $attributeBooleanMock,
+        \PHPUnit\Framework\MockObject\MockObject $attributeMock,
+        \PHPUnit\Framework\MockObject\MockObject $attributeBooleanMock,
         array $options = []
     ) {
         if (isset($options[self::ATTRIBUTE_CODE]['visible'])) {

--- a/app/code/Magento/Customer/Test/Unit/Model/Plugin/CustomerFlushFormKeyTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Plugin/CustomerFlushFormKeyTest.php
@@ -12,7 +12,7 @@ use Magento\Framework\Data\Form\FormKey as DataFormKey;
 use Magento\Framework\Event\Observer;
 use Magento\PageCache\Observer\FlushFormKey;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class CustomerFlushFormKeyTest extends TestCase
 {

--- a/app/code/Magento/Customer/Test/Unit/Ui/Component/DataProvider/DocumentTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Ui/Component/DataProvider/DocumentTest.php
@@ -17,7 +17,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Phrase;
 use Magento\Store\Api\Data\WebsiteInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class DocumentTest

--- a/app/code/Magento/Deploy/Test/Unit/Console/Command/App/SensitiveConfigSet/CollectorFactoryTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Console/Command/App/SensitiveConfigSet/CollectorFactoryTest.php
@@ -11,7 +11,7 @@ use Magento\Deploy\Console\Command\App\SensitiveConfigSet\CollectorInterface;
 use Magento\Deploy\Console\Command\App\SensitiveConfigSet\InteractiveCollector;
 use Magento\Deploy\Console\Command\App\SensitiveConfigSet\SimpleCollector;
 use Magento\Framework\ObjectManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use stdClass;
 
 class CollectorFactoryTest extends \PHPUnit\Framework\TestCase

--- a/app/code/Magento/Deploy/Test/Unit/Console/Command/App/SensitiveConfigSet/InteractiveCollectorTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Console/Command/App/SensitiveConfigSet/InteractiveCollectorTest.php
@@ -6,7 +6,7 @@
 namespace Magento\Deploy\Test\Unit\Console\Command\App\SensitiveConfigSet;
 
 use Magento\Deploy\Console\Command\App\SensitiveConfigSet\InteractiveCollector;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;

--- a/app/code/Magento/Deploy/Test/Unit/Console/Command/App/SensitiveConfigSet/SensitiveConfigSetFacadeTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Console/Command/App/SensitiveConfigSet/SensitiveConfigSetFacadeTest.php
@@ -17,7 +17,7 @@ use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/app/code/Magento/Deploy/Test/Unit/Console/Command/App/SensitiveConfigSet/SimpleCollectorTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Console/Command/App/SensitiveConfigSet/SimpleCollectorTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Question\QuestionFactory;
 use Symfony\Component\Console\Helper\QuestionHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class SimpleCollectorTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Deploy/Test/Unit/Console/Command/App/SensitiveConfigSetCommandTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Console/Command/App/SensitiveConfigSetCommandTest.php
@@ -12,7 +12,7 @@ use Magento\Deploy\Console\Command\App\SensitiveConfigSetCommand;
 use Magento\Deploy\Model\DeploymentConfig\ChangeDetector;
 use Magento\Deploy\Model\DeploymentConfig\Hash;
 use Magento\Framework\Console\Cli;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**

--- a/app/code/Magento/Deploy/Test/Unit/Model/ConfigWriterTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Model/ConfigWriterTest.php
@@ -12,7 +12,7 @@ use Magento\Framework\App\Config\Value;
 use Magento\Framework\App\DeploymentConfig\Writer;
 use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\Stdlib\ArrayManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class ConfigWriterTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Deploy/Test/Unit/Model/DeploymentConfig/ImporterPoolTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Model/DeploymentConfig/ImporterPoolTest.php
@@ -10,7 +10,7 @@ use Magento\Deploy\Model\DeploymentConfig\ImporterPool;
 use Magento\Deploy\Model\DeploymentConfig\ValidatorFactory;
 use Magento\Framework\App\DeploymentConfig\ValidatorInterface;
 use Magento\Framework\ObjectManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 class ImporterPoolTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Deploy/Test/Unit/Model/DeploymentConfig/ValidatorFactoryTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Model/DeploymentConfig/ValidatorFactoryTest.php
@@ -8,7 +8,7 @@ namespace Magento\Deploy\Test\Unit\Model\DeploymentConfig;
 use Magento\Deploy\Model\DeploymentConfig\ValidatorFactory;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Store\Model\Config\Validator;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 class ValidatorFactoryTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Deploy/Test/Unit/Model/FilesystemTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Model/FilesystemTest.php
@@ -14,7 +14,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Store\Model\Config\StoreView;
 use Magento\User\Model\ResourceModel\User\Collection;
 use Magento\User\Model\User;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Symfony\Component\Console\Output\OutputInterface;
 use Magento\Framework\Validator\Locale;
 use Magento\Framework\Setup\Lists;

--- a/app/code/Magento/Deploy/Test/Unit/Model/ModeTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Model/ModeTest.php
@@ -17,7 +17,7 @@ use Magento\Framework\App\DeploymentConfig\Reader;
 use Magento\Framework\App\DeploymentConfig\Writer;
 use Magento\Framework\App\MaintenanceMode;
 use Magento\Framework\App\State;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Magento\Framework\Config\File\ConfigFilePool;

--- a/app/code/Magento/Deploy/Test/Unit/Process/QueueTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Process/QueueTest.php
@@ -14,7 +14,7 @@ use Magento\Framework\Locale\ResolverInterface as LocaleResolver;
 use Magento\Framework\App\ResourceConnection;
 use Psr\Log\LoggerInterface;
 
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Deployment Queue class unit tests

--- a/app/code/Magento/Deploy/Test/Unit/Service/DeployStaticContentTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Service/DeployStaticContentTest.php
@@ -22,7 +22,7 @@ use Magento\Framework\ObjectManagerInterface;
 
 use Psr\Log\LoggerInterface;
 
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Static Content deploy service class unit tests

--- a/app/code/Magento/Deploy/Test/Unit/Service/DeployTranslationsDictionaryTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Service/DeployTranslationsDictionaryTest.php
@@ -13,7 +13,7 @@ use Magento\Framework\Translate\Js\Config as JsTranslationConfig;
 
 use Psr\Log\LoggerInterface;
 
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Translation Dictionaries deploy service class unit tests

--- a/app/code/Magento/Deploy/Test/Unit/Service/MinifyTemplatesTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Service/MinifyTemplatesTest.php
@@ -10,7 +10,7 @@ use Magento\Deploy\Service\MinifyTemplates;
 use Magento\Framework\App\Utility\Files;
 use Magento\Framework\View\Template\Html\MinifierInterface;
 
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Minify Templates service class unit tests

--- a/app/code/Magento/Deploy/Test/Unit/Strategy/CompactDeployTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Strategy/CompactDeployTest.php
@@ -10,7 +10,7 @@ use Magento\Deploy\Package\Package;
 use Magento\Deploy\Package\PackagePool;
 use Magento\Deploy\Process\Queue;
 
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Compact deployment service class implementation unit tests

--- a/app/code/Magento/Developer/Test/Unit/Model/Logger/Handler/SyslogTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Model/Logger/Handler/SyslogTest.php
@@ -12,7 +12,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Logger\Monolog;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * @inheritdoc

--- a/app/code/Magento/Dhl/Test/Unit/Model/CarrierTest.php
+++ b/app/code/Magento/Dhl/Test/Unit/Model/CarrierTest.php
@@ -30,7 +30,7 @@ use Magento\Shipping\Model\Simplexml\Element;
 use Magento\Shipping\Model\Simplexml\ElementFactory;
 use Magento\Store\Model\StoreManager;
 use Magento\Store\Model\Website;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Psr\Log\LoggerInterface;
 use Magento\Store\Model\ScopeInterface;
 

--- a/app/code/Magento/Dhl/Test/Unit/Model/Validator/XmlValidatorTest.php
+++ b/app/code/Magento/Dhl/Test/Unit/Model/Validator/XmlValidatorTest.php
@@ -7,7 +7,7 @@
 namespace Magento\Dhl\Test\Unit\Model\Validator;
 
 use Magento\Sales\Exception\DocumentValidationException;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Framework\Xml\Security;
 use Magento\Dhl\Model\Validator\ResponseErrorProcessor;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;

--- a/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
@@ -14,7 +14,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\DataObject;
 use Magento\Framework\HTTP\ZendClient;
 use Magento\Framework\HTTP\ZendClientFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * FixerIo Test

--- a/app/code/Magento/Directory/Test/Unit/Model/ResourceModel/Region/CollectionTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/ResourceModel/Region/CollectionTest.php
@@ -17,7 +17,7 @@ use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\DataObject;
 use Psr\Log\LoggerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class CollectionTest

--- a/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/BatchDataMapper/ProductDataMapperTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/BatchDataMapper/ProductDataMapperTest.php
@@ -195,7 +195,7 @@ class ProductDataMapperTest extends \PHPUnit\Framework\TestCase
      * @param array attributeData
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    private function getAttribute(array $attributeData): \PHPUnit_Framework_MockObject_MockObject
+    private function getAttribute(array $attributeData): \PHPUnit\Framework\MockObject\MockObject
     {
         $attributeMock = $this->createMock(Attribute::class);
         $attributeMock->method('getAttributeCode')->willReturn($attributeData['code']);

--- a/app/code/Magento/Elasticsearch/Test/Unit/SearchAdapter/Query/Builder/MatchTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/SearchAdapter/Query/Builder/MatchTest.php
@@ -9,7 +9,7 @@ use Magento\Elasticsearch\Model\Adapter\FieldMapperInterface;
 use Magento\Elasticsearch\SearchAdapter\Query\Builder\Match as MatchQueryBuilder;
 use Magento\Framework\Search\Request\Query\Match as MatchRequestQuery;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class MatchTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Fedex/Test/Unit/Model/CarrierTest.php
+++ b/app/code/Magento/Fedex/Test/Unit/Model/CarrierTest.php
@@ -35,7 +35,7 @@ use Magento\Shipping\Model\Tracking\Result\StatusFactory;
 use Magento\Shipping\Model\Tracking\ResultFactory;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/app/code/Magento/GoogleOptimizer/Test/Unit/Ui/DataProvider/Product/Form/Modifier/GoogleOptimizerTest.php
+++ b/app/code/Magento/GoogleOptimizer/Test/Unit/Ui/DataProvider/Product/Form/Modifier/GoogleOptimizerTest.php
@@ -13,7 +13,7 @@ use Magento\Ui\Component\Form\Element\Input;
 use Magento\Ui\Component\Form\Element\Textarea;
 use Magento\Ui\Component\Form\Field;
 use Magento\Ui\Component\Form\Fieldset;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class GoogleOptimizerTest

--- a/app/code/Magento/MessageQueue/Test/Unit/Model/Cron/ConsumersRunner/PidConsumerManagerTest.php
+++ b/app/code/Magento/MessageQueue/Test/Unit/Model/Cron/ConsumersRunner/PidConsumerManagerTest.php
@@ -10,7 +10,7 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Framework\Filesystem\Directory\ReadInterface;
 use Magento\Framework\Filesystem;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class PidConsumerManagerTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/MessageQueue/Test/Unit/Model/Cron/ConsumersRunnerTest.php
+++ b/app/code/Magento/MessageQueue/Test/Unit/Model/Cron/ConsumersRunnerTest.php
@@ -6,7 +6,7 @@
 namespace Magento\MessageQueue\Test\Unit\Model\Cron;
 
 use Magento\Framework\MessageQueue\ConnectionTypeResolver;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Framework\ShellInterface;
 use Magento\Framework\MessageQueue\Consumer\ConfigInterface as ConsumerConfigInterface;
 use Magento\Framework\MessageQueue\Consumer\Config\ConsumerConfigItemInterface;

--- a/app/code/Magento/Multishipping/Test/Unit/Model/Checkout/Type/MultishippingTest.php
+++ b/app/code/Magento/Multishipping/Test/Unit/Model/Checkout/Type/MultishippingTest.php
@@ -45,7 +45,7 @@ use Magento\Quote\Model\ShippingAssignment;
 use Magento\Sales\Model\Order\Email\Sender\OrderSender;
 use Magento\Sales\Model\OrderFactory;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use \PHPUnit\Framework\TestCase;
 use Magento\Quote\Model\Quote\Payment;
 use Magento\Payment\Model\Method\AbstractMethod;
@@ -513,7 +513,7 @@ class MultishippingTest extends \PHPUnit\Framework\TestCase
      * @param string $paymentProviderCode
      * @return PHPUnit_Framework_MockObject_MockObject
      */
-    private function getPaymentMock(string $paymentProviderCode): PHPUnit_Framework_MockObject_MockObject
+    private function getPaymentMock(string $paymentProviderCode): MockObject
     {
         $abstractMethod = $this->getMockBuilder(AbstractMethod::class)
             ->disableOriginalConstructor()
@@ -535,7 +535,7 @@ class MultishippingTest extends \PHPUnit\Framework\TestCase
      * @param \Magento\Catalog\Model\Product\Type\Simple|PHPUnit_Framework_MockObject_MockObject $simpleProductTypeMock
      * @return PHPUnit_Framework_MockObject_MockObject
      */
-    private function getProductMock($simpleProductTypeMock): PHPUnit_Framework_MockObject_MockObject
+    private function getProductMock($simpleProductTypeMock): MockObject
     {
         $productMock = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
             ->disableOriginalConstructor()
@@ -551,7 +551,7 @@ class MultishippingTest extends \PHPUnit\Framework\TestCase
      * @param \Magento\Catalog\Model\Product|PHPUnit_Framework_MockObject_MockObject $productMock
      * @return PHPUnit_Framework_MockObject_MockObject
      */
-    private function getQuoteItemMock($productType, $productMock): PHPUnit_Framework_MockObject_MockObject
+    private function getQuoteItemMock($productType, $productMock): MockObject
     {
         $quoteItemMock = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
             ->disableOriginalConstructor()
@@ -573,7 +573,7 @@ class MultishippingTest extends \PHPUnit\Framework\TestCase
         $quoteItemMock,
         string $productType,
         array $infoBuyRequest
-    ): PHPUnit_Framework_MockObject_MockObject {
+    ): MockObject {
         $quoteAddressItemMock = $this->getMockBuilder(\Magento\Quote\Model\Quote\Address\Item::class)
             ->disableOriginalConstructor()
             ->setMethods(['getQuoteItem', 'setProductType', 'setProductOptions', 'getParentItem'])
@@ -658,7 +658,7 @@ class MultishippingTest extends \PHPUnit\Framework\TestCase
         $orderAddressMock,
         $orderPaymentMock,
         $orderItemMock
-    ): PHPUnit_Framework_MockObject_MockObject {
+    ): MockObject {
         $orderMock = $this->getMockBuilder(\Magento\Sales\Model\Order::class)
             ->disableOriginalConstructor()
             ->setMethods(

--- a/app/code/Magento/OfflinePayments/Test/Unit/Block/Info/CheckmoTest.php
+++ b/app/code/Magento/OfflinePayments/Test/Unit/Block/Info/CheckmoTest.php
@@ -8,7 +8,7 @@ namespace Magento\OfflinePayments\Test\Unit\Block\Info;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\OfflinePayments\Block\Info\Checkmo;
 use Magento\Payment\Model\Info;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * CheckmoTest contains list of test for block methods testing

--- a/app/code/Magento/OfflinePayments/Test/Unit/Observer/BeforeOrderPaymentSaveObserverTest.php
+++ b/app/code/Magento/OfflinePayments/Test/Unit/Observer/BeforeOrderPaymentSaveObserverTest.php
@@ -12,7 +12,7 @@ use Magento\OfflinePayments\Model\Banktransfer;
 use Magento\OfflinePayments\Model\Cashondelivery;
 use Magento\OfflinePayments\Observer\BeforeOrderPaymentSaveObserver;
 use Magento\Sales\Model\Order\Payment;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\OfflinePayments\Model\Checkmo;
 
 class BeforeOrderPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase

--- a/app/code/Magento/OfflineShipping/Test/Unit/Model/Quote/Address/FreeShippingTest.php
+++ b/app/code/Magento/OfflineShipping/Test/Unit/Model/Quote/Address/FreeShippingTest.php
@@ -14,7 +14,7 @@ use Magento\Quote\Model\Quote\Address;
 use Magento\Quote\Model\Quote\Item;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class FreeShippingTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Payment/Test/Unit/Gateway/Command/GatewayCommandTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Gateway/Command/GatewayCommandTest.php
@@ -14,7 +14,7 @@ use Magento\Payment\Gateway\Request\BuilderInterface;
 use Magento\Payment\Gateway\Response\HandlerInterface;
 use Magento\Payment\Gateway\Validator\ResultInterface;
 use Magento\Payment\Gateway\Validator\ValidatorInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/app/code/Magento/Payment/Test/Unit/Model/Checks/CanUseForCountry/CountryProviderTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Model/Checks/CanUseForCountry/CountryProviderTest.php
@@ -9,7 +9,7 @@ use Magento\Directory\Helper\Data;
 use Magento\Payment\Model\Checks\CanUseForCountry\CountryProvider;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Address;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * CountryProviderTest contains tests for CountryProvider class

--- a/app/code/Magento/Payment/Test/Unit/Model/Method/AdapterTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Model/Method/AdapterTest.php
@@ -18,7 +18,7 @@ use Magento\Payment\Gateway\Validator\ValidatorInterface;
 use Magento\Payment\Gateway\Validator\ValidatorPoolInterface;
 use Magento\Payment\Model\InfoInterface;
 use Magento\Payment\Model\Method\Adapter;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/Payment/Test/Unit/Observer/SalesOrderBeforeSaveObserverTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Observer/SalesOrderBeforeSaveObserverTest.php
@@ -222,7 +222,7 @@ class SalesOrderBeforeSaveObserverTest extends \PHPUnit\Framework\TestCase
      * @param \PHPUnit_Framework_MockObject_MockObject $order
      * @param array $methods
      */
-    private function _prepareNeverInvokedOrderMethods(\PHPUnit_Framework_MockObject_MockObject $order, $methods = [])
+    private function _prepareNeverInvokedOrderMethods(\PHPUnit\Framework\MockObject\MockObject $order, $methods = [])
     {
         foreach ($methods as $method) {
             $order->expects($this->never())->method($method);

--- a/app/code/Magento/Paypal/Test/Unit/Block/Adminhtml/Order/ViewTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Block/Adminhtml/Order/ViewTest.php
@@ -13,7 +13,7 @@ use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
 use PHPUnit\Framework\TestCase;
 use Magento\Framework\Exception\LocalizedException;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 /**

--- a/app/code/Magento/Paypal/Test/Unit/Block/Adminhtml/System/Config/Fieldset/HintTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Block/Adminhtml/System/Config/Fieldset/HintTest.php
@@ -8,7 +8,7 @@ namespace Magento\Paypal\Test\Unit\Block\Adminhtml\System\Config\Fieldset;
 use Magento\Framework\Data\Form\Element\AbstractElement;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Hint;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class HintTest

--- a/app/code/Magento/Paypal/Test/Unit/Controller/Payflow/ReturnUrlTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Controller/Payflow/ReturnUrlTest.php
@@ -20,7 +20,7 @@ use Magento\Paypal\Model\Config;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Sales\Model\OrderFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ReturnUrlTest

--- a/app/code/Magento/Paypal/Test/Unit/Model/ExpressTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/ExpressTest.php
@@ -19,7 +19,7 @@ use Magento\Quote\Api\Data\PaymentInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Sales\Model\Order\Payment\Transaction\BuilderInterface;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ExpressTest

--- a/app/code/Magento/Paypal/Test/Unit/Model/Payflow/AvsEmsCodeMapperTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/Payflow/AvsEmsCodeMapperTest.php
@@ -9,7 +9,7 @@ use Magento\Paypal\Model\Config;
 use Magento\Paypal\Model\Info;
 use Magento\Paypal\Model\Payflow\AvsEmsCodeMapper;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class AvsEmsCodeMapperTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Paypal/Test/Unit/Model/Payflow/CvvEmsCodeMapperTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/Payflow/CvvEmsCodeMapperTest.php
@@ -9,7 +9,7 @@ use Magento\Paypal\Model\Config;
 use Magento\Paypal\Model\Info;
 use Magento\Paypal\Model\Payflow\CvvEmsCodeMapper;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class CvvEmsCodeMapperTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Paypal/Test/Unit/Model/Payflow/Service/Request/SecureTokenTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/Payflow/Service/Request/SecureTokenTest.php
@@ -12,7 +12,7 @@ use Magento\Paypal\Model\Payflow\Service\Request\SecureToken;
 use Magento\Paypal\Model\Payflow\Transparent;
 use Magento\Paypal\Model\PayflowConfig;
 use Magento\Quote\Model\Quote;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Test class for \Magento\Paypal\Model\Payflow\Service\Request\SecureToken

--- a/app/code/Magento/Paypal/Test/Unit/Model/Payflow/Service/Response/TransactionTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/Payflow/Service/Response/TransactionTest.php
@@ -12,7 +12,7 @@ use Magento\Paypal\Model\Payflow\Service\Response\Transaction;
 use Magento\Paypal\Model\Payflow\Transparent;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Api\Data\CartInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @see Transaction

--- a/app/code/Magento/Paypal/Test/Unit/Model/Payflow/Service/Response/Validator/AVSResponseTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/Payflow/Service/Response/Validator/AVSResponseTest.php
@@ -8,7 +8,7 @@ namespace Magento\Paypal\Test\Unit\Model\Payflow\Service\Response\Validator;
 use Magento\Payment\Model\Method\ConfigInterface;
 use Magento\Paypal\Model\Payflow\Service\Response\Validator\AVSResponse;
 use Magento\Paypal\Model\Payflow\Transparent;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class AVSResponseTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Paypal/Test/Unit/Model/Payflow/Service/Response/Validator/IAVSResponseTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/Payflow/Service/Response/Validator/IAVSResponseTest.php
@@ -9,7 +9,7 @@ use Magento\Framework\DataObject;
 use Magento\Paypal\Model\Payflow\Service\Response\Validator\IAVSResponse;
 use Magento\Paypal\Model\Payflow\Transparent;
 use Magento\Paypal\Model\PayflowConfig;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class IAVSResponseTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Paypal/Test/Unit/Model/PayflowproTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/PayflowproTest.php
@@ -21,7 +21,7 @@ use Magento\Sales\Model\Order\Payment;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Payment\Model\InfoInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/Quote/Test/Unit/Model/GuestCart/GuestShippingMethodManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/GuestCart/GuestShippingMethodManagementTest.php
@@ -7,7 +7,7 @@
 
 namespace Magento\Quote\Test\Unit\Model\GuestCart;
 
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Api\Data\AddressInterface;
 use Magento\Quote\Api\ShipmentEstimationInterface;

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/ShippingAssignment/ShippingProcessorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/ShippingAssignment/ShippingProcessorTest.php
@@ -12,7 +12,7 @@ use Magento\Quote\Api\Data\ShippingInterface;
 use Magento\Quote\Model\Quote\ShippingAssignment\ShippingProcessor;
 use Magento\Quote\Model\ShippingAddressManagement;
 use Magento\Quote\Model\ShippingMethodManagement;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ShippingProcessorTest

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteRepository/Plugin/AccessChangeQuoteControlTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteRepository/Plugin/AccessChangeQuoteControlTest.php
@@ -12,7 +12,7 @@ use Magento\Quote\Model\QuoteRepository\Plugin\AccessChangeQuoteControl;
 use Magento\Quote\Model\Quote;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Quote\Model\QuoteRepository;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class AccessChangeQuoteControlTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Quote/Test/Unit/Model/ShippingMethodManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/ShippingMethodManagementTest.php
@@ -18,7 +18,7 @@ use Magento\Quote\Model\QuoteRepository;
 use Magento\Quote\Model\ResourceModel\Quote\Address as QuoteAddressResource;
 use Magento\Quote\Model\ShippingMethodManagement;
 use Magento\Store\Model\Store;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/Reports/Test/Unit/Block/Adminhtml/Sales/Coupons/GridTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Block/Adminhtml/Sales/Coupons/GridTest.php
@@ -118,7 +118,7 @@ class GridTest extends \PHPUnit\Framework\TestCase
         \Magento\Framework\DataObject $filterData,
         string $resourceCollectionName,
         int $collectionSize
-    ): \PHPUnit_Framework_MockObject_MockObject {
+    ): \PHPUnit\Framework\MockObject\MockObject {
         $collectionMock = $this->getMockBuilder($resourceCollectionName)
             ->disableOriginalConstructor()
             ->getMock();

--- a/app/code/Magento/Review/Test/Unit/Observer/ProcessProductAfterDeleteEventObserverTest.php
+++ b/app/code/Magento/Review/Test/Unit/Observer/ProcessProductAfterDeleteEventObserverTest.php
@@ -14,7 +14,7 @@ use Magento\Review\Model\ResourceModel\Rating;
 use Magento\Review\Model\ResourceModel\Review;
 use Magento\Review\Observer\ProcessProductAfterDeleteEventObserver;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class ProcessProductAfterDeleteEventObserverTest

--- a/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Address/FormTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Address/FormTest.php
@@ -20,7 +20,7 @@ use Magento\Sales\Block\Adminhtml\Order\Address\Form;
 use Magento\Sales\Model\AdminOrder\Create;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Address;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Backend\Model\Session\Quote as QuoteSession;
 
 /**

--- a/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/FormTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/FormTest.php
@@ -25,7 +25,7 @@ use Magento\Sales\Model\AdminOrder\Create;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/CreateTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/CreateTest.php
@@ -26,7 +26,7 @@ use Magento\Quote\Model\Quote\Item\Updater;
 use Magento\Sales\Model\AdminOrder\Create;
 use Magento\Sales\Model\AdminOrder\Product;
 use Magento\Quote\Model\QuoteFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/InvoiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/InvoiceTest.php
@@ -11,7 +11,7 @@ use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\ResourceModel\Order\Invoice\Collection as InvoiceCollection;
 use Magento\Sales\Model\ResourceModel\OrderFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class InvoiceTest

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/State/AuthorizeCommandTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/State/AuthorizeCommandTest.php
@@ -10,7 +10,7 @@ use Magento\Sales\Api\Data\OrderPaymentInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment\State\AuthorizeCommand;
 use Magento\Sales\Model\Order\StatusResolver;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @see AuthorizeCommand

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/State/CaptureCommandTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/State/CaptureCommandTest.php
@@ -10,7 +10,7 @@ use Magento\Sales\Api\Data\OrderPaymentInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment\State\CaptureCommand;
 use Magento\Sales\Model\Order\StatusResolver;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @see CaptureCommand

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/State/OrderCommandTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/State/OrderCommandTest.php
@@ -10,7 +10,7 @@ use Magento\Sales\Api\Data\OrderPaymentInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment\State\OrderCommand;
 use Magento\Sales\Model\Order\StatusResolver;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @see OrderCommand

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/State/RegisterCaptureNotificationCommandTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/State/RegisterCaptureNotificationCommandTest.php
@@ -10,7 +10,7 @@ use Magento\Sales\Api\Data\OrderPaymentInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment\State\RegisterCaptureNotificationCommand;
 use Magento\Sales\Model\Order\StatusResolver;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @see RegisterCaptureNotificationCommand

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/PaymentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/PaymentTest.php
@@ -15,7 +15,7 @@ use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\Order\OrderStateResolverInterface;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Sales\Model\Order\Payment\Transaction;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class PaymentTest

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ShipmentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ShipmentTest.php
@@ -10,7 +10,7 @@ use Magento\Sales\Model\Order\Shipment;
 use Magento\Sales\Model\Order\Shipment\Item as ShipmentItem;
 use Magento\Sales\Model\ResourceModel\Order\Shipment\Comment\Collection;
 use Magento\Sales\Model\ResourceModel\Order\Shipment\Comment\CollectionFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class ShipmentTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/StatusResolverTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/StatusResolverTest.php
@@ -10,7 +10,7 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
 use Magento\Sales\Model\Order\Config;
 use Magento\Sales\Model\Order\StatusResolver;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class StatusResolverTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Provider/NotSyncedDataProviderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Provider/NotSyncedDataProviderTest.php
@@ -8,7 +8,7 @@ namespace Magento\Sales\Test\Unit\Model\ResourceModel\Provider;
 use Magento\Framework\ObjectManager\TMapFactory;
 use Magento\Sales\Model\ResourceModel\Provider\NotSyncedDataProvider;
 use Magento\Sales\Model\ResourceModel\Provider\NotSyncedDataProviderInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class for testing not synchronized DataProvider.

--- a/app/code/Magento/Sales/Test/Unit/Model/Service/CreditmemoServiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Service/CreditmemoServiceTest.php
@@ -10,7 +10,7 @@ namespace Magento\Sales\Test\Unit\Model\Service;
 use Magento\Sales\Model\Order;
 
 use Magento\Sales\Api\Data\CreditmemoInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class CreditmemoServiceTest

--- a/app/code/Magento/Sales/Test/Unit/Observer/AssignOrderToCustomerObserverTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Observer/AssignOrderToCustomerObserverTest.php
@@ -14,7 +14,7 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Observer\AssignOrderToCustomerObserver;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class AssignOrderToCustomerObserverTest

--- a/app/code/Magento/Sales/Test/Unit/Ui/Component/DataProvider/DocumentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Ui/Component/DataProvider/DocumentTest.php
@@ -12,7 +12,7 @@ use Magento\Framework\Api\AttributeValue;
 use Magento\Framework\Api\AttributeValueFactory;
 use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Ui\Component\DataProvider\Document;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class DocumentTest

--- a/app/code/Magento/SalesRule/Test/Unit/Model/Rule/Action/Discount/CartFixedTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/Rule/Action/Discount/CartFixedTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\SalesRule\Test\Unit\Model\Rule\Action\Discount;
 
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests for Magento\SalesRule\Model\Rule\Action\Discount\CartFixed.

--- a/app/code/Magento/Signifyd/Test/Unit/Block/Adminhtml/CaseInfoTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Block/Adminhtml/CaseInfoTest.php
@@ -12,7 +12,7 @@ use Magento\Signifyd\Api\Data\CaseInterface;
 use Magento\Signifyd\Block\Adminhtml\CaseInfo;
 use Magento\Signifyd\Model\CaseManagement;
 use Magento\Signifyd\Model\Config;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests for Signifyd block information.

--- a/app/code/Magento/Signifyd/Test/Unit/Controller/Webhooks/HandlerTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Controller/Webhooks/HandlerTest.php
@@ -19,7 +19,7 @@ use Magento\Signifyd\Model\SignifydGateway\Response\WebhookMessage;
 use Magento\Signifyd\Model\SignifydGateway\Response\WebhookMessageReader;
 use Magento\Signifyd\Model\SignifydGateway\Response\WebhookRequest;
 use Magento\Signifyd\Model\SignifydGateway\Response\WebhookRequestValidator;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/app/code/Magento/Signifyd/Test/Unit/Model/CaseServices/UpdatingServiceFactoryTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/CaseServices/UpdatingServiceFactoryTest.php
@@ -13,7 +13,7 @@ use Magento\Signifyd\Model\CaseServices\UpdatingServiceFactory;
 use Magento\Signifyd\Model\Config;
 use Magento\Signifyd\Model\MessageGenerators\GeneratorFactory;
 use Magento\Signifyd\Model\MessageGenerators\GeneratorInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Contains tests for case updating service factory.

--- a/app/code/Magento/Signifyd/Test/Unit/Model/CaseServices/UpdatingServiceTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/CaseServices/UpdatingServiceTest.php
@@ -14,7 +14,7 @@ use Magento\Signifyd\Model\MessageGenerators\GeneratorException;
 use Magento\Signifyd\Model\MessageGenerators\GeneratorInterface;
 use Magento\Signifyd\Model\OrderStateService;
 use Magento\Signifyd\Model\SalesOrderGrid\OrderGridUpdater;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Contains tests with different negative and positive scenarios for case updating service.

--- a/app/code/Magento/Signifyd/Test/Unit/Model/CommentsHistoryUpdaterTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/CommentsHistoryUpdaterTest.php
@@ -10,7 +10,7 @@ use Magento\Sales\Api\Data\OrderStatusHistoryInterface;
 use Magento\Sales\Model\Order\Status\HistoryFactory;
 use Magento\Signifyd\Api\Data\CaseInterface;
 use Magento\Signifyd\Model\CommentsHistoryUpdater;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Sales\Api\OrderStatusHistoryRepositoryInterface;
 
 /**

--- a/app/code/Magento/Signifyd/Test/Unit/Model/CustomerOrdersTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/CustomerOrdersTest.php
@@ -12,7 +12,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Sales\Api\Data\OrderSearchResultInterface;
 use Magento\Sales\Model\Order;
 use Magento\Signifyd\Model\CustomerOrders;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Psr\Log\LoggerInterface;
 

--- a/app/code/Magento/Signifyd/Test/Unit/Model/Guarantee/CancelingServiceTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/Guarantee/CancelingServiceTest.php
@@ -13,7 +13,7 @@ use Magento\Signifyd\Model\Guarantee\CancelGuaranteeAbility;
 use Magento\Signifyd\Model\Guarantee\CancelingService;
 use Magento\Signifyd\Model\SignifydGateway\Gateway;
 use Magento\Signifyd\Model\SignifydGateway\GatewayException;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/app/code/Magento/Signifyd/Test/Unit/Model/Guarantee/CreationServiceTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/Guarantee/CreationServiceTest.php
@@ -13,7 +13,7 @@ use Magento\Signifyd\Model\Guarantee\CreateGuaranteeAbility;
 use Magento\Signifyd\Model\Guarantee\CreationService;
 use Magento\Signifyd\Model\SignifydGateway\Gateway;
 use Magento\Signifyd\Model\SignifydGateway\GatewayException;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use \PHPUnit\Framework\TestCase as TestCase;
 use Psr\Log\LoggerInterface;
 

--- a/app/code/Magento/Signifyd/Test/Unit/Model/MessageGenerators/CaseRescoreTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/MessageGenerators/CaseRescoreTest.php
@@ -9,7 +9,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Signifyd\Api\CaseRepositoryInterface;
 use Magento\Signifyd\Api\Data\CaseInterface;
 use Magento\Signifyd\Model\MessageGenerators\CaseRescore;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests for Signifyd CaseRescore message generator.

--- a/app/code/Magento/Signifyd/Test/Unit/Model/MessageGenerators/GeneratorFactoryTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/MessageGenerators/GeneratorFactoryTest.php
@@ -10,7 +10,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Signifyd\Model\MessageGenerators\PatternGenerator;
 use Magento\Signifyd\Model\MessageGenerators\CaseRescore;
 use Magento\Signifyd\Model\MessageGenerators\GeneratorFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Contains tests for messages generators factory.

--- a/app/code/Magento/Signifyd/Test/Unit/Model/OrderStateServiceTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/OrderStateServiceTest.php
@@ -11,7 +11,7 @@ use Magento\Sales\Model\OrderFactory;
 use Magento\Signifyd\Api\Data\CaseInterface;
 use Magento\Signifyd\Model\CommentsHistoryUpdater;
 use Magento\Signifyd\Model\OrderStateService;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class OrderStateServiceTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Signifyd/Test/Unit/Model/PaymentVerificationFactoryTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/PaymentVerificationFactoryTest.php
@@ -9,7 +9,7 @@ use Magento\Framework\ObjectManagerInterface;
 use Magento\Payment\Api\PaymentVerificationInterface;
 use Magento\Signifyd\Model\PaymentVerificationFactory;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Payment\Gateway\ConfigInterface;
 
 class PaymentVerificationFactoryTest extends \PHPUnit\Framework\TestCase

--- a/app/code/Magento/Signifyd/Test/Unit/Model/SalesOrderGrid/OrderGridUpdaterTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/SalesOrderGrid/OrderGridUpdaterTest.php
@@ -8,7 +8,7 @@ namespace Magento\Signifyd\Test\Unit\Model\SalesOrderGrid;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Sales\Model\ResourceModel\GridInterface;
 use Magento\Signifyd\Model\SalesOrderGrid\OrderGridUpdater;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class OrderGridUpdaterTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Signifyd/Test/Unit/Model/SignifydGateway/Client/HttpClientFactoryTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/SignifydGateway/Client/HttpClientFactoryTest.php
@@ -11,7 +11,7 @@ use Magento\Signifyd\Model\Config;
 use Magento\Framework\HTTP\ZendClient;
 use Magento\Framework\HTTP\ZendClientFactory;
 use Magento\Framework\Json\EncoderInterface;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class HttpClientFactoryTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Signifyd/Test/Unit/Model/SignifydGateway/Client/ResponseHandlerTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/SignifydGateway/Client/ResponseHandlerTest.php
@@ -10,7 +10,7 @@ use Magento\Framework\Json\DecoderInterface;
 use Magento\Signifyd\Model\SignifydGateway\ApiCallException;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use \Zend_Http_Response as Response;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class ResponseHandlerTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Signifyd/Test/Unit/Model/SignifydGateway/GatewayTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/SignifydGateway/GatewayTest.php
@@ -9,7 +9,7 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Signifyd\Api\CaseRepositoryInterface;
 use Magento\Signifyd\Api\Data\CaseInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Signifyd\Model\SignifydGateway\Gateway;
 use Magento\Signifyd\Model\SignifydGateway\GatewayException;
 use Magento\Signifyd\Model\SignifydGateway\Request\CreateCaseBuilderInterface;

--- a/app/code/Magento/Signifyd/Test/Unit/Model/SignifydOrderSessionIdTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Model/SignifydOrderSessionIdTest.php
@@ -8,7 +8,7 @@ namespace Magento\Signifyd\Test\Unit\Model;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Framework\DataObject\IdentityGeneratorInterface;
 use Magento\Signifyd\Model\SignifydOrderSessionId;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class SignifydOrderSessionIdTest tests that SignifydOrderSessionId class dependencies

--- a/app/code/Magento/Signifyd/Test/Unit/Observer/PlaceOrderTest.php
+++ b/app/code/Magento/Signifyd/Test/Unit/Observer/PlaceOrderTest.php
@@ -15,7 +15,7 @@ use Magento\Sales\Model\Order\Payment;
 use Magento\Signifyd\Api\CaseCreationServiceInterface;
 use Magento\Signifyd\Model\Config;
 use Magento\Signifyd\Observer\PlaceOrder;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Psr\Log\LoggerInterface;
 
 class PlaceOrderTest extends \PHPUnit\Framework\TestCase

--- a/app/code/Magento/Sitemap/Test/Unit/Model/SitemapConfigReaderTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/SitemapConfigReaderTest.php
@@ -24,7 +24,7 @@ class SitemapConfigReaderTest extends \PHPUnit\Framework\TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    private function getScopeConfigMock(): \PHPUnit_Framework_MockObject_MockObject
+    private function getScopeConfigMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         $scopeConfigMock = $this->getMockForAbstractClass(ScopeConfigInterface::class);
         $scopeConfigMock->expects($this->any())

--- a/app/code/Magento/Store/Test/Unit/App/Config/Source/InitialConfigSourceTest.php
+++ b/app/code/Magento/Store/Test/Unit/App/Config/Source/InitialConfigSourceTest.php
@@ -9,7 +9,7 @@ use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\DeploymentConfig\Reader;
 use Magento\Framework\DataObject;
 use Magento\Store\App\Config\Source\InitialConfigSource;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * @inheritdoc

--- a/app/code/Magento/Store/Test/Unit/Model/Config/Importer/DataDifferenceCalculatorTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/Config/Importer/DataDifferenceCalculatorTest.php
@@ -8,7 +8,7 @@ namespace Magento\Store\Test\Unit\Model\Config\Importer;
 use Magento\Framework\App\Config\ConfigSourceInterface;
 use Magento\Store\Model\Config\Importer\DataDifferenceCalculator;
 use Magento\Store\Model\ScopeInterface;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * @inheritdoc

--- a/app/code/Magento/Store/Test/Unit/Model/Config/Importer/Processor/DeleteTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/Config/Importer/Processor/DeleteTest.php
@@ -19,7 +19,7 @@ use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreRepository;
 use Magento\Store\Model\Website;
 use Magento\Store\Model\WebsiteRepository;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Test for Delete processor.

--- a/app/code/Magento/Store/Test/Unit/Model/Config/Importer/Processor/ProcessorFactoryTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/Config/Importer/Processor/ProcessorFactoryTest.php
@@ -11,7 +11,7 @@ use Magento\Store\Model\Config\Importer\Processor\Create;
 use Magento\Store\Model\Config\Importer\Processor\Delete;
 use Magento\Store\Model\Config\Importer\Processor\ProcessorFactory;
 use Magento\Store\Model\Config\Importer\Processor\ProcessorInterface;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * @inheritdoc

--- a/app/code/Magento/Store/Test/Unit/Model/Config/Importer/Processor/UpdateTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/Config/Importer/Processor/UpdateTest.php
@@ -16,7 +16,7 @@ use Magento\Store\Model\ResourceModel\Website as WebsiteResource;
 use Magento\Store\Model\WebsiteFactory;
 use Magento\Store\Model\ResourceModel\Group as GroupResource;
 use Magento\Store\Model\ResourceModel\Store as StoreResource;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 use Magento\Store\Model\Store;
 use Magento\Framework\Event\ManagerInterface;
 

--- a/app/code/Magento/Store/Test/Unit/Model/Config/ImporterTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/Config/ImporterTest.php
@@ -10,7 +10,7 @@ use Magento\Store\Model\Config\Importer;
 use Magento\Store\Model\ResourceModel\Website;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManager;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Test for Importer.

--- a/app/code/Magento/Store/Test/Unit/Model/Message/EmptyGroupCategoryTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/Message/EmptyGroupCategoryTest.php
@@ -6,7 +6,7 @@
 namespace Magento\Store\Test\Unit\Model\Message;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Store\Model\Message\EmptyGroupCategory;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\ResourceModel\Group\Collection;

--- a/app/code/Magento/Tax/Test/Unit/Block/Adminhtml/Rule/Edit/FormTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Block/Adminhtml/Rule/Edit/FormTest.php
@@ -16,7 +16,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Tax\Model\Rate\Source;
 use Magento\Tax\Model\TaxClass\Source\Customer;
 use Magento\Tax\Model\TaxClass\Source\Product;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Test for Tax Rule Edit Form

--- a/app/code/Magento/Tax/Test/Unit/Controller/Adminhtml/Rule/AjaxLoadRatesTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Controller/Adminhtml/Rule/AjaxLoadRatesTest.php
@@ -15,7 +15,7 @@ use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Tax\Model\Rate\Provider as RatesProvider;
 use Magento\Tax\Controller\Adminhtml\Rule\AjaxLoadRates;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Test for AjaxLoadTest

--- a/app/code/Magento/Tax/Test/Unit/Model/TaxAddressManagerTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/TaxAddressManagerTest.php
@@ -7,7 +7,7 @@ namespace Magento\Tax\Test\Unit\Model;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Tax\Model\TaxAddressManager;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class TaxAddressManagerTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Tax/Test/Unit/Model/TaxRuleCollectionTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/TaxRuleCollectionTest.php
@@ -14,7 +14,7 @@ use Magento\Tax\Api\Data\TaxRateSearchResultsInterface;
 use Magento\Tax\Api\TaxRuleRepositoryInterface;
 use Magento\Tax\Model\Calculation\Rule;
 use \Magento\Tax\Model\TaxRuleCollection;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class TaxRuleCollectionTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Tax/Test/Unit/Observer/AfterAddressSaveObserverTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Observer/AfterAddressSaveObserverTest.php
@@ -11,7 +11,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\PageCache\Model\Config;
 use Magento\Tax\Api\TaxAddressManagerInterface;
 use Magento\Tax\Helper\Data;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/Tax/Test/Unit/Observer/CustomerLoggedInObserverTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Observer/CustomerLoggedInObserverTest.php
@@ -6,7 +6,7 @@
 namespace Magento\Tax\Test\Unit\Observer;
 
 use Magento\Tax\Api\TaxAddressManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class CustomerLoggedInObserverTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Tax/Test/Unit/Plugin/Checkout/CustomerData/CartTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Plugin/Checkout/CustomerData/CartTest.php
@@ -13,7 +13,7 @@ use Magento\Quote\Model\Quote\Item;
 use Magento\Tax\Block\Item\Price\Renderer;
 use Magento\Tax\Plugin\Checkout\CustomerData\Cart;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class CartTest extends TestCase
 {

--- a/app/code/Magento/Theme/Test/Unit/Model/Source/InitialThemeSourceTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Source/InitialThemeSourceTest.php
@@ -13,7 +13,7 @@ use Magento\Framework\DB\Select;
 use Magento\Theme\Model\ResourceModel\Theme;
 use Magento\Theme\Model\ResourceModel\ThemeFactory;
 use Magento\Theme\Model\Source\InitialThemeSource;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/Ui/Test/Unit/Component/AbstractComponentTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/AbstractComponentTest.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Ui\Test\Unit\Component;
 
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponent\ContentType\ContentTypeInterface;
 use Magento\Framework\View\Element\UiComponentInterface;

--- a/app/code/Magento/Ups/Test/Unit/Model/CarrierCollectRatesOptionsTest.php
+++ b/app/code/Magento/Ups/Test/Unit/Model/CarrierCollectRatesOptionsTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Ups\Test\Unit\Model;
 
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Ups\Model\Carrier;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Quote\Model\Quote\Address\RateResult\ErrorFactory as RateResultErrorFactory;

--- a/app/code/Magento/Ups/Test/Unit/Model/CarrierTest.php
+++ b/app/code/Magento/Ups/Test/Unit/Model/CarrierTest.php
@@ -21,7 +21,7 @@ use Magento\Shipping\Model\Rate\ResultFactory;
 use Magento\Shipping\Model\Simplexml\Element;
 use Magento\Shipping\Model\Simplexml\ElementFactory;
 use Magento\Ups\Model\Carrier;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/app/code/Magento/Usps/Test/Unit/Model/CarrierTest.php
+++ b/app/code/Magento/Usps/Test/Unit/Model/CarrierTest.php
@@ -27,7 +27,7 @@ use Magento\Shipping\Model\Simplexml\Element;
 use Magento\Shipping\Model\Simplexml\ElementFactory;
 use Magento\Usps\Helper\Data as DataHelper;
 use Magento\Usps\Model\Carrier;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/Vault/Test/Unit/Block/Customer/AccountTokensTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Block/Customer/AccountTokensTest.php
@@ -12,7 +12,7 @@ use Magento\Vault\Model\AccountPaymentTokenFactory;
 use Magento\Vault\Model\CreditCardTokenFactory;
 use Magento\Vault\Model\CustomerTokenManagement;
 use Magento\Vault\Model\PaymentToken;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class AccountTokensTest

--- a/app/code/Magento/Vault/Test/Unit/Model/AccountPaymentTokenFactoryTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Model/AccountPaymentTokenFactoryTest.php
@@ -11,7 +11,7 @@ use Magento\Vault\Api\Data\PaymentTokenInterface;
 use Magento\Vault\Model\PaymentTokenFactory;
 use Magento\Vault\Model\AccountPaymentTokenFactory;
 use Magento\Vault\Model\PaymentToken;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class AccountPaymentTokenFactoryTest

--- a/app/code/Magento/Vault/Test/Unit/Model/CreditCardTokenFactoryTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Model/CreditCardTokenFactoryTest.php
@@ -11,7 +11,7 @@ use Magento\Vault\Api\Data\PaymentTokenInterface;
 use Magento\Vault\Model\PaymentTokenFactory;
 use Magento\Vault\Model\CreditCardTokenFactory;
 use Magento\Vault\Model\PaymentToken;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class CreditCardTokenFactoryTest

--- a/app/code/Magento/Vault/Test/Unit/Model/CustomerTokenManagementTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Model/CustomerTokenManagementTest.php
@@ -9,7 +9,7 @@ use Magento\Customer\Model\Session;
 use Magento\Vault\Api\Data\PaymentTokenInterface;
 use Magento\Vault\Model\CustomerTokenManagement;
 use Magento\Vault\Model\PaymentTokenManagement;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class CustomerTokenManagementTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Vault/Test/Unit/Model/Method/VaultTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Model/Method/VaultTest.php
@@ -21,7 +21,7 @@ use Magento\Vault\Api\Data\PaymentTokenInterface;
 use Magento\Vault\Api\PaymentTokenManagementInterface;
 use Magento\Vault\Model\Method\Vault;
 use Magento\Vault\Model\VaultPaymentInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class VaultTest

--- a/app/code/Magento/Vault/Test/Unit/Model/PaymentMethodListTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Model/PaymentMethodListTest.php
@@ -11,7 +11,7 @@ use Magento\Payment\Model\Method\InstanceFactory;
 use Magento\Payment\Model\MethodInterface;
 use Magento\Vault\Model\VaultPaymentInterface;
 use Magento\Vault\Model\PaymentMethodList;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class PaymentMethodListTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Vault/Test/Unit/Model/PaymentTokenRepositoryTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Model/PaymentTokenRepositoryTest.php
@@ -16,7 +16,7 @@ use Magento\Vault\Model\PaymentTokenRepository;
 use Magento\Vault\Model\ResourceModel\PaymentToken as PaymentTokenResourceModel;
 use Magento\Vault\Model\ResourceModel\PaymentToken\Collection;
 use Magento\Vault\Model\ResourceModel\PaymentToken\CollectionFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class PaymentTokenRepositoryTest

--- a/app/code/Magento/Vault/Test/Unit/Model/Ui/Adminhtml/TokensConfigProviderTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Model/Ui/Adminhtml/TokensConfigProviderTest.php
@@ -29,7 +29,7 @@ use Magento\Vault\Model\Ui\Adminhtml\TokensConfigProvider;
 use Magento\Vault\Model\Ui\TokenUiComponentInterface;
 use Magento\Vault\Model\Ui\TokenUiComponentProviderInterface;
 use Magento\Vault\Model\VaultPaymentInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class TokensConfigProviderTest

--- a/app/code/Magento/Vault/Test/Unit/Model/Ui/TokensConfigProviderTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Model/Ui/TokensConfigProviderTest.php
@@ -15,7 +15,7 @@ use Magento\Vault\Model\Ui\TokensConfigProvider;
 use Magento\Vault\Model\Ui\TokenUiComponentInterface;
 use Magento\Vault\Model\Ui\TokenUiComponentProviderInterface;
 use Magento\Vault\Model\VaultPaymentInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ConfigProviderTest

--- a/app/code/Magento/Vault/Test/Unit/Model/Ui/VaultConfigProviderTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Model/Ui/VaultConfigProviderTest.php
@@ -12,7 +12,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Vault\Api\PaymentMethodListInterface;
 use Magento\Vault\Model\Ui\VaultConfigProvider;
 use Magento\Vault\Model\VaultPaymentInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class VaultConfigProviderTest

--- a/app/code/Magento/Vault/Test/Unit/Observer/AfterPaymentSaveObserverTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Observer/AfterPaymentSaveObserverTest.php
@@ -16,7 +16,7 @@ use Magento\Sales\Model\Order\Payment;
 use Magento\Vault\Model\PaymentToken;
 use Magento\Vault\Model\PaymentTokenManagement;
 use Magento\Vault\Observer\AfterPaymentSaveObserver;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class AfterPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Weee/Test/Unit/Observer/AddPaymentWeeeItemTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Observer/AddPaymentWeeeItemTest.php
@@ -18,7 +18,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Weee\Helper\Data;
 use Magento\Weee\Observer\AddPaymentWeeeItem;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class AddPaymentWeeeItemTest

--- a/app/code/Magento/Weee/Test/Unit/Observer/AfterAddressSaveTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Observer/AfterAddressSaveTest.php
@@ -7,7 +7,7 @@ namespace Magento\Weee\Test\Unit\Observer;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Tax\Api\TaxAddressManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class AfterAddressSaveTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Weee/Test/Unit/Observer/CustomerLoggedInTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Observer/CustomerLoggedInTest.php
@@ -6,7 +6,7 @@
 namespace Magento\Weee\Test\Unit\Observer;
 
 use Magento\Tax\Api\TaxAddressManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class CustomerLoggedInTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Weee/Test/Unit/Observer/SetWeeeRendererInFormObserverTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Observer/SetWeeeRendererInFormObserverTest.php
@@ -14,7 +14,7 @@ use Magento\Framework\View\LayoutInterface;
 use Magento\Weee\Model\Tax;
 use Magento\Weee\Observer\SetWeeeRendererInFormObserver;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class AddPaymentWeeeItemTest

--- a/dev/tests/functional/lib/Magento/Mtf/Client/Element/ConditionsElement.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Client/Element/ConditionsElement.php
@@ -287,7 +287,7 @@ class ConditionsElement extends SimpleElement
             try {
                 $newCondition->find($this->typeNew, Locator::SELECTOR_XPATH, 'select')->setValue($type);
                 $isSetType = true;
-            } catch (\PHPUnit_Extensions_Selenium2TestCase_WebDriverException $e) {
+            } catch (\PHPUnit\Extensions\Selenium2TestCase\WebDriverException $e) {
                 $isSetType = false;
                 $this->exception = $e;
                 $this->eventManager->dispatchEvent(['exception'], [__METHOD__, $this->getAbsoluteSelector()]);
@@ -338,7 +338,7 @@ class ConditionsElement extends SimpleElement
                     } elseif ($this->fillText($rule, $param)) {
                         $isSet = true;
                     }
-                } catch (\PHPUnit_Extensions_Selenium2TestCase_WebDriverException $e) {
+                } catch (\PHPUnit\Extensions\Selenium2TestCase\WebDriverException $e) {
                     $isSet = false;
                     $this->exception = $e;
                     $this->eventManager->dispatchEvent(['exception'], [__METHOD__, $this->getAbsoluteSelector()]);

--- a/dev/tests/functional/tests/app/Magento/Backend/Test/Block/Menu.php
+++ b/dev/tests/functional/tests/app/Magento/Backend/Test/Block/Menu.php
@@ -96,7 +96,7 @@ class Menu extends Block
         // Resolve an issue on with "Offset within element cannot be scrolled into view" on low screen resolution
         try {
             $this->_rootElement->find($subMenuItem, Locator::SELECTOR_XPATH)->hover();
-        } catch (\PHPUnit_Extensions_Selenium2TestCase_WebDriverException  $e) {
+        } catch (\PHPUnit\Extensions\Selenium2TestCase\WebDriverException  $e) {
         }
         $this->_rootElement->find($subMenuItem, Locator::SELECTOR_XPATH)->click();
         if ($waitMenuItemNotVisible) {

--- a/dev/tests/functional/tests/app/Magento/Backend/Test/Constraint/AssertHttpsHeaderOptionsAvailable.php
+++ b/dev/tests/functional/tests/app/Magento/Backend/Test/Constraint/AssertHttpsHeaderOptionsAvailable.php
@@ -66,7 +66,7 @@ class AssertHttpsHeaderOptionsAvailable extends AbstractConstraint
                     true,
                     $fieldName . " configuration is enabled with options Yes & No."
                 );
-            } catch (\PHPUnit_Extensions_Selenium2TestCase_WebDriverException $e) {
+            } catch (\PHPUnit\Extensions\Selenium2TestCase\WebDriverException $e) {
                 \PHPUnit\Framework\Assert::assertFalse(
                     true,
                     $fieldName . " configuration is not enabled with options Yes & No."

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductPage.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductPage.php
@@ -97,7 +97,7 @@ class AssertProductPage extends AbstractAssertForm
         $expectedName = $this->product->getName();
         try {
             $actualName = $this->productView->getProductName();
-        } catch (\PHPUnit_Extensions_Selenium2TestCase_WebDriverException $e) {
+        } catch (\PHPUnit\Extensions\Selenium2TestCase\WebDriverException $e) {
             return "Could not find product '{$this->product->getName()}' name on the page.\n" . $e->getMessage();
         }
 
@@ -167,7 +167,7 @@ class AssertProductPage extends AbstractAssertForm
         $expectedSku = $this->product->getSku();
         try {
             $actualSku = $this->productView->getProductSku();
-        } catch (\PHPUnit_Extensions_Selenium2TestCase_WebDriverException $e) {
+        } catch (\PHPUnit\Extensions\Selenium2TestCase\WebDriverException $e) {
             return "Could not find product {$this->product->getName()}' SKU on the page.\n" . $e->getMessage();
         }
 

--- a/dev/tests/functional/tests/app/Magento/Cms/Test/Block/Adminhtml/Page/Edit/Tab/Content.php
+++ b/dev/tests/functional/tests/app/Magento/Cms/Test/Block/Adminhtml/Page/Edit/Tab/Content.php
@@ -94,7 +94,7 @@ class Content extends Tab
         if ($addWidgetButton->isVisible()) {
             try {
                 $addWidgetButton->click();
-            } catch (\PHPUnit_Extensions_Selenium2TestCase_WebDriverException $e) {
+            } catch (\PHPUnit\Extensions\Selenium2TestCase\WebDriverException $e) {
                 $this->browser->find($this->header)->hover();
                 $addWidgetButton->click();
             }

--- a/dev/tests/functional/tests/app/Magento/Integration/Test/Constraint/AssertIntegrationSuccessSaveMessageNotPresent.php
+++ b/dev/tests/functional/tests/app/Magento/Integration/Test/Constraint/AssertIntegrationSuccessSaveMessageNotPresent.php
@@ -27,7 +27,7 @@ class AssertIntegrationSuccessSaveMessageNotPresent extends AbstractConstraint
         if ($integrationIndex->getMessagesBlock()->isVisible()) {
             try {
                 $integrationIndex->getMessagesBlock()->getSuccessMessage();
-            } catch (\PHPUnit_Extensions_Selenium2TestCase_WebDriverException $e) {
+            } catch (\PHPUnit\Extensions\Selenium2TestCase\WebDriverException $e) {
                 $noSuccessMessage = true;
             }
         } else {

--- a/dev/tests/functional/tests/app/Magento/Swagger/Test/Page/SwaggerUiPage.php
+++ b/dev/tests/functional/tests/app/Magento/Swagger/Test/Page/SwaggerUiPage.php
@@ -218,7 +218,7 @@ class SwaggerUiPage
                     $url = $_ENV['app_frontend_url'] . $pattern;
                     $browser->open($url);
                     return true;
-                } catch (\PHPUnit_Extensions_Selenium2TestCase_WebDriverException $e) {
+                } catch (\PHPUnit\Extensions\Selenium2TestCase\WebDriverException $e) {
                     return false;
                 }
             }

--- a/dev/tests/functional/tests/app/Magento/User/Test/TestStep/LoginUserOnBackendStep.php
+++ b/dev/tests/functional/tests/app/Magento/User/Test/TestStep/LoginUserOnBackendStep.php
@@ -99,7 +99,7 @@ class LoginUserOnBackendStep implements TestStepInterface
 
         try {
             $this->login();
-        } catch (\PHPUnit_Extensions_Selenium2TestCase_WebDriverException $e) {
+        } catch (\PHPUnit\Extensions\Selenium2TestCase\WebDriverException $e) {
             if (strpos($e->getMessage(), 'Timed out after') !== false) {
                 $messages = $this->adminAuth->getMessagesBlock();
                 if (in_array($messages->getErrorMessage(), $this->errorMessages, true)) {

--- a/dev/tests/functional/tests/app/Magento/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetInstanceType/WidgetInstanceForm.php
+++ b/dev/tests/functional/tests/app/Magento/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetInstanceType/WidgetInstanceForm.php
@@ -112,7 +112,7 @@ class WidgetInstanceForm extends Form
         try {
             $this->browser->find($anchor, $anchorStrategy)->hover();
             $this->_rootElement->find($element, $elementStrategy)->click();
-        } catch (\PHPUnit_Extensions_Selenium2TestCase_WebDriverException $e) {
+        } catch (\PHPUnit\Extensions\Selenium2TestCase\WebDriverException $e) {
             return false;
         }
         return true;

--- a/dev/tests/integration/framework/Magento/TestFramework/Listener/ExtededTestdox.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Listener/ExtededTestdox.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\TestFramework\Listener;
 
-class ExtededTestdox extends \PHPUnit_Util_Printer implements \PHPUnit\Framework\TestListener
+class ExtededTestdox extends \PHPUnit\Util\Printer implements \PHPUnit\Framework\TestListener
 {
     /**
      * @var \PHPUnit_Util_TestDox_NamePrettifier
@@ -76,7 +76,7 @@ class ExtededTestdox extends \PHPUnit_Util_Printer implements \PHPUnit\Framework
     {
         parent::__construct($out);
 
-        $this->prettifier = new \PHPUnit_Util_TestDox_NamePrettifier();
+        $this->prettifier = new \PHPUnit\Util\TestDox\NamePrettifier();
         $this->startRun();
     }
 
@@ -103,7 +103,7 @@ class ExtededTestdox extends \PHPUnit_Util_Printer implements \PHPUnit\Framework
     public function addError(\PHPUnit\Framework\Test $test, \Exception $e, $time)
     {
         if ($test instanceof $this->testTypeOfInterest) {
-            $this->testStatus = \PHPUnit_Runner_BaseTestRunner::STATUS_ERROR;
+            $this->testStatus = \PHPUnit\Runner\BaseTestRunner::STATUS_ERROR;
             $this->failed++;
         }
     }
@@ -119,7 +119,7 @@ class ExtededTestdox extends \PHPUnit_Util_Printer implements \PHPUnit\Framework
     public function addFailure(\PHPUnit\Framework\Test $test, \PHPUnit\Framework\AssertionFailedError $e, $time)
     {
         if ($test instanceof $this->testTypeOfInterest) {
-            $this->testStatus = \PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE;
+            $this->testStatus = \PHPUnit\Runner\BaseTestRunner::STATUS_FAILURE;
             $this->failed++;
         }
     }
@@ -135,7 +135,7 @@ class ExtededTestdox extends \PHPUnit_Util_Printer implements \PHPUnit\Framework
     public function addIncompleteTest(\PHPUnit\Framework\Test $test, \Exception $e, $time)
     {
         if ($test instanceof $this->testTypeOfInterest) {
-            $this->testStatus = \PHPUnit_Runner_BaseTestRunner::STATUS_INCOMPLETE;
+            $this->testStatus = \PHPUnit\Runner\BaseTestRunner::STATUS_INCOMPLETE;
             $this->incomplete++;
         }
     }
@@ -152,7 +152,7 @@ class ExtededTestdox extends \PHPUnit_Util_Printer implements \PHPUnit\Framework
     public function addSkippedTest(\PHPUnit\Framework\Test $test, \Exception $e, $time)
     {
         if ($test instanceof $this->testTypeOfInterest) {
-            $this->testStatus = \PHPUnit_Runner_BaseTestRunner::STATUS_SKIPPED;
+            $this->testStatus = \PHPUnit\Runner\BaseTestRunner::STATUS_SKIPPED;
             $this->skipped++;
         }
     }
@@ -169,7 +169,7 @@ class ExtededTestdox extends \PHPUnit_Util_Printer implements \PHPUnit\Framework
     public function addRiskyTest(\PHPUnit\Framework\Test $test, \Exception $e, $time)
     {
         if ($test instanceof $this->testTypeOfInterest) {
-            $this->testStatus = \PHPUnit_Runner_BaseTestRunner::STATUS_RISKY;
+            $this->testStatus = \PHPUnit\Runner\BaseTestRunner::STATUS_RISKY;
             $this->risky++;
         }
     }
@@ -220,7 +220,7 @@ class ExtededTestdox extends \PHPUnit_Util_Printer implements \PHPUnit\Framework
             $this->write('.');
             $this->currentTestMethodPrettified = $this->prettifier->prettifyTestMethod($test->getName(false));
 
-            $this->testStatus = \PHPUnit_Runner_BaseTestRunner::STATUS_PASSED;
+            $this->testStatus = \PHPUnit\Runner\BaseTestRunner::STATUS_PASSED;
         }
     }
 
@@ -237,13 +237,13 @@ class ExtededTestdox extends \PHPUnit_Util_Printer implements \PHPUnit\Framework
                 $this->tests[$this->currentTestMethodPrettified] = ['success' => 0, 'failure' => 0, 'time' => 0];
             }
 
-            if ($this->testStatus == \PHPUnit_Runner_BaseTestRunner::STATUS_PASSED) {
+            if ($this->testStatus == \PHPUnit\Runner\BaseTestRunner::STATUS_PASSED) {
                 $this->tests[$this->currentTestMethodPrettified]['success']++;
             }
-            if ($this->testStatus == \PHPUnit_Runner_BaseTestRunner::STATUS_ERROR) {
+            if ($this->testStatus == \PHPUnit\Runner\BaseTestRunner::STATUS_ERROR) {
                 $this->tests[$this->currentTestMethodPrettified]['failure']++;
             }
-            if ($this->testStatus == \PHPUnit_Runner_BaseTestRunner::STATUS_FAILURE) {
+            if ($this->testStatus == \PHPUnit\Runner\BaseTestRunner::STATUS_FAILURE) {
                 $this->tests[$this->currentTestMethodPrettified]['failure']++;
             }
             $this->tests[$this->currentTestMethodPrettified]['time'] += $time;

--- a/dev/tests/integration/testsuite/Magento/Authorizenet/Model/DirectpostTest.php
+++ b/dev/tests/integration/testsuite/Magento/Authorizenet/Model/DirectpostTest.php
@@ -15,7 +15,7 @@ use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class contains tests for Direct Post integration

--- a/dev/tests/integration/testsuite/Magento/Braintree/Controller/Adminhtml/Invoice/CreateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Braintree/Controller/Adminhtml/Invoice/CreateTest.php
@@ -17,7 +17,7 @@ use Magento\Framework\Message\MessageInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\TestFramework\TestCase\AbstractBackendController;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @magentoAppArea adminhtml

--- a/dev/tests/integration/testsuite/Magento/Braintree/Controller/Adminhtml/Payment/GetClientTokenTest.php
+++ b/dev/tests/integration/testsuite/Magento/Braintree/Controller/Adminhtml/Payment/GetClientTokenTest.php
@@ -14,7 +14,7 @@ use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Store\Api\StoreRepositoryInterface;
 use Magento\TestFramework\TestCase\AbstractBackendController;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests \Magento\Braintree\Controller\Adminhtml\Payment\GetClientToken

--- a/dev/tests/integration/testsuite/Magento/Checkout/Api/PaymentInformationManagementTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Api/PaymentInformationManagementTest.php
@@ -19,7 +19,7 @@ use Magento\Quote\Api\Data\PaymentInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\ObjectManager;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class PaymentInformationManagementTest

--- a/dev/tests/integration/testsuite/Magento/Config/Console/Command/ConfigSetCommandTest.php
+++ b/dev/tests/integration/testsuite/Magento/Config/Console/Command/ConfigSetCommandTest.php
@@ -21,7 +21,7 @@ use Magento\Framework\Stdlib\ArrayManager;
 use Magento\Store\Model\ScopeInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\Framework\App\Config\ReinitableConfigInterface;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/IndexTest.php
@@ -514,7 +514,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
         array $sender,
         int $customerId,
         $newEmail = null
-    ) : \PHPUnit_Framework_MockObject_MockObject {
+    ) : \PHPUnit\Framework\MockObject\MockObject {
         $area = \Magento\Framework\App\Area::AREA_FRONTEND;
         $customer = $this->customerRepository->getById($customerId);
         $storeId = $customer->getStoreId();
@@ -564,7 +564,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
      * @param string $className
      */
     protected function addEmailMockToClass(
-        \PHPUnit_Framework_MockObject_MockObject $transportBuilderMock,
+        \PHPUnit\Framework\MockObject\MockObject $transportBuilderMock,
         $className
     ) {
         $mocked = $this->_objectManager->create(

--- a/dev/tests/integration/testsuite/Magento/Framework/TranslateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/TranslateTest.php
@@ -8,7 +8,7 @@ namespace Magento\Framework;
 
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\Helper\CacheCleaner;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @magentoAppIsolation enabled

--- a/dev/tests/integration/testsuite/Magento/Multishipping/Model/Checkout/Type/MultishippingTest.php
+++ b/dev/tests/integration/testsuite/Magento/Multishipping/Model/Checkout/Type/MultishippingTest.php
@@ -21,7 +21,7 @@ use Magento\Sales\Model\Order\Email\Sender\OrderSender;
 use Magento\Sales\Model\Service\OrderService;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\ObjectManager;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @magentoAppArea frontend

--- a/dev/tests/integration/testsuite/Magento/Paypal/Model/Api/NvpTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Model/Api/NvpTest.php
@@ -15,7 +15,7 @@ use Magento\Paypal\Model\Config;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\QuoteRepository;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/dev/tests/integration/testsuite/Magento/Paypal/Model/Payflow/Service/Request/SecureTokenTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Model/Payflow/Service/Request/SecureTokenTest.php
@@ -18,7 +18,7 @@ use Magento\Store\Api\StoreRepositoryInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\ObjectManager;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @magentoAppIsolation enabled

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/Form/AccountTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/Form/AccountTest.php
@@ -102,7 +102,7 @@ class AccountTest extends \PHPUnit\Framework\TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    private function getFormFactoryMock(): \PHPUnit_Framework_MockObject_MockObject
+    private function getFormFactoryMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         /** @var AttributeMetadataInterfaceFactory $attributeMetadataFactory */
         $attributeMetadataFactory = $this->objectManager->create(AttributeMetadataInterfaceFactory::class);

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/Form/AddressTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/Form/AddressTest.php
@@ -21,7 +21,7 @@ use Magento\Store\Api\WebsiteRepositoryInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\Helper\Xpath;
 use Magento\TestFramework\ObjectManager;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Block/Adminhtml/Order/Create/FormTest.php
@@ -18,7 +18,7 @@ use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Store\Model\Store;
 use Magento\TestFramework\Helper\Bootstrap;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @magentoAppArea adminhtml

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Create/SaveTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Create/SaveTest.php
@@ -14,7 +14,7 @@ use Magento\Framework\Message\MessageInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Sales\Model\Service\OrderService;
 use Magento\TestFramework\TestCase\AbstractBackendController;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class SaveTest extends AbstractBackendController
 {

--- a/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/AuthTest.php
+++ b/dev/tests/integration/testsuite/Magento/User/Controller/Adminhtml/AuthTest.php
@@ -321,7 +321,7 @@ class AuthTest extends \Magento\TestFramework\TestCase\AbstractBackendController
      * @param string $originalClassName
      */
     protected function addMockToClass(
-        \PHPUnit_Framework_MockObject_MockObject $transportBuilderMock,
+        \PHPUnit\Framework\MockObject\MockObject $transportBuilderMock,
         $originalClassName
     ) {
         $userMock = $this->_objectManager->create(

--- a/dev/tests/integration/testsuite/Magento/Usps/Api/GuestCouponManagementTest.php
+++ b/dev/tests/integration/testsuite/Magento/Usps/Api/GuestCouponManagementTest.php
@@ -23,7 +23,7 @@ use Magento\Quote\Api\GuestShipmentEstimationInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\ObjectManager;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/dev/tests/static/framework/Magento/CodeMessDetector/Test/Unit/Rule/Design/AllPurposeActionTest.php
+++ b/dev/tests/static/framework/Magento/CodeMessDetector/Test/Unit/Rule/Design/AllPurposeActionTest.php
@@ -12,7 +12,7 @@ use Magento\CodeMessDetector\Rule\Design\AllPurposeAction;
 use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\ActionInterface;
 use PHPUnit\Framework\TestCase as TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use PHPUnit\Framework\MockObject\Builder\InvocationMocker as InvocationMocker;
 use PHPMD\Report;
 use PHPMD\Node\ClassNode;

--- a/dev/tests/static/framework/Magento/CodeMessDetector/Test/Unit/Rule/Design/FinalImplementationTest.php
+++ b/dev/tests/static/framework/Magento/CodeMessDetector/Test/Unit/Rule/Design/FinalImplementationTest.php
@@ -7,7 +7,7 @@
 namespace Magento\CodeMessDetector\Test\Unit\Rule\Design;
 
 use PHPUnit\Framework\TestCase as TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use PHPUnit\Framework\MockObject\Matcher\InvokedRecorder as InvokedRecorder;
 use PHPUnit\Framework\MockObject\Builder\InvocationMocker as InvocationMocker;
 use Magento\CodeMessDetector\Rule\Design\FinalImplementation;

--- a/lib/internal/Magento/Framework/App/Test/Unit/Config/ConfigPathResolverTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Config/ConfigPathResolverTest.php
@@ -7,7 +7,7 @@ namespace Magento\Framework\App\Test\Unit\Config;
 
 use Magento\Framework\App\Config\ScopeCodeResolver;
 use Magento\Framework\App\Config\ConfigPathResolver;
-use \PHPUnit_Framework_MockObject_MockObject as Mock;
+use \PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * {@inheritdoc}

--- a/lib/internal/Magento/Framework/App/Test/Unit/Config/MetadataConfigTypeProcessorTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Config/MetadataConfigTypeProcessorTest.php
@@ -11,7 +11,7 @@ use Magento\Framework\App\Config\Data\ProcessorFactory;
 use Magento\Framework\App\Config\Data\ProcessorInterface;
 use Magento\Framework\App\Config\Initial;
 use Magento\Framework\App\Config\MetadataConfigTypeProcessor;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class MetadataConfigTypeProcessorTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/App/Test/Unit/Config/MetadataProcessorTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Config/MetadataProcessorTest.php
@@ -9,7 +9,7 @@ use Magento\Framework\App\Config\MetadataProcessor;
 use Magento\Framework\App\Config\Initial;
 use Magento\Framework\App\Config\Data\ProcessorFactory;
 use Magento\Framework\App\Config\Data\ProcessorInterface;
-use \PHPUnit_Framework_MockObject_MockObject as Mock;
+use \PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * {@inheritdoc}

--- a/lib/internal/Magento/Framework/App/Test/Unit/Config/Scope/ValidatorTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Config/Scope/ValidatorTest.php
@@ -12,7 +12,7 @@ use Magento\Framework\App\ScopeResolverInterface;
 use Magento\Framework\App\ScopeResolverPool;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\App\Scope\Validator;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @deprecated As tested model class was moved to another directory,

--- a/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/FileReaderTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/FileReaderTest.php
@@ -10,7 +10,7 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\Filesystem\DriverPool;
-use \PHPUnit_Framework_MockObject_MockObject as Mock;
+use \PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * @inheritdoc

--- a/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/WriterTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/WriterTest.php
@@ -18,7 +18,7 @@ use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\ReadInterface;
 use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Framework\Phrase;
-use \PHPUnit_Framework_MockObject_MockObject as Mock;
+use \PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/lib/internal/Magento/Framework/App/Test/Unit/Scope/ValidatorTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Scope/ValidatorTest.php
@@ -12,7 +12,7 @@ use Magento\Framework\App\ScopeResolverInterface;
 use Magento\Framework\App\ScopeResolverPool;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\App\Scope\Validator;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class ValidatorTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/App/Test/Unit/StaticResourceTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/StaticResourceTest.php
@@ -19,7 +19,7 @@ use Magento\Framework\App\ObjectManager\ConfigLoader;
 use Magento\Framework\App\StaticResource;
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use Psr\Log\LoggerInterface;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/lib/internal/Magento/Framework/App/Test/Unit/View/Deployment/VersionTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/View/Deployment/VersionTest.php
@@ -11,7 +11,7 @@ use Magento\Framework\App\State;
 use Magento\Framework\App\View\Deployment\Version\StorageInterface;
 use Psr\Log\LoggerInterface;
 use Magento\Framework\Config\ConfigOptionsListConstants;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class VersionTest

--- a/lib/internal/Magento/Framework/Code/Test/Unit/GeneratorTest.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/GeneratorTest.php
@@ -12,7 +12,7 @@ use Psr\Log\LoggerInterface;
 use Magento\Framework\ObjectManager\Code\Generator\Factory;
 use Magento\Framework\ObjectManager\Code\Generator\Proxy;
 use Magento\Framework\Interception\Code\Generator\Interceptor;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 use PHPUnit\Framework\TestCase;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Code\Generator\EntityAbstract;

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/Code/Generator/InterceptorTest.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/Code/Generator/InterceptorTest.php
@@ -9,7 +9,7 @@ namespace Magento\Framework\Interception\Test\Unit\Code\Generator;
 use Composer\Autoload\ClassLoader;
 use Magento\Framework\Code\Generator\Io;
 use Magento\Framework\Interception\Code\Generator\Interceptor;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class InterceptorTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/Deployed/CodesTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/Deployed/CodesTest.php
@@ -11,7 +11,7 @@ use Magento\Framework\Filesystem\Directory\ReadInterface;
 use Magento\Framework\Locale\Deployed\Codes;
 use Magento\Framework\View\Design\Theme\FlyweightFactory;
 use Magento\Framework\View\Design\ThemeInterface;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Test for Codes class.

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/Deployed/OptionsTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/Deployed/OptionsTest.php
@@ -15,7 +15,7 @@ use Magento\Framework\Locale\Deployed\Options;
 use Magento\Framework\Locale\ListsInterface;
 use Magento\Framework\View\Design\ThemeInterface;
 use Magento\Framework\View\DesignInterface;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Test for Options class.

--- a/lib/internal/Magento/Framework/Logger/Test/Unit/Handler/SystemTest.php
+++ b/lib/internal/Magento/Framework/Logger/Test/Unit/Handler/SystemTest.php
@@ -9,7 +9,7 @@ use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\Logger\Handler\Exception;
 use Magento\Framework\Logger\Handler\System;
 use Monolog\Logger;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 class SystemTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/FactoryTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/FactoryTest.php
@@ -9,7 +9,7 @@ namespace Magento\Framework\ObjectManager\Test\Unit\Code\Generator;
 use Magento\Framework\Code\Generator\Io;
 use Magento\Framework\ObjectManager\Code\Generator\Factory;
 use Magento\Framework\ObjectManager\Code\Generator\Sample;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class FactoryTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/GenerateRepositoryTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/GenerateRepositoryTest.php
@@ -8,7 +8,7 @@ namespace Magento\Framework\ObjectManager\Test\Unit\Code\Generator;
 use Composer\Autoload\ClassLoader;
 use Magento\Framework\Code\Generator\Io;
 use Magento\Framework\ObjectManager\Code\Generator\Repository;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class RepositoryTest

--- a/lib/internal/Magento/Framework/Reflection/Test/Unit/TypeCasterTest.php
+++ b/lib/internal/Magento/Framework/Reflection/Test/Unit/TypeCasterTest.php
@@ -8,7 +8,7 @@ namespace Magento\Framework\Reflection\Test\Unit;
 use Magento\Framework\Reflection\TypeCaster;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\Serialize\Serializer\Json;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Type caster Test

--- a/lib/internal/Magento/Framework/Search/Test/Unit/Adapter/Mysql/MapperTest.php
+++ b/lib/internal/Magento/Framework/Search/Test/Unit/Adapter/Mysql/MapperTest.php
@@ -9,7 +9,7 @@ use Magento\Framework\DB\Select;
 use Magento\Framework\Search\Adapter\Mysql\Mapper;
 use Magento\Framework\Search\Adapter\Mysql\Query\Builder\Match;
 use Magento\Framework\Search\Adapter\Mysql\TemporaryStorage;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Magento\Framework\Search\Request\Query\BoolExpression;
 use Magento\Framework\Search\Request\Query\Filter;
 use Magento\Framework\Search\Request\QueryInterface;

--- a/lib/internal/Magento/Framework/Search/Test/Unit/Adapter/Mysql/Query/Builder/MatchTest.php
+++ b/lib/internal/Magento/Framework/Search/Test/Unit/Adapter/Mysql/Query/Builder/MatchTest.php
@@ -8,7 +8,7 @@ namespace Magento\Framework\Search\Test\Unit\Adapter\Mysql\Query\Builder;
 use Magento\Framework\DB\Select;
 use Magento\Framework\Search\Request\Query\BoolExpression;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 class MatchTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/Test/Unit/DB/AggregatedFieldDataConverterTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/DB/AggregatedFieldDataConverterTest.php
@@ -75,8 +75,8 @@ class AggregatedFieldDataConverterTest extends \PHPUnit\Framework\TestCase
      */
     private function assertCallsDelegation(
         $connection,
-        \PHPUnit_Framework_MockObject_MockObject $fieldConverterOne,
-        \PHPUnit_Framework_MockObject_MockObject $fieldConverterTwo,
+        \PHPUnit\Framework\MockObject\MockObject $fieldConverterOne,
+        \PHPUnit\Framework\MockObject\MockObject $fieldConverterTwo,
         $queryModifier
     ) {
         $fieldConverterOne->expects($this->once())

--- a/lib/internal/Magento/Framework/Test/Unit/FlagManagerTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/FlagManagerTest.php
@@ -9,7 +9,7 @@ use Magento\Framework\FlagFactory;
 use Magento\Framework\Flag\FlagResource;
 use Magento\Framework\Flag;
 use Magento\Framework\FlagManager;
-use \PHPUnit_Framework_MockObject_MockObject as Mock;
+use \PHPUnit\Framework\MockObject\MockObject as Mock;
 
 /**
  * Class FlagManagerTest

--- a/lib/internal/Magento/Framework/TestFramework/Unit/Block/Adminhtml.php
+++ b/lib/internal/Magento/Framework/TestFramework/Unit/Block/Adminhtml.php
@@ -202,7 +202,7 @@ class Adminhtml extends \PHPUnit\Framework\TestCase
      * @return \PHPUnit\Framework\MockObject\Builder\InvocationMocker
      */
     protected function _setStub(
-        \PHPUnit_Framework_MockObject_MockObject $object,
+        \PHPUnit\Framework\MockObject\MockObject $object,
         $stubName,
         $return = null,
         $expects = null

--- a/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ProxyTesting.php
+++ b/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ProxyTesting.php
@@ -26,7 +26,7 @@ class ProxyTesting
      */
     public function invokeWithExpectations(
         $object,
-        \PHPUnit_Framework_MockObject_MockObject $proxiedObject,
+        \PHPUnit\Framework\MockObject\MockObject $proxiedObject,
         $method,
         $params = [],
         $proxiedResult = null,

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/CalendarTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/CalendarTest.php
@@ -10,7 +10,7 @@ use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\View\Element\Html\Calendar;
 use Magento\Framework\View\Element\Template\Context;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use \PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * @see Calendar

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/DbStatusCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/DbStatusCommandTest.php
@@ -12,7 +12,7 @@ use Magento\Setup\Console\Command\DbStatusCommand;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Setup\Model\ObjectManagerProvider;
 use Magento\Framework\ObjectManagerInterface;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/DeployStaticContentCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/DeployStaticContentCommandTest.php
@@ -20,7 +20,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 use Symfony\Component\Console\Tester\CommandTester;
 
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 class DeployStaticContentCommandTest extends \PHPUnit\Framework\TestCase
 {

--- a/setup/src/Magento/Setup/Test/Unit/Console/CompilerPreparationTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/CompilerPreparationTest.php
@@ -13,7 +13,7 @@ use Magento\Framework\Filesystem\Driver\File;
 use Symfony\Component\Console\Input\ArgvInput;
 use Zend\ServiceManager\ServiceManager;
 use Magento\Setup\Console\CompilerPreparation;
-use PHPUnit_Framework_MockObject_MockObject as Mock;
+use PHPUnit\Framework\MockObject\MockObject as Mock;
 
 class CompilerPreparationTest extends \PHPUnit\Framework\TestCase
 {

--- a/setup/src/Magento/Setup/Test/Unit/Controller/ExtensionGridTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Controller/ExtensionGridTest.php
@@ -9,7 +9,7 @@ use Magento\Setup\Controller\ExtensionGrid;
 use Magento\Setup\Model\Grid\Extension;
 use Magento\Setup\Model\PackagesAuth;
 use Magento\Setup\Model\PackagesData;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ExtensionGridTest

--- a/setup/src/Magento/Setup/Test/Unit/Controller/UpdateExtensionGridTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Controller/UpdateExtensionGridTest.php
@@ -7,7 +7,7 @@ namespace Magento\Setup\Test\Unit\Controller;
 
 use Magento\Setup\Controller\UpdateExtensionGrid;
 use Magento\Setup\Model\Grid\Extension;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Zend\View\Model\JsonModel;
 use Zend\View\Model\ViewModel;
 

--- a/setup/src/Magento/Setup/Test/Unit/Model/Grid/ExtensionTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/Grid/ExtensionTest.php
@@ -8,7 +8,7 @@ namespace Magento\Setup\Test\Unit\Model\Grid;
 use Magento\Framework\Composer\ComposerInformation;
 use Magento\Setup\Model\Grid\Extension;
 use Magento\Setup\Model\PackagesData;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Class ExtensionTest

--- a/setup/src/Magento/Setup/Test/Unit/Model/PackagesDataTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/PackagesDataTest.php
@@ -9,7 +9,7 @@ namespace Magento\Setup\Test\Unit\Model;
 use Composer\Package\RootPackage;
 use Magento\Framework\Composer\ComposerInformation;
 use Magento\Setup\Model\PackagesData;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject as MockObject;
 
 /**
  * Tests Magento\Setup\Model\PackagesData


### PR DESCRIPTION
I am not 100% sure, that this does not break the tests.

PHPUnit classes MUST be used in namespaced version, eg \PHPUnit\Framework\TestCase instead of \PHPUnit_Framework_TestCase.
