### PR TITLE
Class definition

### DIFF
--- a/app/code/Magento/Backend/Block/Store/Switcher/Form/Renderer/Fieldset/Element.php
+++ b/app/code/Magento/Backend/Block/Store/Switcher/Form/Renderer/Fieldset/Element.php
@@ -10,8 +10,7 @@ namespace Magento\Backend\Block\Store\Switcher\Form\Renderer\Fieldset;
  * @api
  * @since 100.0.2
  */
-class Element extends \Magento\Backend\Block\Widget\Form\Renderer\Fieldset\Element implements
-    \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Element extends \Magento\Backend\Block\Widget\Form\Renderer\Fieldset\Element implements \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
 {
     /**
      * Form element which re-rendering

--- a/app/code/Magento/Backend/Block/Widget/Form/Element/Gallery.php
+++ b/app/code/Magento/Backend/Block/Widget/Form/Element/Gallery.php
@@ -13,8 +13,7 @@ use Magento\Framework\Data\Form\Element\AbstractElement;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Gallery extends \Magento\Backend\Block\Template implements
-    \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Gallery extends \Magento\Backend\Block\Template implements \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
 {
     /**
      * @var AbstractElement|null

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/AbstractFilter.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/AbstractFilter.php
@@ -13,8 +13,7 @@ namespace Magento\Backend\Block\Widget\Grid\Column\Filter;
  * @deprecated 100.2.0 in favour of UI component implementation
  * @since 100.0.2
  */
-class AbstractFilter extends \Magento\Backend\Block\AbstractBlock implements
-    \Magento\Backend\Block\Widget\Grid\Column\Filter\FilterInterface
+class AbstractFilter extends \Magento\Backend\Block\AbstractBlock implements \Magento\Backend\Block\Widget\Grid\Column\Filter\FilterInterface
 {
     /**
      * Column related to filter

--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Item/Additional/DefaultAdditional.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/Item/Additional/DefaultAdditional.php
@@ -10,8 +10,7 @@ namespace Magento\Backend\Block\Widget\Grid\Massaction\Item\Additional;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class DefaultAdditional extends \Magento\Backend\Block\Widget\Form\Generic implements
-    \Magento\Backend\Block\Widget\Grid\Massaction\Item\Additional\AdditionalInterface
+class DefaultAdditional extends \Magento\Backend\Block\Widget\Form\Generic implements \Magento\Backend\Block\Widget\Grid\Massaction\Item\Additional\AdditionalInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Bundle/Model/Link.php
+++ b/app/code/Magento/Bundle/Model/Link.php
@@ -10,8 +10,7 @@ namespace Magento\Bundle\Model;
  * Class Link
  * @codeCoverageIgnore
  */
-class Link extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Bundle\Api\Data\LinkInterface
+class Link extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Bundle\Api\Data\LinkInterface
 {
     /**#@+
      * Constants

--- a/app/code/Magento/Bundle/Model/Option.php
+++ b/app/code/Magento/Bundle/Model/Option.php
@@ -14,8 +14,7 @@ namespace Magento\Bundle\Model;
  * @method Option setParentId(int $value)
  * @since 100.0.2
  */
-class Option extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Bundle\Api\Data\OptionInterface
+class Option extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Bundle\Api\Data\OptionInterface
 {
     /**#@+
      * Constants

--- a/app/code/Magento/Bundle/Model/Source/Option/Type.php
+++ b/app/code/Magento/Bundle/Model/Source/Option/Type.php
@@ -15,9 +15,7 @@ use Magento\Framework\Api\ExtensionAttributesFactory;
  * Class Type
  *
  */
-class Type extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Framework\Option\ArrayInterface,
-    \Magento\Bundle\Api\Data\OptionTypeInterface
+class Type extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Framework\Option\ArrayInterface, \Magento\Bundle\Api\Data\OptionTypeInterface
 {
     /**#@+
      * Constants

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/Attributes.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/Attributes.php
@@ -23,8 +23,7 @@ use Magento\Framework\Data\Form\Element\AbstractElement;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @since 100.0.2
  */
-class Attributes extends \Magento\Catalog\Block\Adminhtml\Form implements
-    \Magento\Backend\Block\Widget\Tab\TabInterface
+class Attributes extends \Magento\Catalog\Block\Adminhtml\Form implements \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
      * @var \Magento\Catalog\Model\ProductFactory

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Frontend/Product/Watermark.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Frontend/Product/Watermark.php
@@ -13,8 +13,7 @@ use Magento\Framework\Data\Form\Element\AbstractElement;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Watermark extends \Magento\Backend\Block\AbstractBlock implements
-    \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Watermark extends \Magento\Backend\Block\AbstractBlock implements \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
 {
     /**
      * @var \Magento\Framework\Data\Form\Element\Factory

--- a/app/code/Magento/Catalog/Block/Navigation.php
+++ b/app/code/Magento/Catalog/Block/Navigation.php
@@ -17,8 +17,7 @@ use Magento\Customer\Model\Context;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @since 100.0.2
  */
-class Navigation extends \Magento\Framework\View\Element\Template implements
-    \Magento\Framework\DataObject\IdentityInterface
+class Navigation extends \Magento\Framework\View\Element\Template implements \Magento\Framework\DataObject\IdentityInterface
 {
     /**
      * @var Category

--- a/app/code/Magento/Catalog/Block/Product/NewProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/NewProduct.php
@@ -12,8 +12,7 @@ use Magento\Customer\Model\Context as CustomerContext;
  *
  * @SuppressWarnings(PHPMD.LongVariable)
  */
-class NewProduct extends \Magento\Catalog\Block\Product\AbstractProduct implements
-    \Magento\Framework\DataObject\IdentityInterface
+class NewProduct extends \Magento\Catalog\Block\Product\AbstractProduct implements \Magento\Framework\DataObject\IdentityInterface
 {
     /**
      * Default value for products count that will be shown

--- a/app/code/Magento/Catalog/Block/Product/ProductList/Related.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Related.php
@@ -16,8 +16,7 @@ use Magento\Framework\View\Element\AbstractBlock;
  * @SuppressWarnings(PHPMD.LongVariable)
  * @since 100.0.2
  */
-class Related extends \Magento\Catalog\Block\Product\AbstractProduct implements
-    \Magento\Framework\DataObject\IdentityInterface
+class Related extends \Magento\Catalog\Block\Product\AbstractProduct implements \Magento\Framework\DataObject\IdentityInterface
 {
     /**
      * @var Collection

--- a/app/code/Magento/Catalog/Block/Product/ProductList/Upsell.php
+++ b/app/code/Magento/Catalog/Block/Product/ProductList/Upsell.php
@@ -15,8 +15,7 @@ use Magento\Catalog\Model\ResourceModel\Product\Collection;
  * @SuppressWarnings(PHPMD.LongVariable)
  * @since 100.0.2
  */
-class Upsell extends \Magento\Catalog\Block\Product\AbstractProduct implements
-    \Magento\Framework\DataObject\IdentityInterface
+class Upsell extends \Magento\Catalog\Block\Product\AbstractProduct implements \Magento\Framework\DataObject\IdentityInterface
 {
     /**
      * @var int

--- a/app/code/Magento/Catalog/Model/Category.php
+++ b/app/code/Magento/Catalog/Model/Category.php
@@ -39,10 +39,7 @@ use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @since 100.0.2
  */
-class Category extends \Magento\Catalog\Model\AbstractModel implements
-    \Magento\Framework\DataObject\IdentityInterface,
-    \Magento\Catalog\Api\Data\CategoryInterface,
-    \Magento\Catalog\Api\Data\CategoryTreeInterface
+class Category extends \Magento\Catalog\Model\AbstractModel implements \Magento\Framework\DataObject\IdentityInterface, \Magento\Catalog\Api\Data\CategoryInterface, \Magento\Catalog\Api\Data\CategoryTreeInterface
 {
     /**
      * Entity code.

--- a/app/code/Magento/Catalog/Model/Category/Attribute.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute.php
@@ -10,8 +10,7 @@ namespace Magento\Catalog\Model\Category;
  *
  * @method \Magento\Eav\Api\Data\AttributeExtensionInterface getExtensionAttributes()
  */
-class Attribute extends \Magento\Catalog\Model\Entity\Attribute implements
-    \Magento\Catalog\Api\Data\CategoryAttributeInterface
+class Attribute extends \Magento\Catalog\Model\Entity\Attribute implements \Magento\Catalog\Api\Data\CategoryAttributeInterface
 {
     const SCOPE_STORE = 0;
 

--- a/app/code/Magento/Catalog/Model/CategoryLink.php
+++ b/app/code/Magento/Catalog/Model/CategoryLink.php
@@ -9,8 +9,7 @@ namespace Magento\Catalog\Model;
 /**
  * @codeCoverageIgnore
  */
-class CategoryLink extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\Catalog\Api\Data\CategoryLinkInterface
+class CategoryLink extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\Catalog\Api\Data\CategoryLinkInterface
 {
     /**#@+
      * Constants

--- a/app/code/Magento/Catalog/Model/CategoryProductLink.php
+++ b/app/code/Magento/Catalog/Model/CategoryProductLink.php
@@ -9,8 +9,7 @@ namespace Magento\Catalog\Model;
 /**
  * @codeCoverageIgnore
  */
-class CategoryProductLink extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\Catalog\Api\Data\CategoryProductLinkInterface
+class CategoryProductLink extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\Catalog\Api\Data\CategoryProductLinkInterface
 {
     /**#@+
      * Constant for confirmation status

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -39,10 +39,7 @@ use Magento\Framework\Pricing\SaleableInterface;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @since 100.0.2
  */
-class Product extends \Magento\Catalog\Model\AbstractModel implements
-    IdentityInterface,
-    SaleableInterface,
-    ProductInterface
+class Product extends \Magento\Catalog\Model\AbstractModel implements IdentityInterface, SaleableInterface, ProductInterface
 {
     /**
      * @var ProductLinkRepositoryInterface

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Type.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Type.php
@@ -9,8 +9,7 @@ namespace Magento\Catalog\Model\Product\Attribute;
 /**
  * @codeCoverageIgnore
  */
-class Type extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Catalog\Api\Data\ProductAttributeTypeInterface
+class Type extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Catalog\Api\Data\ProductAttributeTypeInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Catalog/Model/Product/Configuration/Item/Option.php
+++ b/app/code/Magento/Catalog/Model/Product/Configuration/Item/Option.php
@@ -11,8 +11,7 @@
  */
 namespace Magento\Catalog\Model\Product\Configuration\Item;
 
-class Option extends \Magento\Framework\DataObject implements
-    \Magento\Catalog\Model\Product\Configuration\Item\Option\OptionInterface
+class Option extends \Magento\Framework\DataObject implements \Magento\Catalog\Model\Product\Configuration\Item\Option\OptionInterface
 {
     /**
      * Returns value of this option

--- a/app/code/Magento/Catalog/Model/Product/Option/Type.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type.php
@@ -9,8 +9,7 @@ namespace Magento\Catalog\Model\Product\Option;
 /**
  * @codeCoverageIgnore
  */
-class Type extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Catalog\Api\Data\ProductCustomOptionTypeInterface
+class Type extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Catalog\Api\Data\ProductCustomOptionTypeInterface
 {
     /**#@+
      * Constants

--- a/app/code/Magento/Catalog/Model/Product/TierPrice.php
+++ b/app/code/Magento/Catalog/Model/Product/TierPrice.php
@@ -9,8 +9,7 @@ namespace Magento\Catalog\Model\Product;
 /**
  * @codeCoverageIgnore
  */
-class TierPrice extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Catalog\Api\Data\ProductTierPriceInterface
+class TierPrice extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Catalog\Api\Data\ProductTierPriceInterface
 {
     /**
      * Retrieve tier qty

--- a/app/code/Magento/Catalog/Model/ProductLink/Link.php
+++ b/app/code/Magento/Catalog/Model/ProductLink/Link.php
@@ -9,8 +9,7 @@ namespace Magento\Catalog\Model\ProductLink;
 /**
  * @codeCoverageIgnore
  */
-class Link extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Catalog\Api\Data\ProductLinkInterface
+class Link extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Catalog\Api\Data\ProductLinkInterface
 {
     /**#@+
      * Constants

--- a/app/code/Magento/Catalog/Model/ProductOptions/Config.php
+++ b/app/code/Magento/Catalog/Model/ProductOptions/Config.php
@@ -10,8 +10,7 @@ use Magento\Framework\Serialize\SerializerInterface;
 /**
  * Provides product options configuration
  */
-class Config extends \Magento\Framework\Config\Data implements
-    \Magento\Catalog\Model\ProductOptions\ConfigInterface
+class Config extends \Magento\Framework\Config\Data implements \Magento\Catalog\Model\ProductOptions\ConfigInterface
 {
     /**
      * Constructor

--- a/app/code/Magento/Catalog/Model/ProductRender/FormattedPriceInfo.php
+++ b/app/code/Magento/Catalog/Model/ProductRender/FormattedPriceInfo.php
@@ -11,8 +11,7 @@ use Magento\Catalog\Api\Data\ProductRender\FormattedPriceInfoInterface;
 /**
  * @inheritdoc
  */
-class FormattedPriceInfo extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    FormattedPriceInfoInterface
+class FormattedPriceInfo extends \Magento\Framework\Model\AbstractExtensibleModel implements FormattedPriceInfoInterface
 {
     /**
      * @inheritdoc

--- a/app/code/Magento/Catalog/Model/ProductRender/Image.php
+++ b/app/code/Magento/Catalog/Model/ProductRender/Image.php
@@ -11,8 +11,7 @@ use Magento\Catalog\Api\Data\ProductRender\ImageInterface;
 /**
  * Product image renderer model.
  */
-class Image extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    ImageInterface
+class Image extends \Magento\Framework\Model\AbstractExtensibleModel implements ImageInterface
 {
     /**
      * Set url to image.

--- a/app/code/Magento/Catalog/Model/ProductRender/PriceInfo.php
+++ b/app/code/Magento/Catalog/Model/ProductRender/PriceInfo.php
@@ -12,8 +12,7 @@ use Magento\Catalog\Api\Data\ProductRender\PriceInfoInterface;
 /**
  * @inheritdoc
  */
-class PriceInfo extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    PriceInfoInterface
+class PriceInfo extends \Magento\Framework\Model\AbstractExtensibleModel implements PriceInfoInterface
 {
     /**
      * @return string

--- a/app/code/Magento/Catalog/Model/ProductWebsiteLink.php
+++ b/app/code/Magento/Catalog/Model/ProductWebsiteLink.php
@@ -6,8 +6,7 @@
 
 namespace Magento\Catalog\Model;
 
-class ProductWebsiteLink extends \Magento\Framework\Api\AbstractSimpleObject implements
-    \Magento\Catalog\Api\Data\ProductWebsiteLinkInterface
+class ProductWebsiteLink extends \Magento\Framework\Api\AbstractSimpleObject implements \Magento\Catalog\Api\Data\ProductWebsiteLinkInterface
 {
     /**#@+
      * Field names

--- a/app/code/Magento/Catalog/Model/ResourceModel/Eav/Attribute.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Eav/Attribute.php
@@ -28,9 +28,7 @@ use Magento\Framework\Stdlib\DateTime\DateTimeFormatterInterface;
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @since 100.0.2
  */
-class Attribute extends \Magento\Eav\Model\Entity\Attribute implements
-    \Magento\Catalog\Api\Data\ProductAttributeInterface,
-    \Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface
+class Attribute extends \Magento\Eav\Model\Entity\Attribute implements \Magento\Catalog\Api\Data\ProductAttributeInterface, \Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface
 {
     const MODULE_NAME = 'Magento_Catalog';
 

--- a/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext.php
+++ b/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext.php
@@ -20,10 +20,7 @@ use Magento\Indexer\Model\ProcessManager;
  * @api
  * @since 100.0.2
  */
-class Fulltext implements
-    \Magento\Framework\Indexer\ActionInterface,
-    \Magento\Framework\Mview\ActionInterface,
-    \Magento\Framework\Indexer\DimensionalIndexerInterface
+class Fulltext implements \Magento\Framework\Indexer\ActionInterface, \Magento\Framework\Mview\ActionInterface, \Magento\Framework\Indexer\DimensionalIndexerInterface
 {
     /**
      * Indexer ID in configuration

--- a/app/code/Magento/CatalogSearch/Model/ResourceModel/Search/Collection.php
+++ b/app/code/Magento/CatalogSearch/Model/ResourceModel/Search/Collection.php
@@ -13,8 +13,7 @@ namespace Magento\CatalogSearch\Model\ResourceModel\Search;
  * @api
  * @since 100.0.2
  */
-class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection implements
-    \Magento\Search\Model\SearchCollectionInterface
+class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection implements \Magento\Search\Model\SearchCollectionInterface
 {
     /**
      * Attribute collection

--- a/app/code/Magento/Checkout/Block/Cart/Item/Renderer.php
+++ b/app/code/Magento/Checkout/Block/Cart/Item/Renderer.php
@@ -25,8 +25,7 @@ use Magento\Catalog\Model\Product\Configuration\Item\ItemResolverInterface;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
-class Renderer extends \Magento\Framework\View\Element\Template implements
-    \Magento\Framework\DataObject\IdentityInterface
+class Renderer extends \Magento\Framework\View\Element\Template implements \Magento\Framework\DataObject\IdentityInterface
 {
     /**
      * @var \Magento\Checkout\Model\Session

--- a/app/code/Magento/Checkout/Model/PaymentDetails.php
+++ b/app/code/Magento/Checkout/Model/PaymentDetails.php
@@ -8,8 +8,7 @@ namespace Magento\Checkout\Model;
 /**
  * @codeCoverageIgnoreStart
  */
-class PaymentDetails extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Checkout\Api\Data\PaymentDetailsInterface
+class PaymentDetails extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Checkout\Api\Data\PaymentDetailsInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Cms/Block/Page.php
+++ b/app/code/Magento/Cms/Block/Page.php
@@ -13,8 +13,7 @@ use Magento\Store\Model\ScopeInterface;
  * @api
  * @since 100.0.2
  */
-class Page extends \Magento\Framework\View\Element\AbstractBlock implements
-    \Magento\Framework\DataObject\IdentityInterface
+class Page extends \Magento\Framework\View\Element\AbstractBlock implements \Magento\Framework\DataObject\IdentityInterface
 {
     /**
      * @var \Magento\Cms\Model\Template\FilterProvider

--- a/app/code/Magento/Config/Block/System/Config/Form/Field.php
+++ b/app/code/Magento/Config/Block/System/Config/Form/Field.php
@@ -14,8 +14,7 @@ namespace Magento\Config\Block\System\Config\Form;
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  * @since 100.0.2
  */
-class Field extends \Magento\Backend\Block\Template implements
-    \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Field extends \Magento\Backend\Block\Template implements \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
 {
     /**
      * Retrieve element HTML markup

--- a/app/code/Magento/Config/Block/System/Config/Form/Field/Heading.php
+++ b/app/code/Magento/Config/Block/System/Config/Form/Field/Heading.php
@@ -15,8 +15,7 @@ namespace Magento\Config\Block\System\Config\Form\Field;
  * @api
  * @since 100.0.2
  */
-class Heading extends \Magento\Backend\Block\AbstractBlock implements
-    \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Heading extends \Magento\Backend\Block\AbstractBlock implements \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
 {
     /**
      * Render element html

--- a/app/code/Magento/Config/Block/System/Config/Form/Fieldset.php
+++ b/app/code/Magento/Config/Block/System/Config/Form/Fieldset.php
@@ -15,8 +15,7 @@ use Magento\Framework\Data\Form\Element\AbstractElement;
  * @api
  * @since 100.0.2
  */
-class Fieldset extends \Magento\Backend\Block\AbstractBlock implements
-    \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Fieldset extends \Magento\Backend\Block\AbstractBlock implements \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
 {
     /**
      * @var \Magento\Backend\Model\Auth\Session

--- a/app/code/Magento/Config/Model/Config/Backend/Encrypted.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Encrypted.php
@@ -12,8 +12,7 @@ namespace Magento\Config\Model\Config\Backend;
  * @api
  * @since 100.0.2
  */
-class Encrypted extends \Magento\Framework\App\Config\Value implements
-    \Magento\Framework\App\Config\Data\ProcessorInterface
+class Encrypted extends \Magento\Framework\App\Config\Value implements \Magento\Framework\App\Config\Data\ProcessorInterface
 {
     /**
      * @var \Magento\Framework\Encryption\EncryptorInterface

--- a/app/code/Magento/Config/Model/Config/Structure/Element/Group/Proxy.php
+++ b/app/code/Magento/Config/Model/Config/Structure/Element/Group/Proxy.php
@@ -9,8 +9,7 @@ namespace Magento\Config\Model\Config\Structure\Element\Group;
  * @api
  * @since 100.0.2
  */
-class Proxy extends \Magento\Config\Model\Config\Structure\Element\Group implements
-    \Magento\Framework\ObjectManager\NoninterceptableInterface
+class Proxy extends \Magento\Config\Model\Config\Structure\Element\Group implements \Magento\Framework\ObjectManager\NoninterceptableInterface
 {
     /**
      * Object manager

--- a/app/code/Magento/Config/Model/Config/Structure/Search/Proxy.php
+++ b/app/code/Magento/Config/Model/Config/Structure/Search/Proxy.php
@@ -9,9 +9,7 @@ namespace Magento\Config\Model\Config\Structure\Search;
  * @api
  * @since 100.0.2
  */
-class Proxy implements
-    \Magento\Config\Model\Config\Structure\SearchInterface,
-    \Magento\Framework\ObjectManager\NoninterceptableInterface
+class Proxy implements \Magento\Config\Model\Config\Structure\SearchInterface, \Magento\Framework\ObjectManager\NoninterceptableInterface
 {
     /**
      * Object manager

--- a/app/code/Magento/Config/Model/ResourceModel/Config.php
+++ b/app/code/Magento/Config/Model/ResourceModel/Config.php
@@ -14,8 +14,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
  * @api
  * @since 100.0.2
  */
-class Config extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implements
-    \Magento\Framework\App\Config\ConfigResource\ConfigInterface
+class Config extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implements \Magento\Framework\App\Config\ConfigResource\ConfigInterface
 {
     /**
      * Define main table

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable/Attribute.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable/Attribute.php
@@ -15,8 +15,7 @@ use Magento\Framework\EntityManager\MetadataPool;
  * @method Attribute setProductAttribute(\Magento\Eav\Model\Entity\Attribute\AbstractAttribute $value)
  * @method \Magento\Eav\Model\Entity\Attribute\AbstractAttribute getProductAttribute()
  */
-class Attribute extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\ConfigurableProduct\Api\Data\OptionInterface
+class Attribute extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\ConfigurableProduct\Api\Data\OptionInterface
 {
     /**
      * Constants for field names

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable/OptionValue.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable/OptionValue.php
@@ -11,8 +11,7 @@ namespace Magento\ConfigurableProduct\Model\Product\Type\Configurable;
  * Class OptionValue
  *
  */
-class OptionValue extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\ConfigurableProduct\Api\Data\OptionValueInterface
+class OptionValue extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\ConfigurableProduct\Api\Data\OptionValueInterface
 {
     /**#@+
      * Constants for field names

--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/Renderer/Region.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/Renderer/Region.php
@@ -8,8 +8,7 @@ namespace Magento\Customer\Block\Adminhtml\Edit\Renderer;
 /**
  * Customer address region field renderer
  */
-class Region extends \Magento\Backend\Block\AbstractBlock implements
-    \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Region extends \Magento\Backend\Block\AbstractBlock implements \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
 {
     /**
      * @var \Magento\Directory\Helper\Data

--- a/app/code/Magento/Customer/Model/Data/Address.php
+++ b/app/code/Magento/Customer/Model/Data/Address.php
@@ -17,8 +17,7 @@ use \Magento\Framework\Api\AttributeValueFactory;
  * @api
  * @since 100.0.2
  */
-class Address extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\Customer\Api\Data\AddressInterface
+class Address extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\Customer\Api\Data\AddressInterface
 {
     /**
      * @var \Magento\Customer\Api\AddressMetadataInterface

--- a/app/code/Magento/Customer/Model/Data/AttributeMetadata.php
+++ b/app/code/Magento/Customer/Model/Data/AttributeMetadata.php
@@ -11,9 +11,7 @@ use Magento\Customer\Api\Data\AttributeMetadataInterface;
 /**
  * Customer attribute metadata class.
  */
-class AttributeMetadata extends \Magento\Framework\Api\AbstractSimpleObject implements
-    \Magento\Customer\Api\Data\AttributeMetadataInterface,
-    \Magento\Eav\Api\Data\AttributeDefaultValueInterface
+class AttributeMetadata extends \Magento\Framework\Api\AbstractSimpleObject implements \Magento\Customer\Api\Data\AttributeMetadataInterface, \Magento\Eav\Api\Data\AttributeDefaultValueInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Customer/Model/Data/Customer.php
+++ b/app/code/Magento/Customer/Model/Data/Customer.php
@@ -12,8 +12,7 @@ use \Magento\Framework\Api\AttributeValueFactory;
  * Class Customer
  * @SuppressWarnings(PHPMD.ExcessivePublicCount)
  */
-class Customer extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\Customer\Api\Data\CustomerInterface
+class Customer extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\Customer\Api\Data\CustomerInterface
 {
     /**
      * @var \Magento\Customer\Api\CustomerMetadataInterface

--- a/app/code/Magento/Customer/Model/Data/Group.php
+++ b/app/code/Magento/Customer/Model/Data/Group.php
@@ -9,8 +9,7 @@ namespace Magento\Customer\Model\Data;
 /**
  * Customer Group data model.
  */
-class Group extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\Customer\Api\Data\GroupInterface
+class Group extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\Customer\Api\Data\GroupInterface
 {
     /**
      * Get ID

--- a/app/code/Magento/Customer/Model/Data/Option.php
+++ b/app/code/Magento/Customer/Model/Data/Option.php
@@ -11,8 +11,7 @@ namespace Magento\Customer\Model\Data;
 /**
  * Class Option
  */
-class Option extends \Magento\Framework\Api\AbstractSimpleObject implements
-    \Magento\Customer\Api\Data\OptionInterface
+class Option extends \Magento\Framework\Api\AbstractSimpleObject implements \Magento\Customer\Api\Data\OptionInterface
 {
     /**
      * Get option label

--- a/app/code/Magento/Customer/Model/Data/Region.php
+++ b/app/code/Magento/Customer/Model/Data/Region.php
@@ -9,8 +9,7 @@ namespace Magento\Customer\Model\Data;
  * Data Model implementing Address Region interface
  *
  */
-class Region extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\Customer\Api\Data\RegionInterface
+class Region extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\Customer\Api\Data\RegionInterface
 {
     /**
      * Get region code

--- a/app/code/Magento/Customer/Model/Data/ValidationResults.php
+++ b/app/code/Magento/Customer/Model/Data/ValidationResults.php
@@ -10,8 +10,7 @@ namespace Magento\Customer\Model\Data;
 /**
  * Validation results data model.
  */
-class ValidationResults extends \Magento\Framework\Api\AbstractSimpleObject implements
-    \Magento\Customer\Api\Data\ValidationResultsInterface
+class ValidationResults extends \Magento\Framework\Api\AbstractSimpleObject implements \Magento\Customer\Api\Data\ValidationResultsInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Customer/Model/Data/ValidationRule.php
+++ b/app/code/Magento/Customer/Model/Data/ValidationRule.php
@@ -7,8 +7,7 @@ namespace Magento\Customer\Model\Data;
 
 use Magento\Customer\Api\Data\ValidationRuleInterface;
 
-class ValidationRule extends \Magento\Framework\Api\AbstractSimpleObject implements
-    \Magento\Customer\Api\Data\ValidationRuleInterface
+class ValidationRule extends \Magento\Framework\Api\AbstractSimpleObject implements \Magento\Customer\Api\Data\ValidationRuleInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Directory/Model/Data/CountryInformation.php
+++ b/app/code/Magento/Directory/Model/Data/CountryInformation.php
@@ -11,8 +11,7 @@ namespace Magento\Directory\Model\Data;
  *
  * @codeCoverageIgnore
  */
-class CountryInformation extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\Directory\Api\Data\CountryInformationInterface
+class CountryInformation extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\Directory\Api\Data\CountryInformationInterface
 {
     const KEY_COUNTRY_ID = 'country_id';
     const KEY_COUNTRY_TWO_LETTER_ABBREVIATION = 'country_abbreviation2';

--- a/app/code/Magento/Directory/Model/Data/CurrencyInformation.php
+++ b/app/code/Magento/Directory/Model/Data/CurrencyInformation.php
@@ -12,8 +12,7 @@ namespace Magento\Directory\Model\Data;
  *
  * @codeCoverageIgnore
  */
-class CurrencyInformation extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\Directory\Api\Data\CurrencyInformationInterface
+class CurrencyInformation extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\Directory\Api\Data\CurrencyInformationInterface
 {
     const KEY_BASE_CURRENCY_CODE = 'base_currency_code';
     const KEY_BASE_CURRENCY_SYMBOL = 'base_currency_symbol';

--- a/app/code/Magento/Directory/Model/Data/ExchangeRate.php
+++ b/app/code/Magento/Directory/Model/Data/ExchangeRate.php
@@ -12,8 +12,7 @@ namespace Magento\Directory\Model\Data;
  *
  * @codeCoverageIgnore
  */
-class ExchangeRate extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\Directory\Api\Data\ExchangeRateInterface
+class ExchangeRate extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\Directory\Api\Data\ExchangeRateInterface
 {
     const KEY_CURRENCY_TO = 'currency_to';
     const KEY_RATE = 'rate';

--- a/app/code/Magento/Directory/Model/Data/RegionInformation.php
+++ b/app/code/Magento/Directory/Model/Data/RegionInformation.php
@@ -11,8 +11,7 @@ namespace Magento\Directory\Model\Data;
  *
  * @codeCoverageIgnore
  */
-class RegionInformation extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\Directory\Api\Data\RegionInformationInterface
+class RegionInformation extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\Directory\Api\Data\RegionInformationInterface
 {
     const KEY_REGION_ID   = 'region_id';
     const KEY_REGION_CODE = 'region_code';

--- a/app/code/Magento/Downloadable/Helper/Catalog/Product/Configuration.php
+++ b/app/code/Magento/Downloadable/Helper/Catalog/Product/Configuration.php
@@ -11,8 +11,7 @@ namespace Magento\Downloadable\Helper\Catalog\Product;
  *
  * @author     Magento Core Team <core@magentocommerce.com>
  */
-class Configuration extends \Magento\Framework\App\Helper\AbstractHelper implements
-    \Magento\Catalog\Helper\Product\Configuration\ConfigurationInterface
+class Configuration extends \Magento\Framework\App\Helper\AbstractHelper implements \Magento\Catalog\Helper\Product\Configuration\ConfigurationInterface
 {
     /**
      * Catalog product configuration

--- a/app/code/Magento/Eav/Model/Entity/Attribute.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute.php
@@ -18,8 +18,7 @@ use Magento\Framework\Stdlib\DateTime\DateTimeFormatterInterface;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @since 100.0.2
  */
-class Attribute extends \Magento\Eav\Model\Entity\Attribute\AbstractAttribute implements
-    \Magento\Framework\DataObject\IdentityInterface
+class Attribute extends \Magento\Eav\Model\Entity\Attribute\AbstractAttribute implements \Magento\Framework\DataObject\IdentityInterface
 {
     /**
      * Attribute code max length.

--- a/app/code/Magento/Eav/Model/Entity/Attribute/AbstractAttribute.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/AbstractAttribute.php
@@ -20,9 +20,7 @@ use Magento\Framework\Serialize\Serializer\Json;
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @since 100.0.2
  */
-abstract class AbstractAttribute extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    AttributeInterface,
-    \Magento\Eav\Api\Data\AttributeInterface
+abstract class AbstractAttribute extends \Magento\Framework\Model\AbstractExtensibleModel implements AttributeInterface, \Magento\Eav\Api\Data\AttributeInterface
 {
     const TYPE_STATIC = 'static';
 

--- a/app/code/Magento/Eav/Model/Entity/Attribute/FrontendLabel.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/FrontendLabel.php
@@ -9,7 +9,6 @@ namespace Magento\Eav\Model\Entity\Attribute;
 /**
  * @codeCoverageIgnore
  */
-class FrontendLabel extends OptionLabel implements
-    \Magento\Eav\Api\Data\AttributeFrontendLabelInterface
+class FrontendLabel extends OptionLabel implements \Magento\Eav\Api\Data\AttributeFrontendLabelInterface
 {
 }

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Group.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Group.php
@@ -19,8 +19,7 @@ use Magento\Framework\Api\AttributeValueFactory;
  * @method \Magento\Eav\Model\Entity\Attribute\Group setTabGroupCode(string $value)
  * @since 100.0.2
  */
-class Group extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Eav\Api\Data\AttributeGroupInterface
+class Group extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Eav\Api\Data\AttributeGroupInterface
 {
     /**
      * @var \Magento\Framework\Filter\Translit

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Set.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Set.php
@@ -25,8 +25,7 @@ use Magento\Framework\Exception\LocalizedException;
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Set extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Eav\Api\Data\AttributeSetInterface
+class Set extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Eav\Api\Data\AttributeSetInterface
 {
     /**#@+
      * Constants

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php
@@ -13,9 +13,7 @@ namespace Magento\Eav\Model\Entity\Attribute\Source;
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  * @since 100.0.2
  */
-abstract class AbstractSource implements
-    \Magento\Eav\Model\Entity\Attribute\Source\SourceInterface,
-    \Magento\Framework\Option\ArrayInterface
+abstract class AbstractSource implements \Magento\Eav\Model\Entity\Attribute\Source\SourceInterface, \Magento\Framework\Option\ArrayInterface
 {
     /**
      * Reference to the attribute instance

--- a/app/code/Magento/Eav/Model/Entity/Attribute/ValidationRule.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/ValidationRule.php
@@ -9,8 +9,7 @@ namespace Magento\Eav\Model\Entity\Attribute;
 /**
  * @codeCoverageIgnore
  */
-class ValidationRule extends \Magento\Framework\Model\AbstractModel implements
-    \Magento\Eav\Api\Data\AttributeValidationRuleInterface
+class ValidationRule extends \Magento\Framework\Model\AbstractModel implements \Magento\Eav\Api\Data\AttributeValidationRuleInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Eav/Model/Entity/Increment/AbstractIncrement.php
+++ b/app/code/Magento/Eav/Model/Entity/Increment/AbstractIncrement.php
@@ -15,8 +15,7 @@ namespace Magento\Eav\Model\Entity\Increment;
  * @api
  * @since 100.0.2
  */
-abstract class AbstractIncrement extends \Magento\Framework\DataObject implements
-    \Magento\Eav\Model\Entity\Increment\IncrementInterface
+abstract class AbstractIncrement extends \Magento\Framework\DataObject implements \Magento\Eav\Model\Entity\Increment\IncrementInterface
 {
     /**
      * Get pad length

--- a/app/code/Magento/GiftMessage/Model/Message.php
+++ b/app/code/Magento/GiftMessage/Model/Message.php
@@ -14,8 +14,7 @@ use Magento\Framework\Api\AttributeValueFactory;
  * @author      Magento Core Team <core@magentocommerce.com>
  * @since 100.0.2
  */
-class Message extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\GiftMessage\Api\Data\MessageInterface
+class Message extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\GiftMessage\Api\Data\MessageInterface
 {
     /**
      * @var \Magento\GiftMessage\Model\TypeFactory

--- a/app/code/Magento/GoogleOptimizer/Block/Adminhtml/AbstractTab.php
+++ b/app/code/Magento/GoogleOptimizer/Block/Adminhtml/AbstractTab.php
@@ -7,8 +7,7 @@
  */
 namespace Magento\GoogleOptimizer\Block\Adminhtml;
 
-abstract class AbstractTab extends \Magento\Backend\Block\Widget\Form implements
-    \Magento\Backend\Block\Widget\Tab\TabInterface
+abstract class AbstractTab extends \Magento\Backend\Block\Widget\Form implements \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
      * @var \Magento\GoogleOptimizer\Helper\Data

--- a/app/code/Magento/GoogleOptimizer/Block/Code/Category.php
+++ b/app/code/Magento/GoogleOptimizer/Block/Code/Category.php
@@ -12,8 +12,7 @@ namespace Magento\GoogleOptimizer\Block\Code;
  * @api
  * @since 100.0.2
  */
-class Category extends \Magento\GoogleOptimizer\Block\AbstractCode implements
-    \Magento\Framework\DataObject\IdentityInterface
+class Category extends \Magento\GoogleOptimizer\Block\AbstractCode implements \Magento\Framework\DataObject\IdentityInterface
 {
     /**
      * @var string Entity name in registry

--- a/app/code/Magento/GoogleOptimizer/Block/Code/Product.php
+++ b/app/code/Magento/GoogleOptimizer/Block/Code/Product.php
@@ -12,8 +12,7 @@ namespace Magento\GoogleOptimizer\Block\Code;
  * @api
  * @since 100.0.2
  */
-class Product extends \Magento\GoogleOptimizer\Block\AbstractCode implements
-    \Magento\Framework\DataObject\IdentityInterface
+class Product extends \Magento\GoogleOptimizer\Block\AbstractCode implements \Magento\Framework\DataObject\IdentityInterface
 {
     /**
      * @var Product name in registry

--- a/app/code/Magento/Indexer/Model/ResourceModel/Mview/View/State/Collection.php
+++ b/app/code/Magento/Indexer/Model/ResourceModel/Mview/View/State/Collection.php
@@ -5,8 +5,7 @@
  */
 namespace Magento\Indexer\Model\ResourceModel\Mview\View\State;
 
-class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection implements
-    \Magento\Framework\Mview\View\State\CollectionInterface
+class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection implements \Magento\Framework\Mview\View\State\CollectionInterface
 {
     /**
      * Collection initialization

--- a/app/code/Magento/InstantPurchase/PaymentMethodIntegration/Integration.php
+++ b/app/code/Magento/InstantPurchase/PaymentMethodIntegration/Integration.php
@@ -11,10 +11,7 @@ use Magento\Vault\Model\VaultPaymentInterface;
 /**
  * Vault payment method integration with instant purchase facade.
  */
-class Integration implements
-    AvailabilityCheckerInterface,
-    PaymentTokenFormatterInterface,
-    PaymentAdditionalInformationProviderInterface
+class Integration implements AvailabilityCheckerInterface, PaymentTokenFormatterInterface, PaymentAdditionalInformationProviderInterface
 {
     /**
      * @var VaultPaymentInterface

--- a/app/code/Magento/Integration/Block/Adminhtml/Integration/Activate/Permissions/Tab/Webapi.php
+++ b/app/code/Magento/Integration/Block/Adminhtml/Integration/Activate/Permissions/Tab/Webapi.php
@@ -16,8 +16,7 @@ use Magento\Integration\Model\Integration as IntegrationModel;
  * @api
  * @since 100.0.2
  */
-class Webapi extends \Magento\Backend\Block\Widget\Form\Generic implements
-    \Magento\Backend\Block\Widget\Tab\TabInterface
+class Webapi extends \Magento\Backend\Block\Widget\Form\Generic implements \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
      * @var string[]

--- a/app/code/Magento/Integration/Block/Adminhtml/Integration/Edit/Tab/Webapi.php
+++ b/app/code/Magento/Integration/Block/Adminhtml/Integration/Edit/Tab/Webapi.php
@@ -15,8 +15,7 @@ use Magento\Integration\Model\Integration as IntegrationModel;
  * @api
  * @since 100.0.2
  */
-class Webapi extends \Magento\Backend\Block\Widget\Form\Generic implements
-    \Magento\Backend\Block\Widget\Tab\TabInterface
+class Webapi extends \Magento\Backend\Block\Widget\Form\Generic implements \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
      * Root ACL Resource

--- a/app/code/Magento/Integration/Model/ResourceModel/Oauth/Token/RequestLog.php
+++ b/app/code/Magento/Integration/Model/ResourceModel/Oauth/Token/RequestLog.php
@@ -12,9 +12,7 @@ use Magento\Integration\Model\Oauth\Token\RequestLog\Config as RequestLogConfig;
 /**
  * Resource model for failed authentication attempts to retrieve admin/customer token.
  */
-class RequestLog extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implements
-    ReaderInterface,
-    WriterInterface
+class RequestLog extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implements ReaderInterface, WriterInterface
 {
     /**
      * @var \Magento\Framework\Stdlib\DateTime\DateTime

--- a/app/code/Magento/MediaStorage/Model/File/Storage/Response.php
+++ b/app/code/Magento/MediaStorage/Model/File/Storage/Response.php
@@ -10,9 +10,7 @@ use Magento\Framework\App\Request\Http as HttpRequest;
 use Magento\Framework\Stdlib\Cookie\CookieMetadataFactory;
 use Magento\Framework\Stdlib\CookieManagerInterface;
 
-class Response extends Http implements
-    \Magento\Framework\App\Response\FileInterface,
-    \Magento\Framework\App\PageCache\NotCacheableInterface
+class Response extends Http implements \Magento\Framework\App\Response\FileInterface, \Magento\Framework\App\PageCache\NotCacheableInterface
 {
     /**
      * @var \Magento\Framework\File\Transfer\Adapter\Http

--- a/app/code/Magento/Msrp/Model/ProductRender/MsrpPriceInfo.php
+++ b/app/code/Magento/Msrp/Model/ProductRender/MsrpPriceInfo.php
@@ -9,8 +9,7 @@ use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Eav\AttributeFactory;
 use Magento\Msrp\Api\Data\ProductRender\MsrpPriceInfoInterface;
 
-class MsrpPriceInfo extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    MsrpPriceInfoInterface
+class MsrpPriceInfo extends \Magento\Framework\Model\AbstractExtensibleModel implements MsrpPriceInfoInterface
 {
     /**
      * @inheritdoc

--- a/app/code/Magento/Multishipping/Controller/Checkout.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout.php
@@ -15,8 +15,7 @@ use Magento\Framework\Exception\StateException;
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-abstract class Checkout extends \Magento\Checkout\Controller\Action implements
-    \Magento\Checkout\Controller\Express\RedirectLoginInterface
+abstract class Checkout extends \Magento\Checkout\Controller\Action implements \Magento\Checkout\Controller\Express\RedirectLoginInterface
 {
     /**
      * Constructor

--- a/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
+++ b/app/code/Magento/OfflineShipping/Model/Carrier/Freeshipping.php
@@ -19,8 +19,7 @@ use Magento\Quote\Model\Quote\Address\RateRequest;
  * @api
  * @since 100.0.2
  */
-class Freeshipping extends \Magento\Shipping\Model\Carrier\AbstractCarrier implements
-    \Magento\Shipping\Model\Carrier\CarrierInterface
+class Freeshipping extends \Magento\Shipping\Model\Carrier\AbstractCarrier implements \Magento\Shipping\Model\Carrier\CarrierInterface
 {
     /**
      * @var string

--- a/app/code/Magento/OfflineShipping/Model/Carrier/Pickup.php
+++ b/app/code/Magento/OfflineShipping/Model/Carrier/Pickup.php
@@ -13,8 +13,7 @@ use Magento\Quote\Model\Quote\Address\RateRequest;
  * @api
  * @since 100.0.2
  */
-class Pickup extends \Magento\Shipping\Model\Carrier\AbstractCarrier implements
-    \Magento\Shipping\Model\Carrier\CarrierInterface
+class Pickup extends \Magento\Shipping\Model\Carrier\AbstractCarrier implements \Magento\Shipping\Model\Carrier\CarrierInterface
 {
     /**
      * @var string

--- a/app/code/Magento/OfflineShipping/Model/Carrier/Tablerate.php
+++ b/app/code/Magento/OfflineShipping/Model/Carrier/Tablerate.php
@@ -15,8 +15,7 @@ use Magento\Quote\Model\Quote\Address\RateRequest;
  * @api
  * @since 100.0.2
  */
-class Tablerate extends \Magento\Shipping\Model\Carrier\AbstractCarrier implements
-    \Magento\Shipping\Model\Carrier\CarrierInterface
+class Tablerate extends \Magento\Shipping\Model\Carrier\AbstractCarrier implements \Magento\Shipping\Model\Carrier\CarrierInterface
 {
     /**
      * @var string

--- a/app/code/Magento/Payment/Model/Method/AbstractMethod.php
+++ b/app/code/Magento/Payment/Model/Method/AbstractMethod.php
@@ -27,9 +27,7 @@ use Magento\Directory\Helper\Data as DirectoryHelper;
  * @see https://devdocs.magento.com/guides/v2.1/payments-integrations/payment-gateway/payment-gateway-intro.html
  * @since 100.0.2
  */
-abstract class AbstractMethod extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    MethodInterface,
-    PaymentMethodInterface
+abstract class AbstractMethod extends \Magento\Framework\Model\AbstractExtensibleModel implements MethodInterface, PaymentMethodInterface
 {
     const STATUS_UNKNOWN = 'UNKNOWN';
 

--- a/app/code/Magento/Paypal/Controller/Express/AbstractExpress.php
+++ b/app/code/Magento/Paypal/Controller/Express/AbstractExpress.php
@@ -14,10 +14,7 @@ use Magento\Framework\App\Action\HttpPostActionInterface;
  * Abstract Express Checkout Controller
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-abstract class AbstractExpress extends AppAction implements
-    RedirectLoginInterface,
-    HttpGetActionInterface,
-    HttpPostActionInterface
+abstract class AbstractExpress extends AppAction implements RedirectLoginInterface, HttpGetActionInterface, HttpPostActionInterface
 {
     /**
      * @var \Magento\Paypal\Model\Express\Checkout

--- a/app/code/Magento/Paypal/Model/Method/Agreement.php
+++ b/app/code/Magento/Paypal/Model/Method/Agreement.php
@@ -13,8 +13,7 @@ use Magento\Store\Model\Store;
  * Paypal Billing Agreement method
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Agreement extends \Magento\Paypal\Model\Payment\Method\Billing\AbstractAgreement implements
-    \Magento\Paypal\Model\Billing\Agreement\MethodInterface
+class Agreement extends \Magento\Paypal\Model\Payment\Method\Billing\AbstractAgreement implements \Magento\Paypal\Model\Billing\Agreement\MethodInterface
 {
     /**
      * Method code

--- a/app/code/Magento/Quote/Model/Cart/Currency.php
+++ b/app/code/Magento/Quote/Model/Cart/Currency.php
@@ -8,8 +8,7 @@ namespace Magento\Quote\Model\Cart;
 /**
  * @codeCoverageIgnore
  */
-class Currency extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Quote\Api\Data\CurrencyInterface
+class Currency extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Quote\Api\Data\CurrencyInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Quote/Model/Cart/ShippingMethod.php
+++ b/app/code/Magento/Quote/Model/Cart/ShippingMethod.php
@@ -12,8 +12,7 @@ use Magento\Quote\Api\Data\ShippingMethodInterface;
  *
  * @codeCoverageIgnore
  */
-class ShippingMethod extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    ShippingMethodInterface
+class ShippingMethod extends \Magento\Framework\Api\AbstractExtensibleObject implements ShippingMethodInterface
 {
     /**
      * Returns the shipping carrier code.

--- a/app/code/Magento/Quote/Model/GuestCart/GuestShippingMethodManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestShippingMethodManagement.php
@@ -17,10 +17,7 @@ use Magento\Quote\Model\QuoteIdMaskFactory;
 /**
  * Shipping method management class for guest carts.
  */
-class GuestShippingMethodManagement implements
-    \Magento\Quote\Api\GuestShippingMethodManagementInterface,
-    \Magento\Quote\Model\GuestCart\GuestShippingMethodManagementInterface,
-    GuestShipmentEstimationInterface
+class GuestShippingMethodManagement implements \Magento\Quote\Api\GuestShippingMethodManagementInterface, \Magento\Quote\Model\GuestCart\GuestShippingMethodManagementInterface, GuestShipmentEstimationInterface
 {
     /**
      * @var ShippingMethodManagementInterface

--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -97,8 +97,7 @@ use Magento\Store\Model\StoreManagerInterface;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @since 100.0.2
  */
-class Address extends \Magento\Customer\Model\Address\AbstractAddress implements
-    \Magento\Quote\Api\Data\AddressInterface
+class Address extends \Magento\Customer\Model\Address\AbstractAddress implements \Magento\Quote\Api\Data\AddressInterface
 {
     const RATES_FETCH = 1;
 

--- a/app/code/Magento/Quote/Model/Quote/Item/AbstractItem.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/AbstractItem.php
@@ -47,8 +47,7 @@ use Magento\Framework\Api\AttributeValueFactory;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @since 100.0.2
  */
-abstract class AbstractItem extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Catalog\Model\Product\Configuration\Item\ItemInterface
+abstract class AbstractItem extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Catalog\Model\Product\Configuration\Item\ItemInterface
 {
     /**
      * @var Item|null

--- a/app/code/Magento/Quote/Model/Quote/Item/Option.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/Option.php
@@ -16,8 +16,7 @@ namespace Magento\Quote\Model\Quote\Item;
  * @method \Magento\Quote\Model\Quote\Item\Option setCode(string $value)
  * @method \Magento\Quote\Model\Quote\Item\Option setValue(string $value)
  */
-class Option extends \Magento\Framework\Model\AbstractModel implements
-    \Magento\Catalog\Model\Product\Configuration\Item\Option\OptionInterface
+class Option extends \Magento\Framework\Model\AbstractModel implements \Magento\Catalog\Model\Product\Configuration\Item\Option\OptionInterface
 {
     /**
      * @var \Magento\Quote\Model\Quote\Item

--- a/app/code/Magento/Quote/Model/ShippingMethodManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingMethodManagement.php
@@ -23,10 +23,7 @@ use Magento\Quote\Model\ResourceModel\Quote\Address as QuoteAddressResource;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class ShippingMethodManagement implements
-    \Magento\Quote\Api\ShippingMethodManagementInterface,
-    \Magento\Quote\Model\ShippingMethodManagementInterface,
-    ShipmentEstimationInterface
+class ShippingMethodManagement implements \Magento\Quote\Api\ShippingMethodManagementInterface, \Magento\Quote\Model\ShippingMethodManagementInterface, ShipmentEstimationInterface
 {
     /**
      * Quote repository.

--- a/app/code/Magento/Rule/Block/Newchild.php
+++ b/app/code/Magento/Rule/Block/Newchild.php
@@ -7,8 +7,7 @@ namespace Magento\Rule\Block;
 
 use Magento\Framework\Data\Form\Element\AbstractElement;
 
-class Newchild extends \Magento\Framework\View\Element\AbstractBlock implements
-    \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Newchild extends \Magento\Framework\View\Element\AbstractBlock implements \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
 {
     /**
      * @param AbstractElement $element

--- a/app/code/Magento/Sales/Api/Data/ShipmentItemCreationInterface.php
+++ b/app/code/Magento/Sales/Api/Data/ShipmentItemCreationInterface.php
@@ -14,9 +14,7 @@ namespace Magento\Sales\Api\Data;
  * @api
  * @since 100.1.2
  */
-interface ShipmentItemCreationInterface extends
-    LineItemInterface,
-    \Magento\Framework\Api\ExtensibleDataInterface
+interface ShipmentItemCreationInterface extends LineItemInterface, \Magento\Framework\Api\ExtensibleDataInterface
 {
     /**
      * Retrieve existing extension attributes object or create a new one.

--- a/app/code/Magento/Sales/Api/Data/ShipmentItemInterface.php
+++ b/app/code/Magento/Sales/Api/Data/ShipmentItemInterface.php
@@ -13,9 +13,7 @@ namespace Magento\Sales\Api\Data;
  * @api
  * @since 100.0.2
  */
-interface ShipmentItemInterface extends
-    \Magento\Sales\Api\Data\LineItemInterface,
-    \Magento\Framework\Api\ExtensibleDataInterface
+interface ShipmentItemInterface extends \Magento\Sales\Api\Data\LineItemInterface, \Magento\Framework\Api\ExtensibleDataInterface
 {
     /**#@+
      * Constants for keys of data array. Identical to the name of the getter in snake case

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Totals.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Totals.php
@@ -12,7 +12,7 @@ namespace Magento\Sales\Block\Adminhtml\Order;
  * @author      Magento Core Team <core@magentocommerce.com>
  * @since 100.0.2
  */
-class Totals extends \Magento\Sales\Block\Adminhtml\Totals//\Magento\Sales\Block\Adminhtml\Order\AbstractOrder
+class Totals extends \Magento\Sales\Block\Adminhtml\Totals //\Magento\Sales\Block\Adminhtml\Order\AbstractOrder
 {
     /**
      * Initialize order totals array

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Creditmemos.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Creditmemos.php
@@ -11,8 +11,7 @@ namespace Magento\Sales\Block\Adminhtml\Order\View\Tab;
  * @api
  * @since 100.0.2
  */
-class Creditmemos extends \Magento\Framework\View\Element\Text\ListText implements
-    \Magento\Backend\Block\Widget\Tab\TabInterface
+class Creditmemos extends \Magento\Framework\View\Element\Text\ListText implements \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Info.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Info.php
@@ -12,8 +12,7 @@ namespace Magento\Sales\Block\Adminhtml\Order\View\Tab;
  * @author      Magento Core Team <core@magentocommerce.com>
  * @since 100.0.2
  */
-class Info extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder implements
-    \Magento\Backend\Block\Widget\Tab\TabInterface
+class Info extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder implements \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
      * Retrieve order model instance

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Invoices.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Invoices.php
@@ -11,8 +11,7 @@ namespace Magento\Sales\Block\Adminhtml\Order\View\Tab;
  * @api
  * @since 100.0.2
  */
-class Invoices extends \Magento\Framework\View\Element\Text\ListText implements
-    \Magento\Backend\Block\Widget\Tab\TabInterface
+class Invoices extends \Magento\Framework\View\Element\Text\ListText implements \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
      * {@inheritdoc}

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Shipments.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Shipments.php
@@ -11,8 +11,7 @@ namespace Magento\Sales\Block\Adminhtml\Order\View\Tab;
  * @api
  * @since 100.0.2
  */
-class Shipments extends \Magento\Framework\View\Element\Text\ListText implements
-    \Magento\Backend\Block\Widget\Tab\TabInterface
+class Shipments extends \Magento\Framework\View\Element\Text\ListText implements \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
      * Core registry

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Transactions.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Transactions.php
@@ -11,8 +11,7 @@ namespace Magento\Sales\Block\Adminhtml\Order\View\Tab;
  * @api
  * @since 100.0.2
  */
-class Transactions extends \Magento\Framework\View\Element\Text\ListText implements
-    \Magento\Backend\Block\Widget\Tab\TabInterface
+class Transactions extends \Magento\Framework\View\Element\Text\ListText implements \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
      * @var \Magento\Framework\AuthorizationInterface

--- a/app/code/Magento/Sales/Model/Order/Tax/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Tax/Item.php
@@ -8,8 +8,7 @@ namespace Magento\Sales\Model\Order\Tax;
 /**
  * Sales Order Tax Item model
  */
-class Item extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Tax\Api\Data\OrderTaxDetailsItemInterface
+class Item extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Tax\Api\Data\OrderTaxDetailsItemInterface
 {
     /**#@+
      * Constants defined for keys of array, makes typos less likely

--- a/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Actions.php
+++ b/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Actions.php
@@ -7,8 +7,7 @@ namespace Magento\SalesRule\Block\Adminhtml\Promo\Quote\Edit\Tab;
 
 use Magento\Framework\App\ObjectManager;
 
-class Actions extends \Magento\Backend\Block\Widget\Form\Generic implements
-    \Magento\Ui\Component\Layout\Tabs\TabInterface
+class Actions extends \Magento\Backend\Block\Widget\Form\Generic implements \Magento\Ui\Component\Layout\Tabs\TabInterface
 {
     /**
      * Core registry

--- a/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Conditions.php
+++ b/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Conditions.php
@@ -7,8 +7,7 @@ namespace Magento\SalesRule\Block\Adminhtml\Promo\Quote\Edit\Tab;
 
 use Magento\Framework\App\ObjectManager;
 
-class Conditions extends \Magento\Backend\Block\Widget\Form\Generic implements
-    \Magento\Ui\Component\Layout\Tabs\TabInterface
+class Conditions extends \Magento\Backend\Block\Widget\Form\Generic implements \Magento\Ui\Component\Layout\Tabs\TabInterface
 {
     /**
      * Core registry

--- a/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Labels.php
+++ b/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Labels.php
@@ -5,8 +5,7 @@
  */
 namespace Magento\SalesRule\Block\Adminhtml\Promo\Quote\Edit\Tab;
 
-class Labels extends \Magento\Backend\Block\Widget\Form\Generic implements
-    \Magento\Ui\Component\Layout\Tabs\TabInterface
+class Labels extends \Magento\Backend\Block\Widget\Form\Generic implements \Magento\Ui\Component\Layout\Tabs\TabInterface
 {
     /**
      * @var \Magento\SalesRule\Model\RuleFactory

--- a/app/code/Magento/SalesRule/Model/Coupon.php
+++ b/app/code/Magento/SalesRule/Model/Coupon.php
@@ -11,8 +11,7 @@ namespace Magento\SalesRule\Model;
  * @api
  * @since 100.0.2
  */
-class Coupon extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\SalesRule\Api\Data\CouponInterface
+class Coupon extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\SalesRule\Api\Data\CouponInterface
 {
     const KEY_COUPON_ID = 'coupon_id';
     const KEY_RULE_ID = 'rule_id';

--- a/app/code/Magento/SalesRule/Model/Coupon/Massgenerator.php
+++ b/app/code/Magento/SalesRule/Model/Coupon/Massgenerator.php
@@ -10,8 +10,7 @@ namespace Magento\SalesRule\Model\Coupon;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Massgenerator extends \Magento\Framework\Model\AbstractModel implements
-    \Magento\SalesRule\Model\Coupon\CodegeneratorInterface
+class Massgenerator extends \Magento\Framework\Model\AbstractModel implements \Magento\SalesRule\Model\Coupon\CodegeneratorInterface
 {
     /**
      * Maximum probability of guessing the coupon on the first attempt

--- a/app/code/Magento/SalesRule/Model/Data/Condition.php
+++ b/app/code/Magento/SalesRule/Model/Data/Condition.php
@@ -14,8 +14,7 @@ use Magento\SalesRule\Api\Data\ConditionInterface;
  *
  * @codeCoverageIgnore
  */
-class Condition extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\SalesRule\Api\Data\ConditionInterface
+class Condition extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\SalesRule\Api\Data\ConditionInterface
 {
     const KEY_CONDITION_TYPE = 'condition_type';
     const KEY_CONDITIONS = 'conditions';

--- a/app/code/Magento/SalesRule/Model/Data/CouponGenerationSpec.php
+++ b/app/code/Magento/SalesRule/Model/Data/CouponGenerationSpec.php
@@ -12,8 +12,7 @@ namespace Magento\SalesRule\Model\Data;
  *
  * @codeCoverageIgnore
  */
-class CouponGenerationSpec extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\SalesRule\Api\Data\CouponGenerationSpecInterface
+class CouponGenerationSpec extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\SalesRule\Api\Data\CouponGenerationSpecInterface
 {
     const KEY_RULE_ID = 'rule_id';
     const KEY_FORMAT = 'format';

--- a/app/code/Magento/SalesRule/Model/Data/CouponMassDeleteResult.php
+++ b/app/code/Magento/SalesRule/Model/Data/CouponMassDeleteResult.php
@@ -10,8 +10,7 @@ namespace Magento\SalesRule\Model\Data;
  *
  * @codeCoverageIgnore
  */
-class CouponMassDeleteResult extends \Magento\Framework\Api\AbstractSimpleObject implements
-    \Magento\SalesRule\Api\Data\CouponMassDeleteResultInterface
+class CouponMassDeleteResult extends \Magento\Framework\Api\AbstractSimpleObject implements \Magento\SalesRule\Api\Data\CouponMassDeleteResultInterface
 {
     const FAILED_ITEMS = 'failed_items';
     const MISSING_ITEMS = 'missing_items';

--- a/app/code/Magento/SalesRule/Model/Data/RuleLabel.php
+++ b/app/code/Magento/SalesRule/Model/Data/RuleLabel.php
@@ -12,8 +12,7 @@ namespace Magento\SalesRule\Model\Data;
  *
  * @codeCoverageIgnore
  */
-class RuleLabel extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\SalesRule\Api\Data\RuleLabelInterface
+class RuleLabel extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\SalesRule\Api\Data\RuleLabelInterface
 {
     const KEY_STORE_ID = 'store_id';
     const KEY_STORE_LABEL = 'store_label';

--- a/app/code/Magento/SalesRule/Model/ResourceModel/Coupon.php
+++ b/app/code/Magento/SalesRule/Model/ResourceModel/Coupon.php
@@ -12,8 +12,7 @@ use Magento\Framework\Model\AbstractModel;
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Coupon extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implements
-    \Magento\SalesRule\Model\Spi\CouponResourceInterface
+class Coupon extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implements \Magento\SalesRule\Model\Spi\CouponResourceInterface
 {
     /**
      * Constructor adds unique fields

--- a/app/code/Magento/Store/Model/Data/StoreConfig.php
+++ b/app/code/Magento/Store/Model/Data/StoreConfig.php
@@ -10,8 +10,7 @@ namespace Magento\Store\Model\Data;
  *
  * @codeCoverageIgnore
  */
-class StoreConfig extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\Store\Api\Data\StoreConfigInterface
+class StoreConfig extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\Store\Api\Data\StoreConfigInterface
 {
     const KEY_ID = 'id';
     const KEY_CODE = 'code';

--- a/app/code/Magento/Store/Model/Group.php
+++ b/app/code/Magento/Store/Model/Group.php
@@ -16,10 +16,7 @@ namespace Magento\Store\Model;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @since 100.0.2
  */
-class Group extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Framework\DataObject\IdentityInterface,
-    \Magento\Store\Api\Data\GroupInterface,
-    \Magento\Framework\App\ScopeInterface
+class Group extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Framework\DataObject\IdentityInterface, \Magento\Store\Api\Data\GroupInterface, \Magento\Framework\App\ScopeInterface
 {
     const ENTITY = 'store_group';
 

--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -36,11 +36,7 @@ use Zend\Uri\UriFactory;
  * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  * @since 100.0.2
  */
-class Store extends AbstractExtensibleModel implements
-    AppScopeInterface,
-    UrlScopeInterface,
-    IdentityInterface,
-    StoreInterface
+class Store extends AbstractExtensibleModel implements AppScopeInterface, UrlScopeInterface, IdentityInterface, StoreInterface
 {
     /**
      * Store Id key name

--- a/app/code/Magento/Store/Model/StoreManager.php
+++ b/app/code/Magento/Store/Model/StoreManager.php
@@ -15,9 +15,7 @@ use Magento\Store\Model\ResourceModel\StoreWebsiteRelation;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class StoreManager implements
-    \Magento\Store\Model\StoreManagerInterface,
-    \Magento\Store\Api\StoreWebsiteRelationInterface
+class StoreManager implements \Magento\Store\Model\StoreManagerInterface, \Magento\Store\Api\StoreWebsiteRelationInterface
 {
     /**
      * Application run code

--- a/app/code/Magento/Store/Model/Website.php
+++ b/app/code/Magento/Store/Model/Website.php
@@ -23,10 +23,7 @@ namespace Magento\Store\Model;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @since 100.0.2
  */
-class Website extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Framework\DataObject\IdentityInterface,
-    \Magento\Framework\App\ScopeInterface,
-    \Magento\Store\Api\Data\WebsiteInterface
+class Website extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Framework\DataObject\IdentityInterface, \Magento\Framework\App\ScopeInterface, \Magento\Store\Api\Data\WebsiteInterface
 {
     const ENTITY = 'store_website';
 

--- a/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
+++ b/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
@@ -29,8 +29,7 @@ use Magento\Swatches\Model\SwatchAttributesProvider;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @since 100.0.2
  */
-class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\Configurable implements
-    \Magento\Framework\DataObject\IdentityInterface
+class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\Configurable implements \Magento\Framework\DataObject\IdentityInterface
 {
     /**
      * Path to template file with Swatch renderer.

--- a/app/code/Magento/Tax/Model/ClassModel.php
+++ b/app/code/Magento/Tax/Model/ClassModel.php
@@ -12,8 +12,7 @@ use Magento\Framework\Exception\CouldNotDeleteException;
 /**
  * Tax class model
  */
-class ClassModel extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Tax\Api\Data\TaxClassInterface
+class ClassModel extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Tax\Api\Data\TaxClassInterface
 {
     /**#@+
      * Constants defined for keys of array, makes typos less likely

--- a/app/code/Magento/Tax/Model/Sales/Order/Details.php
+++ b/app/code/Magento/Tax/Model/Sales/Order/Details.php
@@ -10,8 +10,7 @@ namespace Magento\Tax\Model\Sales\Order;
 /**
  * @codeCoverageIgnore
  */
-class Details extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Tax\Api\Data\OrderTaxDetailsInterface
+class Details extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Tax\Api\Data\OrderTaxDetailsInterface
 {
     /**#@+
      * Constants defined for keys of array, makes typos less likely

--- a/app/code/Magento/Tax/Model/Sales/Order/Tax.php
+++ b/app/code/Magento/Tax/Model/Sales/Order/Tax.php
@@ -18,8 +18,7 @@ namespace Magento\Tax\Model\Sales\Order;
  * @method \Magento\Tax\Model\Sales\Order\Tax setBaseRealAmount(float $value)
  * @codeCoverageIgnore
  */
-class Tax extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    \Magento\Tax\Api\Data\OrderTaxDetailsAppliedTaxInterface
+class Tax extends \Magento\Framework\Model\AbstractExtensibleModel implements \Magento\Tax\Api\Data\OrderTaxDetailsAppliedTaxInterface
 {
     /**#@+
      * Constants defined for keys of array, makes typos less likely

--- a/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/AbstractTab.php
+++ b/app/code/Magento/Theme/Block/Adminhtml/System/Design/Theme/Edit/AbstractTab.php
@@ -11,8 +11,7 @@ namespace Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.DepthOfInheritance)
  */
-abstract class AbstractTab extends \Magento\Backend\Block\Widget\Form\Generic implements
-    \Magento\Backend\Block\Widget\Tab\TabInterface
+abstract class AbstractTab extends \Magento\Backend\Block\Widget\Form\Generic implements \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
      * @var \Magento\Framework\ObjectManagerInterface

--- a/app/code/Magento/Theme/Model/ResourceModel/Theme/Collection.php
+++ b/app/code/Magento/Theme/Model/ResourceModel/Theme/Collection.php
@@ -8,9 +8,7 @@ namespace Magento\Theme\Model\ResourceModel\Theme;
 /**
  * Theme collection
  */
-class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection implements
-    \Magento\Framework\View\Design\Theme\Label\ListInterface,
-    \Magento\Framework\View\Design\Theme\ListInterface
+class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection implements \Magento\Framework\View\Design\Theme\Label\ListInterface, \Magento\Framework\View\Design\Theme\ListInterface
 {
     /**
      * Default page size

--- a/app/code/Magento/Theme/Model/ResourceModel/Theme/Data/Collection.php
+++ b/app/code/Magento/Theme/Model/ResourceModel/Theme/Data/Collection.php
@@ -8,9 +8,7 @@ namespace Magento\Theme\Model\ResourceModel\Theme\Data;
 /**
  * Theme data collection
  */
-class Collection extends \Magento\Theme\Model\ResourceModel\Theme\Collection implements
-    \Magento\Framework\View\Design\Theme\Label\ListInterface,
-    \Magento\Framework\View\Design\Theme\ListInterface
+class Collection extends \Magento\Theme\Model\ResourceModel\Theme\Collection implements \Magento\Framework\View\Design\Theme\Label\ListInterface, \Magento\Framework\View\Design\Theme\ListInterface
 {
     /**
      * @inheritdoc

--- a/app/code/Magento/Theme/Model/ResourceModel/Theme/File/Collection.php
+++ b/app/code/Magento/Theme/Model/ResourceModel/Theme/File/Collection.php
@@ -8,8 +8,7 @@ namespace Magento\Theme\Model\ResourceModel\Theme\File;
 /**
  * Theme files collection
  */
-class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection implements
-    \Magento\Framework\View\Design\Theme\File\CollectionInterface
+class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection implements \Magento\Framework\View\Design\Theme\File\CollectionInterface
 {
     /**
      * Collection initialization

--- a/app/code/Magento/Translation/Model/ResourceModel/Translate.php
+++ b/app/code/Magento/Translation/Model/ResourceModel/Translate.php
@@ -10,8 +10,7 @@ use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\Config;
 use Magento\Translation\App\Config\Type\Translation;
 
-class Translate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implements
-    \Magento\Framework\Translate\ResourceInterface
+class Translate extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implements \Magento\Framework\Translate\ResourceInterface
 {
     /**
      * @var \Magento\Framework\App\ScopeResolverInterface

--- a/app/code/Magento/Weee/Block/Renderer/Weee/Tax.php
+++ b/app/code/Magento/Weee/Block/Renderer/Weee/Tax.php
@@ -11,8 +11,7 @@ use Magento\Framework\Data\Form\Element\AbstractElement;
 /**
  * Adminhtml weee tax item renderer
  */
-class Tax extends \Magento\Backend\Block\Widget implements
-    \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
+class Tax extends \Magento\Backend\Block\Widget implements \Magento\Framework\Data\Form\Element\Renderer\RendererInterface
 {
     /**
      * @var AbstractElement|null

--- a/app/code/Magento/Weee/Model/ProductRender/WeeeAdjustmentAttribute.php
+++ b/app/code/Magento/Weee/Model/ProductRender/WeeeAdjustmentAttribute.php
@@ -13,8 +13,7 @@ use Magento\Weee\Api\Data\ProductRender\WeeeAdjustmentAttributeInterface;
  * @api
  * @since 100.2.0
  */
-class WeeeAdjustmentAttribute extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    WeeeAdjustmentAttributeInterface
+class WeeeAdjustmentAttribute extends \Magento\Framework\Model\AbstractExtensibleModel implements WeeeAdjustmentAttributeInterface
 {
     /**
      * @inheritdoc

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Properties.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Properties.php
@@ -16,8 +16,7 @@ namespace Magento\Widget\Block\Adminhtml\Widget\Instance\Edit\Tab;
  * @SuppressWarnings(PHPMD.DepthOfInheritance)
  * @since 100.0.2
  */
-class Properties extends \Magento\Widget\Block\Adminhtml\Widget\Options implements
-    \Magento\Backend\Block\Widget\Tab\TabInterface
+class Properties extends \Magento\Widget\Block\Adminhtml\Widget\Options implements \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
      * Widget config parameters

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Settings.php
@@ -15,8 +15,7 @@ namespace Magento\Widget\Block\Adminhtml\Widget\Instance\Edit\Tab;
  * @api
  * @since 100.0.2
  */
-class Settings extends \Magento\Backend\Block\Widget\Form\Generic implements
-    \Magento\Backend\Block\Widget\Tab\TabInterface
+class Settings extends \Magento\Backend\Block\Widget\Form\Generic implements \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
      * Core registry

--- a/app/code/Magento/Wishlist/Model/Item/Option.php
+++ b/app/code/Magento/Wishlist/Model/Item/Option.php
@@ -16,8 +16,7 @@ use Magento\Catalog\Api\ProductRepositoryInterface;
  * @api
  * @since 100.0.2
  */
-class Option extends \Magento\Framework\Model\AbstractModel implements
-    \Magento\Catalog\Model\Product\Configuration\Item\Option\OptionInterface
+class Option extends \Magento\Framework\Model\AbstractModel implements \Magento\Catalog\Model\Product\Configuration\Item\Option\OptionInterface
 {
     /**
      * @var Item

--- a/dev/tests/api-functional/_files/Magento/TestModuleDefaultHydrator/Model/Data/ExtensionAttribute.php
+++ b/dev/tests/api-functional/_files/Magento/TestModuleDefaultHydrator/Model/Data/ExtensionAttribute.php
@@ -5,8 +5,7 @@
  */
 namespace Magento\TestModuleDefaultHydrator\Model\Data;
 
-class ExtensionAttribute extends \Magento\Framework\Api\AbstractSimpleObject implements
-    \Magento\TestModuleDefaultHydrator\Api\Data\ExtensionAttributeInterface
+class ExtensionAttribute extends \Magento\Framework\Api\AbstractSimpleObject implements \Magento\TestModuleDefaultHydrator\Api\Data\ExtensionAttributeInterface
 {
     /**
      * Get id

--- a/dev/tests/api-functional/_files/Magento/TestModuleMSC/Model/Data/CustomAttributeNestedDataObject.php
+++ b/dev/tests/api-functional/_files/Magento/TestModuleMSC/Model/Data/CustomAttributeNestedDataObject.php
@@ -13,8 +13,7 @@ use Magento\TestModuleMSC\Api\Data\CustomAttributeNestedDataObjectInterface;
  *
  * @method \Magento\TestModuleMSC\Api\Data\CustomAttributeNestedDataObjectExtensionInterface getExtensionAttributes()
  */
-class CustomAttributeNestedDataObject extends \Magento\Framework\Model\AbstractExtensibleModel implements
-    CustomAttributeNestedDataObjectInterface
+class CustomAttributeNestedDataObject extends \Magento\Framework\Model\AbstractExtensibleModel implements CustomAttributeNestedDataObjectInterface
 {
     /**
      * @return string

--- a/dev/tests/functional/tests/app/Magento/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Magento/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingIncludingTax.php
@@ -9,8 +9,7 @@ namespace Magento\Downloadable\Test\Constraint;
 /**
  * Checks that prices excl and incl tax on order review and customer order pages are equal to specified in dataset.
  */
-class AssertTaxCalculationAfterCheckoutDownloadableExcludingIncludingTax extends
- AbstractAssertTaxCalculationAfterCheckoutDownloadable
+class AssertTaxCalculationAfterCheckoutDownloadableExcludingIncludingTax extends AbstractAssertTaxCalculationAfterCheckoutDownloadable
 {
     /**
      * Constraint severeness

--- a/dev/tests/functional/tests/app/Magento/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingTax.php
+++ b/dev/tests/functional/tests/app/Magento/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableExcludingTax.php
@@ -11,8 +11,7 @@ use Magento\Customer\Test\Fixture\Customer;
 /**
  * Checks that prices excl tax on order review and customer order pages are equal to specified in dataset.
  */
-class AssertTaxCalculationAfterCheckoutDownloadableExcludingTax extends
- AbstractAssertTaxCalculationAfterCheckoutDownloadable
+class AssertTaxCalculationAfterCheckoutDownloadableExcludingTax extends AbstractAssertTaxCalculationAfterCheckoutDownloadable
 {
     /**
      * Constraint severeness

--- a/dev/tests/functional/tests/app/Magento/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableIncludingTax.php
+++ b/dev/tests/functional/tests/app/Magento/Downloadable/Test/Constraint/AssertTaxCalculationAfterCheckoutDownloadableIncludingTax.php
@@ -9,8 +9,7 @@ namespace Magento\Downloadable\Test\Constraint;
 /**
  * Checks that prices incl tax on order review and customer order pages are equal to specified in dataset.
  */
-class AssertTaxCalculationAfterCheckoutDownloadableIncludingTax extends
- AbstractAssertTaxCalculationAfterCheckoutDownloadable
+class AssertTaxCalculationAfterCheckoutDownloadableIncludingTax extends AbstractAssertTaxCalculationAfterCheckoutDownloadable
 {
     /**
      * Constraint severeness.

--- a/dev/tests/functional/tests/app/Magento/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Magento/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingIncludingTax.php
@@ -11,8 +11,7 @@ use Magento\Mtf\Fixture\FixtureInterface;
 /**
  * Checks that prices excl tax on category, product and cart pages are equal to specified in dataset.
  */
-class AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingIncludingTax extends
- AbstractAssertTaxRuleIsAppliedToAllPricesDownloadable
+class AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingIncludingTax extends AbstractAssertTaxRuleIsAppliedToAllPricesDownloadable
 {
     /**
      * Constraint severeness.

--- a/dev/tests/functional/tests/app/Magento/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingTax.php
+++ b/dev/tests/functional/tests/app/Magento/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingTax.php
@@ -11,8 +11,7 @@ use Magento\Mtf\Fixture\FixtureInterface;
 /**
  * Checks that product prices excl tax on category, product and cart pages are equal to specified in dataset.
  */
-class AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingTax extends
- AbstractAssertTaxRuleIsAppliedToAllPricesDownloadable
+class AssertTaxRuleIsAppliedToAllPricesDownloadableExcludingTax extends AbstractAssertTaxRuleIsAppliedToAllPricesDownloadable
 {
     /**
      * Constraint severeness.

--- a/dev/tests/functional/tests/app/Magento/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableIncludingTax.php
+++ b/dev/tests/functional/tests/app/Magento/Downloadable/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesDownloadableIncludingTax.php
@@ -11,8 +11,7 @@ use Magento\Mtf\Fixture\FixtureInterface;
 /**
  * Checks that prices incl tax on category, product and cart pages are equal to specified in dataset.
  */
-class AssertTaxRuleIsAppliedToAllPricesDownloadableIncludingTax extends
- AbstractAssertTaxRuleIsAppliedToAllPricesDownloadable
+class AssertTaxRuleIsAppliedToAllPricesDownloadableIncludingTax extends AbstractAssertTaxRuleIsAppliedToAllPricesDownloadable
 {
     /**
      * Constraint severeness.

--- a/dev/tests/functional/tests/app/Magento/GroupedProduct/Test/Constraint/AbstractAssertTaxRuleIsAppliedToAllPricesOnGroupedProductPage.php
+++ b/dev/tests/functional/tests/app/Magento/GroupedProduct/Test/Constraint/AbstractAssertTaxRuleIsAppliedToAllPricesOnGroupedProductPage.php
@@ -18,8 +18,7 @@ use Magento\Tax\Test\Constraint\AbstractAssertTaxRuleIsAppliedToAllPrices;
 /**
  * Checks that prices excl tax on category, product and cart pages are equal to specified in dataset.
  */
-abstract class AbstractAssertTaxRuleIsAppliedToAllPricesOnGroupedProductPage extends
- AbstractAssertTaxRuleIsAppliedToAllPrices
+abstract class AbstractAssertTaxRuleIsAppliedToAllPricesOnGroupedProductPage extends AbstractAssertTaxRuleIsAppliedToAllPrices
 {
     /**
      * Get grouped product view prices.

--- a/dev/tests/functional/tests/app/Magento/GroupedProduct/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesGroupedExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Magento/GroupedProduct/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesGroupedExcludingIncludingTax.php
@@ -11,8 +11,7 @@ use Magento\Mtf\Fixture\FixtureInterface;
 /**
  * Checks that prices excl tax on category, product and cart pages are equal to specified in dataset.
  */
-class AssertTaxRuleIsAppliedToAllPricesGroupedExcludingIncludingTax extends
- AbstractAssertTaxRuleIsAppliedToAllPricesOnGroupedProductPage
+class AssertTaxRuleIsAppliedToAllPricesGroupedExcludingIncludingTax extends AbstractAssertTaxRuleIsAppliedToAllPricesOnGroupedProductPage
 {
     /**
      * @inheritdoc

--- a/dev/tests/functional/tests/app/Magento/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Magento/Tax/Test/Constraint/AssertTaxCalculationAfterCheckoutExcludingIncludingTax.php
@@ -9,8 +9,7 @@ namespace Magento\Tax\Test\Constraint;
 /**
  * Checks that prices excl and incl tax on order review and customer order pages are equal to specified in dataset.
  */
-class AssertTaxCalculationAfterCheckoutExcludingIncludingTax extends
- AbstractAssertTaxCalculationAfterCheckout
+class AssertTaxCalculationAfterCheckoutExcludingIncludingTax extends AbstractAssertTaxCalculationAfterCheckout
 {
     /**
      * Constraint severeness.

--- a/dev/tests/functional/tests/app/Magento/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingIncludingTax.php
+++ b/dev/tests/functional/tests/app/Magento/Tax/Test/Constraint/AssertTaxRuleIsAppliedToAllPricesExcludingIncludingTax.php
@@ -12,8 +12,7 @@ use Magento\Mtf\Fixture\FixtureInterface;
 /**
  * Checks that prices excl and incl tax on category, product and cart pages are equal to specified in dataset
  */
-class AssertTaxRuleIsAppliedToAllPricesExcludingIncludingTax extends
- AbstractAssertTaxRuleIsAppliedToAllPrices
+class AssertTaxRuleIsAppliedToAllPricesExcludingIncludingTax extends AbstractAssertTaxRuleIsAppliedToAllPrices
 {
     /**
      * Constraint severeness.

--- a/dev/tests/integration/_files/Magento/TestModuleExtensionAttributes/Model/Data/FakeAttributeMetadata.php
+++ b/dev/tests/integration/_files/Magento/TestModuleExtensionAttributes/Model/Data/FakeAttributeMetadata.php
@@ -10,8 +10,7 @@ namespace Magento\TestModuleExtensionAttributes\Model\Data;
 /**
  * Customer attribute metadata class.
  */
-class FakeAttributeMetadata extends \Magento\Framework\Api\AbstractSimpleObject implements
-    \Magento\TestModuleExtensionAttributes\Api\Data\FakeAttributeMetadataInterface
+class FakeAttributeMetadata extends \Magento\Framework\Api\AbstractSimpleObject implements \Magento\TestModuleExtensionAttributes\Api\Data\FakeAttributeMetadataInterface
 {
     /**
      * {@inheritdoc}

--- a/dev/tests/integration/_files/Magento/TestModuleExtensionAttributes/Model/Data/FakeCustomer.php
+++ b/dev/tests/integration/_files/Magento/TestModuleExtensionAttributes/Model/Data/FakeCustomer.php
@@ -11,8 +11,7 @@ namespace Magento\TestModuleExtensionAttributes\Model\Data;
  * Class Customer
  *
  */
-class FakeCustomer extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\TestModuleExtensionAttributes\Api\Data\FakeCustomerInterface
+class FakeCustomer extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\TestModuleExtensionAttributes\Api\Data\FakeCustomerInterface
 {
     /**
      * Get email address

--- a/dev/tests/integration/_files/Magento/TestModuleExtensionAttributes/Model/FakeAttributeMetadata.php
+++ b/dev/tests/integration/_files/Magento/TestModuleExtensionAttributes/Model/FakeAttributeMetadata.php
@@ -10,8 +10,7 @@ namespace Magento\TestModuleExtensionAttributes\Api\Model;
 /**
  * Customer attribute metadata class.
  */
-class FakeAttributeMetadata extends \Magento\Framework\Api\AbstractSimpleObject implements
-    \Magento\TestModuleExtensionAttributes\Api\Data\FakeAttributeMetadataInterface
+class FakeAttributeMetadata extends \Magento\Framework\Api\AbstractSimpleObject implements \Magento\TestModuleExtensionAttributes\Api\Data\FakeAttributeMetadataInterface
 {
     /**
      * {@inheritdoc}

--- a/dev/tests/integration/_files/Magento/TestModuleExtensionAttributes/Model/FakeCustomer.php
+++ b/dev/tests/integration/_files/Magento/TestModuleExtensionAttributes/Model/FakeCustomer.php
@@ -11,8 +11,7 @@ namespace Magento\TestModuleExtensionAttributes\Api\Model;
  * Class Customer
  *
  */
-class FakeCustomer extends \Magento\Framework\Api\AbstractExtensibleObject implements
-    \Magento\TestModuleExtensionAttributes\Api\Data\FakeCustomerInterface
+class FakeCustomer extends \Magento\Framework\Api\AbstractExtensibleObject implements \Magento\TestModuleExtensionAttributes\Api\Data\FakeCustomerInterface
 {
     /**
      * Get customer id

--- a/dev/tests/integration/testsuite/Magento/Backend/App/Request/BackendValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/App/Request/BackendValidatorTest.php
@@ -111,7 +111,7 @@ class BackendValidatorTest extends TestCase
         $l = self::AWARE_LOCATION_VALUE;
         $p = self::AWARE_VALIDATION_PARAM;
 
-        return new class($l, $p) extends AbstractAction{
+        return new class($l, $p) extends AbstractAction {
 
             /**
              * @var string
@@ -173,7 +173,7 @@ class BackendValidatorTest extends TestCase
             ->get(ResponseInterface::class);
         $m = self::CSRF_AWARE_MESSAGE;
 
-        return new class ($r, $m) implements CsrfAwareActionInterface {
+        return new class($r, $m) implements CsrfAwareActionInterface {
 
             /**
              * @var ResponseInterface

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/EntityAbstractTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/EntityAbstractTest.php
@@ -103,8 +103,7 @@ class EntityAbstractTest extends \PHPUnit\Framework\TestCase
  * @codingStandardsIgnoreStart
  * Stub abstract class which provide to change protected property "$_disabledAttrs" and test methods depended on it
  */
-abstract class Stub_Magento_ImportExport_Model_Export_AbstractEntity extends
-    \Magento\ImportExport\Model\Export\AbstractEntity
+abstract class Stub_Magento_ImportExport_Model_Export_AbstractEntity extends \Magento\ImportExport\Model\Export\AbstractEntity
 {
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,

--- a/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/cyclomatic_and_bic_revision/BicPatch.php
+++ b/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/cyclomatic_and_bic_revision/BicPatch.php
@@ -13,10 +13,7 @@ use Magento\Framework\Setup\Patch\PatchVersionInterface;
 /**
  * @package Magento\TestSetupDeclarationModule3\Setup
  */
-class BicPatch implements
-    DataPatchInterface,
-    PatchRevertableInterface,
-    PatchVersionInterface
+class BicPatch implements DataPatchInterface, PatchRevertableInterface, PatchVersionInterface
 {
     /**
      * @var ResourceConnection

--- a/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/cyclomatic_and_bic_revision/RefBicPatch.php
+++ b/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/cyclomatic_and_bic_revision/RefBicPatch.php
@@ -13,10 +13,7 @@ use Magento\Framework\Setup\Patch\PatchVersionInterface;
 /**
  * @package Magento\TestSetupDeclarationModule3\Setup
  */
-class RefBicPatch implements
-    DataPatchInterface,
-    PatchRevertableInterface,
-    PatchVersionInterface
+class RefBicPatch implements DataPatchInterface, PatchRevertableInterface, PatchVersionInterface
 {
     /**
      * @var ResourceConnection

--- a/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/patches_revision/IncrementalSomeIntegerPatch.php
+++ b/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/patches_revision/IncrementalSomeIntegerPatch.php
@@ -14,10 +14,7 @@ use Magento\Framework\Setup\Patch\PatchVersionInterface;
  * Class InstallData
  * @package Magento\TestSetupDeclarationModule3\Setup
  */
-class IncrementalSomeIntegerPatch implements
-    DataPatchInterface,
-    PatchRevertableInterface,
-    PatchVersionInterface
+class IncrementalSomeIntegerPatch implements DataPatchInterface, PatchRevertableInterface, PatchVersionInterface
 {
     /**
      * @var ResourceConnection

--- a/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/patches_revision/LlNextChainPatch.php
+++ b/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/patches_revision/LlNextChainPatch.php
@@ -13,10 +13,7 @@ use Magento\Framework\Setup\Patch\PatchVersionInterface;
 /**
  * @package Magento\TestSetupDeclarationModule3\Setup
  */
-class LlNextChainPatch implements
-    DataPatchInterface,
-    PatchRevertableInterface,
-    PatchVersionInterface
+class LlNextChainPatch implements DataPatchInterface, PatchRevertableInterface, PatchVersionInterface
 {
     /**
      * @var ResourceConnection

--- a/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/patches_revision/NextChainPatch.php
+++ b/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/patches_revision/NextChainPatch.php
@@ -13,10 +13,7 @@ use Magento\Framework\Setup\Patch\PatchVersionInterface;
 /**
  * @package Magento\TestSetupDeclarationModule3\Setup
  */
-class NextChainPatch implements
-    DataPatchInterface,
-    PatchRevertableInterface,
-    PatchVersionInterface
+class NextChainPatch implements DataPatchInterface, PatchRevertableInterface, PatchVersionInterface
 {
     /**
      * @var ResourceConnection

--- a/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/patches_revision/ReferenceIncrementalSomeIntegerPatch.php
+++ b/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/patches_revision/ReferenceIncrementalSomeIntegerPatch.php
@@ -14,10 +14,7 @@ use Magento\Framework\Setup\Patch\PatchVersionInterface;
  * Class ReferenceIncrementalSomeIntegerPatch
  * @package Magento\TestSetupDeclarationModule3\Setup
  */
-class ReferenceIncrementalSomeIntegerPatch implements
-    DataPatchInterface,
-    PatchRevertableInterface,
-    PatchVersionInterface
+class ReferenceIncrementalSomeIntegerPatch implements DataPatchInterface, PatchRevertableInterface, PatchVersionInterface
 {
     /**
      * @var ResourceConnection

--- a/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/patches_revision/ZFirstPatch.php
+++ b/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule3/revisions/patches_revision/ZFirstPatch.php
@@ -15,10 +15,7 @@ use Magento\Framework\Setup\Patch\PatchVersionInterface;
  * Class InstallData
  * @package Magento\TestSetupDeclarationModule3\Setup
  */
-class ZFirstPatch implements
-    DataPatchInterface,
-    PatchVersionInterface,
-    PatchRevertableInterface
+class ZFirstPatch implements DataPatchInterface, PatchVersionInterface, PatchRevertableInterface
 {
     /**
      * @var ResourceConnection

--- a/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule5/revisions/patches/SomePatch.php
+++ b/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule5/revisions/patches/SomePatch.php
@@ -14,10 +14,7 @@ use Magento\Framework\Setup\Patch\PatchVersionInterface;
  * Class SomePatch
  * @package Magento\TestSetupDeclarationModule3\Setup
  */
-class SomePatch implements
-    DataPatchInterface,
-    PatchRevertableInterface,
-    PatchVersionInterface
+class SomePatch implements DataPatchInterface, PatchRevertableInterface, PatchVersionInterface
 {
     /**
      * @var ResourceConnection

--- a/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule5/revisions/patches/SomeSkippedPatch.php
+++ b/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule5/revisions/patches/SomeSkippedPatch.php
@@ -14,10 +14,7 @@ use Magento\Framework\Setup\Patch\PatchVersionInterface;
  * Class SomePatch
  * @package Magento\TestSetupDeclarationModule3\Setup
  */
-class SomeSkippedPatch implements
-    DataPatchInterface,
-    PatchRevertableInterface,
-    PatchVersionInterface
+class SomeSkippedPatch implements DataPatchInterface, PatchRevertableInterface, PatchVersionInterface
 {
     /**
      * @var ResourceConnection

--- a/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule7/revisions/swap_with_declaration/SomePatch.php
+++ b/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule7/revisions/swap_with_declaration/SomePatch.php
@@ -14,9 +14,7 @@ use Magento\Framework\Setup\Patch\PatchVersionInterface;
  * Class SomePatch
  * @package Magento\TestSetupDeclarationModule3\Setup
  */
-class SomePatch implements
-    DataPatchInterface,
-    PatchVersionInterface
+class SomePatch implements DataPatchInterface, PatchVersionInterface
 {
     /**
      * @var ResourceConnection

--- a/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule7/revisions/swap_with_declaration/SomeSkippedPatch.php
+++ b/dev/tests/setup-integration/_files/Magento/TestSetupDeclarationModule7/revisions/swap_with_declaration/SomeSkippedPatch.php
@@ -13,9 +13,7 @@ use Magento\Framework\Setup\Patch\PatchVersionInterface;
  * Class SomePatch
  * @package Magento\TestSetupDeclarationModule3\Setup
  */
-class SomeSkippedPatch implements
-    DataPatchInterface,
-    PatchVersionInterface
+class SomeSkippedPatch implements DataPatchInterface, PatchVersionInterface
 {
     /**
      * @var ResourceConnection

--- a/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/ExtensibleSample.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/ExtensibleSample.php
@@ -11,8 +11,7 @@ use Magento\Framework\Model\AbstractExtensibleModel;
 /**
  * Class ExtensibleSample
  */
-class ExtensibleSample extends AbstractExtensibleModel implements
-    \Magento\Framework\Api\Test\Unit\Code\Generator\ExtensibleSampleInterface
+class ExtensibleSample extends AbstractExtensibleModel implements \Magento\Framework\Api\Test\Unit\Code\Generator\ExtensibleSampleInterface
 {
     /**
      * {@inheritdoc}

--- a/lib/internal/Magento/Framework/App/AreaList/Proxy.php
+++ b/lib/internal/Magento/Framework/App/AreaList/Proxy.php
@@ -7,8 +7,7 @@
  */
 namespace Magento\Framework\App\AreaList;
 
-class Proxy extends \Magento\Framework\App\AreaList implements
-    \Magento\Framework\ObjectManager\NoninterceptableInterface
+class Proxy extends \Magento\Framework\App\AreaList implements \Magento\Framework\ObjectManager\NoninterceptableInterface
 {
     /**
      * Object Manager instance

--- a/lib/internal/Magento/Framework/App/Cache/Proxy.php
+++ b/lib/internal/Magento/Framework/App/Cache/Proxy.php
@@ -11,9 +11,7 @@ use \Magento\Framework\ObjectManager\NoninterceptableInterface;
 /**
  * System cache proxy model
  */
-class Proxy implements
-    CacheInterface,
-    NoninterceptableInterface
+class Proxy implements CacheInterface, NoninterceptableInterface
 {
     /**
      * @var \Magento\Framework\ObjectManagerInterface

--- a/lib/internal/Magento/Framework/App/Route/ConfigInterface/Proxy.php
+++ b/lib/internal/Magento/Framework/App/Route/ConfigInterface/Proxy.php
@@ -10,9 +10,7 @@ namespace Magento\Framework\App\Route\ConfigInterface;
 /**
  * Proxy class for \Magento\Framework\App\ResourceConnection
  */
-class Proxy implements
-    \Magento\Framework\App\Route\ConfigInterface,
-    \Magento\Framework\ObjectManager\NoninterceptableInterface
+class Proxy implements \Magento\Framework\App\Route\ConfigInterface, \Magento\Framework\ObjectManager\NoninterceptableInterface
 {
     /**
      * Object Manager instance

--- a/lib/internal/Magento/Framework/Code/Generator/ClassGenerator.php
+++ b/lib/internal/Magento/Framework/Code/Generator/ClassGenerator.php
@@ -8,8 +8,7 @@ namespace Magento\Framework\Code\Generator;
 use Zend\Code\Generator\MethodGenerator;
 use Zend\Code\Generator\PropertyGenerator;
 
-class ClassGenerator extends \Zend\Code\Generator\ClassGenerator implements
-    \Magento\Framework\Code\Generator\CodeGeneratorInterface
+class ClassGenerator extends \Zend\Code\Generator\ClassGenerator implements \Magento\Framework\Code\Generator\CodeGeneratorInterface
 {
     /**
      * Possible doc block options

--- a/lib/internal/Magento/Framework/DataObject/Copy/Config/Data/Proxy.php
+++ b/lib/internal/Magento/Framework/DataObject/Copy/Config/Data/Proxy.php
@@ -8,8 +8,7 @@ namespace Magento\Framework\DataObject\Copy\Config\Data;
 /**
  * Proxy class for @see \Magento\Framework\DataObject\Copy\Config\Data
  */
-class Proxy extends \Magento\Framework\DataObject\Copy\Config\Data implements
-    \Magento\Framework\ObjectManager\NoninterceptableInterface
+class Proxy extends \Magento\Framework\DataObject\Copy\Config\Data implements \Magento\Framework\ObjectManager\NoninterceptableInterface
 {
     /**
      * Object Manager instance

--- a/lib/internal/Magento/Framework/GraphQl/Schema/Type/ListOfType.php
+++ b/lib/internal/Magento/Framework/GraphQl/Schema/Type/ListOfType.php
@@ -10,10 +10,7 @@ namespace Magento\Framework\GraphQl\Schema\Type;
 /**
  * Wrapper for GraphQl ListOfType
  */
-class ListOfType extends \GraphQL\Type\Definition\ListOfType implements
-    WrappedTypeInterface,
-    InputTypeInterface,
-    OutputTypeInterface
+class ListOfType extends \GraphQL\Type\Definition\ListOfType implements WrappedTypeInterface, InputTypeInterface, OutputTypeInterface
 {
 
 }

--- a/lib/internal/Magento/Framework/GraphQl/Schema/Type/NonNull.php
+++ b/lib/internal/Magento/Framework/GraphQl/Schema/Type/NonNull.php
@@ -10,10 +10,7 @@ namespace Magento\Framework\GraphQl\Schema\Type;
 /**
  * Wrapper for GraphQl NonNull
  */
-class NonNull extends \GraphQL\Type\Definition\NonNull implements
-    WrappedTypeInterface,
-    InputTypeInterface,
-    OutputTypeInterface
+class NonNull extends \GraphQL\Type\Definition\NonNull implements WrappedTypeInterface, InputTypeInterface, OutputTypeInterface
 {
 
 }

--- a/lib/internal/Magento/Framework/Model/AbstractExtensibleModel.php
+++ b/lib/internal/Magento/Framework/Model/AbstractExtensibleModel.php
@@ -16,8 +16,7 @@ use Magento\Framework\Api\ExtensionAttributesFactory;
  * Implementations may choose to process custom attributes as their persistence requires them to.
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  */
-abstract class AbstractExtensibleModel extends AbstractModel implements
-    \Magento\Framework\Api\CustomAttributesDataInterface
+abstract class AbstractExtensibleModel extends AbstractModel implements \Magento\Framework\Api\CustomAttributesDataInterface
 {
     /**
      * @var ExtensionAttributesFactory

--- a/lib/internal/Magento/Framework/Model/ResourceModel/Type/Db/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Type/Db/Pdo/Mysql.php
@@ -13,8 +13,7 @@ use Magento\Framework\DB\SelectFactory;
 
 // @codingStandardsIgnoreStart
 
-class Mysql extends \Magento\Framework\Model\ResourceModel\Type\Db implements
-    ConnectionAdapterInterface
+class Mysql extends \Magento\Framework\Model\ResourceModel\Type\Db implements ConnectionAdapterInterface
 // @codingStandardsIgnoreEnd
 {
     /**

--- a/lib/internal/Magento/Framework/Mview/Config/Data/Proxy.php
+++ b/lib/internal/Magento/Framework/Mview/Config/Data/Proxy.php
@@ -8,8 +8,7 @@ namespace Magento\Framework\Mview\Config\Data;
 /**
  * Proxy class for \Magento\Framework\Mview\Config\Data
  */
-class Proxy extends \Magento\Framework\Mview\Config\Data implements
-    \Magento\Framework\ObjectManager\NoninterceptableInterface
+class Proxy extends \Magento\Framework\Mview\Config\Data implements \Magento\Framework\ObjectManager\NoninterceptableInterface
 {
     /**
      * Object Manager instance

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Column.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Column.php
@@ -8,9 +8,7 @@ namespace Magento\Framework\Setup\Declaration\Schema\Dto;
 /**
  * Column structural element.
  */
-class Column extends GenericElement implements
-    ElementInterface,
-    TableElementInterface
+class Column extends GenericElement implements ElementInterface, TableElementInterface
 {
     /**
      * Element type.

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Blob.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Blob.php
@@ -14,9 +14,7 @@ use Magento\Framework\Setup\Declaration\Schema\Dto\Table;
  * We can have few binary types: blob, mediumblob, longblob.
  * Declared in SQL, like blob.
  */
-class Blob extends Column implements
-    ElementDiffAwareInterface,
-    ColumnNullableAwareInterface
+class Blob extends Column implements ElementDiffAwareInterface, ColumnNullableAwareInterface
 {
     /**
      * @var bool

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Boolean.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Boolean.php
@@ -13,10 +13,7 @@ use Magento\Framework\Setup\Declaration\Schema\Dto\Table;
  * Boolean column.
  * Declared in SQL, like TINYINT(1) or BOOL or BOOLEAN. Alias for integer or binary type.
  */
-class Boolean extends Column implements
-    ElementDiffAwareInterface,
-    ColumnNullableAwareInterface,
-    ColumnDefaultAwareInterface
+class Boolean extends Column implements ElementDiffAwareInterface, ColumnNullableAwareInterface, ColumnDefaultAwareInterface
 {
     /**
      * @var bool

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Date.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Date.php
@@ -15,9 +15,7 @@ use Magento\Framework\Setup\Declaration\Schema\Dto\Table;
  * Does not have any additional params.
  * Is represented like: YY:MM:DD.
  */
-class Date extends Column implements
-    ElementDiffAwareInterface,
-    ColumnNullableAwareInterface
+class Date extends Column implements ElementDiffAwareInterface, ColumnNullableAwareInterface
 {
     /**
      * @var bool

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Integer.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Integer.php
@@ -14,12 +14,7 @@ use Magento\Framework\Setup\Declaration\Schema\Dto\Table;
  * Declared in SQL, like INT(11) or BIGINT(20).
  * Where digit is padding, how many zeros should be added before first non-zero digit.
  */
-class Integer extends Column implements
-    ElementDiffAwareInterface,
-    ColumnUnsignedAwareInterface,
-    ColumnNullableAwareInterface,
-    ColumnIdentityAwareInterface,
-    ColumnDefaultAwareInterface
+class Integer extends Column implements ElementDiffAwareInterface, ColumnUnsignedAwareInterface, ColumnNullableAwareInterface, ColumnIdentityAwareInterface, ColumnDefaultAwareInterface
 {
     /**
      * @var bool

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Real.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Real.php
@@ -15,11 +15,7 @@ use Magento\Framework\Setup\Declaration\Schema\Dto\Table;
  * where S - is scale, P - is precision.
  * https://dev.mysql.com/doc/refman/5.7/en/precision-math-decimal-characteristics.html
  */
-class Real extends Column implements
-    ElementDiffAwareInterface,
-    ColumnUnsignedAwareInterface,
-    ColumnNullableAwareInterface,
-    ColumnDefaultAwareInterface
+class Real extends Column implements ElementDiffAwareInterface, ColumnUnsignedAwareInterface, ColumnNullableAwareInterface, ColumnDefaultAwareInterface
 {
     /**
      * @var int

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/StringBinary.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/StringBinary.php
@@ -14,10 +14,7 @@ use Magento\Framework\Setup\Declaration\Schema\Dto\Table;
  * Declared in SQL, like VARCHAR(L), BINARY(L)
  * where L - length.
  */
-class StringBinary extends Column implements
-    ElementDiffAwareInterface,
-    ColumnNullableAwareInterface,
-    ColumnDefaultAwareInterface
+class StringBinary extends Column implements ElementDiffAwareInterface, ColumnNullableAwareInterface, ColumnDefaultAwareInterface
 {
     /**
      * @var bool

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Text.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Text.php
@@ -13,9 +13,7 @@ use Magento\Framework\Setup\Declaration\Schema\Dto\Table;
  * Text column.
  * Declared in SQL, like: TEXT, TINYTEXT, MEDIUMTEXT, LONGTEXT.
  */
-class Text extends Column implements
-    ElementDiffAwareInterface,
-    ColumnNullableAwareInterface
+class Text extends Column implements ElementDiffAwareInterface, ColumnNullableAwareInterface
 {
     /**
      * @var bool

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Timestamp.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Timestamp.php
@@ -14,10 +14,7 @@ use Magento\Framework\Setup\Declaration\Schema\Dto\Table;
  * Declared in SQL, like Timestamp.
  * Has 2 additional params: default and on_update.
  */
-class Timestamp extends Column implements
-    ElementDiffAwareInterface,
-    ColumnDefaultAwareInterface,
-    ColumnNullableAwareInterface
+class Timestamp extends Column implements ElementDiffAwareInterface, ColumnDefaultAwareInterface, ColumnNullableAwareInterface
 {
     /**
      * @var string

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Constraint.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Constraint.php
@@ -9,9 +9,7 @@ namespace Magento\Framework\Setup\Declaration\Schema\Dto;
  * Constraint structural element.
  * Used for creating additional rules on db tables.
  */
-class Constraint extends GenericElement implements
-    ElementInterface,
-    TableElementInterface
+class Constraint extends GenericElement implements ElementInterface, TableElementInterface
 {
     /**
      * In case if we will need to change this object: add, modify or drop, we will need

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/GenericElement.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/GenericElement.php
@@ -15,8 +15,7 @@ namespace Magento\Framework\Setup\Declaration\Schema\Dto;
  *  - constraint
  *  - index
  */
-abstract class GenericElement implements
-    ElementInterface
+abstract class GenericElement implements ElementInterface
 {
     /**
      * High level type.

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Index.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Index.php
@@ -9,10 +9,7 @@ namespace Magento\Framework\Setup\Declaration\Schema\Dto;
  * Index structural element.
  * Used to speedup read operations from SQL database.
  */
-class Index extends GenericElement implements
-    ElementInterface,
-    TableElementInterface,
-    ElementDiffAwareInterface
+class Index extends GenericElement implements ElementInterface, TableElementInterface, ElementDiffAwareInterface
 {
     /**
      * Element type.

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Table.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Table.php
@@ -14,9 +14,7 @@ use Magento\Framework\Setup\Declaration\Schema\Dto\Constraints\Reference;
  * Aggregate inside itself: columns, constraints and indexes
  * Resource is also specified on this strucural element
  */
-class Table extends GenericElement implements
-    ElementInterface,
-    ElementDiffAwareInterface
+class Table extends GenericElement implements ElementInterface, ElementDiffAwareInterface
 {
     /**
      * In case if we will need to change this object: add, modify or drop, we will need

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/_files/data_patch_classes.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/_files/data_patch_classes.php
@@ -32,9 +32,7 @@ class OtherDataPatch implements \Magento\Framework\Setup\Patch\DataPatchInterfac
     }
 }
 
-class SomeDataPatch implements
-    \Magento\Framework\Setup\Patch\DataPatchInterface,
-    \Magento\Framework\Setup\Patch\PatchVersionInterface
+class SomeDataPatch implements \Magento\Framework\Setup\Patch\DataPatchInterface, \Magento\Framework\Setup\Patch\PatchVersionInterface
 {
     /**
      * {@inheritdoc}
@@ -71,9 +69,7 @@ class SomeDataPatch implements
     }
 }
 
-class NonTransactionableDataPatch implements
-    \Magento\Framework\Setup\Patch\DataPatchInterface,
-    \Magento\Framework\Setup\Patch\NonTransactionableInterface
+class NonTransactionableDataPatch implements \Magento\Framework\Setup\Patch\DataPatchInterface, \Magento\Framework\Setup\Patch\NonTransactionableInterface
 {
 
     /**
@@ -100,9 +96,7 @@ class NonTransactionableDataPatch implements
     }
 }
 
-class RevertableDataPatch implements
-    \Magento\Framework\Setup\Patch\DataPatchInterface,
-    \Magento\Framework\Setup\Patch\PatchRevertableInterface
+class RevertableDataPatch implements \Magento\Framework\Setup\Patch\DataPatchInterface, \Magento\Framework\Setup\Patch\PatchRevertableInterface
 {
     /**
      * {@inheritdoc}

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/_files/schema_patch_classes.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/_files/schema_patch_classes.php
@@ -32,9 +32,7 @@ class OtherSchemaPatch implements \Magento\Framework\Setup\Patch\SchemaPatchInte
     }
 }
 
-class SomeSchemaPatch implements
-    \Magento\Framework\Setup\Patch\SchemaPatchInterface,
-    \Magento\Framework\Setup\Patch\PatchVersionInterface
+class SomeSchemaPatch implements \Magento\Framework\Setup\Patch\SchemaPatchInterface, \Magento\Framework\Setup\Patch\PatchVersionInterface
 {
     /**
      * {@inheritdoc}

--- a/lib/internal/Magento/Framework/Translate/Inline/Proxy.php
+++ b/lib/internal/Magento/Framework/Translate/Inline/Proxy.php
@@ -8,8 +8,7 @@ namespace Magento\Framework\Translate\Inline;
 /**
  * Proxy class for \Magento\Framework\Translate\Inline
  */
-class Proxy extends \Magento\Framework\Translate\Inline implements
-    \Magento\Framework\ObjectManager\NoninterceptableInterface
+class Proxy extends \Magento\Framework\Translate\Inline implements \Magento\Framework\ObjectManager\NoninterceptableInterface
 {
     /**
      * Object Manager instance

--- a/lib/internal/Magento/Framework/View/Design/Theme/Customization/AbstractFile.php
+++ b/lib/internal/Magento/Framework/View/Design/Theme/Customization/AbstractFile.php
@@ -10,9 +10,7 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 /**
  * Theme file service abstract class
  */
-abstract class AbstractFile implements
-    \Magento\Framework\View\Design\Theme\Customization\FileInterface,
-    \Magento\Framework\View\Design\Theme\Customization\FileAssetInterface
+abstract class AbstractFile implements \Magento\Framework\View\Design\Theme\Customization\FileInterface, \Magento\Framework\View\Design\Theme\Customization\FileAssetInterface
 {
     /**
      * Customization path

--- a/lib/internal/Magento/Framework/Webapi/Response.php
+++ b/lib/internal/Magento/Framework/Webapi/Response.php
@@ -7,8 +7,7 @@
  */
 namespace Magento\Framework\Webapi;
 
-class Response extends \Magento\Framework\HTTP\PhpEnvironment\Response implements
-    \Magento\Framework\App\Response\HttpInterface
+class Response extends \Magento\Framework\HTTP\PhpEnvironment\Response implements \Magento\Framework\App\Response\HttpInterface
 {
     /**
      * Character set which must be used in response.

--- a/setup/src/Magento/Setup/Module.php
+++ b/setup/src/Magento/Setup/Module.php
@@ -14,9 +14,7 @@ use Zend\ModuleManager\Feature\ConfigProviderInterface;
 use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\MvcEvent;
 
-class Module implements
-    BootstrapListenerInterface,
-    ConfigProviderInterface
+class Module implements BootstrapListenerInterface, ConfigProviderInterface
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Whitespace around the keywords of a class, trait or interfaces definition should be one space. 