### PR TITLE
[Backport] Add filter for `NOT FIND_IN_SET` sql conditions

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -2854,6 +2854,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * - array("gteq" => $greaterOrEqualValue)
      * - array("lteq" => $lessOrEqualValue)
      * - array("finset" => $valueInSet)
+     * - array("nfinset" => $valueNotInSet)
      * - array("regexp" => $regularExpression)
      * - array("seq" => $stringValue)
      * - array("sneq" => $stringValue)
@@ -2883,6 +2884,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             'gteq'          => "{{fieldName}} >= ?",
             'lteq'          => "{{fieldName}} <= ?",
             'finset'        => "FIND_IN_SET(?, {{fieldName}})",
+            'nfinset'       => "NOT FIND_IN_SET(?, {{fieldName}})",
             'regexp'        => "{{fieldName}} REGEXP ?",
             'from'          => "{{fieldName}} >= ?",
             'to'            => "{{fieldName}} <= ?",


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20607
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Add a filter on a collection for condition NOT FIND_IN_SET. This cannot be be done via addAttributeToFilter or addFieldToFilter because the method Magento\Framework\DB\Adapter\Pdo\Mysql::prepareSqlCondition does not contain a map item for NOT FIND_IN_SET.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
