### PR TITLE
changes for Product-detail-tabbing-issue-fixes

### DIFF
--- a/lib/web/mage/tabs.js
+++ b/lib/web/mage/tabs.js
@@ -72,7 +72,7 @@ define([
 
             if (anchor && isValid) {
                 $.each(self.contents, function (i) {
-                    if ($(this).attr('id') === anchorId) {
+                    if ($(this).attr('id') === anchorId || $(this).find('#' + anchorId).length) {
                         self.collapsibles.not(self.collapsibles.eq(i)).collapsible('forceDeactivate');
 
                         return false;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

Description (*)

  1.  On 2.3.0 product detail page 2 tabs are getting active once arrived from product listing page.

Fixed Issues (if relevant)

  1.  magento/magento2#<#21077>: Tabbing issue on product detail page

Manual testing scenarios (*)

 1.  In Frontend product listing page on list view mode click on Add Your Review link of product it will re-direct on product detail page. Once arrived on product detail page only review tab keep active.

![image](https://user-images.githubusercontent.com/18117994/52691818-153eb680-2f88-11e9-88b6-6fd725bc63c4.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
