### PR TITLE
Issue#21232

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/Attributes.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/Attributes.php
@@ -87,6 +87,7 @@ class Attributes extends \Magento\Catalog\Block\Adminhtml\Form implements
          * for using it in elements generation
          */
         $form->setDataObject($this->_productFactory->create());
+        $form->setHtmlIdPrefix('attributes_');
         $this->_setFieldset($attributes, $fieldset, $this->getFormExcludedFieldList());
         $form->setFieldNameSuffix('attributes');
         $this->setForm($form);
@@ -127,7 +128,7 @@ class Attributes extends \Magento\Catalog\Block\Adminhtml\Form implements
     {
         // Add name attribute to checkboxes that correspond to multiselect elements
         $nameAttributeHtml = $element->getExtType() === 'multiple' ? 'name="' . $element->getId() . '_checkbox"' : '';
-        $elementId = $element->getId();
+        $elementId = $element->getHtmlId();
         $dataAttribute = "data-disable='{$elementId}'";
         $dataCheckboxName = "toggle_" . "{$elementId}";
         $checkboxLabel = __('Change');

--- a/app/code/Magento/Catalog/Test/Mftf/Data/ProductAttributeData.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Data/ProductAttributeData.xml
@@ -115,4 +115,25 @@
         <data key="used_for_sort_by">true</data>
         <requiredEntity type="FrontendLabel">ProductAttributeFrontendLabel</requiredEntity>
     </entity>
+    <entity name="productAttributeWithCodeContainer" type="ProductAttribute">
+        <data key="attribute_code">container</data>
+        <data key="frontend_input">select</data>
+        <data key="scope">global</data>
+        <data key="is_required">false</data>
+        <data key="is_unique">false</data>
+        <data key="is_searchable">true</data>
+        <data key="is_visible">true</data>
+        <data key="is_visible_in_advanced_search">true</data>
+        <data key="is_visible_on_front">true</data>
+        <data key="is_filterable">true</data>
+        <data key="is_filterable_in_search">true</data>
+        <data key="used_in_product_listing">true</data>
+        <data key="is_used_for_promo_rules">true</data>
+        <data key="is_comparable">true</data>
+        <data key="is_used_in_grid">true</data>
+        <data key="is_visible_in_grid">true</data>
+        <data key="is_filterable_in_grid">true</data>
+        <data key="used_for_sort_by">true</data>
+        <requiredEntity type="FrontendLabel">ProductAttributeFrontendLabel</requiredEntity>
+    </entity>
 </entities>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminEditProductAttributesSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminEditProductAttributesSection.xml
@@ -9,14 +9,18 @@
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="AdminEditProductAttributesSection">
-        <element name="AttributeName" type="text" selector="#name"/>
-        <element name="ChangeAttributeNameToggle" type="checkbox" selector="#toggle_name"/>
-        <element name="NameError" type="text" selector="#name-error"/>
-        <element name="AttributePrice" type="text" selector="#price"/>
-        <element name="ChangeAttributePriceToggle" type="checkbox" selector="#toggle_price"/>
-        <element name="PriceError" type="text" selector="#price-error"/>
-        <element name="AttributeDescription" type="text" selector="#description"/>
-        <element name="ChangeAttributeDescriptionToggle" type="checkbox" selector="#toggle_description"/>
+        <element name="AttributeName" type="text" selector="#attributes_name"/>
+        <element name="AttributeNameDisabled" type="text" selector="#attributes_name[disabled]"/>
+        <element name="ChangeAttributeNameToggle" type="checkbox" selector="#toggle_attributes_name"/>
+        <element name="AttributeContainer" type="select" selector="#attributes_container"/>
+        <element name="AttributeContainerDisabled" type="select" selector="#attributes_container[disabled]"/>
+        <element name="ChangeAttributeContainerToggle" type="checkbox" selector="#toggle_attributes_container"/>
+        <element name="NameError" type="text" selector="#attributes_name-error"/>
+        <element name="AttributePrice" type="text" selector="#attributes_price"/>
+        <element name="ChangeAttributePriceToggle" type="checkbox" selector="#toggle_attributes_price"/>
+        <element name="PriceError" type="text" selector="#attributes_price-error"/>
+        <element name="AttributeDescription" type="text" selector="#attributes_description"/>
+        <element name="ChangeAttributeDescriptionToggle" type="checkbox" selector="#toggle_attributes_description"/>
         <element name="Save" type="button" selector="button[title=Save]" timeout="30"/>
         <element name="defaultLabel" type="text" selector="//td[contains(text(), '{{attributeName}}')]/following-sibling::td[contains(@class, 'col-frontend_label')]" parameterized="true"/>
     </section>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassUpdateProductAttributesMissingRequiredFieldTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassUpdateProductAttributesMissingRequiredFieldTest.xml
@@ -28,12 +28,17 @@
             <createData entity="ApiSimpleProduct" stepKey="createProductTwo">
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
+            <createData entity="productAttributeWithCodeContainer" stepKey="createAttributeWithCodeContainer"/>
+            <createData entity="AddToDefaultSet" stepKey="createAttributeWithCodeContainerAddToAttributeSet">
+                <requiredEntity createDataKey="createAttributeWithCodeContainer"/>
+            </createData>
         </before>
         <after>
             <amOnPage url="{{AdminLogoutPage.url}}" stepKey="amOnLogoutPage"/>
             <deleteData createDataKey="createProductOne" stepKey="deleteProductOne"/>
             <deleteData createDataKey="createProductTwo" stepKey="deleteProductTwo"/>
             <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <deleteData createDataKey="createAttributeWithCodeContainer" stepKey="deleteAttributeWithCodeContainer"/>
         </after>
 
         <!-- Search and select products -->
@@ -50,6 +55,10 @@
         <waitForPageLoad stepKey="waitForBulkUpdatePage"/>
         <seeInCurrentUrl stepKey="seeInUrl" url="catalog/product_action_attribute/edit/"/>
         <click selector="{{AdminEditProductAttributesSection.ChangeAttributeNameToggle}}" stepKey="toggleToChangeName"/>
+        <seeElement stepKey="seeDisabled" selector="{{AdminEditProductAttributesSection.AttributeContainerDisabled}}"/>
+        <click selector="{{AdminEditProductAttributesSection.ChangeAttributeContainerToggle}}" stepKey="toggleToEnableContainerAttribute"/>
+        <seeElement stepKey="seeEnabled" selector="{{AdminEditProductAttributesSection.AttributeContainer}}"/>
+        <click selector="{{AdminEditProductAttributesSection.ChangeAttributeContainerToggle}}" stepKey="toggleToDisableContainerAttribute"/>
         <click selector="{{AdminEditProductAttributesSection.Save}}" stepKey="save"/>
         <see stepKey="seeError" selector="{{AdminEditProductAttributesSection.NameError}}" userInput="This is a required field"/>
     </test>


### PR DESCRIPTION
### Description (*)

Added "attributes_" prefiix to id of input fields of attributes in Mass Update Products Attributes page

### Fixed Issues
magento/magento2#21232:  Custom select attribute code "container" breaks javascript on update attributes

### Manual testing scenarios (*)
    Create a custom select attribute with a code of "container"
    Go to the Catalog->Products and check the box next to at least one product.
    Click the Action dropdown and select "Update Attributes"
    Scroll down until you see your container attribute and you will see that it is not disabled

### Contribution checklist (*)
 - [*] Pull request has a meaningful description of its purpose
 - [*] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [*] All automated tests passed successfully (all builds on Travis CI are green)
