### PR TITLE
span tag for more swatches link

### DIFF
--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -511,7 +511,7 @@ define([
 
                 // Add more button
                 if (moreLimit === countAttributes++) {
-                    html += '<a href="#" class="' + moreClass + '">' + moreText + '</a>';
+                    html += '<a href="#" class="' + moreClass + '">'<span> + moreText + '</span></a>';
                 }
 
                 id = this.id;

--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -511,7 +511,7 @@ define([
 
                 // Add more button
                 if (moreLimit === countAttributes++) {
-                    html += '<a href="#" class="' + moreClass + '">'<span> + moreText + '</span></a>';
+                    html += '<a href="#" class="' + moreClass + '"><span>' + moreText + '</span></a>';
                 }
 
                 id = this.id;


### PR DESCRIPTION
Good afternoon,

In our case, when you want to do a modification for this element, with by example, in using .lib-button-icon utility mixin, you can not hide the text without hiding icon.

You can not hide text in html tag without before and after pseudo-elements.

I needed to change directly the "More" dictionnary string, before, by adding html tag in it.

This modification purpose to not use js mixins.

Ilan PARMENTIER