### PR TITLE
Add missing fluent interface for class ItemCreation

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Invoice/ItemCreation.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/ItemCreation.php
@@ -42,6 +42,7 @@ class ItemCreation implements InvoiceItemCreationInterface
     public function setOrderItemId($orderItemId)
     {
         $this->orderItemId = $orderItemId;
+        return $this;
     }
 
     /**
@@ -58,6 +59,7 @@ class ItemCreation implements InvoiceItemCreationInterface
     public function setQty($qty)
     {
         $this->qty = $qty;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The current implementation of ItemCreation is missing the fluent interface.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Try to create invoice items with $this->invoiceItemCreationFactory->create()
2. Apply data with $this->invoiceItemCreationFactory->create()->setOrderItemId($orderItemId)->setQty($qty);