### PR TITLE
Checkout edit products: Fix using fieldset instead of div

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/configure/updatecart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/configure/updatecart.phtml
@@ -12,7 +12,7 @@
 <?php $buttonTitle = __('Update Cart'); ?>
 <?php if ($_product->isSaleable()): ?>
     <div class="box-tocart update">
-        <fieldset class="fieldset">
+        <div class="fieldset">
             <?php if ($block->shouldRenderQuantity()): ?>
             <div class="field qty">
                 <label class="label" for="qty"><span><?= /* @escapeNotVerified */ __('Qty') ?></span></label>
@@ -37,7 +37,7 @@
                 </button>
                 <?= $block->getChildHtml('', true) ?>
             </div>
-        </fieldset>
+        </div>
     </div>
     <script type="text/x-magento-init">
         {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When editing a product's quantity after it is placed in cart, the "amount" looks odd in Chrome. In Firefox, it looks fine. It looks like Chrome aplies different styles to a `fieldset` element than Firefox. This results in this in Chrome:
![image](https://user-images.githubusercontent.com/13721712/54270781-7c985800-4580-11e9-8a60-e4af90e3fc78.png)

Whereas, in Firefox, it looks fine:
![image](https://user-images.githubusercontent.com/13721712/54270869-a782ac00-4580-11e9-9bc6-217961c9f63c.png)

This is not so much a problem which most likely couldn't be resolved with some css. However, it is bad developer experience as the (almost) same [template](app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml:15) which handles the initial "add to cart" process uses a `div`, and not a `fieldset`.

Therefore, this pr reverts back to using a `div`, to avoid unnessecary bugs like this one. It does not have an effect on the overall layout of the site as all css classes are left intact.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Put an item in cart
2. Click "edit" in cart

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
