### PR TITLE
Fix #21372 - Admin Search Suggestions Toggle Not Working

### DIFF
--- a/app/code/Magento/Search/Block/FormMini.php
+++ b/app/code/Magento/Search/Block/FormMini.php
@@ -3,22 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * Search form.mini block
- */
 namespace Magento\Search\Block;
 
 use \Magento\Framework\View\Element\Template;
 use \Magento\Framework\View\Element\Template\Context;
 
 /**
+ * Search form.mini block
+ *
  * @api
  * @since 100.0.2
  */
 class FormMini extends Template
 {
-
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
@@ -35,8 +34,6 @@ class FormMini extends Template
     private $serializer;
 
     /**
-     * Constructor
-     *
      * @param Context $context
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
@@ -47,27 +44,23 @@ class FormMini extends Template
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Framework\Serialize\Serializer\Json $serializer = null,
         array $data = []
-    )
-    {
+    ) {
+        parent::__construct($context, $data);
         $this->scopeConfig = $scopeConfig;
         $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(\Magento\Framework\Serialize\Serializer\Json::class);
-
-        parent::__construct($context, $data);
     }
 
-
     /**
-     * getSerializedConfig
+     * Returns serialized config
      *
      * @return mixed
      */
-    public function getSerializedConfig() {
+    public function getSerializedConfig()
+    {
         $storeScope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE;
+        $searchSuggestionConfig = $this->scopeConfig->getValue(self::XML_PATH_SEARCH_SUGGESTION, $storeScope);
 
-        return $this->serializer->serialize([
-            'searchSuggestionEnabled' => $this->scopeConfig->getValue(self::XML_PATH_SEARCH_SUGGESTION, $storeScope),
-        ]);
+        return $this->serializer->serialize(['searchSuggestionEnabled' => $searchSuggestionConfig]);
     }
-    
 }

--- a/app/code/Magento/Search/Block/FormMini.php
+++ b/app/code/Magento/Search/Block/FormMini.php
@@ -7,7 +7,7 @@
 /**
  * Search form.mini block
  */
-namespace Demac\CoreRewrite\Search\Block;
+namespace Magento\Search\Block;
 
 use \Magento\Framework\View\Element\Template;
 use \Magento\Framework\View\Element\Template\Context;

--- a/app/code/Magento/Search/Block/FormMini.php
+++ b/app/code/Magento/Search/Block/FormMini.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * Search form.mini block
+ */
+namespace Magento\Search\Block;
+
+use Magento\Framework\UrlFactory;
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Element\Template\Context;
+use Magento\Search\Model\ResourceModel\Query\CollectionFactory;
+
+/**
+ * @api
+ * @since 100.0.2
+ */
+class FormMini extends Template
+{
+
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * Search Suggestions Enabled
+     */
+    const XML_PATH_SEARCH_SUGGESTION = 'catalog/search/search_suggestion_enabled';
+
+    /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
+     * Constructor
+     *
+     * @param Template\Context $context
+     * @param array $data
+     * @param Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     */
+    public function __construct(
+        Template\Context $context,
+        array $data = [],
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+    )
+    {
+        $this->scopeConfig = $scopeConfig;
+        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
+
+        parent::__construct($context, $data);
+    }
+
+
+    /**
+     * getSerializedConfig
+     *
+     * @return mixed
+     */
+    public function getSerializedConfig() {
+        $storeScope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE;
+
+        return $this->serializer->serialize([
+            'searchSuggestionEnabled' => $this->scopeConfig->getValue(self::XML_PATH_SEARCH_SUGGESTION, $storeScope),
+        ]);
+    }
+    
+    
+}

--- a/app/code/Magento/Search/Block/FormMini.php
+++ b/app/code/Magento/Search/Block/FormMini.php
@@ -7,13 +7,10 @@
 /**
  * Search form.mini block
  */
-namespace Magento\Search\Block;
+namespace Demac\CoreRewrite\Search\Block;
 
-use Magento\Framework\UrlFactory;
-use Magento\Framework\UrlInterface;
-use Magento\Framework\View\Element\Template;
-use Magento\Framework\View\Element\Template\Context;
-use Magento\Search\Model\ResourceModel\Query\CollectionFactory;
+use \Magento\Framework\View\Element\Template;
+use \Magento\Framework\View\Element\Template\Context;
 
 /**
  * @api
@@ -40,16 +37,16 @@ class FormMini extends Template
     /**
      * Constructor
      *
-     * @param Template\Context $context
-     * @param array $data
-     * @param Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param Context $context
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @param array $data
      */
     public function __construct(
-        Template\Context $context,
-        array $data = [],
+        Context $context,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+        \Magento\Framework\Serialize\Serializer\Json $serializer = null,
+        array $data = []
     )
     {
         $this->scopeConfig = $scopeConfig;
@@ -72,6 +69,5 @@ class FormMini extends Template
             'searchSuggestionEnabled' => $this->scopeConfig->getValue(self::XML_PATH_SEARCH_SUGGESTION, $storeScope),
         ]);
     }
