### PR TITLE
[Backport]-issue-195196 Can't upload customer Image attribute programmatically

### DIFF
--- a/app/code/Magento/Eav/Model/Attribute/Data/File.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/File.php
@@ -146,7 +146,7 @@ class File extends \Magento\Eav\Model\Attribute\Data\AbstractData
             return $this->_fileValidator->getMessages();
         }
 
-        if (!empty($value['tmp_name']) && !is_uploaded_file($value['tmp_name'])) {
+        if (!empty($value['tmp_name']) && !file_exists($value['tmp_name'])) {
             return [__('"%1" is not a valid file.', $label)];
         }
 

--- a/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js
@@ -14,7 +14,8 @@ define([
     'Magento_Ui/js/lib/validation/validator',
     'Magento_Ui/js/form/element/abstract',
     'mage/translate',
-    'jquery/file-uploader'
+    'jquery/file-uploader',
+    'mage/adminhtml/tools'
 ], function ($, _, utils, uiAlert, validator, Element, $t) {
     'use strict';
 

--- a/app/code/Magento/Variable/view/adminhtml/web/variables.js
+++ b/app/code/Magento/Variable/view/adminhtml/web/variables.js
@@ -9,7 +9,8 @@ define([
     'mage/translate',
     'Magento_Ui/js/modal/modal',
     'jquery/ui',
-    'prototype'
+    'prototype',
+    'mage/adminhtml/tools'
 ], function (jQuery, $t) {
     'use strict';
 

--- a/lib/web/mage/adminhtml/tools.js
+++ b/lib/web/mage/adminhtml/tools.js
@@ -89,12 +89,6 @@ function checkByProductPriceType(elem) {
 
 }
 
-Event.observe(window, 'load', function () {
-    if ($('price_default') && $('price_default').checked) {
-        $('price').disabled = 'disabled';
-    }
-});
-
 function toggleSeveralValueElements(checkbox, containers, excludedElements, checked) {
     'use strict';
 


### PR DESCRIPTION
### Original PR #19988
 
### Description (*)
Could not load image for customer attribute, error: Base64 is not defined "

### Fixed Issues (if relevant)
1. magento/magento2#19983: Could not load image for customer attribute,


### Manual testing scenarios (*)
1-Create customer attribute type file -> 
```
$eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);
        $eavSetup->addAttribute(
            \Magento\Customer\Model\Customer::ENTITY,
            'sample_attribute2',
            [
                'type'         => 'text',
                'label'        => 'Sample Attribute',
                'input'        => 'file',
                'required'     => false,
                'visible'      => true,
                'user_defined' => false,
                'position'     => 999,
                'system'       => 0,
            ]
        );
        $sampleAttribute = $this->eavConfig->getAttribute(Customer::ENTITY, 'sample_attribute');

        // more used_in_forms ['adminhtml_checkout','adminhtml_customer','adminhtml_customer_address','customer_account_edit','customer_address_edit','customer_register_address']
        $sampleAttribute->setData(
            'used_in_forms',
            ['adminhtml_customer','customer_register_address','customer_address_edit','customer_account_edit']

        );
        $sampleAttribute->save();
```
**2. try to upload image on adminhtml customer edit.**

### Expected Result 
No errors in Console, Image uploaded 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
