### PR TITLE
Method argument space

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Plugin/IndexerConfigData.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Plugin/IndexerConfigData.php
@@ -41,7 +41,7 @@ class IndexerConfigData
             if (!$path && isset($data[$indexerId])) {
                 unset($data[$indexerId]);
             } elseif ($path) {
-                list($firstKey,) = explode('/', $path);
+                list($firstKey, ) = explode('/', $path);
                 if ($firstKey == $indexerId) {
                     $data = $default;
                 }

--- a/dev/tools/UpgradeScripts/pre_composer_update_2.3.php
+++ b/dev/tools/UpgradeScripts/pre_composer_update_2.3.php
@@ -73,7 +73,7 @@ if (isset($opts['help'])) {
 
 try {
     if (version_compare(PHP_VERSION, '7.1', '<') || version_compare(PHP_VERSION, '7.3', '>=')) {
-        preg_match('/^\d+\.\d+\.\d+/',PHP_VERSION, $matches);
+        preg_match('/^\d+\.\d+\.\d+/', PHP_VERSION, $matches);
         $phpVersion = $matches[0];
         throw new Exception("Invalid PHP version '$phpVersion'. Magento 2.3 requires PHP 7.1 or 7.2");
     }
@@ -208,7 +208,7 @@ try {
     // Add the repository to composer.json if needed without overwriting any existing ones
     $repoUrls = array_map(function ($r) { return $r['url']; }, $composerData['repositories']);
     if (!in_array($repo, $repoUrls)) {
-        $repoLabels = array_map('strtolower',array_keys($composerData['repositories']));
+        $repoLabels = array_map('strtolower', array_keys($composerData['repositories']));
         $newLabel = 'magento';
         if (in_array($newLabel, $repoLabels)) {
             $count = count($repoLabels);

--- a/lib/internal/Magento/Framework/Acl/Test/Unit/Role/RegistryTest.php
+++ b/lib/internal/Magento/Framework/Acl/Test/Unit/Role/RegistryTest.php
@@ -84,7 +84,7 @@ class RegistryTest extends \PHPUnit\Framework\TestCase
     {
         $roleId = 1;
         $parentRoleId = 2;
-        list($role,) = $this->initRoles($roleId, $parentRoleId);
+        list($role, ) = $this->initRoles($roleId, $parentRoleId);
 
         $this->model->addParent($role, 26);
     }

--- a/lib/internal/Magento/Framework/Image/Adapter/Gd2.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/Gd2.php
@@ -428,7 +428,7 @@ class Gd2 extends \Magento\Framework\Image\Adapter\AbstractAdapter
      */
     public function watermark($imagePath, $positionX = 0, $positionY = 0, $opacity = 30, $tile = false)
     {
-        list($watermarkSrcWidth, $watermarkSrcHeight, $watermarkFileType,) = $this->_getImageOptions($imagePath);
+        list($watermarkSrcWidth, $watermarkSrcHeight, $watermarkFileType, ) = $this->_getImageOptions($imagePath);
         $this->_getFileAttributes();
         $watermark = call_user_func(
             $this->_getCallback('create', $watermarkFileType, 'Unsupported watermark image format.'),

--- a/lib/internal/Magento/Framework/View/Asset/Source.php
+++ b/lib/internal/Magento/Framework/View/Asset/Source.php
@@ -170,7 +170,7 @@ class Source
      */
     public function getSourceContentType(LocalInterface $asset)
     {
-        list(,,$type) = $this->preProcess($asset);
+        list(, , $type) = $this->preProcess($asset);
         return $type;
     }
 


### PR DESCRIPTION
In method arguments and method call, there MUST NOT be a space before each comma and there MUST be one space after each comma. Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line. 