### PR TITLE
Make the module list more deterministic

### DIFF
--- a/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
+++ b/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
@@ -134,7 +134,7 @@ class Loader
         $modules = $this->prearrangeModules($origList);
 
         $expanded = [];
-        foreach ($modules as $moduleName => $value) {
+        foreach (array_keys($modules) as $moduleName) {
             $sequence = $this->expandSequence($origList, $moduleName);
             asort($sequence);
 

--- a/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
+++ b/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
@@ -126,16 +126,21 @@ class Loader
      *
      * @param array $origList
      * @return array
-     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     * @throws \Exception
      */
-    private function sortBySequence($origList)
+    private function sortBySequence(array $origList): array
     {
         ksort($origList);
+        $modules = $this->prearrangeModules($origList);
+
         $expanded = [];
-        foreach ($origList as $moduleName => $value) {
+        foreach ($modules as $moduleName => $value) {
+            $sequence = $this->expandSequence($origList, $moduleName);
+            asort($sequence);
+
             $expanded[] = [
                 'name' => $moduleName,
-                'sequence' => $this->expandSequence($origList, $moduleName),
+                'sequence' => $sequence,
             ];
         }
 
@@ -143,7 +148,7 @@ class Loader
         $total = count($expanded);
         for ($i = 0; $i < $total - 1; $i++) {
             for ($j = $i; $j < $total; $j++) {
-                if (in_array($expanded[$j]['name'], $expanded[$i]['sequence'])) {
+                if (in_array($expanded[$j]['name'], $expanded[$i]['sequence'], true)) {
                     $temp = $expanded[$i];
                     $expanded[$i] = $expanded[$j];
                     $expanded[$j] = $temp;
@@ -157,6 +162,27 @@ class Loader
         }
 
         return $result;
+    }
+
+    /**
+     * Prearrange all modules by putting those from Magento before the others
+     *
+     * @param array $modules
+     * @return array
+     */
+    private function prearrangeModules(array $modules): array
+    {
+        $breakdown = ['magento' => [], 'others' => []];
+
+        foreach ($modules as $moduleName => $moduleDetails) {
+            if (strpos($moduleName, 'Magento_') !== false) {
+                $breakdown['magento'][$moduleName] = $moduleDetails;
+            } else {
+                $breakdown['others'][$moduleName] = $moduleDetails;
+            }
+        }
+
+        return array_merge($breakdown['magento'], $breakdown['others']);
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
I've found that the modules ranking in the `app/etc/config` is not completely deterministic as a module addition will affect the ranking of unrelated modules. This generates a lot of conflicts when starting a Magento project since many modules are likely to be added.

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I tried the changes proposed in #16120 at first, but the implementation was likely incomplete as I was still able to reproduce the issue. So, I came to the conclusion that we need to sort the sequence of each module AND to put all Magento modules at the top of the list before performing the bubble sorting. There is no impact on the prioritization process itself. However by keeping third-party modules together, we will mitigate the impact of a module addition because it will be naturally added at the end of the list without messing Magento modules ranking. I've also added a specific unit test.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #16116: Modules sort order in config.php is being inconsistent when no changes being made
2. #8479: Sequence of module load order should be deterministic

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Perform a `setup:upgrade`.
2. Commit the `app/etc/config.php` file.
3. Create a new module which depends of another module.
4. Perform a new `setup:upgrade`.
5. The new module is added in the `app/etc/config.php` file, but the ranking of several unrelated modules is also affected.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
