### PR TITLE
[backport] Focus not proper on configurable product swatches 2.2

### DIFF
--- a/app/code/Magento/Swatches/view/frontend/web/css/swatches.css
+++ b/app/code/Magento/Swatches/view/frontend/web/css/swatches.css
@@ -31,6 +31,10 @@
     margin-top: 10px;
 }
 
+.swatch-attribute-options:focus {
+    box-shadow: none;
+}
+
 .swatch-option {
     /*width: 30px;*/
     padding: 1px 2px;
@@ -45,6 +49,10 @@
     border: 1px solid rgb(218, 218, 218);
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.swatch-option:focus {
+    box-shadow: 0 0 3px 1px #68a8e0;
 }
 
 .swatch-option.text {

--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
@@ -294,6 +294,11 @@
     }
 
     .product-options-wrapper {
+        .fieldset {
+            &:focus {
+                box-shadow: none;
+            }
+        }
         .fieldset-product-options-inner {
             .legend {
                 .lib-css(font-weight, @font-weight__semibold);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
On configurable product page, swatches not having proper focus
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #20992: focus not proper

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1.  go on configurable product
2.  click on add to cart button without selecting any option

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

Backport for: https://github.com/magento/magento2/pull/20992