### PR TITLE
[Backport] Fix magento root package identification for metapackage installation

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/ComposerInformationTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/ComposerInformationTest.php
@@ -92,7 +92,7 @@ class ComposerInformationTest extends \PHPUnit\Framework\TestCase
     public function testGetRequiredExtensions($composerDir)
     {
         $this->setupDirectory($composerDir);
-        $expectedExtensions = ['ctype', 'gd', 'spl', 'dom', 'simplexml', 'mcrypt', 'hash', 'curl', 'iconv', 'intl'];
+        $expectedExtensions = ['ctype', 'gd', 'spl', 'dom', 'simplexml', 'mcrypt', 'hash', 'curl', 'iconv'];
 
         /** @var \Magento\Framework\Composer\ComposerInformation $composerInfo */
         $composerInfo = $this->objectManager->create(

--- a/lib/internal/Magento/Framework/Composer/ComposerInformation.php
+++ b/lib/internal/Magento/Framework/Composer/ComposerInformation.php
@@ -148,7 +148,6 @@ class ComposerInformation
             /** @var CompletePackageInterface $package */
             foreach ($this->getLocker()->getLockedRepository()->getPackages() as $package) {
                 $requires = array_keys($package->getRequires());
-                $requires = array_merge($requires, array_keys($package->getDevRequires()));
                 $allPlatformReqs = array_merge($allPlatformReqs, $requires);
             }
         }


### PR DESCRIPTION
Original pull request: https://github.com/magento/magento2/pull/22116

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fix issue with failing Magento installing process (`php bin/magento setup:install`) for installation via metapackage, because of issue in root package defining.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21136: Magento installation via metapackage: checkExtensions fails, because isMagentoRoot works incorrectly for installation

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Steps to reproduce could be takes from issue.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
