### PR TITLE
[Backport] Fixed curl adapter to properly set http version based on $http_ver argument

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
@@ -183,6 +183,12 @@ class Curl implements \Zend_Http_Client_Adapter_Interface
             curl_setopt($this->_getResource(), CURLOPT_CUSTOMREQUEST, 'GET');
         }
 
+        if ($http_ver === \Zend_Http_Client::HTTP_1) {
+            curl_setopt($this->_getResource(), CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+        } elseif ($http_ver === \Zend_Http_Client::HTTP_0) {
+            curl_setopt($this->_getResource(), CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
+        }
+
         if (is_array($headers)) {
             curl_setopt($this->_getResource(), CURLOPT_HTTPHEADER, $headers);
         }


### PR DESCRIPTION
### Original Pull Request
#21549 

### Description (*)
The curl HTTP adapter currently does not respect the value of the `$http_ver` argument to the `write` method causing `\Magento\Framework\HTTP\ZendClient` to throw an exception causing a fatal error when making a request to an HTTP/2 capable server from a client server that has HTTP/2 curl libraries loaded.

```
Fatal error: Uncaught Zend_Http_Exception: Invalid header line detected in /Volumes/Server/sites/vaporbeast.vbst/vendor/magento/zendframework1/library/Zend/Http/Response.php on line 572
```

### Fixed Issues (if relevant)
1. #19845 (this was attempting to fix same thing, but was reverted in commit 55b8bf813f4 because it was done incorrectly)
2. #21251 (backport of #19845; should not be merged due to issues with original PR)

### Manual testing scenarios (*)

Use `\Magento\Framework\HTTP\ZendClient` to make a request to an HTTP/2 capable endpoint from a system with HTTP/2 enabled curl libraries. Without this change in place, the client will fail to parse the response headers because the regex found in `\Zend_Http_Response::extractHeaders` is specifically expecting `HTTP 1.1` or `HTTP 1.0` in the response.

To reproduce the issue, the following code snippet may be used:
```
$client = new \Magento\Framework\HTTP\ZendClient();
$client->setUri('https://davidalger.com/robots.txt');
$result = $client->request();
var_dump($result->getHeaders());
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
