### PR TITLE
Correct bug 21993 config:set not storing scoped values

### DIFF
--- a/app/code/Magento/Config/Console/Command/ConfigSet/DefaultProcessor.php
+++ b/app/code/Magento/Config/Console/Command/ConfigSet/DefaultProcessor.php
@@ -90,10 +90,10 @@ class DefaultProcessor implements ConfigSetProcessorInterface
         }
 
         try {
-            $config = $this->configFactory->create([
+            $config = $this->configFactory->create(['data' => [
                 'scope' => $scope,
                 'scope_code' => $scopeCode,
-            ]);
+            ]]);
             $config->setDataByPath($path, $value);
             $config->save();
         } catch (\Exception $exception) {

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/DefaultProcessorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/DefaultProcessorTest.php
@@ -103,7 +103,7 @@ class DefaultProcessorTest extends \PHPUnit\Framework\TestCase
         $config = $this->createMock(Config::class);
         $this->configFactory->expects($this->once())
             ->method('create')
-            ->with(['scope' => $scope, 'scope_code' => $scopeCode])
+            ->with(['data' => ['scope' => $scope, 'scope_code' => $scopeCode]])
             ->willReturn($config);
         $config->expects($this->once())
             ->method('setDataByPath')


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Supply scope type and scope code to configFactory as data array, so that these values are forwarded to the Config instance.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21993: config:set not storing scoped values

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. see  magento/magento2#21993: config:set not storing scoped values

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
