### PR TITLE
Fixed #20917 Alignment Issue While Editing Order Data containing Downlodable Products in Admin Section

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
@@ -462,6 +462,18 @@ label.mage-error {
     }
 }
 
+.admin__fieldset{
+    &.downloadable{
+        .admin__control-checkbox {
+            & + label{
+                &:before {
+                    margin-right: 10px;
+                }
+            }
+        }
+    }
+}
+
 .admin__data-grid-toolbar {
     *,
     *:before,


### PR DESCRIPTION
Fixed #20917 Alignment Issue While Editing Order Data containing Downlodable Products in Admin Section

### Preconditions (*)
1. Magento 2.2
2. php 7.2

### Steps to reproduce (*)
>> login into admin panel 
>> go to Order grid section from Sales > Orders
>> Edit any order containing downladable product with "Links can be purchased separately" enabled.
>> a modal will appear like http://i.imgur.com/MJePtn5.png
>> now click on configure button, another modal will display and issue will appear

### Expected result (*)
![expected_result](https://user-images.githubusercontent.com/13777300/52174743-410ab100-27be-11e9-8615-f7582a5879ce.png)


### Actual result (*)
![actual_result](https://user-images.githubusercontent.com/13777300/52174746-4a941900-27be-11e9-9e69-19d2cdf87662.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
