### PR TITLE
Catalog rule with is oneof/ not one of not working with SKU #21618

### DIFF
--- a/app/code/Magento/CatalogRule/Model/Rule/Condition/ConditionsToSearchCriteriaMapper.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Condition/ConditionsToSearchCriteriaMapper.php
@@ -252,10 +252,25 @@ class ConditionsToSearchCriteriaMapper
         return $this->filterFactory->create([
             'data' => [
                 Filter::KEY_FIELD => $field,
-                Filter::KEY_VALUE => $value,
+                Filter::KEY_VALUE => $this->getValueParsed($value, $conditionType),
                 Filter::KEY_CONDITION_TYPE => $this->mapRuleOperatorToSQLCondition($conditionType)
             ]
         ]);
+    }
+
+    /**
+     * Retrieve parsed value
+     * @param $value
+     * @param $conditionType
+     * @return null|string|string[]
+     */
+    private function getValueParsed($value, $conditionType)
+    {
+        if (!is_array($value) && ($conditionType == '!()' || $conditionType == '()')) {
+            $value = preg_replace('/\s*,\s*/', ',', $value);
+        }
+
+        return $value;
     }
 
     /**

--- a/app/code/Magento/CatalogRule/Model/Rule/Condition/ConditionsToSearchCriteriaMapper.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Condition/ConditionsToSearchCriteriaMapper.php
@@ -260,11 +260,11 @@ class ConditionsToSearchCriteriaMapper
 
     /**
      * Retrieve parsed value
-     * @param $value
-     * @param $conditionType
+     * @param string $value
+     * @param string $conditionType
      * @return null|string|string[]
      */
-    private function getValueParsed($value, $conditionType)
+    private function getValueParsed(string $value, string $conditionType)
     {
         if (!is_array($value) && ($conditionType == '!()' || $conditionType == '()')) {
             $value = preg_replace('/\s*,\s*/', ',', $value);

--- a/app/code/Magento/Rule/view/adminhtml/web/rules.js
+++ b/app/code/Magento/Rule/view/adminhtml/web/rules.js
@@ -434,7 +434,7 @@ define([
             grid.reloadParams = {
                 'selected[]': this.chooserSelectedItems.keys()
             };
-            this.updateElement.value = this.chooserSelectedItems.keys().join(', ');
+            this.updateElement.value = this.chooserSelectedItems.keys().join(',');
         }
     };
 


### PR DESCRIPTION


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
While we choosing SKUs from product chooser grid, condition input field is populated with selected SKUs and they are separated with comma and a single space. Magento is not stripping this space while creating product search filter.

`SELECT e.* FROM catalog_product_entityASeINNER JOINcatalog_product_websiteASproduct_website ON product_website.product_id = e.entity_id AND product_website.website_id IN(1) WHERE ((e.sku IN('tp1', ' tp2', ' tp3')))`

As per above query tp2 & tp3 won't be included in the result because of space in-front of SKU.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21618 Catalog rule with is oneof/ not one of not working with SKU 
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Include SKU attribute in promo rule conditions Store > Attributes > Product > Edit SKU > Use for Promo Rule Conditions > Yes
2.  Create Catalogue rule, fill required values
3. While configuring conditions, choose Product attribute SKU with is one of or is not of condition
3.1. If ALL of these conditions are TRUE SKU is one of
4. Rule should be applied to all SKUs in the selected list

### Applied Fixes

1. Removed space after comma while we choosing SKU from chooser grid. 
2. Parsed condition values while creating search filter


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
