### PR TITLE
Make page title for forgot password page translatable

### DIFF
--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_forgotpassword.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_forgotpassword.xml
@@ -7,11 +7,11 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
-        <title>Forgot Your Password</title>
+        <title>Password forgotten</title>
     </head>
     <body>
-        <referenceBlock name="root">
-            <action method="setHeaderTitle">
+        <referenceBlock name="page.main.title">
+            <action method="setPageTitle">
                 <argument translate="true" name="title" xsi:type="string">Password forgotten</argument>
             </action>
         </referenceBlock>


### PR DESCRIPTION
Original PR: #18598 --> had to be on 2.3 develop branch

### Description (*)
The page title always showed English, because the wrong method was being used to make it translatable.

### Manual testing scenarios (*)
1. Use another language than English (with translation)
2. See that the page title is actually translated

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
