### PR TITLE
[Backport] Update details.phtml

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/details.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/details.phtml
@@ -25,7 +25,7 @@
                      data-role="collapsible" id="tab-label-<?= /* @escapeNotVerified */ $alias ?>">
                     <a class="data switch"
                        tabindex="-1"
-                       data-toggle="switch"
+                       data-toggle="trigger"
                        href="#<?= /* @escapeNotVerified */ $alias ?>"
                        id="tab-label-<?= /* @escapeNotVerified */ $alias ?>-title">
                         <?= /* @escapeNotVerified */ $label ?>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20858
Good afternoon,

I just encountered a problem with product's tabs in product info.
I realized when description or other custom tabs have links, when you click on it, nothing happen.

It caused by the script mage/tabs.js in details.phtml.

The current link to trigger the tab is declared with data-role="switch" instead of a data-role="trigger".

https://github.com/magento/magento2/blob/4f232511ceba6f1f7bf6f73b3b5609bd087f8c74/app/code/Magento/Catalog/view/frontend/templates/product/view/details.phtml#L24-L37

When not even the trigger and the header is declared respectively by data-role="heading" and data-role="trigger", the script based it search on the current collapsible panel declared by data-role="collapsible".

https://github.com/magento/magento2/blob/4f232511ceba6f1f7bf6f73b3b5609bd087f8c74/lib/web/mage/tabs.js#L99-L124

You can simply try by adding a link in the product description.

Tell me if I am wrong.

Cheers,
Ilan PARMENTIER