### PR TITLE
Removing unnecessary php doc param from UiComponentGenerator constructor

### DIFF
--- a/app/code/Magento/Ui/Model/UiComponentGenerator.php
+++ b/app/code/Magento/Ui/Model/UiComponentGenerator.php
@@ -32,7 +32,6 @@ class UiComponentGenerator
      * UiComponentGenerator constructor.
      * @param ContextFactory $contextFactory
      * @param UiComponentFactory $uiComponentFactory
-     * @param array $data
      */
     public function __construct(
         ContextFactory $contextFactory,


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Removed array $data parameter of constructor class in Magento\Ui\Model\UiComponentGenerator.
Number,type of parameters used in PHPDoc comment does not match with ones in respective function.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
