### PR TITLE
#17796 : Seems that `catalog_product_entity_media_gallery` contains u…

### DIFF
--- a/app/code/Magento/Catalog/etc/db_schema.xml
+++ b/app/code/Magento/Catalog/etc/db_schema.xml
@@ -786,8 +786,6 @@
         <column xsi:type="varchar" name="value" nullable="true" length="255" comment="Value"/>
         <column xsi:type="varchar" name="media_type" nullable="false" length="32" default="image"
                 comment="Media entry type"/>
-        <column xsi:type="smallint" name="disabled" padding="5" unsigned="true" nullable="false" identity="false"
-                default="0" comment="Visibility status"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="value_id"/>
         </constraint>

--- a/app/code/Magento/Catalog/etc/db_schema_whitelist.json
+++ b/app/code/Magento/Catalog/etc/db_schema_whitelist.json
@@ -459,8 +459,7 @@
             "attribute_id": true,
             "entity_id": true,
             "value": true,
-            "media_type": true,
-            "disabled": true
+            "media_type": true
         },
         "index": {
             "CATALOG_PRODUCT_ENTITY_MEDIA_GALLERY_ATTRIBUTE_ID": true,
@@ -729,6 +728,7 @@
     "catalog_product_index_website": {
         "column": {
             "website_id": true,
+            "default_store_id": true,
             "website_date": true,
             "rate": true,
             "default_store_id": true
@@ -1003,6 +1003,9 @@
             "is_parent": true,
             "store_id": true,
             "visibility": true
+        },
+        "index": {
+            "CAT_CTGR_PRD_IDX_TMP_PRD_ID_CTGR_ID_STORE_ID": true
         },
         "constraint": {
             "PRIMARY": true


### PR DESCRIPTION
Fixed the issue "Seems that `catalog_product_entity_media_gallery` contains unused `disabled` field. #17796"

Preconditions (*)
    1. Magento 2.2.5 and above clean install
    2. PHP 7.1

### Description (*)
Steps to reproduce (*)
   1. Install 2.2.5 and above magento version.
   2. Open `catalog_product_entity_media_gallery` table in any SQL Editor.
   3. Review structure.
   4. You will get "disabled" column.

**Expected result (*)**
   <pre> Table catalog_product_entity_media_gallery without disabled field.</pre>
**Actual result (*)**
   <pre>Table catalog_product_entity_media_gallery with disabled field.</pre>

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
