### PR TITLE
Updated sprintf usage;  Simplified isset usage

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
@@ -8,6 +8,9 @@ namespace Magento\Catalog\Model\Indexer\Category\Flat;
 
 use Magento\Framework\App\ResourceConnection;
 
+/**
+ * Abstract action class for category flat indexers.
+ */
 class AbstractAction
 {
     /**
@@ -496,6 +499,8 @@ class AbstractAction
     }
 
     /**
+     * Get category metadata instance.
+     *
      * @return \Magento\Framework\EntityManager\EntityMetadata
      */
     private function getCategoryMetadata()
@@ -509,6 +514,8 @@ class AbstractAction
     }
 
     /**
+     * Get skip static columns instance.
+     *
      * @return array
      */
     private function getSkipStaticColumns()

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/AbstractAction.php
@@ -130,7 +130,7 @@ class AbstractAction
         $table = $this->connection->newTable(
             $tableName
         )->setComment(
-            sprintf("Catalog Category Flat", $tableName)
+            'Catalog Category Flat'
         );
 
         //Adding columns
@@ -378,7 +378,7 @@ class AbstractAction
         $linkField = $this->getCategoryMetadata()->getLinkField();
         foreach ($attributesType as $type) {
             foreach ($this->getAttributeTypeValues($type, $entityIds, $storeId) as $row) {
-                if (isset($row[$linkField]) && isset($row['attribute_id'])) {
+                if (isset($row[$linkField], $row['attribute_id'])) {
                     $attributeId = $row['attribute_id'];
                     if (isset($attributes[$attributeId])) {
                         $attributeCode = $attributes[$attributeId]['attribute_code'];

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderByBasePrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderByBasePrice.php
@@ -85,7 +85,7 @@ class LinkedProductSelectBuilderByBasePrice implements LinkedProductSelectBuilde
                 []
             )->joinInner(
                 [BaseSelectProcessorInterface::PRODUCT_TABLE_ALIAS => $productTable],
-                sprintf('%s.entity_id = link.child_id', BaseSelectProcessorInterface::PRODUCT_TABLE_ALIAS, $linkField),
+                sprintf('%s.entity_id = link.child_id', BaseSelectProcessorInterface::PRODUCT_TABLE_ALIAS),
                 ['entity_id']
             )->joinInner(
                 ['t' => $priceAttribute->getBackendTable()],

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderByBasePrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/LinkedProductSelectBuilderByBasePrice.php
@@ -11,6 +11,9 @@ use Magento\Framework\App\ObjectManager;
 use Magento\Framework\DB\Select;
 use Magento\Store\Model\Store;
 
+/**
+ * Provide Select object for retrieve product id with minimal price.
+ */
 class LinkedProductSelectBuilderByBasePrice implements LinkedProductSelectBuilderInterface
 {
     /**
@@ -69,7 +72,7 @@ class LinkedProductSelectBuilderByBasePrice implements LinkedProductSelectBuilde
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function build($productId)
     {


### PR DESCRIPTION
### Description (*)

**1.** Simplified if condition using AND-logic (&&) for checking two isset statements to use a single one with multiple parameters.  By definition `isset()`:

> If multiple parameters are supplied then isset() will return TRUE only if all of the parameters are set. Evaluation goes from left to right and stops as soon as an unset variable is encountered. 
> https://secure.php.net/manual/en/function.isset.php


**2.** Updated sprintf() usage:

i.  Removed unnecessary `sprintf()` where no parameters are specified.
ii. Removed unused parameters from `sprintf()` usage.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
