### PR TITLE
code clean

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Php/LiveCodeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Php/LiveCodeTest.php
@@ -7,7 +7,6 @@
 namespace Magento\Test\Php;
 
 use Magento\Framework\App\Utility\Files;
-use Magento\Framework\Component\ComponentRegistrar;
 use Magento\TestFramework\CodingStandard\Tool\CodeMessDetector;
 use Magento\TestFramework\CodingStandard\Tool\CodeSniffer;
 use Magento\TestFramework\CodingStandard\Tool\CodeSniffer\Wrapper;


### PR DESCRIPTION
### Description (*)
Remove the statement "use Magento\Framework\Component\ComponentRegistrar;" as it is not used anywhere in the file.

### Manual testing scenarios (*)
1. Ran the test file in phpstorm
