### PR TITLE
Updated nginx.conf.sample for .well-known

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -33,6 +33,13 @@ charset UTF-8;
 error_page 404 403 = /errors/404.php;
 #add_header "X-UA-Compatible" "IE=Edge";
 
+# Allow .well-known directory to serve files for SSL verification.
+location ^~ /.well-known {
+    alias $MAGE_ROOT/.well-known/;
+    auth_basic off;
+    allow all;
+}
+
 # PHP entry point for setup application
 location ~* ^/setup($|/) {
     root $MAGE_ROOT;


### PR DESCRIPTION
A useful directory for enabling SSL via lets encrypt / cert bot or manually adding SSL certificates.
This was not served when using the sample as a config in Nginx.


Resolves certbot verification
Detail: Invalid response from
.. /.well-known/acme-challenge/RwtcM-....

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
