### PR TITLE
Fix $attributes default value

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ImageFactory.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageFactory.php
@@ -131,10 +131,10 @@ class ImageFactory
      *
      * @param Product $product
      * @param string $imageId
-     * @param array|null $attributes
+     * @param array $attributes
      * @return ImageBlock
      */
-    public function create(Product $product, string $imageId, array $attributes = null): ImageBlock
+    public function create(Product $product, string $imageId, array $attributes = []): ImageBlock
     {
         $viewImageConfig = $this->presentationConfig->getViewConfig()->getMediaAttributes(
             'Magento_Catalog',


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The method `$this->getStringCustomAttributes($attributes)` causes Exception when `$attributes` value is `null`.
I think that default value for `$attributes` must be empty array because inside of getStringCustomAttributes() will try to do a foreach to a null value.

### Fixed Issues (if relevant)

$attributes default value now is empty array

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Inject ImageFactory in your construct method
2. Try to do $this->imageFactory->create($product, $imageId)
3. Will cause Exception

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
