### PR TITLE
[backport]  Product attribute option manager's existing option check fails

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/OptionManagement.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/OptionManagement.php
@@ -47,7 +47,7 @@ class OptionManagement implements \Magento\Catalog\Api\ProductAttributeOptionMan
                 /** @var \Magento\Eav\Api\Data\AttributeOptionInterface $attributeOption */
                     $attributeOption = $attributeOption->getLabel();
             });
-            if (in_array($option->getLabel(), $currentOptions)) {
+            if (in_array($option->getLabel(), $currentOptions, true)) {
                 return false;
             }
         }

--- a/app/code/Magento/Catalog/Model/Product/Attribute/OptionManagement.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/OptionManagement.php
@@ -8,6 +8,9 @@ namespace Magento\Catalog\Model\Product\Attribute;
 
 use Magento\Framework\Exception\InputException;
 
+/**
+ * Option management model for product attribute.
+ */
 class OptionManagement implements \Magento\Catalog\Api\ProductAttributeOptionManagementInterface
 {
     /**
@@ -25,7 +28,7 @@ class OptionManagement implements \Magento\Catalog\Api\ProductAttributeOptionMan
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getItems($attributeCode)
     {
@@ -36,7 +39,7 @@ class OptionManagement implements \Magento\Catalog\Api\ProductAttributeOptionMan
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function add($attributeCode, $option)
     {
@@ -59,7 +62,7 @@ class OptionManagement implements \Magento\Catalog\Api\ProductAttributeOptionMan
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function delete($attributeCode, $optionId)
     {


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/19451

### Description (*)
Product attribute option manager's existing option check fails
Added strict flag to in_array

### Fixed Issues (if relevant)
1. #18246

### Manual testing scenarios (*)
1. Add attribute options by calling \Magento\Catalog\Model\Product\Attribute\OptionManagement::add
2. Add attribute option that has admin scope value '01'.
3. Add another option for same attribute that has admin scope value '1'.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
