### PR TITLE
Add alt text to saved payment method for accessibility

### DIFF
--- a/app/code/Magento/Payment/Model/CcConfigProvider.php
+++ b/app/code/Magento/Payment/Model/CcConfigProvider.php
@@ -44,7 +44,7 @@ class CcConfigProvider implements ConfigProviderInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getConfig()
     {

--- a/app/code/Magento/Payment/Model/CcConfigProvider.php
+++ b/app/code/Magento/Payment/Model/CcConfigProvider.php
@@ -69,7 +69,7 @@ class CcConfigProvider implements ConfigProviderInterface
         }
 
         $types = $this->ccConfig->getCcAvailableTypes();
-        foreach (array_keys($types) as $code) {
+        foreach ($types as $code => $label) {
             if (!array_key_exists($code, $this->icons)) {
                 $asset = $this->ccConfig->createAsset('Magento_Payment::images/cc/' . strtolower($code) . '.png');
                 $placeholder = $this->assetSource->findSource($asset);
@@ -78,7 +78,8 @@ class CcConfigProvider implements ConfigProviderInterface
                     $this->icons[$code] = [
                         'url' => $asset->getUrl(),
                         'width' => $width,
-                        'height' => $height
+                        'height' => $height,
+                        'title' => __($label),
                     ];
                 }
             }

--- a/app/code/Magento/Payment/Test/Unit/Model/CcConfigProviderTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Model/CcConfigProviderTest.php
@@ -42,12 +42,14 @@ class CcConfigProviderTest extends \PHPUnit\Framework\TestCase
                         'vi' => [
                             'url' => 'http://cc.card/vi.png',
                             'width' => getimagesize($imagesDirectoryPath . 'vi.png')[0],
-                            'height' => getimagesize($imagesDirectoryPath . 'vi.png')[1]
+                            'height' => getimagesize($imagesDirectoryPath . 'vi.png')[1],
+                            'title' => __('Visa'),
                         ],
                         'ae' => [
                             'url' => 'http://cc.card/ae.png',
                             'width' => getimagesize($imagesDirectoryPath . 'ae.png')[0],
-                            'height' => getimagesize($imagesDirectoryPath . 'ae.png')[1]
+                            'height' => getimagesize($imagesDirectoryPath . 'ae.png')[1],
+                            'title' => __('American Express'),
                         ]
                     ]
                 ]
@@ -56,11 +58,13 @@ class CcConfigProviderTest extends \PHPUnit\Framework\TestCase
 
         $ccAvailableTypesMock = [
             'vi' => [
+                'title' => 'Visa',
                 'fileId' => 'Magento_Payment::images/cc/vi.png',
                 'path' => $imagesDirectoryPath . 'vi.png',
                 'url' => 'http://cc.card/vi.png'
             ],
             'ae' => [
+                'title' => 'American Express',
                 'fileId' => 'Magento_Payment::images/cc/ae.png',
                 'path' => $imagesDirectoryPath . 'ae.png',
                 'url' => 'http://cc.card/ae.png'
@@ -68,7 +72,11 @@ class CcConfigProviderTest extends \PHPUnit\Framework\TestCase
         ];
         $assetMock = $this->createMock(\Magento\Framework\View\Asset\File::class);
 
-        $this->ccConfigMock->expects($this->once())->method('getCcAvailableTypes')->willReturn($ccAvailableTypesMock);
+        $this->ccConfigMock->expects($this->once())->method('getCcAvailableTypes')
+            ->willReturn(array_combine(
+                array_keys($ccAvailableTypesMock),
+                array_column($ccAvailableTypesMock, 'title')
+            ));
 
         $this->ccConfigMock->expects($this->atLeastOnce())
             ->method('createAsset')

--- a/app/code/Magento/Vault/view/frontend/web/template/payment/form.html
+++ b/app/code/Magento/Vault/view/frontend/web/template/payment/form.html
@@ -19,7 +19,8 @@
             <img data-bind="attr: {
             'src': getIcons(getCardType()).url,
             'width': getIcons(getCardType()).width,
-            'height': getIcons(getCardType()).height
+            'height': getIcons(getCardType()).height,
+            'alt': getIcons(getCardType()).title
             }" class="payment-icon">
             <span translate="'ending'"></span>
             <span text="getMaskedCard()"></span>


### PR DESCRIPTION
### Description (*)
Adds alt attribute value describing the credit card type or stored payment methods during checkout.

### Fixed Issues (if relevant)
1. magento/magento2#21089: No accessible label for vault-saved credit card type

### Manual testing scenarios (*)
1. Save credit card using a Vault-enabled payment method, such as Braintree.
2. Go to payment step on checkout.
3. Inspect stored card logo for corresponding alt text.
<img width="874" alt="screen shot 2019-02-08 at 6 22 47 pm" src="https://user-images.githubusercontent.com/12674247/52511808-c1228380-2bcf-11e9-898f-9f835b5d9b03.png">

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

