### PR TITLE
#19835 Fix admin header buttons flicker

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/templates/pageactions.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/pageactions.phtml
@@ -8,7 +8,7 @@
 
 ?>
 <?php if ($block->getChildHtml()):?>
-    <div data-mage-init='{"floatingHeader": {}}' class="page-actions" <?= /* @escapeNotVerified */ $block->getUiId('content-header') ?>>
+    <div data-mage-init='{"floatingHeader": {}}' class="page-actions floating-header" <?= /* @escapeNotVerified */ $block->getUiId('content-header') ?>>
         <?= $block->getChildHtml() ?>
     </div>
 <?php endif; ?>

--- a/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/_actions-bar.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/_actions-bar.less
@@ -46,6 +46,10 @@
     @_page-action__indent: 1.3rem;
     float: right;
 
+    &.floating-header {
+        &:extend(.page-actions-buttons all);
+    }
+
     .page-main-actions & {
         &._fixed {
             left: @page-wrapper__indent-left;

--- a/lib/web/mage/backend/floating-header.js
+++ b/lib/web/mage/backend/floating-header.js
@@ -48,6 +48,7 @@ define([
             this.element.wrapInner($('<div/>', {
                 'class': 'page-actions-inner', 'data-title': title
             }));
+            this.element.removeClass('floating-header');
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fixed button flicker issue after page load due to re-ordering. 
It happens because "floatingHeader" widget, that wraps header buttons in flex container. However during page loading buttons aren't in flexbox wrapper.

### Fixed Issues (if relevant)
1. magento/magento2#19835: Admin grid button flicker issue after page load due to re-ordering

### Manual testing scenarios (*)
1. Open any admin page with more than 1 button in header. For example: Content -> Design -> Configuration and open design configuration of any scope. During page rendering buttons in header are change their order and can be misclicked to wrong button.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
