### PR TITLE
Fixed issue #20032

### DIFF
--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -122,6 +122,20 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                         \Magento\Downloadable\Model\Link::XML_PATH_LINKS_TITLE,
                         ScopeInterface::SCOPE_STORE
                     );
+                
+                $configlinkStatus =  $this
+                    ->_scopeConfig
+                    ->getValue(
+                        'catalog/downloadable/order_item_status',
+                        ScopeInterface::SCOPE_STORE
+                    );
+                
+                if ($configlinkStatus == \Magento\Sales\Model\Order\Item::STATUS_PENDING) {
+                    $linkStatus = \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE;
+                } else {
+                    $linkStatus = \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING;
+                }
+                
                 $linkPurchased->setLinkSectionTitle($linkSectionTitle)->save();
                 foreach ($linkIds as $linkId) {
                     if (isset($links[$linkId])) {
@@ -150,7 +164,7 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                         )->setNumberOfDownloadsBought(
                             $numberOfDownloads
                         )->setStatus(
-                            \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING
+                            $linkStatus
                         )->setCreatedAt(
                             $orderItem->getCreatedAt()
                         )->setUpdatedAt(

--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -122,20 +122,6 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                         \Magento\Downloadable\Model\Link::XML_PATH_LINKS_TITLE,
                         ScopeInterface::SCOPE_STORE
                     );
-                
-                $configlinkStatus =  $this
-                    ->_scopeConfig
-                    ->getValue(
-                        'catalog/downloadable/order_item_status',
-                        ScopeInterface::SCOPE_STORE
-                    );
-                
-                if ($configlinkStatus == \Magento\Sales\Model\Order\Item::STATUS_PENDING) {
-                    $linkStatus = \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE;
-                } else {
-                    $linkStatus = \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING;
-                }
-                
                 $linkPurchased->setLinkSectionTitle($linkSectionTitle)->save();
                 foreach ($linkIds as $linkId) {
                     if (isset($links[$linkId])) {
@@ -164,7 +150,7 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                         )->setNumberOfDownloadsBought(
                             $numberOfDownloads
                         )->setStatus(
-                            $linkStatus
+                            \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING
                         )->setCreatedAt(
                             $orderItem->getCreatedAt()
                         )->setUpdatedAt(

--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -149,8 +149,6 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                             $linkHash
                         )->setNumberOfDownloadsBought(
                             $numberOfDownloads
-                        )->setStatus(
-                            \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING
                         )->setCreatedAt(
                             $orderItem->getCreatedAt()
                         )->setUpdatedAt(

--- a/app/code/Magento/Downloadable/etc/events.xml
+++ b/app/code/Magento/Downloadable/etc/events.xml
@@ -10,7 +10,7 @@
         <observer name="downloadable_observer" instance="Magento\Downloadable\Observer\SaveDownloadableOrderItemObserver" />
     </event>
     <event name="sales_order_save_after">
-        <observer name="downloadable_observer_linkstatus" instance="Magento\Downloadable\Observer\SetLinkStatusObserver" />
+        <observer name="downloadable_observer" instance="Magento\Downloadable\Observer\SetLinkStatusObserver" />
     </event>
     <event name="sales_model_service_quote_submit_success">
         <observer name="checkout_type_onepage_save_order_after" instance="Magento\Downloadable\Observer\SetHasDownloadableProductsObserver" />

--- a/app/code/Magento/Downloadable/etc/events.xml
+++ b/app/code/Magento/Downloadable/etc/events.xml
@@ -10,7 +10,7 @@
         <observer name="downloadable_observer" instance="Magento\Downloadable\Observer\SaveDownloadableOrderItemObserver" />
     </event>
     <event name="sales_order_save_after">
-        <observer name="downloadable_observer" instance="Magento\Downloadable\Observer\SetLinkStatusObserver" />
+        <observer name="downloadable_observer_linkstatus" instance="Magento\Downloadable\Observer\SetLinkStatusObserver" />
     </event>
     <event name="sales_model_service_quote_submit_success">
         <observer name="checkout_type_onepage_save_order_after" instance="Magento\Downloadable\Observer\SetHasDownloadableProductsObserver" />


### PR DESCRIPTION
 Fixed issue #20032 Download links don't work when checking out as guest, even when Downloadable Product Options -> Order Item Status To Enable Downloads is set to pending

### Description (*)

Fixed issue #20032 Download links don't work when checking out as guest, even when Downloadable Product Options -> Order Item Status To Enable Downloads is set to pending

### Fixed Issues (if relevant)

1. magento/magento2 #20032: Download links don't work when checking out as guest, even when Downloadable Product Options -> Order Item Status To Enable Downloads is set to pending


### Manual testing scenarios (*)

   1. Make a downloadable product with shareable links
   2. Set Admin -> Stores -> Configuration -> Catalog -> Downloadable Product Options -> Shareable to Yes
    3.Set Admin -> Stores -> Configuration -> Catalog -> Downloadable Product Options -> Disable Guest Checkout if Cart Contains Downloadable Items to No.
    4.Set Admin -> System -> Configuration -> Catalog -> Downloadable Product Options -> Order Item Status To Enable Downloads to 'Pending.'
    5.Clear cache
   6. Open a browser in incognito mode and add the downloadable product to your cart without logging in
    7.Checkout as guest with a valid email address
   8. Click on the link or links sent in the confirmation email


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
