### PR TITLE
Fix allowing SQL injections in addExpressionFieldToSelect

### DIFF
--- a/lib/internal/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php
@@ -350,7 +350,8 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
 
         $fullExpression = $expression;
         foreach ($fields as $fieldKey => $fieldItem) {
-            $fullExpression = str_replace('{{' . $fieldKey . '}}', $fieldItem, $fullExpression);
+            $quotedFieldItem =  $this->getConnection()->quote($fieldItem);
+            $fullExpression = str_replace('{{' . $fieldKey . '}}', $quotedFieldItem, $fullExpression);
         }
 
         $this->getSelect()->columns([$alias => $fullExpression]);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The str_replace function used in `addExpressionFieldToSelect` directly adds the string in `$fieldItem` to the query. Here `$expression` must be checked by the developer to not have any dangerous content. But as developers expect magento core functions to prevent sql injection, they are prone to put input parameters directly inside `$fields` which can lead to sql injections. Other function `addFieldToSelect` in the same class ends up with quoted text. But this is not the case with this function.

### Fixed Issues (if relevant)
A similar issue happened in an opensource magento extension MageFan Module-Blog where developers apparently expected passing a search term as `$fieldItem` into this function to be safe which lead to SQL Injection:
https://github.com/magefan/module-blog/issues/228
Although a pull request was proposed there to quote the input parameter within extension code, it is safer for the upstream code of magento to prevent such cases.

### Manual testing scenarios (*)
Trigger an action which leads to call of:
```
Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;:addExpressionFieldToSelect
```
With a `"` as `$fieldItem`. The result is a crash report:
```
2 exception(s):
Exception #0 (Zend_Db_Statement_Exception): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '"""), 4)) AS `search_rate` FROM `magefan_blog_post` AS `main_table`
 INNER JOIN ' at line 1, query was: SELECT `main_table`.*, (0               + FORMAT(MATCH (title, meta_keywords, meta_description, identifier, content) AGAINST ("""), 4)) AS `search_rate` FROM `magefan_blog_post` AS `main_table`
 INNER JOIN `magefan_blog_post_store` AS `store_table` ON main_table.post_id = store_table.post_id WHERE (`is_active` = '1') AND (`publish_time` <= '2019-02-27 14:54:43') AND ((`title` LIKE '%\"%') OR (`short_content` LIKE '%\"%') OR (`content` LIKE '%\"%')) AND (store_table.store_id IN('1', 0)) GROUP BY `main_table`.`post_id` ORDER BY search_rate DESC, publish_time DESC
 LIMIT 10
Exception #1 (PDOException): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '"""), 4)) AS `search_rate` FROM `magefan_blog_post` AS `main_table`
 INNER JOIN ' at line 1

Exception #0 (Zend_Db_Statement_Exception): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '"""), 4)) AS `search_rate` FROM `magefan_blog_post` AS `main_table`
 INNER JOIN ' at line 1, query was: SELECT `main_table`.*, (0               + FORMAT(MATCH (title, meta_keywords, meta_description, identifier, content) AGAINST ("""), 4)) AS `search_rate` FROM `magefan_blog_post` AS `main_table`
 INNER JOIN `magefan_blog_post_store` AS `store_table` ON main_table.post_id = store_table.post_id WHERE (`is_active` = '1') AND (`publish_time` <= '2019-02-27 14:54:43') AND ((`title` LIKE '%\"%') OR (`short_content` LIKE '%\"%') OR (`content` LIKE '%\"%')) AND (store_table.store_id IN('1', 0)) GROUP BY `main_table`.`post_id` ORDER BY search_rate DESC, publish_time DESC
 LIMIT 10
#0 /var/www/html/lib/internal/Magento/Framework/DB/Statement/Pdo/Mysql.php(93): Zend_Db_Statement_Pdo->_execute(Array)
#1 /var/www/html/vendor/magento/zendframework1/library/Zend/Db/Statement.php(303): Magento\Framework\DB\Statement\Pdo\Mysql->_execute(Array)
#2 /var/www/html/vendor/magento/zendframework1/library/Zend/Db/Adapter/Abstract.php(480): Zend_Db_Statement->execute(Array)
#3 /var/www/html/vendor/magento/zendframework1/library/Zend/Db/Adapter/Pdo/Abstract.php(238): Zend_Db_Adapter_Abstract->query('SELECT `main_ta...', Array)
#4 /var/www/html/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php(541): Zend_Db_Adapter_Pdo_Abstract->query('SELECT `main_ta...', Array)
#5 /var/www/html/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php(615): Magento\Framework\DB\Adapter\Pdo\Mysql->_query('SELECT `main_ta...', Array)
#6 /var/www/html/vendor/magento/zendframework1/library/Zend/Db/Adapter/Abstract.php(737): Magento\Framework\DB\Adapter\Pdo\Mysql->query(Object(Magento\Framework\DB\Select), Array)
#7 /var/www/html/lib/internal/Magento/Framework/Data/Collection/Db/FetchStrategy/Query.php(21): Zend_Db_Adapter_Abstract->fetchAll(Object(Magento\Framework\DB\Select), Array)
#8 /var/www/html/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php(778): Magento\Framework\Data\Collection\Db\FetchStrategy\Query->fetchAll(Object(Magento\Framework\DB\Select), Array)
#9 /var/www/html/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php(674): Magento\Framework\Data\Collection\AbstractDb->_fetchAll(Object(Magento\Framework\DB\Select))
#10 /var/www/html/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php(577): Magento\Framework\Data\Collection\AbstractDb->getData()
#11 /var/www/html/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php(562): Magento\Framework\Data\Collection\AbstractDb->loadWithFilter(false, false)
#12 /var/www/html/lib/internal/Magento/Framework/Data/Collection.php(843): Magento\Framework\Data\Collection\AbstractDb->load()
```
### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
