### PR TITLE
SHQ18-1568 Updating UPS endpoint to use https. Http is no longer reli…

### DIFF
--- a/app/code/Magento/Ups/Model/Carrier.php
+++ b/app/code/Magento/Ups/Model/Carrier.php
@@ -77,7 +77,7 @@ class Carrier extends AbstractCarrierOnline implements CarrierInterface
      *
      * @var string
      */
-    protected $_defaultCgiGatewayUrl = 'https://www.ups.com:80/using/services/rave/qcostcgi.cgi';
+    protected $_defaultCgiGatewayUrl = 'https://www.ups.com/using/services/rave/qcostcgi.cgi';
 
     /**
      * Test urls for shipment

--- a/app/code/Magento/Ups/Model/Carrier.php
+++ b/app/code/Magento/Ups/Model/Carrier.php
@@ -77,7 +77,7 @@ class Carrier extends AbstractCarrierOnline implements CarrierInterface
      *
      * @var string
      */
-    protected $_defaultCgiGatewayUrl = 'http://www.ups.com:80/using/services/rave/qcostcgi.cgi';
+    protected $_defaultCgiGatewayUrl = 'https://www.ups.com:80/using/services/rave/qcostcgi.cgi';
 
     /**
      * Test urls for shipment

--- a/app/code/Magento/Ups/etc/config.xml
+++ b/app/code/Magento/Ups/etc/config.xml
@@ -19,7 +19,7 @@
                 <cutoff_cost />
                 <dest_type>RES</dest_type>
                 <free_method>GND</free_method>
-                <gateway_url>http://www.ups.com/using/services/rave/qcostcgi.cgi</gateway_url>
+                <gateway_url>https://www.ups.com/using/services/rave/qcostcgi.cgi</gateway_url>
                 <gateway_xml_url>https://onlinetools.ups.com/ups.app/xml/Rate</gateway_xml_url>
                 <handling>0</handling>
                 <model>Magento\Ups\Model\Carrier</model>


### PR DESCRIPTION
…ably returning rates

This PR changes the UPS (non XML) endpoint from http to https. UPS are no longer returning rates reliably via a http request.

Test by placing any item into the cart with a weight > 0 and ship to a valid state and zip code such as NY 11705