### PR TITLE
7637 incorrect method annotation is misleading

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -960,14 +960,14 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * @param   string $columnName
      * @param   array|string $definition  string specific or universal array DB Server definition
      * @param   string $schemaName
-     * @return  true|\Zend_Db_Statement_Pdo
+     * @return  $this
      * @throws  \Zend_Db_Exception
      */
     public function addColumn($tableName, $columnName, $definition, $schemaName = null)
     {
         $this->getSchemaListener()->addColumn($tableName, $columnName, $definition);
         if ($this->tableColumnExists($tableName, $columnName, $schemaName)) {
-            return true;
+            return $this;
         }
 
         $primaryKey = '';
@@ -990,11 +990,11 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
             $primaryKey
         );
 
-        $result = $this->rawQuery($sql);
+        $this->rawQuery($sql);
 
         $this->resetDdlCache($tableName, $schemaName);
 
-        return $result;
+        return $this;
     }
 
     /**

--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -960,7 +960,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      * @param   string $columnName
      * @param   array|string $definition  string specific or universal array DB Server definition
      * @param   string $schemaName
-     * @return  $this
+     * @return  \Magento\Framework\DB\Adapter\AdapterInterface
      * @throws  \Zend_Db_Exception
      */
     public function addColumn($tableName, $columnName, $definition, $schemaName = null)


### PR DESCRIPTION
### Description (*)
The `addColumn` function of `Magento\Framework\DB\Adapter\Pdo\Mysql` doesn't return correct type of value. According to the Interface `Magento\Framework\DB\Adapter\AdapterInterface`, which `Magento\Framework\DB\Adapter\Pdo\Mysql` is implementing, that function should return an object that is realizes adapter interface

### Fixed Issues (if relevant)
1. magento/magento2#7637: Incorrect method annotation is misleading

### Manual testing scenarios (*)
1. Create an InstallSchema or UpgradeSchema class in a custom module and add the following line of code somewhere within:
```
$setup->getConnection->addColumn('test',
    'name',
    [
        'TYPE' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
        'NULLABLE' => true,
        'COMMENT' => 'Name'
    ]
)->commit();
```
2. run `bin/magento setup:upgrade`

### Expected result
Column is added, commit is done.

### Actual result
A fatal PHP error occurs: there is no commit() method implemented for type `Magento\Framework\DB\Statement\Pdo\Mysql`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
