### PR TITLE
Fix broken admin order after emptying order and readding items

### DIFF
--- a/app/code/Magento/Checkout/etc/di.xml
+++ b/app/code/Magento/Checkout/etc/di.xml
@@ -49,7 +49,4 @@
             </argument>
         </arguments>
     </type>
-    <type name="Magento\Quote\Model\Quote">
-        <plugin name="clear_addresses_after_product_delete" type="Magento\Checkout\Plugin\Model\Quote\ResetQuoteAddresses"/>
-    </type>
 </config>

--- a/app/code/Magento/Checkout/etc/frontend/di.xml
+++ b/app/code/Magento/Checkout/etc/frontend/di.xml
@@ -95,4 +95,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Quote\Model\Quote">
+        <plugin name="clear_addresses_after_product_delete" type="Magento\Checkout\Plugin\Model\Quote\ResetQuoteAddresses"/>
+    </type>
 </config>

--- a/dev/tests/integration/testsuite/Magento/Checkout/Plugin/Model/Quote/ResetQuoteAddressesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Plugin/Model/Quote/ResetQuoteAddressesTest.php
@@ -21,6 +21,7 @@ class ResetQuoteAddressesTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @magentoDataFixture Magento/Checkout/_files/quote_with_virtual_product_and_address.php
+     * @magentoAppArea frontend
      *
      * @return void
      */


### PR DESCRIPTION
### Description (*)
After filling in a backend Magento Admin new order and then removing all items from the order creation screen, when you then add an item back in you cannot select any shipping rates and "Sorry, no quotes are available" appears until you modify the address to cause it to re-save the address.

Investigation shows the following commit causes this regression by wiping the address from the database when last item is removed from the quote, even though in Magento Admin the address should still remain.
https://github.com/magento/magento2/commit/4c5372df21dd3a32b79f7162b46e4907fea8fc40

### Manual testing scenarios (*)
1. Login to Magento Admin and go to Sales, Orders and click Create New Order
2. Click Create New Customer
3. Enter a product into the order and complete the email and address fields, unticking shipping same as billing and filling in another address in the shipping address
4. Shipping methods will be visible
5. Now empty the product list and then add another product back in
6. Click get shipping in the shipping area, if there is a link to do so
7. Note it says Sorry, no quotes available even though the address is filled in above
8. Modify address such as telephone number and retry - the shipping methods now appear

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)