### PR TITLE
[Backport] Fixed wrong proxing in the inventory observer

### DIFF
--- a/app/code/Magento/CatalogInventory/etc/di.xml
+++ b/app/code/Magento/CatalogInventory/etc/di.xml
@@ -44,7 +44,7 @@
     </type>
     <type name="Magento\CatalogInventory\Observer\UpdateItemsStockUponConfigChangeObserver">
         <arguments>
-            <argument name="resourceStock" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Proxy</argument>
+            <argument name="resourceStockItem" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Item\Proxy</argument>
         </arguments>
     </type>
     <type name="Magento\Catalog\Model\Layer">


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21731
### Description (*)
FIxed the wrong proxy `resourceStock` argument for the `\Magento\CatalogInventory\Observer\UpdateItemsStockUponConfigChangeObserver`.

![image](https://user-images.githubusercontent.com/20116393/54267634-42c85100-4582-11e9-9c80-9ff1b2c25b91.png)

Module di.xml
` <argument name="resourceStock" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Proxy</argument>`
changed to 
`<argument name="resourceStockItem" xsi:type="object">Magento\CatalogInventory\Model\ResourceModel\Stock\Item\Proxy</argument>`


### Fixed Issues (if relevant)
These changes are needed for 
magento/graphql-ce#167: Add support for '@magentoConfigFixture' annotation on GraphQL API-functional tests
PR: magento/graphql-ce#351

### Manual testing scenarios (*)
No testing scenarios.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
