### PR TITLE
Fix Model\Widget#getConfigAsObject losing it's type declaration

### DIFF
--- a/app/code/Magento/Widget/Model/Widget.php
+++ b/app/code/Magento/Widget/Model/Widget.php
@@ -151,8 +151,8 @@ class Widget
         $widget = $this->getAsCanonicalArray($widget);
 
         // Save all nodes to object data
-        $object->setType($type);
         $object->setData($widget);
+        $object->setType($type);
 
         // Correct widget parameters and convert its data to objects
         $newParams = $this->prepareWidgetParameters($object);


### PR DESCRIPTION
### Description (*)
Fix an issue where the `getConfigAsObject()` method loses it's type declaration. This causes issues for any class that extends the Model class and requires it in the `prepareWidgetParameters` method.

Due to the order of the data calls the setType call (which is a magic setData('type') method) will be overwritten by the following setData call.

### Manual testing scenarios (*)
1. Create a Override class that extends `Magento\Widget\Model\Widget`
2. DI the new class `<preference for="Magento\Widget\Model\Widget" type="Your\New\Model" />`
3. Override `prepareWidgetParameters(DataObject $object)`
4. Dump `$object->getType()`, the result will be null instead of the Widget type

After this PR it will return the class of the Widget in question.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
