### PR TITLE
Allow multiple conditions for expired quotes collection

### DIFF
--- a/app/code/Magento/Sales/Cron/CleanExpiredQuotes.php
+++ b/app/code/Magento/Sales/Cron/CleanExpiredQuotes.php
@@ -30,12 +30,12 @@ class CleanExpiredQuotes
     /**
      * @var array
      */
-    private $expireQuotesFilterFields = [];
+    protected $expireQuotesFilterFields = [];
 
     /**
      * @var ExpireQuotesFilterFieldsProvider
      */
-    protected $expireQuotesFilterFieldsProvider;
+    private $expireQuotesFilterFieldsProvider;
 
     /**
      * @param StoresConfig $storesConfig

--- a/app/code/Magento/Sales/Cron/CleanExpiredQuotes.php
+++ b/app/code/Magento/Sales/Cron/CleanExpiredQuotes.php
@@ -61,6 +61,10 @@ class CleanExpiredQuotes
     public function execute()
     {
         $lifetimes = $this->storesConfig->getStoresConfigByPath('checkout/cart/delete_quote_after');
+        $fields = array_merge(
+            $this->getExpireQuotesAdditionalFilterFields(),
+            $this->expireQuotesFilterFieldsProvider->getFields()
+        );
         foreach ($lifetimes as $storeId => $lifetime) {
             $lifetime *= self::LIFETIME;
 
@@ -70,11 +74,6 @@ class CleanExpiredQuotes
             $quotes->addFieldToFilter('store_id', $storeId);
             $quotes->addFieldToFilter('updated_at', ['to' => date("Y-m-d", time() - $lifetime)]);
             $quotes->addFieldToFilter('is_active', 0);
-            
-            $fields = array_merge(
-                $this->getExpireQuotesAdditionalFilterFields(),
-                $this->expireQuotesFilterFieldsProvider->getFields()
-            );
 
             foreach ($fields as $field => $condition) {
                 $quotes->addFieldToFilter($field, $condition);

--- a/app/code/Magento/Sales/Cron/CleanExpiredQuotes.php
+++ b/app/code/Magento/Sales/Cron/CleanExpiredQuotes.php
@@ -20,12 +20,12 @@ class CleanExpiredQuotes
     /**
      * @var StoresConfig
      */
-    private $storesConfig;
+    protected $storesConfig;
 
     /**
      * @var QuoteCollectionFactory
      */
-    private $quoteCollectionFactory;
+    protected $quoteCollectionFactory;
 
     /**
      * @var array
@@ -35,7 +35,7 @@ class CleanExpiredQuotes
     /**
      * @var ExpireQuotesFilterFieldsProvider
      */
-    private $expireQuotesFilterFieldsProvider;
+    protected $expireQuotesFilterFieldsProvider;
 
     /**
      * @param StoresConfig $storesConfig

--- a/app/code/Magento/Sales/Cron/CleanExpiredQuotes.php
+++ b/app/code/Magento/Sales/Cron/CleanExpiredQuotes.php
@@ -70,8 +70,13 @@ class CleanExpiredQuotes
             $quotes->addFieldToFilter('store_id', $storeId);
             $quotes->addFieldToFilter('updated_at', ['to' => date("Y-m-d", time() - $lifetime)]);
             $quotes->addFieldToFilter('is_active', 0);
+            
+            $fields = array_merge(
+                $this->getExpireQuotesAdditionalFilterFields(),
+                $this->expireQuotesFilterFieldsProvider->getFields()
+            );
 
-            foreach ($this->expireQuotesFilterFieldsProvider->getFields() as $field => $condition) {
+            foreach ($fields as $field => $condition) {
                 $quotes->addFieldToFilter($field, $condition);
             }
 
@@ -99,6 +104,6 @@ class CleanExpiredQuotes
      */
     public function setExpireQuotesAdditionalFilterFields(array $fields)
     {
-        $this->expireQuotesFilterFields = array_merge($this->expireQuotesFilterFields, $fields);
+        $this->expireQuotesFilterFields = $fields;
     }
 }

