### PR TITLE
[Backport] Fixed issue #20911 In admin login password forgot password page wrong css used to make it vertially aling middle 

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
@@ -253,7 +253,7 @@ label.mage-error {
 
         .captcha-reload {
             float: right;
-            vertical-align: middle;
+            margin-top: 15px;
         }
     }
 }

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
@@ -407,7 +407,7 @@ label.mage-error {
             padding: 0;
             width: 16px;
             z-index: 1;
-            
+
             &:before {
                 // @codingStandardsIgnoreStart
                 &:extend(.admin__control-checkbox + label:before);

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
@@ -407,16 +407,20 @@ label.mage-error {
             padding: 0;
             width: 16px;
             z-index: 1;
-
+            
             &:before {
+                // @codingStandardsIgnoreStart
                 &:extend(.admin__control-checkbox + label:before);
+                // @codingStandardsIgnoreEnd
                 left: 0;
                 position: absolute;
                 top: 0;
             }
 
             &:after {
+                // @codingStandardsIgnoreStart
                 &:extend(.action-multicheck-wrap .action-multicheck-toggle:after);
+                // @codingStandardsIgnoreEnd
                 top: 40% !important;
             }
         }
@@ -424,7 +428,9 @@ label.mage-error {
         &:focus {
             + label {
                 &:after {
+                    // @codingStandardsIgnoreStart
                     &:extend(.action-multicheck-wrap .action-multicheck-toggle._active:after);
+                    // @codingStandardsIgnoreEnd
                 }
             }
         }
@@ -432,7 +438,9 @@ label.mage-error {
         &._checked {
             + label {
                 &:before {
+                    // @codingStandardsIgnoreStart
                     &:extend(.admin__control-checkbox:checked + label:before);
+                    // @codingStandardsIgnoreEnd
                 }
             }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20914
Fixed issue #20911 In admin login password forgot password page wrong css used to make it vertially aling middle 

### Description (*)
Fixed issue #20911 In admin login password forgot password page wrong css used to make it vertially aling middle 

### Fixed Issues (if relevant)

1. magento/magento2 #20911: In admin login password forgot password page wrong css used to make it vertially aling middle 

### Manual testing scenarios (*)

   1. Open admin login page and click on forgot password link
    2.inspect on reload captcha button and view css on that button vertial-align: middle; used but will not work with float

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
