### PR TITLE
Solve custom option dropdown issue

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/CustomOptions.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/CustomOptions.php
@@ -11,6 +11,7 @@ use Magento\Catalog\Model\ProductOptions\ConfigInterface;
 use Magento\Catalog\Model\Config\Source\Product\Options\Price as ProductOptionsPrice;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\Stdlib\ArrayManager;
+use Magento\Ui\Component\Form\Element\Hidden;
 use Magento\Ui\Component\Modal;
 use Magento\Ui\Component\Container;
 use Magento\Ui\Component\DynamicRows;
@@ -867,10 +868,9 @@ class CustomOptions extends AbstractModifier
                 'data' => [
                     'config' => [
                         'componentType' => Field::NAME,
-                        'formElement' => Input::NAME,
+                        'formElement' => Hidden::NAME,
                         'dataScope' => static::FIELD_SORT_ORDER_NAME,
                         'dataType' => Number::NAME,
-                        'visible' => false,
                         'sortOrder' => $sortOrder,
                     ],
                 ],


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Admin Customizable Options Dropdown sort_order issue

### Fixed Issues (if relevant)

1. magento/magento2#20989: Admin Customizable Options Dropdown sort_order issue

### Manual testing scenarios (*)
1. Go to Catalog > Products
2. Edit/New Product
3. Expand Customizable Options and click on Add Option
4. Choose Drop Dowm as New Option Type
5. Add 1 or 2 Values 
6 . Now , Change Option type from drop down to field or area
7. Now again choose Drop Dowm as Option Type
8. Add 1 or 2 Values 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
