### PR TITLE
No closing tag

### DIFF
--- a/app/code/Magento/Customer/view/adminhtml/templates/edit/js.phtml
+++ b/app/code/Magento/Customer/view/adminhtml/templates/edit/js.phtml
@@ -5,5 +5,3 @@
  */
 
 // @codingStandardsIgnoreFile
-
-?>


### PR DESCRIPTION
The closing ?> tag MUST be omitted from files containing only PHP. 