### PR TITLE
Extra space from left in top message section (Notification section)

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_AdminNotification/web/css/source/_module.less
+++ b/app/design/adminhtml/Magento/backend/Magento_AdminNotification/web/css/source/_module.less
@@ -83,7 +83,7 @@
 
 .message-system-short-wrapper {
     overflow: hidden;
-    padding: 0 1.5rem 0 @indent__l;
+    padding: 0 1.5rem 0 1rem;
 }
 
 .message-system-collapsible {


### PR DESCRIPTION
Extra space from left in top message section (Notification section)

### Description (*)
Extra space from left in top message section (Notification section)

### Manual testing scenarios (*)
1. Open admin panel and login 
2. wait in dashboard notification will show tin top of the page (ref screenshot)

### Expected result (*)
![sol](https://user-images.githubusercontent.com/26018716/52200797-b1cdce00-288f-11e9-9c26-3d4bf631b988.png)

### Actual result (*)
![issue](https://user-images.githubusercontent.com/26018716/52201517-a54a7500-2891-11e9-96c8-ee7730695099.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
