### PR TITLE
Fixed product import requiring an attribute that does not apply to the product type

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Type/AbstractType.php
@@ -476,6 +476,8 @@ abstract class AbstractType
                 // check value for non-empty in the case of required attribute?
                 if (isset($rowData[$attrCode]) && strlen($rowData[$attrCode])) {
                     $error |= !$this->_entityModel->isAttributeValid($attrCode, $attrParams, $rowData, $rowNum);
+                } elseif(isset($rowData['product_type']) && !in_array($rowData['product_type'], $attrParams['apply_to'])){
+                    // This attribute does not apply for this product type
                 } elseif ($this->_isAttributeRequiredCheckNeeded($attrCode) && $attrParams['is_required']) {
                     // For the default scope - if this is a new product or
                     // for an old product, if the imported doc has the column present for the attrCode


### PR DESCRIPTION

### Description (*)
When you want to import products in Magento using the built-in import logic (usually CSV files), the validation of product rows may fail if a required attribute is missing but not needed for this product type.
The import validation does not consider the "applies_to" product types when determining that an attribute is required.

### Fixed Issues (if relevant)

### Manual testing scenarios (*)
1. Create an attribute that is required, but only applies to simple products (you may need to set the "apply_to" field in the DB as there is no UI for that).
2. Try to run an import both simple and grouped products, but leave the required attribute empty for the grouped product.
3. The import will mention validation errors for the attribute, saying it is required, even though it does not apply to the grouped product type

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
