### PR TITLE
Fixed calculation of 'Total' column under "Last Orders" listing on the admin dashboard

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
@@ -830,7 +830,13 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
             ? '(main_table.base_subtotal - %2$s - %1$s - (ABS(main_table.base_discount_amount) - %3$s - %4$s))'
             : '((main_table.base_subtotal - %1$s - %2$s - (ABS(main_table.base_discount_amount) - %3$s - %4$s)) '
                 . ' * main_table.base_to_global_rate)';
-        return sprintf($template, $baseSubtotalRefunded, $baseSubtotalCanceled, $baseDiscountRefunded, $baseDiscountCanceled);
+        return sprintf(
+            $template,
+            $baseSubtotalRefunded,
+            $baseSubtotalCanceled,
+            $baseDiscountRefunded,
+            $baseDiscountCanceled
+        );
     }
 
     /**

--- a/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
@@ -773,6 +773,7 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
             !$convertCurrency,
             $this->getConnection()->getIfNullSql('main_table.base_subtotal_refunded', 0),
             $this->getConnection()->getIfNullSql('main_table.base_subtotal_canceled', 0),
+            $this->getConnection()->getIfNullSql('main_table.base_discount_refunded', 0),
             $this->getConnection()->getIfNullSql('main_table.base_discount_canceled', 0)
         );
         $this->getSelect()->columns(['revenue' => $expr]);
@@ -795,6 +796,7 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
             $storeId,
             $this->getConnection()->getIfNullSql('main_table.base_subtotal_refunded', 0),
             $this->getConnection()->getIfNullSql('main_table.base_subtotal_canceled', 0),
+            $this->getConnection()->getIfNullSql('main_table.base_discount_refunded', 0),
             $this->getConnection()->getIfNullSql('main_table.base_discount_canceled', 0)
         );
 
@@ -813,6 +815,7 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
      * @param int $storeId
      * @param string $baseSubtotalRefunded
      * @param string $baseSubtotalCanceled
+     * @param string $baseDiscountRefunded
      * @param string $baseDiscountCanceled
      * @return string
      */
@@ -820,13 +823,14 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
         $storeId,
         $baseSubtotalRefunded,
         $baseSubtotalCanceled,
