### PR TITLE
Fixed WhiteSpace issue in product grid

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_listings.less
+++ b/app/design/frontend/Magento/luma/Magento_Catalog/web/css/source/module/_listings.less
@@ -34,12 +34,12 @@
 
     .product {
         &-items {
-            font-size: 0;
+            .lib-inline-block-space-container();
             &:extend(.abs-reset-list all);
         }
 
         &-item {
-            font-size: 1.4rem;
+            .lib-inline-block-space-item();
             vertical-align: top;
 
             .products-grid & {


### PR DESCRIPTION
Fixes ##There are some whitespaces in between li tags, that's why product grid showing 3 products instead of 4. Mention in #20140 and #21244

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
#21244: Luma theme huge whitespace on category grid
#20140: Product per row not proper on listing page

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Please consider PR #18168 before applying this as lib-line-height mixin still have `normal` issue


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
