### PR TITLE
Remove setting of page title from Form/Register block and add title to customer_account_create layout

### DIFF
--- a/app/code/Magento/Customer/Block/Form/Register.php
+++ b/app/code/Magento/Customer/Block/Form/Register.php
@@ -87,17 +87,6 @@ class Register extends \Magento\Directory\Block\Data
     }
 
     /**
-     * Prepare layout
-     *
-     * @return $this
-     */
-    protected function _prepareLayout()
-    {
-        $this->pageConfig->getTitle()->set(__('Create New Customer Account'));
-        return parent::_prepareLayout();
-    }
-
-    /**
      * Retrieve form posting url
      *
      * @return string

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_create.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_create.xml
@@ -6,6 +6,9 @@
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <title>Create New Customer Account</title>
+    </head>
     <body>
         <referenceBlock name="head.components">
             <block class="Magento\Framework\View\Element\Js\Components" name="customer_account_create_head_components" template="Magento_Customer::js/components.phtml"/>


### PR DESCRIPTION
### Description
The Customer Registration Form Block `Magento\Customer\Block\Form\Register` sets the page title. If this block is included on another page, the title might be overwritten with "Create New Customer Account". I removed this behaviour from the block and instead set the page title in the layout of Customer Registration Page. 

This fix is analog to the one in [this pull request](https://github.com/magento/magento2/pull/20583).

### Manual testing scenarios
1. Go to Customer Account Registration Page. The title of the page should be equal to "Create New Customer Account"
2. Insert `Magento\Customer\Block\Form\Register` Block into a page. The title of that page should not be overridden by string "Create New Customer Account"

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
