### PR TITLE
Currency import Undefined index error #21487:

### DIFF
--- a/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
@@ -14,7 +14,7 @@ class CurrencyConverterApi extends AbstractImport
     /**
      * @var string
      */
-    const CURRENCY_CONVERTER_URL = 'http://free.currencyconverterapi.com/api/v3/convert?q={{CURRENCY_FROM}}_{{CURRENCY_TO}}'
+    const CURRENCY_CONVERTER_URL = 'https://free.currencyconverterapi.com/api/v6/convert?q={{CURRENCY_FROM}}_{{CURRENCY_TO}}'
     .'&compact=ultra&apiKey={{ACCESS_KEY}}'; //@codingStandardsIgnoreLine
 
     /**

--- a/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
@@ -168,18 +168,18 @@ class CurrencyConverterApi extends AbstractImport
     /**
      * Validates rates response.
      * @param array $response
-     * @param string $baseCurrency
+     * @param string $currencyFrom
      * @param string $currenciesTo
      * @return bool
      */
-    private function validateResponse(array $response, string $baseCurrency, string $currenciesTo): bool
+    private function validateResponse(array $response, string $currencyFrom, string $currenciesTo): bool
     {
         if (isset($response['error'])) {
             $this->_messages[] = $response['error'];
 
             return false;
         }
-        if (!isset($response[$baseCurrency.'_'.$currenciesTo])) {
+        if (empty($response[$currencyFrom.'_'.$currenciesTo])) {
             $this->_messages[] = __('We can\'t retrieve a rate for %1.', $currenciesTo);
 
             return false;

--- a/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/CurrencyConverterApiTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/CurrencyConverterApiTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Directory\Test\Unit\Model\Currency\Import;
+
+use Magento\Directory\Model\Currency;
+use Magento\Directory\Model\Currency\Import\CurrencyConverterApi;
+use Magento\Directory\Model\CurrencyFactory;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\DataObject;
+use Magento\Framework\HTTP\ZendClient;
+use Magento\Framework\HTTP\ZendClientFactory;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+/**
+ * CurrencyConverterApiTest Test
+ */
+class CurrencyConverterApiTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var CurrencyConverterApi
+     */
+    private $model;
+
+    /**
+     * @var CurrencyFactory|MockObject
+     */
+    private $currencyFactory;
+
+    /**
+     * @var ZendClientFactory|MockObject
+     */
+    private $httpClientFactory;
+
+    /**
+     * @var ScopeConfigInterface|MockObject
+     */
+    private $scopeConfig;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->currencyFactory = $this->getMockBuilder(CurrencyFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $this->httpClientFactory = $this->getMockBuilder(ZendClientFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $this->scopeConfig = $this->getMockBuilder(ScopeConfigInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods([])
+            ->getMock();
+
+        $this->model = new CurrencyConverterApi($this->currencyFactory, $this->scopeConfig, $this->httpClientFactory);
+    }
+
+    /**
+     * Test Fetch Rates
+     *
+     * @return void
+     */
+    public function testFetchRates(): void
+    {
+        $currencyFromList = ['USD'];
+        $currencyToList = ['EUR', 'UAH'];
+        $responseBody = '{"USD_EUR":0.879215}';
+        $expectedCurrencyRateList = ['USD' => ['EUR' => 0.879215, 'UAH' => null]];
+        $message = "We can't retrieve a rate for UAH.";
+
+        $this->scopeConfig->method('getValue')
+            ->withConsecutive(
+                ['currency/currencyconverterapi/api_key', 'store'],
+                ['currency/currencyconverterapi/timeout', 'store']
+            )
+            ->willReturnOnConsecutiveCalls('api_key', 100);
+
+        /** @var Currency|MockObject $currency */
+        $currency = $this->getMockBuilder(Currency::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        /** @var ZendClient|MockObject $httpClient */
+        $httpClient = $this->getMockBuilder(ZendClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        /** @var DataObject|MockObject $currencyMock */
+        $httpResponse = $this->getMockBuilder(DataObject::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getBody'])
+            ->getMock();
+
+        $this->currencyFactory->method('create')
+            ->willReturn($currency);
+        $currency->method('getConfigBaseCurrencies')
+            ->willReturn($currencyFromList);
+        $currency->method('getConfigAllowCurrencies')
+            ->willReturn($currencyToList);
+
+        $this->httpClientFactory->method('create')
+            ->willReturn($httpClient);
+        $httpClient->method('setUri')
+            ->willReturnSelf();
+        $httpClient->method('setConfig')
+            ->willReturnSelf();
+        $httpClient->method('request')
+            ->willReturn($httpResponse);
+        $httpResponse->method('getBody')
+            ->willReturn($responseBody);
+
+        self::assertEquals($expectedCurrencyRateList, $this->model->fetchRates());
+
+        $messages = $this->model->getMessages();
+        self::assertNotEmpty($messages);
+        self::assertTrue(is_array($messages));
+        self::assertEquals($message, (string)$messages[0]);
+    }
+}

--- a/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/CurrencyConverterApiTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/CurrencyConverterApiTest.php
@@ -72,7 +72,7 @@ class CurrencyConverterApiTest extends \PHPUnit\Framework\TestCase
         $currencyFromList = ['USD'];
         $currencyToList = ['EUR', 'UAH'];
         $responseBody = '{"USD_EUR":0.879215}';
-        $expectedCurrencyRateList = ['USD' => ['EUR' => 0.879215, 'UAH' => null]];
+        $expectedRateList = ['USD' => ['EUR' => 0.879215, 'UAH' => null]];
         $message = "We can't retrieve a rate for UAH.";
 
         $this->scopeConfig->method('getValue')
@@ -114,7 +114,7 @@ class CurrencyConverterApiTest extends \PHPUnit\Framework\TestCase
         $httpResponse->method('getBody')
             ->willReturn($responseBody);
 
-        self::assertEquals($expectedCurrencyRateList, $this->model->fetchRates());
+        self::assertEquals($expectedRateList, $this->model->fetchRates());
 
         $messages = $this->model->getMessages();
         self::assertNotEmpty($messages);

--- a/app/code/Magento/Directory/etc/adminhtml/system.xml
+++ b/app/code/Magento/Directory/etc/adminhtml/system.xml
@@ -47,7 +47,12 @@
             </group>
             <group id="currencyconverterapi" translate="label" sortOrder="45" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Currency Converter API</label>
-                <field id="timeout" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="api_key" translate="label" type="obscure" sortOrder="5" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>API Key</label>
+                    <config_path>currency/currencyconverterapi/api_key</config_path>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                </field>
+                <field id="timeout" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Connection Timeout in Seconds</label>
                 </field>
             </group>

--- a/app/code/Magento/Directory/etc/config.xml
+++ b/app/code/Magento/Directory/etc/config.xml
@@ -24,6 +24,7 @@
             </fixerio>
             <currencyconverterapi>
                 <timeout>100</timeout>
+                <api_key backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
             </currencyconverterapi>
             <import>
                 <enabled>0</enabled>


### PR DESCRIPTION
- API key is required for free version of currencyconverterapi

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
CurrencyConverterApi is using http://free.currencyconverterapi.com service for importing currency rates. API key is now required for the free server requests and this is not implemented on current Magento core code. 
Because of missing API key, https://free.currencyconverterapi.com/api/v6/convert?q=USD_EUR,USD_UAH&compact=ultra
it return following response {"status":400,"error":"API Key is required."}
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21487: Currency import Undefined index error

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.  Setup multiple currencies from Stores >> Settings>> Configuration > Currency Setup
2. Go to Admin > Stores > Currency Rates
3. Select Currency Converter API in the dropdown and click the import button
3.1 It will return API key missing error instead of "Notice: Undefined index:" warning
4. Create https://free.currencyconverterapi.com API key and setup that key  from Stores >> Settings>> Configuration > Currency Setup > Currency Converter API
5. Select Currency Converter API in the dropdown and click the import button
5.1 Currency rates imported 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
