### PR TITLE
Sets admin store code for admin area/controllers

### DIFF
--- a/app/code/Magento/Store/App/FrontController/Plugin/DefaultStore.php
+++ b/app/code/Magento/Store/App/FrontController/Plugin/DefaultStore.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Store\App\FrontController\Plugin;
 
-use Magento\Store\Model\Store;
 use \Magento\Store\Model\StoreResolver\ReaderList;
 use \Magento\Store\Model\ScopeInterface;
 
@@ -49,7 +48,7 @@ class DefaultStore
         $scopeCode = null
     ) {
         $this->runMode = $scopeCode ? $runMode : ScopeInterface::SCOPE_WEBSITE;
-        $this->scopeCode = $scopeCode ? $scopeCode : Store::ADMIN_CODE;
+        $this->scopeCode = $scopeCode;
         $this->readerList = $readerList;
         $this->storeManager = $storeManager;
     }

--- a/app/code/Magento/Store/App/FrontController/Plugin/DefaultStore.php
+++ b/app/code/Magento/Store/App/FrontController/Plugin/DefaultStore.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Store\App\FrontController\Plugin;
 
+use Magento\Store\Model\Store;
 use \Magento\Store\Model\StoreResolver\ReaderList;
 use \Magento\Store\Model\ScopeInterface;
 
@@ -48,7 +49,7 @@ class DefaultStore
         $scopeCode = null
     ) {
         $this->runMode = $scopeCode ? $runMode : ScopeInterface::SCOPE_WEBSITE;
-        $this->scopeCode = $scopeCode;
+        $this->scopeCode = $scopeCode ? $scopeCode : Store::ADMIN_CODE;
         $this->readerList = $readerList;
         $this->storeManager = $storeManager;
     }

--- a/app/code/Magento/Store/etc/di.xml
+++ b/app/code/Magento/Store/etc/di.xml
@@ -114,7 +114,7 @@
     <type name="Magento\Store\App\FrontController\Plugin\DefaultStore">
         <arguments>
             <argument name="runMode" xsi:type="init_parameter">Magento\Store\Model\StoreManager::PARAM_RUN_TYPE</argument>
-            <argument name="scopeCode" xsi:type="init_parameter">Magento\Store\Model\StoreManager::PARAM_RUN_CODE</argument>
+            <argument name="scopeCode" xsi:type="const">Magento\Store\Model\Store::ADMIN_CODE</argument>
         </arguments>
     </type>
     <virtualType name="Magento\Store\Model\ResourceModel\Group\Collection\FetchStrategy" type="Magento\Framework\Data\Collection\Db\FetchStrategy\Cache">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

`\Magento\Store\Model\StoreManagerInterface` in the admin area was always returning details of Default store instead of the admin store. 

If you try below code in backend controller or any other file running for backend

```
/** @var \Magento\Store\Model\StoreManagerInterface $storeManager */
$storeManager->getStore()->getId()
```

You will get default store ID ideally 1 instead of admin store id ideally 0

So this pull request fixes this problem and set the admin store as a current store instead of the default store. 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#12354: When the Admin is on a different domain, redirect always fails and causes it to redirect to the front page 
2. magento/magento2#3147: Admin always return default store code, not admin
3. magento/magento2#12502: Admin controller redirects to frontend

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Verified by getting current store id in the custom admin controller
2. Verified code `$resultRedirect->setUrl($this->_redirect->getRefererUrl());` from custom admin controller when admin panel has custom domain configured. Previously, it was redirecting to frontend but now it redirects back to referral admin URL

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
