### PR TITLE
Checkout Page Cancel button is not working #21327

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/billing-address.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/billing-address.js
@@ -201,6 +201,7 @@ function (
                 this.isAddressDetailsVisible(true);
             }
         },
+        
         /**
          * Manage cancel button visibility
          */

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/billing-address.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/billing-address.js
@@ -201,7 +201,7 @@ function (
                 this.isAddressDetailsVisible(true);
             }
         },
-        
+
         /**
          * Manage cancel button visibility
          */

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/billing-address.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/billing-address.js
@@ -201,6 +201,12 @@ function (
                 this.isAddressDetailsVisible(true);
             }
         },
+        /**
+         * Manage cancel button visibility
+         */
+        canUseCancelBillingAddress: ko.computed(function () {
+            return quote.billingAddress() || lastSelectedBillingAddress;
+        }),
 
         /**
          * Restore billing address

--- a/app/code/Magento/Checkout/view/frontend/web/template/billing-address.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/billing-address.html
@@ -22,7 +22,7 @@
                 <button class="action action-update" type="button" data-bind="click: updateAddress">
                     <span data-bind="i18n: 'Update'"></span>
                 </button>
-                <button class="action action-cancel" type="button" data-bind="click: cancelAddressEdit">
+                <button class="action action-cancel" type="button" data-bind="click: cancelAddressEdit, visible: canUseCancelBillingAddress()">
                     <span data-bind="i18n: 'Cancel'"></span>
                 </button>
             </div>


### PR DESCRIPTION
### Description

Checkout billing cancel button is not required if billing address is not available with current quote. Currently this 'Cancel' button is visible and not functional.

### Steps for replicating issue:
1. Add virtual product to basket as guest user
2. Checkout page will show input fields for adding billing address with update & Cancel buttons
3. Update button will save billing address, but Cancel button is not doing anything
4. If you update billing address and then click edit button, it will re-open billing address fields, at this time cancel button is functional. It will hide billing fields and help to go back to previous state.
5. If you are logged in user with saved address, cancel button will work


### Fixed Issues (if relevant)

1. magento/magento2#21327: Checkout Page Cancel button is not working

### Manual testing scenarios (*)

1.  Add virtual product to checkout as Guest user without any saved billing address
1.1.  Cancel button will be hidden on checkout page

2. Add virtual product to basket as guest user
2.1. Add billing address and click update button
2.2  Billing address form will be changed to HTML address with edit button,.
2.3 Click Billing address edit button
2.4 Billing address form will be displayed with cancel button, cancel button will help to move back to previous state

3. Add virtual product to checkout as logged in user with saved address
3.1. Checkout page will load with customer saved billing address
3.3. Choose new address option from address drop down
3.4 Billing address form will be displayed with Cancel button

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
