### PR TITLE
Email-template-popup-blank-fixes:: Email Template Information Insert …

### DIFF
--- a/app/code/Magento/Email/Block/Adminhtml/Template/Edit/Form.php
+++ b/app/code/Magento/Email/Block/Adminhtml/Template/Edit/Form.php
@@ -187,11 +187,11 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         $variables = $this->_variables->toOptionArray(true);
         $customVariables = $this->_variableFactory->create()->getVariablesOptionArray(true);
         if ($customVariables) {
-            $variables = array_merge_recursive($variables, $customVariables);
+            $variables[] = $customVariables;
         }
         $template = $this->getEmailTemplate();
         if ($template->getId() && ($templateVariables = $template->getVariablesOptionArray(true))) {
-            $variables = array_merge_recursive($variables, $templateVariables);
+            $variables[] = $templateVariables;
         }
         return $variables;
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
2.3.0
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2 #20111: Email Template Information Insert Variable popup blank

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.Go to admin>>MARKETING>>Email Templates>> edit the template

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
