### PR TITLE
Fatal error page occurs if use wrong shipment id passed in url

### DIFF
--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/View.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/Shipment/View.php
@@ -71,9 +71,8 @@ class View extends \Magento\Backend\App\Action
             $resultPage->getConfig()->getTitle()->prepend("#" . $shipment->getIncrementId());
             return $resultPage;
         } else {
-            $resultForward = $this->resultForwardFactory->create();
-            $resultForward->forward('noroute');
-            return $resultForward;
+            $resultRedirect = $this->resultRedirectFactory->create();
+            return $resultRedirect->setPath('sales/shipment');
         }
     }
 }

--- a/app/code/Magento/Shipping/Controller/Adminhtml/Order/ShipmentLoader.php
+++ b/app/code/Magento/Shipping/Controller/Adminhtml/Order/ShipmentLoader.php
@@ -16,7 +16,8 @@ use Magento\Sales\Api\ShipmentRepositoryInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order\ShipmentDocumentFactory;
 use Magento\Sales\Api\Data\ShipmentItemCreationInterface;
-
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Exception\InputException;
 /**
  * Class ShipmentLoader
  *
@@ -110,7 +111,15 @@ class ShipmentLoader extends DataObject
         $orderId = $this->getOrderId();
         $shipmentId = $this->getShipmentId();
         if ($shipmentId) {
-            $shipment = $this->shipmentRepository->get($shipmentId);
+            try {
+                $shipment = $this->shipmentRepository->get($shipmentId);
+            } catch (NoSuchEntityException $e) {  
+                $this->messageManager->addErrorMessage(__('This shipment no longer exists.'));
+                return false;
+            } catch (InputException $e) {
+                $this->messageManager->addErrorMessage(__('This shipment no longer exists.'));
+                return false;
+            }
         } elseif ($orderId) {
             $order = $this->orderRepository->get($orderId);
 


### PR DESCRIPTION
Fatal error page occurs if use wrong shipment id passed in url

### Preconditions (*)

2.3 or 2.3 Develop

Php 7.2

### Descriptions (*)

Fatal error page occurs if use wrong shipment id passed in url

### Manual testing scenarios (*)

1. Create An Order In Magento

2. Create shipment of that Order

3. View the created  shipment

4. Now change the shipment id from url(use that id which does not exist) and run the url.


### Expected result (*)

A proper error message should come

### Actual Result (*)

Fatal error page occurs

![screenshot-i-21010-2-3-develop instances magento-community engineering-2019-02-06-17-02-48](https://user-images.githubusercontent.com/25526052/52340632-41ad7c80-2a36-11e9-8b39-e521a60a72d5.png)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
