### PR TITLE
Issue Fix 15163 :  PayPal PayFlow Pro: "Comment 1" field set incorrectly

### DIFF
--- a/app/code/Magento/Paypal/Model/Payflowpro.php
+++ b/app/code/Magento/Paypal/Model/Payflowpro.php
@@ -894,7 +894,7 @@ class Payflowpro extends \Magento\Payment\Model\Method\Cc implements GatewayInte
         $orderIncrementId = $order->getIncrementId();
         $request->setCustref($orderIncrementId)
             ->setInvnum($orderIncrementId)
-            ->setComment1($orderIncrementId);
+            ->setData('comment1', $orderIncrementId);
     }
 
     /**

--- a/app/code/Magento/Paypal/Test/Unit/Model/PayflowlinkTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/PayflowlinkTest.php
@@ -131,7 +131,7 @@ class PayflowlinkTest extends \PHPUnit\Framework\TestCase
             ->method('postRequest')
             ->willReturn($response);
 
-        $this->payflowRequest->expects($this->exactly(3))
+        $this->payflowRequest->expects($this->exactly(4))
             ->method('setData')
             ->willReturnMap(
                 [


### PR DESCRIPTION
Fixed #15163 
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
PayPal PayFlow Pro: "Comment 1" field set incorrectly & approrpiate Unit Test Case.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#15163: PayPal PayFlow Pro: "Comment 1" field set incorrectly
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Complete any order using PayPal Payflow Pro as the payment method.
2. ...

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
