### PR TITLE
Solved swagger response of product attribute option is_default

### DIFF
--- a/app/code/Magento/Directory/Model/ResourceModel/Country/Collection.php
+++ b/app/code/Magento/Directory/Model/ResourceModel/Country/Collection.php
@@ -327,7 +327,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
 
         foreach ($options as $key => $option) {
             if (isset($defaultCountry[$option['value']])) {
-                $options[$key]['is_default'] = $defaultCountry[$option['value']];
+                $options[$key]['is_default'] = !empty($defaultCountry[$option['value']]);
             }
         }
     }


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento/magento2#18525: Incorrect Swager Definition for eav-data-attribute-option-interface

### Manual testing scenarios (*)
Example : https://MAGENTO-HOST-NAME/rest/all/V1/products/attributes/country_of_manufacture
For above example URL it will give "is_default": true for the default selected country  

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
