### PR TITLE
added min=0 to qty field product detail page

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
@@ -20,6 +20,7 @@
                 <input type="number"
                        name="qty"
                        id="qty"
+                       min="0"
                        value="<?= /* @escapeNotVerified */ $block->getProductDefaultQty() * 1 ?>"
                        title="<?= /* @escapeNotVerified */ __('Qty') ?>"
                        class="input-text qty"

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/configure/updatecart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/configure/updatecart.phtml
@@ -20,6 +20,7 @@
                     <input type="number"
                            name="qty"
                            id="qty"
+                           min="0"
                            value=""
                            title="<?= /* @escapeNotVerified */ __('Qty') ?>"
                            class="input-text qty"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
On product detail page it is possible to go to minus values using keyboard. Once the add to cart button is clicked validation error - "Please enter a quantity greater than 0" shown.



### Manual testing scenarios (*)

1.Go to product detail page
2. Decrease the qty by using arrow keys
 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
