### PR TITLE
Magento backend catalog MSRP without currency symbol

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
@@ -190,6 +190,13 @@
                 <label translate="true">Websites</label>
             </settings>
         </column>
+        <column name="special_price" class="Magento\Catalog\Ui\Component\Listing\Columns\Price" sortOrder="110">
+            <settings>
+                <addField>true</addField>
+                <filter>textRange</filter>
+                <label translate="true">Special Price</label>
+            </settings>
+        </column>
         <column name="cost" class="Magento\Catalog\Ui\Component\Listing\Columns\Price" sortOrder="120">
             <settings>
                 <addField>true</addField>

--- a/app/code/Magento/Msrp/view/adminhtml/ui_component/product_listing.xml
+++ b/app/code/Magento/Msrp/view/adminhtml/ui_component/product_listing.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <columns name="product_columns" class="Magento\Catalog\Ui\Component\Listing\Columns">
+        <column name="msrp" class="Magento\Catalog\Ui\Component\Listing\Columns\Price" sortOrder="130">
+            <settings>
+                <addField>true</addField>
+                <filter>textRange</filter>
+                <label translate="true">Manufacturer's Suggested Retail Price</label>
+            </settings>
+        </column>
+    </columns>
+</listing>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed Magento backend catalog "MSRP" without currency symbol.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21910: Magento backend catalog "MSRP" without currency symbol

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Admin Menu > Stores > Settings > Configuration > Sales > Minimum Advertised Price = Yes
2. Navigate to admin catalog product grid
3. Using "Columns" selection, add 'Manufacturer's Suggested Retail Price'(MSRP) column in the grid

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
