### PR TITLE
disable add to cart until page load

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
@@ -32,7 +32,7 @@
             <button type="submit"
                     title="<?= /* @escapeNotVerified */ $buttonTitle ?>"
                     class="action primary tocart"
-                    id="product-addtocart-button">
+                    id="product-addtocart-button" disabled>
                 <span><?= /* @escapeNotVerified */ $buttonTitle ?></span>
             </button>
             <?= $block->getChildHtml('', true) ?>

--- a/app/code/Magento/Catalog/view/frontend/web/js/validate-product.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/validate-product.js
@@ -42,7 +42,7 @@ define([
                     return false;
                 }
             });
-            $(this.options.addToCartButtonSelector).attr('disabled',false);
+            $(this.options.addToCartButtonSelector).attr('disabled', false);
         }
     });
 

--- a/app/code/Magento/Catalog/view/frontend/web/js/validate-product.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/validate-product.js
@@ -13,7 +13,8 @@ define([
     $.widget('mage.productValidate', {
         options: {
             bindSubmit: false,
-            radioCheckboxClosest: '.nested'
+            radioCheckboxClosest: '.nested',
+            addToCartButtonSelector: '.action.tocart'
         },
 
         /**
@@ -41,6 +42,7 @@ define([
                     return false;
                 }
             });
+            $(this.options.addToCartButtonSelector).attr('disabled',false);
         }
     });
 


### PR DESCRIPTION
### Description (*)
Open a configurable product having DropDown options
When the page is being loaded, you will notice that the dropdowns has no values
Click Add To Cart button during this time. The page will be reloaded and a notice message "Open a configurable product having DropDown options" will be shown

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
