### PR TITLE
[Backport] Fixed issue if there are multiple skus in catalog rule condition combination

### DIFF
--- a/app/code/Magento/Rule/Model/Condition/Product/AbstractProduct.php
+++ b/app/code/Magento/Rule/Model/Condition/Product/AbstractProduct.php
@@ -520,6 +520,10 @@ abstract class AbstractProduct extends \Magento\Rule\Model\Condition\AbstractCon
             ) ? $this->_localeFormat->getNumber(
                 $arr['is_value_parsed']
             ) : false;
+        } elseif (!empty($arr['operator']) && $arr['operator'] == '()') {
+            if (isset($arr['value'])) {
+                $arr['value'] = preg_replace('/\s*,\s*/', ',', $arr['value']);
+            }
         }
 
         return parent::loadArray($arr);

--- a/app/code/Magento/Rule/Model/Condition/Product/AbstractProduct.php
+++ b/app/code/Magento/Rule/Model/Condition/Product/AbstractProduct.php
@@ -95,8 +95,8 @@ abstract class AbstractProduct extends \Magento\Rule\Model\Condition\AbstractCon
      * @param \Magento\Catalog\Model\ResourceModel\Product $productResource
      * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\Collection $attrSetCollection
      * @param \Magento\Framework\Locale\FormatInterface $localeFormat
-     * @param ProductCategoryList|null $categoryList
      * @param array $data
+     * @param ProductCategoryList|null $categoryList
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
@@ -710,6 +710,7 @@ abstract class AbstractProduct extends \Magento\Rule\Model\Condition\AbstractCon
 
     /**
      * Correct '==' and '!=' operators
+     *
      * Categories can't be equal because product is included categories selected by administrator and in their parents
      *
      * @return string


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20923
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
Fixed issue if there are multiple skus in catalog rule condition combination
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In catalog rule, if there are multiple skus and the condition is 'in one of' then the discount applies only on the first sku.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Have a Magento v2.3 clean installation.
2. Go to Stores > Attributes > Product and edit sku attribute.
3. Go to **Storefront Properties** tab and set **YES** for **Use for Promo Rule Conditions**.
4. Go to Marketing > Promotions > Catalog Price Rule and Add New Rule.
5. Create a new rule, select SKU as the product attribute from the condition dropdown, select **is one of** as a condition and select more than one SKU in the value.
6. Click on Save and Apply.
7. Refresh Magento cache by navigating System > Tools > Cache Management.
8. **Before:** On the frontend, the discount applies only on the first SKU from the condition.
**After:** The discount applies on all the products from the condition.

Following are the before after videos of the issue:

[Before Video
](https://drive.google.com/file/d/1EdAfnDlgta2aTllWE1Q3zsmbKZq5P8D3/view?usp=sharing)
[After Video](https://drive.google.com/file/d/1JXg1nUpKAiJGryx60ua9YW_yV6A69S0g/view?usp=sharing)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
