### PR TITLE
[2.3] Database Media Storage - Transactional Emails will now extract image from database in Database Media Storage mode

### DIFF
--- a/app/code/Magento/Email/Model/AbstractTemplate.php
+++ b/app/code/Magento/Email/Model/AbstractTemplate.php
@@ -17,8 +17,9 @@ use Magento\Store\Model\Store;
 use Magento\MediaStorage\Helper\File\Storage\Database;
 
 /**
- * Template model class
+ * Template model class.
  *
+ * phpcs:disable Magento2.Classes.AbstractApi
  * @author      Magento Core Team <core@magentocommerce.com>
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.TooManyFields)
@@ -505,7 +506,6 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
 
     /**
      * Apply design config so that emails are processed within the context of the appropriate area/store/theme.
-     * Can be called multiple times without issue.
      *
      * @return bool
      */
@@ -679,8 +679,7 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
     }
 
     /**
-     * Save current design config and replace with design config from specified store
-     * Event is not dispatched.
+     * Save current design config and replace with design config from specified store. Event is not dispatched.
      *
      * @param null|bool|int|string $storeId
      * @param string $area

--- a/app/code/Magento/Email/Model/AbstractTemplate.php
+++ b/app/code/Magento/Email/Model/AbstractTemplate.php
@@ -215,7 +215,8 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
         $this->templateFactory = $templateFactory;
         $this->filterManager = $filterManager;
         $this->urlModel = $urlModel;
-        $this->fileStorageDatabase = $fileStorageDatabase ?: \Magento\Framework\App\ObjectManager::getInstance()->get(Database::class);
+        $this->fileStorageDatabase = $fileStorageDatabase ?:
+            \Magento\Framework\App\ObjectManager::getInstance()->get(Database::class);
         parent::__construct($context, $registry, null, null, $data);
     }
 

--- a/app/code/Magento/Email/Model/AbstractTemplate.php
+++ b/app/code/Magento/Email/Model/AbstractTemplate.php
@@ -14,6 +14,7 @@ use Magento\Framework\Model\AbstractModel;
 use Magento\Store\Model\Information as StoreInformation;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
+use Magento\MediaStorage\Helper\File\Storage\Database;
 
 /**
  * Template model class
@@ -164,6 +165,11 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
     private $urlModel;
 
     /**
+     * @var Database
+     */
+    private $fileStorageDatabase;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\View\DesignInterface $design
      * @param \Magento\Framework\Registry $registry
@@ -177,6 +183,7 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
      * @param \Magento\Framework\Filter\FilterManager $filterManager
      * @param \Magento\Framework\UrlInterface $urlModel
      * @param array $data
+     * @param Database $fileStorageDatabase
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
@@ -193,7 +200,8 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
         \Magento\Email\Model\TemplateFactory $templateFactory,
         \Magento\Framework\Filter\FilterManager $filterManager,
         \Magento\Framework\UrlInterface $urlModel,
-        array $data = []
+        array $data = [],
+        Database $fileStorageDatabase = null
     ) {
         $this->design = $design;
         $this->area = isset($data['area']) ? $data['area'] : null;
@@ -207,6 +215,7 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
         $this->templateFactory = $templateFactory;
         $this->filterManager = $filterManager;
         $this->urlModel = $urlModel;
+        $this->fileStorageDatabase = $fileStorageDatabase ?: \Magento\Framework\App\ObjectManager::getInstance()->get(Database::class);
         parent::__construct($context, $registry, null, null, $data);
     }
 
@@ -394,6 +403,11 @@ abstract class AbstractTemplate extends AbstractModel implements TemplateTypesIn
         if ($fileName) {
             $uploadDir = \Magento\Email\Model\Design\Backend\Logo::UPLOAD_DIR;
             $mediaDirectory = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA);
