### PR TITLE
category cms block to schema

### DIFF
--- a/app/code/Magento/CmsGraphQl/Model/Resolver/CategoryBlock.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/CategoryBlock.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CmsGraphQl\Model\Resolver;
+
+use Magento\CmsGraphQl\Model\Resolver\DataProvider\Block as BlockDataProvider;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+/**
+ * CMS blocks field resolver, used for GraphQL request processing
+ */
+class CategoryBlock implements ResolverInterface
+{
+    /**
+     * @var BlockDataProvider
+     */
+    private $blockDataProvider;
+
+    /**
+     * @param BlockDataProvider $blockDataProvider
+     */
+    public function __construct(
+        BlockDataProvider $blockDataProvider
+    ) {
+        $this->blockDataProvider = $blockDataProvider;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+
+        if(isset($value['landing_page'])) {
+            $blocksData = $this->getBlocksData($value['landing_page']);
+            return $blocksData;
+        }
+        return [];
+    }
+
+
+    /**
+     * @param string $blockIdentifier
+     * @return array
+     * @throws GraphQlNoSuchEntityException
+     */
+    private function getBlocksData(string $blockIdentifier): array
+    {
+        $blocksData = [];
+        try {
+            $blocksData = $this->blockDataProvider->getData($blockIdentifier);
+        } catch (NoSuchEntityException $e) {
+            throw new GraphQlNoSuchEntityException(__($e->getMessage()), $e);
+        }
+        return $blocksData;
+    }
+}

--- a/app/code/Magento/CmsGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CmsGraphQl/etc/schema.graphqls
@@ -39,3 +39,8 @@ type CmsBlock @doc(description: "CMS block defines all CMS block information") {
     title: String @doc(description: "CMS block title")
     content: String @doc(description: "CMS block content")
 }
+
+interface CategoryInterface  {
+    categoryBlock:
+    CmsBlock @resolver(class: "Magento\\CmsGraphQl\\Model\\Resolver\\CategoryBlock") @doc(description: "The CMS block query returns information about CMS blocks")
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This allows graphql for category to include cmsBlock as part of that query, returning a rendered static block if assigned to the category and called with landing_page

### Manual testing scenarios (*)
Install and configure pwa-studio, in graphql playground, you can open getCategory query  and add the following:

```
landing_page
    				categoryBlock {
              identifier
              content
            }
```
this will return an assigned static block.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
