### PR TITLE
Fixed #19432 Customer group auto-assign prevents data from being saved

### DIFF
--- a/app/code/Magento/Customer/Observer/AfterAddressSaveObserver.php
+++ b/app/code/Magento/Customer/Observer/AfterAddressSaveObserver.php
@@ -123,7 +123,6 @@ class AfterAddressSaveObserver implements ObserverInterface
         /** @var $customerAddress Address */
         $customerAddress = $observer->getCustomerAddress();
         $customer = $customerAddress->getCustomer();
-        $customer->getAddressesCollection()->clear();
 
         if (!$this->_customerAddress->isVatValidationEnabled($customer->getStore())
             || $this->_coreRegistry->registry(self::VIV_PROCESSED_FLAG)
@@ -140,6 +139,7 @@ class AfterAddressSaveObserver implements ObserverInterface
             ) {
                 $defaultGroupId = $this->_groupManagement->getDefaultGroup($customer->getStore())->getId();
                 if (!$customer->getDisableAutoGroupChange() && $customer->getGroupId() != $defaultGroupId) {
+                    $customer->getAddressesCollection()->clear();
                     $customer->setGroupId($defaultGroupId);
                     $customer->save();
                     $this->customerSession->setCustomerGroupId($defaultGroupId);
@@ -157,6 +157,7 @@ class AfterAddressSaveObserver implements ObserverInterface
                 );
 
                 if (!$customer->getDisableAutoGroupChange() && $customer->getGroupId() != $newGroupId) {
+                    $customer->getAddressesCollection()->clear();
                     $customer->setGroupId($newGroupId);
                     $customer->save();
                     $this->customerSession->setCustomerGroupId($newGroupId);

--- a/app/code/Magento/Customer/Observer/AfterAddressSaveObserver.php
+++ b/app/code/Magento/Customer/Observer/AfterAddressSaveObserver.php
@@ -123,6 +123,7 @@ class AfterAddressSaveObserver implements ObserverInterface
         /** @var $customerAddress Address */
         $customerAddress = $observer->getCustomerAddress();
         $customer = $customerAddress->getCustomer();
+        $customer->getAddressesCollection()->clear();
 
         if (!$this->_customerAddress->isVatValidationEnabled($customer->getStore())
             || $this->_coreRegistry->registry(self::VIV_PROCESSED_FLAG)


### PR DESCRIPTION
Fixed #19432 Customer group auto-assign prevents data from being saved

### Preconditions (*)
1. Any Magento 2.2.* version. **EDIT**: This was also tested on 2.3.0
2. Auto-assign of customer group based on an (in)valid VAT ID is enabled and configured.
3. PHP 7.0 (and tested with PHP 7.1 as well).
4. Clean install of Magento.

### Steps to reproduce (*)
1. Log into the backoffice and go to "Stores => Configuration => Customers => Customer Configuration.
2. Enable Automatic Assignment to Customer Group under "Create New Account Options".
3. Set a different customer group for a valid VAT ID and for an invalid VAT ID.
e.g: Group for Valid VAT ID - Domestic = Retailer, Group for Invalid VAT ID = General.
4. Create a new account on the frontend and create an address with an invalid VAT ID.
5. Check the new customer group in the backoffice (customer should be General).
6. Enter a valid VAT ID for the customer in the existing address and some other changes to the account like the firstname and save the customer.
7. Check the customer group and check the VAT ID.

### Expected result (*)
1. Customer group is changed accordingly to Retailer.
2. VAT ID is properly updated.
3. Other customer data is properly updated.

### Actual result (*)
1. Customer group is changed accordingly to Retailer.
2. VAT ID is **_not_** updated (old value remains).
3. Other customer data is **_not_** updated (old values remain).

### Additional information on the possible cause (*)
1. Try making the same changes again and save the customer.
Result: The new data is now saved, the customer group remains Retailer (as a valid VAT ID is provided).
2. Change the customer group to General and save the customer.
Result: The customer group is now General.
3. Save the customer again.
Result: The customer group is now Retailer.
4. Enter an invalid VAT ID and save the customer.
Result: The customer group is now General, the new VAT ID is **_not_** saved.
5. Save the customer again.
Result: The customer group is now Retailer (because of the old valid VAT ID).

This would suggest any data being saved during the auto-change of the customer group other than the group change itself is ignored completely and not updated in the database.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
