### PR TITLE
Misconfigured aria-labelledby for product tabs

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/details.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/details.phtml
@@ -22,7 +22,6 @@
                     $label = $block->getChildData($alias, 'title');
                 ?>
                 <div class="data item title"
-                     aria-labelledby="tab-label-<?= /* @escapeNotVerified */ $alias ?>-title"
                      data-role="collapsible" id="tab-label-<?= /* @escapeNotVerified */ $alias ?>">
                     <a class="data switch"
                        tabindex="-1"
@@ -32,7 +31,8 @@
                         <?= /* @escapeNotVerified */ $label ?>
                     </a>
                 </div>
-                <div class="data item content" id="<?= /* @escapeNotVerified */ $alias ?>" data-role="content">
+                <div class="data item content" 
+                     aria-labelledby="tab-label-<?= /* @escapeNotVerified */ $alias ?>-title" id="<?= /* @escapeNotVerified */ $alias ?>" data-role="content">
                     <?= /* @escapeNotVerified */ $html ?>
                 </div>
             <?php endforeach;?>


### PR DESCRIPTION
Good afternoon,

I find out attribute aria-labelledby is misconfigured for jquery ui tabs in product page.

It must be declared for content of tab and not title.

Ilan PARMENTIER

Source : 
https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html#sc1_label