### PR TITLE
[Catalog] Render configurable swatches based on the widget's configuration

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/Widget/NewWidget.php
+++ b/app/code/Magento/Catalog/Block/Product/Widget/NewWidget.php
@@ -54,11 +54,6 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
     private $serializer;
 
     /**
-     * @var Configurable|null
-     */
-    private $configurableList;
-
-    /**
      * NewWidget constructor.
      *
      * @param \Magento\Catalog\Block\Product\Context $context
@@ -67,7 +62,6 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
      * @param \Magento\Framework\App\Http\Context $httpContext
      * @param array $data
      * @param Json|null $serializer
-     * @param Configurable|null $configurableList
      */
     public function __construct(
         \Magento\Catalog\Block\Product\Context $context,
@@ -75,8 +69,7 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
         \Magento\Catalog\Model\Product\Visibility $catalogProductVisibility,
         \Magento\Framework\App\Http\Context $httpContext,
         array $data = [],
-        Json $serializer = null,
-        Configurable $configurableList = null
+        Json $serializer = null
     ) {
         parent::__construct(
             $context,
@@ -87,7 +80,6 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
         );
 
         $this->serializer = $serializer ?: ObjectManager::getInstance()->get(Json::class);
-        $this->configurableList = $configurableList ?: ObjectManager::getInstance()->get(Configurable::class);
     }
 
     /**
@@ -300,11 +292,10 @@ class NewWidget extends \Magento\Catalog\Block\Product\NewProduct implements \Ma
      */
     public function getProductDetailsHtml(\Magento\Catalog\Model\Product $product)
     {
-        $renderer =  $this->configurableList;
+        $renderer = $this->getLayout()->getBlock('widget.product.type.details.renderers.configurable');
 
         if ($renderer) {
             $renderer->setProduct($product);
-            $renderer->setTemplate('product/listing/renderer.phtml');
 
             return $renderer->toHtml();
         }

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
@@ -60,9 +60,11 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                 <?php if ($templateType): ?>
                                     <?= $block->getReviewsSummaryHtml($_item, $templateType) ?>
                                 <?php endif; ?>
+                                <?php echo $block->getProductDetailsHtml($_item); ?>
 
                                 <?php if ($showWishlist || $showCompare || $showCart): ?>
-                                    <div class="product-item-actions">
+                                    <div class="product-item-inner">
+                                        <div class="product-item-actions">
                                         <?php if ($showCart): ?>
                                             <div class="actions-primary">
                                                 <?php if ($_item->isSaleable()): ?>
@@ -73,15 +75,14 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                                             <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
                                                         </button>
                                                     <?php else: ?>
-                                                        <?php
-                                                            $postDataHelper = $this->helper('Magento\Framework\Data\Helper\PostHelper');
-                                                            $postData = $postDataHelper->getPostData($block->getAddToCartUrl($_item), ['product' => $_item->getEntityId()])
-                                                        ?>
-                                                        <button class="action tocart primary"
-                                                                data-post='<?= /* @escapeNotVerified */ $postData ?>'
-                                                                type="button" title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>">
-                                                            <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
-                                                        </button>
+                                                        <form data-role="tocart-form" data-product-sku="<?= $block->escapeHtml($_item->getSku()) ?>" action="<?= /* @NoEscape */ $block->getAddToCartUrl($_item) ?>" method="post">
+                                                            <?php echo $block->getBlockHtml('formkey') ?>
+                                                            <button type="submit"
+                                                                    title="<?php echo $block->escapeHtml(__('Add to Cart')) ?>"
+                                                                    class="action tocart primary">
+                                                                <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
+                                                            </button>
+                                                        </form>
                                                     <?php endif; ?>
                                                 <?php else: ?>
                                                     <?php if ($_item->getIsSalable()): ?>
@@ -114,6 +115,7 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                         <?php endif; ?>
                                     </div>
                                 <?php endif; ?>
+                                </div>
                             </div>
                         </div>
                      </li>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_list.phtml
@@ -59,58 +59,59 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                     <?php if ($templateType): ?>
                                         <?= $block->getReviewsSummaryHtml($_item, $templateType) ?>
                                     <?php endif; ?>
-
+                                    <?php echo $block->getProductDetailsHtml($_item); ?>
                                     <?php if ($showWishlist || $showCompare || $showCart): ?>
-                                        <div class="product-item-actions">
-                                            <?php if ($showCart): ?>
-                                                <div class="actions-primary">
-                                                    <?php if ($_item->isSaleable()): ?>
-                                                        <?php if (!$_item->getTypeInstance()->isPossibleBuyFromList($_item)): ?>
-                                                            <button class="action tocart primary"
-                                                                    data-mage-init='{"redirectUrl":{"url":"<?= /* @escapeNotVerified */ $block->getAddToCartUrl($_item) ?>"}}'
-                                                                    type="button" title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>">
-                                                                <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
-                                                            </button>
+                                        <div class="product-item-inner">
+                                            <div class="product-item-actions">
+                                                <?php if ($showCart): ?>
+                                                    <div class="actions-primary">
+                                                        <?php if ($_item->isSaleable()): ?>
+                                                            <?php if (!$_item->getTypeInstance()->isPossibleBuyFromList($_item)): ?>
+                                                                <button class="action tocart primary"
+                                                                        data-mage-init='{"redirectUrl":{"url":"<?= /* @escapeNotVerified */ $block->getAddToCartUrl($_item) ?>"}}'
+                                                                        type="button" title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>">
+                                                                    <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
+                                                                </button>
+                                                            <?php else: ?>
+                                                                <form data-role="tocart-form" data-product-sku="<?= $block->escapeHtml($_item->getSku()) ?>" action="<?= /* @NoEscape */ $block->getAddToCartUrl($_item) ?>" method="post">
+                                                                    <?php echo $block->getBlockHtml('formkey') ?>
+                                                                    <button type="submit"
+                                                                            title="<?php echo $block->escapeHtml(__('Add to Cart')) ?>"
+                                                                            class="action tocart primary">
+                                                                        <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
+                                                                    </button>
+                                                                </form>
+                                                            <?php endif; ?>
                                                         <?php else: ?>
-                                                            <?php
-                                                                $postDataHelper = $this->helper('Magento\Framework\Data\Helper\PostHelper');
-                                                                $postData = $postDataHelper->getPostData($block->getAddToCartUrl($_item), ['product' => $_item->getEntityId()])
-                                                            ?>
-                                                            <button class="action tocart primary"
-                                                                    data-post='<?= /* @escapeNotVerified */ $postData ?>'
-                                                                    type="button" title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>">
-                                                                <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
-                                                            </button>
+                                                            <?php if ($_item->getIsSalable()): ?>
+                                                                <div class="stock available"><span><?= /* @escapeNotVerified */ __('In stock') ?></span></div>
+                                                            <?php else: ?>
+                                                                <div class="stock unavailable"><span><?= /* @escapeNotVerified */ __('Out of stock') ?></span></div>
+                                                            <?php endif; ?>
                                                         <?php endif; ?>
-                                                    <?php else: ?>
-                                                        <?php if ($_item->getIsSalable()): ?>
-                                                            <div class="stock available"><span><?= /* @escapeNotVerified */ __('In stock') ?></span></div>
-                                                        <?php else: ?>
-                                                            <div class="stock unavailable"><span><?= /* @escapeNotVerified */ __('Out of stock') ?></span></div>
+                                                    </div>
+                                                <?php endif; ?>
+                                                <?php if ($showWishlist || $showCompare): ?>
+                                                    <div class="actions-secondary" data-role="add-to-links">
+                                                        <?php if ($this->helper('Magento\Wishlist\Helper\Data')->isAllow() && $showWishlist): ?>
+                                                            <a href="#"
+                                                               data-post='<?= /* @escapeNotVerified */ $block->getAddToWishlistParams($_item) ?>'
+                                                               class="action towishlist" data-action="add-to-wishlist"
+                                                               title="<?= /* @escapeNotVerified */ __('Add to Wish List') ?>">
+                                                                <span><?= /* @escapeNotVerified */ __('Add to Wish List') ?></span>
+                                                            </a>
                                                         <?php endif; ?>
-                                                    <?php endif; ?>
-                                                </div>
-                                            <?php endif; ?>
-                                            <?php if ($showWishlist || $showCompare): ?>
-                                                <div class="actions-secondary" data-role="add-to-links">
-                                                    <?php if ($this->helper('Magento\Wishlist\Helper\Data')->isAllow() && $showWishlist): ?>
-                                                        <a href="#"
-                                                           data-post='<?= /* @escapeNotVerified */ $block->getAddToWishlistParams($_item) ?>'
-                                                           class="action towishlist" data-action="add-to-wishlist"
-                                                           title="<?= /* @escapeNotVerified */ __('Add to Wish List') ?>">
-                                                            <span><?= /* @escapeNotVerified */ __('Add to Wish List') ?></span>
-                                                        </a>
-                                                    <?php endif; ?>
-                                                    <?php if ($block->getAddToCompareUrl() && $showCompare): ?>
-                                                        <?php $compareHelper = $this->helper('Magento\Catalog\Helper\Product\Compare'); ?>
-                                                        <a href="#" class="action tocompare"
-                                                           title="<?= /* @escapeNotVerified */ __('Add to Compare') ?>"
-                                                           data-post='<?= /* @escapeNotVerified */ $compareHelper->getPostDataParams($_item) ?>'>
-                                                            <span><?= /* @escapeNotVerified */ __('Add to Compare') ?></span>
-                                                        </a>
-                                                    <?php endif; ?>
-                                                </div>
-                                            <?php endif; ?>
+                                                        <?php if ($block->getAddToCompareUrl() && $showCompare): ?>
+                                                            <?php $compareHelper = $this->helper('Magento\Catalog\Helper\Product\Compare'); ?>
+                                                            <a href="#" class="action tocompare"
+                                                               title="<?= /* @escapeNotVerified */ __('Add to Compare') ?>"
+                                                               data-post='<?= /* @escapeNotVerified */ $compareHelper->getPostDataParams($_item) ?>'>
+                                                                <span><?= /* @escapeNotVerified */ __('Add to Compare') ?></span>
+                                                            </a>
+                                                        <?php endif; ?>
+                                                    </div>
+                                                <?php endif; ?>
+                                            </div>
                                         </div>
                                     <?php endif; ?>
                                     <?php if ($description):?>

--- a/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
+++ b/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
@@ -148,7 +148,11 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
      */
     public function getCacheKey()
     {
-        return parent::getCacheKey() . '-' . $this->getProduct()->getId();
+        if ($product = $this->getProduct()) {
+            return parent::getCacheKey() . '-' . $product->getId();
+        }
+
+        return parent::getCacheKey();
     }
 
     /**

--- a/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
+++ b/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
@@ -254,8 +254,13 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
      */
     protected function isProductHasSwatchAttribute()
     {
-        $swatchAttributes = $this->swatchAttributesProvider->provide($this->getProduct());
-        return count($swatchAttributes) > 0;
+        if ($product = $this->getProduct()) {
+            $swatchAttributes = $this->swatchAttributesProvider->provide($product);
+
+            return count($swatchAttributes) > 0;
+        }
+
+        return false;
     }
 
     /**

--- a/app/code/Magento/Widget/view/frontend/layout/default.xml
+++ b/app/code/Magento/Widget/view/frontend/layout/default.xml
@@ -7,5 +7,12 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <body/>
+    <body>
+        <referenceContainer name="root">
+            <block class="Magento\Swatches\Block\Product\Renderer\Listing\Configurable"
+                   name="widget.product.type.details.renderers.configurable" as="widget.configurable"
+                   template="Magento_Swatches::product/listing/renderer.phtml"
+                   ifconfig="catalog/frontend/show_swatches_in_product_list" />
+        </referenceContainer>
+    </body>
 </page>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes the configurable swatches rendering based on the widget's configuration. 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14134: Swatches not showing on homepage New products widget
2. ...

### Manual testing scenarios (*)
1. Create a configurable product with color swatches
2. Use `New Products` widget for showing it on homepage or any other place

**Grid Mode**
![xnip2019-02-27_18-53-53](https://user-images.githubusercontent.com/15868188/53507719-0e07c480-3ac1-11e9-87f7-ec0d39f26e92.jpg)

**List Mode**
![xnip2019-02-27_18-55-38](https://user-images.githubusercontent.com/15868188/53507835-4ad3bb80-3ac1-11e9-87f6-14c52ecb8ea5.jpg)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
