### PR TITLE
Contact us layout in I-pad not proper

### DIFF
--- a/app/code/Magento/Contact/view/frontend/web/css/source/_module.less
+++ b/app/code/Magento/Contact/view/frontend/web/css/source/_module.less
@@ -16,6 +16,7 @@
             .form.contact {
                 float: none;
                 width: 50%;
+                min-width: 600px;
             }
         }
     }

--- a/app/code/Magento/Contact/view/frontend/web/css/source/_module.less
+++ b/app/code/Magento/Contact/view/frontend/web/css/source/_module.less
@@ -16,9 +16,18 @@
             .form.contact {
                 float: none;
                 width: 50%;
-                min-width: 600px;
             }
         }
+    }
+}
+
+//
+// Desktop
+// _____________________________________________
+
+.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
+    .contact-index-index .column:not(.sidebar-additional) .form.contact {
+        min-width: 600px;
     }
 }
 
@@ -36,7 +45,6 @@
             .form.contact {
                 float: none;
                 width: 100%;
-                min-width: auto;
             }
         }
     }

--- a/app/code/Magento/Contact/view/frontend/web/css/source/_module.less
+++ b/app/code/Magento/Contact/view/frontend/web/css/source/_module.less
@@ -36,6 +36,7 @@
             .form.contact {
                 float: none;
                 width: 100%;
+                min-width: auto;
             }
         }
     }

--- a/app/code/Magento/Contact/view/frontend/web/css/source/_module.less
+++ b/app/code/Magento/Contact/view/frontend/web/css/source/_module.less
@@ -22,8 +22,8 @@
 }
 
 //
-// Desktop
-// _____________________________________________
+//  Desktop
+//  _____________________________________________
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .contact-index-index .column:not(.sidebar-additional) .form.contact {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Contact us layout in I-pad not proper

### Preconditions (*)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Magento 2.3, 2.2
2. Contact us layout in I-pad not proper

### Steps to reproduce (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open contact us form in I-pad

### Expected result (*)
1. If you check the create account form, orders and returns form, advance search form (forms in I-pad views) - it behaves much better in terms of responsive design.

![Contact_Us_1](https://user-images.githubusercontent.com/18118631/54825044-9baa8e80-4cd2-11e9-8dff-3eb6df68d8bb.jpg)

### Actual result (*)
1. If you take a look at iPad resolution - the form is quite small

![Contact_Us_2](https://user-images.githubusercontent.com/18118631/54825074-b11fb880-4cd2-11e9-9e5a-c458e47904e4.jpg)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
