### PR TITLE
#14674 Add ChangeStoreCode switcher to StoreSwither pool of swichers …

### DIFF
--- a/app/code/Magento/Store/Model/StoreSwitcher/ChangeStoreCode.php
+++ b/app/code/Magento/Store/Model/StoreSwitcher/ChangeStoreCode.php
@@ -1,8 +1,9 @@
-<?php declare(strict_types=1);
+<?php
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Store\Model\StoreSwitcher;
 
@@ -27,10 +28,10 @@ class ChangeStoreCode implements StoreSwitcherInterface
     {
         if ($fromStore->isUseStoreInUrl()) {
             if (\strpos($redirectUrl, $fromStore->getBaseUrl()) !== false) {
-                $redirectUrl = \str_replace($fromStore->getBaseUrl(), $targetStore->getBaseUrl(), $redirectUrl);
-            } else {
-                $redirectUrl = $targetStore->getBaseUrl();
+                return \str_replace($fromStore->getBaseUrl(), $targetStore->getBaseUrl(), $redirectUrl);
             }
+
+            $redirectUrl = $targetStore->getBaseUrl();
         }
 
         return $redirectUrl;

--- a/app/code/Magento/Store/Model/StoreSwitcher/ChangeStoreCode.php
+++ b/app/code/Magento/Store/Model/StoreSwitcher/ChangeStoreCode.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Store\Model\StoreSwitcher;
+
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreSwitcherInterface;
+
+/**
+ * Class ChangeStoreCode
+ *
+ * Changes store code in redirect url from current store code to target store code
+ *
+ * @package Magento\Store\Model\StoreSwitcher
+ * @since   2.3.0
+ */
+class ChangeStoreCode implements StoreSwitcherInterface
+{
+    /**
+     * @inheritdoc
+     * @since 2.3.0
+     */
+    public function switch(StoreInterface $fromStore, StoreInterface $targetStore, string $redirectUrl): string
+    {
+        if ($fromStore->isUseStoreInUrl()) {
+            if (\strpos($redirectUrl, $fromStore->getBaseUrl()) !== false) {
+                $redirectUrl = \str_replace($fromStore->getBaseUrl(), $targetStore->getBaseUrl(), $redirectUrl);
+            } else {
+                $redirectUrl = $targetStore->getBaseUrl();
+            }
+        }
+
+        return $redirectUrl;
+    }
+}

--- a/app/code/Magento/Store/etc/di.xml
+++ b/app/code/Magento/Store/etc/di.xml
@@ -436,6 +436,7 @@
                 <item name="cleanTargetUrl" xsi:type="object">Magento\Store\Model\StoreSwitcher\CleanTargetUrl</item>
                 <item name="manageStoreCookie" xsi:type="object">Magento\Store\Model\StoreSwitcher\ManageStoreCookie</item>
                 <item name="managePrivateContent" xsi:type="object">Magento\Store\Model\StoreSwitcher\ManagePrivateContent</item>
+                <item name="changeStoreCode" xsi:type="object" sortOrder="999">Magento\Store\Model\StoreSwitcher\ChangeStoreCode</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
…that changes store code in redirect url from current store code to target store code

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Issue started after deleting part of code responsible for replacing store codes in URL in this commit: https://github.com/magento/magento2/commit/68a26051c713bc6d0396fca59de189b9832e43b3#diff-285a7e574ab3ef96f4df4d9b1d326428L144

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14674: Language Switcher is not working on Magento 2.2.3

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Enable web/url/use_store
2. Go to any page of your multi-store website
3. Switch scope using /stores/store/switch/?___store=<target_store_code>&___from_store=<current_store_code>&uenc=<base64encoded_reference_link>

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)