-    
     
 }

--- a/app/code/Magento/Search/view/frontend/layout/default.xml
+++ b/app/code/Magento/Search/view/frontend/layout/default.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="header-wrapper">
-            <block class="Magento\Framework\View\Element\Template" name="top.search" as="topSearch" template="Magento_Search::form.mini.phtml" />
+            <block class="Magento\Search\Block\FormMini" name="top.search" as="topSearch" template="Magento_Search::form.mini.phtml" />
         </referenceContainer>
         <referenceBlock name="footer_links">
             <block class="Magento\Framework\View\Element\Html\Link\Current" ifconfig="catalog/seo/search_terms" name="search-term-popular-link">

--- a/app/code/Magento/Search/view/frontend/templates/form.mini.phtml
+++ b/app/code/Magento/Search/view/frontend/templates/form.mini.phtml
@@ -15,6 +15,9 @@ $helper = $this->helper(\Magento\Search\Helper\Data::class);
     <div class="block block-title"><strong><?= /* @escapeNotVerified */ __('Search') ?></strong></div>
     <div class="block block-content">
         <form class="form minisearch" id="search_mini_form" action="<?= /* @escapeNotVerified */ $helper->getResultUrl() ?>" method="get">
+            <script>
+                window.searchConfig = <?= /* @escapeNotVerified */ $block->getSerializedConfig() ?>;
+            </script>
             <div class="field search">
                 <label class="label" for="search" data-role="minisearch-label">
                     <span><?= /* @escapeNotVerified */ __('Search') ?></span>

--- a/app/code/Magento/Search/view/frontend/web/js/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/js/form-mini.js
@@ -62,6 +62,9 @@ define([
             _.bindAll(this, '_onKeyDown', '_onPropertyChange', '_onSubmit');
 
             this.submitBtn.disabled = true;
+            if (typeof window.searchConfig !== 'undefined' && window.searchConfig.searchSuggestionEnabled == false) {
+                this.submitBtn.disabled = false;
+            }
 
             this.element.attr('autocomplete', this.options.autocomplete);
 

--- a/app/code/Magento/Search/view/frontend/web/js/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/js/form-mini.js
@@ -276,6 +276,10 @@ define([
          * @private
          */
         _onPropertyChange: function () {
+            if (typeof window.searchConfig !== 'undefined' && window.searchConfig.searchSuggestionEnabled == false) {
+                return false;
+            }
+            
             var searchField = this.element,
                 clonePosition = {
                     position: 'absolute',


### PR DESCRIPTION
Fix reported bug of broken admin toggle for frontend

### Description (*)
Loads system config value for Enable/Disable search suggestions, add conditional check on search suggestion request.

### Fixed Issues (if relevant)
1. magento/magento2#21372: Admin Search Suggestions Toggle Not Working

### Manual testing scenarios (*)
Scenario 1:
1. Enable Search Suggestions in Admin
2. Enter a search result on frontend (submit it, press enter)
3. Begin entering the same search query
4. Suggestions should appear

Scenario 2:
1. Disable Search Suggestions in Admin
2. Enter a search result on frontend (submit it, press enter)
3. Begin entering the same search query
4. Suggestions should **NOT** appear


### Contribution checklist (*)
 - [ x ] Pull request has a meaningful description of its purpose
 - [ x ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
