### PR TITLE
Fixes nested array for used products cache key

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
@@ -1249,7 +1249,7 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
             $product->getStoreId(),
             $this->getCustomerSession()->getCustomerGroupId()
         ];
-        if (!is_null($requiredAttributeIds)) {
+        if ($requiredAttributeIds !== null) {
             sort($requiredAttributeIds);
             $keyParts[] = implode('', $requiredAttributeIds);
         }

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
@@ -1232,6 +1232,8 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
     /**
      * Returns array of sub-products for specified configurable product
      *
+     * $requiredAttributeIds - one dimensional array, if provided
+     *
      * Result array contains all children for specified configurable product
      *
      * @param  \Magento\Catalog\Model\Product $product
@@ -1245,9 +1247,12 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
             __METHOD__,
             $product->getData($metadata->getLinkField()),
             $product->getStoreId(),
-            $this->getCustomerSession()->getCustomerGroupId(),
-            $requiredAttributeIds
+            $this->getCustomerSession()->getCustomerGroupId()
         ];
+        if (!is_null($requiredAttributeIds)) {
+            sort($requiredAttributeIds);
+            $keyParts[] = implode('', $requiredAttributeIds);
+        }
         $cacheKey = $this->getUsedProductsCacheKey($keyParts);
         return $this->loadUsedProducts($product, $cacheKey);
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When $requiredAttributeIds is passed as an array, it was previously being added to the $keyParts array directly, which resulted in a nested array. When this nested array is passed to getUsedProductsCacheKey(), the implode() in that function throws a notice and produces a cache key that contains the non-unique string "Array" as a part. This can result in caching errors where simple children of configurable products are concerned (e.g., swatches).

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
N/A - no existing issue found

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Call Magento\ConfigurableProduct\Model\Product\Type\Configurable::getUsedProducts($product, $requiredAttributeIds = null) passing different $requiredAttributeIds arrays of attribute codes and confirm that Magento\ConfigurableProduct\Model\Product\Type\Configurable::getUsedProducts() returns unique cache keys for each.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
