### PR TITLE
Default empty array for $batchSizeAdjusters

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/BatchSizeCalculator.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/BatchSizeCalculator.php
@@ -32,7 +32,7 @@ class BatchSizeCalculator
      * @param array $estimators
      * @param array $batchSizeAdjusters
      */
-    public function __construct(array $batchRowsCount, array $estimators, array $batchSizeAdjusters)
+    public function __construct(array $batchRowsCount, array $estimators, array $batchSizeAdjusters = [])
     {
         $this->batchRowsCount = $batchRowsCount;
         $this->estimators = $estimators;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Removing module-bundle, module-configurable and module-grouped will lead into error during price reindex.
This is caused because this three modules implement in di.xml an array value for `batchSizeAdjusters`. Removing they batchSizeAdjusters will be null.
Simple product and virtual product don't set any batchSizeAdjusters on di.xml because they don't need.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21854: Missing required argument $batchSizeAdjusters of Magento\Catalog\Model\ResourceModel\Product\Indexer\Price\BatchSizeCalculator 

### Manual testing scenarios (*)
1. disable module-bundle, module-configurable and module-grouped in composer.json 
```
"replace": {
  "magento/module-bundle": "*",
  "magento/module-grouped": "*",
  "magento/module-configurable":"*"
}
```
2. run `bin/magento index:reindex catalog_product_price`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
