### PR TITLE
[Backport] Fixed Minicart close button overlapping

### DIFF
--- a/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
+++ b/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
@@ -59,7 +59,7 @@
 
     .modal-custom {
         .action-close {
-            .lib-css(margin, @indent__m);
+            .lib-css(margin, 15px);
         }
     }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20615
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Minicart close button overlapping in shipping address section whenever any user open minicart in mobile view on the checkout page
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20614: Minicart close button overlapping in shipping address section whenever any user open minicart in mobile view on the checkout page

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Steps to reproduce
Note : Testing should be in responsive view
Step 1: Go to frontend
Step 2: Login as customer
Step 3: Now add any product to cart and go to checkout
Step 4: In shipping address steps, open minicart

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
