### PR TITLE
[Backport] [Catalog] Fixing compare block product removing action from sidebar

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/_module.less
@@ -534,6 +534,15 @@
             }
         }
 
+        .block-compare {
+            .action {
+                &.delete {
+                    &:extend(.abs-remove-button-for-blocks all);
+                    right: initial;
+                }
+            }
+        }
+
         .action.tocart {
             border-radius: 0;
         }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21102
### Description (*)
This PR allows to open the product from the Comparing Products sidebar's block.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21101: Unable to open the product from sidebar's Compare Products block
2. ...

### Manual testing scenarios (*)
1. Add a product to your Compare Products list
2. Check the sidebar for new added product for comparing
3. Click on the Product's name

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
