### PR TITLE
Added RewriteBase directive template in .htaccess file into pub/media folder

### DIFF
--- a/pub/media/.htaccess
+++ b/pub/media/.htaccess
@@ -23,6 +23,9 @@ SetHandler default-handler
     Options +FollowSymLinks
     RewriteEngine on
 
+    ## you can put here your pub/media folder path relative to web root
+    #RewriteBase /magento/pub/media/
+
 ############################################
 ## never rewrite for existing files
     RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
### Description
This PR adds RewriteBase directive template into .htaccess file under pub/media folder, useful in case the need is to install Magento code under a directory inside the web root. 
Setting this directive into .htaccess file in Magento's root and without setting it into .htaccess under pub/media folder cause a media file missing by Apache Web Server due to specified `RewriteRule` directive that points to `../get.php`. 
A similar issue was already fixed in #13678 and relative branch portings.

### Fixed Issues
none

### Manual testing scenarios
none

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
