### PR TITLE
Show error message when customer click on Add to cart button without selecting atleast one product from recently orderred list

### DIFF
--- a/app/code/Magento/Checkout/Controller/Cart/Addgroup.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Addgroup.php
@@ -74,6 +74,8 @@ class Addgroup extends \Magento\Checkout\Controller\Cart
                 }
             }
             $this->cart->save();
+        } else {
+            $this->messageManager->addErrorMessage(__('Please select atleast one product to add to cart'));
         }
         return $this->_goBack();
     }

--- a/app/code/Magento/Checkout/Controller/Cart/Addgroup.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Addgroup.php
@@ -4,17 +4,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Checkout\Controller\Cart;
 
 use Magento\Checkout\Model\Cart as CustomerCart;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Escaper;
 use Magento\Framework\App\ObjectManager;
 use Magento\Sales\Model\Order\Item;
 
 /**
+ * Add grouped items controller.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Addgroup extends \Magento\Checkout\Controller\Cart
+class Addgroup extends \Magento\Checkout\Controller\Cart implements HttpPostActionInterface
 {
     /**
      * @var Escaper
@@ -44,6 +48,8 @@ class Addgroup extends \Magento\Checkout\Controller\Cart
     }
 
     /**
+     * Add items in group.
+     *
      * @return \Magento\Framework\Controller\Result\Redirect
      */
     public function execute()

--- a/app/code/Magento/Checkout/Controller/Cart/Addgroup.php
+++ b/app/code/Magento/Checkout/Controller/Cart/Addgroup.php
@@ -75,7 +75,7 @@ class Addgroup extends \Magento\Checkout\Controller\Cart
             }
             $this->cart->save();
         } else {
-            $this->messageManager->addErrorMessage(__('Please select atleast one product to add to cart'));
+            $this->messageManager->addErrorMessage(__('Please select at least one product to add to cart'));
         }
         return $this->_goBack();
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
It should display a proper error message when customer click on Add to cart button without selecting at least one product from the recently ordered list

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://github.com/magento/magento2/issues/21398

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
