### PR TITLE
Fix issue with possibly colliding form-fields

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/web/catalog/category/assign-products.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/catalog/category/assign-products.js
@@ -56,7 +56,7 @@ define([
                 checkbox = null;
 
             if (trElement) {
-                checkbox = Element.getElementsBySelector(trElement, 'input');
+                checkbox = Element.getElementsBySelector(trElement, 'input[type="checkbox"]');
 
                 if (checkbox[0]) {
                     checked = isInput ? checkbox[0].checked : !checkbox[0].checked;


### PR DESCRIPTION
### Description (*)

It is possible for modules to extend the form-fields within a grid. Therefore it can happen that other formfields - especially hidden fields - are added to a grid so that the query does not only return checkboxes but also other form-fields. And then the first form-field is not necessary the checkbox we want in this case.

This change alters the selector that is used to query for the first checkbox by actually only requesting checkbox-fields. So the chances are much higher that the checkbox-field we want is actually the first item of the list.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->


<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. There was not yet an issue (AFAIK)

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add a hidden field before the checkbox in the grid of products of a category
2. Try to add or remove a product to or from the category

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
