### PR TITLE
Make database default foreign keys ON_DELETE consistent

### DIFF
--- a/lib/internal/Magento/Framework/DB/Ddl/Table.php
+++ b/lib/internal/Magento/Framework/DB/Ddl/Table.php
@@ -480,13 +480,13 @@ class Table
         }
 
         switch ($onDelete) {
-            case self::ACTION_CASCADE:
+            case self::ACTION_NO_ACTION:
             case self::ACTION_RESTRICT:
             case self::ACTION_SET_DEFAULT:
             case self::ACTION_SET_NULL:
                 break;
             default:
-                $onDelete = self::ACTION_NO_ACTION;
+                $onDelete = self::ACTION_CASCADE;
         }
 
         $this->_foreignKeys[$upperName] = [


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Function `Magento\Framework\DB\Ddl\Table::addForeignKey` has onDelete parameter default to null which leads to be set in the table as NO ACTION

Function `Magento\Framework\DB\Adapter\AdapterInterface::addForeignKey` has onDelete parameters default which leads to be set in the table as CASCADE

This commit makes both to output same results

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
$connection is a `Magento\Framework\DB\Adapter\AdapterInterface` object in this example

`$connection->newTable('TEST')->addForeignKey('TEST_123', 'field', 'customer_entity', 'entity_id')`
vs 
`$connection->addForeignKey('TEST_123', 'TEST', 'field', 'customer_entity', 'entity_id')`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
