### PR TITLE
[Backport] Fixed - Lifetime update syntax error #13309

### DIFF
--- a/lib/internal/Magento/Framework/Cache/Backend/Database.php
+++ b/lib/internal/Magento/Framework/Cache/Backend/Database.php
@@ -432,7 +432,7 @@ class Database extends \Zend_Cache_Backend implements \Zend_Cache_Backend_Extend
             return $this->_getConnection()->update(
                 $this->_getDataTable(),
                 ['expire_time' => new \Zend_Db_Expr('expire_time+' . $extraLifetime)],
-                ['id=?' => $id, 'expire_time = 0 OR expire_time>' => time()]
+                ['id=?' => $id, 'expire_time = 0 OR expire_time>?' => time()]
             );
         } else {
             return true;

--- a/lib/internal/Magento/Framework/Cache/Backend/Database.php
+++ b/lib/internal/Magento/Framework/Cache/Backend/Database.php
@@ -27,11 +27,11 @@
  * ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
  */
 
-/**
- * Database cache backend
- */
 namespace Magento\Framework\Cache\Backend;
 
+/**
+ * Database cache backend.
+ */
 class Database extends \Zend_Cache_Backend implements \Zend_Cache_Backend_ExtendedInterface
 {
     /**
@@ -139,7 +139,7 @@ class Database extends \Zend_Cache_Backend implements \Zend_Cache_Backend_Extend
      *
      * Note : return value is always "string" (unserialization is done by the core not by the backend)
      *
-     * @param  string  $id                     Cache id
+     * @param  string $id Cache id
      * @param  boolean $doNotTestCacheValidity If set to true, the cache validity won't be tested
      * @return string|false cached datas
      */


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19634
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fixed issue of Lifetime update syntax error

### Fixed Issues (if relevant)
1. magento/magento2#13309: Lifetime update syntax error

### Manual testing scenarios (*)
magento2/lib/internal/Magento/Framework/Cache/Backend/Database.php

Line 435
['id=?' => $id, 'expire_time = 0 OR expire_time>' => time()] 

Should be (question sign is missing):
['id=?' => $id, 'expire_time = 0 OR expire_time>?' => time()]

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
