### PR TITLE
Shopping cart update AJAX request now honors base urls

### DIFF
--- a/app/code/Magento/Checkout/Block/Cart/Grid.php
+++ b/app/code/Magento/Checkout/Block/Cart/Grid.php
@@ -162,7 +162,7 @@ class Grid extends \Magento\Checkout\Block\Cart
      *
      * @return string
      */
-    public function getValidationUrl()
+    public function getValidationUrl(): string
     {
         return $this->getUrl('checkout/cart/updateItemQty', ['_secure' => $this->getRequest()->isSecure()]);
     }

--- a/app/code/Magento/Checkout/Block/Cart/Grid.php
+++ b/app/code/Magento/Checkout/Block/Cart/Grid.php
@@ -158,6 +158,16 @@ class Grid extends \Magento\Checkout\Block\Cart
     }
 
     /**
+     * Return validation url for shopping cart update form
+     *
+     * @return string
+     */
+    public function getValidationUrl()
+    {
+        return $this->getUrl('checkout/cart/updateItemQty', ['_secure' => $this->getRequest()->isSecure()]);
+    }
+
+    /**
      * Verify if display pager on shopping cart
      * If cart block has custom_items and items qty in the shopping cart<limit from stores configuration
      *

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
@@ -14,7 +14,7 @@
           method="post"
           id="form-validate"
           data-mage-init='{"Magento_Checkout/js/action/update-shopping-cart":
-              {"validationURL" : "/checkout/cart/updateItemQty"}
+              {"validationURL" : "<?= $block->getValidationUrl() ?>"}
           }'
           class="form form-cart">
     <?= $block->getBlockHtml('formkey') ?>


### PR DESCRIPTION
### Description (*)
Fixes a problem manifesting whenever Magento has been installed to a subfolder which will cause a shopping cart update requests return 404. Please note that cart update executes two requests: checkout/cart/updateItemQty (validation) and checkout/cart/updatePost (page update) and only the first one fails. 

### Manual testing scenarios (*)
1. Install Magento to subfolde (such as http://website.com/magento/)
2. Install sample data or create a product
3. Put product to shopping cart and got to cart page
4. Make sure that Inspector is activated and Preserve Log is turned on
5. Change product quantity in cart and press "Update".
6. Magento will make two requests of which first responds with 404

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
