### PR TITLE
Static tests: forbid 'or' instead of '||' #21062.

### DIFF
--- a/dev/tests/static/framework/Magento/ruleset.xml
+++ b/dev/tests/static/framework/Magento/ruleset.xml
@@ -84,5 +84,6 @@
 
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
     <rule ref="Squiz.Functions.GlobalFunction"/>
+    <rule ref="Squiz.Operators.ValidLogicalOperators"/>
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
 </ruleset>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Added `Squiz.Operators.ValidLogicalOperators` PHP-CS rule

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21062: Static tests: forbid 'or' instead of '||' 

### Manual testing scenarios (*)
Just make sure PHP-CS asks you to avoid the literal logical operators
![image](https://user-images.githubusercontent.com/26086561/53413878-f6074680-39d5-11e9-9a84-dc05f6dc7c7f.png)
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
