### PR TITLE
Creditmemo show negative total amount #20797

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
@@ -35,8 +35,9 @@ class Tax extends AbstractTotal
             $orderItemTax = (double)$orderItem->getTaxInvoiced();
             $baseOrderItemTax = (double)$orderItem->getBaseTaxInvoiced();
             $orderItemQty = (double)$orderItem->getQtyInvoiced();
+            $orderTaxCompensation = (double)$orderItem->getDiscountTaxCompensationAmount();
 
-            if ($orderItemTax && $orderItemQty) {
+            if (($orderItemTax || $orderTaxCompensation) && $orderItemQty) {
                 /**
                  * Check item tax amount
                  */

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Total/TaxTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Total/TaxTest.php
@@ -610,6 +610,75 @@ class TaxTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
+        // scenario 6: 1 item, 1 invoiced, price with included tax
+        // order and invoice with applied full discount
+        $result['creditmemo_with_full_discount'] = [
+            'order_data' => [
+                'data_fields' => [
+                    'shipping_tax_amount' => 0.38,
+                    'base_shipping_tax_amount' => 0.38,
+                    'shipping_discount_tax_compensation_amount' => 0,
+                    'base_shipping_discount_tax_compensation_amount' => 0,
+                    'tax_amount' => 0.38,
+                    'base_tax_amount' => 0.38,
+                    'tax_invoiced' => 0.38,
+                    'base_tax_invoiced' => 0.38,
+                    'tax_refunded' => 0,
+                    'base_tax_refunded' => 0,
+                    'shipping_amount' => 4.62,
+                    'base_shipping_amount' => 4.62,
+
+                ],
+            ],
+            'creditmemo_data' => [
+                'items' => [
+                    'item_1' => [
+                        'order_item' => [
+                            'qty_invoiced' => 1,
+                            'tax_invoiced' => 0,
+                            'tax_refunded' => 0,
+                            'base_tax_invoiced' => 0,
+                            'base_tax_refunded' => 0,
+                            'discount_tax_compensation_amount' =>  5.87,
+                            'base_discount_tax_compensation_amount' =>  5.87,
+                            'qty_refunded' => 0,
+                        ],
+                        'is_last' => true,
+                        'qty' => 1,
+                    ],
+                ],
+                'is_last' => false,
+                'data_fields' => [
+                    'grand_total' => 5,
+                    'base_grand_total' => 5,
+                    'base_shipping_amount' => 4.62,
+                    'tax_amount' => 0.38,
+                    'base_tax_amount' => 0.38,
+                    'invoice' => new MagentoObject(
+                        [
+                            'shipping_tax_amount' => 0.38,
+                            'base_shipping_tax_amount' => 0.38,
+                            'shipping_discount_tax_compensation_amount' => 0,
+                            'base_shipping_discount_tax_compensation_amount' => 0,
+                        ]
+                    ),
+                ],
+            ],
+            'expected_results' => [
+                'creditmemo_items' => [
+                    'item_1' => [
+                        'tax_amount' => 0,
+                        'base_tax_amount' => 0,
+                    ],
+                ],
+                'creditmemo_data' => [
+                    'grand_total' => 5,
+                    'base_grand_total' => 5,
+                    'tax_amount' => 0.38,
+                    'base_tax_amount' => 0.38,
+                ],
+            ],
+        ];
         return $result;
     }
 


### PR DESCRIPTION
### Description (*)
Origin issue https://github.com/magento/magento2/issues/20797
#### Preconditions (*)
Magento 2.2.x and Magento 2.3.x
use next configuration
![screenshot from 2019-01-30 12-08-04](https://user-images.githubusercontent.com/44254165/51977319-cecd6000-248f-11e9-88d8-6470764a6e06.png)
tax rule configuration
![screenshot from 2019-01-30 12-07-35](https://user-images.githubusercontent.com/44254165/51977321-d1c85080-248f-11e9-82fa-d3baf45e2d6d.png)

### Manual testing scenarios (*)
put order with tax and full discount
invoice this order
Refund the order

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
