### PR TITLE
Added space above color swatches on product page.

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
@@ -305,10 +305,10 @@
             &-listing {
                 margin-bottom: @indent__s;
             }
-
-            .swatch-attribute {
-				margin-bttom: @indent__s;
-			}
+		
+	    .swatch-attribute {
+		margin-bttom: @indent__s;
+	    }
         }
 
         &-more {

--- a/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
@@ -305,6 +305,10 @@
             &-listing {
                 margin-bottom: @indent__s;
             }
+
+            .swatch-attribute {
+				margin-bttom: @indent__s;
+			}
         }
 
         &-more {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
1. This is direct PR because it is small change.
2. Version magento 2.3
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Added space above color swatches on product page.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to frontend any product detail page look into color swatches. see attched screenshot.
2. Actual Result.
![actual-result](https://user-images.githubusercontent.com/43638601/52468349-793f3480-2bae-11e9-8af8-e68108d29b4c.jpg)
3. Expected Result.
![expected-result](https://user-images.githubusercontent.com/43638601/52468369-8bb96e00-2bae-11e9-88ae-49179328dff4.jpg)



### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
