### PR TITLE
Fixed#18508 collect-totals API call not updating the selected shippingMethod

### DIFF
--- a/app/code/Magento/Quote/Model/ShippingMethodManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingMethodManagement.php
@@ -168,7 +168,7 @@ class ShippingMethodManagement implements
         }
 
         try {
-             $quote->collectTotals(); 
+            $quote->collectTotals(); 
         } catch (\Exception $e) {
             throw new CouldNotSaveException(__('The shipping method can\'t be set. %1', $e->getMessage()));
         }

--- a/app/code/Magento/Quote/Model/ShippingMethodManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingMethodManagement.php
@@ -168,7 +168,7 @@ class ShippingMethodManagement implements
         }
 
         try {
-            $quote->collectTotals(); 
+             $quote->collectTotals(); 
         } catch (\Exception $e) {
             throw new CouldNotSaveException(__('The shipping method can\'t be set. %1', $e->getMessage()));
         }

--- a/app/code/Magento/Quote/Model/ShippingMethodManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingMethodManagement.php
@@ -168,7 +168,7 @@ class ShippingMethodManagement implements
         }
 
         try {
-             $quote->collectTotals(); 
+            $quote->collectTotals();
         } catch (\Exception $e) {
             throw new CouldNotSaveException(__('The shipping method can\'t be set. %1', $e->getMessage()));
         }

--- a/app/code/Magento/Quote/Model/ShippingMethodManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingMethodManagement.php
@@ -168,7 +168,7 @@ class ShippingMethodManagement implements
         }
 
         try {
-            $this->quoteRepository->save($quote->collectTotals());
+            $quote->collectTotals();
         } catch (\Exception $e) {
             throw new CouldNotSaveException(__('The shipping method can\'t be set. %1', $e->getMessage()));
         }

--- a/app/code/Magento/Quote/Model/ShippingMethodManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingMethodManagement.php
@@ -168,7 +168,7 @@ class ShippingMethodManagement implements
         }
 
         try {
-            $quote->collectTotals();
+             $quote->collectTotals(); 
         } catch (\Exception $e) {
             throw new CouldNotSaveException(__('The shipping method can\'t be set. %1', $e->getMessage()));
         }


### PR DESCRIPTION
Update repository with latest changes

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Replaced $this->quoteRepository->save($quote->collectTotals()); with $quote->collectTotals() at set method function in Magento\Quote\Model\ShippingMethodManagement.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18508: collect-totals API call not updating the selected shippingMethod
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Tested it with multiple shipping methods.
2. Checked it with different payment methods in request payload

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 