### PR TITLE
Remove Environment emulation for better performance on sitemap generation

### DIFF
--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
@@ -7,13 +7,15 @@
 namespace Magento\Sitemap\Controller\Adminhtml\Sitemap;
 
 use Magento\Backend\App\Action;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Sitemap\Controller\Adminhtml\Sitemap;
 use Magento\Store\Model\App\Emulation;
 use Magento\Framework\App\ObjectManager;
 
 /**
  * Generate sitemap file
  */
-class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
+class Generate extends Sitemap implements HttpGetActionInterface
 {
     /** @var \Magento\Store\Model\App\Emulation $appEmulation */
     private $appEmulation;

--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Generate.php
@@ -10,6 +10,9 @@ use Magento\Backend\App\Action;
 use Magento\Store\Model\App\Emulation;
 use Magento\Framework\App\ObjectManager;
 
+/**
+ * Generate sitemap file
+ */
 class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
 {
     /** @var \Magento\Store\Model\App\Emulation $appEmulation */
@@ -44,14 +47,7 @@ class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
         // if sitemap record exists
         if ($sitemap->getId()) {
             try {
-                //We need to emulate to get the correct frontend URL for the product images
-                $this->appEmulation->startEnvironmentEmulation(
-                    $sitemap->getStoreId(),
-                    \Magento\Framework\App\Area::AREA_FRONTEND,
-                    true
-                );
                 $sitemap->generateXml();
-
                 $this->messageManager->addSuccessMessage(
                     __('The sitemap "%1" has been generated.', $sitemap->getSitemapFilename())
                 );
@@ -59,8 +55,6 @@ class Generate extends \Magento\Sitemap\Controller\Adminhtml\Sitemap
                 $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {
                 $this->messageManager->addExceptionMessage($e, __('We can\'t generate the sitemap right now.'));
-            } finally {
-                $this->appEmulation->stopEnvironmentEmulation();
             }
         } else {
             $this->messageManager->addErrorMessage(__('We can\'t find a sitemap to generate.'));

--- a/app/code/Magento/Sitemap/Model/Observer.php
+++ b/app/code/Magento/Sitemap/Model/Observer.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Sitemap\Model;
 
-use Magento\Store\Model\App\Emulation;
 use Magento\Sitemap\Model\EmailNotification as SitemapEmail;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Sitemap\Model\ResourceModel\Sitemap\CollectionFactory;
@@ -58,11 +57,6 @@ class Observer
     private $collectionFactory;
 
     /**
-     * @var Emulation
-     */
-    private $appEmulation;
-
-    /**
      * @var $emailNotification
      */
     private $emailNotification;
@@ -72,17 +66,14 @@ class Observer
      * @param ScopeConfigInterface $scopeConfig
      * @param CollectionFactory $collectionFactory
      * @param EmailNotification $emailNotification
-     * @param Emulation $appEmulation
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
         CollectionFactory $collectionFactory,
-        SitemapEmail $emailNotification,
-        Emulation $appEmulation
+        SitemapEmail $emailNotification
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->collectionFactory = $collectionFactory;
-        $this->appEmulation = $appEmulation;
         $this->emailNotification = $emailNotification;
     }
 
@@ -114,17 +105,9 @@ class Observer
         foreach ($collection as $sitemap) {
             /* @var $sitemap \Magento\Sitemap\Model\Sitemap */
             try {
-                $this->appEmulation->startEnvironmentEmulation(
-                    $sitemap->getStoreId(),
-                    \Magento\Framework\App\Area::AREA_FRONTEND,
-                    true
-                );
-
                 $sitemap->generateXml();
             } catch (\Exception $e) {
                 $errors[] = $e->getMessage();
-            } finally {
-                $this->appEmulation->stopEnvironmentEmulation();
             }
         }
         if ($errors && $recipient) {

--- a/app/code/Magento/Sitemap/Model/ResourceModel/Catalog/Product.php
+++ b/app/code/Magento/Sitemap/Model/ResourceModel/Catalog/Product.php
@@ -389,6 +389,7 @@ class Product extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      */
     protected function _loadProductImages($product, $storeId)
     {
+        $this->_storeManager->setCurrentStore($storeId);
         /** @var $helper \Magento\Sitemap\Helper\Data */
         $helper = $this->_sitemapData;
         $imageIncludePolicy = $helper->getProductImageIncludePolicy($storeId);

--- a/app/code/Magento/Sitemap/Test/Unit/Model/ObserverTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/ObserverTest.php
@@ -118,7 +118,7 @@ class ObserverTest extends \PHPUnit\Framework\TestCase
             ->method('getStoreId')
             ->willReturn($storeId);
 
-        $this->sitemapMock->expects($this->at(1))
+        $this->sitemapMock->expects($this->once())
             ->method('generateXml')
             ->willThrowException(new \Exception($exception));
 
@@ -129,17 +129,6 @@ class ObserverTest extends \PHPUnit\Framework\TestCase
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             )
             ->willReturn('error-recipient@example.com');
-
-        $this->appEmulationMock->expects($this->at(0))
-            ->method('startEnvironmentEmulation')
-            ->with(
-                $storeId,
-                Area::AREA_FRONTEND,
-                true
-            );
-
-        $this->appEmulationMock->expects($this->at(1))
-            ->method('stopEnvironmentEmulation');
 
         $this->observer->scheduledGenerateSitemaps();
     }


### PR DESCRIPTION
### Description (*)
We dont need to use Environment emulation we just need to add in https://github.com/magento/magento2/blob/a5330a77625445ebc4552eaf3e7c34d44b26d2b2/app/code/Magento/Sitemap/Model/ResourceModel/Catalog/Product.php#L390 this `$this->_storeManager->setCurrentStore($storeId);` 

### Fixed Issues (if relevant)
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)
Website URL 1: https://my_website.com
Website URL 2: https://my_website.co.uk

Got to Stores->Configuration->Catalog->XML Sitemap->General Settings:
2.Set to Enable, Start Time, Frequency Daily etc...
TIP: I've set to a few minutes before checking!

Website 1 should have images url referencing Website 1 domain = https://my_website.com

1.2 - Same steps for manual generating sitemap

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
