### PR TITLE
Fix for bug HEAD request returns 404 #21299

### DIFF
--- a/app/code/Magento/Cms/Controller/Index/Index.php
+++ b/app/code/Magento/Cms/Controller/Index/Index.php
@@ -7,6 +7,7 @@ namespace Magento\Cms\Controller\Index;
 
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\App\Action\HttpHeadActionInterface;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ObjectManager;
@@ -21,8 +22,9 @@ use Magento\Framework\App\Action\Action;
 
 /**
  * Home page. Needs to be accessible by POST because of the store switching.
+ * Needs to accessible by curl HEAD requests
  */
-class Index extends Action implements HttpGetActionInterface, HttpPostActionInterface
+class Index extends Action implements HttpGetActionInterface, HttpPostActionInterface, HttpHeadActionInterface
 {
     /**
      * @var ForwardFactory


### PR DESCRIPTION

### Description

After clearing Magento2.3 full page cache,if we try to access Magento 2.3 home via CURL HEAD requests, it returns 404 response and that response is cached for future requests.  This is because of new HttpMethodValidator

### Fixed Issues 

1. magento/magento2#21299: HEAD request returns 404

### Steps to reproduce
Use vanilla Magento 2.3 instance  
1. Clear Full page cache
2. Try to access home page via curl  curl -X HEAD -i http://shop.dev.magento.com/
3. 404 response will be return
4. Try to access home page via browser, 404 page will return
5. Clear full page cache and try to access home page - home page content will return

### debug log
[2019-02-19 09:23:52] main.DEBUG: URI '/'' cannot be accessed with HEAD method (Magento\Cms\Controller\Index\Index) [] []
[2019-02-19 09:23:52] main.DEBUG: Request validation failed for action "Magento\Cms\Controller\Index\Index\Interceptor" [] []

### Manual testing scenarios (*)

1. Clear Full page cache
2. Try to access home page via curl  curl -X HEAD -i http://shop.dev.magento.com/
3. 200 response will be return
4. Try to access home page via browser, it will render home page instead of 404 page

### Contribution checklist (*)
 - [x ] Pull request has a meaningful description of its purpose
 - [x ] All commits are accompanied by meaningful commit messages
 - [] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
