### PR TITLE
Date range validation not happening with CMS page's custom design update

### DIFF
--- a/app/code/Magento/Cms/Model/ResourceModel/Page.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Page.php
@@ -104,6 +104,13 @@ class Page extends AbstractDb
      */
     protected function _beforeSave(AbstractModel $object)
     {
+        if (!$this->validateDateRange($object)) {
+            throw new LocalizedException(
+                __(
+                    "End Date must follow Start Date."
+                )
+            );
+        }
         /*
          * For two attributes which represent timestamp data in DB
          * we should make converting such as:
@@ -263,6 +270,33 @@ class Page extends AbstractDb
     protected function isValidPageIdentifier(AbstractModel $object)
     {
         return preg_match('/^[a-z0-9][a-z0-9_\/-]+(\.[a-z0-9_-]+)?$/', $object->getData('identifier'));
+    }
+
+    /**
+     *  Validate date range
+     *
+     * @param AbstractModel $object
+     * @return bool
+     */
+    protected function validateDateRange(AbstractModel $object)
+    {
+        $fromDate = $toDate = null;
+
+        if ($object->getData('custom_theme_from') && $object->getData('custom_theme_to')) {
+            $fromDate = $object->getData('custom_theme_from');
+            $toDate = $object->getData('custom_theme_to');
+        }
+
+        if ($fromDate && $toDate) {
+            $fromDate = new \DateTime($fromDate);
+            $toDate = new \DateTime($toDate);
+
+            if ($fromDate > $toDate) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
In the process of creating CMS page, if user wants to  add custom design update, the from_date and to_date validation is not happening. Added a fix for that.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Go to Admin>content>pages>Add new page
Add required info
Add custom design update with from date(02/1/2019) and to date(01/20/2019)
No error message given.But in other places which uses this functionality validate the date range(Catalog price rules)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
