### PR TITLE
[Frontend] Fixing the accessibility standards violation

### DIFF
--- a/lib/web/css/source/lib/_resets.less
+++ b/lib/web/css/source/lib/_resets.less
@@ -105,13 +105,6 @@
             .lib-css(box-shadow, @focus__box-shadow);
         }
     }
-
-    input[type="radio"],
-    input[type="checkbox"] {
-        &:focus { 
-            box-shadow: none;
-        }
-    }
 }
 
 //


### PR DESCRIPTION
### Description (*)
This PR reverts the changes made in #20861, because those changes violate the accessibility standards when navigating with keyboard.

2.1 Keyboard Accessible: **Make all functionality available from a keyboard.**
_Source:_ https://www.w3.org/TR/WCAG20/#keyboard-operation

Also the confirmed issue #20859 isn't actual.

So we should keep the shadow on focus for radio and checkboxes to make the keyboard navigation smoother.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open any page with the form containing checkboxes or radio buttons.
2. You should be able to navigate through the form using keyboard (tab key).
3. The checkboxes and radio buttons should be highlighted on focus while navigating through the form.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
