### PR TITLE
[Backport] fix #21750 remove translation of product attribute label

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/attributes.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/attributes.phtml
@@ -23,8 +23,8 @@
             <tbody>
             <?php foreach ($_additional as $_data): ?>
                 <tr>
-                    <th class="col label" scope="row"><?= $block->escapeHtml(__($_data['label'])) ?></th>
-                    <td class="col data" data-th="<?= $block->escapeHtml(__($_data['label'])) ?>"><?= /* @escapeNotVerified */ $_helper->productAttribute($_product, $_data['value'], $_data['code']) ?></td>
+                    <th class="col label" scope="row"><?= $block->escapeHtml($_data['label']) ?></th>
+                    <td class="col data" data-th="<?= $block->escapeHtml($_data['label']) ?>"><?= /* @escapeNotVerified */ $_helper->productAttribute($_product, $_data['value'], $_data['code']) ?></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21751
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Removed translation of attribute label

### Fixed Issues (if relevant)
1. magento/magento2#21750: Product attribute labels are translated


### Manual testing scenarios (*)
Add product attribute into product page.
Add store specific label
add same phrase into translation file
Expected result (*)
Attribute label is not translated and kept as set in admin (store specific label)
Actual result (*)
Attribute label is translated

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
