### PR TITLE
MysqlMq: Use new MessageQueue Config interface, update unit tests

### DIFF
--- a/app/code/Magento/MysqlMq/Model/Driver/Bulk/Exchange.php
+++ b/app/code/Magento/MysqlMq/Model/Driver/Bulk/Exchange.php
@@ -6,7 +6,7 @@
 namespace Magento\MysqlMq\Model\Driver\Bulk;
 
 use Magento\Framework\MessageQueue\Bulk\ExchangeInterface;
-use Magento\Framework\MessageQueue\ConfigInterface as MessageQueueConfig;
+use Magento\Framework\MessageQueue\Topology\ConfigInterface as MessageQueueConfig;
 use Magento\MysqlMq\Model\QueueManagement;
 
 /**
@@ -41,7 +41,19 @@ class Exchange implements ExchangeInterface
      */
     public function enqueue($topic, array $envelopes)
     {
-        $queueNames = $this->messageQueueConfig->getQueuesByTopic($topic);
+        $queueNames = [];
+        $exchanges = $this->messageQueueConfig->getExchanges();
+        foreach ($exchanges as $exchange) {
+          // @todo Is there a more reliable way to identify MySQL exchanges?
+          if ($exchange->getConnection() == 'db') {
+            foreach ($exchange->getBindings() as $binding) {
+              // This only supports exact matching of topics.
+              if ($binding->getTopic() == $topic) {
+                $queueNames[] = $binding->getDestination();
+              }
+            }
+          }
+        }
         $messages = array_map(
             function ($envelope) {
                 return $envelope->getBody();

--- a/app/code/Magento/MysqlMq/Setup/Recurring.php
+++ b/app/code/Magento/MysqlMq/Setup/Recurring.php
@@ -8,7 +8,7 @@ namespace Magento\MysqlMq\Setup;
 use Magento\Framework\Setup\InstallSchemaInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
-use Magento\Framework\MessageQueue\ConfigInterface as MessageQueueConfig;
+use Magento\Framework\MessageQueue\Topology\ConfigInterface as MessageQueueConfig;
 
 /**
  * Class Recurring
@@ -35,10 +35,9 @@ class Recurring implements InstallSchemaInterface
     {
         $setup->startSetup();
 
-        $binds = $this->messageQueueConfig->getBinds();
         $queues = [];
-        foreach ($binds as $bind) {
-            $queues[] = $bind[MessageQueueConfig::BIND_QUEUE];
+        foreach ($this->messageQueueConfig->getQueues() as $queue) {
+          $queues[] = $queue->getName();
         }
         $connection = $setup->getConnection();
         $existingQueues = $connection->fetchCol($connection->select()->from($setup->getTable('queue'), 'name'));

--- a/app/code/Magento/MysqlMq/Test/Unit/Model/Driver/Bulk/ExchangeTest.php
+++ b/app/code/Magento/MysqlMq/Test/Unit/Model/Driver/Bulk/ExchangeTest.php
@@ -12,7 +12,7 @@ namespace Magento\MysqlMq\Test\Unit\Model\Driver\Bulk;
 class ExchangeTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Magento\Framework\MessageQueue\ConfigInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\MessageQueue\Topology\ConfigInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $messageQueueConfig;
 
@@ -33,7 +33,7 @@ class ExchangeTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUp()
     {
-        $this->messageQueueConfig = $this->getMockBuilder(\Magento\Framework\MessageQueue\ConfigInterface::class)
+        $this->messageQueueConfig = $this->getMockBuilder(\Magento\Framework\MessageQueue\Topology\ConfigInterface::class)
             ->disableOriginalConstructor()->getMock();
         $this->queueManagement = $this->getMockBuilder(\Magento\MysqlMq\Model\QueueManagement::class)
             ->disableOriginalConstructor()->getMock();
@@ -56,10 +56,40 @@ class ExchangeTest extends \PHPUnit\Framework\TestCase
     public function testEnqueue()
     {
         $topicName = 'topic.name';
-        $queueNames = ['queue0', 'queue1'];
+        $queueNames = ['queue0'];
+
+        $binding1 = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItem\BindingInterface::class);
+        $binding1->expects($this->once())
+            ->method('getTopic')
+            ->willReturn($topicName);
+        $binding1->expects($this->once())
+            ->method('getDestination')
+            ->willReturn($queueNames[0]);
+
+        $binding2 = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItem\BindingInterface::class);
+        $binding2->expects($this->once())
+            ->method('getTopic')
+            ->willReturn('different.topic');
+        $binding2->expects($this->never())
+            ->method('getDestination');
+
+        $exchange1 = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItemInterface::class);
+        $exchange1->expects($this->once())
+            ->method('getConnection')
+            ->willReturn('db');
+        $exchange1->expects($this->once())
+            ->method('getBindings')
+            ->willReturn([$binding1, $binding2]);
+        $exchange2 = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItemInterface::class);
+        $exchange2->expects($this->once())
+            ->method('getConnection')
+            ->willReturn('amqp');
+        $exchange2->expects($this->never())
+            ->method('getBindings');
+
         $envelopeBody = 'serializedMessage';
         $this->messageQueueConfig->expects($this->once())
-            ->method('getQueuesByTopic')->with($topicName)->willReturn($queueNames);
+            ->method('getExchanges')->willReturn([$exchange1, $exchange2]);
         $envelope = $this->getMockBuilder(\Magento\Framework\MessageQueue\EnvelopeInterface::class)
             ->disableOriginalConstructor()->getMock();
         $envelope->expects($this->once())->method('getBody')->willReturn($envelopeBody);

--- a/app/code/Magento/MysqlMq/Test/Unit/Setup/RecurringTest.php
+++ b/app/code/Magento/MysqlMq/Test/Unit/Setup/RecurringTest.php
@@ -24,7 +24,7 @@ class RecurringTest extends \PHPUnit\Framework\TestCase
     private $model;
 
     /**
-     * @var \Magento\Framework\MessageQueue\ConfigInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\MessageQueue\Topology\ConfigInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $messageQueueConfig;
 
@@ -34,7 +34,7 @@ class RecurringTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $this->objectManager = new ObjectManager($this);
-        $this->messageQueueConfig = $this->getMockBuilder(\Magento\Framework\MessageQueue\ConfigInterface::class)
+        $this->messageQueueConfig = $this->getMockBuilder(\Magento\Framework\MessageQueue\Topology\ConfigInterface::class)
             ->getMockForAbstractClass();
         $this->model = $this->objectManager->getObject(
             \Magento\MysqlMq\Setup\Recurring::class,
@@ -49,23 +49,14 @@ class RecurringTest extends \PHPUnit\Framework\TestCase
      */
     public function testInstall()
     {
-        $binds = [
-            'first_bind' => [
-                'queue' => 'queue_name_1',
-                'exchange' => 'magento-db',
-                'topic' => 'queue.topic.1'
-            ],
-            'second_bind' => [
-                'queue' => 'queue_name_2',
-                'exchange' => 'magento-db',
-                'topic' => 'queue.topic.2'
-            ],
-            'third_bind' => [
-                'queue' => 'queue_name_3',
-                'exchange' => 'magento-db',
-                'topic' => 'queue.topic.3'
-            ]
-        ];
+        for ($i = 1; $i <=3; $i++) {
+            $queue = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\QueueConfigItemInterface::class);
+            $queue->expects($this->once())
+                ->method('getName')
+                ->willReturn('queue_name_'. $i);
+            $queues[] = $queue;
+        }
+
         $dbQueues = [
             'queue_name_1',
             'queue_name_2',
@@ -81,7 +72,7 @@ class RecurringTest extends \PHPUnit\Framework\TestCase
             ->getMockForAbstractClass();
 
         $setup->expects($this->once())->method('startSetup')->willReturnSelf();
-        $this->messageQueueConfig->expects($this->once())->method('getBinds')->willReturn($binds);
+        $this->messageQueueConfig->expects($this->once())->method('getQueues')->willReturn($queues);
         $connection = $this->getMockBuilder(\Magento\Framework\DB\Adapter\AdapterInterface::class)
             ->getMockForAbstractClass();
         $setup->expects($this->once())->method('getConnection')->willReturn($connection);


### PR DESCRIPTION

### Description (*)
This fixes the deprecated usage of the old ConfigInterface in MysqlMQ

### Fixed Issues (if relevant)

1. magento/magento2#21904:  \Magento\MysqlMq\Model\Driver\Exchange uses deprecated getQueuesByTopic, results in exception

### Manual testing scenarios (*)
See issue, using the MysqlMq adapter for a message queue is currently not working at all.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
