### PR TITLE
$product->getUrlInStore() does not allow to override the scope in backend context

### DIFF
--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -13,6 +13,7 @@ use Magento\Framework\App\ObjectManager;
  * Class \Magento\Backend\Model\UrlInterface
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  * @api
  * @since 100.0.2
  */
@@ -367,6 +368,19 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
     }
 
     /**
+     * Set scope entity
+     *
+     * @param mixed $scopeId
+     * @return \Magento\Framework\UrlInterface
+     */
+    public function setScope($scopeId)
+    {
+        parent::setScope($scopeId);
+        $this->_scope = $this->_scopeResolver->getScope($scopeId);
+        return $this;
+    }
+
+    /**
      * Set custom auth session
      *
      * @param \Magento\Backend\Model\Auth\Session $session
@@ -402,13 +416,13 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
     }
 
     /**
-     * Retrieve action path.
-     * Add backend area front name as a prefix to action path
+     * Retrieve action path, add backend area front name as a prefix to action path
      *
      * @return string
      */
     protected function _getActionPath()
     {
+
         $path = parent::_getActionPath();
         if ($path) {
             if ($this->getAreaFrontName()) {
@@ -448,8 +462,7 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
     }
 
     /**
-     * Get config data by path
-     * Use only global config values for backend
+     * Get config data by path, use only global config values for backend
      *
      * @param string $path
      * @return null|string

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/UrlTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/UrlTest.php
@@ -42,6 +42,46 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->assertStringEndsWith('simple-product.html', $this->_model->getUrlInStore($product));
     }
 
+    /**
+     * @magentoDataFixture Magento/Store/_files/second_store.php
+     * @magentoConfigFixture default_store web/unsecure/base_url http://sample.com/
+     * @magentoConfigFixture default_store web/unsecure/base_link_url http://sample.com/
+     * @magentoConfigFixture fixturestore_store web/unsecure/base_url http://sample-second.com/
+     * @magentoConfigFixture fixturestore_store web/unsecure/base_link_url http://sample-second.com/
+     * @magentoDataFixture Magento/Catalog/_files/product_simple_multistore.php
+     * @dataProvider getUrlsWithSecondStoreProvider
+     * @magentoAppArea adminhtml
+     */
+    public function testGetUrlInStoreWithSecondStore($storeCode, $expectedProductUrl)
+    {
+        $repository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Catalog\Model\ProductRepository::class
+        );
+        /** @var \Magento\Store\Model\Store $store */
+        $store = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+            ->create(\Magento\Store\Model\Store::class);
+        $store->load($storeCode, 'code');
+        /** @var \Magento\Store\Model\Store $store */
+
+        $product = $repository->get('simple');
+
+        $this->assertEquals(
+            $expectedProductUrl,
+            $this->_model->getUrlInStore($product, ['_scope' => $store->getId(), '_nosid' => true])
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function getUrlsWithSecondStoreProvider()
+    {
+        return [
+           'case1' => ['fixturestore', 'http://sample-second.com/index.php/simple-product-one.html'],
+           'case2' => ['default', 'http://sample.com/index.php/simple-product-one.html']
+        ];
+    }
+
     public function testGetProductUrl()
     {
         $repository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(


### PR DESCRIPTION
### Description (*)
Magento always uses the 'admin' scope (and the default base url) to retrieve product url and returns incorrect url.

By calling the method $product->getUrlInStore(['_scope' => 2, '_nosid' => true]); I'm always retreiving the product's url with default scope in it. (for example http://default.website/catalog/product/view/...)

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/4247 getProductUrl does not allow to override the scope in backend context

### Manual testing scenarios (*)
On backend edit page try to get product url from second website
1. Create 2 websites
2. Set difference web urls for websites
3. get product Url on adminhtml in product Edit $product->getUrlInStore(['_scope' => 2, '_nosid' => true]); 
4. You must have url like http://second.website/product.html

Same steps on frontend.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
