### PR TITLE
Remove timestap from current date when saving product special price from date

### DIFF
--- a/app/code/Magento/Catalog/Observer/SetSpecialPriceStartDate.php
+++ b/app/code/Magento/Catalog/Observer/SetSpecialPriceStartDate.php
@@ -3,9 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Catalog\Observer;
 
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 
 /**
  *  Set value for Special Price start date
@@ -13,21 +16,20 @@ use Magento\Framework\Event\ObserverInterface;
 class SetSpecialPriceStartDate implements ObserverInterface
 {
     /**
-     * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface
+     * @var TimezoneInterface
      */
     private $localeDate;
 
     /**
-     * @param \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate
-     * @codeCoverageIgnore
+     * @param TimezoneInterface $localeDate
      */
-    public function __construct(\Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate)
+    public function __construct(TimezoneInterface $localeDate)
     {
         $this->localeDate = $localeDate;
     }
 
     /**
-     * Set the current date to Special Price From attribute if it empty
+     * Set the current date to Special Price From attribute if it's empty.
      *
      * @param \Magento\Framework\Event\Observer $observer
      * @return $this
@@ -36,8 +38,8 @@ class SetSpecialPriceStartDate implements ObserverInterface
     {
         /** @var  $product \Magento\Catalog\Model\Product */
         $product = $observer->getEvent()->getProduct();
-        if ($product->getSpecialPrice() && !$product->getSpecialFromDate()) {
-            $product->setData('special_from_date', $this->localeDate->date());
+        if ($product->getSpecialPrice() && ! $product->getSpecialFromDate()) {
+            $product->setData('special_from_date', $this->localeDate->date()->setTime(0, 0));
         }
 
         return $this;


### PR DESCRIPTION
### Description (*)
Full timestamp is saved when creating a new product with a special price but without a special price from value.

With this fix, the time is reset so only the date will be saved. This is also in line with the UI where only a date can be selected.

### Fixed Issues (if relevant)
1. None I could find.

### Manual testing scenarios (*)
1. Set configuration on global scope `general/locale/timezone` > `Europe/Amsterdam`.
2. Set configuration on en_US scope `general/locale/timezone` > `America/New_York`.
3. Create new simple product with special price (leave special price from date empty).
4. Product will be saved with a current timestamp using the `Europe/Amsterdam` timezone.
5. Navigate to product on frontend (en_US store), no special price is shown. This is because special price from date is checked against the `America/New_York` timezone. This isn't the case for another five hours.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
