### PR TITLE
Custom option type select - Allow modify list of single selection option types

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
@@ -10,6 +10,8 @@ use Magento\Framework\Exception\LocalizedException;
 
 /**
  * Catalog product option select type
+ *
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  */
 class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
 {

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
@@ -58,8 +58,8 @@ class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
         parent::__construct($checkoutSession, $scopeConfig, $data);
 
         $this->singleSelectionTypes = $singleSelectionTypes ?: [
-            \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_DROP_DOWN,
-            \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_RADIO,
+            'drop_down' => \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_DROP_DOWN,
+            'radio' => \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_RADIO,
         ];
     }
 

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
@@ -31,22 +31,34 @@ class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
     protected $string;
 
     /**
+     * @var array
+     */
+    private $singleSelectionTypes;
+
+    /**
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Framework\Stdlib\StringUtils $string
      * @param \Magento\Framework\Escaper $escaper
      * @param array $data
+     * @param array $singleSelectionTypes
      */
     public function __construct(
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Framework\Stdlib\StringUtils $string,
         \Magento\Framework\Escaper $escaper,
-        array $data = []
+        array $data = [],
+        array $singleSelectionTypes = []
     ) {
         $this->string = $string;
         $this->_escaper = $escaper;
         parent::__construct($checkoutSession, $scopeConfig, $data);
+
+        $this->singleSelectionTypes = $singleSelectionTypes ?: [
+            \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_DROP_DOWN,
+            \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_RADIO,
+        ];
     }
 
     /**
@@ -310,10 +322,6 @@ class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
      */
     protected function _isSingleSelection()
     {
-        $single = [
-            \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_DROP_DOWN,
-            \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_RADIO,
-        ];
-        return in_array($this->getOption()->getType(), $single);
+        return in_array($this->getOption()->getType(), $this->singleSelectionTypes, true);
     }
 }

--- a/app/code/Magento/Catalog/etc/di.xml
+++ b/app/code/Magento/Catalog/etc/di.xml
@@ -1164,4 +1164,12 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Catalog\Model\Product\Option\Type\Select">
+        <arguments>
+            <argument name="singleSelectionTypes" xsi:type="array">
+                <item name="drop_down" xsi:type="const">Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_DROP_DOWN</item>
+                <item name="radio" xsi:type="const">Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_RADIO</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
### Description (*)
When I wanted to add one more type for "select" option group:
![screenshot1](https://user-images.githubusercontent.com/1873745/54351916-4a0e5e00-4659-11e9-8ae9-90c9c8027d86.png)
But there is no ability to mark own custom option type as "single select".

This PR adds ability to add own custom option type to this list by adding following code to di.xml file of own module:
```xml
    <type name="Magento\Catalog\Model\Product\Option\Type\Select">
        <arguments>
            <argument name="singleSelectionOptionTypes" xsi:type="array">
                <item name="my_custom_option_type" xsi:type="const">VendorName\ModuelName\Model\PathToMyModel::OPTION_TYPE_MY_CUSTOM_OPTION_TYPE</item>
            </argument>
        </arguments>
    </type>
```

This method is used in a lot of places, for example during validating custom option values during adding product to cart.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
