### PR TITLE
Add getDescendantHtml() and getDescendantBlock() method to AbstractBlock class.

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/AbstractBlock.php
+++ b/lib/internal/Magento/Framework/View/Element/AbstractBlock.php
@@ -487,6 +487,37 @@ abstract class AbstractBlock extends \Magento\Framework\DataObject implements Bl
     }
 
     /**
+     * Retrive descendant block by name
+     *
+     * @param string $alias
+     * @return \Magento\Framework\View\Element\AbstractBlock|bool
+     */
+    public function getDescendantBlock($alias)
+    {
+        $parent = $this;
+        $child = $parent->getChildBlock($alias);
+
+        if ($child) {
+            return $child;
+        } else {
+            $layout = $parent->getLayout();
+            $name = $parent->getNameInLayout();
+
+            foreach ($layout->getChildBlocks($name) as $child) {
+                $descendant = $child->getDescendantBlock($alias);
+
+                if ($descendant) {
+                    return $descendant;
+                }
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    /**
      * Retrieve child block HTML
      *
      * @param   string $alias
@@ -513,6 +544,25 @@ abstract class AbstractBlock extends \Magento\Framework\DataObject implements Bl
         }
 
         return $out;
+    }
+
+    /**
+     * Retrieve descendant block HTML
+     *
+     * @param   string $alias
+     * @param   boolean $useCache
+     * @return  string
+     */
+    public function getDescendantHtml($alias, $useCache = true)
+    {
+        $descendant = $this->getDescendantBlock($alias);
+
+        if ($descendant) {
+            $layout = $descendant->getLayout();
+            return $layout->renderElement($alias, $useCache);
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
We need to render descendant elements which are not direct children from template sometimes.

There is already getChildHtml() and even getChildChildHtml() methods there, while the getChildChildHtml() can only reach 2 levels deep.

So the purpose of getDescendantHtml() and getDescendantBlock() is to provide a general approach to search though the element tree.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
N/A

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Test out this method from a template file, for example:

    ```
    <div class="menu-area">
        <a href="javascript:void(0)" class="shop-menu">Shop</a>
        <?php echo $this->getDescendantHtml("store.menu"); ?>
    </div>
    ```

### Contribution checklist (*)
 - [* ] Pull request has a meaningful description of its purpose
 - [* ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
