### PR TITLE
magento/magento2#21714: Magento frontend validation ignores formnovalidate

### DIFF
--- a/lib/web/mage/backend/validation.js
+++ b/lib/web/mage/backend/validation.js
@@ -96,10 +96,6 @@
         options: {
             messagesId: 'messages',
             forceIgnore: '',
-            ignore: ':disabled, .ignore-validate, .no-display.template, ' +
-                ':disabled input, .ignore-validate input, .no-display.template input, ' +
-                ':disabled select, .ignore-validate select, .no-display.template select, ' +
-                ':disabled textarea, .ignore-validate textarea, .no-display.template textarea',
             errorElement: 'label',
             errorUrl: typeof BASE_URL !== 'undefined' ? BASE_URL : null,
 

--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -1821,6 +1821,11 @@
     $.widget('mage.validation', {
         options: {
             meta: 'validate',
+            ignore: ':disabled, .ignore-validate, .no-display.template, ' +
+              ':disabled input, .ignore-validate input, .no-display.template input, ' +
+              ':disabled select, .ignore-validate select, .no-display.template select, ' +
+              ':disabled textarea, .ignore-validate textarea, .no-display.template textarea,' +
+              '[formnovalidate="formnovalidate"]',
             onfocusout: false,
             onkeyup: false,
             onclick: false,


### PR DESCRIPTION
### Description (*)
- ignoring validation for fields known from backend was moved to base mage/validator so frontend can use it as well
- added support for `formnovalidate` attribute

### Fixed Issues (if relevant)
magento/magento2#21714: Magento frontend validation ignores formnovalidate

### Manual testing scenarios (*)
Test I - validation from backend ported to frontend:
1. Go to a product page
2. try to add a product to cart with qty -1 - validation should fail
3. add class `ignore-validate` to qty input
4. try to add a product to cart - validation should pass and 1 product should be added to cart

Test II - validation from backend ported to frontend:
1. Go to a product page
2. try to add a product to cart with qty -1 - validation should fail
3. add attribute `formnovalidate="formnovalidate"` to qty input
4. try to add a product to cart - validation should pass and 1 product should be added to cart

Repeat above tests on a validated form element in Admin Panel to make sure that there is no regression.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] - *N/A* -  All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
