### PR TITLE
ipad-view-order-summary-block

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
@@ -233,21 +233,21 @@
 //  _____________________________________________
 
 @media only screen and (max-width: @screen__m) {
-  .opc-block-summary {
-    .product-item {
-      .product-item-inner {
-        display: block;
-      }
+    .opc-block-summary {
+        .product-item {
+            .product-item-inner {
+                display: block;
+            }
 
-      .product-item-name-block {
-        display: block;
-        text-align: left;
-      }
+            .product-item-name-block {
+                display: block;
+                text-align: left;
+            }
 
-      .subtotal {
-        display: block;
-        text-align: left;
-      }
+            .subtotal {
+                display: block;
+                text-align: left;
+            }
+        }
     }
-  }
 }

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
@@ -148,14 +148,14 @@
             }
 
             .product-item-name-block {
-                display: table-cell;
+                display: block;
                 padding-right: @indent__xs;
                 text-align: left;
             }
 
             .subtotal {
-                display: table-cell;
-                text-align: right;
+                display: block;
+                text-align: left;
             }
 
             .price {

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
@@ -227,3 +227,27 @@
         }
     }
 }
+
+//
+//  Tablet
+//  _____________________________________________
+
+@media only screen and (max-width: @screen__m) {
+  .opc-block-summary {
+    .product-item {
+      .product-item-inner {
+        display: block;
+      }
+
+      .product-item-name-block {
+        display: block;
+        text-align: left;
+      }
+
+      .subtotal {
+        display: block;
+        text-align: left;
+      }
+    }
+  }
+}


### PR DESCRIPTION
In checkout page product price not align proper in order summary block for iPad view


### Description (*)
1.Go to checkout page by adding product
2.In order summary block product price not align proper in ipad view

### Fixed Issues (if relevant)
In checkout page product price not align proper in order summary block for ipad view #20855

### Manual testing scenarios (*)
actual result
![alignmentcheckout](https://user-images.githubusercontent.com/18118638/52057380-dde50880-258a-11e9-8d34-6cc46704f5ed.jpg)

after fixing:
![alignmentcorrect](https://user-images.githubusercontent.com/18118638/52057395-e4738000-258a-11e9-9d70-c548a73a14bb.jpg)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
