### PR TITLE
[Backport] Assign with and, or, replaced by &&, ||

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Attribute/Validate.php
@@ -158,7 +158,7 @@ class Validate extends \Magento\Catalog\Controller\Adminhtml\Product\Attribute
     {
         $adminValues = [];
         foreach ($optionsValues as $optionKey => $values) {
-            if (!(isset($deletedOptions[$optionKey]) and $deletedOptions[$optionKey] === '1')) {
+            if (!(isset($deletedOptions[$optionKey]) && $deletedOptions[$optionKey] === '1')) {
                 $adminValues[] = reset($values);
             }
         }

--- a/app/code/Magento/Paypal/Controller/Transparent/RequestSecureToken.php
+++ b/app/code/Magento/Paypal/Controller/Transparent/RequestSecureToken.php
@@ -82,7 +82,7 @@ class RequestSecureToken extends \Magento\Framework\App\Action\Action
         /** @var Quote $quote */
         $quote = $this->sessionManager->getQuote();
 
-        if (!$quote or !$quote instanceof Quote) {
+        if (!$quote || !$quote instanceof Quote) {
             return $this->getErrorResponse();
         }
 

--- a/app/code/Magento/Paypal/Controller/Transparent/RequestSecureToken.php
+++ b/app/code/Magento/Paypal/Controller/Transparent/RequestSecureToken.php
@@ -106,6 +106,8 @@ class RequestSecureToken extends \Magento\Framework\App\Action\Action
     }
 
     /**
+     * Get error response.
+     *
      * @return Json
      */
     private function getErrorResponse()

--- a/app/code/Magento/Security/Model/SecurityChecker/Quantity.php
+++ b/app/code/Magento/Security/Model/SecurityChecker/Quantity.php
@@ -47,7 +47,7 @@ class Quantity implements SecurityCheckerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function check($securityEventType, $accountReference = null, $longIp = null)
     {

--- a/app/code/Magento/Security/Model/SecurityChecker/Quantity.php
+++ b/app/code/Magento/Security/Model/SecurityChecker/Quantity.php
@@ -53,7 +53,7 @@ class Quantity implements SecurityCheckerInterface
     {
         $isEnabled = $this->securityConfig->getPasswordResetProtectionType() != ResetMethod::OPTION_NONE;
         $allowedAttemptsNumber = $this->securityConfig->getMaxNumberPasswordResetRequests();
-        if ($isEnabled and $allowedAttemptsNumber) {
+        if ($isEnabled && $allowedAttemptsNumber) {
             $collection = $this->prepareCollection($securityEventType, $accountReference, $longIp);
             if ($collection->count() >= $allowedAttemptsNumber) {
                 throw new SecurityViolationException(

--- a/app/code/Magento/SendFriend/Model/SendFriend.php
+++ b/app/code/Magento/SendFriend/Model/SendFriend.php
@@ -236,7 +236,7 @@ class SendFriend extends \Magento\Framework\Model\AbstractModel
         }
 
         $email = $this->getSender()->getEmail();
-        if (empty($email) or !\Zend_Validate::is($email, \Magento\Framework\Validator\EmailAddress::class)) {
+        if (empty($email) || !\Zend_Validate::is($email, \Magento\Framework\Validator\EmailAddress::class)) {
             $errors[] = __('Invalid Sender Email');
         }
 
@@ -281,13 +281,13 @@ class SendFriend extends \Magento\Framework\Model\AbstractModel
         // validate array
         if (!is_array(
             $recipients
-        ) or !isset(
+        ) || !isset(
             $recipients['email']
-        ) or !isset(
+        ) || !isset(
             $recipients['name']
-        ) or !is_array(
+        ) || !is_array(
             $recipients['email']
-        ) or !is_array(
+        ) || !is_array(
             $recipients['name']
         )
         ) {
@@ -487,7 +487,7 @@ class SendFriend extends \Magento\Framework\Model\AbstractModel
             $oldTimes = explode(',', $oldTimes);
             foreach ($oldTimes as $oldTime) {
                 $periodTime = $time - $this->_sendfriendData->getPeriod();
-                if (is_numeric($oldTime) and $oldTime >= $periodTime) {
+                if (is_numeric($oldTime) && $oldTime >= $periodTime) {
                     $newTimes[] = $oldTime;
                 }
             }

--- a/app/code/Magento/SendFriend/Model/SendFriend.php
+++ b/app/code/Magento/SendFriend/Model/SendFriend.php
@@ -16,6 +16,7 @@ use Magento\Framework\Exception\LocalizedException as CoreException;
  * @method \Magento\SendFriend\Model\SendFriend setTime(int $value)
  *
  * @author      Magento Core Team <core@magentocommerce.com>
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  *
  * @api
@@ -162,6 +163,8 @@ class SendFriend extends \Magento\Framework\Model\AbstractModel
     }
 
     /**
+     * Send email.
+     *
      * @return $this
      * @throws CoreException
      */

--- a/app/code/Magento/Tax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/Magento/Tax/Model/Sales/Total/Quote/Tax.php
@@ -264,7 +264,7 @@ class Tax extends CommonTaxCollector
     {
         $extraTaxableDetails = [];
         foreach ($itemsByType as $itemType => $itemTaxDetails) {
-            if ($itemType != self::ITEM_TYPE_PRODUCT and $itemType != self::ITEM_TYPE_SHIPPING) {
+            if ($itemType != self::ITEM_TYPE_PRODUCT && $itemType != self::ITEM_TYPE_SHIPPING) {
                 foreach ($itemTaxDetails as $itemCode => $itemTaxDetail) {
                     /** @var \Magento\Tax\Api\Data\TaxDetailsInterface $taxDetails */
                     $taxDetails = $itemTaxDetail[self::KEY_ITEM];

--- a/app/code/Magento/Tax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/Magento/Tax/Model/Sales/Total/Quote/Tax.php
@@ -407,6 +407,7 @@ class Tax extends CommonTaxCollector
 
     /**
      * Process model configuration array.
+     *
      * This method can be used for changing totals collect sort order
      *
      * @param   array $config

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/ClassesTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/ClassesTest.php
@@ -191,7 +191,7 @@ class ClassesTest extends \PHPUnit\Framework\TestCase
         foreach ($classes as $class) {
             $class = trim($class, '\\');
             try {
-                if (strrchr($class, '\\') === false and !Classes::isVirtual($class)) {
+                if (strrchr($class, '\\') === false && !Classes::isVirtual($class)) {
                     $badUsages[] = $class;
                     continue;
                 } else {

--- a/lib/internal/Magento/Framework/Filter/Template.php
+++ b/lib/internal/Magento/Framework/Filter/Template.php
@@ -227,7 +227,7 @@ class Template implements \Zend_Filter_Interface
     {
         // Processing of {template config_path=... [...]} statement
         $templateParameters = $this->getParameters($construction[2]);
-        if (!isset($templateParameters['config_path']) or !$this->getTemplateProcessor()) {
+        if (!isset($templateParameters['config_path']) || !$this->getTemplateProcessor()) {
             // Not specified template or not set include processor
             $replacedValue = '{Error in template processing}';
         } else {

--- a/lib/internal/Magento/Framework/Message/Manager.php
+++ b/lib/internal/Magento/Framework/Message/Manager.php
@@ -226,7 +226,7 @@ class Manager implements ManagerInterface
         $items = $this->getMessages(false, $group)->getItems();
 
         foreach ($messages as $message) {
-            if ($message instanceof MessageInterface and !in_array($message, $items, false)) {
+            if ($message instanceof MessageInterface && !in_array($message, $items, false)) {
                 $this->addMessage($message, $group);
             }
         }

--- a/lib/internal/Magento/Framework/Message/Manager.php
+++ b/lib/internal/Magento/Framework/Message/Manager.php
@@ -11,6 +11,8 @@ use Magento\Framework\App\ObjectManager;
 
 /**
  * Message manager model
+ *
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class Manager implements ManagerInterface

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/Session.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/Session.php
@@ -301,7 +301,7 @@ class Session implements ConfigOptionsListInterface
 
         if (isset($options[self::INPUT_KEY_SESSION_REDIS_LOG_LEVEL])) {
             $level = $options[self::INPUT_KEY_SESSION_REDIS_LOG_LEVEL];
-            if (($level < 0) or ($level > 7)) {
+            if (($level < 0) || ($level > 7)) {
                 $errors[] = "Invalid Redis log level '{$level}'. Valid range is 0-7, inclusive.";
             }
         }

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/Session.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/Session.php
@@ -124,7 +124,7 @@ class Session implements ConfigOptionsListInterface
     ];
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function getOptions()
@@ -250,7 +250,7 @@ class Session implements ConfigOptionsListInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function createConfig(array $options, DeploymentConfig $deploymentConfig)
     {
@@ -281,7 +281,7 @@ class Session implements ConfigOptionsListInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function validate(array $options, DeploymentConfig $deploymentConfig)
     {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20628
### Description (*)
It is recommended to use the &&, || operators, instead of and, or to prevent confusion.

I kept the integrity of the source code on the occurrences with xor that returns boolean , if we use ^ instead of xor it'll return integer.

### Fixed Issues (if relevant)
N/A