### PR TITLE
[Catalog] [MediaStorage] Fix watermark in media application

### DIFF
--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -24,6 +24,8 @@ use Magento\Theme\Model\ResourceModel\Theme\Collection;
 use Magento\Framework\App\Filesystem\DirectoryList;
 
 /**
+ * Image resize service.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ImageResize
@@ -123,7 +125,8 @@ class ImageResize
     }
 
     /**
-     * Create resized images of different sizes from an original image
+     * Create resized images of different sizes from an original image.
+     *
      * @param string $originalImageName
      * @throws NotFoundException
      */
@@ -141,7 +144,8 @@ class ImageResize
     }
 
     /**
-     * Create resized images of different sizes from themes
+     * Create resized images of different sizes from themes.
+     *
      * @param array|null $themes
      * @return \Generator
      * @throws NotFoundException
@@ -169,7 +173,8 @@ class ImageResize
     }
 
     /**
-     * Search the current theme
+     * Search the current theme.
+     *
      * @return array
      */
     private function getThemesInUse(): array
@@ -187,7 +192,8 @@ class ImageResize
     }
 
     /**
-     * Get view images data from themes
+     * Get view images data from themes.
+     *
      * @param array $themes
      * @return array
      */
@@ -211,7 +217,8 @@ class ImageResize
     }
 
     /**
-     * Get unique image index
+     * Get unique image index.
+     *
      * @param array $imageData
      * @return string
      */
@@ -223,7 +230,8 @@ class ImageResize
     }
 
     /**
-     * Make image
+     * Make image.
+     *
      * @param string $originalImagePath
      * @param array $imageParams
      * @return Image
@@ -241,7 +249,8 @@ class ImageResize
     }
 
     /**
-     * Resize image
+     * Resize image.
+     *
      * @param array $viewImage
      * @param string $originalImagePath
      * @param string $originalImageName

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -257,9 +257,41 @@ class ImageResize
             ]
         );
 
+        if (isset($imageParams['watermark_file'])) {
+            if ($imageParams['watermark_height'] !== null) {
+                $image->setWatermarkHeight($imageParams['watermark_height']);
+            }
+
+            if ($imageParams['watermark_width'] !== null) {
+                $image->setWatermarkWidth($imageParams['watermark_width']);
+            }
+
+            if ($imageParams['watermark_position'] !== null) {
+                $image->setWatermarkPosition($imageParams['watermark_position']);
+            }
+
+            if ($imageParams['watermark_image_opacity'] !== null) {
+                $image->setWatermarkImageOpacity($imageParams['watermark_image_opacity']);
+            }
+
+            $image->watermark($this->getWatermarkFilePath($imageParams['watermark_file']));
+        }
+
         if ($imageParams['image_width'] !== null && $imageParams['image_height'] !== null) {
             $image->resize($imageParams['image_width'], $imageParams['image_height']);
         }
         $image->save($imageAsset->getPath());
+    }
+
+    /**
+     * Returns watermark file absolute path
+     *
+     * @param string $file
+     * @return string
+     */
+    private function getWatermarkFilePath($file)
+    {
+        $path = $this->imageConfig->getMediaPath('/watermark/' . $file);
+        return $this->mediaDirectory->getAbsolutePath($path);
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
While media request Magento doesn't process watermarks. Also while `catalog:images:resize` watermarks are not processing for base catalog images. Watermark process was added in resize image function to fix media get request and console catalog images resize process.

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21154: 2.3.0 Watermark not showing on images

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
* Create categories
* Create products
* Upload a watermark
* Set image opacity to 10, image size to 40x50, image position to tile, and saved configuration.
* Tap the Cache Management link in the system message. Then, refresh the invalid cache & catalog media cache

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
