### PR TITLE
[Backport] #18347 - Element 'css', attribute 'as': The attribute 'as' is not allowed. (CSS preloading)

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/etc/head.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/head.xsd
@@ -20,6 +20,15 @@
         <xs:attribute name="type" type="xs:string"/>
         <xs:attribute name="order" type="xs:integer"/>
         <xs:attribute name="src_type" type="xs:string"/>
+        <xs:attribute name="as">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="font" />
+                    <xs:enumeration value="script" />
+                    <xs:enumeration value="style" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="metaType">


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20495
### Description (*)
Added `as` attribute to `linkType` in `lib/internal/Magento/Framework/View/Layout/etc/head.xsd` with 3 possible options: `style`, `script` and `font`. Why only these 3 ? Because in my opinion only those should be added to the head (and would be needed by developers).

Related links: [](url)
- [link: The External Resource Link element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#Attributes)
- [Preload: What Is It Good For?](https://www.smashingmagazine.com/2016/02/preload-what-is-it-good-for/)

### Fixed Issues (if relevant)
1. magento/magento2#18347: Element 'css', attribute 'as': The attribute 'as' is not allowed. (CSS preloading)

### Manual testing scenarios (*)
Described in the Issue's description.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
