### PR TITLE
Ensure `__toString()` catches all error types

### DIFF
--- a/app/code/Magento/Ui/TemplateEngine/Xhtml/Result.php
+++ b/app/code/Magento/Ui/TemplateEngine/Xhtml/Result.php
@@ -115,7 +115,7 @@ class Result implements ResultInterface
             $this->compiler->compile($templateRootElement, $this->component, $this->component);
             $this->appendLayoutConfiguration();
             $result = $this->compiler->postprocessing($this->template->__toString());
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->logger->critical($e->getMessage());
             $result = $e->getMessage();
         }


### PR DESCRIPTION
### Description (*)
In PHP 7.1 `catch (\Exception ...)` does not catch fatal errors. Because this function can possibly throw fatal errors such as "`Call to a member function getRequestFieldName() on null`" which is an instance of `\Error`, we should catch `\Throwable` to ensure the exception makes it into the logger and `$result` is assigned the message.


### Fixed Issues (if relevant)
1. Exception message expected to be assigned to a variable is instead handled by PHP's default Fatal Error handler.

### Contribution checklist (*)
 - [*] Pull request has a meaningful description of its purpose
 - [*] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [*] All automated tests passed successfully (all builds on Travis CI are green)
