### PR TITLE
[Backport] Full Tax Summary display wrong numbers

### DIFF
--- a/app/code/Magento/Tax/view/frontend/web/js/view/checkout/summary/tax.js
+++ b/app/code/Magento/Tax/view/frontend/web/js/view/checkout/summary/tax.js
@@ -13,13 +13,16 @@ define([
     'Magento_Checkout/js/model/quote',
     'Magento_Checkout/js/model/totals',
     'jquery',
-    'mage/translate'
-], function (ko, Component, quote, totals, $, $t) {
+    'mage/translate',
+    'underscore'
+], function (ko, Component, quote, totals, $t, _) {
     'use strict';
 
     var isTaxDisplayedInGrandTotal = window.checkoutConfig.includeTaxInGrandTotal,
         isFullTaxSummaryDisplayed = window.checkoutConfig.isFullTaxSummaryDisplayed,
-        isZeroTaxDisplayed = window.checkoutConfig.isZeroTaxDisplayed;
+        isZeroTaxDisplayed = window.checkoutConfig.isZeroTaxDisplayed,
+        taxAmount = 0,
+        rates = 0;
 
     return Component.extend({
         defaults: {
@@ -97,6 +100,33 @@ define([
          */
         formatPrice: function (amount) {
             return this.getFormattedPrice(amount);
+        },
+
+        /**
+         * @param {*} parent
+         * @param {*} percentage
+         * @return {*|String}
+         */
+        getTaxAmount: function (parent, percentage) {
+            var totalPercentage = 0;
+
+            taxAmount = parent.amount;
+            rates = parent.rates;
+            _.each(rates, function (rate) {
+                totalPercentage += parseFloat(rate.percent);
+            });
+
+            return this.getFormattedPrice(this.getPercentAmount(taxAmount, totalPercentage, percentage));
+        },
+
+        /**
+         * @param {*} amount
+         * @param {*} totalPercentage
+         * @param {*} percentage
+         * @return {*|String}
+         */
+        getPercentAmount: function (amount, totalPercentage, percentage) {
+            return parseFloat(amount * percentage / totalPercentage);
         },
 
         /**

--- a/app/code/Magento/Tax/view/frontend/web/template/checkout/cart/totals/tax.html
+++ b/app/code/Magento/Tax/view/frontend/web/template/checkout/cart/totals/tax.html
@@ -32,18 +32,16 @@
             <!-- ko if: !percent -->
                 <th class="mark" scope="row" colspan="1" data-bind="text: title"></th>
             <!-- /ko -->
-            <!-- ko if: $index() == 0 -->
-                <td class="amount" rowspan="1">
-                    <!-- ko if: $parents[1].isCalculated() -->
-                    <span class="price"
-                          data-bind="text: $parents[1].formatPrice($parents[0].amount), attr: {'data-th': title, 'rowspan': $parents[0].rates.length }"></span>
-                    <!-- /ko -->
-                    <!-- ko ifnot: $parents[1].isCalculated() -->
-                    <span class="not-calculated"
-                          data-bind="text: $parents[1].formatPrice($parents[0].amount), attr: {'data-th': title, 'rowspan': $parents[0].rates.length }"></span>
-                    <!-- /ko -->
-                </td>
-            <!-- /ko -->
+            <td class="amount" rowspan="1">
+                <!-- ko if: $parents[1].isCalculated() -->
+                <span class="price"
+                      data-bind="text: $parents[1].getTaxAmount($parents[0], percent), attr: {'data-th': title, 'rowspan': $parents[0].rates.length }"></span>
+                <!-- /ko -->
+                <!-- ko ifnot: $parents[1].isCalculated() -->
+                <span class="not-calculated"
+                      data-bind="text: $parents[1].getTaxAmount($parents[0], percent), attr: {'data-th': title, 'rowspan': $parents[0].rates.length }"></span>
+                <!-- /ko -->
+            </td>
         </tr>
         <!-- /ko -->
     <!-- /ko -->

--- a/app/code/Magento/Tax/view/frontend/web/template/checkout/summary/tax.html
+++ b/app/code/Magento/Tax/view/frontend/web/template/checkout/summary/tax.html
@@ -43,18 +43,16 @@
             <!-- ko if: !percent -->
                 <th class="mark" scope="row" data-bind="text: title"></th>
             <!-- /ko -->
-            <!-- ko if: $index() == 0 -->
-                <td class="amount">
-                    <!-- ko if: $parents[1].isCalculated() -->
-                    <span class="price"
-                          data-bind="text: $parents[1].formatPrice($parents[0].amount), attr: {'data-th': title, 'rowspan': $parents[0].rates.length }"></span>
-                    <!-- /ko -->
-                    <!-- ko ifnot: $parents[1].isCalculated() -->
-                    <span class="not-calculated"
-                          data-bind="text: $parents[1].formatPrice($parents[0].amount), attr: {'data-th': title, 'rowspan': $parents[0].rates.length }"></span>
-                    <!-- /ko -->
-                </td>
-            <!-- /ko -->
+            <td class="amount">
+                <!-- ko if: $parents[1].isCalculated() -->
+                <span class="price"
+                      data-bind="text: $parents[1].getTaxAmount($parents[0], percent), attr: {'data-th': title, 'rowspan': $parents[0].rates.length }"></span>
+                <!-- /ko -->
+                <!-- ko ifnot: $parents[1].isCalculated() -->
+                <span class="not-calculated"
+                      data-bind="text: $parents[1].getTaxAmount($parents[0], percent), attr: {'data-th': title, 'rowspan': $parents[0].rates.length }"></span>
+                <!-- /ko -->
+            </td>
         </tr>
         <!-- /ko -->
     <!-- /ko -->


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
#20682
### Description (*)

The full tax summary is displaying total tax, instead of showing individual tax value.

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19701: Magento 2.3 Shopping Cart Taxes Missing Calc Line
2. magento/magento2#11358: Full Tax Summary display wrong numbers.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Manual Testing

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
