### PR TITLE
quantity-not-center-align-on-review-order

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Multishipping/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Multishipping/web/css/source/_module.less
@@ -348,8 +348,15 @@
                 &.table-order-review {
                     > tbody {
                         > tr {
-                            > td.col.qty {
-                                text-align: center;
+                            > td {
+                                &.col {
+                                    &.subtotal {
+                                        border-bottom: none;
+                                    }
+                                    &.qty {
+                                        text-align: center;
+                                    }
+                                }
                             }
                         }
                     }

--- a/app/design/frontend/Magento/luma/Magento_Multishipping/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Multishipping/web/css/source/_module.less
@@ -345,6 +345,15 @@
 
             .data.table {
                 &:extend(.abs-checkout-order-review all);
+                &.table-order-review {
+                    > tbody {
+                        > tr {
+                            > td.col.qty {
+                                text-align: center;
+                            }
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
On multishipping checkout review order page quantity not center align and border bottom appearing twice on mobile view

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. on mobile dive
2. add product to cart with login customer 
3. go to cart page
4. Check Out with Multiple Addresses
5. Go to Shipping Information
6. Continue to Billing Information
7. Go to Review Your Order
8. check quantity and subtotal of product

### Expected result (*)
![image](https://user-images.githubusercontent.com/18118539/52406709-60724880-2af4-11e9-8ac4-72abb589cf55.png)



### Actual result (*)
![image](https://user-images.githubusercontent.com/18118539/52406785-87c91580-2af4-11e9-8119-6dc6ebc8fc1c.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
