### PR TITLE
Removed useless sprintf and removed code no longer needed

### DIFF
--- a/app/code/Magento/Downloadable/Model/ResourceModel/Link.php
+++ b/app/code/Magento/Downloadable/Model/ResourceModel/Link.php
@@ -5,10 +5,6 @@
  */
 namespace Magento\Downloadable\Model\ResourceModel;
 
-use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Framework\App\ObjectManager;
-use Magento\Framework\EntityManager\MetadataPool;
-
 /**
  * Downloadable Product  Samples resource model
  *
@@ -17,11 +13,6 @@ use Magento\Framework\EntityManager\MetadataPool;
  */
 class Link extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 {
-    /**
-     * @var MetadataPool
-     */
-    private $metadataPool;
-
     /**
      * Catalog data
      *
@@ -210,10 +201,7 @@ class Link extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             []
         )->join(
             ['cpe' => $this->getTable('catalog_product_entity')],
-            sprintf(
-                'cpe.entity_id = m.product_id',
-                $this->getMetadataPool()->getMetadata(ProductInterface::class)->getLinkField()
-            ),
+            'cpe.entity_id = m.product_id',
             []
         )->joinLeft(
             ['st' => $this->getTable('downloadable_link_title')],
@@ -233,17 +221,5 @@ class Link extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     protected function _createCurrency()
     {
         return $this->_currencyFactory->create();
-    }
-
-    /**
-     * Get MetadataPool instance
-     * @return MetadataPool
-     */
-    private function getMetadataPool()
-    {
-        if (!$this->metadataPool) {
-            $this->metadataPool = ObjectManager::getInstance()->get(MetadataPool::class);
-        }
-        return $this->metadataPool;
     }
 }

--- a/app/code/Magento/Downloadable/Model/ResourceModel/Link.php
+++ b/app/code/Magento/Downloadable/Model/ResourceModel/Link.php
@@ -216,6 +216,8 @@ class Link extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     }
 
     /**
+     * Get Currency model.
+     *
      * @return \Magento\Directory\Model\Currency
      */
     protected function _createCurrency()


### PR DESCRIPTION
### Description (*)

Removed `sprintf` usage, which was unnecessary.  The sprintf's unused parameter had related code that could now be removed to simplify the class and overall complexity.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
