### PR TITLE
[Backport] view-order-price-subtotal-alignment-not-proper-mobile

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Sales/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Sales/web/css/source/_module.less
@@ -295,7 +295,10 @@
         }
     }
     .order-items.table-wrapper {
-        .col.price, .col.qty, .col.subtotal, .col.msrp {
+        .col.price,
+        .col.qty,
+        .col.subtotal,
+        .col.msrp {
             text-align: left;
         }
     }

--- a/app/design/frontend/Magento/blank/Magento_Sales/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Sales/web/css/source/_module.less
@@ -294,6 +294,11 @@
             }
         }
     }
+    .order-items.table-wrapper {
+        .col.price, .col.qty, .col.subtotal, .col.msrp {
+            text-align: left;
+        }
+    }
 }
 
 .media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
@@ -422,6 +422,14 @@
             &:extend(.abs-sidebar-totals-mobile all);
         }
     }
+    .order-items.table-wrapper {
+        .col.price,
+        .col.qty,
+        .col.subtotal,
+        .col.msrp {
+            text-align: left;
+        }
+    }
 }
 
 .media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {

--- a/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
@@ -503,6 +503,11 @@
             }
         }
     }
+    .order-items.table-wrapper {
+        .col.price, .col.qty, .col.subtotal, .col.msrp {
+            text-align: left;
+        }
+    }
 }
 
 .media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {

--- a/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
@@ -503,11 +503,6 @@
             }
         }
     }
-    .order-items.table-wrapper {
-        .col.price, .col.qty, .col.subtotal, .col.msrp {
-            text-align: left;
-        }
-    }
 }
 
 .media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20466
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20299: Order item details label not aligned in mobile view
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open frontend and login as customer
2. Go to my account section
3. Click on My order link and open detail any order in mobile
4. You will issue as shown in screenshot

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
