### PR TITLE
[Backport] recent-order-product-title-misaligned

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/_module.less
@@ -489,7 +489,7 @@
         .product-items-names {
             .product-item {
                 margin-bottom: @indent__s;
-              display: flex;
+                display: flex;
             }
 
             .product-item-name {

--- a/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/_module.less
@@ -488,8 +488,8 @@
 
         .product-items-names {
             .product-item {
-                margin-bottom: @indent__s;
                 display: flex;
+                margin-bottom: @indent__s;
             }
 
             .product-item-name {

--- a/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Catalog/web/css/source/_module.less
@@ -489,6 +489,7 @@
         .product-items-names {
             .product-item {
                 margin-bottom: @indent__s;
+              display: flex;
             }
 
             .product-item-name {

--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
@@ -563,8 +563,8 @@
 
         .product-items-names {
             .product-item {
-                margin-bottom: @indent__s;
                 display: flex;
+                margin-bottom: @indent__s;
             }
 
             .product-item-name {

--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
@@ -564,7 +564,7 @@
         .product-items-names {
             .product-item {
                 margin-bottom: @indent__s;
-              display: flex;
+                display: flex;
             }
 
             .product-item-name {

--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
@@ -564,6 +564,7 @@
         .product-items-names {
             .product-item {
                 margin-bottom: @indent__s;
+              display: flex;
             }
 
             .product-item-name {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20501
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20500: Recent Order Product Title Misaligned in Sidebar
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Place order
2. Check recent order in sidebar on listing pages or account pages

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
