### PR TITLE
Provide possibility to use default value for Media Gallery Entry attributes

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery.php
@@ -42,6 +42,13 @@ class Gallery extends \Magento\Framework\View\Element\AbstractBlock
      * @var string
      */
     protected $name = 'product[media_gallery]';
+    
+    /**
+     * Gallery "use_default" checkbox name
+     *
+     * @var string
+     */
+    private $useDefaultName = 'product[use_default_media_gallery]';
 
     /**
      * Html id for data scope
@@ -164,6 +171,22 @@ class Gallery extends \Magento\Framework\View\Element\AbstractBlock
     {
         return $this->name;
     }
+    
+    /**
+     * @return string
+     */
+    public function getUseDefaultHtmlId()
+    {
+        return sprintf('%s_%s_use_default', $this->getFieldNameSuffix(), $this->getHtmlId());
+    }
+    
+    /**
+     * @return string
+     */
+    public function getUserDefaultName()
+    {
+        return $this->useDefaultName;
+    }
 
     /**
      * @return string
@@ -218,6 +241,26 @@ class Gallery extends \Magento\Framework\View\Element\AbstractBlock
             return false;
         }
         return $defaultValue === false;
+    }
+    
+    /**
+     * Check default gallery usage fact
+     *
+     * @return bool
+     */
+    public function usedDefaultGallery()
+    {
+        $gallery = $this->getImages();
+        
+        if (!empty($gallery['images'])) {
+            foreach ($gallery['images'] as $image) {
+                if ($image['store_id'] != $this->_getDefaultStoreId()) {
+                    return false;
+                }
+            }
+        }
+    
+        return true;
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Product/Gallery/UpdateHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/UpdateHandler.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Catalog\Model\Product\Gallery;
 
-use Magento\Framework\EntityManager\Operation\ExtensionInterface;
+use Magento\Store\Model\Store;
 
 /**
  * Update handler for catalog product gallery.
@@ -50,6 +50,24 @@ class UpdateHandler extends \Magento\Catalog\Model\Product\Gallery\CreateHandler
         $this->resourceModel->deleteGallery($recordsToDelete);
 
         $this->removeDeletedImages($filesToDelete);
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    protected function processNewAndExistingImages($product, array &$images)
+    {
+        $storeId = $product->getStoreId();
+        
+        if ($product->getData('use_default_media_gallery') && $storeId !== Store::DEFAULT_STORE_ID) {
+            $valuesToDelete = array_column($images, 'value_id');
+            
+            $this->resourceModel->deleteGallery($valuesToDelete, $storeId);
+            
+            return;
+        }
+        
+        parent::processNewAndExistingImages($product, $images);
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/GalleryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/GalleryTest.php
@@ -345,6 +345,11 @@ class GalleryTest extends \PHPUnit\Framework\TestCase
         $this->connection->expects($this->any())->method('getIfNullSql')->will(
             $this->returnValueMap([
                 [
+                    '`value`.`store_id`',
+                    '`default_value`.`store_id`',
+                    'IFNULL(`value`.`store_id`,`default_value`.`store_id`) AS `store_id`'
+                ],
+                [
                     '`value`.`label`',
                     '`default_value`.`label`',
                     'IFNULL(`value`.`label`, `default_value`.`label`)'
@@ -372,6 +377,7 @@ class GalleryTest extends \PHPUnit\Framework\TestCase
             []
         )->willReturnSelf();
         $this->select->expects($this->at(4))->method('columns')->with([
+            'store_id' => 'IFNULL(`value`.`store_id`,`default_value`.`store_id`) AS `store_id`',
             'label' => 'IFNULL(`value`.`label`, `default_value`.`label`)',
             'position' => 'IFNULL(`value`.`position`, `default_value`.`position`)',
             'disabled' => 'IFNULL(`value`.`disabled`, `default_value`.`disabled`)',

--- a/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/ImagesTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Ui/DataProvider/Product/Form/Modifier/ImagesTest.php
@@ -54,7 +54,8 @@ class ImagesTest extends AbstractModifierTest
                     'media_gallery' => [
                         'images' => [
                             [
-                                'label' => null
+                                'label' => null,
+                                'store_id' => 0
                             ]
                         ]
                     ]

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Images.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Images.php
@@ -64,11 +64,19 @@ class Images extends AbstractModifier
             && !empty($data[$modelId][self::DATA_SOURCE_DEFAULT]['media_gallery'])
             && !empty($data[$modelId][self::DATA_SOURCE_DEFAULT]['media_gallery']['images'])
         ) {
+            $useDefaultGallery = true;
+    
             foreach ($data[$modelId][self::DATA_SOURCE_DEFAULT]['media_gallery']['images'] as $index => $image) {
                 if (!isset($image['label'])) {
                     $data[$modelId][self::DATA_SOURCE_DEFAULT]['media_gallery']['images'][$index]['label'] = "";
                 }
+        
+                if ($useDefaultGallery && (int)$image['store_id'] !== \Magento\Store\Model\Store::DEFAULT_STORE_ID) {
+                    $useDefaultGallery = false;
+                }
             }
+    
+            $data[$modelId][self::DATA_SOURCE_DEFAULT]['use_default_media_gallery'] = $useDefaultGallery;
         }
 
         return $data;

--- a/app/code/Magento/Catalog/view/adminhtml/requirejs-config.js
+++ b/app/code/Magento/Catalog/view/adminhtml/requirejs-config.js
@@ -10,6 +10,7 @@ var config = {
             newCategoryDialog:    'Magento_Catalog/js/new-category-dialog',
             categoryTree:         'Magento_Catalog/js/category-tree',
             productGallery:       'Magento_Catalog/js/product-gallery',
+            galleryUseDefault:    'Magento_Catalog/js/product-gallery-use-default',
             baseImage:            'Magento_Catalog/catalog/base-image-uploader',
             productAttributes:    'Magento_Catalog/catalog/product-attributes',
             categoryCheckboxTree: 'Magento_Catalog/js/category-checkbox-tree'

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/helper/gallery.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/helper/gallery.phtml
@@ -7,9 +7,28 @@
 // @codingStandardsIgnoreFile
 
 /** @var $block \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content */
-$elementName = $block->getElement()->getName() . '[images]';
+/** @var $element \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery*/
+$element = $block->getElement();
+$elementName = $element->getName() . '[images]';
+$useDefaultChecked = $element->usedDefaultGallery() ? 'checked' : '';
+$useDefaultHtmlId = $element->getUseDefaultHtmlId();
+$overlayClass = 'product-gallery-block-overlay';
 $formName = $block->getFormName();
 ?>
+
+<?php if ($block->hasUseDefault()) :?>
+    <div class="admin__field-service">
+        <input type="checkbox"
+               id="<?= $block->escapeHtml($useDefaultHtmlId) ?>"
+               class="admin__control-checkbox"
+               name="<?= $block->escapeHtml($element->getUserDefaultName()) ?>"
+               data-form-part="<?= $block->escapeHtml($formName) ?>" <?= $block->escapeHtml($useDefaultChecked) ?> >
+        <label class="admin__field-label" for="<?= $block->escapeHtml($useDefaultHtmlId) ?>">
+            <?= $block->escapeHtml(__('Use Default Values')) ?>
+        </label>
+    </div>
+<?php endif ?>
+
 <div id="<?= $block->getHtmlId() ?>"
      class="gallery"
      data-mage-init='{"productGallery":{"template":"#<?= $block->getHtmlId() ?>-template"}}'
@@ -215,6 +234,21 @@ $formName = $block->getFormName();
             </div>
     </script>
     <?= $block->getChildHtml('new-video') ?>
+
+    <?php if ($block->hasUseDefault()) :?>
+        <div class="<?= $block->escapeHtml($overlayClass) ?>"></div>
+
+        <script type="text/x-magento-init">
+            {
+                "#<?= $block->escapeHtml($useDefaultHtmlId) ?>" : {
+                    "galleryUseDefault" : {
+                        "overlayId": ".<?= $block->escapeHtml($overlayClass) ?>"
+                    }
+                }
+            }
+        </script>
+    <?php endif;?>
+    
 </div>
 <script>
     jQuery('body').trigger('contentUpdated');

--- a/app/code/Magento/Catalog/view/adminhtml/web/js/product-gallery-use-default.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/product-gallery-use-default.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define([
+    'jquery'
+], function ($) {
+    'use strict';
+
+    return function (params, inputSelector) {
+        var overlay = $(params.overlayId);
+
+        $(inputSelector).on('change', function (event) {
+            if ($(event.target).prop('checked')) {
+                overlay.show();
+            } else {
+                overlay.hide();
+            }
+        });
+
+        $(inputSelector).triggerHandler('change');
+    };
+});
+


### PR DESCRIPTION
### Fixed Issues
This pull request provides an implementation of the p.1 Required Fix from the following issue:
https://github.com/magento/community-features/issues/23

### Manual testing scenarios
_Initial check (on a new product)_
1. Go to Catalog -> Products
2. Create a new product
3. Upload any image(s) to the product's gallery
4. Save the product
5. Change Store View to any value (except All Store Views)
6. Unfold "Images and Videos"

Expected result: checkbox "Use Default Values" is visible and checked, any actions with existing images are blocked by overlay

_Edit gallery in Store View scope_
1. Go to "Edit" page of any product, that has a gallery, but does not have gallery values on store level
2. Change Store View to any value (except All Store Views)
3. Uncheck "Use Default Values" checkbox
4. Make any change (e.g. change images order)
5. Save the product

Expected result: checkbox "Use Default Values" is not checked, overlay is not displayed, changes on store level are applied

_Reset galley attributes to Default_
1. Go to "Edit" page of any product, that has gallery values on store level
2. Change Store View to any value (except All Store Views)
3. Check "Use Default Values" checkbox
5. Save the product

Expected result: after checkbox "Use Default Values" is checked - overlay is displayed, after save - gallery attributes of store level are removed.

### Related pull requests
ProductVideo: https://github.com/magento/magento2/pull/21041
Theme: https://github.com/magento/magento2/pull/21369

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
