### PR TITLE
[Backport] icon text showing feature

### DIFF
--- a/lib/web/css/source/lib/_icons.less
+++ b/lib/web/css/source/lib/_icons.less
@@ -25,9 +25,12 @@
     @_icon-font-text-hide: @icon-font__text-hide,
     @_icon-font-display: @icon-font__display
 ) when (@_icon-font-position = before) {
-    ._lib-icon-text-hide(@_icon-font-text-hide);
     .lib-css(display, @_icon-font-display);
-    text-decoration: none;
+    text-decoration: none; 
+    
+    & when not (@_icon-font-content = false) {
+        ._lib-icon-text-hide(@_icon-font-text-hide);
+    }
 
     &:before {
         ._lib-icon-font(
@@ -68,10 +71,13 @@
     @_icon-font-text-hide: @icon-font__text-hide,
     @_icon-font-display: @icon-font__display
 ) when (@_icon-font-position = after) {
-    ._lib-icon-text-hide(@_icon-font-text-hide);
     .lib-css(display, @_icon-font-display);
     text-decoration: none;
-
+    
+    & when not (@_icon-font-content = false) {
+        ._lib-icon-text-hide(@_icon-font-text-hide);
+    }
+    
     &:after {
         ._lib-icon-font(
             @_icon-font-content,
@@ -151,8 +157,11 @@
     @_icon-image-text-hide: @icon__text-hide
 ) when (@_icon-image-position = before) {
     display: inline-block;
-    ._lib-icon-text-hide(@_icon-image-text-hide);
-
+    
+    & when not (@_icon-image = false) {
+        ._lib-icon-text-hide(@_icon-font-text-hide);
+    }
+    
     &:before {
         ._lib-icon-image(
             @_icon-image,
@@ -179,7 +188,10 @@
     @_icon-image-text-hide: @icon__text-hide
 ) when (@_icon-image-position = after) {
     display: inline-block;
-    ._lib-icon-text-hide(@_icon-image-text-hide);
+    
+    & when not (@_icon-image = false) {
+        ._lib-icon-text-hide(@_icon-font-text-hide);
+    }
 
     &:after {
         ._lib-icon-image(

--- a/lib/web/css/source/lib/_icons.less
+++ b/lib/web/css/source/lib/_icons.less
@@ -159,7 +159,7 @@
     display: inline-block;
     
     & when not (@_icon-image = false) {
-        ._lib-icon-text-hide(@_icon-font-text-hide);
+        ._lib-icon-text-hide(@_icon-image-text-hide);
     }
     
     &:before {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18706
added feature to show text when icon is set to false


### Description (*)
Added feature to force set show text = true  when icon is set to false. Currently when you want to remove icon you have to go and set each @_icon-font-text-hide = true manually 
It would make more sense to have it always shown when icon not existing.


### Fixed Issues (if relevant)

### Manual testing scenarios (*)
add icon with @_icon-font-text-hide= false and also icon-content = false 
text should be shown as icon is false 


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
