### PR TITLE
[Backport]  Sitemap filename can't exceed 32 characters #13937 

### DIFF
--- a/app/code/Magento/Sitemap/Block/Adminhtml/Edit/Form.php
+++ b/app/code/Magento/Sitemap/Block/Adminhtml/Edit/Form.php
@@ -48,6 +48,8 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     }
 
     /**
+     * Configure form for sitemap.
+     *
      * @return $this
      */
     protected function _prepareForm()

--- a/app/code/Magento/Sitemap/Block/Adminhtml/Edit/Form.php
+++ b/app/code/Magento/Sitemap/Block/Adminhtml/Edit/Form.php
@@ -73,7 +73,8 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'name' => 'sitemap_filename',
                 'required' => true,
                 'note' => __('example: sitemap.xml'),
-                'value' => $model->getSitemapFilename()
+                'value' => $model->getSitemapFilename(),
+                'class' => 'validate-length maximum-length-32'
             ]
         );
 

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Save.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Save.php
@@ -5,11 +5,18 @@
  */
 namespace Magento\Sitemap\Controller\Adminhtml\Sitemap;
 
-use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Controller;
+use Magento\Framework\Validator\StringLength;
+use Magento\MediaStorage\Model\File\Validator\AvailablePath;
+use Magento\Sitemap\Model\SitemapFactory;
 
