### PR TITLE
[Reports] Fixed refreshing the reports statistics

### DIFF
--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics/RefreshLifetime.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics/RefreshLifetime.php
@@ -6,7 +6,10 @@
  */
 namespace Magento\Reports\Controller\Adminhtml\Report\Statistics;
 
-class RefreshLifetime extends \Magento\Reports\Controller\Adminhtml\Report\Statistics
+use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
+use Magento\Reports\Controller\Adminhtml\Report\Statistics;
+
+class RefreshLifetime extends Statistics implements HttpPostActionInterface
 {
     /**
      * Refresh statistics for all period

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics/RefreshLifetime.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Statistics/RefreshLifetime.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -9,6 +8,9 @@ namespace Magento\Reports\Controller\Adminhtml\Report\Statistics;
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
 use Magento\Reports\Controller\Adminhtml\Report\Statistics;
 
+/**
+ * Refresh statistics action.
+ */
 class RefreshLifetime extends Statistics implements HttpPostActionInterface
 {
     /**


### PR DESCRIPTION

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes the refreshing of the reports lifetime statistics.

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
1. magento/magento2#20819: [Reports] Refresh Reports Lifetime Statistics action redirects to 404
2. ...

### Manual testing scenarios (*)
1. Open the backend
2. Navigate to Reports / Refresh Statistics [Statistics]
3. Select several reports
4. Choose from the Action dropdown **Refresh Lifetime Statistics**
5. Click Submit

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
