### PR TITLE
Fix for issue #21477 sets CURRENT_TIMESTAMP on updated_at fields

### DIFF
--- a/app/code/Magento/Integration/etc/db_schema.xml
+++ b/app/code/Magento/Integration/etc/db_schema.xml
@@ -107,7 +107,7 @@
                 comment="Oauth consumer"/>
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="Creation Time"/>
-        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="0"
+        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="Update Time"/>
         <column xsi:type="smallint" name="setup_type" padding="5" unsigned="true" nullable="false" identity="false"
                 default="0" comment="Integration type - manual or config file"/>

--- a/app/code/Magento/Quote/etc/db_schema.xml
+++ b/app/code/Magento/Quote/etc/db_schema.xml
@@ -108,7 +108,7 @@
                 default="0" comment="Quote Id"/>
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="Created At"/>
-        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="0"
+        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="Updated At"/>
         <column xsi:type="int" name="customer_id" padding="10" unsigned="true" nullable="true" identity="false"
                 comment="Customer Id"/>
@@ -218,7 +218,7 @@
                 default="0" comment="Quote Id"/>
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="Created At"/>
-        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="0"
+        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="Updated At"/>
         <column xsi:type="int" name="product_id" padding="10" unsigned="true" nullable="true" identity="false"
                 comment="Product Id"/>
@@ -322,7 +322,7 @@
                 default="0" comment="Quote Item Id"/>
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="Created At"/>
-        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="0"
+        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="Updated At"/>
         <column xsi:type="text" name="applied_rule_ids" nullable="true" comment="Applied Rule Ids"/>
         <column xsi:type="text" name="additional_data" nullable="true" comment="Additional Data"/>
@@ -434,7 +434,7 @@
                 default="0" comment="Quote Id"/>
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="Created At"/>
-        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="0"
+        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="Updated At"/>
         <column xsi:type="varchar" name="method" nullable="true" length="255" comment="Method"/>
         <column xsi:type="varchar" name="cc_type" nullable="true" length="255" comment="Cc Type"/>
@@ -470,7 +470,7 @@
                 default="0" comment="Address Id"/>
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="Created At"/>
-        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="0"
+        <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="Updated At"/>
         <column xsi:type="varchar" name="carrier" nullable="true" length="255" comment="Carrier"/>
         <column xsi:type="varchar" name="carrier_title" nullable="true" length="255" comment="Carrier Title"/>


### PR DESCRIPTION
### Description
Fix for issue #21477 sets CURRENT_TIMESTAMP on updated_at fields in the DB Schema.

### Fixed Issues (if relevant)
1. magento/magento2#21477: Magento 2.3 quote_item table has incorrect default value in declarative schema

### Manual testing scenarios

Check database after creating a quote and placing an item in the quote that updated at field is filled correctly. 
