### PR TITLE
Fixed issue #20802 Dashboard Refresh Statistics action redirects to 404

### DIFF
--- a/app/code/Magento/Backend/Controller/Adminhtml/Dashboard/RefreshStatistics.php
+++ b/app/code/Magento/Backend/Controller/Adminhtml/Dashboard/RefreshStatistics.php
@@ -5,8 +5,8 @@
  */
 
 namespace Magento\Backend\Controller\Adminhtml\Dashboard;
-
-class RefreshStatistics extends \Magento\Reports\Controller\Adminhtml\Report\Statistics
+use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+class RefreshStatistics extends \Magento\Reports\Controller\Adminhtml\Report\Statistics implements HttpGetActionInterface
 {
     /**
      * @param \Magento\Backend\App\Action\Context $context


### PR DESCRIPTION
Fixed issue #20802 Dashboard Refresh Statistics action redirects to 404

### Description (*)
Fixed issue #20802 Dashboard Refresh Statistics action redirects to 404

### Fixed Issues (if relevant)

1. magento/magento2 #20802 Dashboard Refresh Statistics action redirects to 404


### Manual testing scenarios (*)

    1.Open the backend (on Dashboard)
    2.Click on the Reload Data button


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
