### PR TITLE
Issue Fixed #21034: Invalid return type in docstring

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/PhpEnvironment/Request.php
+++ b/lib/internal/Magento/Framework/HTTP/PhpEnvironment/Request.php
@@ -14,7 +14,10 @@ use Zend\Uri\UriFactory;
 use Zend\Uri\UriInterface;
 
 /**
+ * HTTP Request for current PHP environment.
+ *
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  */
 class Request extends \Zend\Http\PhpEnvironment\Request
 {
@@ -586,6 +589,7 @@ class Request extends \Zend\Http\PhpEnvironment\Request
 
     /**
      * Access values contained in the superglobals as public members
+     *
      * Order of precedence: 1. GET, 2. POST, 3. COOKIE, 4. SERVER, 5. ENV
      *
      * @see http://msdn.microsoft.com/en-us/library/system.web.httprequest.item.aspx
@@ -795,6 +799,8 @@ class Request extends \Zend\Http\PhpEnvironment\Request
     }
 
     /**
+     * Get flag value for whether the request is forwarded or not.
+     *
      * @return bool
      * @codeCoverageIgnore
      */
@@ -804,6 +810,8 @@ class Request extends \Zend\Http\PhpEnvironment\Request
     }
 
     /**
+     * Set flag value for whether the request is forwarded or not.
+     *
      * @param bool $forwarded
      * @return $this
      * @codeCoverageIgnore

--- a/lib/internal/Magento/Framework/HTTP/PhpEnvironment/Request.php
+++ b/lib/internal/Magento/Framework/HTTP/PhpEnvironment/Request.php
@@ -683,7 +683,7 @@ class Request extends \Zend\Http\PhpEnvironment\Request
      *
      * @param string $name Header name to retrieve.
      * @param mixed|null $default Default value to use when the requested header is missing.
-     * @return bool|HeaderInterface
+     * @return bool|string
      */
     public function getHeader($name, $default = false)
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21034: Magento\Framework\HTTP\PhpEnvironment\Request::getHeader() has incorrect return type in dockblock 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
