### PR TITLE
Fixed Issue #14633 Sub-admin role related issue in order view page in magento 2 admin

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Creditmemos.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Creditmemos.php
@@ -14,6 +14,26 @@ namespace Magento\Sales\Block\Adminhtml\Order\View\Tab;
 class Creditmemos extends \Magento\Framework\View\Element\Text\ListText implements
     \Magento\Backend\Block\Widget\Tab\TabInterface
 {
+     /**
+     * @var Magento\Framework\AuthorizationInterface
+     */
+    private $authorization;
+    
+    /**
+	 * @param \Magento\Framework\View\Element\Context $context
+	 * @param array $data
+	 * @param \Magento\Framework\AuthorizationInterface|null $authorization
+	 */
+    
+	public function __construct(
+		\Magento\Framework\View\Element\Context $context,
+		array $data = [], 
+		\Magento\Framework\AuthorizationInterface $authorization = null
+	){
+		$this->authorization = $authorization ?  : \Magento\Framework\App\ObjectManager::getInstance()->get(Magento\Framework\AuthorizationInterface::class);
+		parent::__construct ($context,$data);
+	}
+    
     /**
      * {@inheritdoc}
      */
@@ -35,7 +55,7 @@ class Creditmemos extends \Magento\Framework\View\Element\Text\ListText implemen
      */
     public function canShowTab()
     {
-        return true;
+        return $this->authorization->isAllowed('Magento_Sales::creditmemo');     
     }
 
     /**
@@ -46,3 +66,4 @@ class Creditmemos extends \Magento\Framework\View\Element\Text\ListText implemen
         return false;
     }
 }
+

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Invoices.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Invoices.php
@@ -15,6 +15,26 @@ class Invoices extends \Magento\Framework\View\Element\Text\ListText implements
     \Magento\Backend\Block\Widget\Tab\TabInterface
 {
     /**
+     * @var Magento\Framework\AuthorizationInterface
+     */
+    private $authorization;
+    
+    /**
+	 *
+	 * @param \Magento\Framework\View\Element\Context $context
+	 * @param array $data
+	 * @param \Magento\Framework\AuthorizationInterface|null $authorization
+	 */
+	public function __construct(
+		\Magento\Framework\View\Element\Context $context,
+		array $data = [],
+		\Magento\Framework\AuthorizationInterface $authorization = null
+	) {
+		$this->authorization = $authorization?: \Magento\Framework\App\ObjectManager::getInstance()->get(Magento\Framework\AuthorizationInterface::class);
+		parent::__construct($context, $data);
+	}
+    
+    /**
      * {@inheritdoc}
      */
     public function getTabLabel()
@@ -35,7 +55,7 @@ class Invoices extends \Magento\Framework\View\Element\Text\ListText implements
      */
     public function canShowTab()
     {
-        return true;
+        return $this->authorization->isAllowed('Magento_Sales::invoice');
     }
 
     /**

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Shipments.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/Shipments.php
@@ -21,19 +21,27 @@ class Shipments extends \Magento\Framework\View\Element\Text\ListText implements
      */
     protected $_coreRegistry = null;
 
+     /**
+     * @var Magento\Framework\AuthorizationInterface
+     */
+    private $authorization;
+    
     /**
      * Collection factory
      *
      * @param \Magento\Framework\View\Element\Context $context
      * @param \Magento\Framework\Registry $coreRegistry
+     * @param \Magento\Framework\AuthorizationInterface|null $authorization
      * @param array $data
      */
     public function __construct(
         \Magento\Framework\View\Element\Context $context,
         \Magento\Framework\Registry $coreRegistry,
-        array $data = []
+        array $data = [],
+        \Magento\Framework\AuthorizationInterface $authorization = null
     ) {
         $this->_coreRegistry = $coreRegistry;
+        $this->authorization = $authorization?: \Magento\Framework\App\ObjectManager::getInstance()->get(Magento\Framework\AuthorizationInterface::class);
         parent::__construct($context, $data);
     }
 
@@ -68,7 +76,7 @@ class Shipments extends \Magento\Framework\View\Element\Text\ListText implements
      */
     public function canShowTab()
     {
-        if ($this->getOrder()->getIsVirtual()) {
+        if ($this->getOrder()->getIsVirtual() || !$this->authorization->isAllowed('Magento_Sales::ship')) {
             return false;
         }
         return true;


### PR DESCRIPTION
Fixed Issue #14633 Sub-admin role related issue in order view page in magento 2 admin

### Description (*)
Fixed Issue #14633 Sub-admin role related issue in order view page in magento 2 admin

### Fixed Issues (if relevant)

1. magento/magento2 #14633: Sub-admin role related issue in order view page in magento 2 admin
2. ...

### Manual testing scenarios (*)

I have created one sub admin user from Magento admin. This user can only view orders, add a comment and operate on shipping. I gave some permissions for sub admin user. Please check the below image:
![screenshotacl](https://user-images.githubusercontent.com/25526052/52173490-896ca380-27ab-11e9-8f80-359601ae262d.png)

So as you can see I have disabled Invoice and Credit memo role of this sub-admin.
But when I logged in as sub admin and go to order view page.Sometime Pop will come with "Something Went Wrong" and sometimes js error comes in console

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
