### PR TITLE
[Backport] Fixed issue #20555 Meta Keywords/Meta Description are input field in product form while they are defined as textarea

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/General.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/General.php
@@ -361,8 +361,10 @@ class General extends AbstractModifier
                 'allowImport' => !$this->locator->getProduct()->getId(),
             ];
 
-            if (!in_array($listener, $textListeners)) {
-                $importsConfig['elementTmpl'] = 'ui/form/element/input';
+            if (in_array($listener, $textListeners)) {
+                $importsConfig['cols'] = 15;
+                $importsConfig['rows'] = 2;
+                $importsConfig['elementTmpl'] = 'ui/form/element/textarea';
             }
 
             $meta = $this->arrayManager->merge($listenerPath . static::META_CONFIG_PATH, $meta, $importsConfig);


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20556
Fixed issue #20555 Meta Keywords/Meta Description are input field in product form while they are defined as textarea

### Description (*)
Fixed issue #20555 Meta Keywords/Meta Description are input field in product form while they are defined as textarea

### Fixed Issues (if relevant)

1. magento/magento2 #20555: Meta Keywords/Meta Description are input field in product form while they are defined as textarea

### Manual testing scenarios (*)

1. Go to Store->Attributes->Product.
2. Search for Meta Keywords/Meta description.
3. View them, you will able to see their 'Catalog Input Type for Store Owner' is Textarea.
4. Now go to Catalog->Product
5. Click on 'Add Product button' Or Edit Product.
6. Go to Search engine optimization tab.
7. You will see Meta Keywords/Meta description are showing text field instead of textarea.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
