### PR TITLE
Fixed Issue #20908 error message icon alignment mm19in

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/components/_messages.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/components/_messages.less
@@ -111,7 +111,7 @@
         content: @alert-icon__error__content;
         font-size: @alert-icon__error__font-size;
         left: 2.2rem;
-        margin-top: .5rem;
+        margin-top: -.9rem;
     }
 }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

1. magento/magento2#20908: Bundle product edit/add page error message icon alignment is not proper at 'Customizable Options'

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to admin create/edit any Bundle product
2. Go to Customizable Options tab >  the error message with icon should be with proper alignment.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
