### PR TITLE
[Backport] Fixed: #21278, Add sort order on downloadable links

### DIFF
--- a/app/code/Magento/Downloadable/Ui/DataProvider/Product/Form/Modifier/Links.php
+++ b/app/code/Magento/Downloadable/Ui/DataProvider/Product/Form/Modifier/Links.php
@@ -3,22 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier;
 
-use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
 use Magento\Catalog\Model\Locator\LocatorInterface;
+use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
 use Magento\Downloadable\Model\Product\Type;
-use Magento\Downloadable\Model\Source\TypeUpload;
 use Magento\Downloadable\Model\Source\Shareable;
-use Magento\Store\Model\StoreManagerInterface;
+use Magento\Downloadable\Model\Source\TypeUpload;
 use Magento\Framework\Stdlib\ArrayManager;
-use Magento\Ui\Component\DynamicRows;
 use Magento\Framework\UrlInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Magento\Ui\Component\Container;
+use Magento\Ui\Component\DynamicRows;
 use Magento\Ui\Component\Form;
 
 /**
- * Class adds a grid with links
+ * Class adds a grid with links.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class Links extends AbstractModifier
@@ -86,7 +88,7 @@ class Links extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function modifyData(array $data)
     {
@@ -101,7 +103,7 @@ class Links extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function modifyMeta(array $meta)
@@ -160,6 +162,8 @@ class Links extends AbstractModifier
     }
 
     /**
+     * Get dynamic rows meta.
+     *
      * @return array
      */
     protected function getDynamicRows()
@@ -180,6 +184,8 @@ class Links extends AbstractModifier
     }
 
     /**
+     * Get single link record meta.
+     *
      * @return array
      */
     protected function getRecord()
@@ -221,6 +227,8 @@ class Links extends AbstractModifier
     }
 
     /**
+     * Get link title meta.
+     *
      * @return array
      */
     protected function getTitleColumn()
@@ -248,6 +256,8 @@ class Links extends AbstractModifier
     }
 
     /**
+     * Get link price meta.
+     *
      * @return array
      */
     protected function getPriceColumn()
@@ -283,6 +293,8 @@ class Links extends AbstractModifier
     }
 
     /**
+     * Get link file element meta.
+     *
      * @return array
      */
     protected function getFileColumn()
@@ -347,6 +359,8 @@ class Links extends AbstractModifier
     }
 
     /**
+     * Get sample container meta.
+     *
      * @return array
      */
     protected function getSampleColumn()
@@ -407,6 +421,8 @@ class Links extends AbstractModifier
     }
 
     /**
+     * Get link "is sharable" element meta.
+     *
      * @return array
      */
     protected function getShareableColumn()
@@ -425,6 +441,8 @@ class Links extends AbstractModifier
     }
 
     /**
+     * Get link "max downloads" element meta.
+     *
      * @return array
      */
     protected function getMaxDownloadsColumn()

--- a/app/code/Magento/Downloadable/Ui/DataProvider/Product/Form/Modifier/Links.php
+++ b/app/code/Magento/Downloadable/Ui/DataProvider/Product/Form/Modifier/Links.php
@@ -208,12 +208,12 @@ class Links extends AbstractModifier
             'children',
             $record,
             [
-                'container_link_title' => $this->getTitleColumn(),
-                'container_link_price' => $this->getPriceColumn(),
-                'container_file' => $this->getFileColumn(),
-                'container_sample' => $this->getSampleColumn(),
-                'is_shareable' => $this->getShareableColumn(),
-                'max_downloads' => $this->getMaxDownloadsColumn(),
+                'container_link_title' => $this->getTitleColumn(10),
+                'container_link_price' => $this->getPriceColumn(20),
+                'container_file' => $this->getFileColumn(30),
+                'container_sample' => $this->getSampleColumn(40),
+                'is_shareable' => $this->getShareableColumn(50),
+                'max_downloads' => $this->getMaxDownloadsColumn(60),
                 'position' => $recordPosition,
                 'action_delete' => $recordActionDelete,
             ]
@@ -221,9 +221,10 @@ class Links extends AbstractModifier
     }
 
     /**
+     * @param int $sortOrder
      * @return array
      */
-    protected function getTitleColumn()
+    protected function getTitleColumn($sortOrder)
     {
         $titleContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -232,6 +233,7 @@ class Links extends AbstractModifier
             'label' => __('Title'),
             'showLabel' => false,
             'dataScope' => '',
+            'sortOrder' => $sortOrder,
         ];
         $titleField['arguments']['data']['config'] = [
             'formElement' => Form\Element\Input::NAME,
@@ -247,9 +249,10 @@ class Links extends AbstractModifier
     }
 
     /**
+     * @param int $sortOrder
      * @return array
      */
