### PR TITLE
Fixed #17311 Region is always required when creating a new order in the Admin area

### DIFF
--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/Renderer/Region.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/Renderer/Region.php
@@ -48,7 +48,7 @@ class Region extends \Magento\Backend\Block\AbstractBlock implements
 
         $regionId = $element->getForm()->getElement('region_id')->getValue();
 
-        $html = '<div class="field field-state required admin__field _required">';
+        $html = '<div class="field field-state admin__field">';
         $element->setClass('input-text admin__control-text');
         $element->setRequired(true);
         $html .= $element->getLabelHtml() . '<div class="control admin__field-control">';


### PR DESCRIPTION
Fixed #17311 Region is always required when creating a new order in the Admin area

### Preconditions
<!---
    Please provide as detailed information about your environment as possible.
    For example Magento version, tag, HEAD, PHP & MySQL version, etc..
-->
1.  Magento 2.2.5
2.  PHP 7.0.31
3.  MariaDB 10.1.29
4.  Apache 2.4.29
5.  Ubuntu 18.04

### Steps to reproduce
<!---
    It is important to provide a set of clear steps to reproduce this bug.
    If relevant please include code samples
-->
1. Have a clean Magento 2.2.5 install (composer create-project)
2. In the Admin area go to Sales -> Orders
3. Click "Create New Order"
4. Click "Create New Customer"
5. State/Province is mandatory as the selected country is United States
6. Change country to "The Netherlands" (Where state/province isn't mandatory)
7. State/Provice is still required

### Expected result
<!--- Tell us what should happen -->
1. Region should only be required for countries that are selected in the "State is Required for" configuration option under Stories -> Configuration -> General -> General -> State Options.


### Actual result
<!--- Tell us what happens instead -->
1. Region is always mandatory when creating a new address from the "Create New Order" form.
2. This functionality works properly when creating a new address under Customers, adding a new Customer. ect.

The problem is most likely in this class:
https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Customer/Block/Adminhtml/Edit/Renderer/Region.php#L51

* Line 51: always a required and _required CSS class
* Line 53: always a setRequired(true)
* Line 63: always a required-entry CSS class

If the above is true then this bug applies to all versions from 2.0 to 2.3

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
