### PR TITLE
Fixed #18717 UrlRewrite removes query string from url, if url has trailing slash 

### DIFF
--- a/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
+++ b/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
@@ -118,7 +118,7 @@ class DbStorage extends AbstractStorage
                 $redirectTypes = [OptionProvider::TEMPORARY, OptionProvider::PERMANENT];
 
                 // If request path matches the DB value or it's redirect - we can return result from DB
-                $canReturnResultFromDb = ($resultFromDb[UrlRewrite::REQUEST_PATH] === $requestPath
+                $canReturnResultFromDb = (rtrim($resultFromDb[UrlRewrite::REQUEST_PATH], '/') === rtrim($requestPath, '/')
                     || in_array((int)$resultFromDb[UrlRewrite::REDIRECT_TYPE], $redirectTypes, true));
 
                 // Otherwise return 301 redirect to request path from DB results


### PR DESCRIPTION
Fixed #18717 UrlRewrite removes query string from url, if url has trailing slash 

### Preconditions (*)
When customer opens url with trailing slash and query string like http://magento-host.com/some-url-key/?foo=bar, Magento redirects to url without trailing slash and truncates query string, so customer is redirected to http://magento-host.com/some-url-key.
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento version 2.2.5 or 2.2.6
2. No customizations for the store, Luma + Sample Data

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Open any product or category page.
2. Manually add `/?foo=bar&bar=baz` to the url and open this link

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. After the page has been loaded, query string remain in url

### Actual result (*)
1. Query string is removed from url

### Additional information
1. The issue is not reproduced when we avoid using url rewrites, e.g. http://magento-host.com/catalog/product/view/id/{product-id}/?foo=bar&bar=baz, and actually there is no redirect in this case.
2. The issue seems to be happen in \Magento\UrlRewrite\Model\Storage\DbStorage::doFindOneByData
~~~~
$data[UrlRewrite::REQUEST_PATH] = [
    rtrim($requestPath, '/'),
    rtrim($requestPath, '/') . '/',
];
~~~~
We are looking for both urls (with trailing slash and without it), but when verifying the result from database we do not check it.
~~~~
// If request path matches the DB value or it's redirect - we can return result from DB
$canReturnResultFromDb = ($resultFromDb[UrlRewrite::REQUEST_PATH] === $requestPath || in_array((int)$resultFromDb[UrlRewrite::REDIRECT_TYPE], $redirectTypes, true));
~~~~

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
