### PR TITLE
[Backport] Issue fixed #20128 : Date range returns the same start and end date

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
@@ -445,7 +445,7 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
                 break;
 
             case 'custom':
-                $dateStart = $customStart ? $customStart : $dateEnd;
+                $dateStart = $customStart ? $customStart : $dateStart;
                 $dateEnd = $customEnd ? $customEnd : $dateEnd;
                 break;
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/20129
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Date range returns the same start and end date incase `custom`.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20128: Magento\Reports\Model\ResourceModel\Order\Collection->getDateRange() - Error in code

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Use of getDateRange() with `custom` as `$range`.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
