### PR TITLE
Improve swatch table overflow handling

### DIFF
--- a/app/code/Magento/Swatches/view/adminhtml/web/css/swatches.css
+++ b/app/code/Magento/Swatches/view/adminhtml/web/css/swatches.css
@@ -153,6 +153,18 @@
     min-width: 65px;
 }
 
+[class^=swatch-col],
+[class^=col-]:not(.col-draggable):not(.col-default) {
+    min-width: 150px;
+}
+
+#swatch-visual-options-panel,
+#swatch-text-options-panel,
+#manage-options-panel {
+    overflow: auto;
+    width: 100%;
+}
+
 .data-table .col-swatch-min-width input[type="text"] {
     padding: inherit;
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Updates swatches.css to add overflow:auto to the three swatch tables (text, dropdown & visual) to allow for scrolling if the amount of inputs exceeds the available space and increase the min width of inputs (150px) within the table for better usability. 

Intentionally left original input width (50px) as a fallback.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19932: Fix Swatch Overflow issue
2. magento/magento2#19933: [backport] Fix Swatch Overflow issue

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add multiple store view and languages to your store (Our store has 19 but you should be able to reach replicate the issue with less)
2. Open an attribute page within the Admin area to configure (Stores > Product > Any attribute).
3. Table inputs at the bottom for languages should be too small to to use effectively
4. If 3. isn't true add more store views, the more that are added the smaller the input fields get.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
