### PR TITLE
#18698 Fixed order email sending via order async email sending when order was created with disabled email sending

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
@@ -97,7 +97,7 @@ class OrderSender extends Sender
      */
     public function send(Order $order, $forceSyncMode = false)
     {
-        $order->setSendEmail(true);
+        $order->setSendEmail($this->identityContainer->isEnabled());
 
         if (!$this->globalConfig->getValue('sales_email/general/async_sending') || $forceSyncMode) {
             if ($this->checkAndSend($order)) {

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
@@ -55,10 +55,10 @@ class OrderSender extends Sender
      * @param OrderIdentity $identityContainer
      * @param Order\Email\SenderBuilderFactory $senderBuilderFactory
      * @param \Psr\Log\LoggerInterface $logger
+     * @param Renderer $addressRenderer
      * @param PaymentHelper $paymentHelper
      * @param OrderResource $orderResource
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $globalConfig
-     * @param Renderer $addressRenderer
      * @param ManagerInterface $eventManager
      */
     public function __construct(

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/OrderSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/OrderSenderTest.php
@@ -64,7 +64,7 @@ class OrderSenderTest extends AbstractSenderTest
 
         $this->orderMock->expects($this->once())
             ->method('setSendEmail')
-            ->with(true);
+            ->with($emailSendingResult);
 
         $this->globalConfig->expects($this->once())
             ->method('getValue')
@@ -72,7 +72,7 @@ class OrderSenderTest extends AbstractSenderTest
             ->willReturn($configValue);
 
         if (!$configValue || $forceSyncMode) {
-            $this->identityContainerMock->expects($this->once())
+            $this->identityContainerMock->expects($this->exactly(2))
                 ->method('isEnabled')
                 ->willReturn($emailSendingResult);
 
@@ -118,7 +118,7 @@ class OrderSenderTest extends AbstractSenderTest
 
                     $this->orderMock->expects($this->once())
                         ->method('setEmailSent')
-                        ->with(true);
+                        ->with($emailSendingResult);
 
                     $this->orderResourceMock->expects($this->once())
                         ->method('saveAttribute')
@@ -210,7 +210,7 @@ class OrderSenderTest extends AbstractSenderTest
             ->with('sales_email/general/async_sending')
             ->willReturn(false);
 
-        $this->identityContainerMock->expects($this->once())
+        $this->identityContainerMock->expects($this->exactly(2))
             ->method('isEnabled')
             ->willReturn(true);
 


### PR DESCRIPTION
### Description (*)
Fixed order email sending via order async email sending when order was created with disabled email sending
### Preconditions (*)
- Magento 2.3.*
- Magento 2.2.*
- CRON should be enabled
- the *sales_email/general/async_sending* config should be enabled (Stores->Configuration->Sales->Sales Emails->General Settings->Asynchronous sending)

### Fixed Issues (if relevant)

1. https://github.com/magento/magento2/issues/18698: Magento triggers and sends some of order emails exactly one month later,while the order email was not enabled then

### Manual testing scenarios (*)
1. disable order emails from Stores->configuration->sales emails to not send any email on any new order
2. after some time , enable the order emails from Stores->configuration->sales emails to send email on new orders
2. after CRON running the *sales_send_order_emails* cronjob, you will receive an email of the order creation  (the **bin/magento cron:run** command can be used to trigger the CRON)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
