### PR TITLE
Fix $attributes default value

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ImageFactory.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageFactory.php
@@ -160,7 +160,6 @@ class ImageFactory
             );
         }
 
-        $attributes = $attributes === null ? [] : $attributes;
         $data = [
             'data' => [
                 'template' => 'Magento_Catalog::product/image_with_borders.phtml',
@@ -169,7 +168,7 @@ class ImageFactory
                 'height' => $imageMiscParams['image_height'],
                 'label' => $this->getLabel($product, $imageMiscParams['image_type']),
                 'ratio' => $this->getRatio($imageMiscParams['image_width'], $imageMiscParams['image_height']),
-                'custom_attributes' => $this->getStringCustomAttributes($attributes),
+                'custom_attributes' => $this->getStringCustomAttributes((array) $attributes),
                 'class' => $this->getClass($attributes),
                 'product_id' => $product->getId()
             ],

--- a/app/code/Magento/Catalog/Block/Product/ImageFactory.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageFactory.php
@@ -160,6 +160,8 @@ class ImageFactory
             );
         }
 
+        $attributes = $attributes === null ? [] : $attributes;
+        
         $data = [
             'data' => [
                 'template' => 'Magento_Catalog::product/image_with_borders.phtml',
@@ -168,7 +170,7 @@ class ImageFactory
                 'height' => $imageMiscParams['image_height'],
                 'label' => $this->getLabel($product, $imageMiscParams['image_type']),
                 'ratio' => $this->getRatio($imageMiscParams['image_width'], $imageMiscParams['image_height']),
-                'custom_attributes' => $this->getStringCustomAttributes((array) $attributes),
+                'custom_attributes' => $this->getStringCustomAttributes($attributes),
                 'class' => $this->getClass($attributes),
                 'product_id' => $product->getId()
             ],

--- a/app/code/Magento/Catalog/Block/Product/ImageFactory.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageFactory.php
@@ -160,7 +160,7 @@ class ImageFactory
             );
         }
 
-        $attributes = (is_null($attributes)) ? [] : $attributes;
+        $attributes = $attributes === null ? [] : $attributes;
         $data = [
             'data' => [
                 'template' => 'Magento_Catalog::product/image_with_borders.phtml',

--- a/app/code/Magento/Catalog/Block/Product/ImageFactory.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageFactory.php
@@ -76,7 +76,6 @@ class ImageFactory
     private function getStringCustomAttributes(array $attributes): string
     {
         $result = [];
-        $attributes = (is_null($attributes)) ? [] : $attributes;
         foreach ($attributes as $name => $value) {
             if ($name != 'class') {
                 $result[] = $name . '="' . $value . '"';
@@ -161,6 +160,7 @@ class ImageFactory
             );
         }
 
+        $attributes = (is_null($attributes)) ? [] : $attributes;
         $data = [
             'data' => [
                 'template' => 'Magento_Catalog::product/image_with_borders.phtml',

--- a/app/code/Magento/Catalog/Block/Product/ImageFactory.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageFactory.php
@@ -76,6 +76,7 @@ class ImageFactory
     private function getStringCustomAttributes(array $attributes): string
     {
         $result = [];
+        $attributes = (is_null($attributes)) ? [] : $attributes;
         foreach ($attributes as $name => $value) {
             if ($name != 'class') {
                 $result[] = $name . '="' . $value . '"';
@@ -131,10 +132,10 @@ class ImageFactory
      *
      * @param Product $product
      * @param string $imageId
-     * @param array $attributes
+     * @param array|null $attributes
      * @return ImageBlock
      */
-    public function create(Product $product, string $imageId, array $attributes = []): ImageBlock
+    public function create(Product $product, string $imageId, array $attributes = null): ImageBlock
     {
         $viewImageConfig = $this->presentationConfig->getViewConfig()->getMediaAttributes(
             'Magento_Catalog',

--- a/app/code/Magento/Catalog/Block/Product/ImageFactory.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageFactory.php
@@ -131,10 +131,10 @@ class ImageFactory
      *
      * @param Product $product
      * @param string $imageId
-     * @param array|null $attributes
+     * @param array $attributes
      * @return ImageBlock
      */
-    public function create(Product $product, string $imageId, array $attributes = null): ImageBlock
+    public function create(Product $product, string $imageId, array $attributes = []): ImageBlock
     {
         $viewImageConfig = $this->presentationConfig->getViewConfig()->getMediaAttributes(
             'Magento_Catalog',


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The method `$this->getStringCustomAttributes($attributes)` causes Exception when `$attributes` value is `null`.
I think that default value for `$attributes` must be empty array because inside of getStringCustomAttributes() will try to do a foreach to a null value.

### Fixed Issues (if relevant)

$attributes default value now is empty array

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Inject ImageFactory in your construct method
2. Try to do $this->imageFactory->create($product, $imageId)
3. Will cause Exception

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
