### PR TITLE
[2.2][Backport] Database Media Storage - Admin Product Edit Page handles recreates images correctly when pub/media/catalog is cleared.

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
@@ -19,6 +19,7 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\App\ObjectManager;
 use Magento\Backend\Block\DataProviders\UploadConfig as ImageUploadConfigDataProvider;
+use Magento\MediaStorage\Helper\File\Storage\Database;
 
 class Content extends \Magento\Backend\Block\Widget
 {
@@ -48,24 +49,33 @@ class Content extends \Magento\Backend\Block\Widget
     private $imageHelper;
 
     /**
+     * @var Database
+     */
+    private $fileStorageDatabase;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Framework\Json\EncoderInterface $jsonEncoder
      * @param \Magento\Catalog\Model\Product\Media\Config $mediaConfig
      * @param array $data
      * @param ImageUploadConfigDataProvider $imageUploadConfigDataProvider
+     * @param Database $fileStorageDatabase
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\Json\EncoderInterface $jsonEncoder,
         \Magento\Catalog\Model\Product\Media\Config $mediaConfig,
         array $data = [],
-        ImageUploadConfigDataProvider $imageUploadConfigDataProvider = null
+        ImageUploadConfigDataProvider $imageUploadConfigDataProvider = null,
+        Database $fileStorageDatabase = null
     ) {
         $this->_jsonEncoder = $jsonEncoder;
         $this->_mediaConfig = $mediaConfig;
         parent::__construct($context, $data);
         $this->imageUploadConfigDataProvider = $imageUploadConfigDataProvider
             ?: ObjectManager::getInstance()->get(ImageUploadConfigDataProvider::class);
+        $this->fileStorageDatabase = $fileStorageDatabase
+            ?: ObjectManager::getInstance()->get(Database::class);
     }
 
     /**
@@ -153,6 +163,13 @@ class Content extends \Magento\Backend\Block\Widget
             $images = $this->sortImagesByPosition($value['images']);
             foreach ($images as &$image) {
                 $image['url'] = $this->_mediaConfig->getMediaUrl($image['file']);
+                if ($this->fileStorageDatabase->checkDbUsage() &&
+                    !$mediaDir->isFile($this->_mediaConfig->getMediaPath($image['file']))
+                ) {
+                    $this->fileStorageDatabase->saveFileToFilesystem(
+                        $this->_mediaConfig->getMediaPath($image['file'])
+                    );
+                }
                 try {
                     $fileHandler = $mediaDir->stat($this->_mediaConfig->getMediaPath($image['file']));
                     $image['size'] = $fileHandler['size'];

--- a/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Product/Helper/Form/Gallery/ContentTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Adminhtml/Product/Helper/Form/Gallery/ContentTest.php
@@ -9,6 +9,7 @@ use Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content;
 use Magento\Catalog\Model\Entity\Attribute;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\Phrase;
+use Magento\MediaStorage\Helper\File\Storage\Database;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -51,6 +52,11 @@ class ContentTest extends \PHPUnit\Framework\TestCase
     protected $imageHelper;
 
     /**
+     * @var \Magento\MediaStorage\Helper\File\Storage\Database|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $databaseMock;
+
+    /**
      * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
      */
     protected $objectManager;
@@ -71,13 +77,18 @@ class ContentTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->databaseMock = $this->getMockBuilder(Database::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->content = $this->objectManager->getObject(
             \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content::class,
             [
                 'mediaConfig' => $this->mediaConfigMock,
                 'jsonEncoder' => $this->jsonEncoderMock,
-                'filesystem' => $this->fileSystemMock
+                'filesystem' => $this->fileSystemMock,
+                'fileStorageDatabase' => $this->databaseMock
             ]
         );
     }
@@ -142,6 +153,13 @@ class ContentTest extends \PHPUnit\Framework\TestCase
         $this->mediaConfigMock->expects($this->any())->method('getMediaPath')->willReturnMap($mediaPath);
         $this->readMock->expects($this->any())->method('stat')->willReturnMap($sizeMap);
         $this->jsonEncoderMock->expects($this->once())->method('encode')->willReturnCallback('json_encode');
