### PR TITLE
[Backport] Fixing swatch style issue on product attribute form

### DIFF
--- a/app/code/Magento/Swatches/view/adminhtml/web/css/swatches.css
+++ b/app/code/Magento/Swatches/view/adminhtml/web/css/swatches.css
@@ -149,6 +149,16 @@
     width: 50px;
 }
 
+
+.col-swatch-min-width {
+    min-width: 65px;
+}
+
+.data-table .col-swatch-min-width input[type="text"] {
+    padding: inherit;
+}
+
+
 .swatches-visual-col.unavailable:after {
     position: absolute;
     width: 35px;

--- a/app/code/Magento/Ui/Component/MassAction/Filter.php
+++ b/app/code/Magento/Ui/Component/MassAction/Filter.php
@@ -98,10 +98,14 @@ class Filter
                 throw new LocalizedException(__('Please select item(s).'));
             }
         }
-
+        
+        $filterIds = $this->getFilterIds();
+        if(is_array($selected)){
+            $filterIds = array_unique(array_merge($this->getFilterIds(), $selected));
+        }
         $collection->addFieldToFilter(
             $collection->getIdFieldName(),
-            ['in' => $this->getFilterIds()]
+            ['in' => $filterIds]
         );
 
         return $collection;


### PR DESCRIPTION
### Description (*)
Styles for the swatch input are broken

### Fixed Issues (if relevant)
1. magento/magento2#20513: Create a new product attribute form. Styles for the swatch input looks broken

### Manual testing scenarios (*)
1. In Admin go to Stores > Attributes > Product > Add New Attribute
2. In "Attribute Properties" > Catalog Input Type for Store Owner > Choose "Text Swatch"
3. In Manage Swatch (Values of Your Attribute) > Add Swatch

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
