### PR TITLE
14857: prevent cache drop for frontend caches on sitemap generation

### DIFF
--- a/app/code/Magento/Robots/Model/Config/Value.php
+++ b/app/code/Magento/Robots/Model/Config/Value.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Robots\Model\Config;
 
 use Magento\Framework\App\Cache\TypeListInterface;

--- a/app/code/Magento/Robots/Model/Config/Value.php
+++ b/app/code/Magento/Robots/Model/Config/Value.php
@@ -32,9 +32,8 @@ class Value extends ConfigValue implements IdentityInterface
     const CACHE_TAG = 'robots';
 
     /**
-     * Model cache tag for clear cache in after save and after delete
+     * @inheritdoc
      *
-     * @var string
      * @since 100.2.0
      */
     protected $_cacheTag = [self::CACHE_TAG];

--- a/app/code/Magento/Robots/Model/Config/Value.php
+++ b/app/code/Magento/Robots/Model/Config/Value.php
@@ -37,7 +37,7 @@ class Value extends ConfigValue implements IdentityInterface
      * @var string
      * @since 100.2.0
      */
-    protected $_cacheTag = true;
+    protected $_cacheTag = [self::CACHE_TAG];
 
     /**
      * @var StoreManagerInterface

--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Sitemap\Model;
 
 use Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot;
@@ -15,6 +16,8 @@ use Magento\Sitemap\Model\ItemProvider\ItemProviderInterface;
 use Magento\Sitemap\Model\ResourceModel\Sitemap as SitemapResource;
 
 /**
+ * Sitemap model.
+ *
  * @method string getSitemapType()
  * @method \Magento\Sitemap\Model\Sitemap setSitemapType(string $value)
  * @method string getSitemapFilename()

--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -154,9 +154,8 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel implements \Magento
     protected $dateTime;
 
     /**
-     * Model cache tag for clear cache in after save and after delete
+     * @inheritdoc
      *
-     * @var string
      * @since 100.2.0
      */
     protected $_cacheTag = [Value::CACHE_TAG];

--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -159,7 +159,7 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel implements \Magento
      * @var string
      * @since 100.2.0
      */
-    protected $_cacheTag = true;
+    protected $_cacheTag = [Value::CACHE_TAG];
 
     /**
      * Item resolver


### PR DESCRIPTION
### Description
Introduces a (dummy) cache tag for frontend in sitemap and robots generation. This prevents the
default and page_cache to be dropped completely. The cache tag for full_page cache is not
modified.

### Fixed Issues (if relevant)
1. magento/magento2#14857: Sitemap generation cron job flushes entire cache

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. In Magento admin go to _Marketing >> Site Map_
1. watch the `debug.log`
1. Generate sitemap from admin
    1. the sitemap is generated successfully
    1. cache invalidation is logged for `"tags":["robots_dummy"]` (redis)
    1. cache invalidation is logged for `"tagsPattern":"((^|,)robots_1(,|$))"}` (varnish)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
