### PR TITLE
404 page occurs in case of Wrong invoice id passed in url

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/View.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/View.php
@@ -44,9 +44,8 @@ class View extends \Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoice\V
     {
         $invoice = $this->getInvoice();
         if (!$invoice) {
-            /** @var \Magento\Framework\Controller\Result\Forward $resultForward */
-            $resultForward = $this->resultForwardFactory->create();
-            return $resultForward->forward('noroute');
+            $resultRedirect = $this->resultRedirectFactory->create();
+            return $resultRedirect->setPath('sales/invoice');
         }
 
         /** @var \Magento\Backend\Model\View\Result\Page $resultPage */


### PR DESCRIPTION
404 page occurs in case of Wrong invoice id passed in url

### Preconditions (*)

2.3 or 2.3 Develop

Php 7.2

### Descriptions (*)

404 page occurs in case of Wrong invoice id

### Manual testing scenarios (*)

1. Create An Order In Magento
2. Create Invoice of that Order
3. View the created  invoice
4. Now change the invoice id from url(use that id which does not exist) and run the url.

### Expected result (*)

A proper error message should come without any 404 page and redirection must be in Invoice Grid

### Actual Result (*)

A 404 page occurs with error message
![invoice error](https://user-images.githubusercontent.com/25526052/52340398-b2a06480-2a35-11e9-8667-7407f1048feb.png)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
