### PR TITLE
Fixed Vault token visibility option

### DIFF
--- a/app/code/Magento/Vault/Observer/VaultEnableAssigner.php
+++ b/app/code/Magento/Vault/Observer/VaultEnableAssigner.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Vault\Observer;
 
 use Magento\Framework\Event\Observer;
@@ -10,13 +12,15 @@ use Magento\Payment\Observer\AbstractDataAssignObserver;
 use Magento\Quote\Api\Data\PaymentInterface;
 use Magento\Vault\Model\Ui\VaultConfigProvider;
 
+/**
+ * Sets visibility for Vault payment
+ */
 class VaultEnableAssigner extends AbstractDataAssignObserver
 {
     /**
-     * @param Observer $observer
-     * @return void
+     * @inheritdoc
      */
-    public function execute(\Magento\Framework\Event\Observer $observer)
+    public function execute(Observer $observer)
     {
         $data = $this->readDataArgument($observer);
 
@@ -26,12 +30,14 @@ class VaultEnableAssigner extends AbstractDataAssignObserver
             return;
         }
 
+        $payment = $this->readPaymentModelArgument($observer);
+        $isVisible = false;
         if (isset($additionalData[VaultConfigProvider::IS_ACTIVE_CODE])) {
-            $payment = $this->readPaymentModelArgument($observer);
-            $payment->setAdditionalInformation(
-                VaultConfigProvider::IS_ACTIVE_CODE,
-                filter_var($additionalData[VaultConfigProvider::IS_ACTIVE_CODE], FILTER_VALIDATE_BOOLEAN)
+            $isVisible = filter_var(
+                $additionalData[VaultConfigProvider::IS_ACTIVE_CODE],
+                FILTER_VALIDATE_BOOLEAN
             );
         }
+        $payment->setAdditionalInformation(VaultConfigProvider::IS_ACTIVE_CODE, $isVisible);
     }
 }

--- a/app/code/Magento/Vault/Test/Unit/Observer/VaultEnableAssignerTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Observer/VaultEnableAssignerTest.php
@@ -17,8 +17,14 @@ use Magento\Vault\Model\Ui\VaultConfigProvider;
 use Magento\Vault\Observer\VaultEnableAssigner;
 use PHPUnit\Framework\MockObject\MockObject;
 
+/**
+ * Test for Magento\Vault\Observer\VaultEnableAssigner
+ */
 class VaultEnableAssignerTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * Test not active code
+     */
     public function testExecuteNoActiveCode()
     {
         $dataObject = new DataObject();
@@ -35,6 +41,8 @@ class VaultEnableAssignerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test main flow
+     *
      * @param string $activeCode
      * @param boolean $expectedBool
      * @dataProvider booleanDataProvider
@@ -69,6 +77,8 @@ class VaultEnableAssignerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Data provider for testExecute
+     *
      * @return array
      */
     public function booleanDataProvider()
@@ -85,6 +95,8 @@ class VaultEnableAssignerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Get observer mock that returns an event instance based on provided return map
+     *
      * @param array $returnMap
      * @return MockObject|Observer
      */

--- a/app/code/Magento/Vault/Test/Unit/Observer/VaultEnableAssignerTest.php
+++ b/app/code/Magento/Vault/Test/Unit/Observer/VaultEnableAssignerTest.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Vault\Test\Unit\Observer;
 
 use Magento\Framework\DataObject;
@@ -13,6 +15,7 @@ use Magento\Payment\Observer\AbstractDataAssignObserver;
 use Magento\Quote\Api\Data\PaymentInterface;
 use Magento\Vault\Model\Ui\VaultConfigProvider;
 use Magento\Vault\Observer\VaultEnableAssigner;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class VaultEnableAssignerTest extends \PHPUnit\Framework\TestCase
 {
@@ -47,8 +50,7 @@ class VaultEnableAssignerTest extends \PHPUnit\Framework\TestCase
         );
         $paymentModel = $this->createMock(InfoInterface::class);
 
-        $paymentModel->expects(static::once())
-            ->method('setAdditionalInformation')
+        $paymentModel->method('setAdditionalInformation')
             ->with(
                 VaultConfigProvider::IS_ACTIVE_CODE,
                 $expectedBool
@@ -77,37 +79,14 @@ class VaultEnableAssignerTest extends \PHPUnit\Framework\TestCase
             ['on', true],
             ['false', false],
             ['0', false],
-            ['off', false]
+            ['off', false],
+            [null, false]
         ];
-    }
-
-    public function testExecuteNever()
-    {
-        $dataObject = new DataObject(
-            [
-                PaymentInterface::KEY_ADDITIONAL_DATA => []
-            ]
-        );
-        $paymentModel = $this->createMock(InfoInterface::class);
-
-        $paymentModel->expects(static::never())
-            ->method('setAdditionalInformation');
-
-        $observer = $this->getPreparedObserverWithMap(
-            [
-                [AbstractDataAssignObserver::DATA_CODE, $dataObject],
-                [AbstractDataAssignObserver::MODEL_CODE, $paymentModel]
-            ]
-        );
-
-        $vaultEnableAssigner = new VaultEnableAssigner();
-
-        $vaultEnableAssigner->execute($observer);
     }
 
     /**
      * @param array $returnMap
-     * @return \PHPUnit_Framework_MockObject_MockObject|Observer
+     * @return MockObject|Observer
      */
     private function getPreparedObserverWithMap(array $returnMap)
     {
@@ -118,10 +97,10 @@ class VaultEnableAssignerTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $observer->expects(static::atLeastOnce())
+        $observer->expects(self::atLeastOnce())
             ->method('getEvent')
             ->willReturn($event);
-        $event->expects(static::atLeastOnce())
+        $event->expects(self::atLeastOnce())
             ->method('getDataByKey')
             ->willReturnMap(
                 $returnMap


### PR DESCRIPTION
Fixed incorrect behavior for `Save for later use` checkbox if it wasn't checked.
Relates to https://github.com/magento/magento2/issues/19515.