### PR TITLE
Remove existing rates and compose cross rates

### DIFF
--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currency/SaveRates.php
@@ -11,6 +11,27 @@ use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterf
 
 class SaveRates extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Currency implements HttpPostActionInterface
 {
+    private const TBL_DIRECTORY_CURRENCY_RATE = 'directory_currency_rate';
+
+    /** @var \Magento\Framework\DB\Adapter\AdapterInterface */
+    private $conn;
+    /** @var \Magento\Framework\Locale\FormatInterface */
+    private $format;
+    /** @var \Magento\Framework\App\ResourceConnection */
+    private $resource;
+
+    public function __construct(
+        \Magento\Backend\App\Action\Context $context,
+        \Magento\Framework\Registry $coreRegistry,
+        \Magento\Framework\App\ResourceConnection $resource,
+        \Magento\Framework\Locale\FormatInterface $format
+    ) {
+        parent::__construct($context, $coreRegistry);
+        $this->resource = $resource;
+        $this->conn = $this->resource->getConnection();
+        $this->format = $format;
+    }
+
     /**
      * Save rates action
      *
@@ -21,21 +42,41 @@ class SaveRates extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Curr
         $data = $this->getRequest()->getParam('rate');
         if (is_array($data)) {
             try {
-                foreach ($data as $currencyCode => $rate) {
-                    foreach ($rate as $currencyTo => $value) {
-                        $value = abs($this->_objectManager->get(
-                            \Magento\Framework\Locale\FormatInterface::class
-                        )->getNumber($value));
-                        $data[$currencyCode][$currencyTo] = $value;
-                        if ($value == 0) {
+                /* registry for already processed currencies to build cross rates values */
+                $currenciesProcessed = [];
+                foreach ($data as $currencyCode => $rates) {
+                    foreach ($rates as $currencyTo => $value) {
+                        /* direct rate */
+                        $rateDirect = abs($this->format->getNumber($value));
+                        $data[$currencyCode][$currencyTo] = $rateDirect;
+                        if ($rateDirect == 0) {
                             $this->messageManager->addWarning(
                                 __('Please correct the input data for "%1 => %2" rate.', $currencyCode, $currencyTo)
                             );
+                        } else {
+                            /* reverse rate */
+                            $rateReverse = 1 / $rateDirect;
+                            $rateReverse = abs($this->format->getNumber($rateReverse));
+                            $data[$currencyTo][$currencyCode] = $rateReverse;
+
+                            /* cross rates for already processed currencies */
+                            foreach ($currenciesProcessed as $currencyCross) {
+                                $rateBase = $data[$currencyCode][$currencyCross];
+                                /* direct cross */
+                                $crossDirect = $rateBase / $rateDirect;
+                                $crossDirect = abs($this->format->getNumber($crossDirect));
+                                $data[$currencyTo][$currencyCross] = $crossDirect;
+                                /* reverse cross */
+                                $crossReverse = 1 / $crossDirect;
+                                $crossReverse = abs($this->format->getNumber($crossReverse));
+                                $data[$currencyCross][$currencyTo] = $crossReverse;
+
+                            }
+                            $currenciesProcessed[] = $currencyTo;
                         }
                     }
                 }
-
-                $this->_objectManager->create(\Magento\Directory\Model\Currency::class)->saveRates($data);
+                $this->updateRates($data);
                 $this->messageManager->addSuccess(__('All valid rates have been saved.'));
             } catch (\Exception $e) {
                 $this->messageManager->addError($e->getMessage());
@@ -43,5 +84,27 @@ class SaveRates extends \Magento\CurrencySymbol\Controller\Adminhtml\System\Curr
         }
 
         $this->_redirect('adminhtml/*/');
+    }
+
+    private function removeOldRates()
+    {
+        $table = $this->resource->getTableName(self::TBL_DIRECTORY_CURRENCY_RATE);
+        $this->conn->delete($table);
+    }
+
+    /**
+     * Remove existing rates and save new ones.
+     *
+     * @param $data
+     */
+    private function updateRates($data)
+    {
+        /* this is a controller, so we can wrap DB operations with transaction */
+        $this->conn->beginTransaction();
+        $this->removeOldRates();
+        /** @var \Magento\Directory\Model\Currency $currency */
+        $currency = $this->_objectManager->create(\Magento\Directory\Model\Currency::class);
+        $currency->saveRates($data);
+        $this->conn->commit();
     }
 }


### PR DESCRIPTION
### Description (*)
We should remove old rates we does not use and we need to calculate cross-rates for all used currencies because sales order grid displays wrong currency labels for missed rates (`Grand Total (Purchased)` column).

### Manual testing scenarios (*)
Save these currency rates:

![image](https://user-images.githubusercontent.com/5052385/54622963-445ab300-4a73-11e9-80f8-dcef16bc1ef7.png)

then check `directory_currency_rate` table:
```
currency_from|currency_to|rate          
-------------|-----------|--------------
CNY          |EUR        |0.131147540984
CNY          |USD        |0.149031296572
EUR          |CNY        |7.625000000000
EUR          |USD        |1.136363636364
USD          |CNY        |6.710000000000
USD          |EUR        |0.880000000000
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
