### PR TITLE
[Backend] Fixed the dashboard statistics refreshing button

### DIFF
--- a/app/code/Magento/Backend/Controller/Adminhtml/Dashboard/RefreshStatistics.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Dashboard/RefreshStatistics.php
@@ -6,7 +6,10 @@
 
 namespace Magento\Backend\Controller\Adminhtml\Dashboard;
 
-class RefreshStatistics extends \Magento\Reports\Controller\Adminhtml\Report\Statistics
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Reports\Controller\Adminhtml\Report\Statistics;
+
+class RefreshStatistics extends Statistics implements HttpPostActionInterface
 {
     /**
      * @param \Magento\Backend\App\Action\Context $context

--- a/app/code/Magento/Backend/Controller/Adminhtml/Dashboard/RefreshStatistics.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Dashboard/RefreshStatistics.php
@@ -9,6 +9,9 @@ namespace Magento\Backend\Controller\Adminhtml\Dashboard;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Reports\Controller\Adminhtml\Report\Statistics;
 
+/**
+ * Refresh Dashboard statistics action.
+ */
 class RefreshStatistics extends Statistics implements HttpPostActionInterface
 {
     /**
@@ -28,6 +31,8 @@ class RefreshStatistics extends Statistics implements HttpPostActionInterface
     }
 
     /**
+     * Refresh statistics.
+     *
      * @return \Magento\Backend\Model\View\Result\Redirect
      */
     public function execute()

--- a/app/code/Magento/Backend/view/adminhtml/templates/dashboard/totalbar/refreshstatistics.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/dashboard/totalbar/refreshstatistics.phtml
@@ -8,21 +8,13 @@
     <div class="page-actions-inner">
         <div class="page-actions-buttons">
             <?= $block->getChildHtml() ?>
-
-            <form class="action-element"
-                  action="<?= $block->escapeUrl($block->getUrl('*/*/refreshStatistics')) ?>"
-                  method="post">
-                <input
-                    name="form_key"
-                    type="hidden"
-                    value="<?= $block->escapeHtmlAttr($block->getFormKey()) ?>"/>
                 <button
                     class="action-primary"
-                    type="submit"
+                    type="button"
+                    onclick="setLocation('<?= $block->escapeUrl($block->getUrl('*/*/refreshStatistics')) ?>')"
                     title="<?= $block->escapeHtmlAttr(__('Reload Data')) ?>">
                     <?= $block->escapeHtml(__('Reload Data')) ?>
                 </button>
-            </form>
         </div>
     </div>
 </div>

--- a/app/code/Magento/Backend/view/adminhtml/templates/dashboard/totalbar/refreshstatistics.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/dashboard/totalbar/refreshstatistics.phtml
@@ -8,13 +8,21 @@
     <div class="page-actions-inner">
         <div class="page-actions-buttons">
             <?= $block->getChildHtml() ?>
+
+            <form class="action-element"
+                  action="<?= $block->escapeUrl($block->getUrl('*/*/refreshStatistics')) ?>"
+                  method="post">
+                <input
+                    name="form_key"
+                    type="hidden"
+                    value="<?= $block->escapeHtmlAttr($block->getFormKey()) ?>"/>
                 <button
                     class="action-primary"
-                    type="button"
-                    onclick="setLocation('<?= $block->escapeUrl($block->getUrl('*/*/refreshStatistics')) ?>')"
+                    type="submit"
                     title="<?= $block->escapeHtmlAttr(__('Reload Data')) ?>">
                     <?= $block->escapeHtml(__('Reload Data')) ?>
                 </button>
+            </form>
         </div>
     </div>
 </div>


### PR DESCRIPTION
### Description (*)
This PR fixes the refresh the statistics, and provide the same approach as other buttons work (Ship Order, Reorder, etc.)

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20802: [Backend] Dashboard Refresh Statistics action redirects to 404
2. ...

### Manual testing scenarios (*)
1. Open the backend (on Dashboard)
2. Click on the Reload Data button

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
