### PR TITLE
Fixed Luma theme my account Order status tabs 21070

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
@@ -555,13 +555,13 @@
             margin: 0 @tab-control__margin-right 0 0;
 
             a {
-                padding: @tab-control__padding-top @tab-control__padding-right;
+                padding: @tab-control__padding-top @indent__base;
             }
 
             strong {
                 border-bottom: 0;
                 margin-bottom: -1px;
-                padding: @tab-control__padding-top @tab-control__padding-right @tab-control__padding-bottom + 1 @tab-control__padding-left;
+                padding: @tab-control__padding-top @indent__base @tab-control__padding-bottom + 1 @indent__base;
             }
         }
     }
@@ -686,4 +686,24 @@
             }
         }
     }
+}
+
+.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__l) { 
+
+    .order-links {
+        .item {
+            margin: 0 @tab-control__margin-right 0 0;
+
+            a {
+                padding: @tab-control__padding-top @tab-control__padding-right;
+            }
+
+            strong {
+                border-bottom: 0;
+                margin-bottom: -1px;
+                padding: @tab-control__padding-top @tab-control__padding-right @tab-control__padding-bottom + 1 @tab-control__padding-left;
+            }
+        }
+    }
+
 }

--- a/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
@@ -689,7 +689,6 @@
 }
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__l) { 
-
     .order-links {
         .item {
             margin: 0 @tab-control__margin-right 0 0;
@@ -699,11 +698,8 @@
             }
 
             strong {
-                border-bottom: 0;
-                margin-bottom: -1px;
                 padding: @tab-control__padding-top @tab-control__padding-right @tab-control__padding-bottom + 1 @tab-control__padding-left;
             }
         }
     }
-
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed Luma theme my account Order status tabs 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21070:Luma theme my account Order Information status tabs break in tablet view


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Place new order -> My account -> My orders -> select any order -> View Order -> see the order status tabs are breaking. see the attached screenshots
2. It will happen when we will create a cash memo from admin for the order.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
