### PR TITLE
Fixed #20943 No complete validation while creation of attributes.

### DIFF
--- a/app/code/Magento/Eav/Setup/EavSetup.php
+++ b/app/code/Magento/Eav/Setup/EavSetup.php
@@ -791,7 +791,7 @@ class EavSetup
             trim($attributeCode),
             'StringLength',
             ['min' => $minLength, 'max' => $maxLength]
-        );
+        );       
 
         if (!$isAllowedLength) {
             $errorMessage = __(
@@ -802,6 +802,18 @@ class EavSetup
 
             throw new LocalizedException($errorMessage);
         }
+        $validatorAttrCode = new \Zend_Validate_Regex(
+                    ['pattern' => '/^[a-zA-Z\x{600}-\x{6FF}][a-zA-Z\x{600}-\x{6FF}_0-9]{0,60}$/u']
+                );
+                if (!$validatorAttrCode->isValid($attributeCode)) {
+                    $this->messageManager->addErrorMessage(
+                        __(
+                            'Attribute code "%1" is invalid. Please use only letters (a-z or A-Z), ' .
+                            'numbers (0-9) or underscore(_) in this field, first character should be a letter.',
+                            $attributeCode
+                        )
+                    );
+		}
 
         return true;
     }


### PR DESCRIPTION
Issue https://github.com/magento/magento2/issues/20943 Fixed
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1.Magento 2.3
2.PHP 7.2

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1.Create an attribute.
```
$eavSetup->addAttribute(
			\Magento\Catalog\Model\Product::ENTITY,
			'sample_attribute_Test##',
			[
				'type' => 'text',
				'backend' => '',
				'frontend' => '',
				'label' => 'Sample Atrribute',
				'input' => 'text',
				'class' => '',
				'source' => '',
				'global' => \Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface::SCOPE_GLOBAL,
				'visible' => true,
				'required' => true,
				'user_defined' => false,
				'default' => '',
				'searchable' => false,
				'filterable' => false,
				'comparable' => false,
				'visible_on_front' => false,
				'used_in_product_listing' => true,
				'unique' => false,
				'apply_to' => ''
			]
		);
```
2. It will be created . (And it should not create since not special chars other than _ allowed).

3.Edit this attribute from admin panel , you will not allow to edit anything in this attribute due to attributeCode validations.


### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. Programatically created attribute should also be saved like other attributes.
2.

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. You will not able to edit `sample_attribute_Test##` anything due to validations.
2.
