### PR TITLE
[Forwardport] [Checkout] Fix clearing admin quote address when removing all items

### DIFF
--- a/app/code/Magento/Checkout/etc/di.xml
+++ b/app/code/Magento/Checkout/etc/di.xml
@@ -49,7 +49,4 @@
             </argument>
         </arguments>
     </type>
-    <type name="Magento\Quote\Model\Quote">
-        <plugin name="clear_addresses_after_product_delete" type="Magento\Checkout\Plugin\Model\Quote\ResetQuoteAddresses"/>
-    </type>
 </config>

--- a/app/code/Magento/Checkout/etc/frontend/di.xml
+++ b/app/code/Magento/Checkout/etc/frontend/di.xml
@@ -96,4 +96,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Quote\Model\Quote">
+        <plugin name="clear_addresses_after_product_delete" type="Magento\Checkout\Plugin\Model\Quote\ResetQuoteAddresses"/>
+    </type>
 </config>

--- a/dev/tests/integration/testsuite/Magento/Checkout/Plugin/Model/Quote/ResetQuoteAddressesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Plugin/Model/Quote/ResetQuoteAddressesTest.php
@@ -22,6 +22,7 @@ class ResetQuoteAddressesTest extends \PHPUnit\Framework\TestCase
     /**
      * @magentoDataFixture Magento/Checkout/_files/quote_with_virtual_product_and_address.php
      *
+     * @magentoAppArea frontend
      * @return void
      */
     public function testAfterRemoveItem(): void


### PR DESCRIPTION
**Related PR** #21051

### Description (*)
After filling in a backend Magento Admin new order and then removing all items from the order creation screen, when you then add an item back in you cannot select any shipping rates and "Sorry, no quotes are available" appears until you modify the address to cause it to re-save the address.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)
1. Login to Magento Admin and go to Sales, Orders and click Create New Order
2. Click Create New Customer
3. Enter a product into the order and complete the email and address fields, unticking shipping same as billing and filling in another address in the shipping address
4. Shipping methods will be visible
5. Now empty the product list and then add another product back in
6. Click get shipping in the shipping area, if there is a link to do so
7. Note it says Sorry, no quotes available even though the address is filled in above
8. Modify address such as telephone number and retry - the shipping methods now appear

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
