### PR TITLE
As low as displays incorrect pricing on category page, tax appears to be added twice #21383

### DIFF
--- a/app/code/Magento/Catalog/Pricing/Price/MinimalTierPriceCalculator.php
+++ b/app/code/Magento/Catalog/Pricing/Price/MinimalTierPriceCalculator.php
@@ -29,8 +29,10 @@ class MinimalTierPriceCalculator implements MinimalPriceCalculatorInterface
     }
 
     /**
-     * Get raw value of "as low as" as a minimal among tier prices
-     * {@inheritdoc}
+     * Get raw value of "as low as" as a minimal among tier prices{@inheritdoc}
+     *
+     * @param SaleableInterface $saleableItem
+     * @return float|null
      */
     public function getValue(SaleableInterface $saleableItem)
     {
@@ -49,8 +51,10 @@ class MinimalTierPriceCalculator implements MinimalPriceCalculatorInterface
     }
 
     /**
-     * Return calculated amount object that keeps "as low as" value
-     * {@inheritdoc}
+     * Return calculated amount object that keeps "as low as" value{@inheritdoc}
+     *
+     * @param SaleableInterface $saleableItem
+     * @return AmountInterface|null
      */
     public function getAmount(SaleableInterface $saleableItem)
     {

--- a/app/code/Magento/Catalog/Pricing/Price/MinimalTierPriceCalculator.php
+++ b/app/code/Magento/Catalog/Pricing/Price/MinimalTierPriceCalculator.php
@@ -58,6 +58,6 @@ class MinimalTierPriceCalculator implements MinimalPriceCalculatorInterface
 
         return $value === null
             ? null
-            : $this->calculator->getAmount($value, $saleableItem);
+            : $this->calculator->getAmount($value, $saleableItem, 'tax');
     }
 }


### PR DESCRIPTION
### Description (*)

While calculating minimal price, MinimalTierPriceCalculator is applying tax twice. 
https://github.com/magento/magento2/blob/94383aa66cf8a5499399f6e21300bbf73b3384f2/app/code/Magento/Catalog/Pricing/Price/MinimalTierPriceCalculator.php#L35-L49

Above function is returning minimum price with tax, and then Magento is applying tax again while returning calculated amount of minimum price
https://github.com/magento/magento2/blob/94383aa66cf8a5499399f6e21300bbf73b3384f2/app/code/Magento/Catalog/Pricing/Price/MinimalTierPriceCalculator.php#L55-L63

Issue can be fixed by excluding 'tax' while calculating return amount. 

### Fixed Issues (if relevant)

1. magento/magento2#21383: As low as displays incorrect pricing on category page, tax appears to be added twice


### Manual testing scenarios (*)

1.  Create tax rules & rates
1.1 Add 20% tax rate for UK shipping address
2. Create product with tier price and tax class
3. Set Stores->Configuration->Sales->Tax->Price Display Settings->Display Product Prices In Catalog to "Including and Excluding Tax".
4.  Create an account and add UK shipping as default address
5. Check category listing page for newly created item
6. Verify As low as price, it should be minimum tier price + tax

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
