### PR TITLE
Changed canonical_url to relative_url

### DIFF
--- a/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/EntityUrl.php
+++ b/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/EntityUrl.php
@@ -75,7 +75,7 @@ class EntityUrl implements ResolverInterface
         if ($urlRewrite) {
             $result = [
                 'id' => $urlRewrite->getEntityId(),
-                'canonical_url' => $urlRewrite->getTargetPath(),
+                'relative_url' => $urlRewrite->getTargetPath(),
                 'type' => $this->sanitizeType($urlRewrite->getEntityType())
             ];
         }

--- a/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/UrlRewriteGraphQl/etc/schema.graphqls
@@ -1,14 +1,14 @@
 # Copyright © Magento, Inc. All rights reserved.
 # See COPYING.txt for license details.
 
-type EntityUrl @doc(description: "EntityUrl is an output object containing the `id`, `canonical_url`, and `type` attributes") {
-    id: Int @doc(description: "The ID assigned to the object associated with the specified url. This could be a product ID, category ID, or page ID.")
-    canonical_url: String @doc(description: "The internal relative URL. If the specified  url is a redirect, the query returns the redirected URL, not the original.")
-    type: UrlRewriteEntityTypeEnum @doc(description: "One of PRODUCT, CATEGORY, or CMS_PAGE.")
-}
-
 type Query {
     urlResolver(url: String!): EntityUrl @resolver(class: "Magento\\UrlRewriteGraphQl\\Model\\Resolver\\EntityUrl") @doc(description: "The urlResolver query returns the relative URL for a specified product, category or CMS page")
+}
+
+type EntityUrl @doc(description: "EntityUrl is an output object containing the `id`, `canonical_url`, and `type` attributes") {
+    id: Int @doc(description: "The ID assigned to the object associated with the specified url. This could be a product ID, category ID, or page ID.")
+    relative_url: String @doc(description: "The internal relative URL. If the specified  url is a redirect, the query returns the redirected URL, not the original.")
+    type: UrlRewriteEntityTypeEnum @doc(description: "One of PRODUCT, CATEGORY, or CMS_PAGE.")
 }
 
 enum UrlRewriteEntityTypeEnum {


### PR DESCRIPTION
### Description (*)
As per the devdoc, there must be a **relative_url** instead of **canonical_url**.
- https://devdocs.magento.com/guides/v2.3/graphql/reference/url-resolver.html

### Fixed Issues (if relevant)
1. N/A

### Manual testing scenarios (*)
1. Try to execute following GraphQl query as explain in docs.
`{
 urlResolver(url:"joust-duffle-bag.html") {
   id
   relative_url
   type
 }
}`
2. It throws following error:
`{
  "errors": [
    {
      "message": "Cannot query field \"relative_url\" on type \"EntityUrl\".",
      "category": "graphql",
      "locations": [
        {
          "line": 4,
          "column": 4
        }
      ]
    }
  ]
}`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
