### PR TITLE
[2.2] Cache generation, process all images, not just visible ones.

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Image/Cache.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/Cache.php
@@ -102,7 +102,7 @@ class Cache
                 } catch (\Exception $e) {
                     $isException = true;
                     $this->logger->error($e->getMessage());
-                    $this->logger->error(__('The image could not be resized: ') . $image->getPath());
+                    $this->logger->error(__('The image could not be resized: ') . $image['file']);
                 }
             }
         }

--- a/app/code/Magento/Catalog/Model/Product/Image/Cache.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/Cache.php
@@ -95,14 +95,16 @@ class Cache
     public function generate(Product $product)
     {
         $isException = false;
-        foreach ($product->getMediaGallery('images') as $image) {
-            foreach ($this->getData() as $imageData) {
-                try {
-                    $this->processImageData($product, $imageData, $image['file']);
-                } catch (\Exception $e) {
-                    $isException = true;
-                    $this->logger->error($e->getMessage());
-                    $this->logger->error(__('The image could not be resized: ') . $image['file']);
+        if (is_array($product->getMediaGallery('images'))) {
+            foreach ($product->getMediaGallery('images') as $image) {
+                foreach ($this->getData() as $imageData) {
+                    try {
+                        $this->processImageData($product, $imageData, $image['file']);
+                    } catch (\Exception $e) {
+                        $isException = true;
+                        $this->logger->error($e->getMessage());
+                        $this->logger->error(__('The image could not be resized: ') . $image['file']);
+                    }
                 }
             }
         }

--- a/app/code/Magento/Catalog/Model/Product/Image/Cache.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/Cache.php
@@ -95,17 +95,14 @@ class Cache
     public function generate(Product $product)
     {
         $isException = false;
-        $galleryImages = $product->getMediaGalleryImages();
-        if ($galleryImages) {
-            foreach ($galleryImages as $image) {
-                foreach ($this->getData() as $imageData) {
-                    try {
-                        $this->processImageData($product, $imageData, $image->getFile());
-                    } catch (\Exception $e) {
-                        $isException = true;
-                        $this->logger->error($e->getMessage());
-                        $this->logger->error(__('The image could not be resized: ') . $image->getPath());
-                    }
+        foreach ($product->getMediaGallery('images') as $image) {
+            foreach ($this->getData() as $imageData) {
+                try {
+                    $this->processImageData($product, $imageData, $image['file']);
+                } catch (\Exception $e) {
+                    $isException = true;
+                    $this->logger->error($e->getMessage());
+                    $this->logger->error(__('The image could not be resized: ') . $image->getPath());
                 }
             }
         }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Image/CacheTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Image/CacheTest.php
@@ -48,11 +48,6 @@ class CacheTest extends \PHPUnit\Framework\TestCase
      */
     protected $imageHelper;
 
-    /**
-     * @var \Magento\Framework\Data\Collection|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $mediaGalleryCollection;
-
     protected function setUp()
     {
         $this->product = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
@@ -72,10 +67,6 @@ class CacheTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
         $this->imageHelper = $this->getMockBuilder(\Magento\Catalog\Helper\Image::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->mediaGalleryCollection = $this->getMockBuilder(\Magento\Framework\Data\Collection::class)
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
### Description (*)
Saving a product does not process the image cache for images that are set as "hidden" from the gallery.

This causes additional issues in database media storage mode as local copies of database media files are not created for hidden images, but can also cause problems in non-database mode when you have hidden product images that you would like to use elsewhere.

This PR changes the image cache generation process to process ALL images regardless of whether they are hidden or not.

### Fixed Issues (if relevant)
1. magento/magento2#21547 : [2.2] Database Media Storage - New Product Images fail when image is hidden from gallery

### Manual testing scenarios (*)

- Vanilla 2.2-develop install
- Create product, add image, set hidden, save product
- Verify image is created in pub/media/catalog
- Verify cached images are created in pub/media/catalog/cache <- They won't be without this fix

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
