### PR TITLE
[Backport] Curl - allow setting HTTP version

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
@@ -170,6 +170,7 @@ class Curl implements \Zend_Http_Client_Adapter_Interface
 
         // set url to post to
         curl_setopt($this->_getResource(), CURLOPT_URL, $url);
+        curl_setopt($this->_getResource(), CURLOPT_HTTP_VERSION, $http_ver);
         curl_setopt($this->_getResource(), CURLOPT_RETURNTRANSFER, true);
         if ($method == \Zend_Http_Client::POST) {
             curl_setopt($this->_getResource(), CURLOPT_POST, true);


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19845
### Description
Added allow for setting curl http version

### Fixed Issues (if relevant)
1. magento/magento2#19442: Magento/Framework/HTTP/Adapter/Curl.php doesn't allow setting HTTP version

### Manual testing scenarios (*)
1. Create new ZendClient $client
2. Set HTTP version $client->setConfig(['httpversion' => CURL_HTTP_VERSION_1_1])
3. Make a request $client->request()

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

### Additional information
1. magento/magento2#19445: Recovered Pull Request