### PR TITLE
[2.2][Backport] Database Media Storage - Design Config Save functions to be Database Media Storage aware

### DIFF
--- a/app/code/Magento/Theme/Model/Design/Backend/File.php
+++ b/app/code/Magento/Theme/Model/Design/Backend/File.php
@@ -20,6 +20,7 @@ use Magento\Framework\Registry;
 use Magento\Framework\UrlInterface;
 use Magento\MediaStorage\Model\File\UploaderFactory;
 use Magento\Theme\Model\Design\Config\FileUploader\FileProcessor;
+use Magento\MediaStorage\Helper\File\Storage\Database;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -37,6 +38,11 @@ class File extends BackendFile
     private $mime;
 
     /**
+     * @var Database
+     */
+    private $databaseHelper;
+
+    /**
      * @param Context $context
      * @param Registry $registry
      * @param ScopeConfigInterface $config
@@ -48,6 +54,7 @@ class File extends BackendFile
      * @param AbstractResource|null $resource
      * @param AbstractDb|null $resourceCollection
      * @param array $data
+     * @param Database $databaseHelper
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -61,7 +68,8 @@ class File extends BackendFile
         UrlInterface $urlBuilder,
         AbstractResource $resource = null,
         AbstractDb $resourceCollection = null,
-        array $data = []
+        array $data = [],
+        Database $databaseHelper = null
     ) {
         parent::__construct(
             $context,
@@ -76,6 +84,7 @@ class File extends BackendFile
             $data
         );
         $this->urlBuilder = $urlBuilder;
+        $this->databaseHelper = $databaseHelper ?: ObjectManager::getInstance()->get(Database::class);
     }
 
     /**
@@ -100,6 +109,10 @@ class File extends BackendFile
 
         $filename = basename($value['file']);
         $result = $this->_mediaDirectory->copyFile(
+            $this->getTmpMediaPath($filename),
+            $this->_getUploadDir() . '/' . $filename
+        );
+        $this->databaseHelper->renameFile(
             $this->getTmpMediaPath($filename),
             $this->_getUploadDir() . '/' . $filename
         );

--- a/app/code/Magento/Theme/Test/Unit/Model/Design/Backend/FileTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Design/Backend/FileTest.php
@@ -28,6 +28,11 @@ class FileTest extends \PHPUnit\Framework\TestCase
      */
     private $mime;
 
+    /**
+     * @var \Magento\MediaStorage\Helper\File\Storage\Database|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $databaseHelper;
+
     public function setUp()
     {
         $context = $this->getMockObject(\Magento\Framework\Model\Context::class);
@@ -55,6 +60,17 @@ class FileTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->databaseHelper = $this->getMockBuilder(\Magento\MediaStorage\Helper\File\Storage\Database::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $abstractResource = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\AbstractResource::class)
+            ->getMockForAbstractClass();
+
+        $abstractDb = $this->getMockBuilder(\Magento\Framework\Data\Collection\AbstractDb::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
         $this->fileBackend = new File(
             $context,
             $registry,
@@ -63,7 +79,11 @@ class FileTest extends \PHPUnit\Framework\TestCase
             $uploaderFactory,
             $requestData,
             $filesystem,
-            $this->urlBuilder
+            $this->urlBuilder,
+            $abstractResource,
+            $abstractDb,
+            [],
+            $this->databaseHelper
         );
 
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
@@ -195,6 +215,11 @@ class FileTest extends \PHPUnit\Framework\TestCase
                 ],
             ]
         );
+
+        $this->databaseHelper->expects($this->once())
+            ->method('renameFile')
+            ->with($expectedTmpMediaPath, '/' . $expectedFileName)
+            ->willReturn(true);
 
         $this->mediaDirectory->expects($this->once())
             ->method('copyFile')


### PR DESCRIPTION
### Original PR (*)
#21675 

### Description (*)
The functions that process the uploads of the Favicon, Header Image and Transactional Email Logo files do not process the file correctly when in Database Media Storage Mode. This PR fixes that.

### Fixed Issues (if relevant)
1. magento/magento2#21672: Database Media Storage - Design Config fails to save transactional email logo correctly

### Manual testing scenarios (*)
1. Setup Magento
2. Change media storage mode to database
3. Synchronize
4. Save Settings
5. Content->Configuration->Edit->Transactional Emails
6. Upload New Image (but don't save)
7. Verify temporary email logo exists in pub/media
8. Verify temporary email logo exists in database
9. Save Config
10. Verify email logo exists in pub/media
11. Verify email logo exists in database

Repeat for favicon and header logo, ensuring that after save, the file exists correctly in the database.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
