### PR TITLE
[Backport] Removed direct use of SessionManager class, used SessionManagerInterface instead

### DIFF
--- a/app/code/Magento/Customer/CustomerData/Plugin/SessionChecker.php
+++ b/app/code/Magento/Customer/CustomerData/Plugin/SessionChecker.php
@@ -9,6 +9,9 @@ use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Framework\Stdlib\Cookie\CookieMetadataFactory;
 use Magento\Framework\Stdlib\Cookie\PhpCookieManager;
 
+/**
+ * Class SessionChecker
+ */
 class SessionChecker
 {
     /**
@@ -38,6 +41,8 @@ class SessionChecker
      *
      * @param SessionManagerInterface $sessionManager
      * @return void
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Stdlib\Cookie\FailureToSendException
      */
     public function beforeStart(SessionManagerInterface $sessionManager)
     {

--- a/app/code/Magento/Customer/CustomerData/Plugin/SessionChecker.php
+++ b/app/code/Magento/Customer/CustomerData/Plugin/SessionChecker.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Customer\CustomerData\Plugin;
 
-use Magento\Framework\Session\SessionManager;
+use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Framework\Stdlib\Cookie\CookieMetadataFactory;
 use Magento\Framework\Stdlib\Cookie\PhpCookieManager;
 
@@ -36,10 +36,10 @@ class SessionChecker
     /**
      * Delete frontend session cookie if customer session is expired
      *
-     * @param SessionManager $sessionManager
+     * @param SessionManagerInterface $sessionManager
      * @return void
      */
-    public function beforeStart(SessionManager $sessionManager)
+    public function beforeStart(SessionManagerInterface $sessionManager)
     {
         if (!$this->cookieManager->getCookie($sessionManager->getName())
             && $this->cookieManager->getCookie('mage-cache-sessid')

--- a/app/code/Magento/Customer/etc/frontend/di.xml
+++ b/app/code/Magento/Customer/etc/frontend/di.xml
@@ -57,7 +57,7 @@
     <type name="Magento\Checkout\Block\Cart\Sidebar">
         <plugin name="customer_cart" type="Magento\Customer\Model\Cart\ConfigPlugin" />
     </type>
-    <type name="Magento\Framework\Session\SessionManager">
+    <type name="Magento\Framework\Session\SessionManagerInterface">
         <plugin name="session_checker" type="Magento\Customer\CustomerData\Plugin\SessionChecker" />
     </type>
     <type name="Magento\Authorization\Model\CompositeUserContext">

--- a/app/code/Magento/Paypal/Controller/Transparent/RequestSecureToken.php
+++ b/app/code/Magento/Paypal/Controller/Transparent/RequestSecureToken.php
@@ -11,6 +11,7 @@ use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\Session\Generic;
 use Magento\Framework\Session\SessionManager;
+use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Paypal\Model\Payflow\Service\Request\SecureToken;
 use Magento\Paypal\Model\Payflow\Transparent;
 use Magento\Quote\Model\Quote;
@@ -39,7 +40,7 @@ class RequestSecureToken extends \Magento\Framework\App\Action\Action
     private $secureTokenService;
 
     /**
-     * @var SessionManager
+     * @var SessionManager|SessionManagerInterface
      */
     private $sessionManager;
 
@@ -55,6 +56,7 @@ class RequestSecureToken extends \Magento\Framework\App\Action\Action
      * @param SecureToken $secureTokenService
      * @param SessionManager $sessionManager
      * @param Transparent $transparent
+     * @param SessionManagerInterface|null $sessionManagerInterface
      */
     public function __construct(
         Context $context,
@@ -62,12 +64,13 @@ class RequestSecureToken extends \Magento\Framework\App\Action\Action
         Generic $sessionTransparent,
         SecureToken $secureTokenService,
         SessionManager $sessionManager,
-        Transparent $transparent
+        Transparent $transparent,
+        SessionManagerInterface $sessionInterface = null
     ) {
         $this->resultJsonFactory = $resultJsonFactory;
         $this->sessionTransparent = $sessionTransparent;
         $this->secureTokenService = $secureTokenService;
-        $this->sessionManager = $sessionManager;
+        $this->sessionManager = $sessionInterface ?: $sessionManager;
         $this->transparent = $transparent;
         parent::__construct($context);
     }

--- a/app/code/Magento/Paypal/Controller/Transparent/RequestSecureToken.php
+++ b/app/code/Magento/Paypal/Controller/Transparent/RequestSecureToken.php
@@ -56,7 +56,7 @@ class RequestSecureToken extends \Magento\Framework\App\Action\Action
      * @param SecureToken $secureTokenService
      * @param SessionManager $sessionManager
      * @param Transparent $transparent
-     * @param SessionManagerInterface|null $sessionManagerInterface
+     * @param SessionManagerInterface|null $sessionInterface
      */
     public function __construct(
         Context $context,

--- a/lib/internal/Magento/Framework/View/Context.php
+++ b/lib/internal/Magento/Framework/View/Context.php
@@ -335,6 +335,8 @@ class Context
     }
 
     /**
+     * Get Front Name
+     *
      * @see getModuleName
      */
     public function getFrontName()

--- a/lib/internal/Magento/Framework/View/Context.php
+++ b/lib/internal/Magento/Framework/View/Context.php
@@ -14,6 +14,7 @@ use Magento\Framework\App\State as AppState;
 use Magento\Framework\Event\ManagerInterface;
 use Psr\Log\LoggerInterface as Logger;
 use Magento\Framework\Session\SessionManager;
+use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Framework\TranslateInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\View\ConfigInterface as ViewConfig;
@@ -144,6 +145,7 @@ class Context
      * @param Logger $logger
      * @param AppState $appState
      * @param LayoutInterface $layout
+     * @param SessionManagerInterface|null $sessionManager
      *
      * @todo reduce parameter number
      *
@@ -163,7 +165,8 @@ class Context
         CacheState $cacheState,
         Logger $logger,
         AppState $appState,
-        LayoutInterface $layout
+        LayoutInterface $layout,
+        SessionManagerInterface $sessionManager = null
     ) {
         $this->request = $request;
         $this->eventManager = $eventManager;
@@ -171,7 +174,7 @@ class Context
         $this->translator = $translator;
         $this->cache = $cache;
         $this->design = $design;
-        $this->session = $session;
+        $this->session = $sessionManager ?: $session;
         $this->scopeConfig = $scopeConfig;
         $this->frontController = $frontController;
         $this->viewConfig      = $viewConfig;


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19359
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Removed direct use of SessionManager class, used SessionManagerInterface instead.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19274: Why is SessionManager used instead of its Interface?

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Replaced `SessionManager` with `SessionManagerInterface` class

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
