### PR TITLE
[Backport] 13982 customer login block sets the title for the page when rendered

### DIFF
--- a/app/code/Magento/Customer/Block/Form/Login.php
+++ b/app/code/Magento/Customer/Block/Form/Login.php
@@ -48,15 +48,6 @@ class Login extends \Magento\Framework\View\Element\Template
     }
 
     /**
-     * @return $this
-     */
-    protected function _prepareLayout()
-    {
-        $this->pageConfig->getTitle()->set(__('Customer Login'));
-        return parent::_prepareLayout();
-    }
-
-    /**
      * Retrieve form posting url
      *
      * @return string

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_login.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_login.xml
@@ -6,12 +6,10 @@
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <title>Customer Login</title>
+    </head>
     <body>
-        <referenceBlock name="page.main.title">
-            <action method="setPageTitle">
-                <argument name="title" translate="true" xsi:type="string">Customer Login</argument>
-            </action>
-        </referenceBlock>
         <referenceContainer name="content">
             <!-- customer.form.login.extra -->
             <container name="customer.login.container" label="Customer Login Container" htmlTag="div" htmlClass="login-container">

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_login.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_login.xml
@@ -7,6 +7,11 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
+        <referenceBlock name="page.main.title">
+            <action method="setPageTitle">
+                <argument name="title" translate="true" xsi:type="string">Customer Login</argument>
+            </action>
+        </referenceBlock>
         <referenceContainer name="content">
             <!-- customer.form.login.extra -->
             <container name="customer.login.container" label="Customer Login Container" htmlTag="div" htmlClass="login-container">


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20583
### Description
The main Customer Login Block, ``Magento\Customer\Block\Form\Login``sets up the page title.
If you use this block on any page, it rewrites the page title to "Customer Login".

### Fixed Issues
1. magento/magento2#13982: Customer Login Block sets the title for the page when rendered

### Manual testing scenarios
1. Go to Magento login page. The title of the page should be equal to "Customer Login"
2. Insert ``Magento/Customer/Block/Login`` Block into any page
3. The title of that page not be overridden by string "Customer Login"

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