+            if ($this->fileStorageDatabase->checkDbUsage() &&
+                !$mediaDirectory->isFile($uploadDir . '/' . $fileName)
+            ) {
+                $this->fileStorageDatabase->saveFileToFilesystem($uploadDir . '/' . $fileName);
+            }
             if ($mediaDirectory->isFile($uploadDir . '/' . $fileName)) {
                 return $this->storeManager->getStore()->getBaseUrl(
                     \Magento\Framework\UrlInterface::URL_TYPE_MEDIA

--- a/app/code/Magento/Email/Test/Unit/Model/BackendTemplateTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/BackendTemplateTest.php
@@ -12,6 +12,9 @@ namespace Magento\Email\Test\Unit\Model;
 use Magento\Email\Model\BackendTemplate;
 use Magento\Framework\ObjectManagerInterface;
 
+/**
+ * Tests for  adminhtml email template model.
+ */
 class BackendTemplateTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -72,13 +75,13 @@ class BackendTemplateTest extends \PHPUnit\Framework\TestCase
             ->method('get')
             ->willReturnCallback(
                 function ($value) {
-                    switch($value) {
+                    switch ($value) {
                         case \Magento\MediaStorage\Helper\File\Storage\Database::class:
                             return ($this->databaseHelperMock);
                         case \Magento\Email\Model\ResourceModel\Template::class:
                             return ($this->resourceModelMock);
                         default:
-                            return(NULL);
+                            return(null);
                     }
                 }
             );

--- a/app/code/Magento/Email/Test/Unit/Model/BackendTemplateTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/BackendTemplateTest.php
@@ -46,6 +46,11 @@ class BackendTemplateTest extends \PHPUnit\Framework\TestCase
      */
     private $serializerMock;
 
+    /**
+     * @var \Magento\MediaStorage\Helper\File\Storage\Database|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $databaseHelperMock;
+
     protected function setUp()
     {
         $helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
@@ -56,6 +61,7 @@ class BackendTemplateTest extends \PHPUnit\Framework\TestCase
         $this->structureMock = $this->createMock(\Magento\Config\Model\Config\Structure::class);
         $this->structureMock->expects($this->any())->method('getFieldPathsByAttribute')->willReturn(['path' => 'test']);
 
+        $this->databaseHelperMock = $this->createMock(\Magento\MediaStorage\Helper\File\Storage\Database::class);
         $this->resourceModelMock = $this->createMock(\Magento\Email\Model\ResourceModel\Template::class);
         $this->resourceModelMock->expects($this->any())
             ->method('getSystemConfigByPathsAndTemplateId')
@@ -64,8 +70,18 @@ class BackendTemplateTest extends \PHPUnit\Framework\TestCase
         $objectManagerMock = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
         $objectManagerMock->expects($this->any())
             ->method('get')
-            ->with(\Magento\Email\Model\ResourceModel\Template::class)
-            ->will($this->returnValue($this->resourceModelMock));
+            ->willReturnCallback(
+                function ($value) {
+                    switch($value) {
+                        case \Magento\MediaStorage\Helper\File\Storage\Database::class:
+                            return ($this->databaseHelperMock);
+                        case \Magento\Email\Model\ResourceModel\Template::class:
+                            return ($this->resourceModelMock);
+                        default:
+                            return(NULL);
+                    }
+                }
+            );
 
         \Magento\Framework\App\ObjectManager::setInstance($objectManagerMock);
 

--- a/app/code/Magento/Email/composer.json
+++ b/app/code/Magento/Email/composer.json
@@ -12,6 +12,7 @@
         "magento/module-config": "*",
         "magento/module-store": "*",
         "magento/module-theme": "*",
+        "magento/module-media-storage": "*",
         "magento/module-variable": "*"
     },
     "suggest": {


### PR DESCRIPTION
### Description (*)
If the email logo does not exist in pub/media and we are in database storage mode, then magento should copy the image file from database to local pub/media prior to continuing.

### Fixed Issues (if relevant)
1. magento/magento2#21671: Database Media Storage - Transaction emails logo not used when pub/media cleared

### Manual testing scenarios (*)
1. Setup Magento
2. Change media storage mode to database
3. Synchronize
4. Save Settings
5. Set store General Contact email address to valid email
6. Set email logo (Content->Configuration->Edit->Transactional Emails)
7. Clear Cache
8. Verify email logo exists in database <- This will fail on 2.3-develop due to #21672
9. Verify email logo exists in pub/media
10. On Frontend, subscribe to newsletter
11. Verify newsletter email contains logo
12. Clear pub/media, simulating a new cluster node being used
13. On Frontend, subscribe to newsletter (need to use new email address, or delete 1st address in backend first)
14. Verify newsletter email contains logo

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