+
+        $this->readMock->expects($this->any())
+            ->method('isFile')
+            ->will($this->returnValue(true));
+        $this->databaseMock->expects($this->any())
+            ->method('checkDbUsage')
+            ->will($this->returnValue(false));
 
         $this->assertSame(json_encode($imagesResult), $this->content->getImagesJson());
     }
@@ -220,6 +238,13 @@ class ContentTest extends \PHPUnit\Framework\TestCase
         );
         $this->imageHelper->expects($this->any())->method('getDefaultPlaceholderUrl')->willReturn($placeholderUrl);
         $this->jsonEncoderMock->expects($this->once())->method('encode')->willReturnCallback('json_encode');
+
+        $this->readMock->expects($this->any())
+            ->method('isFile')
+            ->will($this->returnValue(true));
+        $this->databaseMock->expects($this->any())
+            ->method('checkDbUsage')
+            ->will($this->returnValue(false));
 
         $this->assertSame(json_encode($imagesResult), $this->content->getImagesJson());
     }
@@ -364,5 +389,53 @@ class ContentTest extends \PHPUnit\Framework\TestCase
             ->willReturn($frontend);
 
         return $mediaAttribute;
+    }
+
+    /**
+     * Test GetImagesJson() calls MediaStorage functions to obtain image from DB prior to stat call
+     *
+     * @return void
+     */
+    public function testGetImagesJsonMediaStorageMode()
+    {
+        $images = [
+            'images' => [
+                [
+                    'value_id' => '0',
+                    'file' => 'file_1.jpg',
+                    'media_type' => 'image',
+                    'position' => '0'
+                ]
+            ]
+        ];
+
+        $mediaPath = [
+            ['file_1.jpg', 'catalog/product/image_1.jpg']
+        ];
+
+        $this->content->setElement($this->galleryMock);
+
+        $this->galleryMock->expects($this->once())
+            ->method('getImages')
+            ->willReturn($images);
+        $this->fileSystemMock->expects($this->once())
+            ->method('getDirectoryRead')
+            ->willReturn($this->readMock);
+        $this->mediaConfigMock->expects($this->any())
+            ->method('getMediaPath')
+            ->willReturnMap($mediaPath);
+
+        $this->readMock->expects($this->any())
+            ->method('isFile')
+            ->will($this->returnValue(false));
+        $this->databaseMock->expects($this->any())
+            ->method('checkDbUsage')
+            ->will($this->returnValue(true));
+
+        $this->databaseMock->expects($this->once())
+            ->method('saveFileToFilesystem')
+            ->with('catalog/product/image_1.jpg');
+
+        $this->content->getImagesJson();
     }
 }


### PR DESCRIPTION
### Original PR (*)
1. #21605 [2.3] Database Storage Mode - Admin Product Edit Page handles recreates images correctly when pub/media/catalog is cleared.

### Description (*)
When in database storage mode, the admin product edit page should copy the database product image to local storage if it doesn't exist and display the image correctly in the admin page. In a clustered environment this happens frequently as new nodes are introduced with empty pub/media which must be populated as required.

When the image code is generated a check is made if we are in db storage mode, and if the file doesnt exist locally it is retrieved and stored locally.

### Fixed Issues (if relevant)
1. magento/magento2#21604: Database Media Storage - Admin Product Edit page does not handle product images correctly in database storage mode

### Manual testing scenarios (*)
1. Vanilla install of 2.2-develop
2. Change mode to database storage, synchronise and save settings
3. Add new product and assign an image
4. Save the product
5. Edit the product and view the images section. Verify image displays correctly in the images and videos section. 
6. Now simulate running on a new node in a cluster by clearing pub/media/catalog
7. Now refresh the product edit page.
8. Verify that the product image is still shown correctly

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
