### PR TITLE
Fixed #15059 Cannot reorder from the first try

### DIFF
--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -582,6 +582,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         }
 
         $quote->getShippingAddress()->unsCachedItemsAll();
+        $quote->getBillingAddress()->unsCachedItemsAll();
         $quote->setTotalsCollectedFlag(false);
 
         $this->quoteRepository->save($quote);

--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -23,6 +23,7 @@ use Psr\Log\LoggerInterface;
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  * @since 100.0.2
  */
 class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\Model\Cart\CartInterface


### PR DESCRIPTION
Fixed #15059 Cannot reorder from the first try
previous related PR #20893 
### Preconditions
1. Latest Magento 2.3-develop

### Steps to reproduce
1. Create a Virtual Product
2. Register a Customer Account
3. Place an Order with the Virtual Product
4. Create an Invoice
5. Try to Reorder

### Expected result
 ![exp](https://user-images.githubusercontent.com/11827230/39755389-53b9f57e-52ce-11e8-88bd-e1d9aeba74f4.png)

![exp1](https://user-images.githubusercontent.com/11827230/39755426-735329b4-52ce-11e8-835d-a2f828fc2cae.png)

### Actual result 
![act1](https://user-images.githubusercontent.com/11827230/39755415-6a7cce26-52ce-11e8-87d6-825b0ef8cc98.png)

![act](https://user-images.githubusercontent.com/11827230/39755434-7be6dee0-52ce-11e8-8f96-0b052e9c8ff9.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
