### PR TITLE
border-appearing-twice-on-subtotal

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Multishipping/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Multishipping/web/css/source/_module.less
@@ -345,6 +345,15 @@
 
             .data.table {
                 &:extend(.abs-checkout-order-review all);
+                &.table-order-review {
+                    > tbody {
+                        > tr {
+                            > td.col.subtotal {
+                                border-bottom: none;
+                            }
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
On multishipping checkout review order page border bottom appearing twice for subtotal on mobile view


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. on mobile dive
2. add product to cart with login customer 
3. go to cart page
4. Check Out with Multiple Addresses
5. Go to Shipping Information
6. Continue to Billing Information
7. Go to Review Your Order
8. check subtotal of product

### Expected result (*)
![image](https://user-images.githubusercontent.com/18118539/52407572-b942e080-2af6-11e9-8887-bbfb97df11d4.png)


### Actual result (*)
![image](https://user-images.githubusercontent.com/18118539/52407633-d2e42800-2af6-11e9-8053-466a50badfcc.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
