### PR TITLE
Fix-issue-21292 Google Analytics isAnonymizedIpActive always true

### DIFF
--- a/app/code/Magento/GoogleAnalytics/Block/Ga.php
+++ b/app/code/Magento/GoogleAnalytics/Block/Ga.php
@@ -75,7 +75,8 @@ class Ga extends \Magento\Framework\View\Element\Template
     }
 
     /**
-     * Render regular page tracking javascript code
+     * Render regular page tracking javascript code.
+     *
      * The custom "page name" may be set from layout or somewhere else. It must start from slash.
      *
      * @param string $accountId

--- a/app/code/Magento/GoogleAnalytics/Block/Ga.php
+++ b/app/code/Magento/GoogleAnalytics/Block/Ga.php
@@ -206,7 +206,7 @@ class Ga extends \Magento\Framework\View\Element\Template
     {
         return [
             'optPageUrl' => $this->getOptPageUrl(),
-            'isAnonymizedIpActive' => (int)$this->_googleAnalyticsData->isAnonymizedIpActive(),
+            'isAnonymizedIpActive' => $this->_googleAnalyticsData->isAnonymizedIpActive(),
             'accountId' => $this->escapeHtmlAttr($accountId, false)
         ];
     }

--- a/app/code/Magento/GoogleAnalytics/Block/Ga.php
+++ b/app/code/Magento/GoogleAnalytics/Block/Ga.php
@@ -205,7 +205,7 @@ class Ga extends \Magento\Framework\View\Element\Template
     {
         return [
             'optPageUrl' => $this->getOptPageUrl(),
-            'isAnonymizedIpActive' => $this->_googleAnalyticsData->isAnonymizedIpActive(),
+            'isAnonymizedIpActive' => (int)$this->_googleAnalyticsData->isAnonymizedIpActive(),
             'accountId' => $this->escapeHtmlAttr($accountId, false)
         ];
     }

--- a/app/code/Magento/GoogleAnalytics/Helper/Data.php
+++ b/app/code/Magento/GoogleAnalytics/Helper/Data.php
@@ -46,6 +46,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function isAnonymizedIpActive($store = null)
     {
-        return $this->scopeConfig->getValue(self::XML_PATH_ANONYMIZE, ScopeInterface::SCOPE_STORE, $store);
+        return (bool)$this->scopeConfig->getValue(self::XML_PATH_ANONYMIZE, ScopeInterface::SCOPE_STORE, $store);
     }
 }


### PR DESCRIPTION
### Description (*)
 Google Analycs correctly activated and Anonymize Ip turned to off.

![deepinscreenshot_select-area_20190218164042](https://user-images.githubusercontent.com/40756439/52958090-06973b80-339c-11e9-9f54-a45f6f6ef245.png)

`If (config.pageTrackingData.isAnonymizedIpActive)` return always true because this is not bool type  

`isAnonymizedIpActive` -> return bool,  but `getValue` in `isAnonymizedIpActive ` - return mixed string or null  so condition looks like if ("0") {ga("set", "anonymizeIp", true)}
and `if ("0")` return true
![deepinscreenshot_select-area_20190218171343](https://user-images.githubusercontent.com/2481206/52960056-9808ac80-33a0-11e9-8fbe-896f0fd3e00f.png)


### Fixed Issues (if relevant)

1. magento/magento2#21292:  Google Analytics isAnonymizedIpActive always true
2. ...

### Manual testing scenarios (*)
1 - Install and activate GA Debbugger chrome extension
2 - Open the chrome console and browse the shop

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
