### PR TITLE
Fixed #20919 Email label and email field not aligned from left for reorder of guest user

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Sales/web/css/source/module/order/_order-account.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Sales/web/css/source/module/order/_order-account.less
@@ -27,3 +27,15 @@
         width: 50%;
     }
 }
+
+.page-create-order {
+    .order-details {
+        &:not(.order-details-existing-customer) {
+            .order-account-information {
+                .field-email {
+                    margin-left: -30px;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixed #20919
Email label and email field not aligned from left for reorder of guest user

Email label and email field not aligned from left for reorder of guest user

### Preconditions (*)
1. Magento 2.3 
2. php 7.2

### Steps to reproduce (*)

1. Open frontend and order an product as guest customer
2. open  admin panel, open order grid from sales > order
3. edit same order whatever you purchase
4. click on reorder button
5. page will open and will get issue ref screenshot

### Expected result (*)

![new order orders operations sales magento admin 3](https://user-images.githubusercontent.com/26018716/52174783-0e14ed00-27bf-11e9-974a-14e761ea4851.png)


### Actual result (*)

![new order orders operations sales magento admin 2](https://user-images.githubusercontent.com/26018716/52174786-1836eb80-27bf-11e9-9075-44082d5959b4.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
