### PR TITLE
issue #21193

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/Config/Config.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Config/Config.php
@@ -245,7 +245,7 @@ class Config implements \Magento\Framework\ObjectManager\ConfigInterface
                             $this->_mergedArguments = [];
                         }
                         if (isset($this->_arguments[$key])) {
-                            $this->_arguments[$key] = array_replace($this->_arguments[$key], $curConfig['arguments']);
+                            $this->_arguments[$key] = array_replace_recursive($this->_arguments[$key], $curConfig['arguments']);
                         } else {
                             $this->_arguments[$key] = $curConfig['arguments'];
                         }

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/ConfigTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/ConfigTest.php
@@ -98,4 +98,19 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $config->extend(['\Some\Class' => ['shared' => true]]);
         $this->assertTrue($config->isShared('Some\Class'));
     }
+
+    public function testMergeNestedNodes()
+    {
+        /** @var \Magento\Framework\ObjectManager\Config\Config $config */
+        $config = $this->objectManagerHelper->getObject(\Magento\Framework\ObjectManager\Config\Config::class);
+        $config->extend(['Some\Class' => ['arguments' => ['nested' => ['global_scope' => 'value']]]]);
+        $config->extend(['Some\Class' => ['arguments' => ['nested' => ['adminhtml_scope' => 'value']]]]);
+        $actualArguments = $config->getArguments('Some\Class');
+        $this->assertEquals([
+            'nested' => [
+                'global_scope' => 'value',
+                'adminhtml_scope' => 'value'
+            ]
+        ], $actualArguments);
+    }
 }

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/ConfigTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/ConfigTest.php
@@ -101,8 +101,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
 
     public function testMergeNestedNodes()
     {
-        /** @var \Magento\Framework\ObjectManager\Config\Config $config */
-        $config = $this->objectManagerHelper->getObject(\Magento\Framework\ObjectManager\Config\Config::class);
+        $config = new Config();
         $config->extend(['Some\Class' => ['arguments' => ['nested' => ['global_scope' => 'value']]]]);
         $config->extend(['Some\Class' => ['arguments' => ['nested' => ['adminhtml_scope' => 'value']]]]);
         $actualArguments = $config->getArguments('Some\Class');
@@ -112,5 +111,14 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
                 'adminhtml_scope' => 'value'
             ]
         ], $actualArguments);
+    }
+
+    public function testExtendMergeDifferentConfigsNodesWithSlashIgnoring()
+    {
+        /** @var \Magento\Framework\ObjectManager\Config\Config $config */
+        $config = new Config();
+        $config->extend(['Some\Class' => ['arguments' => ['data' => ['key1' => 'value1']]]]);
+        $config->extend(['\Some\Class' => ['arguments' => ['data' => ['key2' => 'value2']]]]);
+        $this->assertEquals(['data' => ['key1' => 'value1', 'key2' => 'value2']], $config->getArguments('Some\Class'));
     }
 }


### PR DESCRIPTION
Fixed merging process in configs between global and scoped (frontend, adminhtml etc) areas.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Fixed merging process in configs between general and specific (frontend, adminhtml etc) areas. 
Magento has a lot classes with array node in constructor used as services pull.
Usage array_replace did replacing nodes on first level of constructor attributes, frontend or adminhtml di totally rewrite services pull node.
Developer want's to have possibility to register different services for different scopes (frontend, adminhtml) without loosing general config.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issue
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21193: Types not merged for etc/di.xml etc/adminhtml/di.xml
2. magento/magento2#20891: Fix issue with di.xml config merging for classes array argument in case of different sources and the class name difference in leading slash.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create new module or use existing
2. Add in etc/adminhtml/di.xml
`
<!-- inside config node -->
    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
        <arguments>
            <argument name="collections" xsi:type="array">
                <item name="cms_page_listing_data_source" xsi:type="string">Magento\Cms\Model\ResourceModel\Page\Grid\Collection</item>
                <item name="custom_listing_data_source_adminhtml" xsi:type="string">Magento\Sales\Model\ResourceModel\Order\Creditmemo\Order\Grid\Collection</item>
            </argument>
        </arguments>
    </type>
`
3. Open Sales -> Order page in admin
4. After fix, grid is opened correct.
Before fix, "Not registered handle sales_order_grid_data_source" error was instead grid

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
