### PR TITLE
Use default product gallery values - admin theme styles

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/components/_media-gallery.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/components/_media-gallery.less
@@ -476,3 +476,17 @@
         }
     }
 }
+
+.gallery-overlay-parent {
+    position: relative;
+}
+
+.gallery-overlay {
+    background-color: #adadad;
+    height: 100%;
+    opacity: 0.2;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 10;
+}


### PR DESCRIPTION
### Description
This pull request continues implementation of the "Use Default" feature for product's gallery attributes and contains styles for the following items:
1. Gallery overlay, which blocks gallery editing if "Use Default Values" is checked
2. Overlay parent block - adds "position: relative" to the block that contains overlay

These changes are related to the following pull request:
[Provide possibility to use default value for Media Gallery Entry attributes #21040](https://github.com/magento/magento2/pull/21040)

### Related pull requests
Catalog: https://github.com/magento/magento2/pull/21040
ProductVideo: https://github.com/magento/magento2/pull/21041

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
