### PR TITLE
Paypal Payments Pro IPN Order Pending Status fix

### DIFF
--- a/app/code/Magento/Paypal/Model/Ipn.php
+++ b/app/code/Magento/Paypal/Model/Ipn.php
@@ -298,6 +298,8 @@ class Ipn extends \Magento\Paypal\Model\AbstractIpn implements IpnInterface
             $this->getRequestData('mc_gross'),
             $skipFraudDetection && $parentTransactionId
         );
+        $this->_order->setStatus($this->_order->getConfig()->getStateDefaultStatus(
+            \Magento\Sales\Model\Order::STATE_PROCESSING));
         $this->_order->save();
 
         // notify customer

--- a/app/code/Magento/Paypal/Model/Ipn.php
+++ b/app/code/Magento/Paypal/Model/Ipn.php
@@ -80,7 +80,6 @@ class Ipn extends \Magento\Paypal\Model\AbstractIpn implements IpnInterface
     public function processIpnRequest()
     {
         $this->_addDebugData('ipn', $this->getRequestData());
-        xdebug_break();
         try {
             $this->_getConfig();
             $this->_postBack();

--- a/app/code/Magento/Paypal/Model/Ipn.php
+++ b/app/code/Magento/Paypal/Model/Ipn.php
@@ -80,7 +80,7 @@ class Ipn extends \Magento\Paypal\Model\AbstractIpn implements IpnInterface
     public function processIpnRequest()
     {
         $this->_addDebugData('ipn', $this->getRequestData());
-
+        xdebug_break();
         try {
             $this->_getConfig();
             $this->_postBack();
@@ -298,8 +298,10 @@ class Ipn extends \Magento\Paypal\Model\AbstractIpn implements IpnInterface
             $this->getRequestData('mc_gross'),
             $skipFraudDetection && $parentTransactionId
         );
-        $this->_order->setStatus($this->_order->getConfig()->getStateDefaultStatus(
-            \Magento\Sales\Model\Order::STATE_PROCESSING));
+        if ($skipFraudDetection) {
+            $this->_order->setStatus($this->_order->getConfig()->getStateDefaultStatus(
+                \Magento\Sales\Model\Order::STATE_PROCESSING));
+        }
         $this->_order->save();
 
         // notify customer
@@ -378,7 +380,7 @@ class Ipn extends \Magento\Paypal\Model\AbstractIpn implements IpnInterface
             ->setPreparedMessage($this->_createIpnComment($this->_paypalInfo->explainPendingReason($reason)))
             ->setTransactionId($this->getRequestData('txn_id'))
             ->setIsTransactionClosed(0)
-            ->update(false);
+            ->update(true);
         $this->_order->save();
     }
 

--- a/app/code/Magento/Paypal/Test/Unit/Model/IpnTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/IpnTest.php
@@ -7,6 +7,7 @@
 /**
  * Test class for \Magento\Paypal\Model\Ipn
  */
+
 namespace Magento\Paypal\Test\Unit\Model;
 
 use Magento\Sales\Model\Order;
@@ -40,6 +41,10 @@ class IpnTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
+
+        $orderStatus = $this->createPartialMock(\Magento\Sales\Model\Order\Config::class, ['getStateDefaultStatus']);
+        $orderStatus->expects($this->any())->method('getStateDefaultStatus')->with(\Magento\Sales\Model\Order::STATE_PROCESSING)->will($this->returnValue(\Magento\Sales\Model\Order::STATE_PROCESSING));
+
         $methods = [
             'create',
             'loadByIncrementId',
@@ -53,7 +58,8 @@ class IpnTest extends \PHPUnit\Framework\TestCase
             'getEmailSent',
             'save',
             'getState',
-            'setStatus'
+            'setStatus',
+            'getConfig'
         ];
         $this->_orderMock = $this->createPartialMock(\Magento\Sales\Model\OrderFactory::class, $methods);
         $this->_orderMock->expects($this->any())->method('create')->will($this->returnSelf());
@@ -63,6 +69,7 @@ class IpnTest extends \PHPUnit\Framework\TestCase
         $this->_orderMock->expects($this->any())->method('getStoreId')->will($this->returnSelf());
         $this->_orderMock->expects($this->any())->method('getEmailSent')->will($this->returnValue(true));
         $this->_orderMock->expects($this->any())->method('setStatus')->will($this->returnValue(true));
+        $this->_orderMock->expects($this->any())->method('getConfig')->will($this->returnValue($orderStatus));
 
         $this->configFactory = $this->createPartialMock(\Magento\Paypal\Model\ConfigFactory::class, ['create']);
         $configMock = $this->getMockBuilder(\Magento\Paypal\Model\Config::class)

--- a/app/code/Magento/Paypal/Test/Unit/Model/IpnTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/IpnTest.php
@@ -53,6 +53,7 @@ class IpnTest extends \PHPUnit\Framework\TestCase
             'getEmailSent',
             'save',
             'getState',
+            'setStatus'
         ];
         $this->_orderMock = $this->createPartialMock(\Magento\Sales\Model\OrderFactory::class, $methods);
         $this->_orderMock->expects($this->any())->method('create')->will($this->returnSelf());
@@ -61,6 +62,7 @@ class IpnTest extends \PHPUnit\Framework\TestCase
         $this->_orderMock->expects($this->any())->method('getMethod')->will($this->returnSelf());
         $this->_orderMock->expects($this->any())->method('getStoreId')->will($this->returnSelf());
         $this->_orderMock->expects($this->any())->method('getEmailSent')->will($this->returnValue(true));
+        $this->_orderMock->expects($this->any())->method('setStatus')->will($this->returnValue(true));
 
         $this->configFactory = $this->createPartialMock(\Magento\Paypal\Model\ConfigFactory::class, ['create']);
         $configMock = $this->getMockBuilder(\Magento\Paypal\Model\Config::class)


### PR DESCRIPTION
### Description (*)
Paypal IPN updates Order Payment information automatically upon receiving POST requests from the paypal IPN server.

However upon payment confirmation (no fraud detected), the order status is stuck on pending, preventing shipping actions.

This Fix is solves the order status issue using the least changes possible, so as to not introduce regressions into an important system.

All PhpUnit tests for paypal passed.

### Fixed Issues
1. https://github.com/magento/magento2/issues/18148

### Manual testing scenarios (*)
1. Setup test server exposed to WWW so that it can receive paypal IPN POST
2. Setup sandbox paypal business account, upgrade it to Pro for payment pro.
3. Setup paypal hosted pro solution using legay Nvp/Soap API
4. Make a test order, wait a few seconds for paypal to send POST req
5. Order status should be set to processing.
6. Refund/Chargeback Order inside paypal
7. Order status updated to either paypal_canceled or paypal_reversed.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