-    protected function getPriceColumn()
+    protected function getPriceColumn($sortOrder)
     {
         $priceContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -258,6 +261,7 @@ class Links extends AbstractModifier
             'label' => __('Price'),
             'showLabel' => false,
             'dataScope' => '',
+            'sortOrder' => $sortOrder,
         ];
         $priceField['arguments']['data']['config'] = [
             'formElement' => Form\Element\Input::NAME,
@@ -281,9 +285,10 @@ class Links extends AbstractModifier
     }
 
     /**
+     * @param int $sortOrder
      * @return array
      */
-    protected function getFileColumn()
+    protected function getFileColumn($sortOrder)
     {
         $fileContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -292,6 +297,7 @@ class Links extends AbstractModifier
             'label' => __('File'),
             'showLabel' => false,
             'dataScope' => '',
+            'sortOrder' => $sortOrder,
         ];
         $fileTypeField['arguments']['data']['config'] = [
             'formElement' => Form\Element\Select::NAME,
@@ -344,9 +350,10 @@ class Links extends AbstractModifier
     }
 
     /**
+     * @param int $sortOrder
      * @return array
      */
-    protected function getSampleColumn()
+    protected function getSampleColumn($sortOrder)
     {
         $sampleContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -355,6 +362,7 @@ class Links extends AbstractModifier
             'label' => __('Sample'),
             'showLabel' => false,
             'dataScope' => '',
+            'sortOrder' => $sortOrder,
         ];
         $sampleTypeField['arguments']['data']['config'] = [
             'formElement' => Form\Element\Select::NAME,
@@ -403,9 +411,10 @@ class Links extends AbstractModifier
     }
 
     /**
+     * @param int $sortOrder
      * @return array
      */
-    protected function getShareableColumn()
+    protected function getShareableColumn($sortOrder)
     {
         $shareableField['arguments']['data']['config'] = [
             'label' => __('Shareable'),
@@ -413,6 +422,7 @@ class Links extends AbstractModifier
             'componentType' => Form\Field::NAME,
             'dataType' => Form\Element\DataType\Number::NAME,
             'dataScope' => 'is_shareable',
+            'sortOrder' => $sortOrder,
             'options' => $this->shareable->toOptionArray(),
         ];
 
@@ -420,9 +430,10 @@ class Links extends AbstractModifier
     }
 
     /**
+     * @param int $sortOrder
      * @return array
      */
-    protected function getMaxDownloadsColumn()
+    protected function getMaxDownloadsColumn($sortOrder)
     {
         $maxDownloadsContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -431,6 +442,7 @@ class Links extends AbstractModifier
             'label' => __('Max. Downloads'),
             'showLabel' => false,
             'dataScope' => '',
+            'sortOrder' => $sortOrder,
         ];
         $numberOfDownloadsField['arguments']['data']['config'] = [
             'formElement' => Form\Element\Input::NAME,

--- a/app/code/Magento/Downloadable/Ui/DataProvider/Product/Form/Modifier/Links.php
+++ b/app/code/Magento/Downloadable/Ui/DataProvider/Product/Form/Modifier/Links.php
@@ -208,12 +208,12 @@ class Links extends AbstractModifier
             'children',
             $record,
             [
-                'container_link_title' => $this->getTitleColumn(10),
-                'container_link_price' => $this->getPriceColumn(20),
-                'container_file' => $this->getFileColumn(30),
-                'container_sample' => $this->getSampleColumn(40),
-                'is_shareable' => $this->getShareableColumn(50),
-                'max_downloads' => $this->getMaxDownloadsColumn(60),
+                'container_link_title' => $this->getTitleColumn(),
+                'container_link_price' => $this->getPriceColumn(),
+                'container_file' => $this->getFileColumn(),
+                'container_sample' => $this->getSampleColumn(),
+                'is_shareable' => $this->getShareableColumn(),
+                'max_downloads' => $this->getMaxDownloadsColumn(),
                 'position' => $recordPosition,
                 'action_delete' => $recordActionDelete,
             ]
@@ -221,10 +221,9 @@ class Links extends AbstractModifier
     }
 
     /**
-     * @param int $sortOrder
      * @return array
      */
-    protected function getTitleColumn($sortOrder)
+    protected function getTitleColumn()
     {
         $titleContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -233,7 +232,7 @@ class Links extends AbstractModifier
             'label' => __('Title'),
             'showLabel' => false,
             'dataScope' => '',
-            'sortOrder' => $sortOrder,
+            'sortOrder' => 10,
         ];
         $titleField['arguments']['data']['config'] = [
             'formElement' => Form\Element\Input::NAME,
@@ -249,10 +248,9 @@ class Links extends AbstractModifier
     }
 
     /**
-     * @param int $sortOrder
      * @return array
      */
