### PR TITLE
[Backport] Update price-bundle.js so that correct tier price is calculated while displaying in bundle product

### DIFF
--- a/app/code/Magento/Bundle/view/base/web/js/price-bundle.js
+++ b/app/code/Magento/Bundle/view/base/web/js/price-bundle.js
@@ -376,12 +376,16 @@ define([
             magicKey = _.keys(oneItemPrice)[0],
             lowest = false;
         
-        //sorting based on "price_qty"
-        if(tiers){
-            tiers.sort(function (a, b) {
-                return a.price_qty - b.price_qty;
-            });
-        }
+        //tiers is undefined when options has only one option 
+		if (undefined == tiers) {
+		    var firstKey = Object.keys(optionConfig)[0];
+		    tiers = optionConfig[firstKey].tierPrice;
+		}
+
+		//sorting based on "price_qty"
+        tiers.sort( function (a, b) {
+            return a['price_qty'] - b['price_qty'];
+        });
 
         _.each(tiers, function (tier, index) {
             if (tier['price_qty'] > qty) {

--- a/app/code/Magento/Bundle/view/base/web/js/price-bundle.js
+++ b/app/code/Magento/Bundle/view/base/web/js/price-bundle.js
@@ -377,9 +377,11 @@ define([
             lowest = false;
         
         //sorting based on "price_qty"
-        tiers.sort(function(a, b) {
-            return a.price_qty - b.price_qty;
-        });
+        if(tiers){
+            tiers.sort(function (a, b) {
+                return a.price_qty - b.price_qty;
+            });
+        }
 
         _.each(tiers, function (tier, index) {
             if (tier['price_qty'] > qty) {

--- a/app/code/Magento/Bundle/view/base/web/js/price-bundle.js
+++ b/app/code/Magento/Bundle/view/base/web/js/price-bundle.js
@@ -381,7 +381,7 @@ define([
             tiers = optionConfig[tiersFirstKey].tierPrice;
         }
 
-        tiers.sort( function (a, b) {//sorting based on "price_qty"
+        tiers.sort(function (a, b) {//sorting based on "price_qty"
             return a['price_qty'] - b['price_qty'];
         });
 

--- a/app/code/Magento/Bundle/view/base/web/js/price-bundle.js
+++ b/app/code/Magento/Bundle/view/base/web/js/price-bundle.js
@@ -374,16 +374,14 @@ define([
     function applyTierPrice(oneItemPrice, qty, optionConfig) {
         var tiers = optionConfig.tierPrice,
             magicKey = _.keys(oneItemPrice)[0],
+            tiersFirstKey = _.keys(optionConfig)[0],
             lowest = false;
-        
-        //tiers is undefined when options has only one option 
-		if (undefined == tiers) {
-		    var firstKey = Object.keys(optionConfig)[0];
-		    tiers = optionConfig[firstKey].tierPrice;
-		}
 
-		//sorting based on "price_qty"
-        tiers.sort( function (a, b) {
+        if (undefined === tiers) {//tiers is undefined when options has only one option
+            tiers = optionConfig[tiersFirstKey].tierPrice;
+        }
+
+        tiers.sort( function (a, b) {//sorting based on "price_qty"
             return a['price_qty'] - b['price_qty'];
         });
 

--- a/app/code/Magento/Bundle/view/base/web/js/price-bundle.js
+++ b/app/code/Magento/Bundle/view/base/web/js/price-bundle.js
@@ -375,6 +375,11 @@ define([
         var tiers = optionConfig.tierPrice,
             magicKey = _.keys(oneItemPrice)[0],
             lowest = false;
+        
+        //sorting based on "price_qty"
+        tiers.sort(function(a, b) {
+            return a.price_qty - b.price_qty;
+        });
 
         _.each(tiers, function (tier, index) {
             if (tier['price_qty'] > qty) {

--- a/app/code/Magento/Bundle/view/base/web/js/price-bundle.js
+++ b/app/code/Magento/Bundle/view/base/web/js/price-bundle.js
@@ -377,7 +377,7 @@ define([
             tiersFirstKey = _.keys(optionConfig)[0],
             lowest = false;
 
-        if (undefined === tiers) {//tiers is undefined when options has only one option
+        if (!tiers) {//tiers is undefined when options has only one option
             tiers = optionConfig[tiersFirstKey].tierPrice;
         }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21469
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
By default tier price is sorted by "price_id". With this tier price calculation while displaying in bundle product is wrong. Need to sort tier price by "price_qty".

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21467: Tier price of simple item not working in Bundle product

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create tier price as per described in above issue

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
