### PR TITLE
Also populate the storesCache when importing product only on storevie…

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
@@ -263,6 +263,7 @@ class AfterImportDataObserver implements ObserverInterface
         if ($this->isGlobalScope($product->getStoreId())) {
             $this->populateGlobalProduct($product);
         } else {
+            $this->storesCache[$product->getStoreId()] = true;
             $this->addProductToImport($product, $product->getStoreId());
         }
         return $this;


### PR DESCRIPTION
…w(s) level, previously the storesCache was only populated for products imported on global level. This causes problems with the correct url rewrites to be generated.

### Description (*)
This was discovered by accident while debugging another problem, but it was an easy fix, hence the PR.

When importing a product with a new url key, you can add a flag `save_rewrites_history` with which you can indicate that you want to create a permanent redirect (301 http status code) from the old url key to the new one in the `url_rewrite` table.

Previously, this only worked when importing a product on global level.
If you only want to change the `url_key` on storeview level, without importing the product on global level, this didn't work.

This happens because when trying to find the old url rewrites associated with this product, it uses an internal `storesCache` which contains the storeview id's of the product(s) which you are importing, see [here](https://github.com/magento/magento2/blob/00fb2aa3e258ab728f8e2fec1e99bc9b5f562221/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php#L417-L423).
This `storesCache` variable is only getting set when importing a product on global level, see [here](https://github.com/magento/magento2/blob/00fb2aa3e258ab728f8e2fec1e99bc9b5f562221/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php#L314-L325), but not when importing it only on storeview level, see [here](https://github.com/magento/magento2/blob/00fb2aa3e258ab728f8e2fec1e99bc9b5f562221/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php#L265-L267).

This PR fixes this.

### Fixed Issues (if relevant)
None found

### Manual testing scenarios (*)
1. Setup a new Magento installation based on `2.3-develop`, you need a very recent version, because support for the `save_rewrites_history` flag only got added recently.
2. In the backend, make sure you have at least 2 storeviews, I've used `en_gb` and `en_us` as storeview codes.
3. In the backend, manually create 2 products, with SKU: `Test1`, `Test2`, and translate the url key on storeview level, but make sure to deselect the `Create Permanent Redirect for old URL` checkbox. In the end, the entries in your `url_rewrite` table should look something like this:

| entity_type | entity_id | request_path  | target_path               | redirect_type | store_id |
|-------------|-----------|---------------|---------------------------|---------------|----------|
| product     | 2         | test1-gb.html | catalog/product/view/id/2 | 0             | 2        |
| product     | 2         | test1-us.html | catalog/product/view/id/2 | 0             | 1        |
| product     | 3         | test2-gb.html | catalog/product/view/id/3 | 0             | 2        |
| product     | 3         | test2-us.html | catalog/product/view/id/3 | 0             | 1        |

4. Now prepare two csv files to import:

    * With product on global scope (see first line, no store_view_code):

    ```csv
    sku,store_view_code,product_websites,url_key,save_rewrites_history
    Test1,,base,test1-updated,1
    Test1,en_gb,base,test1-gb-updated,1
    Test1,en_us,base,test1-us-updated,1
    ```

    * With no product on global scope:

    ```csv
    sku,store_view_code,product_websites,url_key,save_rewrites_history
    Test2,en_gb,base,test2-gb-updated,1
    Test2,en_us,base,test2-us-updated,1
    ```

5. In the backend, go to System > Data Transfer > Import
6. Use `Entity Type` => `Products`, `Import Behavior` => `Add/Update` and leave the rest as is
7. Now first import the first csv file, and then start from 5. again and import the second csv file
8. Check the `url_rewrite` table, without this PR it contains only 301 redirects for the Test1 product, but not for the Test2 product:

| entity_type | entity_id | request_path          | target_path               | redirect_type | store_id |
|-------------|-----------|-----------------------|---------------------------|---------------|----------|
| product     | 2         | test1-us-updated.html | catalog/product/view/id/2 | 0             | 1        |
| product     | 2         | test1-gb-updated.html | catalog/product/view/id/2 | 0             | 2        |
| product     | 2         | test1-us.html         | test1-us-updated.html     | 301           | 1        |
| product     | 2         | test1-gb.html         | test1-gb-updated.html     | 301           | 2        |
| product     | 3         | test2-gb-updated.html | catalog/product/view/id/3 | 0             | 2        |
| product     | 3         | test2-us-updated.html | catalog/product/view/id/3 | 0             | 1        |

With this PR, it will also have 301 redirects for the Test2 product.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
