### PR TITLE
Remove 'pub' from report url

### DIFF
--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -17,7 +17,7 @@ class Processor
     const MAGE_ERRORS_LOCAL_XML = 'local.xml';
     const MAGE_ERRORS_DESIGN_XML = 'design.xml';
     const DEFAULT_SKIN = 'default';
-    const ERROR_DIR = 'pub/errors';
+    const ERROR_DIR = 'errors';
 
     /**
      * Page title
@@ -615,7 +615,7 @@ class Processor
     protected function _setReportUrl()
     {
         if ($this->reportId && $this->_config && isset($this->_config->skin)) {
-            $this->reportUrl = "{$this->getBaseUrl(true)}pub/errors/report.php?"
+            $this->reportUrl = $this->getBaseUrl(true) . self::ERROR_DIR . '/report.php?'
                 . http_build_query(['id' => $this->reportId, 'skin' => $this->_config->skin]);
         }
     }


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
- Processor::ERROR_DIR not used before.
- Remove '/pub/' from generated report url to prevent 404 Not found when document root is `$MAGE_ROOT/pub` (according to [Modify docroot to improve security](https://devdocs.magento.com/guides/v2.3/install-gde/tutorials/change-docroot-to-pub.html)). 

### Fixed Issues (if relevant)
Not reported any yet?

### Manual testing scenarios (*)
I couldn't provide manual testing scenarios because I didn't find where `pub/errors/report.php` used from frontend. Is it used anywere at all?

But in debugger it generates invalid url (404 Not found).

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
