### PR TITLE
[Backport] MAGETWO-95819: Customer registration fields not translated

### DIFF
--- a/app/code/Magento/Customer/Model/Metadata/AttributeMetadataCache.php
+++ b/app/code/Magento/Customer/Model/Metadata/AttributeMetadataCache.php
@@ -12,6 +12,7 @@ use Magento\Eav\Model\Entity\Attribute;
 use Magento\Framework\App\Cache\StateInterface;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Cache for attribute metadata
@@ -54,23 +55,32 @@ class AttributeMetadataCache
     private $serializer;
 
     /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * Constructor
      *
      * @param CacheInterface $cache
      * @param StateInterface $state
      * @param SerializerInterface $serializer
      * @param AttributeMetadataHydrator $attributeMetadataHydrator
+     * @param StoreManagerInterface|null $storeManager
      */
     public function __construct(
         CacheInterface $cache,
         StateInterface $state,
         SerializerInterface $serializer,
-        AttributeMetadataHydrator $attributeMetadataHydrator
+        AttributeMetadataHydrator $attributeMetadataHydrator,
+        StoreManagerInterface $storeManager = null
     ) {
         $this->cache = $cache;
         $this->state = $state;
         $this->serializer = $serializer;
         $this->attributeMetadataHydrator = $attributeMetadataHydrator;
+        $this->storeManager = $storeManager ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(StoreManagerInterface::class);
     }
 
     /**
@@ -82,11 +92,12 @@ class AttributeMetadataCache
      */
     public function load($entityType, $suffix = '')
     {
-        if (isset($this->attributes[$entityType . $suffix])) {
-            return $this->attributes[$entityType . $suffix];
+        $storeId = $this->storeManager->getStore()->getId();
+        if (isset($this->attributes[$entityType . $suffix . $storeId])) {
+            return $this->attributes[$entityType . $suffix . $storeId];
         }
         if ($this->isEnabled()) {
-            $cacheKey = self::ATTRIBUTE_METADATA_CACHE_PREFIX . $entityType . $suffix;
+            $cacheKey = self::ATTRIBUTE_METADATA_CACHE_PREFIX . $entityType . $suffix . $storeId;
             $serializedData = $this->cache->load($cacheKey);
             if ($serializedData) {
                 $attributesData = $this->serializer->unserialize($serializedData);
@@ -94,7 +105,7 @@ class AttributeMetadataCache
                 foreach ($attributesData as $key => $attributeData) {
                     $attributes[$key] = $this->attributeMetadataHydrator->hydrate($attributeData);
                 }
-                $this->attributes[$entityType . $suffix] = $attributes;
+                $this->attributes[$entityType . $suffix . $storeId] = $attributes;
                 return $attributes;
             }
         }
@@ -111,9 +122,10 @@ class AttributeMetadataCache
      */
     public function save($entityType, array $attributes, $suffix = '')
     {
-        $this->attributes[$entityType . $suffix] = $attributes;
+        $storeId = $this->storeManager->getStore()->getId();
+        $this->attributes[$entityType . $suffix . $storeId] = $attributes;
         if ($this->isEnabled()) {
-            $cacheKey = self::ATTRIBUTE_METADATA_CACHE_PREFIX . $entityType . $suffix;
+            $cacheKey = self::ATTRIBUTE_METADATA_CACHE_PREFIX . $entityType . $suffix . $storeId;
             $attributesData = [];
             foreach ($attributes as $key => $attribute) {
                 $attributesData[$key] = $this->attributeMetadataHydrator->extract($attribute);

--- a/app/code/Magento/Customer/Test/Unit/Model/Metadata/AttributeMetadataCacheTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Metadata/AttributeMetadataCacheTest.php
@@ -15,7 +15,14 @@ use Magento\Framework\App\Cache\StateInterface;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
+/**
+ * Class AttributeMetadataCache Test
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class AttributeMetadataCacheTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -43,6 +50,16 @@ class AttributeMetadataCacheTest extends \PHPUnit\Framework\TestCase
      */
     private $attributeMetadataCache;
 
+    /**
+     * @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeMock;
+
+    /**
+     * @var StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $storeManagerMock;
+
     protected function setUp()
     {
         $objectManager = new ObjectManager($this);
@@ -50,13 +67,18 @@ class AttributeMetadataCacheTest extends \PHPUnit\Framework\TestCase
         $this->stateMock = $this->createMock(StateInterface::class);
         $this->serializerMock = $this->createMock(SerializerInterface::class);
         $this->attributeMetadataHydratorMock = $this->createMock(AttributeMetadataHydrator::class);
+        $this->storeMock = $this->createMock(StoreInterface::class);
+        $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
+        $this->storeManagerMock->method('getStore')->willReturn($this->storeMock);
+        $this->storeMock->method('getId')->willReturn(1);
         $this->attributeMetadataCache = $objectManager->getObject(
             AttributeMetadataCache::class,
             [
                 'cache' => $this->cacheMock,
                 'state' => $this->stateMock,
                 'serializer' => $this->serializerMock,
-                'attributeMetadataHydrator' => $this->attributeMetadataHydratorMock
+                'attributeMetadataHydrator' => $this->attributeMetadataHydratorMock,
+                'storeManager' => $this->storeManagerMock
             ]
         );
     }
@@ -80,7 +102,8 @@ class AttributeMetadataCacheTest extends \PHPUnit\Framework\TestCase
     {
         $entityType = 'EntityType';
         $suffix = 'none';
-        $cacheKey = AttributeMetadataCache::ATTRIBUTE_METADATA_CACHE_PREFIX . $entityType . $suffix;
+        $storeId = 1;
+        $cacheKey = AttributeMetadataCache::ATTRIBUTE_METADATA_CACHE_PREFIX . $entityType . $suffix . $storeId;
         $this->stateMock->expects($this->once())
             ->method('isEnabled')
             ->with(Type::TYPE_IDENTIFIER)
@@ -96,7 +119,8 @@ class AttributeMetadataCacheTest extends \PHPUnit\Framework\TestCase
     {
         $entityType = 'EntityType';
         $suffix = 'none';
-        $cacheKey = AttributeMetadataCache::ATTRIBUTE_METADATA_CACHE_PREFIX . $entityType . $suffix;
+        $storeId = 1;
+        $cacheKey = AttributeMetadataCache::ATTRIBUTE_METADATA_CACHE_PREFIX . $entityType . $suffix . $storeId;
         $serializedString = 'serialized string';
         $attributeMetadataOneData = [
             'attribute_code' => 'attribute_code',
@@ -156,7 +180,8 @@ class AttributeMetadataCacheTest extends \PHPUnit\Framework\TestCase
     {
         $entityType = 'EntityType';
         $suffix = 'none';
-        $cacheKey = AttributeMetadataCache::ATTRIBUTE_METADATA_CACHE_PREFIX . $entityType . $suffix;
+        $storeId = 1;
+        $cacheKey = AttributeMetadataCache::ATTRIBUTE_METADATA_CACHE_PREFIX . $entityType . $suffix . $storeId;
         $serializedString = 'serialized string';
         $attributeMetadataOneData = [
             'attribute_code' => 'attribute_code',


### PR DESCRIPTION
### Description (*)
This is a backport for commit https://github.com/magento/magento2/commit/679fc6166bae7f19e3cc382b10e4f578e4b17330.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Enable at least EAV cache. 
2. Create 2 websites.
3. Set configuration `Customer Configuration -> Name and Address Options -> Show Tax/VAT Number` on one store to **Optional** and on the other store to **Required**.
4. Check if Tax/VAT field is optional on one store and required on the other.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
