### PR TITLE
[backport] Exceptions when search product with sku like "42-"

### DIFF
--- a/lib/internal/Magento/Framework/Search/Adapter/Mysql/Query/Builder/Match.php
+++ b/lib/internal/Magento/Framework/Search/Adapter/Mysql/Query/Builder/Match.php
@@ -24,7 +24,7 @@ class Match implements QueryInterface
     /**
      * @var string
      */
-    const SPECIAL_CHARACTERS = '+~/\\<>\'":*$#@()!,.?`=%&^';
+    const SPECIAL_CHARACTERS = '-+~/\\<>\'":*$#@()!,.?`=%&^';
 
     const MINIMAL_CHARACTER_LENGTH = 3;
 


### PR DESCRIPTION
### Description (*)
Try to search products with end of string like "-" or "-" 
The exception error appear `Unexpected $end` 
https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html

Original PR #20727 

### Fixed Issues (if relevant)
1. magento/magento2#20716: Exceptions when search product with sku like "42-"
3. magento/magento2#9988 Quick search by SKU not working properly
### Manual testing scenarios (*)

1.Enable the MySql as search engine in configuration.
2.Search in the frontend with sku "42-" or "-"
3.No exception appear

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
