### PR TITLE
[Backport] Fixed issue  Unable to open URL for downloadable product

### DIFF
--- a/app/code/Magento/Downloadable/Helper/Download.php
+++ b/app/code/Magento/Downloadable/Helper/Download.php
@@ -15,6 +15,7 @@ use Magento\Framework\Exception\LocalizedException as CoreException;
 /**
  * Downloadable Products Download Helper
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  */
 class Download extends \Magento\Framework\App\Helper\AbstractHelper
 {
@@ -263,9 +264,9 @@ class Download extends \Magento\Framework\App\Helper\AbstractHelper
         */
         if ($linkType === self::LINK_TYPE_URL) {
             $headers = array_change_key_case(get_headers($this->_resourceFile, 1), CASE_LOWER);
-            if(isset($headers['location'])){
-                $this->_resourceFile  = is_array($headers['location']) ? current($headers['location']): 
-                                        $headers['location'];
+            if (isset($headers['location'])) {
+                $this->_resourceFile  = is_array($headers['location']) ? current($headers['location'])
+                    : $headers['location'];
             }
         }
         

--- a/app/code/Magento/Downloadable/Helper/Download.php
+++ b/app/code/Magento/Downloadable/Helper/Download.php
@@ -185,26 +185,23 @@ class Download extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return string
      */
-    public function getContentType()
+   public function getContentType()
     {
         $this->_getHandle();
-        if ($this->_linkType == self::LINK_TYPE_FILE) {
-            if (function_exists(
-                'mime_content_type'
-            ) && ($contentType = mime_content_type(
-                $this->_workingDirectory->getAbsolutePath($this->_resourceFile)
-            ))
+        if ($this->_linkType === self::LINK_TYPE_FILE) {
+            if (function_exists('mime_content_type')
+                && ($contentType = mime_content_type(
+                    $this->_workingDirectory->getAbsolutePath($this->_resourceFile)
+                ))
             ) {
                 return $contentType;
-            } else {
-                return $this->_downloadableFile->getFileType($this->_resourceFile);
             }
-        } elseif ($this->_linkType == self::LINK_TYPE_URL) {
-            if (is_array($this->_handle->stat($this->_resourceFile)['type'])) {
-                return end($this->_handle->stat($this->_resourceFile)['type']);
-            } else {
-                return $this->_handle->stat($this->_resourceFile)['type'];
-            }
+            return $this->_downloadableFile->getFileType($this->_resourceFile);
+        }
+        if ($this->_linkType === self::LINK_TYPE_URL) {
+            return (is_array($this->_handle->stat($this->_resourceFile)['type'])
+                ? end($this->_handle->stat($this->_resourceFile)['type'])
+                : $this->_handle->stat($this->_resourceFile)['type']);
         }
         return $this->_contentType;
     }

--- a/app/code/Magento/Downloadable/Helper/Download.php
+++ b/app/code/Magento/Downloadable/Helper/Download.php
@@ -256,15 +256,17 @@ class Download extends \Magento\Framework\App\Helper\AbstractHelper
             }
         }
         
-       /**
-        * check header
-        */
-
         $this->_resourceFile = $resourceFile;
-        $headers = array_change_key_case(get_headers($this->_resourceFile, 1), CASE_LOWER);
-        if(isset($headers['location'])){
-            $this->_resourceFile  = is_array($headers['location']) ? current($headers['location']): 
-                                    $headers['location'];
+        
+        /**
+        * check header for urls
+        */
+        if ($this->_linkType === self::LINK_TYPE_URL) {
+            $headers = array_change_key_case(get_headers($this->_resourceFile, 1), CASE_LOWER);
+            if(isset($headers['location'])){
+                $this->_resourceFile  = is_array($headers['location']) ? current($headers['location']): 
+                                        $headers['location'];
+            }
         }
         
         $this->_linkType = $linkType;

--- a/app/code/Magento/Downloadable/Helper/Download.php
+++ b/app/code/Magento/Downloadable/Helper/Download.php
@@ -255,10 +255,19 @@ class Download extends \Magento\Framework\App\Helper\AbstractHelper
                 );
             }
         }
+        
+       /**
+        * check header
+        */
 
         $this->_resourceFile = $resourceFile;
+        $headers = array_change_key_case(get_headers($this->_resourceFile, 1), CASE_LOWER);
+        if(isset($headers['location'])){
+            $this->_resourceFile  = is_array($headers['location']) ? current($headers['location']): 
+                                    $headers['location'];
+        }
+        
         $this->_linkType = $linkType;
-
         return $this;
     }
 

--- a/app/code/Magento/Downloadable/Helper/Download.php
+++ b/app/code/Magento/Downloadable/Helper/Download.php
@@ -185,7 +185,7 @@ class Download extends \Magento\Framework\App\Helper\AbstractHelper
      *
      * @return string
      */
