### PR TITLE
[Backport] Fixed  #21144 Can't change customer group when placing an admin order

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Form/Account.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Form/Account.php
@@ -199,7 +199,7 @@ class Account extends AbstractForm
             if (isset($defaultValue) && !isset($formValues[$code])) {
                 $formValues[$code] = $defaultValue;
             }
-            if ($code === 'group_id' && empty($defaultValue)) {
+            if ($code === 'group_id' && empty($formValues[$code])) {
                 $formValues[$code] = $this->getDefaultCustomerGroup($storeId);
             }
         }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21145
Fixed  #21144 Can't change customer group when placing an admin order

When ordering in the admin, we can't change the customer group when creating a new customer while creating an order.
### Preconditions
1.  Magento 2.3
3.  Several Customer Groups created
### Steps to reproduce
1.  In admin select Sales->Orders.
2.  Select Create New Order
3.  Select Create New Customer
4.  Under Account Information, change the group.
### Expected result
1.  Selected customer group stays selected in select box.
2.  Product prices are updated for the group.
### Actual result
1.  Wait overlay comes up, twice.
2.  Customer group goes back to the default.
3.  Email input box to the right is cleared.
4.  Product prices stay the same.

Note: this issue is similiar to #7974 and #6162

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
