### PR TITLE
Tax in sales order email is displayed after grand total row

### DIFF
--- a/app/code/Magento/Tax/Block/Sales/Order/Tax.php
+++ b/app/code/Magento/Tax/Block/Sales/Order/Tax.php
@@ -12,6 +12,8 @@ namespace Magento\Tax\Block\Sales\Order;
 use Magento\Sales\Model\Order;
 
 /**
+ * Tax totals modification block.
+ *
  * @api
  * @since 100.0.2
  */
@@ -84,7 +86,11 @@ class Tax extends \Magento\Framework\View\Element\Template
         $allowTax = $this->_source->getTaxAmount() > 0 || $this->_config->displaySalesZeroTax($store);
         $grandTotal = (double)$this->_source->getGrandTotal();
         if (!$grandTotal || $allowTax && !$this->_config->displaySalesTaxWithGrandTotal($store)) {
-            $this->_addTax();
+            $taxTotal = new \Magento\Framework\DataObject(['code' => 'tax', 'block_name' => $this->getNameInLayout()]);
+            $totals = $this->getParentBlock()->getTotals();
+            if ($totals['grand_total']) {
+                $this->getParentBlock()->addTotalBefore($taxTotal, 'grand_total');
+            }
         }
 
         $this->_initSubtotal();
@@ -118,6 +124,8 @@ class Tax extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Init Subtotals.
+     *
      * @return $this
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
@@ -199,6 +207,8 @@ class Tax extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Init Shipping.
+     *
      * @return $this
      */
     protected function _initShipping()
@@ -260,6 +270,8 @@ class Tax extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Init discount.
+     *
      * @return void
      */
     protected function _initDiscount()
@@ -267,6 +279,8 @@ class Tax extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Initialization grand total.
+     *
      * @return $this
      */
     protected function _initGrandTotal()
@@ -311,6 +325,8 @@ class Tax extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Get order.
+     *
      * @return Order
      */
     public function getOrder()
@@ -319,6 +335,8 @@ class Tax extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Get Label Properties.
+     *
      * @return array
      */
     public function getLabelProperties()
@@ -327,6 +345,8 @@ class Tax extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Get Value Properties.
+     *
      * @return array
      */
     public function getValueProperties()


### PR DESCRIPTION

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Tax in sales order email is displayed after grand total row. If customers place order by non-base currencies, tax in total row is displayed in strange position.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21768: Issue title
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Added any products into cart.
2. Proceed checkout.
3. Place order with non-base currency.
4. Receive order confirmation email.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
