### PR TITLE
When setting `background` for labels explicitly the labels in admin will

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -545,7 +545,6 @@
             & > .admin__field-label {
                 #mix-grid .column(@field-label-grid__column, @field-grid__columns);
                 cursor: pointer;
-                background: @color-white;
                 left: 0;
                 position: absolute;
                 top: 0;


### PR DESCRIPTION
When setting `background` for labels explicitly the labels in admin will
overlap the `::before` pseudo-element.

I suggest to remove explicit setting for `label` element or replace
`@color-white` to `transparent`.

In some cases developers try to hide elements by setting white
background and higher z-index for the element with white background.
But the proper way of hiding elements is to override templates config or
remove elements by JavaScript.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fix for the minor UI regression bug introduced in 5d3870a57594d91884dd80d312983c840780849b.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
**Before:**
![Screenshot_20190318_154354](https://user-images.githubusercontent.com/11827230/54541245-3426d300-49a2-11e9-89f3-8254d6c39e6b.png)

**After:**
![Screenshot_20190318_155539](https://user-images.githubusercontent.com/11827230/54541261-3d17a480-49a2-11e9-9900-8609e0ae9184.png)

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Check that `app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductCreateTest.xml` is passing.
2. Check that fix in 5d3870a57594d91884dd80d312983c840780849b still works.

### Additional Scenario
1. Create custom attribute Yes/No for example
2. Create attribute set based on default and place that attribute after Price attribute
3. Create simple product with that attribute set and save it
4. Edit the product
5. Switch attribute to Default
6. Switch back again

Expected result: Attribute **Weight** is visible

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
