### PR TITLE
Fix tests breaking when upgrading from 2.2 to 2.3

### DIFF
--- a/app/code/Magento/Sales/Test/Mftf/Section/AdminOrderFormActionSection.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Section/AdminOrderFormActionSection.xml
@@ -12,5 +12,8 @@
         <element name="SubmitOrder" type="button" selector="#submit_order_top_button" timeout="30"/>
         <element name="Cancel" type="button" selector="#reset_order_top_button" timeout="30"/>
         <element name="CreateNewCustomer" type="button" selector="#order-customer-selector .actions button.primary" timeout="30"/>
+        <element name="submitOrder" type="button" selector="#submit_order_top_button" timeout="30"/>
+        <element name="cancel" type="button" selector="#reset_order_top_button" timeout="30"/>
+        <element name="createNewCustomer" type="button" selector="#order-customer-selector .actions button.primary" timeout="30"/>
     </section>
 </sections>


### PR DESCRIPTION
Due to case sensitivity, when upgrading from 2.2 to 2.3 MFTF tests relying on AdminOrderFormActionSection break.