### PR TITLE
[Backport] Number of Lines in a Street Address not setting to default when you checked Use system value in Magento 2.1.7 #13675

### DIFF
--- a/app/code/Magento/Customer/Model/Config/Backend/Address/Street.php
+++ b/app/code/Magento/Customer/Model/Config/Backend/Address/Street.php
@@ -87,15 +87,20 @@ class Street extends \Magento\Framework\App\Config\Value
     {
         $result = parent::afterDelete();
 
-        if ($this->getScope() == \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES) {
-            $attribute = $this->_eavConfig->getAttribute('customer_address', 'street');
-            $website = $this->_storeManager->getWebsite($this->getScopeCode());
-            $attribute->setWebsite($website);
-            $attribute->load($attribute->getId());
-            $attribute->setData('scope_multiline_count', null);
-            $attribute->save();
-        }
+        $attribute = $this->_eavConfig->getAttribute('customer_address', 'street');
+        switch ($this->getScope()) {
+            case \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITES:
+                $website = $this->_storeManager->getWebsite($this->getScopeCode());
+                $attribute->setWebsite($website);
+                $attribute->load($attribute->getId());
+                $attribute->setData('scope_multiline_count', null);
+                break;
 
+            case ScopeConfigInterface::SCOPE_TYPE_DEFAULT:
+                 $attribute->setData('multiline_count', 2);
+                 break;
+        }
+        $attribute->save();
         return $result;
     }
 }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20565
issue https://github.com/magento/magento2/issues/13675
### Description (*)
#### Preconditions
M 2.2.x
M 2.3.x
#### Steps to reproduce
Login to admin and got to Store->configuration->Customer->Customer Configuration-> Name and Address Options
Set Number of Lines in a Street Address to 3 and save
in front end it display 3 street line
Next click on Use system value and save it
Clear cache
Still its show 3 line for street in address

#### Expected result
it should display default street no that is two when you unset the value from Use system value
#### Actual result
it display last saved values instead of default value (i'e 2 )



### Manual testing scenarios (*)
Login to admin and got to Store->configuration->Customer->Customer Configuration-> Name and Address Options
Set Number of Lines in a Street Address to 3 and save
in front end it display 3 street line
Next click on Use system value and save it
Clear cache
Still its show 3 line for street in address

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
