### PR TITLE
[Backport] fixes-customer-information-wishlist-configurable-product-alignment-2.2

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/composite/fieldset/configurable.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/composite/fieldset/configurable.phtml
@@ -17,9 +17,9 @@
     <legend class="legend admin__legend">
         <span><?= /* @escapeNotVerified */ __('Associated Products') ?></span>
     </legend>
-    <div class="product-options">
-        <div class="field admin__field _required required">
-            <?php foreach ($_attributes as $_attribute): ?>
+    <div class="product-options fieldset admin__fieldset">
+        <?php foreach ($_attributes as $_attribute): ?>
+            <div class="field admin__field _required required">
                 <label class="label admin__field-label"><?php
                     /* @escapeNotVerified */ echo $_attribute->getProductAttribute()
                         ->getStoreLabel($_product->getStoreId());
@@ -34,8 +34,8 @@
                         <option><?= /* @escapeNotVerified */ __('Choose an Option...') ?></option>
                     </select>
                 </div>
-            <?php endforeach; ?>
-        </div>
+            </div>
+        <?php endforeach; ?>
     </div>
 </fieldset>
 <script>

--- a/app/code/Magento/Sales/Test/Mftf/Section/AdminOrderFormConfigureProductSection.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Section/AdminOrderFormConfigureProductSection.xml
@@ -9,7 +9,7 @@
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="AdminOrderFormConfigureProductSection">
-        <element name="optionSelect" type="select" selector="//div[@class='product-options']/div/div/select[../../label[text() = '{{option}}']]" parameterized="true"/>
+        <element name="optionSelect" type="select" selector="//div[contains(@class, 'product-options')]//div//label[.='{{option}}']//following-sibling::*//select" parameterized="true"/>
         <element name="quantity" type="input" selector="#product_composite_configure_input_qty"/>
         <element name="ok" type="button" selector=".modal-header .page-actions button[data-role='action']" timeout="30"/>
     </section>

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Block/Adminhtml/Product/Composite/Configure.xml
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Block/Adminhtml/Product/Composite/Configure.xml
@@ -9,7 +9,7 @@
     <fields>
         <qty />
         <attribute>
-            <selector>//div[@class="product-options"]//label[.="%s"]//following-sibling::*//select</selector>
+            <selector>//div[contains(@class, "product-options")]//div//label[.="%s"]//following-sibling::*//select</selector>
             <strategy>xpath</strategy>
             <input>select</input>
         </attribute>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Original PR: #20558: fixes-customer-information-wishlist-configurable-product-alignment
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #20760: admin customer information wishlist configurable product alignment issue while editing
Magento 2.2.x

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1.  Go to admin
2.  In Customers >>All customers>> edit customer>>click on wishlist
3.  Action Configure

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
