### PR TITLE
[Backport] Fix issue with custom option file uploading

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/DirectoryList.php
+++ b/lib/internal/Magento/Framework/Filesystem/DirectoryList.php
@@ -96,11 +96,8 @@ class DirectoryList
         static::validate($config);
         $this->root = $this->normalizePath($root);
         $this->directories = static::getDefaultConfig();
-        $this->directories[self::SYS_TMP] = [self::PATH => realpath(sys_get_temp_dir())];
-        $uploadTmpDir = ini_get('upload_tmp_dir');
-        if ($uploadTmpDir) {
-            $this->directories[self::SYS_TMP] = [self::PATH => realpath($uploadTmpDir)];
-        }
+        $sysTmpPath = ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir();
+        $this->directories[self::SYS_TMP] = [self::PATH => realpath($sysTmpPath)];
 
         // inject custom values from constructor
         foreach ($this->directories as $code => $dir) {

--- a/lib/internal/Magento/Framework/Filesystem/DirectoryList.php
+++ b/lib/internal/Magento/Framework/Filesystem/DirectoryList.php
@@ -8,6 +8,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Framework\Filesystem;
 
 /**
@@ -96,7 +97,7 @@ class DirectoryList
         static::validate($config);
         $this->root = $this->normalizePath($root);
         $this->directories = static::getDefaultConfig();
-        $sysTmpPath = ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir();
+        $sysTmpPath = get_cfg_var('upload_tmp_dir') ?: sys_get_temp_dir();
         $this->directories[self::SYS_TMP] = [self::PATH => realpath($sysTmpPath)];
 
         // inject custom values from constructor

--- a/lib/internal/Magento/Framework/Filesystem/DirectoryList.php
+++ b/lib/internal/Magento/Framework/Filesystem/DirectoryList.php
@@ -97,6 +97,10 @@ class DirectoryList
         $this->root = $this->normalizePath($root);
         $this->directories = static::getDefaultConfig();
         $this->directories[self::SYS_TMP] = [self::PATH => realpath(sys_get_temp_dir())];
+        $uploadTmpDir = ini_get('upload_tmp_dir');
+        if ($uploadTmpDir) {
+            $this->directories[self::SYS_TMP] = [self::PATH => realpath($uploadTmpDir)];
+        }
 
         // inject custom values from constructor
         foreach ($this->directories as $code => $dir) {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21170
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
If `sys_temp_dir` and `upload_tmp_dir` directives in _php.ini_ are different then it causes exception when uploading a file to product custom options on the frontend:

> Path "%1" cannot be used with directory "%2"

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set different values for `sys_temp_dir` and `upload_tmp_dir` in _php.ini_.
2. In magento create simple, visible in catalog product.
3. Add new customizable option to that product with option type **File**.
4. On product page on frontend select file for custom option and press Add to cart button.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
