### PR TITLE
[Backport] Fix #21692 #21752 - logic in constructor of address validator and Locale Resolver check

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Address/Validator.php
+++ b/app/code/Magento/Sales/Model/Order/Address/Validator.php
@@ -48,8 +48,8 @@ class Validator
 
     /**
      * @param DirectoryHelper $directoryHelper
-     * @param CountryFactory  $countryFactory
-     * @param EavConfig       $eavConfig
+     * @param CountryFactory $countryFactory
+     * @param EavConfig $eavConfig
      */
     public function __construct(
         DirectoryHelper $directoryHelper,
@@ -195,7 +195,10 @@ class Validator
     }
 
     /**
+     * Check whether telephone is required for address.
+     *
      * @return bool
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     protected function isTelephoneRequired()
     {
@@ -203,7 +206,10 @@ class Validator
     }
 
     /**
+     * Check whether company is required for address.
+     *
      * @return bool
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     protected function isCompanyRequired()
     {
@@ -211,7 +217,10 @@ class Validator
     }
 
     /**
+     * Check whether fax is required for address.
+     *
      * @return bool
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     protected function isFaxRequired()
     {

--- a/app/code/Magento/Sales/Model/Order/Address/Validator.php
+++ b/app/code/Magento/Sales/Model/Order/Address/Validator.php
@@ -60,6 +60,16 @@ class Validator
         $this->countryFactory = $countryFactory;
         $this->eavConfig = $eavConfig ?: ObjectManager::getInstance()
             ->get(EavConfig::class);
+    }
+
+    /**
+     *
+     * @param \Magento\Sales\Model\Order\Address $address
+     * @return array
+     */
+    public function validate(Address $address)
+    {
+        $warnings = [];
 
         if ($this->isTelephoneRequired()) {
             $this->required['telephone'] = 'Phone Number';
@@ -72,16 +82,7 @@ class Validator
         if ($this->isFaxRequired()) {
             $this->required['fax'] = 'Fax';
         }
-    }
 
-    /**
-     *
-     * @param \Magento\Sales\Model\Order\Address $address
-     * @return array
-     */
-    public function validate(Address $address)
-    {
-        $warnings = [];
         foreach ($this->required as $code => $label) {
             if (!$address->hasData($code)) {
                 $warnings[] = sprintf('%s is a required field', $label);

--- a/app/code/Magento/Sales/Model/Order/Address/Validator.php
+++ b/app/code/Magento/Sales/Model/Order/Address/Validator.php
@@ -63,6 +63,7 @@ class Validator
     }
 
     /**
+     * Validate address.
      *
      * @param \Magento\Sales\Model\Order\Address $address
      * @return array

--- a/lib/internal/Magento/Framework/Locale/Format.php
+++ b/lib/internal/Magento/Framework/Locale/Format.php
@@ -41,7 +41,8 @@ class Format implements \Magento\Framework\Locale\FormatInterface
     }
 
     /**
-     * Returns the first found number from a string
+     * Returns the first found number from a string.
+     *
      * Parsing depends on given locale (grouping and decimal)
      *
      * Examples for input:

--- a/lib/internal/Magento/Framework/Locale/Format.php
+++ b/lib/internal/Magento/Framework/Locale/Format.php
@@ -100,7 +100,7 @@ class Format implements \Magento\Framework\Locale\FormatInterface
         }
 
         $formatter = new \NumberFormatter(
-            $localeCode . '@currency=' . $currency->getCode(),
+            $currency->getCode() ? $localeCode . '@currency=' . $currency->getCode() : $localeCode,
             \NumberFormatter::CURRENCY
         );
         $format = $formatter->getPattern();

--- a/lib/internal/Magento/Framework/Locale/Format.php
+++ b/lib/internal/Magento/Framework/Locale/Format.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\Framework\Locale;
 
+/**
+ * Price locale format.
+ */
 class Format implements \Magento\Framework\Locale\FormatInterface
 {
     /**

--- a/lib/internal/Magento/Framework/Locale/Resolver.php
+++ b/lib/internal/Magento/Framework/Locale/Resolver.php
@@ -9,6 +9,9 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\ObjectManager;
 
+/**
+ * Manages locale config information.
+ */
 class Resolver implements ResolverInterface
 {
     /**
@@ -76,7 +79,7 @@ class Resolver implements ResolverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getDefaultLocalePath()
     {
@@ -84,7 +87,7 @@ class Resolver implements ResolverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setDefaultLocale($locale)
     {
@@ -93,7 +96,7 @@ class Resolver implements ResolverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getDefaultLocale()
     {
@@ -111,7 +114,7 @@ class Resolver implements ResolverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setLocale($locale = null)
     {
@@ -124,7 +127,7 @@ class Resolver implements ResolverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getLocale()
     {
@@ -135,7 +138,7 @@ class Resolver implements ResolverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function emulate($scopeId)
     {
@@ -155,7 +158,7 @@ class Resolver implements ResolverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function revert()
     {

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/FormatTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/FormatTest.php
@@ -53,6 +53,7 @@ class FormatTest extends \PHPUnit\Framework\TestCase
 
         /** @var \Magento\Directory\Model\CurrencyFactory|\PHPUnit_Framework_MockObject_MockObject $currencyFactory */
         $currencyFactory = $this->getMockBuilder(\Magento\Directory\Model\CurrencyFactory::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $this->formatModel = new \Magento\Framework\Locale\Format(


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/21693

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This fixes issue #21692 - error is described there. This is backport for Magento 2.2.

### Fixed Issues (if relevant)
1. magento/magento2#21692: Incorrect constructor of Magento\Sales\Model\Order\Address\Validator

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add custom module with Cli Command and inject `Magento\Sales\Model\Order\Address\Validator` into its constructor
2. Run Magento installation from Cli
3. Verify if installation is finished with success

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)