### PR TITLE
Prevent duplicate variation error during import of configurable products with numerical SKUs

### DIFF
--- a/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
@@ -596,7 +596,7 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
                     $additionalRow['_super_attribute_position'] = $position;
                     $additionalRows[] = $additionalRow;
                     $additionalRow = [];
-                    $position += 1;
+                    $position ++;
                 }
             } else {
                 throw new LocalizedException(

--- a/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableImportExport/Model/Import/Product/Type/Configurable.php
@@ -937,7 +937,7 @@ class Configurable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
         }
         foreach ($dataWithExtraVirtualRows as $option) {
             if (isset($option['_super_products_sku'])) {
-                if (in_array($option['_super_products_sku'], $skus)) {
+                if (in_array($option['_super_products_sku'], $skus, true)) {
                     $error = true;
                     $this->_entityModel->addRowError(
                         sprintf(

--- a/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Import/Product/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Import/Product/Type/ConfigurableTest.php
@@ -636,16 +636,61 @@ class ConfigurableTest extends \Magento\ImportExport\Test\Unit\Model\Import\Abst
             ]
         );
 
+        $rowValidationDataProvider = $this->rowValidationDataProvider();
+
         // Checking that variations with duplicate sku are invalid
-        $duplicateProduct = $this->_getNumericalSkuDataDuplicate();
-        $result = $this->configurable->isRowValid($duplicateProduct, 0);
+        $result = $this->configurable->isRowValid($rowValidationDataProvider['duplicateProduct'], 0);
         $this->assertFalse($result);
 
         // Checking that variations with SKUs that are the same when interpreted as number,
         // but different when interpreted as string are valid
-        $nonDuplicateProduct = $this->_getNumericalSkuDataNonDuplicate();
-        $result = $this->configurable->isRowValid($nonDuplicateProduct, 0);
+        $result = $this->configurable->isRowValid($rowValidationDataProvider['nonDuplicateProduct'], 0);
         $this->assertTrue($result);
+    }
+
+    /**
+     * @return array
+     */
+    public function rowValidationDataProvider()
+    {
+        return [
+            'duplicateProduct' => [
+                'sku' => 'configurableNumericalSkuDuplicateVariation',
+                'store_view_code' => null,
+                'attribute_set_code' => 'Default',
+                'product_type' => 'configurable',
+                'name' => 'Configurable Product with duplicate numerical SKUs in variations',
+                'product_websites' => 'website_1',
+                'configurable_variation_labels' => 'testattr2=Select Configuration',
+                'configurable_variations' => 'sku=1234.1,'
+                    . 'testattr2=attr2val1,'
+                    . 'display=1|sku=1234.1,'
+                    . 'testattr2=attr2val1,'
+                    . 'display=0',
+                '_store' => null,
+                '_attribute_set' => 'Default',
+                '_type' => 'configurable',
+                '_product_websites' => 'website_1',
+            ],
+            'nonDuplicateProduct' => [
+                'sku' => 'configurableNumericalSkuNonDuplicateVariation',
+                'store_view_code' => null,
+                'attribute_set_code' => 'Default',
+                'product_type' => 'configurable',
+                'name' => 'Configurable Product with different numerical SKUs in variations',
+                'product_websites' => 'website_1',
+                'configurable_variation_labels' => 'testattr2=Select Configuration',
+                'configurable_variations' => 'sku=1234.10,'
+                    . 'testattr2=attr2val1,'
+                    . 'display=1|sku=1234.1,'
+                    . 'testattr2=attr2val2,'
+                    . 'display=0',
+                '_store' => null,
+                '_attribute_set' => 'Default',
+                '_type' => 'configurable',
+                '_product_websites' => 'website_1',
+            ]
+        ];
     }
 
     /**
@@ -663,55 +708,5 @@ class ConfigurableTest extends \Magento\ImportExport\Test\Unit\Model\Import\Abst
         $reflectionProperty->setValue($object, $value);
 
         return $object;
-    }
-
-    /**
-     * @return array
-     */
-    protected function _getNumericalSkuDataNonDuplicate(): array
-    {
-        return [
-            'sku' => 'configurableNumericalSkuNonDuplicateVariation',
-            'store_view_code' => null,
-            'attribute_set_code' => 'Default',
-            'product_type' => 'configurable',
-            'name' => 'Configurable Product with different numerical SKUs in variations',
-            'product_websites' => 'website_1',
-            'configurable_variation_labels' => 'testattr2=Select Configuration',
-            'configurable_variations' => 'sku=1234.10,'
-                . 'testattr2=attr2val1,'
-                . 'display=1|sku=1234.1,'
-                . 'testattr2=attr2val2,'
-                . 'display=0',
-            '_store' => null,
-            '_attribute_set' => 'Default',
-            '_type' => 'configurable',
-            '_product_websites' => 'website_1',
-        ];
-    }
-
-    /**
-     * @return array
-     */
-    protected function _getNumericalSkuDataDuplicate(): array
-    {
-        return [
-            'sku' => 'configurableNumericalSkuDuplicateVariation',
-            'store_view_code' => null,
-            'attribute_set_code' => 'Default',
-            'product_type' => 'configurable',
-            'name' => 'Configurable Product with duplicate numerical SKUs in variations',
-            'product_websites' => 'website_1',
-            'configurable_variation_labels' => 'testattr2=Select Configuration',
-            'configurable_variations' => 'sku=1234.1,'
-                . 'testattr2=attr2val1,'
-                . 'display=1|sku=1234.1,'
-                . 'testattr2=attr2val1,'
-                . 'display=0',
-            '_store' => null,
-            '_attribute_set' => 'Default',
-            '_type' => 'configurable',
-            '_product_websites' => 'website_1',
-        ];
     }
 }

--- a/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Import/Product/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Import/Product/Type/ConfigurableTest.php
@@ -586,8 +586,55 @@ class ConfigurableTest extends \Magento\ImportExport\Test\Unit\Model\Import\Abst
             '_type' => 'configurable',
             '_product_websites' => 'website_1',
         ];
+        // Checking that variations with duplicate sku are invalid
+        $duplicateVariationSKU = 'configurableskuI22DuplicateVariation';
+        $duplicateVariationProduct = [
+            'sku' => $duplicateVariationSKU,
+            'store_view_code' => null,
+            'attribute_set_code' => 'Default',
+            'product_type' => 'configurable',
+            'name' => 'Configurable Product with duplicate SKUs in variations',
+            'product_websites' => 'website_1',
+            'configurable_variation_labels' => 'testattr2=Select Color, testattr3=Select Size',
+            'configurable_variations' => 'sku=testconf2-attr2val1-testattr3v1,'
+                . 'testattr2=attr2val1,'
+                . 'testattr3=testattr3v1,'
+                . 'display=1|sku=testconf2-attr2val1-testattr3v1,'
+                . 'testattr2=attr2val1,'
+                . 'testattr3=testattr3v2,'
+                . 'display=0',
+            '_store' => null,
+            '_attribute_set' => 'Default',
+            '_type' => 'configurable',
+            '_product_websites' => 'website_1',
+        ];
+        // Checking that variations with SKUs that are the same when interpreted as number,
+        // but different when interpreted as string are valid
+        $nonDuplicateVariationSKU = 'configurableskuI22NonDuplicateVariation';
+        $nonDuplicateVariationProduct = [
+            'sku' => $nonDuplicateVariationSKU,
+            'store_view_code' => null,
+            'attribute_set_code' => 'Default',
+            'product_type' => 'configurable',
+            'name' => 'Configurable Product with different SKUs in variations',
+            'product_websites' => 'website_1',
+            'configurable_variation_labels' => 'testattr2=Select Color, testattr3=Select Size',
+            'configurable_variations' => 'sku=1234.10,'
+                . 'testattr2=attr2val1,'
+                . 'testattr3=testattr3v1,'
+                . 'display=1|sku=1234.1,'
+                . 'testattr2=attr2val1,'
+                . 'testattr3=testattr3v2,'
+                . 'display=0',
+            '_store' => null,
+            '_attribute_set' => 'Default',
+            '_type' => 'configurable',
+            '_product_websites' => 'website_1',
+        ];
         $bunch[] = $badProduct;
         $bunch[] = $caseInsensitiveProduct;
+        $bunch[] = $duplicateVariationProduct;
+        $bunch[] = $nonDuplicateVariationProduct;
         // Set _attributes to avoid error in Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType.
         $this->setPropertyValue($this->configurable, '_attributes', [
             $badProduct[\Magento\CatalogImportExport\Model\Import\Product::COL_ATTR_SET] => [],
@@ -611,6 +658,12 @@ class ConfigurableTest extends \Magento\ImportExport\Test\Unit\Model\Import\Abst
             $result = $this->configurable->isRowValid($rowData, 0, !isset($this->_oldSku[$rowData['sku']]));
             $this->assertNotNull($result);
             if ($rowData['sku'] === $caseInsensitiveSKU) {
+                $this->assertTrue($result);
+            }
+            if ($rowData['sku'] === $duplicateVariationSKU) {
+                $this->assertFalse($result);
+            }
+            if ($rowData['sku'] === $nonDuplicateVariationSKU) {
                 $this->assertTrue($result);
             }
         }

--- a/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Import/Product/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Import/Product/Type/ConfigurableTest.php
@@ -587,9 +587,9 @@ class ConfigurableTest extends \Magento\ImportExport\Test\Unit\Model\Import\Abst
             '_product_websites' => 'website_1',
         ];
         // Checking that variations with duplicate sku are invalid
-        $duplicateVariationSKU = 'configurableskuI22DuplicateVariation';
-        $duplicateVariationProduct = [
-            'sku' => $duplicateVariationSKU,
+        $duplicateSKU = 'configurableskuI22DuplicateVariation';
+        $duplicateProduct = [
+            'sku' => $duplicateSKU,
             'store_view_code' => null,
             'attribute_set_code' => 'Default',
             'product_type' => 'configurable',
@@ -610,9 +610,9 @@ class ConfigurableTest extends \Magento\ImportExport\Test\Unit\Model\Import\Abst
         ];
         // Checking that variations with SKUs that are the same when interpreted as number,
         // but different when interpreted as string are valid
-        $nonDuplicateVariationSKU = 'configurableskuI22NonDuplicateVariation';
-        $nonDuplicateVariationProduct = [
-            'sku' => $nonDuplicateVariationSKU,
+        $nonDuplicateSKU = 'configurableskuI22NonDuplicateVariation';
+        $nonDuplicateProduct = [
+            'sku' => $nonDuplicateSKU,
             'store_view_code' => null,
             'attribute_set_code' => 'Default',
             'product_type' => 'configurable',
@@ -633,8 +633,8 @@ class ConfigurableTest extends \Magento\ImportExport\Test\Unit\Model\Import\Abst
         ];
         $bunch[] = $badProduct;
         $bunch[] = $caseInsensitiveProduct;
-        $bunch[] = $duplicateVariationProduct;
-        $bunch[] = $nonDuplicateVariationProduct;
+        $bunch[] = $duplicateProduct;
+        $bunch[] = $nonDuplicateProduct;
         // Set _attributes to avoid error in Magento\CatalogImportExport\Model\Import\Product\Type\AbstractType.
         $this->setPropertyValue($this->configurable, '_attributes', [
             $badProduct[\Magento\CatalogImportExport\Model\Import\Product::COL_ATTR_SET] => [],
@@ -660,10 +660,10 @@ class ConfigurableTest extends \Magento\ImportExport\Test\Unit\Model\Import\Abst
             if ($rowData['sku'] === $caseInsensitiveSKU) {
                 $this->assertTrue($result);
             }
-            if ($rowData['sku'] === $duplicateVariationSKU) {
+            if ($rowData['sku'] === $duplicateSKU) {
                 $this->assertFalse($result);
             }
-            if ($rowData['sku'] === $nonDuplicateVariationSKU) {
+            if ($rowData['sku'] === $nonDuplicateSKU) {
                 $this->assertTrue($result);
             }
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When importing configurable products, the validation process checks if the linked variations contain duplicate SKUs, this is done using: `in_array($option['_super_products_sku'], $skus)`. The problem that occurs is when you have SKUs that when compared non strict are considered equal, in_array returns true e.g. `in_array('1234.10', ['1234.1'])`, when using the strict option e.g. `(in_array('1234.10', ['1234.1'], true)` the result is false. Since SKUs are strings the latter is the expected behaviour.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Import a configurable product where the SKUs of the variations are numerical and not compared strictly are equal (e.g. 1234.1 and 1234.10)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
