### PR TITLE
[Backport] 20434 consider url rewrite when change product visibility attribute

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/Products/AdaptUrlRewritesToVisibilityAttribute.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Products/AdaptUrlRewritesToVisibilityAttribute.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogUrlRewrite\Model\Products;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\CatalogUrlRewrite\Model\ProductUrlPathGenerator;
+use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
+use Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException;
+use Magento\UrlRewrite\Model\UrlPersistInterface;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+
+/**
+ *  Save/Delete UrlRewrites by Product ID's and visibility
+ */
+class AdaptUrlRewritesToVisibilityAttribute
+{
+    /**
+     * @var CollectionFactory
+     */
+    private $productCollectionFactory;
+
+    /**
+     * @var ProductUrlRewriteGenerator
+     */
+    private $urlRewriteGenerator;
+
+    /**
+     * @var UrlPersistInterface
+     */
+    private $urlPersist;
+
+    /**
+     * @var ProductUrlPathGenerator
+     */
+    private $urlPathGenerator;
+
+    /**
+     * @param CollectionFactory $collectionFactory
+     * @param ProductUrlRewriteGenerator $urlRewriteGenerator
+     * @param UrlPersistInterface $urlPersist
+     * @param ProductUrlPathGenerator|null $urlPathGenerator
+     */
+    public function __construct(
+        CollectionFactory $collectionFactory,
+        ProductUrlRewriteGenerator $urlRewriteGenerator,
+        UrlPersistInterface $urlPersist,
+        ProductUrlPathGenerator $urlPathGenerator
+    ) {
+        $this->productCollectionFactory = $collectionFactory;
+        $this->urlRewriteGenerator = $urlRewriteGenerator;
+        $this->urlPersist = $urlPersist;
+        $this->urlPathGenerator = $urlPathGenerator;
+    }
+
+    /**
+     * Process Url Rewrites according to the products visibility attribute
+     *
+     * @param array $productIds
+     * @param int $visibility
+     * @throws UrlAlreadyExistsException
+     */
+    public function execute(array $productIds, int $visibility)
+    {
+        $products = $this->getProductsByIds($productIds);
+
+        /** @var Product $product */
+        foreach ($products as $product) {
+            if ($visibility == Visibility::VISIBILITY_NOT_VISIBLE) {
+                $this->urlPersist->deleteByData(
+                    [
+                        UrlRewrite::ENTITY_ID => $product->getId(),
+                        UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
+                    ]
+                );
+            } elseif ($visibility !== Visibility::VISIBILITY_NOT_VISIBLE) {
+                $product->setVisibility($visibility);
+                $productUrlPath = $this->urlPathGenerator->getUrlPath($product);
+                $productUrlRewrite = $this->urlRewriteGenerator->generate($product);
+                $product->unsUrlPath();
+                $product->setUrlPath($productUrlPath);
+
+                try {
+                    $this->urlPersist->replace($productUrlRewrite);
+                } catch (UrlAlreadyExistsException $e) {
+                    throw new UrlAlreadyExistsException(
+                        __(
+                            'Can not change the visibility of the product with SKU equals "%1". '
+                            . 'URL key "%2" for specified store already exists.',
+                            $product->getSku(),
+                            $product->getUrlKey()
+                        ),
+                        $e,
+                        $e->getCode(),
+                        $e->getUrls()
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Get Product Models by Id's
+     *
+     * @param array $productIds
+     * @return array
+     */
+    private function getProductsByIds(array $productIds): array
+    {
+        $productCollection = $this->productCollectionFactory->create();
+        $productCollection->addAttributeToSelect(ProductInterface::VISIBILITY);
+        $productCollection->addAttributeToSelect('url_key');
+        $productCollection->addFieldToFilter(
+            'entity_id',
+            ['in' => array_unique($productIds)]
+        );
+
+        return $productCollection->getItems();
+    }
+}

--- a/app/code/Magento/CatalogUrlRewrite/Observer/ProcessUrlRewriteOnChangeProductVisibilityObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/ProcessUrlRewriteOnChangeProductVisibilityObserver.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogUrlRewrite\Observer;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\CatalogUrlRewrite\Model\Products\AdaptUrlRewritesToVisibilityAttribute;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException;
+
+/**
+ * Consider URL rewrites on change product visibility via mass action
+ */
+class ProcessUrlRewriteOnChangeProductVisibilityObserver implements ObserverInterface
+{
+    /**
+     * @var AdaptUrlRewritesToVisibilityAttribute
+     */
+    private $adaptUrlRewritesToVisibility;
+
+    /**
+     * @param AdaptUrlRewritesToVisibilityAttribute $adaptUrlRewritesToVisibility
+     */
+    public function __construct(AdaptUrlRewritesToVisibilityAttribute $adaptUrlRewritesToVisibility)
+    {
+        $this->adaptUrlRewritesToVisibility = $adaptUrlRewritesToVisibility;
+    }
+
+    /**
+     * Generate urls for UrlRewrites and save it in storage
+     *
+     * @param Observer $observer
+     * @return void
+     * @throws UrlAlreadyExistsException
+     */
+    public function execute(Observer $observer)
+    {
+        $event = $observer->getEvent();
+        $attrData = $event->getAttributesData();
+        $productIds = $event->getProductIds();
+        $visibility = $attrData[ProductInterface::VISIBILITY] ?? 0;
+
+        if (!$visibility || !$productIds) {
+            return;
+        }
+
+        $this->adaptUrlRewritesToVisibility->execute($productIds, (int)$visibility);
+    }
+}

--- a/app/code/Magento/CatalogUrlRewrite/etc/events.xml
+++ b/app/code/Magento/CatalogUrlRewrite/etc/events.xml
@@ -27,6 +27,9 @@
     <event name="catalog_product_save_after">
         <observer name="process_url_rewrite_saving" instance="Magento\CatalogUrlRewrite\Observer\ProductProcessUrlRewriteSavingObserver"/>
     </event>
+    <event name="catalog_product_attribute_update_before">
+        <observer name="process_url_rewrite_on_change_product_visibility" instance="Magento\CatalogUrlRewrite\Observer\ProcessUrlRewriteOnChangeProductVisibilityObserver"/>
+    </event>
     <event name="catalog_category_save_before">
         <observer name="category_url_path_autogeneration" instance="Magento\CatalogUrlRewrite\Observer\CategoryUrlPathAutogeneratorObserver"/>
     </event>

--- a/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/Observer/ProcessUrlRewriteOnChangeVisibilityObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/Observer/ProcessUrlRewriteOnChangeVisibilityObserverTest.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\CatalogUrlRewrite\Observer;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+
+/**
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation disabled
+ */
+class ProcessUrlRewriteOnChangeVisibilityObserverTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private $productRepository;
+
+    /**
+     * @var ManagerInterface
+     */
+    private $eventManager;
+
+    /**
+     * Set up
+     */
+    protected function setUp()
+    {
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->productRepository = $this->objectManager->create(ProductRepositoryInterface::class);
+        $this->eventManager = $this->objectManager->create(ManagerInterface::class);
+    }
+
+    /**
+     * @magentoDataFixture Magento/CatalogUrlRewrite/_files/product_rewrite_multistore.php
+     * @magentoAppIsolation enabled
+     */
+    public function testMakeProductInvisibleViaMassAction()
+    {
+        /** @var \Magento\Catalog\Model\Product $product*/
+        $product = $this->productRepository->get('product1');
+
+        /** @var StoreManagerInterface $storeManager */
+        $storeManager = $this->objectManager->get(StoreManagerInterface::class);
+        $storeManager->setCurrentStore(0);
+
+        $testStore = $storeManager->getStore('test');
+        $productFilter = [
+            UrlRewrite::ENTITY_TYPE => 'product',
+        ];
+
+        $expected = [
+            [
+                'request_path' => "product-1.html",
+                'target_path' => "catalog/product/view/id/" . $product->getId(),
+                'is_auto_generated' => 1,
+                'redirect_type' => 0,
+                'store_id' => '1',
+            ],
+            [
+                'request_path' => "product-1.html",
+                'target_path' => "catalog/product/view/id/" . $product->getId(),
+                'is_auto_generated' => 1,
+                'redirect_type' => 0,
+                'store_id' => $testStore->getId(),
+            ]
+        ];
+
+        $actual = $this->getActualResults($productFilter);
+        foreach ($expected as $row) {
+            $this->assertContains($row, $actual);
+        }
+
+        $this->eventManager->dispatch(
+            'catalog_product_attribute_update_before',
+            [
+                'attributes_data' => [ ProductInterface::VISIBILITY => Visibility::VISIBILITY_NOT_VISIBLE ],
+                'product_ids' => [$product->getId()]
+            ]
+        );
+
+        $actual = $this->getActualResults($productFilter);
+        $this->assertCount(0, $actual);
+    }
+
+    /**
+     * @magentoDataFixture Magento/CatalogUrlRewrite/_files/product_invisible_multistore.php
+     * @magentoAppIsolation enabled
+     */
+    public function testMakeProductVisibleViaMassAction()
+    {
+        /** @var \Magento\Catalog\Model\Product $product*/
+        $product = $this->productRepository->get('product1');
+
+        /** @var StoreManagerInterface $storeManager */
+        $storeManager = $this->objectManager->get(StoreManagerInterface::class);
+        $storeManager->setCurrentStore(0);
+
+        $testStore = $storeManager->getStore('test');
+        $productFilter = [
+            UrlRewrite::ENTITY_TYPE => 'product',
+        ];
+
+        $actual = $this->getActualResults($productFilter);
+        $this->assertCount(0, $actual);
+
+        $this->eventManager->dispatch(
+            'catalog_product_attribute_update_before',
+            [
+                'attributes_data' => [ ProductInterface::VISIBILITY => Visibility::VISIBILITY_BOTH ],
+                'product_ids' => [$product->getId()]
+            ]
+        );
+
+        $expected = [
+            [
+                'request_path' => "product-1.html",
+                'target_path' => "catalog/product/view/id/" . $product->getId(),
+                'is_auto_generated' => 1,
+                'redirect_type' => 0,
+                'store_id' => '1',
+            ],
+            [
+                'request_path' => "product-1.html",
+                'target_path' => "catalog/product/view/id/" . $product->getId(),
+                'is_auto_generated' => 1,
+                'redirect_type' => 0,
+                'store_id' => $testStore->getId(),
+            ]
+        ];
+
+        $actual = $this->getActualResults($productFilter);
+        foreach ($expected as $row) {
+            $this->assertContains($row, $actual);
+        }
+    }
+
+    /**
+     * @magentoDataFixture Magento/CatalogUrlRewrite/_files/products_invisible.php
+     * @magentoAppIsolation enabled
+     */
+    public function testErrorOnDuplicatedUrlKey()
+    {
+        $skus = ['product1', 'product2'];
+        foreach ($skus as $sku) {
+            /** @var \Magento\Catalog\Model\Product $product */
+            $productIds[] = $this->productRepository->get($sku)->getId();
+        }
+        $this->expectException(UrlAlreadyExistsException::class);
+        $this->expectExceptionMessage('Can not change the visibility of the product with SKU equals "product2". '
+            . 'URL key "product-1" for specified store already exists.');
+
+        $this->eventManager->dispatch(
+            'catalog_product_attribute_update_before',
+            [
+                'attributes_data' => [ ProductInterface::VISIBILITY => Visibility::VISIBILITY_BOTH ],
+                'product_ids' => $productIds
+            ]
+        );
+    }
+
+    /**
+     * @param array $filter
+     * @return array
+     */
+    private function getActualResults(array $filter)
+    {
+        /** @var \Magento\UrlRewrite\Model\UrlFinderInterface $urlFinder */
+        $urlFinder = $this->objectManager->get(\Magento\UrlRewrite\Model\UrlFinderInterface::class);
+        $actualResults = [];
+        foreach ($urlFinder->findAllByData($filter) as $url) {
+            $actualResults[] = [
+                'request_path' => $url->getRequestPath(),
+                'target_path' => $url->getTargetPath(),
+                'is_auto_generated' => (int)$url->getIsAutogenerated(),
+                'redirect_type' => $url->getRedirectType(),
+                'store_id' => $url->getStoreId()
+            ];
+        }
+        return $actualResults;
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/_files/product_invisible_multistore.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/_files/product_invisible_multistore.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Setup\CategorySetup;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+\Magento\TestFramework\Helper\Bootstrap::getInstance()
+    ->loadArea(\Magento\Backend\App\Area\FrontNameResolver::AREA_CODE);
+
+require __DIR__ . '/../../Store/_files/store.php';
+
+/** @var $installer CategorySetup */
+$objectManager = Bootstrap::getObjectManager();
+$installer = $objectManager->create(CategorySetup::class);
+$storeManager = $objectManager->get(StoreManagerInterface::class);
+$storeManager->setCurrentStore(0);
+
+/** @var $product \Magento\Catalog\Model\Product */
+$product = $objectManager->create(\Magento\Catalog\Model\Product::class);
+$product->setTypeId(\Magento\Catalog\Model\Product\Type::TYPE_SIMPLE)
+    ->setAttributeSetId($installer->getAttributeSetId('catalog_product', 'Default'))
+    ->setStoreId(0)
+    ->setWebsiteIds([1])
+    ->setName('Product1')
+    ->setSku('product1')
+    ->setPrice(10)
+    ->setWeight(18)
+    ->setStockData(['use_config_manage_stock' => 0])
+    ->setUrlKey('product-1')
+    ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_NOT_VISIBLE)
+    ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED);
+
+/** @var ProductRepositoryInterface $productRepository */
+$productRepository = $objectManager->get(ProductRepositoryInterface::class);
+$productRepository->save($product);

--- a/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/_files/product_invisible_multistore_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/_files/product_invisible_multistore_rollback.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+use Magento\Framework\Exception\NoSuchEntityException;
+
+\Magento\TestFramework\Helper\Bootstrap::getInstance()->getInstance()->reinitialize();
+
+/** @var \Magento\Framework\Registry $registry */
+$registry = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Framework\Registry::class);
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+
+/** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+$productRepository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+    ->get(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+try {
+    $product = $productRepository->get('product1', true);
+    if ($product->getId()) {
+        $productRepository->delete($product);
+    }
+} catch (NoSuchEntityException $e) {
+}
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', false);
+
+require __DIR__ . '/../../Store/_files/store_rollback.php';
+require __DIR__ . '/../../Store/_files/second_store_rollback.php';

--- a/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/_files/product_rewrite_multistore_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/_files/product_rewrite_multistore_rollback.php
@@ -3,10 +3,32 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Registry;
 use Magento\TestFramework\Helper\Bootstrap;
 
-$objectManager = Bootstrap::getObjectManager();
+Bootstrap::getInstance()->getInstance()->reinitialize();
+
+/** @var Registry $registry */
+$registry = Bootstrap::getObjectManager()->get(Registry::class);
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+
+/** @var ProductRepositoryInterface $productRepository */
+$productRepository = Bootstrap::getObjectManager()
+    ->get(ProductRepositoryInterface::class);
+try {
+    $product = $productRepository->get('product1', true);
+    if ($product->getId()) {
+        $productRepository->delete($product);
+    }
+} catch (NoSuchEntityException $e) {
+}
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', false);
 
 require __DIR__ . '/../../Store/_files/store_rollback.php';
 require __DIR__ . '/../../Store/_files/second_store_rollback.php';

--- a/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/_files/products_invisible.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/_files/products_invisible.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Setup\CategorySetup;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+\Magento\TestFramework\Helper\Bootstrap::getInstance()
+    ->loadArea(\Magento\Backend\App\Area\FrontNameResolver::AREA_CODE);
+
+/** @var $installer CategorySetup */
+$objectManager = Bootstrap::getObjectManager();
+$installer = $objectManager->create(CategorySetup::class);
+/** @var ProductRepositoryInterface $productRepository */
+$productRepository = $objectManager->get(ProductRepositoryInterface::class);
+
+$skus = ['product1', 'product2'];
+foreach ($skus as $sku) {
+    /** @var $product \Magento\Catalog\Model\Product */
+    $product = $objectManager->create(\Magento\Catalog\Model\Product::class);
+    $product->setTypeId(\Magento\Catalog\Model\Product\Type::TYPE_SIMPLE)
+        ->setAttributeSetId($installer->getAttributeSetId('catalog_product', 'Default'))
+        ->setStoreId(0)
+        ->setWebsiteIds([1])
+        ->setName('Product1')
+        ->setSku($sku)
+        ->setPrice(10)
+        ->setWeight(18)
+        ->setStockData(['use_config_manage_stock' => 0])
+        ->setUrlKey('product-1')
+        ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_NOT_VISIBLE)
+        ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED);
+    $productRepository->save($product);
+}

--- a/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/_files/products_invisible_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/_files/products_invisible_rollback.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+use Magento\Framework\Exception\NoSuchEntityException;
+
+\Magento\TestFramework\Helper\Bootstrap::getInstance()->getInstance()->reinitialize();
+
+/** @var \Magento\Framework\Registry $registry */
+$registry = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Framework\Registry::class);
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+
+/** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+$productRepository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+    ->get(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+
+$skus = ['product1', 'product2'];
+foreach ($skus as $sku) {
+    try {
+        $product = $productRepository->get($sku, true);
+        if ($product->getId()) {
+            $productRepository->delete($product);
+        }
+    } catch (NoSuchEntityException $e) {
+    }
+}
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', false);
+
+require __DIR__ . '/../../Store/_files/store_rollback.php';
+require __DIR__ . '/../../Store/_files/second_store_rollback.php';


### PR DESCRIPTION
Original PR: #20774 

### Description (*)
Has been implemented observing the saving attribute via mass action, creating/deleting URL rewrites appropriately on the product visibility attribute change. 
For more details see the issue (magento/magento2#20434).

### Fixed Issues (if relevant)
1. magento/magento2#20434: Product URL duplicate M2.2.6

### Manual testing scenarios (*)
CASE 1:

Step 1. Create a product with the following URL (or any of your choice): « mon-produit-de-test » - Visible product (catalog, search)
Step 2. Create a second one with the same values but invisible individually then URL « mon-produit-de-test »
Step 3. Change visibility of the second product to visible via mass action.

The Url Key exist exception should be thrown.

CASE 2:
Step 1. Create a product with the following URL (or any of your choice): « mon-produit-de-test » - Visible product (catalog, search)
Step 2. Set visibility attribute to invisible via product grid mass action

Product URL rewrite should be removed.

CASE 3:
Step 1. Create a product with the following URL (or any of your choice): « mon-produit-de-test » - Not visible
Step 2. Set visibility attribute to visible via product grid mass action

Product URL rewrite should be created.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
