### PR TITLE
Fixed issue #19942 in 2.2

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
@@ -190,13 +190,7 @@ class Save extends \Magento\Backend\App\Action
                 }
             }
             $transactionSave->save();
-
-            if (!empty($data['do_shipment'])) {
-                $this->messageManager->addSuccess(__('You created the invoice and shipment.'));
-            } else {
-                $this->messageManager->addSuccess(__('The invoice has been created.'));
-            }
-
+            
             // send invoice/shipment emails
             try {
                 if (!empty($data['send_email'])) {
@@ -206,6 +200,12 @@ class Save extends \Magento\Backend\App\Action
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
                 $this->messageManager->addError(__('We can\'t send the invoice email right now.'));
             }
+            if (!empty($data['do_shipment'])) {
+                $this->messageManager->addSuccess(__('You created the invoice and shipment.'));
+            } else {
+                $this->messageManager->addSuccess(__('The invoice has been created.'));
+            }
+
             if ($shipment) {
                 try {
                     if (!empty($data['send_email'])) {
@@ -216,6 +216,13 @@ class Save extends \Magento\Backend\App\Action
                     $this->messageManager->addError(__('We can\'t send the shipment right now.'));
                 }
             }
+            
+            if (!empty($data['do_shipment'])) {
+                $this->messageManager->addSuccess(__('You created the invoice and shipment.'));
+            } else {
+                $this->messageManager->addSuccess(__('The invoice has been created.'));
+            }
+
             $this->_objectManager->get(\Magento\Backend\Model\Session::class)->getCommentText(true);
             return $resultRedirect->setPath('sales/order/view', ['order_id' => $orderId]);
         } catch (LocalizedException $e) {

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
@@ -200,12 +200,7 @@ class Save extends \Magento\Backend\App\Action
                 $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
                 $this->messageManager->addError(__('We can\'t send the invoice email right now.'));
             }
-            if (!empty($data['do_shipment'])) {
-                $this->messageManager->addSuccess(__('You created the invoice and shipment.'));
-            } else {
-                $this->messageManager->addSuccess(__('The invoice has been created.'));
-            }
-
+            
             if ($shipment) {
                 try {
                     if (!empty($data['send_email'])) {


### PR DESCRIPTION
Fixed issue #19942 in 2.2 Reference PR #20142


### Description (*)
Fixed issue #19942 in 2.2 Success message is not showing when creating invoice & shipment simultaniously

### Fixed Issues (if relevant)

1. magento/magento2#19942: Success message is not showing when creating invoice & shipment simultaniously

### Manual testing scenarios (*)

    1.Create order from admin panel.
   2. View order at admin panel and Click "create invoice".
   3. Check the checkbox "create shipment" and "Email copy of invoice" while generating invoice. and click submit invoice button.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
