### PR TITLE
Allow change of AbstractPdf top border

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
@@ -45,6 +45,8 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
 
     const XML_PATH_SALES_PDF_CREDITMEMO_PUT_ORDER_ID = 'sales_pdf/creditmemo/put_order_id';
 
+    const LAYOUT_TOP_BORDER_DEFAULT = 830;
+
     /**
      * Zend PDF object
      *
@@ -117,6 +119,11 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
      * @var \Magento\Sales\Model\Order\Address\Renderer
      */
     protected $addressRenderer;
+
+    /**
+     * @var int
+     */
+    protected $topBorder;
 
     /**
      * @param \Magento\Payment\Helper\Data $paymentData
@@ -248,7 +255,7 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
             $imagePath = '/sales/store/logo/' . $image;
             if ($this->_mediaDirectory->isFile($imagePath)) {
                 $image = \Zend_Pdf_Image::imageWithPath($this->_mediaDirectory->getAbsolutePath($imagePath));
-                $top = 830;
+                $top = $this->topBorder ?? self::LAYOUT_TOP_BORDER_DEFAULT;
                 //top border of the page
                 $widthLimit = 270;
                 //half of the page width


### PR DESCRIPTION
When overriding `\Magento\Sales\Model\Order\Pdf\Invoice::newPage()` to your custom module - changing `$this->y = 800` in the method to for example `$this->y=1000` in order to set the header to a higher y-position, the change is later overwritten by `\Magento\Sales\Model\Order\Pdf\AbstractPdf::insertLogo()`

### Description
`\Magento\Sales\Model\Order\Pdf\AbstractPdf::insertLogo()` should say `$top = $this->y` instead of overriding `$this->y` static number `830`.

### Steps to reproduce
1. Override `\Magento\Sales\Model\Order\Pdf\Invoice::newPage()` to your custom module.
2. Change `$this->y = 800` to for example `$this->y = 1000`.
3. Nothing happens, the header stays the same.

See https://github.com/magento/magento2/pull/14000