### PR TITLE
[Backport][Admin] Made configurable product variations table cell label hidden

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
+++ b/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
@@ -5,14 +5,14 @@
  */
 namespace Magento\ConfigurableProduct\Ui\DataProvider\Product\Form\Modifier;
 
+use Magento\Catalog\Model\Locator\LocatorInterface;
 use Magento\Catalog\Model\Product\Attribute\Backend\Sku;
 use Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\AbstractModifier;
-use Magento\Ui\Component\Container;
-use Magento\Ui\Component\Form;
-use Magento\Ui\Component\DynamicRows;
-use Magento\Ui\Component\Modal;
 use Magento\Framework\UrlInterface;
-use Magento\Catalog\Model\Locator\LocatorInterface;
+use Magento\Ui\Component\Container;
+use Magento\Ui\Component\DynamicRows;
+use Magento\Ui\Component\Form;
+use Magento\Ui\Component\Modal;
 
 /**
  * Data provider for Configurable panel
@@ -90,7 +90,7 @@ class ConfigurablePanel extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function modifyData(array $data)
     {
@@ -98,7 +98,7 @@ class ConfigurablePanel extends AbstractModifier
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function modifyMeta(array $meta)
@@ -197,7 +197,7 @@ class ConfigurablePanel extends AbstractModifier
                                         'autoRender' => false,
                                         'componentType' => 'insertListing',
                                         'component' => 'Magento_ConfigurableProduct/js'
-                                            .'/components/associated-product-insert-listing',
+                                            . '/components/associated-product-insert-listing',
                                         'dataScope' => $this->associatedListingPrefix
                                             . static::ASSOCIATED_PRODUCT_LISTING,
                                         'externalProvider' => $this->associatedListingPrefix
@@ -328,14 +328,12 @@ class ConfigurablePanel extends AbstractModifier
                                 'component' => 'Magento_Ui/js/form/components/button',
                                 'actions' => [
                                     [
-                                        'targetName' =>
-                                            $this->dataScopeName . '.configurableModal',
+                                        'targetName' => $this->dataScopeName . '.configurableModal',
                                         'actionName' => 'trigger',
                                         'params' => ['active', true],
                                     ],
                                     [
-                                        'targetName' =>
-                                            $this->dataScopeName . '.configurableModal',
+                                        'targetName' => $this->dataScopeName . '.configurableModal',
                                         'actionName' => 'openModal',
                                     ],
                                 ],
@@ -574,6 +572,7 @@ class ConfigurablePanel extends AbstractModifier
             'dataType' => Form\Element\DataType\Text::NAME,
             'dataScope' => $name,
             'visibleIfCanEdit' => false,
+            'labelVisible' => false,
             'imports' => [
                 'visible' => '!${$.provider}:${$.parentScope}.canEdit'
             ],
@@ -592,6 +591,7 @@ class ConfigurablePanel extends AbstractModifier
             'component' => 'Magento_Ui/js/form/components/group',
             'label' => $label,
             'dataScope' => '',
+            'showLabel' => false
         ];
         $container['children'] = [
             $name . '_edit' => $fieldEdit,


### PR DESCRIPTION
### Original PR #20528
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Made configurable product variations table body cell label hidden, because they were positioned (absolute) all in on place above the table.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20527: Configurable product variations table cell labels wrong position 
2. ...

### Manual testing scenarios (*)
1. ...
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
