### PR TITLE
Fixed #17861  Customer Name Prefix shows white space when extra separator is addes

### DIFF
--- a/app/code/Magento/Customer/Model/Options.php
+++ b/app/code/Magento/Customer/Model/Options.php
@@ -91,7 +91,7 @@ class Options
             return false;
         }
         $result = [];
-        $options = explode(';', $options);
+        $options = array_filter(explode(';', $options));
         foreach ($options as $value) {
             $value = $this->escaper->escapeHtml(trim($value));
             $result[$value] = $value;

--- a/app/code/Magento/Customer/Model/Options.php
+++ b/app/code/Magento/Customer/Model/Options.php
@@ -8,7 +8,11 @@ namespace Magento\Customer\Model;
 use Magento\Config\Model\Config\Source\Nooptreq as NooptreqSource;
 use Magento\Customer\Helper\Address as AddressHelper;
 use Magento\Framework\Escaper;
+use Magento\Store\Api\Data\StoreInterface;
 
+/**
+ * Customer Options.
+ */
 class Options
 {
     /**
@@ -38,7 +42,7 @@ class Options
     /**
      * Retrieve name prefix dropdown options
      *
-     * @param null $store
+     * @param null|string|bool|int|StoreInterface $store
      * @return array|bool
      */
     public function getNamePrefixOptions($store = null)
@@ -52,7 +56,7 @@ class Options
     /**
      * Retrieve name suffix dropdown options
      *
-     * @param null $store
+     * @param null|string|bool|int|StoreInterface $store
      * @return array|bool
      */
     public function getNameSuffixOptions($store = null)
@@ -64,7 +68,9 @@ class Options
     }
 
     /**
-     * @param $options
+     * Unserialize and clear name prefix or suffix options.
+     *
+     * @param string $options
      * @param bool $isOptional
      * @return array|bool
      *
@@ -78,6 +84,7 @@ class Options
 
     /**
      * Unserialize and clear name prefix or suffix options
+     *
      * If field is optional, add an empty first option.
      *
      * @param string $options


### PR DESCRIPTION
Fixed #17861  Customer Name Prefix shows white space when extra separator is addes

White space option is added when extra separator is added.

### Preconditions
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. php7.1
2. Magento 2.2.5

### Steps to reproduce
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1.In admin menu Store->Configuration
Select "Customer Configuration" under confifuration.
Add "Mr;Ms;Mrs;" in "Prefix Dropdown Options"
![prefix1](https://user-images.githubusercontent.com/6185521/44832451-855eb780-ac48-11e8-90cd-c2dfca54e27c.png)


### Expected result
<!--- Tell us what do you expect to happen. -->
1. It should avoid the white space option, if extra separator is added.

### Actual result
<!--- Tell us what happened instead. Include error messages and issues. -->
1.It is displaying extra white space option, and In case of it is required, It throws validation.
![prefix2](https://user-images.githubusercontent.com/6185521/44832568-ca82e980-ac48-11e8-92e4-f61f0b8e7f4b.png)



### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
