### PR TITLE
fix issue with PHP Fatal error:  '\self' is an invalid class name in …

### DIFF
--- a/app/code/Magento/Indexer/Model/Indexer/DependencyDecorator.php
+++ b/app/code/Magento/Indexer/Model/Indexer/DependencyDecorator.php
@@ -141,7 +141,7 @@ class DependencyDecorator implements IndexerInterface
     /**
      * @inheritdoc
      */
-    public function load($indexerId): self
+    public function load($indexerId): IndexerInterface
     {
         $this->indexer->load($indexerId);
         return $this;
@@ -166,7 +166,7 @@ class DependencyDecorator implements IndexerInterface
     /**
      * @inheritdoc
      */
-    public function setState(StateInterface $state): self
+    public function setState(StateInterface $state): IndexerInterface
     {
         $this->indexer->setState($state);
         return $this;
@@ -214,6 +214,7 @@ class DependencyDecorator implements IndexerInterface
 
     /**
      * @inheritdoc
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function invalidate()
     {
@@ -250,6 +251,7 @@ class DependencyDecorator implements IndexerInterface
 
     /**
      * @inheritdoc
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function reindexRow($id)
     {
@@ -262,6 +264,7 @@ class DependencyDecorator implements IndexerInterface
 
     /**
      * @inheritdoc
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function reindexList($ids)
     {


### PR DESCRIPTION
…generated/code/Magento/Indexer/Model/Indexer/DependencyDecorator/Interceptor.php on line 137

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Issue is described at https://github.com/magento/magento2/issues/11905
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)