### PR TITLE
Fixed issue #20828 Newsletter Problem Grid Filter issue

### DIFF
--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Problem/Index.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Problem/Index.php
@@ -6,10 +6,9 @@
  */
 namespace Magento\Newsletter\Controller\Adminhtml\Problem;
 
-use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
 use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
 
-class Index extends \Magento\Newsletter\Controller\Adminhtml\Problem implements HttpGetActionInterface, HttpPostActionInterface
+class Index extends \Magento\Newsletter\Controller\Adminhtml\Problem implements HttpGetActionInterface
 {
     /**
      * Newsletter problems report page

--- a/app/code/Magento/Newsletter/Controller/Adminhtml/Problem/Index.php
+++ b/app/code/Magento/Newsletter/Controller/Adminhtml/Problem/Index.php
@@ -6,9 +6,10 @@
  */
 namespace Magento\Newsletter\Controller\Adminhtml\Problem;
 
+use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
 use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
 
-class Index extends \Magento\Newsletter\Controller\Adminhtml\Problem implements HttpGetActionInterface
+class Index extends \Magento\Newsletter\Controller\Adminhtml\Problem implements HttpGetActionInterface, HttpPostActionInterface
 {
     /**
      * Newsletter problems report page

--- a/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_problem_block.xml
+++ b/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_problem_block.xml
@@ -15,6 +15,7 @@
                     <argument name="message_block_visibility" xsi:type="string">true</argument>
                     <argument name="use_ajax" xsi:type="string">true</argument>
                     <argument name="save_parameters_in_session" xsi:type="string">1</argument>
+                    <argument name="grid_url" xsi:type="url" path="*/*/grid"/>
                 </arguments>
                 <block class="Magento\Backend\Block\Widget\Grid\ColumnSet" name="adminhtml.newslettrer.problem.grid.columnSet" as="grid.columnSet">
                     <arguments>


### PR DESCRIPTION
### Description (*)
Fixed issue #20828 Newsletter Problem Grid Filter issue

### Fixed Issues (if relevant)

1. magento/magento2 #20828 Newsletter Problem Grid Filter issue


### Manual testing scenarios (*)

1.Go To Magento Backend 
2.Navigate to Reports->Newsletter Problem Reports
3.Grid Will Open
4.Click on Search or Reset Filter Button

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
