### PR TITLE
Do not validate length and input rule if attribute value is required but empty

### DIFF
--- a/app/code/Magento/Eav/Model/Attribute/Data/Text.php
+++ b/app/code/Magento/Eav/Model/Attribute/Data/Text.php
@@ -75,6 +75,8 @@ class Text extends \Magento\Eav\Model\Attribute\Data\AbstractData
         if (empty($value) && $value !== '0' && $attribute->getDefaultValue() === null) {
             $label = __($attribute->getStoreLabel());
             $errors[] = __('"%1" is a required value.', $label);
+
+            return $errors;
         }
 
         $validateLengthResult = $this->validateLength($attribute, $value);


### PR DESCRIPTION
Hi,

### Description (*)
The EAV text attribute validation continues even if a required attribute is required but has no value.
It raises the error 
```
Argument 2 passed to Magento\Eav\Model\Attribute\Data\Text::validateLength() must be of the type string, null given, called in /var/www/html/vendor/magento/module-eav/Model/Attribute/Data/Text.php on line 80
```
when creating a customer without a required attribute with GraphQL for example.

### Manual testing scenarios (*)
1. Create a required customer attribute
2. Register a new customer with GraphQL request `createCustomer` but without setting this required attribute
3. Magento should return the error `"Attribute" is a required value.`

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
