### PR TITLE
Added 'Pending Reviews' menu item and corrected ACL label

### DIFF
--- a/app/code/Magento/Review/Block/Adminhtml/Edit.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Edit.php
@@ -159,13 +159,13 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
         }
 
         if ($this->getRequest()->getParam('ret', false) == 'pending') {
-            $this->buttonList->update('back', 'onclick', 'setLocation(\'' . $this->getUrl('catalog/*/pending') . '\')');
+            $this->buttonList->update('back', 'onclick', 'setLocation(\'' . $this->getUrl('*/*/pending') . '\')');
             $this->buttonList->update(
                 'delete',
                 'onclick',
                 'deleteConfirm(' . '\'' . __(
                     'Are you sure you want to do this?'
-                ) . '\' ' . '\'' . $this->getUrl(
+                ) . '\', ' . '\'' . $this->getUrl(
                     '*/*/delete',
                     [$this->_objectId => $this->getRequest()->getParam($this->_objectId), 'ret' => 'pending']
                 ) . '\'' . ')'

--- a/app/code/Magento/Review/Controller/Adminhtml/Product.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product.php
@@ -69,7 +69,7 @@ abstract class Product extends Action
     {
         switch ($this->getRequest()->getActionName()) {
             case 'pending':
-                return $this->_authorization->isAllowed('Magento_Review::pending');
+                return $this->_authorization->isAllowed('Magento_Review::reviews_pending');
                 break;
             default:
                 return $this->_authorization->isAllowed('Magento_Review::reviews_all');

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/Pending.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/Pending.php
@@ -24,6 +24,7 @@ class Pending extends ProductController
         }
         /** @var \Magento\Backend\Model\View\Result\Page $resultPage */
         $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
+        $resultPage->setActiveMenu('Magento_Review::catalog_reviews_ratings_reviews_pending');
         $resultPage->getConfig()->getTitle()->prepend(__('Customer Reviews'));
         $resultPage->getConfig()->getTitle()->prepend(__('Pending Reviews'));
         $this->coreRegistry->register('usePendingFilter', true);

--- a/app/code/Magento/Review/etc/acl.xml
+++ b/app/code/Magento/Review/etc/acl.xml
@@ -16,8 +16,8 @@
                 </resource>
                 <resource id="Magento_Backend::marketing">
                     <resource id="Magento_Backend::marketing_user_content">
-                        <resource id="Magento_Review::reviews_all" title="Reviews" translate="title" sortOrder="10"/>
-                        <resource id="Magento_Review::pending" title="Reviews" translate="title" sortOrder="20"/>
+                        <resource id="Magento_Review::reviews_all" title="All Reviews" translate="title" sortOrder="10"/>
+                        <resource id="Magento_Review::reviews_pending" title="Pending Reviews" translate="title" sortOrder="20"/>
                     </resource>
                 </resource>
             </resource>

--- a/app/code/Magento/Review/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Review/etc/adminhtml/menu.xml
@@ -8,7 +8,8 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
     <menu>
         <add id="Magento_Review::catalog_reviews_ratings_ratings" title="Rating" translate="title" module="Magento_Review" sortOrder="60" parent="Magento_Backend::stores_attributes" action="review/rating/" resource="Magento_Review::ratings"/>
-        <add id="Magento_Review::catalog_reviews_ratings_reviews_all" title="Reviews" translate="title" module="Magento_Review" parent="Magento_Backend::marketing_user_content" sortOrder="10" action="review/product/index" resource="Magento_Review::reviews_all"/>
+        <add id="Magento_Review::catalog_reviews_ratings_reviews_all" title="All Reviews" translate="title" module="Magento_Review" parent="Magento_Backend::marketing_user_content" sortOrder="10" action="review/product/index" resource="Magento_Review::reviews_all"/>
+        <add id="Magento_Review::catalog_reviews_ratings_reviews_pending" title="Pending Reviews" translate="title" module="Magento_Review" parent="Magento_Backend::marketing_user_content" sortOrder="10" action="review/product/pending" resource="Magento_Review::reviews_pending"/>
         <add id="Magento_Review::report_review" title="Reviews" translate="title" module="Magento_Reports" sortOrder="20" parent="Magento_Reports::report" resource="Magento_Reports::review"/>
         <add id="Magento_Review::report_review_customer" title="By Customers" translate="title" sortOrder="10" module="Magento_Review" parent="Magento_Review::report_review" action="reports/report_review/customer" resource="Magento_Reports::review_customer"/>
         <add id="Magento_Review::report_review_product" title="By Products" translate="title" sortOrder="20" module="Magento_Review" parent="Magento_Review::report_review" action="reports/report_review/product" resource="Magento_Reports::review_product"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. Added missing menu item "Pending Reviews" under the admin menu path Marketing > User Content
2. There were duplicate ACL items with text 'Reviews' under System > User Roles > Add New Role > Role Resources. So renamed one to 'All Reviews' and another one to "Pending Reviews"

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20924: Reviews ACL issue - showing Reviews menu two times under System > User Roles > Add New Role > Role Resources

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Verified grid content at the new menu item Marketing > User Content > Pending Reviews
2. Verified ACL access by creating a new admin user with and without the access of 'Pending Reviews' section

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
