### PR TITLE
Tidied spelling/grammar for GraphQL documentation

### DIFF
--- a/app/code/Magento/BundleGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/BundleGraphQl/etc/schema.graphqls
@@ -1,29 +1,29 @@
 # Copyright © Magento, Inc. All rights reserved.
 # See COPYING.txt for license details.
 
-type BundleItem @doc(description: "BundleItem defines an individual item in a bundle product") {
-    option_id: Int @doc(description: "An ID assigned to each type of item in a bundle product")
-    title: String @doc(description: "The display name of the item")
-    required: Boolean @doc(description: "Indicates whether the item must be included in the bundle")
-    type: String @doc(description: "The input type that the customer uses to select the item. Examples include radio button and checkbox")
-    position: Int @doc(description: "he relative position of this item compared to the other bundle items")
-    sku: String @doc(description: "The SKU of the bundle product")
+type BundleItem @doc(description: "BundleItem defines an individual item in a bundle product.") {
+    option_id: Int @doc(description: "An ID assigned to each type of item in a bundle product.")
+    title: String @doc(description: "The display name of the item.")
+    required: Boolean @doc(description: "Indicates whether the item must be included in the bundle.")
+    type: String @doc(description: "The input type that the customer uses to select the item. Examples include radio button and checkbox.")
+    position: Int @doc(description: "he relative position of this item compared to the other bundle items.")
+    sku: String @doc(description: "The SKU of the bundle product.")
     options: [BundleItemOption] @doc(description: "An array of additional options for this bundle item") @resolver(class: "Magento\\BundleGraphQl\\Model\\Resolver\\BundleItemLinks")
 }
 
-type BundleItemOption @doc(description: "BundleItemOption defines characteristics and options for a specific bundle item") {
-    id: Int @doc(description: "The ID assigned to the bundled item option")
+type BundleItemOption @doc(description: "BundleItemOption defines characteristics and options for a specific bundle item.") {
+    id: Int @doc(description: "The ID assigned to the bundled item option.")
     label: String @doc(description: "The text that identifies the bundled item option") @resolver(class: "Magento\\BundleGraphQl\\Model\\Resolver\\Options\\Label")
-    qty: Float @doc(description: "Indicates the quantity of this specific bundle item")
-    position: Int @doc(description: "When a bundle item contains multiple options, the relative position of this option compared to the other options")
-    is_default: Boolean @doc(description: "Indicates whether this option is the default option")
-    price: Float @doc(description: "The price of the selected option")
-    price_type: PriceTypeEnum @doc(description: "One of FIXED, PERCENT, or DYNAMIC")
-    can_change_quantity: Boolean @doc(description: "Indicates whether the customer can change the number of items for this option")
+    qty: Float @doc(description: "Indicates the quantity of this specific bundle item.")
+    position: Int @doc(description: "When a bundle item contains multiple options, the relative position of this option compared to the other options.")
+    is_default: Boolean @doc(description: "Indicates whether this option is the default option.")
+    price: Float @doc(description: "The price of the selected option.")
+    price_type: PriceTypeEnum @doc(description: "One of FIXED, PERCENT, or DYNAMIC.")
+    can_change_quantity: Boolean @doc(description: "Indicates whether the customer can change the number of items for this option.")
     product: ProductInterface @doc(description: "Contains details about this product option") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product")
 }
 
-type BundleProduct implements ProductInterface, PhysicalProductInterface, CustomizableProductInterface @doc(description: "BundleProduct defines basic features of a bundle product and contains multiple BundleItems") {
+type BundleProduct implements ProductInterface, PhysicalProductInterface, CustomizableProductInterface @doc(description: "BundleProduct defines basic features of a bundle product and contains multiple BundleItems.") {
     price_view: PriceViewEnum @doc(description: "One of PRICE_RANGE or AS_LOW_AS") @resolver(class: "Magento\\BundleGraphQl\\Model\\Resolver\\Product\\Fields\\PriceView")
     dynamic_price: Boolean @doc(description: "Indicates whether the bundle product has a dynamic price") @resolver(class: "Magento\\BundleGraphQl\\Model\\Resolver\\Product\\Fields\\DynamicPrice")
     dynamic_sku: Boolean @doc(description: "Indicates whether the bundle product has a dynamic SK") @resolver(class: "Magento\\BundleGraphQl\\Model\\Resolver\\Product\\Fields\\DynamicSku")

--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -5,18 +5,18 @@ type Query {
     products (
         search: String @doc(description: "Performs a full-text search using the specified key words."),
         filter: ProductFilterInput @doc(description: "Identifies which product attributes to search for and return."),
-        pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once. This attribute is optional."),
-        currentPage: Int = 1 @doc(description: "Specifies which page of results to return. The default value is 1."),
-        sort: ProductSortInput @doc(description: "Specifies which attribute to sort on, and whether to return the results in ascending or descending order.")
+        pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once. This attribute is optional. The default value is 20."),
+        currentPage: Int = 1 @doc(description: "Specifies which page of results to return.  This attribute is optional. The default value is 1."),
+        sort: ProductSortInput @doc(description: "Specifies which attribute to sort on, and whether to return the results in ascending or descending order. This attribute is optional.")
      ): Products
      @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Products") @doc(description: "The products query searches for products that match the criteria specified in the search and filter attributes")
     category (
-        id: Int @doc(description: "Id of the category")
+        id: Int @doc(description: "Id of the category.")
     ): CategoryTree
     @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryTree")
 }
 
-enum CurrencyEnum @doc(description: "The list of available currency codes") {
+enum CurrencyEnum @doc(description: "The list of available currency codes.") {
     AFN
     ALL
     AZN
@@ -190,14 +190,14 @@ enum CurrencyEnum @doc(description: "The list of available currency codes") {
 }
 
 type Price @doc(description: "The Price object defines the price of a product as well as any tax-related adjustments.") {
-    amount: Money @doc(description: "The price of a product plus a three-letter currency code")
-    adjustments: [PriceAdjustment] @doc(description: "An array that provides information about tax, weee, or weee_tax adjustments")
+    amount: Money @doc(description: "The price of a product plus a three-letter currency code.")
+    adjustments: [PriceAdjustment] @doc(description: "An array that provides information about tax, weee, or weee_tax adjustments.")
 }
 
 type PriceAdjustment @doc(description: "The PricedAdjustment object defines the amount of money to apply as an adjustment, the type of adjustment to apply, and whether the item is included or excluded from the adjustment.") {
-    amount: Money @doc(description: "The amount of the price adjustment and its currency code")
-    code: PriceAdjustmentCodesEnum @doc(description: "Indicates whether the adjustment involves tax, weee, or weee_tax")
-    description: PriceAdjustmentDescriptionEnum @doc(description: "Indicates whether the entity described by the code attribute is included or excluded from the adjustment")
+    amount: Money @doc(description: "The amount of the price adjustment and its currency code.")
+    code: PriceAdjustmentCodesEnum @doc(description: "Indicates whether the adjustment involves tax, weee, or weee_tax.")
+    description: PriceAdjustmentDescriptionEnum @doc(description: "Indicates whether the entity described by the code attribute is included or excluded from the adjustment.")
 }
 
 enum PriceAdjustmentCodesEnum @doc(description: "Note: This enumeration contains values defined in modules other than the Catalog module.") {
@@ -215,8 +215,8 @@ enum PriceTypeEnum @doc(description: "This enumeration the price type.") {
 }
 
 type Money @doc(description: "A Money object defines a monetary value, including a numeric value and a currency code.") {
-    value: Float @doc(description: "A number expressing a monetary value")
-    currency: CurrencyEnum @doc(description: "A three-letter currency code, such as USD or EUR")
+    value: Float @doc(description: "A number expressing a monetary value.")
+    currency: CurrencyEnum @doc(description: "A three-letter currency code, such as USD or EUR.")
 }
 
 type ProductPrices @doc(description: "The ProductPrices object contains the regular price of an item, as well as its minimum and maximum prices. Only composite products, which include bundle, configurable, and grouped products, can contain a minimum and maximum price.") {
@@ -229,316 +229,316 @@ type ProductLinks implements ProductLinksInterface @doc(description: "ProductLin
 }
 
 interface ProductLinksInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\ProductLinkTypeResolverComposite") @doc(description:"ProductLinks contains information about linked products, including the link type and product type of each item.") {
-    sku: String @doc(description: "The identifier of the linked product")
-    link_type: String @doc(description: "One of related, associated, upsell, or crosssell")
-    linked_product_sku: String @doc(description: "The SKU of the linked product")
-    linked_product_type: String @doc(description: "The type of linked product (simple, virtual, bundle, downloadable, grouped, configurable)")
-    position: Int @doc(description: "The position within the list of product links")
+    sku: String @doc(description: "The identifier of the linked product.")
+    link_type: String @doc(description: "One of related, associated, upsell, or crosssell.")
+    linked_product_sku: String @doc(description: "The SKU of the linked product.")
+    linked_product_type: String @doc(description: "The type of linked product (simple, virtual, bundle, downloadable, grouped, configurable).")
+    position: Int @doc(description: "The position within the list of product links.")
 }
 
 type ProductTierPrices @doc(description: "The ProductTierPrices object defines a tier price, which is a quantity discount offered to a specific customer group.") {
-    customer_group_id: String @doc(description: "The ID of the customer group")
-    qty: Float @doc(description: "The number of items that must be purchased to qualify for tier pricing")
-    value: Float @doc(description: "The price of the fixed price item")
-    percentage_value: Float @doc(description: "The percentage discount of the item")
-    website_id: Float @doc(description: "The ID assigned to the website")
+    customer_group_id: String @doc(description: "The ID of the customer group.")
+    qty: Float @doc(description: "The number of items that must be purchased to qualify for tier pricing.")
+    value: Float @doc(description: "The price of the fixed price item.")
+    percentage_value: Float @doc(description: "The percentage discount of the item.")
+    website_id: Float @doc(description: "The ID assigned to the website.")
 }
 
 interface ProductInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\ProductInterfaceTypeResolverComposite") @doc(description: "The ProductInterface contains attributes that are common to all types of products. Note that descriptions may not be available for custom and EAV attributes.") {
-    id: Int @doc(description: "The ID number assigned to the product") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\EntityIdToId")
+    id: Int @doc(description: "The ID number assigned to the product.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\EntityIdToId")
     name: String @doc(description: "The product name. Customers use this name to identify the product.")
-    sku: String @doc(description: "A number or code assigned to a product to identify the product, options, price, and manufacturer")
+    sku: String @doc(description: "A number or code assigned to a product to identify the product, options, price, and manufacturer.")
     description: ComplexTextValue @doc(description: "Detailed information about the product. The value can include simple HTML tags.") @resolver(class: "\\Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductComplexTextAttribute")
     short_description: ComplexTextValue @doc(description: "A short description of the product. Its use depends on the theme.") @resolver(class: "\\Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductComplexTextAttribute")
-    special_price: Float @doc(description: "The discounted price of the product")
-    special_from_date: String @doc(description: "The beginning date that a product has a special price")
-    special_to_date: String @doc(description: "The end date that a product has a special price")
-    attribute_set_id: Int @doc(description: "The attribute set assigned to the product")
-    meta_title: String @doc(description: "A string that is displayed in the title bar and tab of the browser and in search results lists")
-    meta_keyword: String @doc(description: "A comma-separated list of keywords that are visible only to search engines")
-    meta_description: String @doc(description: "A brief overview of the product for search results listings, maximum 255 characters")
-    image: ProductImage @doc(description: "The relative path to the main image on the product page") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductImage")
-    small_image: ProductImage @doc(description: "The relative path to the small image, which is used on catalog pages") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductImage")
-    thumbnail: ProductImage @doc(description: "The relative path to the product's thumbnail image") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductImage")
+    special_price: Float @doc(description: "The discounted price of the product.")
+    special_from_date: String @doc(description: "The beginning date that a product has a special price.")
+    special_to_date: String @doc(description: "The end date that a product has a special price.")
+    attribute_set_id: Int @doc(description: "The attribute set assigned to the product.")
+    meta_title: String @doc(description: "A string that is displayed in the title bar and tab of the browser and in search results lists.")
+    meta_keyword: String @doc(description: "A comma-separated list of keywords that are visible only to search engines.")
+    meta_description: String @doc(description: "A brief overview of the product for search results listings, maximum 255 characters.")
+    image: ProductImage @doc(description: "The relative path to the main image on the product page.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductImage")
+    small_image: ProductImage @doc(description: "The relative path to the small image, which is used on catalog pages.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductImage")
+    thumbnail: ProductImage @doc(description: "The relative path to the product's thumbnail image.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductImage")
     new_from_date: String @doc(description: "The beginning date for new product listings, and determines if the product is featured as a new product") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\NewFromTo")
-    new_to_date: String @doc(description: "The end date for new product listings") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\NewFromTo")
-    tier_price: Float @doc(description: "The price when tier pricing is in effect and the items purchased threshold has been reached")
-    options_container: String @doc(description: "If the product has multiple options, determines where they appear on the product page")
-    created_at: String @doc(description: "Timestamp indicating when the product was created")
-    updated_at: String @doc(description: "Timestamp indicating when the product was updated")
-    country_of_manufacture: String @doc(description: "The product's country of origin")
-    type_id: String @doc(description: "One of simple, virtual, bundle, downloadable, grouped, or configurable")
-    websites: [Website] @doc(description: "An array of websites in which the product is available") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\Websites")
-    product_links: [ProductLinksInterface] @doc(description: "An array of ProductLinks objects") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductLinks")
-    media_gallery_entries: [MediaGalleryEntry] @doc(description: "An array of MediaGalleryEntry objects") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\MediaGalleryEntries")
-    tier_prices: [ProductTierPrices] @doc(description: "An array of ProductTierPrices objects") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\TierPrices")
-    price: ProductPrices @doc(description: "A ProductPrices object, indicating the price of an item") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\Price")
-    gift_message_available: String @doc(description: "Indicates whether a gift message is available")
-    manufacturer: Int @doc(description: "A number representing the product's manufacturer")
-    categories: [CategoryInterface] @doc(description: "The categories assigned to a product") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Categories")
-    canonical_url: String @doc(description: "Canonical URL") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\CanonicalUrl")
+    new_to_date: String @doc(description: "The end date for new product listings.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\NewFromTo")
+    tier_price: Float @doc(description: "The price when tier pricing is in effect and the items purchased threshold has been reached.")
+    options_container: String @doc(description: "If the product has multiple options, determines where they appear on the product page.")
+    created_at: String @doc(description: "Timestamp indicating when the product was created.")
+    updated_at: String @doc(description: "Timestamp indicating when the product was updated.")
+    country_of_manufacture: String @doc(description: "The product's country of origin.")
+    type_id: String @doc(description: "One of simple, virtual, bundle, downloadable, grouped, or configurable.")
+    websites: [Website] @doc(description: "An array of websites in which the product is available".) @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\Websites")
+    product_links: [ProductLinksInterface] @doc(description: "An array of ProductLinks objects.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductLinks")
+    media_gallery_entries: [MediaGalleryEntry] @doc(description: "An array of MediaGalleryEntry objects.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\MediaGalleryEntries")
+    tier_prices: [ProductTierPrices] @doc(description: "An array of ProductTierPrices objects.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\TierPrices")
+    price: ProductPrices @doc(description: "A ProductPrices object, indicating the price of an item.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\Price")
+    gift_message_available: String @doc(description: "Indicates whether a gift message is available.")
+    manufacturer: Int @doc(description: "A number representing the product's manufacturer.")
+    categories: [CategoryInterface] @doc(description: "The categories assigned to a product.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Categories")
+    canonical_url: String @doc(description: "Canonical URL.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\CanonicalUrl")
 }
 
-interface PhysicalProductInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\ProductInterfaceTypeResolverComposite") @doc(description: "PhysicalProductInterface contains attributes specific to tangible products") {
-    weight: Float @doc(description: "The weight of the item, in units defined by the store")
+interface PhysicalProductInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\ProductInterfaceTypeResolverComposite.") @doc(description: "PhysicalProductInterface contains attributes specific to tangible products.") {
+    weight: Float @doc(description: "The weight of the item, in units defined by the store.")
 }
 
-type CustomizableAreaOption implements CustomizableOptionInterface @doc(description: "CustomizableAreaOption contains information about a text area that is defined as part of a customizable option") {
-    value: CustomizableAreaValue @doc(description: "An object that defines a text area")
-    product_sku: String @doc(description: "The Stock Keeping Unit of the base product")
+type CustomizableAreaOption implements CustomizableOptionInterface @doc(description: "CustomizableAreaOption contains information about a text area that is defined as part of a customizable option.") {
+    value: CustomizableAreaValue @doc(description: "An object that defines a text area.")
+    product_sku: String @doc(description: "The Stock Keeping Unit of the base product.")
 }
 
-type CustomizableAreaValue @doc(description: "CustomizableAreaValue defines the price and sku of a product whose page contains a customized text area") {
-    price: Float @doc(description: "The price assigned to this option")
-    price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC")
-    sku: String @doc(description: "The Stock Keeping Unit for this option")
-    max_characters: Int @doc(description: "The maximum number of characters that can be entered for this customizable option")
+type CustomizableAreaValue @doc(description: "CustomizableAreaValue defines the price and sku of a product whose page contains a customized text area.") {
+    price: Float @doc(description: "The price assigned to this option.")
+    price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC.")
+    sku: String @doc(description: "The Stock Keeping Unit for this option.")
+    max_characters: Int @doc(description: "The maximum number of characters that can be entered for this customizable option.")
 }
 
-type CategoryTree implements CategoryInterface @doc(description: "Category Tree implementation") {
-    children: [CategoryTree] @doc(description: "Child categories tree") @resolve(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryTree")
+type CategoryTree implements CategoryInterface @doc(description: "Category Tree implementation.") {
+    children: [CategoryTree] @doc(description: "Child categories tree.") @resolve(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryTree")
 }
 
-type CustomizableDateOption implements CustomizableOptionInterface @doc(description: "CustomizableDateOption contains information about a date picker that is defined as part of a customizable option") {
+type CustomizableDateOption implements CustomizableOptionInterface @doc(description: "CustomizableDateOption contains information about a date picker that is defined as part of a customizable option.") {
     value: CustomizableDateValue @doc(description: "An object that defines a date field in a customizable option.")
-    product_sku: String @doc(description: "The Stock Keeping Unit of the base product")
+    product_sku: String @doc(description: "The Stock Keeping Unit of the base product.")
 }
 
-type CustomizableDateValue @doc(description: "CustomizableDateValue defines the price and sku of a product whose page contains a customized date picker") {
-    price: Float @doc(description: "The price assigned to this option")
-    price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC")
-    sku: String @doc(description: "The Stock Keeping Unit for this option")
+type CustomizableDateValue @doc(description: "CustomizableDateValue defines the price and sku of a product whose page contains a customized date picker.") {
+    price: Float @doc(description: "The price assigned to this option.")
+    price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC.")
+    sku: String @doc(description: "The Stock Keeping Unit for this option.")
 }
 
-type CustomizableDropDownOption implements CustomizableOptionInterface @doc(description: "CustomizableDropDownOption contains information about a drop down menu that is defined as part of a customizable option") {
-    value: [CustomizableDropDownValue] @doc(description: "An array that defines the set of options for a drop down menu")
+type CustomizableDropDownOption implements CustomizableOptionInterface @doc(description: "CustomizableDropDownOption contains information about a drop down menu that is defined as part of a customizable option.") {
+    value: [CustomizableDropDownValue] @doc(description: "An array that defines the set of options for a drop down menu.")
 }
 
-type CustomizableDropDownValue @doc(description: "CustomizableDropDownValue defines the price and sku of a product whose page contains a customized drop down menu") {
-    option_type_id: Int @doc(description: "The ID assigned to the value")
-    price: Float @doc(description: "The price assigned to this option")
-    price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC")
-    sku: String @doc(description: "The Stock Keeping Unit for this option")
-    title: String @doc(description: "The display name for this option")
-    sort_order: Int @doc(description: "The order in which the option is displayed")
+type CustomizableDropDownValue @doc(description: "CustomizableDropDownValue defines the price and sku of a product whose page contains a customized drop down menu.") {
+    option_type_id: Int @doc(description: "The ID assigned to the value.")
+    price: Float @doc(description: "The price assigned to this option.")
+    price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC.")
+    sku: String @doc(description: "The Stock Keeping Unit for this option.")
+    title: String @doc(description: "The display name for this option.")
+    sort_order: Int @doc(description: "The order in which the option is displayed.")
 }
 
-type CustomizableFieldOption implements CustomizableOptionInterface @doc(description: "CustomizableFieldOption contains information about a text field that is defined as part of a customizable option") {
-    value: CustomizableFieldValue @doc(description: "An object that defines a text field")
-    product_sku: String @doc(description: "The Stock Keeping Unit of the base product")
+type CustomizableFieldOption implements CustomizableOptionInterface @doc(description: "CustomizableFieldOption contains information about a text field that is defined as part of a customizable option.") {
+    value: CustomizableFieldValue @doc(description: "An object that defines a text field.")
+    product_sku: String @doc(description: "The Stock Keeping Unit of the base product.")
 }
 
-type CustomizableFieldValue @doc(description: "CustomizableFieldValue defines the price and sku of a product whose page contains a customized text field") {
-    price: Float @doc(description: "The price of the custom value")
-    price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC")
-    sku: String @doc(description: "The Stock Keeping Unit for this option")
-    max_characters: Int @doc(description: "The maximum number of characters that can be entered for this customizable option")
+type CustomizableFieldValue @doc(description: "CustomizableFieldValue defines the price and sku of a product whose page contains a customized text field.") {
+    price: Float @doc(description: "The price of the custom value.")
+    price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC.")
+    sku: String @doc(description: "The Stock Keeping Unit for this option.")
+    max_characters: Int @doc(description: "The maximum number of characters that can be entered for this customizable option.")
 }
 
-type CustomizableFileOption implements CustomizableOptionInterface @doc(description: "CustomizableFileOption contains information about a file picker that is defined as part of a customizable option") {
-    value: CustomizableFileValue @doc(description: "An object that defines a file value")
-    product_sku: String @doc(description: "The Stock Keeping Unit of the base product")
+type CustomizableFileOption implements CustomizableOptionInterface @doc(description: "CustomizableFileOption contains information about a file picker that is defined as part of a customizable option.") {
+    value: CustomizableFileValue @doc(description: "An object that defines a file value.")
+    product_sku: String @doc(description: "The Stock Keeping Unit of the base product.")
 }
 
-type CustomizableFileValue @doc(description: "CustomizableFileValue defines the price and sku of a product whose page contains a customized file picker") {
-    price: Float @doc(description: "The price assigned to this option")
-    price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC")
-    sku: String @doc(description: "The Stock Keeping Unit for this option")
-    file_extension: String @doc(description: "The file extension to accept")
-    image_size_x: Int @doc(description: "The maximum width of an image")
-    image_size_y: Int @doc(description: "The maximum height of an image")
+type CustomizableFileValue @doc(description: "CustomizableFileValue defines the price and sku of a product whose page contains a customized file picker.") {
+    price: Float @doc(description: "The price assigned to this option.")
+    price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC.")
+    sku: String @doc(description: "The Stock Keeping Unit for this option.")
+    file_extension: String @doc(description: "The file extension to accept.")
+    image_size_x: Int @doc(description: "The maximum width of an image.")
+    image_size_y: Int @doc(description: "The maximum height of an image.")
 }
 
-type ProductImage @doc(description: "Product image information. Contains image relative path, URL and label") {
+type ProductImage @doc(description: "Product image information. Contains image relative path, URL and label.") {
     url: String @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductImage\\Url")
     label: String @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductImage\\Label")
 }
 
 interface CustomizableOptionInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\CustomizableOptionTypeResolver") @doc(description: "The CustomizableOptionInterface contains basic information about a customizable option. It can be implemented by several types of configurable options.") {
-    title: String @doc(description: "The display name for this option")
-    required: Boolean @doc(description: "Indicates whether the option is required")
-    sort_order: Int @doc(description: "The order in which the option is displayed")
+    title: String @doc(description: "The display name for this option.")
+    required: Boolean @doc(description: "Indicates whether the option is required.")
+    sort_order: Int @doc(description: "The order in which the option is displayed.")
     option_id: Int @doc(description: "Option ID")
 }
 
 interface CustomizableProductInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\ProductInterfaceTypeResolverComposite") @doc(description: "CustomizableProductInterface contains information about customizable product options.") {
-    options: [CustomizableOptionInterface] @doc(description: "An array of options for a customizable product") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\Options")
+    options: [CustomizableOptionInterface] @doc(description: "An array of options for a customizable product.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\Options")
 }
 
-interface CategoryInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\CategoryInterfaceTypeResolver") @doc(description: "CategoryInterface contains the full set of attributes that can be returned in a category search") {
-    id: Int @doc(description: "An ID that uniquely identifies the category")
-    description: String @doc(description: "An optional description of the category") @resolver(class: "\\Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\CategoryHtmlAttribute")
-    name: String @doc(description: "The display name of the category")
-    path: String @doc(description: "Category Path")
-    path_in_store: String @doc(description: "Category path in store")
-    url_key: String @doc(description: "The url key assigned to the category")
-    url_path: String @doc(description: "The url path assigned to the category")
-    position: Int @doc(description: "The position of the category relative to other categories at the same level in tree")
-    level: Int @doc(description: "Indicates the depth of the category within the tree")
-    created_at: String @doc(description: "Timestamp indicating when the category was created")
-    updated_at: String @doc(description: "Timestamp indicating when the category was updated")
-    product_count: Int @doc(description: "The number of products in the category") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\ProductsCount")
-    default_sort_by: String @doc(description: "The attribute to use for sorting")
+interface CategoryInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\CategoryInterfaceTypeResolver") @doc(description: "CategoryInterface contains the full set of attributes that can be returned in a category search.") {
+    id: Int @doc(description: "An ID that uniquely identifies the category.")
+    description: String @doc(description: "An optional description of the category.") @resolver(class: "\\Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\CategoryHtmlAttribute")
+    name: String @doc(description: "The display name of the category.")
+    path: String @doc(description: "Category Path.")
+    path_in_store: String @doc(description: "Category path in store.")
+    url_key: String @doc(description: "The url key assigned to the category.")
+    url_path: String @doc(description: "The url path assigned to the category.")
+    position: Int @doc(description: "The position of the category relative to other categories at the same level in tree.")
+    level: Int @doc(description: "Indicates the depth of the category within the tree.")
+    created_at: String @doc(description: "Timestamp indicating when the category was created.")
+    updated_at: String @doc(description: "Timestamp indicating when the category was updated.")
+    product_count: Int @doc(description: "The number of products in the category.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\ProductsCount")
+    default_sort_by: String @doc(description: "The attribute to use for sorting.")
     products(
-        pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once. This attribute is optional."),
-        currentPage: Int = 1 @doc(description: "Specifies which page of results to return. The default value is 1."),
+        pageSize: Int = 20 @doc(description: "Specifies the maximum number of results to return at once. This attribute is optional.The default value is 20."),
+        currentPage: Int = 1 @doc(description: "Specifies which page of results to return. This attribute is optional The default value is 1."),
         sort: ProductSortInput @doc(description: "Specifies which attribute to sort on, and whether to return the results in ascending or descending order.")
-    ): CategoryProducts @doc(description: "The list of products assigned to the category") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\Products")
-    breadcrumbs: [Breadcrumb] @doc(description: "Breadcrumbs, parent categories info") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\Breadcrumbs")
+    ): CategoryProducts @doc(description: "The list of products assigned to the category.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\Products")
+    breadcrumbs: [Breadcrumb] @doc(description: "Breadcrumbs, parent categories info.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\Breadcrumbs")
 }
 
 type Breadcrumb @doc(description: "Breadcrumb item"){
-    category_id: Int @doc(description: "Category ID")
-    category_name: String @doc(description: "Category name")
-    category_level: Int @doc(description: "Category level")
-    category_url_key: String @doc(description: "Category URL key")
+    category_id: Int @doc(description: "Category ID.")
+    category_name: String @doc(description: "Category name.")
+    category_level: Int @doc(description: "Category level.")
+    category_url_key: String @doc(description: "Category URL key.")
 }
 
-type CustomizableRadioOption implements CustomizableOptionInterface @doc(description: "CustomizableRadioOption contains information about a set of radio buttons that are defined as part of a customizable option") {
-    value: [CustomizableRadioValue] @doc(description: "An array that defines a set of radio buttons")
+type CustomizableRadioOption implements CustomizableOptionInterface @doc(description: "CustomizableRadioOption contains information about a set of radio buttons that are defined as part of a customizable option.") {
+    value: [CustomizableRadioValue] @doc(description: "An array that defines a set of radio buttons.")
 }
 
-type CustomizableRadioValue  @doc(description: "CustomizableRadioValue defines the price and sku of a product whose page contains a customized set of radio buttons") {
-    option_type_id: Int @doc(description: "The ID assigned to the value")
-    price: Float @doc(description: "The price assigned to this option")
-    price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC")
-    sku: String @doc(description: "The Stock Keeping Unit for this option")
-    title: String @doc(description: "The display name for this option")
-    sort_order: Int @doc(description: "The order in which the radio button is displayed")
+type CustomizableRadioValue  @doc(description: "CustomizableRadioValue defines the price and sku of a product whose page contains a customized set of radio buttons.") {
+    option_type_id: Int @doc(description: "The ID assigned to the value.")
+    price: Float @doc(description: "The price assigned to this option.")
+    price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC.")
+    sku: String @doc(description: "The Stock Keeping Unit for this option.")
+    title: String @doc(description: "The display name for this option.")
+    sort_order: Int @doc(description: "The order in which the radio button is displayed.")
 }
 
-type VirtualProduct implements ProductInterface, CustomizableProductInterface @doc(description: "A virtual product is non-tangible product that does not require shipping and is not kept in inventory") {
+type VirtualProduct implements ProductInterface, CustomizableProductInterface @doc(description: "A virtual product is non-tangible product that does not require shipping and is not kept in inventory.") {
 }
 
-type SimpleProduct implements ProductInterface, PhysicalProductInterface, CustomizableProductInterface @doc(description: "A simple product is tangible and are usually sold as single units or in fixed quantities")
+type SimpleProduct implements ProductInterface, PhysicalProductInterface, CustomizableProductInterface @doc(description: "A simple product is tangible and is usually sold as single units or in fixed quantities.")
 {
 }
 
-type Products @doc(description: "The Products object is the top-level object returned in a product search") {
-    items: [ProductInterface] @doc(description: "An array of products that match the specified search criteria")
-    page_info: SearchResultPageInfo @doc(description: "An object that includes the page_info and currentPage values specified in the query")
-    total_count: Int @doc(description: "The number of products returned")
-    filters: [LayerFilter] @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\LayerFilters") @doc(description: "Layered navigation filters array")
-    sort_fields: SortFields @doc(description: "An object that includes the default sort field and all available sort fields") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\SortFields")
+type Products @doc(description: "The Products object is the top-level object returned in a product search.") {
+    items: [ProductInterface] @doc(description: "An array of products that match the specified search criteria.")
+    page_info: SearchResultPageInfo @doc(description: "An object that includes the page_info and currentPage values specified in the query.")
+    total_count: Int @doc(description: "The number of products returned.")
+    filters: [LayerFilter] @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\LayerFilters") @doc(description: "Layered navigation filters array.")
+    sort_fields: SortFields @doc(description: "An object that includes the default sort field and all available sort fields.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\SortFields")
 }
 
-type CategoryProducts @doc(description: "The category products object returned in the Category query") {
-    items: [ProductInterface] @doc(description: "An array of products that are assigned to the category")
-    page_info: SearchResultPageInfo @doc(description: "An object that includes the page_info and currentPage values specified in the query")
-    total_count: Int @doc(description: "The number of products returned")
+type CategoryProducts @doc(description: "The category products object returned in the Category query.") {
+    items: [ProductInterface] @doc(description: "An array of products that are assigned to the category.")
+    page_info: SearchResultPageInfo @doc(description: "An object that includes the page_info and currentPage values specified in the query.")
+    total_count: Int @doc(description: "The number of products returned.")
 }
 
 input ProductFilterInput @doc(description: "ProductFilterInput defines the filters to be used in the search. A filter contains at least one attribute, a comparison operator, and the value that is being searched for.") {
     name: FilterTypeInput @doc(description: "The product name. Customers use this name to identify the product.")
-    sku: FilterTypeInput @doc(description: "A number or code assigned to a product to identify the product, options, price, and manufacturer")
+    sku: FilterTypeInput @doc(description: "A number or code assigned to a product to identify the product, options, price, and manufacturer.")
     description: FilterTypeInput @doc(description: "Detailed information about the product. The value can include simple HTML tags.")
     short_description: FilterTypeInput @doc(description: "A short description of the product. Its use depends on the theme.")
-    price: FilterTypeInput @doc(description: "The price of an item")
-    special_price: FilterTypeInput @doc(description: "The discounted price of the product")
-    special_from_date: FilterTypeInput @doc(description: "The beginning date that a product has a special price")
-    special_to_date: FilterTypeInput @doc(description: "The end date that a product has a special price")
-    weight: FilterTypeInput @doc(description: "The weight of the item, in units defined by the store")
-    manufacturer: FilterTypeInput @doc(description: "A number representing the product's manufacturer")
-    meta_title: FilterTypeInput @doc(description: "A string that is displayed in the title bar and tab of the browser and in search results lists")
-    meta_keyword: FilterTypeInput @doc(description: "A comma-separated list of keywords that are visible only to search engines")
-    meta_description: FilterTypeInput @doc(description: "A brief overview of the product for search results listings, maximum 255 characters")
-    image: FilterTypeInput @doc(description: "The relative path to the main image on the product page")
-    small_image: FilterTypeInput @doc(description: "The relative path to the small image, which is used on catalog pages")
-    thumbnail: FilterTypeInput @doc(description: "The relative path to the product's thumbnail image")
-    tier_price: FilterTypeInput @doc(description: "The price when tier pricing is in effect and the items purchased threshold has been reached")
-    news_from_date: FilterTypeInput @doc(description: "The beginning date for new product listings, and determines if the product is featured as a new product")
-    news_to_date: FilterTypeInput @doc(description: "The end date for new product listings")
-    custom_layout_update: FilterTypeInput @doc(description: "XML code that is applied as a layout update to the product page")
+    price: FilterTypeInput @doc(description: "The price of an item.")
+    special_price: FilterTypeInput @doc(description: "The discounted price of the product.")
+    special_from_date: FilterTypeInput @doc(description: "The beginning date that a product has a special price.")
+    special_to_date: FilterTypeInput @doc(description: "The end date that a product has a special price.")
+    weight: FilterTypeInput @doc(description: "The weight of the item, in units defined by the store.")
+    manufacturer: FilterTypeInput @doc(description: "A number representing the product's manufacturer.")
+    meta_title: FilterTypeInput @doc(description: "A string that is displayed in the title bar and tab of the browser and in search results lists.")
+    meta_keyword: FilterTypeInput @doc(description: "A comma-separated list of keywords that are visible only to search engines.")
+    meta_description: FilterTypeInput @doc(description: "A brief overview of the product for search results listings, maximum 255 characters.")
+    image: FilterTypeInput @doc(description: "The relative path to the main image on the product page.")
+    small_image: FilterTypeInput @doc(description: "The relative path to the small image, which is used on catalog pages.")
+    thumbnail: FilterTypeInput @doc(description: "The relative path to the product's thumbnail image.")
+    tier_price: FilterTypeInput @doc(description: "The price when tier pricing is in effect and the items purchased threshold has been reached.")
+    news_from_date: FilterTypeInput @doc(description: "The beginning date for new product listings, and determines if the product is featured as a new product.")
+    news_to_date: FilterTypeInput @doc(description: "The end date for new product listings.")
+    custom_layout_update: FilterTypeInput @doc(description: "XML code that is applied as a layout update to the product page.")
     min_price: FilterTypeInput @doc(description:"The numeric minimal price of the product. Do not include the currency code.")
     max_price: FilterTypeInput @doc(description:"The numeric maximal price of the product. Do not include the currency code.")
     special_price: FilterTypeInput @doc(description:"The numeric special price of the product. Do not include the currency code.")
-    category_id: FilterTypeInput @doc(description: "Category ID the product belongs to")
-    options_container: FilterTypeInput @doc(description: "If the product has multiple options, determines where they appear on the product page")
-    required_options: FilterTypeInput @doc(description: "Indicates whether the product has required options")
-    has_options: FilterTypeInput @doc(description: "Indicates whether additional attributes have been created for the product")
-    image_label: FilterTypeInput @doc(description: "The label assigned to a product image")
-    small_image_label: FilterTypeInput @doc(description: "The label assigned to a product's small image")
-    thumbnail_label: FilterTypeInput @doc(description: "The label assigned to a product's thumbnail image")
-    created_at: FilterTypeInput @doc(description: "Timestamp indicating when the product was created")
-    updated_at: FilterTypeInput @doc(description: "Timestamp indicating when the product was updated")
-    country_of_manufacture: FilterTypeInput @doc(description: "The product's country of origin")
-    custom_layout: FilterTypeInput @doc(description: "The name of a custom layout")
-    gift_message_available: FilterTypeInput @doc(description: "Indicates whether a gift message is available")
-    or: ProductFilterInput @doc(description: "The keyword required to perform a logical OR comparison")
+    category_id: FilterTypeInput @doc(description: "Category ID the product belongs to.")
+    options_container: FilterTypeInput @doc(description: "If the product has multiple options, determines where they appear on the product page.")
+    required_options: FilterTypeInput @doc(description: "Indicates whether the product has required options.")
+    has_options: FilterTypeInput @doc(description: "Indicates whether additional attributes have been created for the product.")
+    image_label: FilterTypeInput @doc(description: "The label assigned to a product image.")
+    small_image_label: FilterTypeInput @doc(description: "The label assigned to a product's small image.")
+    thumbnail_label: FilterTypeInput @doc(description: "The label assigned to a product's thumbnail image.")
+    created_at: FilterTypeInput @doc(description: "Timestamp indicating when the product was created.")
+    updated_at: FilterTypeInput @doc(description: "Timestamp indicating when the product was updated.")
+    country_of_manufacture: FilterTypeInput @doc(description: "The product's country of origin.")
+    custom_layout: FilterTypeInput @doc(description: "The name of a custom layout.")
+    gift_message_available: FilterTypeInput @doc(description: "Indicates whether a gift message is available.")
+    or: ProductFilterInput @doc(description: "The keyword required to perform a logical OR comparison.")
 }
 
-type ProductMediaGalleryEntriesContent @doc(description: "ProductMediaGalleryEntriesContent contains an image in base64 format and basic information about the image") {
-    base64_encoded_data: String @doc(description: "The image in base64 format")
-    type: String @doc(description: "The MIME type of the file, such as image/png")
-    name: String @doc(description: "The file name of the image")
+type ProductMediaGalleryEntriesContent @doc(description: "ProductMediaGalleryEntriesContent contains an image in base64 format and basic information about the image.") {
+    base64_encoded_data: String @doc(description: "The image in base64 format.")
+    type: String @doc(description: "The MIME type of the file, such as image/png.")
+    name: String @doc(description: "The file name of the image.")
 }
 
-type ProductMediaGalleryEntriesVideoContent @doc(description: "ProductMediaGalleryEntriesVideoContent contains a link to a video file and basic information about the video") {
-    media_type: String @doc(description: "Must be external-video")
-    video_provider: String @doc(description: "Describes the video source")
-    video_url: String @doc(description: "The URL to the video")
-    video_title: String @doc(description: "The title of the video")
-    video_description: String @doc(description: "A description of the video")
-    video_metadata: String @doc(description: "Optional data about the video")
+type ProductMediaGalleryEntriesVideoContent @doc(description: "ProductMediaGalleryEntriesVideoContent contains a link to a video file and basic information about the video.") {
+    media_type: String @doc(description: "Must be external-video.")
+    video_provider: String @doc(description: "Describes the video source.")
+    video_url: String @doc(description: "The URL to the video.")
+    video_title: String @doc(description: "The title of the video.")
+    video_description: String @doc(description: "A description of the video.")
+    video_metadata: String @doc(description: "Optional data about the video.")
 }
 
-input ProductSortInput  @doc(description: "ProductSortInput specifies the attribute to use for sorting search results and indicates whether the results are sorted in ascending or descending order") {
+input ProductSortInput  @doc(description: "ProductSortInput specifies the attribute to use for sorting search results and indicates whether the results are sorted in ascending or descending order.") {
     name: SortEnum @doc(description: "The product name. Customers use this name to identify the product.")
-    sku: SortEnum @doc(description: "A number or code assigned to a product to identify the product, options, price, and manufacturer")
+    sku: SortEnum @doc(description: "A number or code assigned to a product to identify the product, options, price, and manufacturer.")
     description: SortEnum @doc(description: "Detailed information about the product. The value can include simple HTML tags.")
     short_description: SortEnum @doc(description: "A short description of the product. Its use depends on the theme.")
-    price: SortEnum @doc(description: "The price of the item")
-    special_price: SortEnum @doc(description: "The discounted price of the product")
-    special_from_date: SortEnum @doc(description: "The beginning date that a product has a special price")
-    special_to_date: SortEnum @doc(description: "The end date that a product has a special price")
-    weight: SortEnum @doc(description: "The weight of the item, in units defined by the store")
-    manufacturer: SortEnum @doc(description: "A number representing the product's manufacturer")
-    meta_title: SortEnum @doc(description: "A string that is displayed in the title bar and tab of the browser and in search results lists")
-    meta_keyword: SortEnum @doc(description: "A comma-separated list of keywords that are visible only to search engines")
-    meta_description: SortEnum @doc(description: "A brief overview of the product for search results listings, maximum 255 characters")
-    image: SortEnum @doc(description: "The relative path to the main image on the product page")
-    small_image: SortEnum @doc(description: "The relative path to the small image, which is used on catalog pages")
-    thumbnail: SortEnum @doc(description: "The relative path to the product's thumbnail image")
-    tier_price: SortEnum @doc(description: "The price when tier pricing is in effect and the items purchased threshold has been reached")
-    news_from_date: SortEnum @doc(description: "The beginning date for new product listings, and determines if the product is featured as a new product")
-    news_to_date: SortEnum @doc(description: "The end date for new product listings")
-    custom_layout_update: SortEnum @doc(description: "XML code that is applied as a layout update to the product page")
-    options_container: SortEnum @doc(description: "If the product has multiple options, determines where they appear on the product page")
-    required_options: SortEnum @doc(description: "Indicates whether the product has required options")
-    has_options: SortEnum @doc(description: "Indicates whether additional attributes have been created for the product")
-    image_label: SortEnum @doc(description: "The label assigned to a product image")
-    small_image_label: SortEnum @doc(description: "The label assigned to a product's small image")
-    thumbnail_label: SortEnum @doc(description: "The label assigned to a product's thumbnail image")
-    created_at: SortEnum @doc(description: "Timestamp indicating when the product was created")
-    updated_at: SortEnum @doc(description: "Timestamp indicating when the product was updated")
-    country_of_manufacture: SortEnum @doc(description: "The product's country of origin")
-    custom_layout: SortEnum @doc(description: "The name of a custom layout")
-    gift_message_available: SortEnum @doc(description: "Indicates whether a gift message is available")
+    price: SortEnum @doc(description: "The price of the item.")
+    special_price: SortEnum @doc(description: "The discounted price of the product.")
+    special_from_date: SortEnum @doc(description: "The beginning date that a product has a special price.")
+    special_to_date: SortEnum @doc(description: "The end date that a product has a special price.")
+    weight: SortEnum @doc(description: "The weight of the item, in units defined by the store.")
+    manufacturer: SortEnum @doc(description: "A number representing the product's manufacturer.")
+    meta_title: SortEnum @doc(description: "A string that is displayed in the title bar and tab of the browser and in search results lists.")
+    meta_keyword: SortEnum @doc(description: "A comma-separated list of keywords that are visible only to search engines.")
+    meta_description: SortEnum @doc(description: "A brief overview of the product for search results listings, maximum 255 characters.")
+    image: SortEnum @doc(description: "The relative path to the main image on the product page.")
+    small_image: SortEnum @doc(description: "The relative path to the small image, which is used on catalog pages.")
+    thumbnail: SortEnum @doc(description: "The relative path to the product's thumbnail image.")
+    tier_price: SortEnum @doc(description: "The price when tier pricing is in effect and the items purchased threshold has been reached.")
+    news_from_date: SortEnum @doc(description: "The beginning date for new product listings, and determines if the product is featured as a new product.")
+    news_to_date: SortEnum @doc(description: "The end date for new product listings.")
+    custom_layout_update: SortEnum @doc(description: "XML code that is applied as a layout update to the product page.")
+    options_container: SortEnum @doc(description: "If the product has multiple options, determines where they appear on the product page.")
+    required_options: SortEnum @doc(description: "Indicates whether the product has required options.")
+    has_options: SortEnum @doc(description: "Indicates whether additional attributes have been created for the product.")
+    image_label: SortEnum @doc(description: "The label assigned to a product image.")
+    small_image_label: SortEnum @doc(description: "The label assigned to a product's small image.")
+    thumbnail_label: SortEnum @doc(description: "The label assigned to a product's thumbnail image.")
+    created_at: SortEnum @doc(description: "Timestamp indicating when the product was created.")
+    updated_at: SortEnum @doc(description: "Timestamp indicating when the product was updated.")
+    country_of_manufacture: SortEnum @doc(description: "The product's country of origin.")
+    custom_layout: SortEnum @doc(description: "The name of a custom layout.")
+    gift_message_available: SortEnum @doc(description: "Indicates whether a gift message is available.")
 }
 
-type MediaGalleryEntry  @doc(description: "MediaGalleryEntry defines characteristics about images and videos associated with a specific product") {
-    id: Int @doc(description: "The identifier assigned to the object")
-    media_type: String @doc(description: "image or video")
-    label: String @doc(description: "The alt text displayed on the UI when the user points to the image")
-    position: Int @doc(description: "The media item's position after it has been sorted")
-    disabled: Boolean @doc(description: "Whether the image is hidden from vie")
-    types: [String] @doc(description: "Array of image types. It can have the following values: image, small_image, thumbnail")
-    file: String @doc(description: "The path of the image on the server")
+type MediaGalleryEntry  @doc(description: "MediaGalleryEntry defines characteristics about images and videos associated with a specific product.") {
+    id: Int @doc(description: "The identifier assigned to the object.")
+    media_type: String @doc(description: "image or video.")
+    label: String @doc(description: "The alt text displayed on the UI when the user points to the image.")
+    position: Int @doc(description: "The media item's position after it has been sorted.")
+    disabled: Boolean @doc(description: "Whether the image is hidden from view.")
+    types: [String] @doc(description: "Array of image types. It can have the following values: image, small_image, thumbnail.")
+    file: String @doc(description: "The path of the image on the server.")
     content: ProductMediaGalleryEntriesContent @doc(description: "Contains a ProductMediaGalleryEntriesContent object")
     video_content: ProductMediaGalleryEntriesVideoContent @doc(description: "Contains a ProductMediaGalleryEntriesVideoContent object")
 }
 
 type LayerFilter {
-    name: String @doc(description: "Layered navigation filter name")
-    request_var: String @doc(description: "Request variable name for filter query")
-    filter_items_count: Int @doc(description: "Count of filter items in filter group")
-    filter_items: [LayerFilterItemInterface] @doc(description: "Array of filter items")
+    name: String @doc(description: "Layered navigation filter name.")
+    request_var: String @doc(description: "Request variable name for filter query.")
+    filter_items_count: Int @doc(description: "Count of filter items in filter group.")
+    filter_items: [LayerFilterItemInterface] @doc(description: "Array of filter items.")
 }
 
 interface LayerFilterItemInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\LayerFilterItemTypeResolverComposite") {
-    label: String @doc(description: "Filter label")
-    value_string: String @doc(description: "Value for filter request variable to be used in query")
-    items_count: Int @doc(description: "Count of items by filter")
+    label: String @doc(description: "Filter label.")
+    value_string: String @doc(description: "Value for filter request variable to be used in query.")
+    items_count: Int @doc(description: "Count of items by filter.")
 }
 
 type LayerFilterItem implements LayerFilterItemInterface {
@@ -546,11 +546,11 @@ type LayerFilterItem implements LayerFilterItemInterface {
 }
 
 type SortField {
-    value: String @doc(description: "Attribute code of sort field")
-    label: String @doc(description: "Label of sort field")
+    value: String @doc(description: "Attribute code of sort field.")
+    label: String @doc(description: "Label of sort field.")
 }
 
-type SortFields @doc(description: "SortFields contains a default value for sort fields and all available sort fields") {
-    default: String @doc(description: "Default value of sort fields")
-    options: [SortField] @doc(description: "Available sort fields")
+type SortFields @doc(description: "SortFields contains a default value for sort fields and all available sort fields.") {
+    default: String @doc(description: "Default value of sort fields.")
+    options: [SortField] @doc(description: "Available sort fields.")
 }

--- a/app/code/Magento/CatalogInventoryGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogInventoryGraphQl/etc/schema.graphqls
@@ -2,11 +2,11 @@
 # See COPYING.txt for license details.
 
 interface ProductInterface {
-    only_x_left_in_stock: Float @doc(description: "Product stock only x left count") @resolver(class: "Magento\\CatalogInventoryGraphQl\\Model\\Resolver\\OnlyXLeftInStockResolver")
-    stock_status: ProductStockStatus @doc(description: "Stock status of the product") @resolver(class: "Magento\\CatalogInventoryGraphQl\\Model\\Resolver\\StockStatusProvider")
+    only_x_left_in_stock: Float @doc(description: "Product stock only x left count.") @resolver(class: "Magento\\CatalogInventoryGraphQl\\Model\\Resolver\\OnlyXLeftInStockResolver")
+    stock_status: ProductStockStatus @doc(description: "Stock status of the product.") @resolver(class: "Magento\\CatalogInventoryGraphQl\\Model\\Resolver\\StockStatusProvider")
 }
 
-enum ProductStockStatus @doc(description: "This enumeration states whether a product stock status is in stock or out of stock") {
+enum ProductStockStatus @doc(description: "This enumeration states whether a product stock status is in stock or out of stock.") {
     IN_STOCK
     OUT_OF_STOCK
 }


### PR DESCRIPTION
### Description (*)
This PR aims to tidy spelling / grammar in GraphQL documentation.  It provides consistent docuemntation on default values for attributes when they are not passed, and highlights non-mandatory fields when maing requests.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A