### PR TITLE
[Backport] Fixed store switcher doesn't work multistore setup with different product urls issue

### DIFF
--- a/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
+++ b/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
@@ -70,15 +70,14 @@ class RewriteUrl implements StoreSwitcherInterface
                 UrlRewrite::TARGET_PATH => $oldRewrite->getTargetPath(),
                 UrlRewrite::STORE_ID => $targetStore->getId(),
             ]);
-
             if (null === $currentRewrites || empty($currentRewrites)) {
                 /** @var \Magento\Framework\App\Response\Http $response */
                 $targetUrl = $targetStore->getBaseUrl();
-            } else {
-                foreach($currentRewrites as $rewrite) {
-                    $targetUrl = $targetStore->getBaseUrl() . $rewrite->getRequestPath();
-                    break;
-                }
+                return $targetUrl;
+            }
+            foreach ($currentRewrites as $rewrite) {
+                $targetUrl = $targetStore->getBaseUrl() . $rewrite->getRequestPath();
+                break;
             }
         }
 

--- a/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
+++ b/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
@@ -65,21 +65,16 @@ class RewriteUrl implements StoreSwitcherInterface
             UrlRewrite::STORE_ID => $oldStoreId,
         ]);
         if ($oldRewrite) {
+            $targetUrl = $targetStore->getBaseUrl();
             // look for url rewrite match on the target store
-            $currentRewrites = $this->urlFinder->findAllByData([
+            $currentRewrite = $this->urlFinder->findOneByData([
                 UrlRewrite::TARGET_PATH => $oldRewrite->getTargetPath(),
                 UrlRewrite::STORE_ID => $targetStore->getId(),
             ]);
-            if (null === $currentRewrites || empty($currentRewrites)) {
-                /** @var \Magento\Framework\App\Response\Http $response */
-                $targetUrl = $targetStore->getBaseUrl();
-                return $targetUrl;
-            }
-            foreach ($currentRewrites as $rewrite) {
-                $targetUrl = $targetStore->getBaseUrl() . $rewrite->getRequestPath();
+            if ($currentRewrite) {
+                $targetUrl .= $currentRewrite->getRequestPath();
             }
         }
-
         return $targetUrl;
     }
 }

--- a/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
+++ b/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
@@ -77,7 +77,6 @@ class RewriteUrl implements StoreSwitcherInterface
             }
             foreach ($currentRewrites as $rewrite) {
                 $targetUrl = $targetStore->getBaseUrl() . $rewrite->getRequestPath();
-                break;
             }
         }
 

--- a/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
+++ b/app/code/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrl.php
@@ -66,13 +66,19 @@ class RewriteUrl implements StoreSwitcherInterface
         ]);
         if ($oldRewrite) {
             // look for url rewrite match on the target store
-            $currentRewrite = $this->urlFinder->findOneByData([
-                UrlRewrite::REQUEST_PATH => $urlPath,
+            $currentRewrites = $this->urlFinder->findAllByData([
+                UrlRewrite::TARGET_PATH => $oldRewrite->getTargetPath(),
                 UrlRewrite::STORE_ID => $targetStore->getId(),
             ]);
-            if (null === $currentRewrite) {
+
+            if (null === $currentRewrites || empty($currentRewrites)) {
                 /** @var \Magento\Framework\App\Response\Http $response */
                 $targetUrl = $targetStore->getBaseUrl();
+            } else {
+                foreach($currentRewrites as $rewrite) {
+                    $targetUrl = $targetStore->getBaseUrl() . $rewrite->getRequestPath();
+                    break;
+                }
             }
         }
 

--- a/dev/tests/integration/testsuite/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrlTest.php
+++ b/dev/tests/integration/testsuite/Magento/UrlRewrite/Model/StoreSwitcher/RewriteUrlTest.php
@@ -90,7 +90,8 @@ class RewriteUrlTest extends \PHPUnit\Framework\TestCase
         $storeRepository = $this->objectManager->create(\Magento\Store\Api\StoreRepositoryInterface::class);
         $toStore = $storeRepository->get($toStoreCode);
 
-        $redirectUrl = $expectedUrl = "http://localhost/page-c";
+        $redirectUrl = "http://localhost/index.php/page-c/";
+        $expectedUrl = "http://localhost/index.php/page-c-on-2nd-store";
 
         $this->assertEquals($expectedUrl, $this->storeSwitcher->switch($fromStore, $toStore, $redirectUrl));
     }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19798
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed store switcher doesn't work multistore setup with different product urls issue
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19714: Fixed store switcher doesn't work multistore setup with different product urls issue

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
