### PR TITLE
Fixes race condition when building merged css/js file during simultaneous requests

### DIFF
--- a/lib/internal/Magento/Framework/View/Asset/MergeStrategy/Direct.php
+++ b/lib/internal/Magento/Framework/View/Asset/MergeStrategy/Direct.php
@@ -6,6 +6,8 @@
 namespace Magento\Framework\View\Asset\MergeStrategy;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Math\Random;
 use Magento\Framework\View\Asset;
 
 /**
@@ -31,27 +33,27 @@ class Direct implements \Magento\Framework\View\Asset\MergeStrategyInterface
     private $cssUrlResolver;
 
     /**
-     * @var \Magento\Framework\Math\Random
+     * @var Random
      */
     private $mathRandom;
 
     /**
      * @param \Magento\Framework\Filesystem $filesystem
      * @param \Magento\Framework\View\Url\CssResolver $cssUrlResolver
-     * @param \Magento\Framework\Math\Random|null $mathRandom
+     * @param Random|null $mathRandom
      */
     public function __construct(
         \Magento\Framework\Filesystem $filesystem,
         \Magento\Framework\View\Url\CssResolver $cssUrlResolver,
-        \Magento\Framework\Math\Random $mathRandom = null
+        Random $mathRandom = null
     ) {
         $this->filesystem = $filesystem;
         $this->cssUrlResolver = $cssUrlResolver;
-        $this->mathRandom = $mathRandom ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\Math\Random::class);;
+        $this->mathRandom = $mathRandom ?: ObjectManager::getInstance()->get(Random::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function merge(array $assetsToMerge, Asset\LocalInterface $resultAsset)
     {
@@ -67,10 +69,9 @@ class Direct implements \Magento\Framework\View\Asset\MergeStrategyInterface
     /**
      * Merge files together and modify content if needed
      *
-     * @param \Magento\Framework\View\Asset\MergeableInterface[] $assetsToMerge
-     * @param \Magento\ Framework\View\Asset\LocalInterface $resultAsset
-     * @return string
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @param array $assetsToMerge
+     * @param Asset\LocalInterface $resultAsset
+     * @return array|string
      */
     private function composeMergedContent(array $assetsToMerge, Asset\LocalInterface $resultAsset)
     {

--- a/lib/internal/Magento/Framework/View/Asset/MergeStrategy/Direct.php
+++ b/lib/internal/Magento/Framework/View/Asset/MergeStrategy/Direct.php
@@ -33,20 +33,21 @@ class Direct implements \Magento\Framework\View\Asset\MergeStrategyInterface
     /**
      * @var \Magento\Framework\Math\Random
      */
-    protected $mathRandom;
+    private $mathRandom;
 
     /**
      * @param \Magento\Framework\Filesystem $filesystem
      * @param \Magento\Framework\View\Url\CssResolver $cssUrlResolver
+     * @param \Magento\Framework\Math\Random|null $mathRandom
      */
     public function __construct(
         \Magento\Framework\Filesystem $filesystem,
         \Magento\Framework\View\Url\CssResolver $cssUrlResolver,
-        \Magento\Framework\Math\Random $mathRandom
+        \Magento\Framework\Math\Random $mathRandom = null
     ) {
         $this->filesystem = $filesystem;
         $this->cssUrlResolver = $cssUrlResolver;
-        $this->mathRandom = $mathRandom;
+        $this->mathRandom = $mathRandom ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\Math\Random::class);;
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Asset/MergeStrategy/Direct.php
+++ b/lib/internal/Magento/Framework/View/Asset/MergeStrategy/Direct.php
@@ -31,15 +31,22 @@ class Direct implements \Magento\Framework\View\Asset\MergeStrategyInterface
     private $cssUrlResolver;
 
     /**
+     * @var \Magento\Framework\Math\Random
+     */
+    protected $mathRandom;
+
+    /**
      * @param \Magento\Framework\Filesystem $filesystem
      * @param \Magento\Framework\View\Url\CssResolver $cssUrlResolver
      */
     public function __construct(
         \Magento\Framework\Filesystem $filesystem,
-        \Magento\Framework\View\Url\CssResolver $cssUrlResolver
+        \Magento\Framework\View\Url\CssResolver $cssUrlResolver,
+        \Magento\Framework\Math\Random $mathRandom
     ) {
         $this->filesystem = $filesystem;
         $this->cssUrlResolver = $cssUrlResolver;
+        $this->mathRandom = $mathRandom;
     }
 
     /**
@@ -49,17 +56,18 @@ class Direct implements \Magento\Framework\View\Asset\MergeStrategyInterface
     {
         $mergedContent = $this->composeMergedContent($assetsToMerge, $resultAsset);
         $filePath = $resultAsset->getPath();
+        $tmpFilePath = $filePath . $this->mathRandom->getUniqueHash('_');
         $staticDir = $this->filesystem->getDirectoryWrite(DirectoryList::STATIC_VIEW);
         $tmpDir = $this->filesystem->getDirectoryWrite(DirectoryList::TMP);
-        $tmpDir->writeFile($filePath, $mergedContent);
-        $tmpDir->renameFile($filePath, $filePath, $staticDir);
+        $tmpDir->writeFile($tmpFilePath, $mergedContent);
+        $tmpDir->renameFile($tmpFilePath, $filePath, $staticDir);
     }
 
     /**
      * Merge files together and modify content if needed
      *
      * @param \Magento\Framework\View\Asset\MergeableInterface[] $assetsToMerge
-     * @param \Magento\Framework\View\Asset\LocalInterface $resultAsset
+     * @param \Magento\ Framework\View\Asset\LocalInterface $resultAsset
      * @return string
      * @throws \Magento\Framework\Exception\LocalizedException
      */

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/MergeStrategy/DirectTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/MergeStrategy/DirectTest.php
@@ -5,11 +5,13 @@
  */
 namespace Magento\Framework\View\Test\Unit\Asset\MergeStrategy;
 
-use Magento\Framework\Filesystem\Directory\WriteInterface;
-use \Magento\Framework\View\Asset\MergeStrategy\Direct;
-
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem\Directory\WriteInterface;
+use Magento\Framework\View\Asset\MergeStrategy\Direct;
 
+/**
+ * Test for Magento\Framework\View\Asset\MergeStrategy\Direct.
+ */
 class DirectTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -69,7 +71,8 @@ class DirectTest extends \PHPUnit\Framework\TestCase
             ->method('getUniqueHash')
             ->willReturn($uniqId);
         $this->tmpDir->expects($this->once())->method('writeFile')->with('foo/result' . $uniqId, '');
-        $this->tmpDir->expects($this->once())->method('renameFile')->with('foo/result' . $uniqId, 'foo/result', $this->staticDir);
+        $this->tmpDir->expects($this->once())->method('renameFile')
+            ->with('foo/result' . $uniqId, 'foo/result', $this->staticDir);
         $this->object->merge([], $this->resultAsset);
     }
 
@@ -83,7 +86,8 @@ class DirectTest extends \PHPUnit\Framework\TestCase
             ->method('getUniqueHash')
             ->willReturn($uniqId);
         $this->tmpDir->expects($this->once())->method('writeFile')->with('foo/result' . $uniqId, 'onetwo');
-        $this->tmpDir->expects($this->once())->method('renameFile')->with('foo/result' . $uniqId, 'foo/result', $this->staticDir);
+        $this->tmpDir->expects($this->once())->method('renameFile')
+            ->with('foo/result' . $uniqId, 'foo/result', $this->staticDir);
         $this->object->merge($assets, $this->resultAsset);
     }
 
@@ -92,7 +96,7 @@ class DirectTest extends \PHPUnit\Framework\TestCase
         $uniqId = '_f929c374767e00712449660ea673f2f5';
         $this->resultAsset->expects($this->exactly(3))
             ->method('getPath')
-            ->will($this->returnValue('foo/result'));
+            ->willReturn('foo/result');
         $this->resultAsset->expects($this->any())->method('getContentType')->will($this->returnValue('css'));
         $assets = $this->prepareAssetsToMerge(['one', 'two']);
         $this->cssUrlResolver->expects($this->exactly(2))
@@ -101,13 +105,14 @@ class DirectTest extends \PHPUnit\Framework\TestCase
         $this->cssUrlResolver->expects($this->once())
             ->method('aggregateImportDirectives')
             ->with('12')
-            ->will($this->returnValue('1020'));
+            ->willReturn('1020');
         $this->mathRandomMock->expects($this->once())
             ->method('getUniqueHash')
             ->willReturn($uniqId);
         $this->staticDir->expects($this->never())->method('writeFile');
         $this->tmpDir->expects($this->once())->method('writeFile')->with('foo/result' . $uniqId, '1020');
-        $this->tmpDir->expects($this->once())->method('renameFile')->with('foo/result' . $uniqId, 'foo/result', $this->staticDir);
+        $this->tmpDir->expects($this->once())->method('renameFile')
+            ->with('foo/result' . $uniqId, 'foo/result', $this->staticDir);
         $this->object->merge($assets, $this->resultAsset);
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixes bug when many requests to a page are made and multiple streams request to build the same merged css or js file sometimes results in serving incomplete files to the client if a second request came in and truncated the part of the work from the first request.

If two requests try and build a merged css or js file both attempt to do so.  Request A starts to build the file, when Request B starts it truncates the temporary file and begins to build its own.  Request A finishes the process and copied a now incomplete file into the final directory and serves it to the customer.  When Request B finishes, it copes the now complete file into the final directory and serves it to the customer.  Only the first customer would notice a problem and it would be resolved on refresh.

This can manifest itself more severely with a CDN.  In the scenario above, the incomplete file would be cached by a CDN edge node.  If request A came from Chicago and request B came from Miami then Chicago node would have the incomplete file and Miami would have the complete file.  All users from Chicago and surrounding areas would have the site broken while it would appear fine to people in Miami.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Enable css merge/minify
2. Enable js merge/minify/bundle
3. Set instance to production mode.
4. Prime cache (load homepage)
5. Flush block_html and full_page cache
6. Load homepage from 10-20 connections simultaneously, save each instance css and js

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