-   public function getContentType()
+    public function getContentType()
     {
         $this->_getHandle();
         if ($this->_linkType === self::LINK_TYPE_FILE) {

--- a/app/code/Magento/Downloadable/Helper/Download.php
+++ b/app/code/Magento/Downloadable/Helper/Download.php
@@ -200,6 +200,9 @@ class Download extends \Magento\Framework\App\Helper\AbstractHelper
                 return $this->_downloadableFile->getFileType($this->_resourceFile);
             }
         } elseif ($this->_linkType == self::LINK_TYPE_URL) {
+           if(is_array($this->_handle->stat($this->_resourceFile)['type'])){
+                return end($this->_handle->stat($this->_resourceFile)['type']);
+            }else
             return $this->_handle->stat($this->_resourceFile)['type'];
         }
         return $this->_contentType;

--- a/app/code/Magento/Downloadable/Helper/Download.php
+++ b/app/code/Magento/Downloadable/Helper/Download.php
@@ -200,10 +200,11 @@ class Download extends \Magento\Framework\App\Helper\AbstractHelper
                 return $this->_downloadableFile->getFileType($this->_resourceFile);
             }
         } elseif ($this->_linkType == self::LINK_TYPE_URL) {
-           if(is_array($this->_handle->stat($this->_resourceFile)['type'])){
+            if (is_array($this->_handle->stat($this->_resourceFile)['type'])) {
                 return end($this->_handle->stat($this->_resourceFile)['type']);
-            }else
-            return $this->_handle->stat($this->_resourceFile)['type'];
+            } else {
+                return $this->_handle->stat($this->_resourceFile)['type'];
+            }
         }
         return $this->_contentType;
     }

--- a/app/code/Magento/Downloadable/Helper/Download.php
+++ b/app/code/Magento/Downloadable/Helper/Download.php
@@ -261,7 +261,7 @@ class Download extends \Magento\Framework\App\Helper\AbstractHelper
         /**
         * check header for urls
         */
-        if ($this->_linkType === self::LINK_TYPE_URL) {
+        if ($linkType === self::LINK_TYPE_URL) {
             $headers = array_change_key_case(get_headers($this->_resourceFile, 1), CASE_LOWER);
             if(isset($headers['location'])){
                 $this->_resourceFile  = is_array($headers['location']) ? current($headers['location']): 

--- a/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
@@ -34,7 +34,7 @@ class Http extends File
         $status = $headers[0];
 
         /* Handling 301 or 302 redirection */
-        if (isset($headers[1]) && preg_match('/^30[12]/', $status)) {
+        if (isset($headers[1]) && preg_match('/30[12]/', $status)) {
             $status = $headers[1];
         }
 

--- a/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
@@ -39,6 +39,11 @@ class Http extends File
         if (strpos($status, '302 Found') !== false && isset($headers[1])) {
             $status = $headers[1];
         }
+        
+        /* Handling 301 redirection */
+        if (strpos($status, '301 Moved Permanently') !== false && isset($headers[1])) {
+            $status = $headers[1];
+        }
 
         if (strpos($status, '200 OK') === false) {
             $result = false;

--- a/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
@@ -27,31 +27,18 @@ class Http extends File
      *
      * @param string $path
      * @return bool
-     * @throws FileSystemException
      */
     public function isExists($path)
     {
         $headers = array_change_key_case(get_headers($this->getScheme() . $path, 1), CASE_LOWER);
-
         $status = $headers[0];
 
-        /* Handling 302 redirection */
-        if (strpos($status, '302 Found') !== false && isset($headers[1])) {
-            $status = $headers[1];
-        }
-        
-        /* Handling 301 redirection */
-        if (strpos($status, '301 Moved Permanently') !== false && isset($headers[1])) {
+        /* Handling 301 or 302 redirection */
+        if (isset($headers[1]) && preg_match('/^30[12]/', $status)) {
             $status = $headers[1];
         }
 
-        if (strpos($status, '200 OK') === false) {
-            $result = false;
-        } else {
-            $result = true;
-        }
-
-        return $result;
+        return !(strpos($status, '200 OK') === false);
     }
 
     /**


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19996
Fixed issue Unable to open URL for downloadable product #18944
Preconditions (*)

1.  Magento V2.2.6 Clean Install.
2.  PHP 7.0.28
3.  No special caching is present.

Steps to reproduce (*)

1.   Create downloadable product.
2.    Add a link to this product, for example https://google.com
3.    Save product.
4.    Order product in front-end.
5.    After order status complete navigate to your downloadable products in front-end.
6.   Click the button to open the URL set in step 2 to download your product.

**Expected result (*)**

    A new page of https://google.com is opened and shown in browser.

 **Actual result (*)**

    Page is not opened correctly and error by Magento is thrown:
    Something went wrong while getting the requested content.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
