### PR TITLE
[Backport][Review] Fix Pending Reviews label, add menu for pending review

### DIFF
--- a/app/code/Magento/Review/Block/Adminhtml/Edit.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Edit.php
@@ -159,13 +159,13 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
         }
 
         if ($this->getRequest()->getParam('ret', false) == 'pending') {
-            $this->buttonList->update('back', 'onclick', 'setLocation(\'' . $this->getUrl('catalog/*/pending') . '\')');
+            $this->buttonList->update('back', 'onclick', 'setLocation(\'' . $this->getUrl('review/*/pending') . '\')');
             $this->buttonList->update(
                 'delete',
                 'onclick',
                 'deleteConfirm(' . '\'' . __(
                     'Are you sure you want to do this?'
-                ) . '\' ' . '\'' . $this->getUrl(
+                ) . '\', ' . '\'' . $this->getUrl(
                     '*/*/delete',
                     [$this->_objectId => $this->getRequest()->getParam($this->_objectId), 'ret' => 'pending']
                 ) . '\'' . ')'

--- a/app/code/Magento/Review/Block/Adminhtml/Edit.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Edit.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Review\Block\Adminhtml;
 
 /**
@@ -56,6 +57,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
      *
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @SuppressWarnings(PHPMD.RequestAwareBlockMethod)
      */
     protected function _construct()
     {

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/Save.php
@@ -9,9 +9,14 @@ use Magento\Review\Controller\Adminhtml\Product as ProductController;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
 
+/**
+ * Save Review action.
+ */
 class Save extends ProductController
 {
     /**
+     * Save Review action.
+     *
      * @return \Magento\Backend\Model\View\Result\Redirect
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
@@ -63,7 +68,7 @@ class Save extends ProductController
             if ($nextId) {
                 $resultRedirect->setPath('review/*/edit', ['id' => $nextId]);
             } elseif ($this->getRequest()->getParam('ret') == 'pending') {
-                $resultRedirect->setPath('*/*/pending');
+                $resultRedirect->setPath('review/*/pending');
             } else {
                 $resultRedirect->setPath('*/*/');
             }

--- a/app/code/Magento/Review/etc/acl.xml
+++ b/app/code/Magento/Review/etc/acl.xml
@@ -17,7 +17,7 @@
                 <resource id="Magento_Backend::marketing">
                     <resource id="Magento_Backend::marketing_user_content">
                         <resource id="Magento_Review::reviews_all" title="Reviews" translate="title" sortOrder="10"/>
-                        <resource id="Magento_Review::pending" title="Reviews" translate="title" sortOrder="20"/>
+                        <resource id="Magento_Review::pending" title="Pending Reviews" translate="title" sortOrder="20"/>
                     </resource>
                 </resource>
             </resource>

--- a/app/code/Magento/Review/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Review/etc/adminhtml/menu.xml
@@ -9,6 +9,7 @@
     <menu>
         <add id="Magento_Review::catalog_reviews_ratings_ratings" title="Rating" translate="title" module="Magento_Review" sortOrder="60" parent="Magento_Backend::stores_attributes" action="review/rating/" resource="Magento_Review::ratings"/>
         <add id="Magento_Review::catalog_reviews_ratings_reviews_all" title="Reviews" translate="title" module="Magento_Review" parent="Magento_Backend::marketing_user_content" sortOrder="10" action="review/product/index" resource="Magento_Review::reviews_all"/>
+        <add id="Magento_Review::catalog_reviews_ratings_pending" title="Pending Reviews" translate="title" module="Magento_Review" parent="Magento_Backend::marketing_user_content" sortOrder="15" action="review/product/pending" resource="Magento_Review::pending"/>
         <add id="Magento_Review::report_review" title="Reviews" translate="title" module="Magento_Reports" sortOrder="20" parent="Magento_Reports::report" resource="Magento_Reports::review"/>
         <add id="Magento_Review::report_review_customer" title="By Customers" translate="title" sortOrder="10" module="Magento_Review" parent="Magento_Review::report_review" action="reports/report_review/customer" resource="Magento_Reports::review_customer"/>
         <add id="Magento_Review::report_review_product" title="By Products" translate="title" sortOrder="20" module="Magento_Review" parent="Magento_Review::report_review" action="reports/report_review/product" resource="Magento_Reports::review_product"/>


### PR DESCRIPTION
### Original PR #20936
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20924: Reviews ACL issue - showing Reviews menu two times under System > User Roles > Add New Role > Role Resources
2. ...

### Manual testing scenarios (*)
1. Go to System > User Roles > Add New Role > Role Resources. Changed label for Pending Reviews menu. [Screenshot](https://www.dropbox.com/s/zsmcbce0s2y2qbe/review_acl_pending.png)
2. Added Pending Reviews menu under Marketing > User Content. [Screenshot](https://www.dropbox.com/s/aatb0k5vczu670k/reviews_pending_menu.png)
3. Edit a review from Pending Reviews grid then on click Back button it was redirecting to the wrong path.
4. Edit a review from Pending Reviews grid then on Save Review it was redirecting to the wrong path. [Screenshot](https://www.dropbox.com/s/anmar1wu4b5oj44/back_review_delete_alert.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