-    protected function getPriceColumn($sortOrder)
+    protected function getPriceColumn()
     {
         $priceContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -261,7 +259,7 @@ class Links extends AbstractModifier
             'label' => __('Price'),
             'showLabel' => false,
             'dataScope' => '',
-            'sortOrder' => $sortOrder,
+            'sortOrder' => 20,
         ];
         $priceField['arguments']['data']['config'] = [
             'formElement' => Form\Element\Input::NAME,
@@ -285,10 +283,9 @@ class Links extends AbstractModifier
     }
 
     /**
-     * @param int $sortOrder
      * @return array
      */
-    protected function getFileColumn($sortOrder)
+    protected function getFileColumn()
     {
         $fileContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -297,7 +294,7 @@ class Links extends AbstractModifier
             'label' => __('File'),
             'showLabel' => false,
             'dataScope' => '',
-            'sortOrder' => $sortOrder,
+            'sortOrder' => 30,
         ];
         $fileTypeField['arguments']['data']['config'] = [
             'formElement' => Form\Element\Select::NAME,
@@ -350,10 +347,9 @@ class Links extends AbstractModifier
     }
 
     /**
-     * @param int $sortOrder
      * @return array
      */
-    protected function getSampleColumn($sortOrder)
+    protected function getSampleColumn()
     {
         $sampleContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -362,7 +358,7 @@ class Links extends AbstractModifier
             'label' => __('Sample'),
             'showLabel' => false,
             'dataScope' => '',
-            'sortOrder' => $sortOrder,
+            'sortOrder' => 40,
         ];
         $sampleTypeField['arguments']['data']['config'] = [
             'formElement' => Form\Element\Select::NAME,
@@ -411,10 +407,9 @@ class Links extends AbstractModifier
     }
 
     /**
-     * @param int $sortOrder
      * @return array
      */
-    protected function getShareableColumn($sortOrder)
+    protected function getShareableColumn()
     {
         $shareableField['arguments']['data']['config'] = [
             'label' => __('Shareable'),
@@ -422,7 +417,7 @@ class Links extends AbstractModifier
             'componentType' => Form\Field::NAME,
             'dataType' => Form\Element\DataType\Number::NAME,
             'dataScope' => 'is_shareable',
-            'sortOrder' => $sortOrder,
+            'sortOrder' => 50,
             'options' => $this->shareable->toOptionArray(),
         ];
 
@@ -430,10 +425,9 @@ class Links extends AbstractModifier
     }
 
     /**
-     * @param int $sortOrder
      * @return array
      */
-    protected function getMaxDownloadsColumn($sortOrder)
+    protected function getMaxDownloadsColumn()
     {
         $maxDownloadsContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -442,7 +436,7 @@ class Links extends AbstractModifier
             'label' => __('Max. Downloads'),
             'showLabel' => false,
             'dataScope' => '',
-            'sortOrder' => $sortOrder,
+            'sortOrder' => 60,
         ];
         $numberOfDownloadsField['arguments']['data']['config'] = [
             'formElement' => Form\Element\Input::NAME,

--- a/app/code/Magento/Downloadable/Ui/DataProvider/Product/Form/Modifier/Samples.php
+++ b/app/code/Magento/Downloadable/Ui/DataProvider/Product/Form/Modifier/Samples.php
@@ -183,8 +183,8 @@ class Samples extends AbstractModifier
             'children',
             $record,
             [
-                'container_sample_title' => $this->getTitleColumn(10),
-                'container_sample' => $this->getSampleColumn(20),
+                'container_sample_title' => $this->getTitleColumn(),
+                'container_sample' => $this->getSampleColumn(),
                 'position' => $recordPosition,
                 'action_delete' => $recordActionDelete,
             ]
@@ -192,10 +192,9 @@ class Samples extends AbstractModifier
     }
 
     /**
-     * @param int $sortOrder
      * @return array
      */
-    protected function getTitleColumn($sortOrder)
+    protected function getTitleColumn()
     {
         $titleContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -204,7 +203,7 @@ class Samples extends AbstractModifier
             'showLabel' => false,
             'label' => __('Title'),
             'dataScope' => '',
-            'sortOrder' => $sortOrder,
+            'sortOrder' => 10,
         ];
         $titleField['arguments']['data']['config'] = [
             'formElement' => Form\Element\Input::NAME,
@@ -220,10 +219,9 @@ class Samples extends AbstractModifier
     }
 
     /**
-     * @param int $sortOrder
      * @return array
      */