--- a/app/code/Magento/Sales/Cron/CleanExpiredQuotes.php
+++ b/app/code/Magento/Sales/Cron/CleanExpiredQuotes.php
@@ -85,6 +85,6 @@ class CleanExpiredQuotes
      */
     public function setExpireQuotesAdditionalFilterFields(array $fields)
     {
-        $this->expireQuotesFilterFields = $fields;
+        $this->expireQuotesFilterFields = array_merge($this->expireQuotesFilterFields, $fields);
     }
 }

--- a/app/code/Magento/Sales/Model/ExpireQuotesFilterFieldsProvider.php
+++ b/app/code/Magento/Sales/Model/ExpireQuotesFilterFieldsProvider.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Model;
+
+/**
+ * Provides expire quotes filter fields.
+ */
+class ExpireQuotesFilterFieldsProvider
+{
+    /**
+     * @var array
+     */
+    private $expireQuotesFilterFields;
+
+    /**
+     * @param array $expireQuotesFilterFields
+     */
+    public function __construct(
+        array $expireQuotesFilterFields = []
+    ) {
+        $this->expireQuotesFilterFields = $expireQuotesFilterFields;
+    }
+
+    /**
+     * Get expire quotes filter fields.
+     *
+     * @return array
+     */
+    public function getFields(): array
+    {
+        return $this->expireQuotesFilterFields;
+    }
+}

--- a/app/code/Magento/Sales/Test/Unit/Cron/CleanExpiredQuotesTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Cron/CleanExpiredQuotesTest.php
@@ -6,6 +6,7 @@
 namespace Magento\Sales\Test\Unit\Cron;
 
 use \Magento\Sales\Cron\CleanExpiredQuotes;
+use Magento\Sales\Model\ExpireQuotesFilterFieldsProvider;
 
 /**
  * Tests Magento\Sales\Cron\CleanExpiredQuotes
@@ -23,6 +24,11 @@ class CleanExpiredQuotesTest extends \PHPUnit\Framework\TestCase
     protected $quoteFactoryMock;
 
     /**
+     * @var ExpireQuotesFilterFieldsProvider|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $expireQuotesFilterFieldsProviderMock;
+
+    /**
      * @var \Magento\Sales\Cron\CleanExpiredQuotes
      */
     protected $observer;
@@ -38,7 +44,13 @@ class CleanExpiredQuotesTest extends \PHPUnit\Framework\TestCase
             ->setMethods(['create'])
             ->getMock();
 
-        $this->observer = new CleanExpiredQuotes($this->storesConfigMock, $this->quoteFactoryMock);
+        $this->expireQuotesFilterFieldsProviderMock = $this->createMock(ExpireQuotesFilterFieldsProvider::class);
+
+        $this->observer = new CleanExpiredQuotes(
+            $this->storesConfigMock,
+            $this->quoteFactoryMock,
+            $this->expireQuotesFilterFieldsProviderMock
+        );
     }
 
     /**
@@ -66,6 +78,10 @@ class CleanExpiredQuotesTest extends \PHPUnit\Framework\TestCase
                 ->method('walk')
                 ->with('delete');
         }
+        $this->expireQuotesFilterFieldsProviderMock->expects($this->any())
+            ->method('getFields')
+            ->willReturn($additionalFilterFields);
+
         $this->observer->setExpireQuotesAdditionalFilterFields($additionalFilterFields);
         $this->observer->execute();
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
With Magento\Sales\Cron\CleanExpiredQuotes::setExpireQuotesAdditionalFilterFields() assigning values directly to the attribute and getExpireQuotesAdditionalFilterFields() being protected isn't callable outside the class, hence unable to add more to the existing condition, rather they end up being replaced with the new ones.

### Fixed Issues (if relevant)
none

### Manual testing scenarios (*)
N/A

### Contribution checklist (*)
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
