### PR TITLE
Fix: Cart is emptied when enter is pressed after changing product quantity

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/shopping-cart.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/shopping-cart.js
@@ -14,7 +14,11 @@ define([
         _create: function () {
             var items, i, reload;
 
-            $(this.options.emptyCartButton).on('click', $.proxy(function () {
+            $(this.options.emptyCartButton).on('click', $.proxy(function (event) {
+                if (event.detail == 0) {
+                    return;
+                }
+
                 $(this.options.emptyCartButton).attr('name', 'update_cart_action_temp');
                 $(this.options.updateCartActionContainer)
                     .attr('name', 'update_cart_action').attr('value', 'empty_cart');

--- a/app/code/Magento/Checkout/view/frontend/web/js/shopping-cart.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/shopping-cart.js
@@ -15,7 +15,7 @@ define([
             var items, i, reload;
 
             $(this.options.emptyCartButton).on('click', $.proxy(function (event) {
-                if (event.detail == 0) {
+                if (event.detail === 0) {
                     return;
                 }
 


### PR DESCRIPTION
### Description (*)
Fix: Cart is emptied when enter is pressed after changing product quantity

### Fixed Issues (if relevant)
magento/magento2#21499: Cart is emptied when enter is pressed after changing product quantity

### Manual testing scenarios (*)
Go to the input qty and press enter key

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
