### PR TITLE
Fixed issue #20911 In admin login password forgot password page wrong css used to make it vertially aling middle 

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
@@ -253,7 +253,7 @@ label.mage-error {
 
         .captcha-reload {
             float: right;
-            vertical-align: middle;
+            margin-top: 15px;
         }
     }
 }


### PR DESCRIPTION
Fixed issue #20911 In admin login password forgot password page wrong css used to make it vertially aling middle 

### Description (*)
Fixed issue #20911 In admin login password forgot password page wrong css used to make it vertially aling middle 

### Fixed Issues (if relevant)

1. magento/magento2 #20911: In admin login password forgot password page wrong css used to make it vertially aling middle 

### Manual testing scenarios (*)

   1. Open admin login page and click on forgot password link
    2.inspect on reload captcha button and view css on that button vertial-align: middle; used but will not work with float

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