+        $baseDiscountRefunded,
         $baseDiscountCanceled
     ) {
         $template = ($storeId != 0)
-            ? '(main_table.base_subtotal - %2$s - %1$s - ABS(main_table.base_discount_amount) - %3$s)'
-            : '((main_table.base_subtotal - %1$s - %2$s - ABS(main_table.base_discount_amount) + %3$s) '
+            ? '(main_table.base_subtotal - %2$s - %1$s - ABS(main_table.base_discount_amount) + %3$s + %4$s)'
+            : '((main_table.base_subtotal - %1$s - %2$s - ABS(main_table.base_discount_amount) + %3$s + %4$s) '
                 . ' * main_table.base_to_global_rate)';
-        return sprintf($template, $baseSubtotalRefunded, $baseSubtotalCanceled, $baseDiscountCanceled);
+        return sprintf($template, $baseSubtotalRefunded, $baseSubtotalCanceled, $baseDiscountRefunded, $baseDiscountCanceled);
     }
 
     /**

--- a/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
@@ -769,7 +769,7 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
      */
     public function addRevenueToSelect($convertCurrency = false)
     {
-        $expr = $this->getTotalsExpression(
+        $expr = $this->getTotalsExpressionWithDiscountRefunded(
             !$convertCurrency,
             $this->getConnection()->getIfNullSql('main_table.base_subtotal_refunded', 0),
             $this->getConnection()->getIfNullSql('main_table.base_subtotal_canceled', 0),
@@ -792,7 +792,7 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
         /**
          * calculate average and total amount
          */
-        $expr = $this->getTotalsExpression(
+        $expr = $this->getTotalsExpressionWithDiscountRefunded(
             $storeId,
             $this->getConnection()->getIfNullSql('main_table.base_subtotal_refunded', 0),
             $this->getConnection()->getIfNullSql('main_table.base_subtotal_canceled', 0),
@@ -810,7 +810,31 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
     }
 
     /**
-     * Get SQL expression for totals
+     * Get SQL expression for totals.
+     *
+     * @param int $storeId
+     * @param string $baseSubtotalRefunded
+     * @param string $baseSubtotalCanceled
+     * @param string $baseDiscountCanceled
+     * @return string
+     * @deprecated
+     * @see getTotalsExpressionWithDiscountRefunded
+     */
+    protected function getTotalsExpression(
+        $storeId,
+        $baseSubtotalRefunded,
+        $baseSubtotalCanceled,
+        $baseDiscountCanceled
+    ) {
+        $template = ($storeId != 0)
+            ? '(main_table.base_subtotal - %2$s - %1$s - ABS(main_table.base_discount_amount) - %3$s)'
+            : '((main_table.base_subtotal - %1$s - %2$s - ABS(main_table.base_discount_amount) + %3$s) '
+            . ' * main_table.base_to_global_rate)';
+        return sprintf($template, $baseSubtotalRefunded, $baseSubtotalCanceled, $baseDiscountCanceled);
+    }
+
+    /**
+     * Get SQL expression for totals with discount refunded.
      *
      * @param int $storeId
      * @param string $baseSubtotalRefunded
@@ -819,7 +843,7 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
      * @param string $baseDiscountCanceled
      * @return string
      */
-    protected function getTotalsExpression(
+    private function getTotalsExpressionWithDiscountRefunded(
         $storeId,
         $baseSubtotalRefunded,
         $baseSubtotalCanceled,

--- a/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
@@ -773,8 +773,8 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
             !$convertCurrency,
             $this->getConnection()->getIfNullSql('main_table.base_subtotal_refunded', 0),
             $this->getConnection()->getIfNullSql('main_table.base_subtotal_canceled', 0),
-            $this->getConnection()->getIfNullSql('main_table.base_discount_refunded', 0),
-            $this->getConnection()->getIfNullSql('main_table.base_discount_canceled', 0)
+            $this->getConnection()->getIfNullSql('ABS(main_table.base_discount_refunded)', 0),
+            $this->getConnection()->getIfNullSql('ABS(main_table.base_discount_canceled)', 0)
         );
         $this->getSelect()->columns(['revenue' => $expr]);
 
@@ -796,8 +796,8 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
             $storeId,
             $this->getConnection()->getIfNullSql('main_table.base_subtotal_refunded', 0),
             $this->getConnection()->getIfNullSql('main_table.base_subtotal_canceled', 0),
-            $this->getConnection()->getIfNullSql('main_table.base_discount_refunded', 0),
-            $this->getConnection()->getIfNullSql('main_table.base_discount_canceled', 0)
+            $this->getConnection()->getIfNullSql('ABS(main_table.base_discount_refunded)', 0),
+            $this->getConnection()->getIfNullSql('ABS(main_table.base_discount_canceled)', 0)
         );
 
         $this->getSelect()->columns(
@@ -827,8 +827,8 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
         $baseDiscountCanceled
     ) {
         $template = ($storeId != 0)
-            ? '(main_table.base_subtotal - %2$s - %1$s - ABS(main_table.base_discount_amount) + %3$s + %4$s)'
-            : '((main_table.base_subtotal - %1$s - %2$s - ABS(main_table.base_discount_amount) + %3$s + %4$s) '
+            ? '(main_table.base_subtotal - %2$s - %1$s - (ABS(main_table.base_discount_amount) - %3$s - %4$s))'
+            : '((main_table.base_subtotal - %1$s - %2$s - (ABS(main_table.base_discount_amount) - %3$s - %4$s)) '
                 . ' * main_table.base_to_global_rate)';
         return sprintf($template, $baseSubtotalRefunded, $baseSubtotalCanceled, $baseDiscountRefunded, $baseDiscountCanceled);
     }


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

The calculation of 'Total' column under "Last Orders" listing on the admin dashboard was wrong. It has below problems.

1. It wasn't considering the refunded discount amount
2. It was subtracting discount canceled  amount instead of adding when viewing data for a particular website or store

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21281: Wrong order amount on the dashboard on Last orders listing when the order has discount and it is partially refunded
2. magento/magento2#18754: Negative order amount in dashboard latest order when order is cancelled where coupon has been used

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
**Testing fix for issue#magento/magento2#18754**

1. Place an order with a coupon code, for example, 4.95 EUR off
2. Cancel the order
3. Go to dashboard select a specific store to view data and notice the total column under "Last Orders" listing

![negative-total](https://user-images.githubusercontent.com/5336201/52895147-4adbdd80-31dc-11e9-84da-336433ad1940.png)


**Testing fix for issue#magento/magento2#21281**

1. Add a product with quantity 3 to Cart
2. Create a 10% discount coupon from admin and apply it to the cart
3. Go to checkout and place order
4. Invoice the order from admin, if placed using the offline payment method
5. Create a credit memo for the order to refund 2 quantities out of 3
6. Now notice the "Total" column for order on the admin dashboard under "Last Orders" listing. The refunded discount amount on credit memo is not considered in the total.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
