### PR TITLE
Bug fixes for #21753 and #21757 (2.2-develop)

### DIFF
--- a/app/code/Magento/Downloadable/Block/Customer/Products/ListProducts.php
+++ b/app/code/Magento/Downloadable/Block/Customer/Products/ListProducts.php
@@ -109,6 +109,27 @@ class ListProducts extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Returns whether or not an item is available for download.
+     *
+     * @param \Magento\Downloadable\Model\Link\Purchased\Item $item
+     * @return bool
+     */
+    public function isItemAvailable($item)
+    {
+        if (
+            $item->getStatus() == \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE ||
+            (
+                1 == $this->_scopeConfig->getValue(\Magento\Downloadable\Model\Link::XML_PATH_CONFIG_STATUS_TO_ENABLE_DOWNLOAD, \Magento\Store\Model\ScopeInterface::SCOPE_STORE) &&
+                $item->getStatus() == \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING
+            )
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Return order view url
      *
      * @param integer $orderId

--- a/app/code/Magento/Downloadable/Controller/Download/Link.php
+++ b/app/code/Magento/Downloadable/Controller/Download/Link.php
@@ -13,6 +13,24 @@ use Magento\Framework\App\ResponseInterface;
 class Link extends \Magento\Downloadable\Controller\Download
 {
     /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    protected $_scopeConfig;
+
+    /**
+     * @param \Magento\Framework\App\Action\Context $context
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(
+        \Magento\Framework\App\Action\Context $context,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+    )
+    {
+        $this->_scopeConfig = $scopeConfig;
+        parent::__construct($context);
+    }
+
+    /**
      * Return customer session object
      *
      * @return \Magento\Customer\Model\Session
@@ -92,7 +110,7 @@ class Link extends \Magento\Downloadable\Controller\Download
             $linkPurchasedItem->getNumberOfDownloadsUsed();
 
         $status = $linkPurchasedItem->getStatus();
-        if ($status == PurchasedLink::LINK_STATUS_AVAILABLE && ($downloadsLeft ||
+        if (($status == PurchasedLink::LINK_STATUS_AVAILABLE || ($status == PurchasedLink::LINK_STATUS_PENDING && 1 == $this->_scopeConfig->getValue(\Magento\Downloadable\Model\Link::XML_PATH_CONFIG_STATUS_TO_ENABLE_DOWNLOAD, \Magento\Store\Model\ScopeInterface::SCOPE_STORE))) && ($downloadsLeft ||
             $linkPurchasedItem->getNumberOfDownloadsBought() == 0)
         ) {
             $resource = '';

--- a/app/code/Magento/Downloadable/Controller/Download/Link.php
+++ b/app/code/Magento/Downloadable/Controller/Download/Link.php
@@ -24,8 +24,7 @@ class Link extends \Magento\Downloadable\Controller\Download
     public function __construct(
         \Magento\Framework\App\Action\Context $context,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
-    )
-    {
+    ) {
         $this->_scopeConfig = $scopeConfig;
         parent::__construct($context);
     }

--- a/app/code/Magento/Downloadable/Model/Link.php
+++ b/app/code/Magento/Downloadable/Model/Link.php
@@ -28,6 +28,8 @@ class Link extends \Magento\Framework\Model\AbstractExtensibleModel implements C
 
     const XML_PATH_CONFIG_IS_SHAREABLE = 'catalog/downloadable/shareable';
 
+    const XML_PATH_CONFIG_STATUS_TO_ENABLE_DOWNLOAD = 'catalog/downloadable/order_item_status';
+
     const LINK_SHAREABLE_YES = 1;
 
     const LINK_SHAREABLE_NO = 0;

--- a/app/code/Magento/Downloadable/view/frontend/templates/customer/products/list.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/customer/products/list.phtml
@@ -38,7 +38,7 @@
                     <td data-th="<?= $block->escapeHtml(__('Date')) ?>" class="col date"><?= /* @escapeNotVerified */ $block->formatDate($_item->getPurchased()->getCreatedAt()) ?></td>
                     <td data-th="<?= $block->escapeHtml(__('Title')) ?>" class="col title">
                         <strong class="product-name"><?= $block->escapeHtml($_item->getPurchased()->getProductName()) ?></strong>
-                        <?php if ($_item->getStatus() == \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE): ?>
+                        <?php if ($block->isItemAvailable($_item)): ?>
                         <a href="<?= /* @escapeNotVerified */ $block->getDownloadUrl($_item) ?>" title="<?= $block->escapeHtml(__('Start Download')) ?>" class="action download" <?= $block->getIsOpenInNewWindow() ? 'onclick="this.target=\'_blank\'"' : '' ?>><?= $block->escapeHtml($_item->getLinkTitle()) ?></a>
                         <?php endif; ?>
                     </td>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixes to enable download links on the "My Downloads" page when Stores -> Configuration -> Catalog -> Downloadable Product Options -> Order Item Status to Enable Downloads is set to "Pending", and to enable downloads to work properly when the same setting is applied.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21753
2. magento/magento2#21757

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to the admin and set Stores -> Configuration -> Catalog -> Downloadable Product Options -> Order Item Status to Enable Downloads to "Pending"
2. Create a user account on the frontend and login
3. Purchase a downloadable product. The product should be placed in the "pending" state after successful completion of payment.
4. Browse to "My Account" -> "My Downloads" and observe that the products now contain links to download where they didn't before the fix in #21753 was applied.
5. Log into the frontend again and purchase another downloadable product as a registered user
6. Click on one of the downloadable product links, which should be in a pending state, and note that the download is now allowed, where previously it wasn't.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
