### PR TITLE
[Backport] Fix for issue #21510: Can't access backend indexers page after creating a custom index

### DIFF
--- a/app/code/Magento/Indexer/Model/Indexer.php
+++ b/app/code/Magento/Indexer/Model/Indexer.php
@@ -361,7 +361,7 @@ class Indexer extends \Magento\Framework\DataObject implements IdxInterface
                 return $this->getView()->getUpdated();
             }
         }
-        return $this->getState()->getUpdated();
+        return $this->getState()->getUpdated() ?: '';
     }
 
     /**

--- a/app/code/Magento/Indexer/Test/Unit/Model/IndexerTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Model/IndexerTest.php
@@ -164,11 +164,11 @@ class IndexerTest extends \PHPUnit\Framework\TestCase
                 }
             }
         } else {
-            $actualGetLatestUpdated = $this->model->getLatestUpdated();
-            $this->assertEquals($getStateGetUpdated, $actualGetLatestUpdated);
+            $getLatestUpdated = $this->model->getLatestUpdated();
+            $this->assertEquals($getStateGetUpdated, $getLatestUpdated);
 
             if ($getStateGetUpdated === null) {
-                $this->assertNotNull($actualGetLatestUpdated);
+                $this->assertNotNull($getLatestUpdated);
             }
         }
     }

--- a/app/code/Magento/Indexer/Test/Unit/Model/IndexerTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Model/IndexerTest.php
@@ -164,7 +164,12 @@ class IndexerTest extends \PHPUnit\Framework\TestCase
                 }
             }
         } else {
-            $this->assertEquals($getStateGetUpdated, $this->model->getLatestUpdated());
+            $actualGetLatestUpdated = $this->model->getLatestUpdated();
+            $this->assertEquals($getStateGetUpdated, $actualGetLatestUpdated);
+
+            if ($getStateGetUpdated === null) {
+                $this->assertNotNull($actualGetLatestUpdated);
+            }
         }
     }
 
@@ -182,7 +187,8 @@ class IndexerTest extends \PHPUnit\Framework\TestCase
             [true, '', '06-Jan-1944'],
             [true, '06-Jan-1944', ''],
             [true, '', ''],
-            [true, '06-Jan-1944', '05-Jan-1944']
+            [true, '06-Jan-1944', '05-Jan-1944'],
+            [false, null, null],
         ];
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Backport of #21575 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #21510: Can't access backend indexers page after creating a custom index

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Implementation of a custom index as the guide: https://devdocs.magento.com/guides/v2.2/extension-dev-guide/indexing-custom.html
2. Login to backend
3. Go to System > Index Management

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
