### PR TITLE
Fix truncateString

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Items/Column/Name.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Items/Column/Name.php
@@ -37,7 +37,7 @@ class Name extends \Magento\Sales\Block\Adminhtml\Items\Column\DefaultColumn
         string $value,
         int $length = 80,
         string $etc = '...',
-        string &$remainder = '',
+        &$remainder = '',
         bool $breakWords = true
     ): string {
         $this->truncateResult = $this->filterManager->truncateFilter(


### PR DESCRIPTION
### Description (*)
Fix truncateString method :  "$_remainder must be of the type string, null given"

### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/16958 : Order View Issue - This tab contains invalid data

### Manual testing scenarios (*)
1. Go to admin
2. Open a specific order in sales
3.  Some Order have the error "This tab contains invalid data"

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
