### PR TITLE
[Backport] Fixed #21425 Date design change show not correctly value in backend

### DIFF
--- a/app/code/Magento/Backend/Block/System/Design/Edit/Tab/General.php
+++ b/app/code/Magento/Backend/Block/System/Design/Edit/Tab/General.php
@@ -6,6 +6,9 @@
 
 namespace Magento\Backend\Block\System\Design\Edit\Tab;
 
+/**
+ * General system tab block.
+ */
 class General extends \Magento\Backend\Block\Widget\Form\Generic
 {
     /**

--- a/app/code/Magento/Backend/Block/System/Design/Edit/Tab/General.php
+++ b/app/code/Magento/Backend/Block/System/Design/Edit/Tab/General.php
@@ -90,7 +90,7 @@ class General extends \Magento\Backend\Block\Widget\Form\Generic
             ]
         );
 
-        $dateFormat = $this->_localeDate->getDateFormat(\IntlDateFormatter::SHORT);
+        $dateFormat = $this->_localeDate->getDateFormatWithLongYear();
         $fieldset->addField(
             'date_from',
             'date',


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21443
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->
 Fixed #21425 Date design change show not correctly value in backend
### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento 2.3.0
2. PHP 7.1.17

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Go to Admin
2. Content > Design > Schedule
3. Add new design change
4. Fill form with date pick to year 21xx
5. Go back to edit one more, click on date icon to see issue

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. Show correctly date Ex: 02/04/2100

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Currently date show 2/4/00
This happen in interface US locale
Reproduced on 2.2.8-dev too

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
