### PR TITLE
[Backport] Trigger contentUpdate on reviews load

### DIFF
--- a/app/code/Magento/Review/view/frontend/web/js/process-reviews.js
+++ b/app/code/Magento/Review/view/frontend/web/js/process-reviews.js
@@ -20,7 +20,7 @@ define([
             showLoader: false,
             loaderContext: $('.product.data.items')
         }).done(function (data) {
-            $('#product-review-container').html(data);
+            $('#product-review-container').html(data).trigger('contentUpdated');
             $('[data-role="product-review"] .pages a').each(function (index, element) {
                 $(element).click(function (event) { //eslint-disable-line max-nested-callbacks
                     processReviews($(element).attr('href'), true);


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21899
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Reviews are being loaded asynchronously and since the HTML content is appended as is custom `data-mage-init` or `text/x-magento-init` scripts are not processed.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add any `<script type="text/x-magento-init">` or `data-mage-init` attributes to the `app/code/Magento/Review/view/frontend/templates/product/view/list.phtml` file.
2. Go to a product page with reviews.
3. When reviews are loaded the custom scripts are loaded as part of the HTML and **not** executed.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
