### PR TITLE
[2.3] Database Media Storage - Admin Product Edit Page handles recreates images correctly when pub/media/catalog is cleared.

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
@@ -19,6 +19,7 @@ use Magento\Framework\View\Element\AbstractBlock;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Backend\Block\DataProviders\ImageUploadConfig as ImageUploadConfigDataProvider;
+use Magento\MediaStorage\Helper\File\Storage\Database;
 
 /**
  * Block for gallery content.
@@ -51,24 +52,33 @@ class Content extends \Magento\Backend\Block\Widget
     private $imageUploadConfigDataProvider;
 
     /**
+     * @var Database
+     */
+    private $fileStorageDatabase;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Framework\Json\EncoderInterface $jsonEncoder
      * @param \Magento\Catalog\Model\Product\Media\Config $mediaConfig
      * @param array $data
      * @param ImageUploadConfigDataProvider $imageUploadConfigDataProvider
+     * @param Database $fileStorageDatabase
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\Json\EncoderInterface $jsonEncoder,
         \Magento\Catalog\Model\Product\Media\Config $mediaConfig,
         array $data = [],
-        ImageUploadConfigDataProvider $imageUploadConfigDataProvider = null
+        ImageUploadConfigDataProvider $imageUploadConfigDataProvider = null,
+        Database $fileStorageDatabase = null
     ) {
         $this->_jsonEncoder = $jsonEncoder;
         $this->_mediaConfig = $mediaConfig;
         parent::__construct($context, $data);
         $this->imageUploadConfigDataProvider = $imageUploadConfigDataProvider
             ?: ObjectManager::getInstance()->get(ImageUploadConfigDataProvider::class);
+        $this->fileStorageDatabase = $fileStorageDatabase
+            ?: ObjectManager::getInstance()->get(Database::class);
     }
 
     /**
@@ -164,6 +174,13 @@ class Content extends \Magento\Backend\Block\Widget
             $images = $this->sortImagesByPosition($value['images']);
             foreach ($images as &$image) {
                 $image['url'] = $this->_mediaConfig->getMediaUrl($image['file']);
+                if ($this->fileStorageDatabase->checkDbUsage() &&
+                    !$mediaDir->isFile($this->_mediaConfig->getMediaPath($image['file']))
+                ) {
+                    $this->fileStorageDatabase->saveFileToFilesystem(
+                        $this->_mediaConfig->getMediaPath($image['file'])
+                    );
+                }
                 try {
                     $fileHandler = $mediaDir->stat($this->_mediaConfig->getMediaPath($image['file']));
                     $image['size'] = $fileHandler['size'];
@@ -187,9 +204,12 @@ class Content extends \Magento\Backend\Block\Widget
     private function sortImagesByPosition($images)
     {
         if (is_array($images)) {
-            usort($images, function ($imageA, $imageB) {
-                return ($imageA['position'] < $imageB['position']) ? -1 : 1;
-            });
+            usort(
+                $images,
+                function ($imageA, $imageB) {
+                    return ($imageA['position'] < $imageB['position']) ? -1 : 1;
+                }
+            );
         }
         return $images;
     }


### PR DESCRIPTION
### Description (*)
When in database storage mode, the admin product edit page should copy the database product image to local storage if it doesn't exist and display the image correctly in the admin page. In a clustered environment this happens frequently as new nodes are introduced with empty pub/media which must be populated as required.

When the image code is generated a check is made if we are in db storage mode, and if the file doesnt exist locally it is retrieved and stored locally.

### Fixed Issues (if relevant)
1. magento/magento2#21604: Database Media Storage - Admin Product Edit page does not handle product images correctly in database storage mode

### Manual testing scenarios (*)
1. Vanilla install of 2.3-develop
2. Change mode to database storage, synchronise and save settings
3. Add new product and assign an image
4. Save the product
5. Edit the product and view the images section. Verify image displays correctly in the images and videos section. (2.3-develop will fail this test due to #21546. Don't worry, carry on the test as we are going to clear the images anyway in Step 6)
6. Now simulate running on a new node in a cluster by clearing pub/media/catalog
7. Now refresh the product edit page.
8. Verify that the product image is still shown correctly

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
