### PR TITLE
Backport - The dropdown state doesn't change if the dropdown is expanded or not

### DIFF
--- a/app/code/Magento/Ui/view/base/web/templates/grid/filters/elements/ui-select-optgroup.html
+++ b/app/code/Magento/Ui/view/base/web/templates/grid/filters/elements/ui-select-optgroup.html
@@ -19,7 +19,7 @@
                 css: {
                     _selected: $parent.root.isSelected(option.value),
                     _hover: $parent.root.isHovered(option, $element),
-                    _expended: $parent.root.getLevelVisibility($data),
+                    _expended: $parent.root.getLevelVisibility($data) || $data.visible,
                     _unclickable: $parent.root.isLabelDecoration($data),
                     _last: $parent.root.addLastElement($data),
                     '_with-checkbox': $parent.root.showCheckbox

--- a/app/code/Magento/Ui/view/base/web/templates/grid/filters/elements/ui-select.html
+++ b/app/code/Magento/Ui/view/base/web/templates/grid/filters/elements/ui-select.html
@@ -125,7 +125,7 @@
                         css: {
                             _selected: $parent.isSelected(option.value),
                             _hover: $parent.isHovered(option, $element),
-                            _expended: $parent.getLevelVisibility($data),
+                            _expended: $parent.getLevelVisibility($data) && $parent.showLevels($data),
                             _unclickable: $parent.isLabelDecoration($data),
                             _last: $parent.addLastElement($data),
                             '_with-checkbox': $parent.showCheckbox
@@ -139,6 +139,7 @@
                     <div class="admin__action-multiselect-dropdown"
                          data-bind="
                             click: function(event){
+                                $parent.showLevels($data);
                                 $parent.openChildLevel($data, $element, event);
                             },
                             clickBubble: false

--- a/app/design/adminhtml/Magento/backend/web/css/source/actions/_actions-multiselect.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/actions/_actions-multiselect.less
@@ -330,7 +330,7 @@
             border-top: @action-multiselect-tree-lines;
             height: 1px;
             top: @action-multiselect-menu-item__padding + @action-multiselect-tree-arrow__size/2;
-            width: @action-multiselect-tree-menu-item__margin-left + @action-multiselect-menu-item__padding;
+            width: @action-multiselect-tree-menu-item__margin-left;
         }
 
         //  Vertical dotted line


### PR DESCRIPTION
#21197

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21196: [UI] The dropdown state doesn't change if the dropdown is expanded or not

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
