### PR TITLE
issue/20975: Query slow when using quotes for integers in WHERE state…

### DIFF
--- a/lib/internal/Magento/Framework/Model/ResourceModel/Db/AbstractDb.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Db/AbstractDb.php
@@ -372,6 +372,8 @@ abstract class AbstractDb extends AbstractResource
      */
     protected function _getLoadSelect($field, $value, $object)
     {
+        $fields = $this->getConnection()->describeTable($this->getMainTable());
+        $value  = $this->getConnection()->prepareColumnValue($fields[$field], $value);
         $field = $this->getConnection()->quoteIdentifier(sprintf('%s.%s', $this->getMainTable(), $field));
         $select = $this->getConnection()->select()->from($this->getMainTable())->where($field . '=?', $value);
         return $select;


### PR DESCRIPTION
…ments

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20975: Query slow when using quotes for integers in WHERE statements

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Load a product in the backend and check the query log.
2. See that for example `SELECT `eav_attribute`.* FROM `eav_attribute` WHERE (`eav_attribute`.`attribute_id`='74')` is now `SELECT `eav_attribute`.* FROM `eav_attribute` WHERE (`eav_attribute`.`attribute_id`=74)`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