-    protected function getSampleColumn($sortOrder)
+    protected function getSampleColumn()
     {
         $sampleContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -232,7 +230,7 @@ class Samples extends AbstractModifier
             'label' => __('File'),
             'showLabel' => false,
             'dataScope' => '',
-            'sortOrder' => $sortOrder,
+            'sortOrder' => 20,
         ];
         $sampleType['arguments']['data']['config'] = [
             'formElement' => Form\Element\Select::NAME,

--- a/app/code/Magento/Downloadable/Ui/DataProvider/Product/Form/Modifier/Samples.php
+++ b/app/code/Magento/Downloadable/Ui/DataProvider/Product/Form/Modifier/Samples.php
@@ -3,21 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Downloadable\Ui\DataProvider\Product\Form\Modifier;
 
-use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
 use Magento\Catalog\Model\Locator\LocatorInterface;
+use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
 use Magento\Downloadable\Model\Product\Type;
 use Magento\Downloadable\Model\Source\TypeUpload;
-use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\Stdlib\ArrayManager;
-use Magento\Ui\Component\DynamicRows;
 use Magento\Framework\UrlInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use Magento\Ui\Component\Container;
+use Magento\Ui\Component\DynamicRows;
 use Magento\Ui\Component\Form;
 
 /**
- * Class adds a grid with samples
+ * Class adds a grid with samples.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class Samples extends AbstractModifier
@@ -77,7 +79,7 @@ class Samples extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function modifyData(array $data)
     {
@@ -90,7 +92,7 @@ class Samples extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function modifyMeta(array $meta)
@@ -135,6 +137,8 @@ class Samples extends AbstractModifier
     }
 
     /**
+     * Get sample rows meta.
+     *
      * @return array
      */
     protected function getDynamicRows()
@@ -155,6 +159,8 @@ class Samples extends AbstractModifier
     }
 
     /**
+     * Get single sample row meta.
+     *
      * @return array
      */
     protected function getRecord()
@@ -192,6 +198,8 @@ class Samples extends AbstractModifier
     }
 
     /**
+     * Get sample title meta.
+     *
      * @return array
      */
     protected function getTitleColumn()
@@ -219,6 +227,8 @@ class Samples extends AbstractModifier
     }
 
     /**
+     * Get sample element meta.
+     *
      * @return array
      */
     protected function getSampleColumn()

--- a/app/code/Magento/Downloadable/Ui/DataProvider/Product/Form/Modifier/Samples.php
+++ b/app/code/Magento/Downloadable/Ui/DataProvider/Product/Form/Modifier/Samples.php
@@ -183,8 +183,8 @@ class Samples extends AbstractModifier
             'children',
             $record,
             [
-                'container_sample_title' => $this->getTitleColumn(),
-                'container_sample' => $this->getSampleColumn(),
+                'container_sample_title' => $this->getTitleColumn(10),
+                'container_sample' => $this->getSampleColumn(20),
                 'position' => $recordPosition,
                 'action_delete' => $recordActionDelete,
             ]
@@ -192,9 +192,10 @@ class Samples extends AbstractModifier
     }
 
     /**
+     * @param int $sortOrder
      * @return array
      */
-    protected function getTitleColumn()
+    protected function getTitleColumn($sortOrder)
     {
         $titleContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -203,6 +204,7 @@ class Samples extends AbstractModifier
             'showLabel' => false,
             'label' => __('Title'),
             'dataScope' => '',
+            'sortOrder' => $sortOrder,
         ];
         $titleField['arguments']['data']['config'] = [
             'formElement' => Form\Element\Input::NAME,
@@ -218,9 +220,10 @@ class Samples extends AbstractModifier
     }
 
     /**
+     * @param int $sortOrder
      * @return array
      */
-    protected function getSampleColumn()
+    protected function getSampleColumn($sortOrder)
     {
         $sampleContainer['arguments']['data']['config'] = [
             'componentType' => Container::NAME,
@@ -229,6 +232,7 @@ class Samples extends AbstractModifier
             'label' => __('File'),
             'showLabel' => false,
             'dataScope' => '',
+            'sortOrder' => $sortOrder,
         ];
         $sampleType['arguments']['data']['config'] = [
             'formElement' => Form\Element\Select::NAME,


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21279
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Fixed: Sort order missing on Downloadable Product Links and Sample Columns.

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In this PR, sortOrder issue fixed for Downloadable Product Links and Sample Columns
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #21278 
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Followed all steps as mentioned in #21278 issue.
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
