### PR TITLE
Magento/Magento2#5730: Changing sort order in admin doesn't work for …

### DIFF
--- a/app/code/Magento/CatalogSearch/Block/Result.php
+++ b/app/code/Magento/CatalogSearch/Block/Result.php
@@ -140,10 +140,6 @@ class Result extends Template
 
         $this->getListBlock()->setAvailableOrders(
             $availableOrders
-        )->setDefaultDirection(
-            'desc'
-        )->setDefaultSortBy(
-            'relevance'
         );
 
         return $this;


### PR DESCRIPTION
…catalog search

- Fix search results default sorting config, remove hard coded sort by 'relevance'

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/magento2/issues/5730: Changing sort order in admin doesn't work for catalog search

### Manual testing scenarios (*)
1. Login to magento store admin
2. Navigate to Stores->Configuration->Catalog->Catalog->Storefront
3. Change Product Listing Sort by to Price
4. Goto magento store frontend and search by keyword

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
