### PR TITLE
Populate label elements for street address fields in checkout

### DIFF
--- a/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
+++ b/app/code/Magento/Checkout/Block/Checkout/AttributeMerger.php
@@ -278,6 +278,7 @@ class AttributeMerger
         for ($lineIndex = 0; $lineIndex < (int)$attributeConfig['size']; $lineIndex++) {
             $isFirstLine = $lineIndex === 0;
             $line = [
+                'label' => __("%1: Line %2", $attributeConfig['label'], $lineIndex + 1),
                 'component' => 'Magento_Ui/js/form/element/abstract',
                 'config' => [
                     // customScope is used to group elements within a single form e.g. they can be validated separately

--- a/app/design/frontend/Magento/blank/Magento_Customer/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Customer/web/css/source/_module.less
@@ -165,7 +165,7 @@
 
     //  Checkout address (create shipping address)
     .field.street {
-        .field.additional {
+        .field {
             .label {
                 &:extend(.abs-visually-hidden all);
             }

--- a/app/design/frontend/Magento/luma/Magento_Customer/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Customer/web/css/source/_module.less
@@ -200,7 +200,7 @@
 
     //  Checkout address (create shipping address)
     .field.street {
-        .field.additional {
+        .field {
             .label {
                 &:extend(.abs-visually-hidden all);
             }


### PR DESCRIPTION
### Description (*)
Populate `<label>` elements for the street fields in checkout. (The elements are already present but are blank by default.) This applies both when entering either a new shipping address or billing address.

The one aspect of this PR I'm not certain is handled the best way is the translation of the label. Glad to see any suggestions for improvements on how I've done this.

### Fixed Issues (if relevant)
magento/magento2#10893: Street fields in checkout don't have a label that's readable by a screenreader

### Manual testing scenarios (*)
1. Add a product to your cart
2. Go to checkout
3. Verify that the street address fields have a linked `<label>` with text populated (e.g., "Street Address: Line 1"). These labels should be hidden visually (since meaning is implied visually by the fieldset legend) but accessible to screen reader software.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
