### PR TITLE
Refactored Retrieval Of Entity ID To Make AbstractDataProvider Usable

### DIFF
--- a/app/code/Magento/Ui/Component/Form.php
+++ b/app/code/Magento/Ui/Component/Form.php
@@ -10,6 +10,7 @@ use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponentInterface;
 
 /**
+ * Ui component Form
  * @api
  * @since 100.0.2
  */
@@ -53,7 +54,7 @@ class Form extends AbstractComponent
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getDataSourceData()
     {

--- a/app/code/Magento/Ui/Component/Form.php
+++ b/app/code/Magento/Ui/Component/Form.php
@@ -60,7 +60,8 @@ class Form extends AbstractComponent
         $dataSource = [];
 
         $id = $this->getContext()->getRequestParam($this->getContext()->getDataProvider()->getRequestFieldName(), null);
-        $filter = $this->filterBuilder->setField($this->getContext()->getDataProvider()->getPrimaryFieldName())
+        $idFieldName = $this->getContext()->getDataProvider()->getPrimaryFieldName();
+        $filter = $this->filterBuilder->setField($idFieldName)
             ->setValue($id)
             ->create();
         $this->getContext()->getDataProvider()
@@ -74,7 +75,7 @@ class Form extends AbstractComponent
             ];
         } elseif (isset($data['items'])) {
             foreach ($data['items'] as $item) {
-                if ($item[$item['id_field_name']] == $id) {
+                if ($item[$idFieldName] == $id) {
                     $dataSource = ['data' => ['general' => $item]];
                 }
             }

--- a/app/code/Magento/Ui/Test/Unit/Component/FormTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/FormTest.php
@@ -9,7 +9,6 @@ use Magento\Framework\Api\Filter;
 use Magento\Framework\Api\FilterBuilder;
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderInterface;
-use Magento\Framework\View\Element\UiComponent\Processor;
 use Magento\Ui\Component\Form;
 
 class FormTest extends \PHPUnit\Framework\TestCase
@@ -168,6 +167,67 @@ class FormTest extends \PHPUnit\Framework\TestCase
         ];
         $dataSource = [
             'data' => $row,
+        ];
+
+        /** @var DataProviderInterface|\PHPUnit_Framework_MockObject_MockObject $dataProviderMock */
+        $dataProviderMock =
+            $this->getMockBuilder(\Magento\Framework\View\Element\UiComponent\DataProvider\DataProviderInterface::class)
+                ->getMock();
+        $dataProviderMock->expects($this->once())
+            ->method('getRequestFieldName')
+            ->willReturn($requestFieldName);
+        $dataProviderMock->expects($this->once())
+            ->method('getPrimaryFieldName')
+            ->willReturn($primaryFieldName);
+
+        $this->contextMock->expects($this->any())
+            ->method('getDataProvider')
+            ->willReturn($dataProviderMock);
+        $this->contextMock->expects($this->once())
+            ->method('getRequestParam')
+            ->with($requestFieldName)
+            ->willReturn($fieldId);
+
+        /** @var Filter|\PHPUnit_Framework_MockObject_MockObject $filterMock */
+        $filterMock = $this->getMockBuilder(\Magento\Framework\Api\Filter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->filterBuilderMock->expects($this->once())
+            ->method('setField')
+            ->with($primaryFieldName)
+            ->willReturnSelf();
+        $this->filterBuilderMock->expects($this->once())
+            ->method('setValue')
+            ->with($fieldId)
+            ->willReturnSelf();
+        $this->filterBuilderMock->expects($this->once())
+            ->method('create')
+            ->willReturn($filterMock);
+
+        $dataProviderMock->expects($this->once())
+            ->method('addFilter')
+            ->with($filterMock);
+        $dataProviderMock->expects($this->once())
+            ->method('getData')
+            ->willReturn($data);
+
+        $this->assertEquals($dataSource, $this->model->getDataSourceData());
+    }
+
+    public function testGetDataSourceDataWithAbstractDataProvider()
+    {
+        $requestFieldName = 'request_id';
+        $primaryFieldName = 'primary_id';
+        $fieldId = 44;
+        $row = ['key' => 'value', $primaryFieldName => $fieldId];
+        $data = [
+            'items' => [$row],
+        ];
+        $dataSource = [
+            'data' => [
+                'general' => $row
+            ],
         ];
 
         /** @var DataProviderInterface|\PHPUnit_Framework_MockObject_MockObject $dataProviderMock */


### PR DESCRIPTION
### Description (*)
When developing backend forms with the help of backend UI components, the `Magento\Ui\DataProvider\AbstractDataProvider` comes in handy. One can simply inherit from it, set one's own collection in the constructor and one could be done. However, in practice, it does not work this way, because `Magento\Ui\Component\Form::getDataSourceData` relies on the fact that the related entity has an `id_field_name` property. Since this is mostly not the case, one gets the following notice:

    Notice: Undefined index: id_field_name in /var/www/magento2/vendor/magento/module-ui/Component/Form.php on line 77

Since one needs to define the primary field name in the data provider XML config anyway, it should be much more robust to get the primary field name from there. It is already used in the filter anyway.

### Fixed Issues (if relevant)
1. n/a

### Manual testing scenarios (*)
1. Create a custom backend UI component form.
2. Implement a data provider, which inherits from `Magento\Ui\DataProvider\AbstractDataProvider` and simply sets a custom collection in the constructor, e.g. a simple order collection of type `Magento\Sales\Model\ResourceModel\Order\Collection`.
3. Open the UI component in the backend in developer mode.
4. See the notice quoted above.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
