### PR TITLE
[Backport] [Sales] Improves the UX by scrolling down the customer to the Recent Orders

### DIFF
--- a/app/code/Magento/Sales/view/frontend/templates/reorder/sidebar.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/reorder/sidebar.phtml
@@ -57,7 +57,7 @@
                     </button>
                 </div>
                 <div class="secondary">
-                    <a class="action view" href="<?= /* @escapeNotVerified */ $block->getUrl('customer/account') ?>">
+                    <a class="action view" href="<?= /* @escapeNotVerified */ $block->getUrl('customer/account') ?>#my-orders-table">
                         <span><?= /* @escapeNotVerified */ __('View All') ?></span>
                     </a>
                 </div>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21100
### Description (*)
This PR improves the UX by scrolling down to the recent orders, after clicking the _View All_ link from the **Recently Ordered** sidebar.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
N/A

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create an account
2. Add some info related to customer (to have more info on customer dashboard)
2.1 Add a new address (billing/shipping)
2.2 Add a product review
2. Create a new order being logged in.
3. Now use the sidebar's _View All_ Recently Ordered link
![xnip2019-02-09_16-34-32](https://user-images.githubusercontent.com/15868188/52522017-9e07da80-2c88-11e9-8052-06b8cd19819a.jpg)

As result, you should get on customer's dashboard and scrolled down till **Recent Orders** grid.
![xnip2019-02-09_16-37-02](https://user-images.githubusercontent.com/15868188/52522364-1ffa0280-2c8d-11e9-89d6-d62b10300886.jpg)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
