### PR TITLE
Allow redis compression options to be specified during `setup:install` process

### DIFF
--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
@@ -28,7 +28,7 @@ class Cache implements ConfigOptionsListInterface
     const INPUT_KEY_CACHE_BACKEND_REDIS_PORT = 'cache-backend-redis-port';
     const INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD = 'cache-backend-redis-password';
     const INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESS_DATA = 'cache-backend-redis-compress-data';
-    const INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY = 'cache-backend-redis-compression-library';
+    const INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIB = 'cache-backend-redis-compression-lib';
     const INPUT_KEY_CACHE_ID_PREFIX = 'cache-id-prefix';
 
     const CONFIG_PATH_CACHE_BACKEND = 'cache/frontend/default/backend';
@@ -37,7 +37,7 @@ class Cache implements ConfigOptionsListInterface
     const CONFIG_PATH_CACHE_BACKEND_PORT = 'cache/frontend/default/backend_options/port';
     const CONFIG_PATH_CACHE_BACKEND_PASSWORD = 'cache/frontend/default/backend_options/password';
     const CONFIG_PATH_CACHE_BACKEND_COMPRESS_DATA = 'cache/frontend/default/backend_options/compress_data';
-    const CONFIG_PATH_CACHE_BACKEND_COMPRESSION_LIBRARY = 'cache/frontend/default/backend_options/compression_library';
+    const CONFIG_PATH_CACHE_BACKEND_COMPRESSION_LIB = 'cache/frontend/default/backend_options/compression_lib';
     const CONFIG_PATH_CACHE_ID_PREFIX = 'cache/frontend/default/id_prefix';
 
     /**
@@ -49,7 +49,7 @@ class Cache implements ConfigOptionsListInterface
         self::INPUT_KEY_CACHE_BACKEND_REDIS_PORT => '6379',
         self::INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD => '',
         self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESS_DATA => '1',
-        self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY => '',
+        self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIB => '',
     ];
 
     /**
@@ -68,7 +68,7 @@ class Cache implements ConfigOptionsListInterface
         self::INPUT_KEY_CACHE_BACKEND_REDIS_PORT => self::CONFIG_PATH_CACHE_BACKEND_PORT,
         self::INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD => self::CONFIG_PATH_CACHE_BACKEND_PASSWORD,
         self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESS_DATA => self::CONFIG_PATH_CACHE_BACKEND_COMPRESS_DATA,
-        self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY => self::CONFIG_PATH_CACHE_BACKEND_COMPRESSION_LIBRARY,
+        self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIB => self::CONFIG_PATH_CACHE_BACKEND_COMPRESSION_LIB,
     ];
 
     /**
@@ -130,10 +130,10 @@ class Cache implements ConfigOptionsListInterface
                 'Set to 0 to disable compression (default is 1, enabled)'
             ),
             new TextConfigOption(
-                self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY,
+                self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIB,
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
-                self::CONFIG_PATH_CACHE_BACKEND_COMPRESSION_LIBRARY,
-                'Compression library to use [snappy,lzf,l4z,zstd,gzip] (leave blank to determine automatically)'
+                self::CONFIG_PATH_CACHE_BACKEND_COMPRESSION_LIB,
+                'Compression lib to use [snappy,lzf,l4z,zstd,gzip] (leave blank to determine automatically)'
             ),
             new TextConfigOption(
                 self::INPUT_KEY_CACHE_ID_PREFIX,

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
@@ -27,6 +27,8 @@ class Cache implements ConfigOptionsListInterface
     const INPUT_KEY_CACHE_BACKEND_REDIS_DATABASE = 'cache-backend-redis-db';
     const INPUT_KEY_CACHE_BACKEND_REDIS_PORT = 'cache-backend-redis-port';
     const INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD = 'cache-backend-redis-password';
+    const INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESS_DATA = 'cache-backend-redis-compress-data';
+    const INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY = 'cache-backend-redis-compression-library';
     const INPUT_KEY_CACHE_ID_PREFIX = 'cache-id-prefix';
 
     const CONFIG_PATH_CACHE_BACKEND = 'cache/frontend/default/backend';
@@ -34,6 +36,8 @@ class Cache implements ConfigOptionsListInterface
     const CONFIG_PATH_CACHE_BACKEND_DATABASE = 'cache/frontend/default/backend_options/database';
     const CONFIG_PATH_CACHE_BACKEND_PORT = 'cache/frontend/default/backend_options/port';
     const CONFIG_PATH_CACHE_BACKEND_PASSWORD = 'cache/frontend/default/backend_options/password';
+    const CONFIG_PATH_CACHE_BACKEND_COMPRESS_DATA = 'cache/frontend/default/backend_options/compress_data';
+    const CONFIG_PATH_CACHE_BACKEND_COMPRESSION_LIBRARY = 'cache/frontend/default/backend_options/compression_library';
     const CONFIG_PATH_CACHE_ID_PREFIX = 'cache/frontend/default/id_prefix';
 
     /**
@@ -43,7 +47,9 @@ class Cache implements ConfigOptionsListInterface
         self::INPUT_KEY_CACHE_BACKEND_REDIS_SERVER => '127.0.0.1',
         self::INPUT_KEY_CACHE_BACKEND_REDIS_DATABASE => '0',
         self::INPUT_KEY_CACHE_BACKEND_REDIS_PORT => '6379',
-        self::INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD => ''
+        self::INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD => '',
+        self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESS_DATA => '0',
+        self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY => '',
     ];
 
     /**
@@ -60,7 +66,9 @@ class Cache implements ConfigOptionsListInterface
         self::INPUT_KEY_CACHE_BACKEND_REDIS_SERVER => self::CONFIG_PATH_CACHE_BACKEND_SERVER,
         self::INPUT_KEY_CACHE_BACKEND_REDIS_DATABASE => self::CONFIG_PATH_CACHE_BACKEND_DATABASE,
         self::INPUT_KEY_CACHE_BACKEND_REDIS_PORT => self::CONFIG_PATH_CACHE_BACKEND_PORT,
-        self::INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD => self::CONFIG_PATH_CACHE_BACKEND_PASSWORD
+        self::INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD => self::CONFIG_PATH_CACHE_BACKEND_PASSWORD,
+        self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESS_DATA => self::CONFIG_PATH_CACHE_BACKEND_COMPRESS_DATA,
+        self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY => self::CONFIG_PATH_CACHE_BACKEND_COMPRESSION_LIBRARY,
     ];
 
     /**
@@ -116,11 +124,23 @@ class Cache implements ConfigOptionsListInterface
                 'Redis server password'
             ),
             new TextConfigOption(
+                self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESS_DATA,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_CACHE_BACKEND_COMPRESS_DATA,
+                'Set to 1 to compress the cache (use 0 to disable)'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_CACHE_BACKEND_COMPRESSION_LIBRARY,
+                'Compression library to use [snappy,lzf,l4z,zstd,gzip] (leave blank to determine automatically)'
+            ),
+            new TextConfigOption(
                 self::INPUT_KEY_CACHE_ID_PREFIX,
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
                 self::CONFIG_PATH_CACHE_ID_PREFIX,
                 'ID prefix for cache keys'
-            )
+            ),
         ];
     }
 

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
@@ -48,7 +48,7 @@ class Cache implements ConfigOptionsListInterface
         self::INPUT_KEY_CACHE_BACKEND_REDIS_DATABASE => '0',
         self::INPUT_KEY_CACHE_BACKEND_REDIS_PORT => '6379',
         self::INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD => '',
-        self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESS_DATA => '0',
+        self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESS_DATA => '1',
         self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY => '',
     ];
 
@@ -127,7 +127,7 @@ class Cache implements ConfigOptionsListInterface
                 self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESS_DATA,
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
                 self::CONFIG_PATH_CACHE_BACKEND_COMPRESS_DATA,
-                'Set to 1 to compress the cache (use 0 to disable)'
+                'Set to 0 to disable compression (default is 1, enabled)'
             ),
             new TextConfigOption(
                 self::INPUT_KEY_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY,

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php
@@ -6,10 +6,10 @@
 
 namespace Magento\Setup\Model\ConfigOptionsList;
 
-use Magento\Framework\Setup\ConfigOptionsListInterface;
-use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Config\Data\ConfigData;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Setup\ConfigOptionsListInterface;
 use Magento\Framework\Setup\Option\SelectConfigOption;
 use Magento\Framework\Setup\Option\TextConfigOption;
 use Magento\Setup\Validator\RedisConnectionValidator;
@@ -68,7 +68,8 @@ class PageCache implements ConfigOptionsListInterface
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PORT => self::CONFIG_PATH_PAGE_CACHE_BACKEND_PORT,
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD => self::CONFIG_PATH_PAGE_CACHE_BACKEND_PASSWORD,
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA => self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESS_DATA,
-        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIB => self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESSION_LIB,
+        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIB =>
+            self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESSION_LIB,
     ];
 
     /**
@@ -234,7 +235,7 @@ class PageCache implements ConfigOptionsListInterface
                 self::CONFIG_PATH_PAGE_CACHE_BACKEND_DATABASE,
                 $this->getDefaultConfigValue(self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_DATABASE)
             );
-        
+
         $config['password'] = isset($options[self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD])
             ? $options[self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD]
             : $deploymentConfig->get(

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php
@@ -26,16 +26,18 @@ class PageCache implements ConfigOptionsListInterface
     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_SERVER = 'page-cache-redis-server';
     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_DATABASE = 'page-cache-redis-db';
     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PORT = 'page-cache-redis-port';
-    const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA = 'page-cache-redis-compress-data';
     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD = 'page-cache-redis-password';
+    const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA = 'page-cache-redis-compress-data';
+    const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY = 'page-cache-redis-compression-library';
     const INPUT_KEY_PAGE_CACHE_ID_PREFIX = 'page-cache-id-prefix';
 
     const CONFIG_PATH_PAGE_CACHE_BACKEND = 'cache/frontend/page_cache/backend';
     const CONFIG_PATH_PAGE_CACHE_BACKEND_SERVER = 'cache/frontend/page_cache/backend_options/server';
     const CONFIG_PATH_PAGE_CACHE_BACKEND_DATABASE = 'cache/frontend/page_cache/backend_options/database';
     const CONFIG_PATH_PAGE_CACHE_BACKEND_PORT = 'cache/frontend/page_cache/backend_options/port';
-    const CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESS_DATA = 'cache/frontend/page_cache/backend_options/compress_data';
     const CONFIG_PATH_PAGE_CACHE_BACKEND_PASSWORD = 'cache/frontend/page_cache/backend_options/password';
+    const CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESS_DATA = 'cache/frontend/page_cache/backend_options/compress_data';
+    const CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESSION_LIBRARY = 'cache/frontend/page_cache/backend_options/compression_library';
     const CONFIG_PATH_PAGE_CACHE_ID_PREFIX = 'cache/frontend/page_cache/id_prefix';
 
     /**
@@ -45,8 +47,9 @@ class PageCache implements ConfigOptionsListInterface
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_SERVER => '127.0.0.1',
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_DATABASE => '1',
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PORT => '6379',
+        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD => '',
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA => '0',
-        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD => ''
+        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY => '',
     ];
 
     /**
@@ -63,8 +66,9 @@ class PageCache implements ConfigOptionsListInterface
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_SERVER => self::CONFIG_PATH_PAGE_CACHE_BACKEND_SERVER,
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_DATABASE => self::CONFIG_PATH_PAGE_CACHE_BACKEND_DATABASE,
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PORT => self::CONFIG_PATH_PAGE_CACHE_BACKEND_PORT,
+        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD => self::CONFIG_PATH_PAGE_CACHE_BACKEND_PASSWORD,
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA => self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESS_DATA,
-        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD => self::CONFIG_PATH_PAGE_CACHE_BACKEND_PASSWORD
+        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY => self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESSION_LIBRARY,
     ];
 
     /**
@@ -114,23 +118,29 @@ class PageCache implements ConfigOptionsListInterface
                 'Redis server listen port'
             ),
             new TextConfigOption(
-                self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA,
-                TextConfigOption::FRONTEND_WIZARD_TEXT,
-                self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESS_DATA,
-                'Set to 1 to compress the full page cache (use 0 to disable)'
-            ),
-            new TextConfigOption(
                 self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD,
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
                 self::CONFIG_PATH_PAGE_CACHE_BACKEND_PASSWORD,
                 'Redis server password'
             ),
             new TextConfigOption(
+                self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESS_DATA,
+                'Set to 1 to compress the full page cache (use 0 to disable)'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESSION_LIBRARY,
+                'Compression library to use [snappy,lzf,l4z,zstd,gzip] (leave blank to determine automatically)'
+            ),
+            new TextConfigOption(
                 self::INPUT_KEY_PAGE_CACHE_ID_PREFIX,
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
                 self::CONFIG_PATH_PAGE_CACHE_ID_PREFIX,
                 'ID prefix for cache keys'
-            )
+            ),
         ];
     }
 

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php
@@ -28,7 +28,7 @@ class PageCache implements ConfigOptionsListInterface
     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PORT = 'page-cache-redis-port';
     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD = 'page-cache-redis-password';
     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA = 'page-cache-redis-compress-data';
-    const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY = 'page-cache-redis-compression-library';
+    const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIB = 'page-cache-redis-compression-lib';
     const INPUT_KEY_PAGE_CACHE_ID_PREFIX = 'page-cache-id-prefix';
 
     const CONFIG_PATH_PAGE_CACHE_BACKEND = 'cache/frontend/page_cache/backend';
@@ -37,7 +37,7 @@ class PageCache implements ConfigOptionsListInterface
     const CONFIG_PATH_PAGE_CACHE_BACKEND_PORT = 'cache/frontend/page_cache/backend_options/port';
     const CONFIG_PATH_PAGE_CACHE_BACKEND_PASSWORD = 'cache/frontend/page_cache/backend_options/password';
     const CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESS_DATA = 'cache/frontend/page_cache/backend_options/compress_data';
-    const CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESSION_LIBRARY = 'cache/frontend/page_cache/backend_options/compression_library';
+    const CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESSION_LIB = 'cache/frontend/page_cache/backend_options/compression_lib';
     const CONFIG_PATH_PAGE_CACHE_ID_PREFIX = 'cache/frontend/page_cache/id_prefix';
 
     /**
@@ -49,7 +49,7 @@ class PageCache implements ConfigOptionsListInterface
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PORT => '6379',
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD => '',
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA => '0',
-        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY => '',
+        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIB => '',
     ];
 
     /**
@@ -68,7 +68,7 @@ class PageCache implements ConfigOptionsListInterface
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PORT => self::CONFIG_PATH_PAGE_CACHE_BACKEND_PORT,
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD => self::CONFIG_PATH_PAGE_CACHE_BACKEND_PASSWORD,
         self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA => self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESS_DATA,
-        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY => self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESSION_LIBRARY,
+        self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIB => self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESSION_LIB,
     ];
 
     /**
@@ -130,9 +130,9 @@ class PageCache implements ConfigOptionsListInterface
                 'Set to 1 to compress the full page cache (use 0 to disable)'
             ),
             new TextConfigOption(
-                self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIBRARY,
+                self::INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESSION_LIB,
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
-                self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESSION_LIBRARY,
+                self::CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESSION_LIB,
                 'Compression library to use [snappy,lzf,l4z,zstd,gzip] (leave blank to determine automatically)'
             ),
             new TextConfigOption(

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
@@ -78,7 +78,6 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey(7, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[7]);
         $this->assertEquals('cache-id-prefix', $options[7]->getName());
-
     }
 
     /**

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
@@ -45,7 +45,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
     public function testGetOptions()
     {
         $options = $this->configOptionsList->getOptions();
-        $this->assertCount(6, $options);
+        $this->assertCount(8, $options);
 
         $this->assertArrayHasKey(0, $options);
         $this->assertInstanceOf(SelectConfigOption::class, $options[0]);
@@ -98,7 +98,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                             'port' => '',
                             'database' => '',
                             'password' => '',
-                            'compress_data' => '0',
+                            'compress_data' => '1',
                             'compression_library' => '',
                         ],
                         'id_prefix' => $this->expectedIdPrefix(),

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
@@ -68,8 +68,17 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('cache-backend-redis-password', $options[4]->getName());
 
         $this->assertArrayHasKey(5, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[6]);
+        $this->assertEquals('cache-backend-redis-compress-data', $options[6]->getName());
+
+        $this->assertArrayHasKey(6, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[7]);
+        $this->assertEquals('cache-backend-redis-compression-library', $options[7]->getName());
+
+        $this->assertArrayHasKey(7, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[5]);
         $this->assertEquals('cache-id-prefix', $options[5]->getName());
+
     }
 
     /**
@@ -88,7 +97,9 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                             'server' => '',
                             'port' => '',
                             'database' => '',
-                            'password' => ''
+                            'password' => '',
+                            'compress_data' => '0',
+                            'compression_library' => '',
                         ],
                         'id_prefix' => $this->expectedIdPrefix(),
                     ]
@@ -115,18 +126,23 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                             'server' => 'localhost',
                             'port' => '1234',
                             'database' => '5',
-                            'password' => ''
+                            'password' => '',
+                            'compress_data' => '1',
+                            'compression_library' => 'gzip',
                         ],
                         'id_prefix' => $this->expectedIdPrefix(),
                     ]
                 ]
             ]
         ];
+
         $options = [
             'cache-backend' => 'redis',
             'cache-backend-redis-server' => 'localhost',
             'cache-backend-redis-port' => '1234',
-            'cache-backend-redis-db' => '5'
+            'cache-backend-redis-db' => '5',
+            'cache-backend-redis-compress-data' => '1',
+            'cache-backend-redis-compression-library' => 'gzip'
         ];
 
         $configData = $this->configOptionsList->createConfig($options, $this->deploymentConfigMock);

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
@@ -98,7 +98,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                             'port' => '',
                             'database' => '',
                             'password' => '',
-                            'compress_data' => '1',
+                            'compress_data' => '',
                             'compression_library' => '',
                         ],
                         'id_prefix' => $this->expectedIdPrefix(),

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
@@ -73,7 +73,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
 
         $this->assertArrayHasKey(6, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[7]);
-        $this->assertEquals('cache-backend-redis-compression-library', $options[7]->getName());
+        $this->assertEquals('cache-backend-redis-compression-lib', $options[7]->getName());
 
         $this->assertArrayHasKey(7, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[5]);
@@ -99,7 +99,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                             'database' => '',
                             'password' => '',
                             'compress_data' => '',
-                            'compression_library' => '',
+                            'compression_lib' => '',
                         ],
                         'id_prefix' => $this->expectedIdPrefix(),
                     ]
@@ -128,7 +128,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                             'database' => '5',
                             'password' => '',
                             'compress_data' => '1',
-                            'compression_library' => 'gzip',
+                            'compression_lib' => 'gzip',
                         ],
                         'id_prefix' => $this->expectedIdPrefix(),
                     ]
@@ -142,7 +142,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
             'cache-backend-redis-port' => '1234',
             'cache-backend-redis-db' => '5',
             'cache-backend-redis-compress-data' => '1',
-            'cache-backend-redis-compression-library' => 'gzip'
+            'cache-backend-redis-compression-lib' => 'gzip'
         ];
 
         $configData = $this->configOptionsList->createConfig($options, $this->deploymentConfigMock);

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
@@ -68,16 +68,16 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('cache-backend-redis-password', $options[4]->getName());
 
         $this->assertArrayHasKey(5, $options);
-        $this->assertInstanceOf(TextConfigOption::class, $options[6]);
-        $this->assertEquals('cache-backend-redis-compress-data', $options[6]->getName());
+        $this->assertInstanceOf(TextConfigOption::class, $options[5]);
+        $this->assertEquals('cache-backend-redis-compress-data', $options[5]->getName());
 
         $this->assertArrayHasKey(6, $options);
-        $this->assertInstanceOf(TextConfigOption::class, $options[7]);
-        $this->assertEquals('cache-backend-redis-compression-lib', $options[7]->getName());
+        $this->assertInstanceOf(TextConfigOption::class, $options[6]);
+        $this->assertEquals('cache-backend-redis-compression-lib', $options[6]->getName());
 
         $this->assertArrayHasKey(7, $options);
-        $this->assertInstanceOf(TextConfigOption::class, $options[5]);
-        $this->assertEquals('cache-id-prefix', $options[5]->getName());
+        $this->assertInstanceOf(TextConfigOption::class, $options[7]);
+        $this->assertEquals('cache-id-prefix', $options[7]->getName());
 
     }
 

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
@@ -78,7 +78,6 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey(7, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[7]);
         $this->assertEquals('page-cache-id-prefix', $options[7]->getName());
-
     }
 
     /**

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
@@ -65,15 +65,20 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
 
         $this->assertArrayHasKey(4, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[4]);
-        $this->assertEquals('page-cache-redis-compress-data', $options[4]->getName());
+        $this->assertEquals('page-cache-redis-password', $options[4]->getName());
 
         $this->assertArrayHasKey(5, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[5]);
-        $this->assertEquals('page-cache-redis-password', $options[5]->getName());
+        $this->assertEquals('page-cache-redis-compress-data', $options[5]->getName());
 
         $this->assertArrayHasKey(6, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[6]);
-        $this->assertEquals('page-cache-id-prefix', $options[6]->getName());
+        $this->assertEquals('page-cache-redis-compression-library', $options[6]->getName());
+
+        $this->assertArrayHasKey(7, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[7]);
+        $this->assertEquals('page-cache-id-prefix', $options[7]->getName());
+
     }
 
     /**
@@ -93,7 +98,8 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
                             'port' => '',
                             'database' => '',
                             'compress_data' => '',
-                            'password' => ''
+                            'password' => '',
+                            'compression_library' => '',
                         ],
                         'id_prefix' => $this->expectedIdPrefix(),
                     ]
@@ -120,8 +126,9 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
                             'server' => 'foo.bar',
                             'port' => '9000',
                             'database' => '6',
+                            'password' => '',
                             'compress_data' => '1',
-                            'password' => ''
+                            'compression_library' => 'gzip',
                         ],
                         'id_prefix' => $this->expectedIdPrefix(),
                     ]
@@ -134,7 +141,8 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
             'page-cache-redis-server' => 'foo.bar',
             'page-cache-redis-port' => '9000',
             'page-cache-redis-db' => '6',
-            'page-cache-redis-compress-data' => '1'
+            'page-cache-redis-compress-data' => '1',
+            'page-cache-redis-compression-library' => 'gzip',
         ];
 
         $configData = $this->configList->createConfig($options, $this->deploymentConfigMock);

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
@@ -45,7 +45,7 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
     public function testGetOptions()
     {
         $options = $this->configList->getOptions();
-        $this->assertCount(7, $options);
+        $this->assertCount(8, $options);
 
         $this->assertArrayHasKey(0, $options);
         $this->assertInstanceOf(SelectConfigOption::class, $options[0]);

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
@@ -73,7 +73,7 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
 
         $this->assertArrayHasKey(6, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[6]);
-        $this->assertEquals('page-cache-redis-compression-library', $options[6]->getName());
+        $this->assertEquals('page-cache-redis-compression-lib', $options[6]->getName());
 
         $this->assertArrayHasKey(7, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[7]);
@@ -99,7 +99,7 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
                             'database' => '',
                             'compress_data' => '',
                             'password' => '',
-                            'compression_library' => '',
+                            'compression_lib' => '',
                         ],
                         'id_prefix' => $this->expectedIdPrefix(),
                     ]
@@ -128,7 +128,7 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
                             'database' => '6',
                             'password' => '',
                             'compress_data' => '1',
-                            'compression_library' => 'gzip',
+                            'compression_lib' => 'gzip',
                         ],
                         'id_prefix' => $this->expectedIdPrefix(),
                     ]
@@ -142,7 +142,7 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
             'page-cache-redis-port' => '9000',
             'page-cache-redis-db' => '6',
             'page-cache-redis-compress-data' => '1',
-            'page-cache-redis-compression-library' => 'gzip',
+            'page-cache-redis-compression-lib' => 'gzip',
         ];
 
         $configData = $this->configList->createConfig($options, $this->deploymentConfigMock);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

When installing magento, "some" redis cache specific options can be specified. The defaults are usually okay, but in some scenarios they need to be changed.

This PR provides the ability to set the compress_data and compression_lib options consistently for default/backend/redis and page_cache/redis.

Providing these options is preferred over hand-rolled `app/etc/env.php` "fiddling" when executing a repeatable installation test for the purpose of environment validation.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. n/a


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. `--cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-port=6379 --cache-backend-redis-db=3 --page-cache=redis  --page-cache-redis-server=127.0.0.1  --page-cache-redis-port=6379  --page-cache-redis-db=4 --cache-backend-redis-compression-lib=lzf --cache-backend-redis-compress-data=1`
2. results in the appropriate change in `app/etc/env.php`
```
...
    'cache' => [
        'frontend' => [
            'default' => [
                'id_prefix' => '74c_',
                'backend' => 'Cm_Cache_Backend_Redis',
                'backend_options' => [
                    'server' => '127.0.0.1',
                    'database' => '3',
                    'port' => '6379',
                    'password' => '',
                    'compress_data' => '1',
                    'compression_lib' => 'lzf'
                ]
            ],
            'page_cache' => [
                'id_prefix' => '74c_',
                'backend' => 'Cm_Cache_Backend_Redis',
                'backend_options' => [
                    'server' => '127.0.0.1',
                    'database' => '4',
                    'port' => '6379',
                    'compress_data' => '1',
                    'password' => '',
                    'compression_lib' => ''
                ]
            ]
        ]
    ]
```
3. installation process should complete and site should function as expected.
4. `Cm_Cache_Backend_Redis` will throw an exception if an invalid `compression_lib` (eg: `notavalidlib`) is supplied and `compress_data` is enabled.
```
./bin/magento setup:install --cache-backend=redis --cache-backend-redis-compression-lib=notavalidlib --cache-backend-redis-compress-data=1
Starting Magento installation:
...
...
Running schema recurring...
In Redis.php line 1186:

  Unrecognized 'compression_lib'.

```
5. Any value can be set as the compression_lib if `compress_data` is disabled (compression will not be attempted).
```
./bin/magento setup:install --cache-backend=redis --cache-backend-redis-compression-lib=notavalidlib --cache-backend-redis-compress-data=0
Starting Magento installation:
...
...
[SUCCESS]: Magento installation complete.
...
```


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
