### PR TITLE
Backport. Creditmemo show negative total amount 

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
@@ -35,8 +35,9 @@ class Tax extends AbstractTotal
             $orderItemTax = (double)$orderItem->getTaxInvoiced();
             $baseOrderItemTax = (double)$orderItem->getBaseTaxInvoiced();
             $orderItemQty = (double)$orderItem->getQtyInvoiced();
+            $orderTaxCompensation = (double)$orderItem->getDiscountTaxCompensationAmount();
 
-            if ($orderItemTax && $orderItemQty) {
+            if (($orderItemTax || $orderTaxCompensation) && $orderItemQty) {
                 /**
                  * Check item tax amount
                  */


### PR DESCRIPTION
Backport for https://github.com/magento/magento2/pull/20798

### Description (*)
Origin issue https://github.com/magento/magento2/issues/20797
#### Preconditions (*)
Magento 2.2.x and Magento 2.3.x
use next configuration
![screenshot from 2019-01-30 12-08-04](https://user-images.githubusercontent.com/44254165/51977319-cecd6000-248f-11e9-88d8-6470764a6e06.png)
tax rule configuration
![screenshot from 2019-01-30 12-07-35](https://user-images.githubusercontent.com/44254165/51977321-d1c85080-248f-11e9-82fa-d3baf45e2d6d.png)

### Fixed Issues (if relevant)
Original PR https://github.com/magento/magento2/pull/20798


### Manual testing scenarios (*)
put order with tax and full discount
invoice this order
Refund the order

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
