### PR TITLE
CSV Product Import - Import a external URL image

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
@@ -198,7 +198,7 @@ class Uploader extends \Magento\MediaStorage\Model\File\Uploader
             );
         }
 
-        $filePath = $this->_directory->getRelativePath($filePath . $fileName);
+        $filePath = strpos($filePath, $fileName) !== false ? $filePath:$this->_directory->getRelativePath($filePath . $fileName);
         $this->_setUploadFile($filePath);
         $destDir = $this->_directory->getAbsolutePath($this->getDestDir());
         $result = $this->save($destDir);


### PR DESCRIPTION
Fixing the problem to import external image. ( the path is duplicated filename it's always return image not exist so we cannot import)

### Description (*)
Actually, you import a product with external url by default module of magento 2. You get the message `Imported resource (image) could not be downloaded from external resource due to timeout or access permissions`. 
This commit provide make a simple check to make sure the filename not add two times to the path.

### Fixed Issues (if relevant)
1. magento/magento2#2666: CSV Product Import - Images reporting failure.

### Manual testing scenarios (*)
1. Import a product with external product image

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
