### PR TITLE
Fix gallery full-screen triggers

### DIFF
--- a/lib/web/mage/gallery/gallery.js
+++ b/lib/web/mage/gallery/gallery.js
@@ -141,7 +141,7 @@ define([
             this.setupBreakpoints();
             this.initFullscreenSettings();
 
-            this.settings.$element.on('mouseup', '.fotorama__stage__frame', function () {
+            this.settings.$element.on('mousedown', '.fotorama__stage__frame', function () {
                 if (
                     !$(this).parents('.fotorama__shadows--left, .fotorama__shadows--right').length &&
                     !$(this).hasClass('fotorama-video-container')


### PR DESCRIPTION
### Preconditions
1. Magento 2.2.7

### Description (*)
We find the issue when tried to select some text or value in the text field on the product page.
When you press mouse on the text and move mouse left up to the image gallery then make mouse up, on the image, it triggers full-screen gallery opening.

### Steps to reproduce:
1. Go to the product page
2. Press mouse on the text (product description) and move mouse left up to the image gallery
3. Make mouse up on the big gallery image

### Expected result
No full-screen gallery. Just selected text.

### Actual result
Full-screen gallery.
