### PR TITLE
Added hash based check to prevent image duplication on product import

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1795,7 +1795,11 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 $position = 0;
                 foreach ($rowImages as $column => $columnImages) {
                     foreach ($columnImages as $columnImageKey => $columnImage) {
-                        $hash = md5_file($importDir . DIRECTORY_SEPARATOR . $columnImage);
+                        $filename = $importDir . DIRECTORY_SEPARATOR . $columnImage;
+                        $hash = '';
+                        if ($this->_mediaDirectory->isReadable($filename)) {
+                            $hash = md5_file($filename);
+                        }
 
                         if (!isset($existingImages[$rowSku])) {
                             $imageAlreadyExists = false;


### PR DESCRIPTION
### Description

I've added a MD5 based hash check to prevent image duplication upon successive product CSV imports.

Note that this is a **proof of concept**, even though it works — sort of.

The problem is that the Add/Update product import method should be declarative, and thus idempotent — it should not cause side effects when importing the same CSV multiple times.

As it stands now, this is not the case (confirmed), running the import multiple times causes images to be added. The "Replace" import method is beyond silly for production systems as it trashes the old IDs (and takes quotes, reports, wish lists, comparison lists, and so on with it).

We also can't replace just the images as it causes the different filenames, thus realistically a filename + hash comparison is the way to go. But filename checks are hard because we're not keeping track of the file metadata upon import (and as the file is renamed when Magento moves it into media/catalog/product, any reference to the old filename is lost) — so the easiest solution that kinda works is a hash based check.

I want to know whether this is the way to implement it or not. It's already a messy, mostly undocumented, class and no straight forward way to implement it properly, but any guidance would be helpful.

- I haven't fully tested this yet
- I'm not happy with code quality yet
- Doesn't delete images, only skips addition of existing images
- Doesn't rename the files — only compares file hash (to do this, I believe, would require Magento to store file metadata)
- Does not work when images are referenced using HTTP
- Crashes if image was not found (Warning: md5_file: failed to open stream..)

### Fixed Issues

- https://github.com/magento/magento2/issues/14398 : Images Not Replaced via CSV Import


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Import product CSV using Add/Update method multiple times
2. Check if image duplication happens or not

There's many testing scenario's actually. Some of them being:

- Use HTTP references in images
- Same filename different file
- Different filename same file
- Same file path for multiple products
- Change image labels/titles, ensure they're updated
- Manipulate thumbnail, small image and base image tags, and ensure it's updated properly after import
- etc.

Please let me know how to proceed and I can amend my commit message and implement it properly.