### PR TITLE
Fixed #6208 Can't sort by "Websites" in the Products > Catalog list 

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
@@ -188,6 +188,7 @@
                 <options class="Magento\Store\Model\ResourceModel\Website\Collection"/>
                 <dataType>text</dataType>
                 <label translate="true">Websites</label>
+                <sortable>false</sortable>
             </settings>
         </column>
         <actionsColumn name="actions" class="Magento\Catalog\Ui\Component\Listing\Columns\ProductActions" sortOrder="200">


### PR DESCRIPTION
made sorting disable for websites as it is not an attribute of product

2nd to last column in the table of your Proudcts titled "Websites" -- clicking the column header the page grays as if it's trying to re-order, and the little down arrow icon appears on the right of the header cell... but the list never actually sorts by what Website it's associated with

### Preconditions
1. Mage 2.1.0
2. PHP7, CentOS
3. at least two websites are created
4. two products are created and each one is assigned to different website

### Steps to reproduce
1. go to products grid 
2. by clicking on grid's head try to sort by Websites

### Actual result
Products are not sorted

### Expected result
 Products are sorted

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
