### PR TITLE
[Backport] magento/magento2#?: fix issue with di.xml config merging for classes array argument in case of different sources and the class name difference in leading slash.

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/Config/Config.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Config/Config.php
@@ -245,7 +245,7 @@ class Config implements \Magento\Framework\ObjectManager\ConfigInterface
                             $this->_mergedArguments = [];
                         }
                         if (isset($this->_arguments[$key])) {
-                            $this->_arguments[$key] = array_replace($this->_arguments[$key], $curConfig['arguments']);
+                            $this->_arguments[$key] = array_replace_recursive($this->_arguments[$key], $curConfig['arguments']);
                         } else {
                             $this->_arguments[$key] = $curConfig['arguments'];
                         }

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/ConfigTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/ConfigTest.php
@@ -98,4 +98,12 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $config->extend(['\Some\Class' => ['shared' => true]]);
         $this->assertTrue($config->isShared('Some\Class'));
     }
+
+    public function testExtendMergeDifferentConfigsNodesWithSlashIgnoring()
+    {
+        $config = new Config();
+        $config->extend(['Some\Class' => ['arguments' => ['data' => ['key1' => 'value1']]]]);
+        $config->extend(['\Some\Class' => ['arguments' => ['data' => ['key2' => 'value2']]]]);
+        $this->assertEquals(['data' => ['key1' => 'value1', 'key2' => 'value2']], $config->getArguments('Some\Class'));
+    }
 }


### PR DESCRIPTION
### Description (*)
See original PR #20891

### Fixed Issues (if relevant)
1. magento/magento2#20409
2. magento/magento2#21193

### Manual testing scenarios 
#### Pre-Conditions
1. Change constructor of \Magento\Cms\Controller\Index\Index and add new argument 'data' (simple way to visualize it):
```
public function __construct(`
`        Context $context,`
        ForwardFactory $resultForwardFactory,
        ScopeConfigInterface $scopeConfig = null,
        Page $page = null,
        array $data = []
    ) {
        var_dump($data);
        die;
    }
```
#### Steps to reproduce
1. Create module A and B with simple config set (registration.php and module.xml).
2. Execute in terminal `php bin/magento setup:upgrade`.
3. Create etc/di.xml for module A:
```
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
    <type name="Magento\Cms\Controller\Index\Index">
        <arguments>
            <argument name="data" xsi:type="array">
                <item name="p1" xsi:type="string">Hello Phrase1</item>
            </argument>
        </arguments>
    </type>
</config>
```
4. Create etc/di.xml for module B:
```
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
    <type name="\Magento\Cms\Controller\Index\Index">
        <arguments>
            <argument name="data" xsi:type="array">
                <item name="p2" xsi:type="string">Hello Phrase2</item>
            </argument>
        </arguments>
    </type>
</config>
```
5. Execute in terminal `php bin/magento cache:flush`
6. Open home page.
#### Expected results
![image](https://user-images.githubusercontent.com/9420807/52169242-c8641000-273d-11e9-8a26-b707950c133f.png)
#### Actual results
![image](https://user-images.githubusercontent.com/9420807/52169295-6d7ee880-273e-11e9-98c8-980105602381.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
