### PR TITLE
Fixed  #17564 Magento 2 inline edit date issues in admin grid with Ui Component

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/date.js
@@ -122,11 +122,10 @@ define([
                     shiftedValue = moment.tz(value, 'UTC').tz(this.storeTimeZone);
                 } else {
                     dateFormat = this.shiftedValue() ? this.outputDateFormat : this.inputDateFormat;
-
                     shiftedValue = moment(value, dateFormat);
                 }
-                if(!shiftedValue.isValid()){
-                    shiftedValue = moment(value,this.inputDateFormat);
+                if (!shiftedValue.isValid()) {
+                    shiftedValue = moment(value, this.inputDateFormat);
                 }
                 shiftedValue = shiftedValue.format(this.pickerDateTimeFormat);
             } else {

--- a/app/code/Magento/Ui/view/base/web/js/form/element/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/date.js
@@ -124,7 +124,7 @@ define([
                     dateFormat = this.shiftedValue() ? this.outputDateFormat : this.inputDateFormat;
                     shiftedValue = moment(value, dateFormat);
                 }
-                
+
                 if (!shiftedValue.isValid()) {
                     shiftedValue = moment(value, this.inputDateFormat);
                 }

--- a/app/code/Magento/Ui/view/base/web/js/form/element/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/date.js
@@ -124,6 +124,7 @@ define([
                     dateFormat = this.shiftedValue() ? this.outputDateFormat : this.inputDateFormat;
                     shiftedValue = moment(value, dateFormat);
                 }
+                
                 if (!shiftedValue.isValid()) {
                     shiftedValue = moment(value, this.inputDateFormat);
                 }

--- a/app/code/Magento/Ui/view/base/web/js/form/element/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/date.js
@@ -125,7 +125,9 @@ define([
 
                     shiftedValue = moment(value, dateFormat);
                 }
-
+                if(!shiftedValue.isValid()){
+                    shiftedValue = moment(value,this.inputDateFormat);
+                }
                 shiftedValue = shiftedValue.format(this.pickerDateTimeFormat);
             } else {
                 shiftedValue = '';


### PR DESCRIPTION
Fixed  #17564 Magento 2 inline edit date issues in admin grid with Ui Component
In magento2 Inline Edit date issues while i edit the record it display current date instead of database date

### Preconditions

Magento version 2.2.3
php 7.0.29
mysqli mysqlnd 5.0.12

### Steps to reproduce

1. So please make any date filed 
<column name="date" class="Magento\Ui\Component\Listing\Columns\Date"> <argument name="data" xsi:type="array"> <item name="config" xsi:type="array"> <item name="filter" xsi:type="string">dateRange</item> <item name="component" xsi:type="string">Magento_Ui/js/grid/columns/date</item> <item name="editor" xsi:type="string">date</item> <item name="dataType" xsi:type="string">date</item> <item name="label" xsi:type="string" translate="true">Date</item> <item name="dateFormat" xsi:type="string" translate="true">MMM dd, YYYY</item> </item> </argument> </column>
2. Open edited Grid,

### Expected result
When make row inline editable an existing record, the date field should show the date from the record


### Actual result

When make row inline editable an existing record, the date field show current date 
![1](https://user-images.githubusercontent.com/40756187/44210955-7bc95000-a170-11e8-8fa9-d5e8dbcada56.gif)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
