### PR TITLE
Add missing php doc params to ConvertSerializedDataToJson class constructor

### DIFF
--- a/app/code/Magento/Quote/Setup/Patch/Data/ConvertSerializedDataToJson.php
+++ b/app/code/Magento/Quote/Setup/Patch/Data/ConvertSerializedDataToJson.php
@@ -6,7 +6,6 @@
 
 namespace Magento\Quote\Setup\Patch\Data;
 
-use Magento\Framework\App\ResourceConnection;
 use Magento\Quote\Setup\ConvertSerializedDataToJsonFactory;
 use Magento\Quote\Setup\QuoteSetupFactory;
 use Magento\Framework\Setup\Patch\DataPatchInterface;

--- a/app/code/Magento/Quote/Setup/Patch/Data/ConvertSerializedDataToJson.php
+++ b/app/code/Magento/Quote/Setup/Patch/Data/ConvertSerializedDataToJson.php
@@ -3,7 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\Quote\Setup\Patch\Data;
 
 use Magento\Quote\Setup\ConvertSerializedDataToJsonFactory;
@@ -12,8 +11,7 @@ use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchVersionInterface;
 
 /**
- * Class ConvertSerializedDataToJson
- * @package Magento\Quote\Setup\Patch
+ * Convert quote serialized data to json.
  */
 class ConvertSerializedDataToJson implements DataPatchInterface, PatchVersionInterface
 {
@@ -49,7 +47,7 @@ class ConvertSerializedDataToJson implements DataPatchInterface, PatchVersionInt
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function apply()
     {
@@ -58,7 +56,7 @@ class ConvertSerializedDataToJson implements DataPatchInterface, PatchVersionInt
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public static function getDependencies()
     {
@@ -68,7 +66,7 @@ class ConvertSerializedDataToJson implements DataPatchInterface, PatchVersionInt
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public static function getVersion()
     {
@@ -76,7 +74,7 @@ class ConvertSerializedDataToJson implements DataPatchInterface, PatchVersionInt
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getAliases()
     {

--- a/app/code/Magento/Quote/Setup/Patch/Data/ConvertSerializedDataToJson.php
+++ b/app/code/Magento/Quote/Setup/Patch/Data/ConvertSerializedDataToJson.php
@@ -36,6 +36,8 @@ class ConvertSerializedDataToJson implements DataPatchInterface, PatchVersionInt
     /**
      * PatchInitial constructor.
      * @param \Magento\Framework\Setup\ModuleDataSetupInterface $moduleDataSetup
+     * @param QuoteSetupFactory $quoteSetupFactory
+     * @param ConvertSerializedDataToJsonFactory $convertSerializedDataToJsonFactory
      */
     public function __construct(
         \Magento\Framework\Setup\ModuleDataSetupInterface $moduleDataSetup,

--- a/app/code/Magento/Ui/Model/UiComponentGenerator.php
+++ b/app/code/Magento/Ui/Model/UiComponentGenerator.php
@@ -47,6 +47,7 @@ class UiComponentGenerator
      * @param string $name
      * @param \Magento\Framework\View\LayoutInterface $layout
      * @return UiComponentInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function generateUiComponent($name, \Magento\Framework\View\LayoutInterface $layout)
     {

--- a/app/code/Magento/Ui/Model/UiComponentGenerator.php
+++ b/app/code/Magento/Ui/Model/UiComponentGenerator.php
@@ -32,7 +32,6 @@ class UiComponentGenerator
      * UiComponentGenerator constructor.
      * @param ContextFactory $contextFactory
      * @param UiComponentFactory $uiComponentFactory
-     * @param array $data
      */
     public function __construct(
         ContextFactory $contextFactory,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Add missing php doc params to ConvertSerializedDataToJson class constructor.
Number,type of parameters used in PHPDoc comment does not match with ones in respective function

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