-class Save extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
+/**
+ * Save sitemap controller.
+ */
+class Save extends \Magento\Sitemap\Controller\Adminhtml\Sitemap implements HttpPostActionInterface
 {
     /**
      * Maximum length of sitemap filename
@@ -17,12 +24,12 @@ class Save extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
     const MAX_FILENAME_LENGTH = 32;
 
     /**
-     * @var \Magento\Framework\Validator\StringLength
+     * @var StringLength
      */
     private $stringValidator;
 
     /**
-     * @var \Magento\MediaStorage\Model\File\Validator\AvailablePath
+     * @var AvailablePath
      */
     private $pathValidator;
 
@@ -37,33 +44,33 @@ class Save extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
     private $filesystem;
 
     /**
-     * @var \Magento\Sitemap\Model\SitemapFactory
+     * @var SitemapFactory
      */
     private $sitemapFactory;
 
     /**
      * Save constructor.
-     * @param Action\Context $context
-     * @param \Magento\Framework\Validator\StringLength $stringValidator
-     * @param \Magento\MediaStorage\Model\File\Validator\AvailablePath $pathValidator
+     * @param Context $context
+     * @param StringLength $stringValidator
+     * @param AvailablePath $pathValidator
      * @param \Magento\Sitemap\Helper\Data $sitemapHelper
      * @param \Magento\Framework\Filesystem $filesystem
-     * @param \Magento\Sitemap\Model\SitemapFactory $sitemapFactory
+     * @param SitemapFactory $sitemapFactory
      */
     public function __construct(
-        \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\Validator\StringLength $stringValidator = null,
-        \Magento\MediaStorage\Model\File\Validator\AvailablePath $pathValidator = null,
+        Context $context,
+        StringLength $stringValidator = null,
+        AvailablePath $pathValidator = null,
         \Magento\Sitemap\Helper\Data $sitemapHelper = null,
         \Magento\Framework\Filesystem $filesystem = null,
-        \Magento\Sitemap\Model\SitemapFactory $sitemapFactory = null
+        SitemapFactory $sitemapFactory = null
     ) {
         parent::__construct($context);
-        $this->stringValidator = $stringValidator ?: $this->_objectManager->get(\Magento\Framework\Validator\StringLength::class);
-        $this->pathValidator = $pathValidator ?: $this->_objectManager->get(\Magento\MediaStorage\Model\File\Validator\AvailablePath::class);
+        $this->stringValidator = $stringValidator ?: $this->_objectManager->get(StringLength::class);
+        $this->pathValidator = $pathValidator ?: $this->_objectManager->get(AvailablePath::class);
         $this->sitemapHelper = $sitemapHelper ?: $this->_objectManager->get(\Magento\Sitemap\Helper\Data::class);
         $this->filesystem = $filesystem ?: $this->_objectManager->get(\Magento\Framework\Filesystem::class);
-        $this->sitemapFactory = $sitemapFactory ?: $this->_objectManager->get(\Magento\Sitemap\Model\SitemapFactory::class);
+        $this->sitemapFactory = $sitemapFactory ?: $this->_objectManager->get(SitemapFactory::class);
     }
 
     /**

--- a/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/SaveTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/SaveTest.php
@@ -14,67 +14,67 @@ class SaveTest extends \PHPUnit\Framework\TestCase
     /**
      * @var \Magento\Sitemap\Controller\Adminhtml\Sitemap\Save
      */
-    protected $saveController;
+    private $saveController;
 
     /**
      * @var \Magento\Backend\App\Action\Context
      */
-    protected $contextMock;
+    private $contextMock;
 
     /**
      * @var \Magento\Framework\HTTP\PhpEnvironment\Request|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $requestMock;
+    private $requestMock;
 
     /**
      * @var \Magento\Framework\Controller\ResultFactory|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $resultFactoryMock;
+    private $resultFactoryMock;
 
     /**
      * @var \Magento\Backend\Model\View\Result\Redirect|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $resultRedirectMock;
+    private $resultRedirectMock;
 
     /**
      * @var \Magento\Framework\ObjectManagerInterface|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $objectManagerMock;
+    private $objectManagerMock;
 
     /**
      * @var \Magento\Framework\Message\ManagerInterface|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $messageManagerMock;
+    private $messageManagerMock;
 
     /**
      * @var \Magento\Framework\Validator\StringLength|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $lengthValidator;
+    private $lengthValidator;
 
     /**
      * @var \Magento\MediaStorage\Model\File\Validator\AvailablePath|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $pathValidator;
+    private $pathValidator;
 
     /**
      * @var \Magento\Sitemap\Helper\Data|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $helper;
+    private $helper;
 
     /**
      * @var \Magento\Framework\Filesystem|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $fileSystem;
+    private $fileSystem;
 
     /**
      * @var \Magento\Sitemap\Model\SitemapFactory|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $siteMapFactory;
+    private $siteMapFactory;
 
     /**
      * @var \Magento\Backend\Model\Session|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $session;
+    private $session;
 
     protected function setUp()
     {

--- a/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/SaveTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/SaveTest.php
@@ -9,6 +9,9 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHe
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Sitemap\Controller\Adminhtml\Sitemap\Save;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class SaveTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/SaveTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/SaveTest.php
@@ -7,6 +7,7 @@ namespace Magento\Sitemap\Test\Unit\Controller\Adminhtml\Sitemap;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Sitemap\Controller\Adminhtml\Sitemap\Save;
 
 class SaveTest extends \PHPUnit\Framework\TestCase
 {
@@ -18,12 +19,7 @@ class SaveTest extends \PHPUnit\Framework\TestCase
     /**
      * @var \Magento\Backend\App\Action\Context
      */
-    protected $context;
-
-    /**
-     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-     */
-    protected $objectManagerHelper;
+    protected $contextMock;
 
     /**
      * @var \Magento\Framework\HTTP\PhpEnvironment\Request|\PHPUnit_Framework_MockObject_MockObject
@@ -50,8 +46,41 @@ class SaveTest extends \PHPUnit\Framework\TestCase
      */
     protected $messageManagerMock;
 
+    /**
+     * @var \Magento\Framework\Validator\StringLength|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $lengthValidator;
+
+    /**
+     * @var \Magento\MediaStorage\Model\File\Validator\AvailablePath|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $pathValidator;
+
+    /**
+     * @var \Magento\Sitemap\Helper\Data|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $helper;
+
+    /**
+     * @var \Magento\Framework\Filesystem|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $fileSystem;
+
+    /**
+     * @var \Magento\Sitemap\Model\SitemapFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $siteMapFactory;
+
+    /**
+     * @var \Magento\Backend\Model\Session|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $session;
+
     protected function setUp()
     {
+        $this->contextMock = $this->getMockBuilder(\Magento\Backend\App\Action\Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->requestMock = $this->getMockBuilder(\Magento\Framework\App\RequestInterface::class)
             ->disableOriginalConstructor()
             ->setMethods(['getPostValue'])
@@ -66,27 +95,48 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $this->messageManagerMock = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
             ->getMock();
-
+        $this->helper = $this->getMockBuilder(\Magento\Sitemap\Helper\Data::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->resultFactoryMock->expects($this->once())
             ->method('create')
             ->with(ResultFactory::TYPE_REDIRECT)
             ->willReturn($this->resultRedirectMock);
+        $this->session = $this->getMockBuilder(\Magento\Backend\Model\Session::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setFormData'])
+            ->getMock();
 
-        $this->objectManagerHelper = new ObjectManagerHelper($this);
-        $this->context = $this->objectManagerHelper->getObject(
-            \Magento\Backend\App\Action\Context::class,
-            [
-                'resultFactory' => $this->resultFactoryMock,
-                'request' => $this->requestMock,
-                'messageManager' => $this->messageManagerMock,
-                'objectManager' => $this->objectManagerMock
-            ]
-        );
-        $this->saveController = $this->objectManagerHelper->getObject(
-            \Magento\Sitemap\Controller\Adminhtml\Sitemap\Save::class,
-            [
-                'context' => $this->context
-            ]
+        $this->contextMock->expects($this->once())
+            ->method('getMessageManager')
+            ->willReturn($this->messageManagerMock);
+        $this->contextMock->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($this->requestMock);
+        $this->contextMock->expects($this->once())
+            ->method('getResultFactory')
+            ->willReturn($this->resultFactoryMock);
+        $this->contextMock->expects($this->once())
+            ->method('getSession')
+            ->willReturn($this->session);
+
+        $this->lengthValidator = $this->getMockBuilder(\Magento\Framework\Validator\StringLength::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->pathValidator =
+            $this->getMockBuilder(\Magento\MediaStorage\Model\File\Validator\AvailablePath::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->fileSystem = $this->createMock(\Magento\Framework\Filesystem::class);
+        $this->siteMapFactory = $this->createMock(\Magento\Sitemap\Model\SitemapFactory::class);
+
+        $this->saveController = new Save(
+            $this->contextMock,
+            $this->lengthValidator,
+            $this->pathValidator,
+            $this->helper,
+            $this->fileSystem,
+            $this->siteMapFactory
         );
     }
 
@@ -105,11 +155,8 @@ class SaveTest extends \PHPUnit\Framework\TestCase
 
     public function testTryToSaveInvalidDataShouldFailWithErrors()
     {
-        $validatorClass = \Magento\MediaStorage\Model\File\Validator\AvailablePath::class;
-        $helperClass = \Magento\Sitemap\Helper\Data::class;
         $validPaths = [];
         $messages = ['message1', 'message2'];
-        $sessionClass = \Magento\Backend\Model\Session::class;
         $data = ['sitemap_filename' => 'sitemap_filename', 'sitemap_path' => '/sitemap_path'];
         $siteMapId = 1;
 
@@ -121,37 +168,83 @@ class SaveTest extends \PHPUnit\Framework\TestCase
             ->with('sitemap_id')
             ->willReturn($siteMapId);
 
-        $validator = $this->createMock($validatorClass);
-        $validator->expects($this->once())
+        $this->pathValidator->expects($this->once())
             ->method('setPaths')
             ->with($validPaths)
             ->willReturnSelf();
-        $validator->expects($this->once())
+        $this->pathValidator->expects($this->once())
             ->method('isValid')
             ->with('/sitemap_path/sitemap_filename')
             ->willReturn(false);
-        $validator->expects($this->once())
+        $this->pathValidator->expects($this->once())
             ->method('getMessages')
             ->willReturn($messages);
 
-        $helper = $this->createMock($helperClass);
-        $helper->expects($this->once())
+        $this->helper->expects($this->once())
             ->method('getValidPaths')
             ->willReturn($validPaths);
 
-        $session = $this->createPartialMock($sessionClass, ['setFormData']);
-        $session->expects($this->once())
+        $this->session->expects($this->once())
             ->method('setFormData')
             ->with($data)
             ->willReturnSelf();
 
-        $this->objectManagerMock->expects($this->once())
-            ->method('create')
-            ->with($validatorClass)
-            ->willReturn($validator);
-        $this->objectManagerMock->expects($this->any())
-            ->method('get')
-            ->willReturnMap([[$helperClass, $helper], [$sessionClass, $session]]);
+        $this->messageManagerMock->expects($this->at(0))
+            ->method('addErrorMessage')
+            ->withConsecutive(
+                [$messages[0]],
+                [$messages[1]]
+            )
+            ->willReturnSelf();
+
+        $this->resultRedirectMock->expects($this->once())
+            ->method('setPath')
+            ->with('adminhtml/*/edit', ['sitemap_id' => $siteMapId])
+            ->willReturnSelf();
+
+        $this->assertSame($this->resultRedirectMock, $this->saveController->execute());
+    }
+
+    public function testTryToSaveInvalidFileNameShouldFailWithErrors()
+    {
+        $validPaths = [];
+        $messages = ['message1', 'message2'];
+        $data = ['sitemap_filename' => 'sitemap_filename', 'sitemap_path' => '/sitemap_path'];
+        $siteMapId = 1;
+
+        $this->requestMock->expects($this->once())
+            ->method('getPostValue')
+            ->willReturn($data);
+        $this->requestMock->expects($this->once())
+            ->method('getParam')
+            ->with('sitemap_id')
+            ->willReturn($siteMapId);
+
+        $this->lengthValidator->expects($this->once())
+            ->method('isValid')
+            ->with('sitemap_filename')
+            ->willReturn(false);
+        $this->lengthValidator->expects($this->once())
+            ->method('getMessages')
+            ->willReturn($messages);
+
+        $this->pathValidator->expects($this->once())
+            ->method('setPaths')
+            ->with($validPaths)
+            ->willReturnSelf();
+        $this->pathValidator->expects($this->once())
+            ->method('isValid')
+            ->with('/sitemap_path/sitemap_filename')
+            ->willReturn(true);
+
+        $this->helper->expects($this->once())
+            ->method('getValidPaths')
+            ->willReturn($validPaths);
+
+        $this->session->expects($this->once())
+            ->method('setFormData')
+            ->with($data)
+            ->willReturnSelf();
 
         $this->messageManagerMock->expects($this->at(0))
             ->method('addErrorMessage')


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20044
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

The Sitemap filename length validation was not added , hence added `\Magento\Framework\Validator\StringLength` max 32 length validation for sitemap filename and it will not trim filename exceeding 32 chars. Client side validation in filename field of form is also added to fix this issue `'validate-length maximum-length-32'`. Updated `saveTest` unit test case.
### Fixed Issues (if relevant)

1. magento/magento2##13937: Issue title : Sitemap filename can't exceed 32 characters

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
