### PR TITLE
Disable cron:run when maintenance mode is enabled

### DIFF
--- a/app/code/Magento/Cron/Test/Unit/Console/Command/CronCommandTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Console/Command/CronCommandTest.php
@@ -97,7 +97,7 @@ class CronCommandTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testWithDisabledMaintenanceMode()
+    public function testWithMaintenanceModeEnabled()
     {
         $this->maintenanceModeMock->expects($this->once())
             ->method('isOn')

--- a/app/code/Magento/Cron/Test/Unit/Console/Command/CronCommandTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Console/Command/CronCommandTest.php
@@ -101,7 +101,7 @@ class CronCommandTest extends \PHPUnit\Framework\TestCase
     {
         $this->maintenanceModeMock->expects($this->once())
             ->method('isOn')
-            ->willReturn(false);
+            ->willReturn(true);
         $this->objectManagerFactory->expects($this->never())
             ->method('create');
         $this->deploymentConfigMock->expects($this->never())


### PR DESCRIPTION
### Description

I believe cron jobs should be disabled while `setup:upgrade` is being run, to avoid concurrent accesses, which can lead to table locks that can make setup upgrade fail, plus we'll be using stale/wrong data for the cron jobs.

Since the maintenance mode makes sure the frontend is inaccessible, avoiding any writes to the database through it, I believe we should disable crons as well, as they have a heavy impact on the database.

### Manual testing scenarios

1. Run `php bin/magento maintenance:enable`;
2. Run `php bin/magento cron:run`;
3. Cron jobs should not run;

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
