### PR TITLE
Fixed #13319 , Incorrect method return value in \Magento\Shipping\Model\Carrier\AbstractCarrier::getTotalNumOfBoxes()

### DIFF
--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
@@ -531,10 +531,10 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
     }
 
     /**
-     * Sets the number of boxes for shipping
+     * Gets the average weight of each box available for shipping
      *
-     * @param int $weight in some measure
-     * @return int
+     * @param float $weight in some measure
+     * @return float
      */
     public function getTotalNumOfBoxes($weight)
     {
@@ -545,7 +545,7 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
         $maxPackageWeight = $this->getConfigData('max_package_weight');
         if ($weight > $maxPackageWeight && $maxPackageWeight != 0) {
             $this->_numBoxes = ceil($weight / $maxPackageWeight);
-            $weight = $weight / $this->_numBoxes;
+            $weight = (float)$weight / $this->_numBoxes;
         }
 
         return $weight;


### PR DESCRIPTION
Fixed #13319 , Incorrect method return value in \Magento\Shipping\Model\Carrier\AbstractCarrier::getTotalNumOfBoxes() 
 
added type casting and updated function comment..

<!--- Provide a general summary of the issue in the Title above -->
<!--- Before adding new issues, please, check this article https://github.com/magento/magento2/wiki/Issue-reporting-guidelines-->

Please see the method `getTotalNumOfBoxes()` in `\Magento\Shipping\Model\Carrier\AbstractCarrier`: https://github.com/magento/magento2/blob/2.2.2/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php#L512-L531

Incoming `$weight` parameter is not checked to be integer. Moreover, even if it is, you can still get a float result when `$weight > $maxPackageWeight` since these are both arbitrary numbers.

This method is a member of `AbstractCarrier` class commonly used for 3-rd party implementations of the Shipmen Carrier SPI and might be used by 3rd-party developers in their modules.
In order to apply proper validation and\or rounding around the method's return results, it would be helpful to see the actual return value in PHPDocs which are commonly used by IDEs when providing hints, for example here: http://take.ms/9dnaD

Additionally, the method name is severely misleading: it implies the method is a getter, however it can modify object's internal state. Moreover, the value returned is in fact what seems to be an average weight of a box, not "Total number of boxes" as one might assume.

**Backward Compatibility:** Please note that Magento's USPS implementation expects float return value, implying internal knowledge of the method: https://github.com/magento/magento2/blob/2.2.2/app/code/Magento/Usps/Model/Carrier.php#L341
If any rounding is to be added, it should probably be done via a new extra method, deprecating the old one (if at all)

### Preconditions
<!--- Provide a more detailed information of environment you use -->
<!--- Magento version, tag, HEAD, etc., PHP & MySQL version, etc.. -->
1. Magento CE 2.1.10, Magento CE 2.2.2
2. PHP 7.0.18

### Steps to reproduce
<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1. Open file app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
2. Scroll down to getTotalNumOfBoxes method

### Expected result
<!--- Tell us what should happen -->
1. Observe correct return type "float" declared in PHPDoc block 
OR proper rounding applied to the `$weight` variable.

### Actual result
<!--- Tell us what happens instead -->
1. Observe incorrect return type "int" declared in PHPDoc block
AND no rounding applied to $weight variable

<!--- (This may be platform independent comment) -->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

