### PR TITLE
[module-backend] Check dispatch status in Authentication::aroundDispatch()

### DIFF
--- a/app/code/Magento/Backend/App/Action/Plugin/Authentication.php
+++ b/app/code/Magento/Backend/App/Action/Plugin/Authentication.php
@@ -114,32 +114,34 @@ class Authentication
         \Closure $proceed,
         \Magento\Framework\App\RequestInterface $request
     ) {
-        $requestedActionName = $request->getActionName();
-        if (in_array($requestedActionName, $this->_openActions)) {
-            $request->setDispatched(true);
-        } else {
-            if ($this->_auth->getUser()) {
-                $this->_auth->getUser()->reload();
-            }
-            if (!$this->_auth->isLoggedIn()) {
-                $this->_processNotLoggedInUser($request);
+        if (!$request->isDispatched()) {
+            if (in_array($request->getActionName(), $this->_openActions)) {
+                $request->setDispatched(true);
             } else {
-                $this->_auth->getAuthStorage()->prolong();
-
-                $backendApp = null;
-                if ($request->getParam('app')) {
-                    $backendApp = $this->backendAppList->getCurrentApp();
+                if ($this->_auth->getUser()) {
+                    $this->_auth->getUser()->reload();
                 }
 
-                if ($backendApp) {
-                    $resultRedirect = $this->resultRedirectFactory->create();
-                    $baseUrl = \Magento\Framework\App\Request\Http::getUrlNoScript($this->backendUrl->getBaseUrl());
-                    $baseUrl = $baseUrl . $backendApp->getStartupPage();
-                    return $resultRedirect->setUrl($baseUrl);
+                if (!$this->_auth->isLoggedIn()) {
+                    $this->_processNotLoggedInUser($request);
+                } else {
+                    $this->_auth->getAuthStorage()->prolong();
+
+                    /** @var \Magento\Backend\App\BackendApp|null $backendApp */
+                    $backendApp = $request->getParam('app') ? $this->backendAppList->getCurrentApp() : null;
+
+                    if ($backendApp) {
+                        $resultRedirect = $this->resultRedirectFactory->create();
+                        $baseUrl = \Magento\Framework\App\Request\Http::getUrlNoScript($this->backendUrl->getBaseUrl());
+                        $baseUrl = $baseUrl . $backendApp->getStartupPage();
+                        return $resultRedirect->setUrl($baseUrl);
+                    }
                 }
             }
+
+            $this->_auth->getAuthStorage()->refreshAcl();
         }
-        $this->_auth->getAuthStorage()->refreshAcl();
+
         return $proceed($request);
     }
 

--- a/dev/tests/integration/testsuite/Magento/Backend/App/AbstractActionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/App/AbstractActionTest.php
@@ -56,10 +56,16 @@ class AbstractActionTest extends \Magento\TestFramework\TestCase\AbstractBackend
             'form_key' => $formKey->getFormKey(),
         ];
 
-        $this->getRequest()->setPostValue($postLogin);
-        $this->dispatch('backend/admin/system_account/index');
+        /** @var \Magento\Framework\App\RequestInterface $request */
+        $request = $this->getRequest();
 
+        $request->setDispatched(false);
+        $request->setPostValue($postLogin);
+
+        /** @var string $expected */
         $expected = 'backend/admin/system_account/index';
+
+        $this->dispatch($expected);
         $this->assertRedirect($this->stringContains($expected));
     }
 

--- a/dev/tests/integration/testsuite/Magento/Backend/Controller/Adminhtml/AuthTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Controller/Adminhtml/AuthTest.php
@@ -105,7 +105,12 @@ class AuthTest extends \Magento\TestFramework\TestCase\AbstractController
     {
         /** @var \Magento\Framework\Data\Form\FormKey $formKey */
         $formKey = $this->_objectManager->get(\Magento\Framework\Data\Form\FormKey::class);
-        $this->getRequest()->setPostValue(
+
+        /** @var \Magento\Framework\App\RequestInterface $request */
+        $request = $this->getRequest();
+
+        $request->setDispatched(false);
+        $request->setPostValue(
             [
                 'login' => [
                     'username' => \Magento\TestFramework\Bootstrap::ADMIN_NAME,
@@ -197,7 +202,12 @@ class AuthTest extends \Magento\TestFramework\TestCase\AbstractController
         /** @var \Magento\Framework\Data\Form\FormKey $formKey */
         $formKey = $this->_objectManager->get(\Magento\Framework\Data\Form\FormKey::class);
         $params['form_key'] = $formKey->getFormKey();
-        $this->getRequest()->setPostValue($params);
+
+        /** @var \Magento\Framework\App\RequestInterface $request */
+        $request = $this->getRequest();
+
+        $request->setDispatched(false);
+        $request->setPostValue($params);
         $this->dispatch('backend/admin/auth/login');
         $this->assertSessionMessages(
             $this->equalTo(

--- a/dev/tests/integration/testsuite/Magento/Captcha/Observer/CaseBackendLoginActionWithInvalidCaptchaReturnsErrorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Captcha/Observer/CaseBackendLoginActionWithInvalidCaptchaReturnsErrorTest.php
@@ -36,7 +36,12 @@ class CaseBackendLoginActionWithInvalidCaptchaReturnsErrorTest extends AbstractC
             'captcha' => ['backend_login' => 'some_unrealistic_captcha_value'],
             'form_key' => $formKey->getFormKey(),
         ];
-        $this->getRequest()->setPostValue($post);
+
+        /** @var \Magento\Framework\App\RequestInterface $request */
+        $request = $this->getRequest();
+
+        $request->setDispatched(false);
+        $request->setPostValue($post);
         $this->dispatch('backend/admin');
         $this->assertSessionMessages($this->equalTo([(string)__('Incorrect CAPTCHA.')]), MessageInterface::TYPE_ERROR);
         $backendUrlModel = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(

--- a/dev/tests/integration/testsuite/Magento/Captcha/Observer/CaseCaptchaIsRequiredAfterFailedLoginAttemptsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Captcha/Observer/CaseCaptchaIsRequiredAfterFailedLoginAttemptsTest.php
@@ -35,7 +35,12 @@ class CaseCaptchaIsRequiredAfterFailedLoginAttemptsTest extends \Magento\TestFra
             'captcha' => ['backend_login' => 'some_unrealistic_captcha_value'],
             'form_key' => $formKey->getFormKey(),
         ];
-        $this->getRequest()->setPostValue($post);
+
+        /** @var \Magento\Framework\App\RequestInterface $request */
+        $request = $this->getRequest();
+
+        $request->setDispatched(false);
+        $request->setPostValue($post);
         $this->dispatch('backend/admin');
         $this->assertSessionMessages($this->equalTo([(string)__('Incorrect CAPTCHA.')]), MessageInterface::TYPE_ERROR);
         $backendUrlModel = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(


### PR DESCRIPTION
[module-backend] Check dispatch status before executing `Authentication::aroundDispatch()`

### Description (*)

Add initial check for `$request->isDispatched()` to `Magento\Backend\App\Action\Plugin\Authentication::aroundDispatch()`. This provides an opportunity for earlier plugins to authenticate and dispatch the request without having to override the class via `<preference>`.

### Fixed Issues (if relevant)

N/A

### Manual testing scenarios (*)

1. Create module `Sample_Module` with `etc/adminhtml/di.xml` and `Plugin/Authentication.php`.
2. Add `<type name="Magento\Backend\App\AbstractAction"><plugin name="sample_module_plugin_dispatch" type="Sample\Module\Plugin\Authentication" sortOrder="10"/></type>` to `etc/adminhtml/di.xml`.
3. Copy `Magento\Backend\App\Action\Plugin\Authentication` to `Plugin\Authentication`, update namespace, remove `aroundDispatch`, and add `beforeDispatch`:

```
public function beforeDispatch(
  \Magento\Backend\App\AbstractAction $subject,
  \Magento\Framework\App\RequestInterface $request
) {
  $request->setDispatched(true);
}
```

4. Set breakpoint after `if (!$request->isDispatched()) {` in `Magento\Backend\App\Action\Plugin\Authentication::aroundDispatch()`, which should not execute.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)