### PR TITLE
Update Customer grid index after a customer import

### DIFF
--- a/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
@@ -685,8 +685,8 @@ class Customer extends AbstractCustomer
      */
     private function reindexCustomers($customerIdsToReindex = [])
     {
-        $indexer = $this->_indexerRegistry->get('customer_grid');
         if (is_array($customerIdsToReindex) && count($customerIdsToReindex) > 0) {
+            $indexer = $this->_indexerRegistry->get('customer_grid');
             $indexer->reindexList($customerIdsToReindex);
         }
     }

--- a/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
@@ -129,7 +129,7 @@ class Customer extends AbstractCustomer
     /**
      * @var IndexerRegistry
      */
-    protected $_indexerRegistry;
+    private $indexerRegistry;
 
     /**
      * {@inheritdoc}
@@ -258,7 +258,7 @@ class Customer extends AbstractCustomer
         $this->_initStores(true)->_initAttributes();
 
         $this->_customerModel = $customerFactory->create();
-        $this->_indexerRegistry = $indexerRegistry ?: ObjectManager::getInstance()->get(IndexerRegistry::class);
+        $this->indexerRegistry = $indexerRegistry ?: ObjectManager::getInstance()->get(IndexerRegistry::class);
         /** @var $customerResource \Magento\Customer\Model\ResourceModel\Customer */
         $customerResource = $this->_customerModel->getResource();
         $this->_entityTable = $customerResource->getEntityTable();
@@ -689,7 +689,7 @@ class Customer extends AbstractCustomer
     private function reindexCustomers($customerIdsToReindex = [])
     {
         if (is_array($customerIdsToReindex) && count($customerIdsToReindex) > 0) {
-            $indexer = $this->_indexerRegistry->get('customer_grid');
+            $indexer = $this->indexerRegistry->get('customer_grid');
             $indexer->reindexList($customerIdsToReindex);
         }
     }

--- a/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
+++ b/app/code/Magento/CustomerImportExport/Model/Import/Customer.php
@@ -9,6 +9,8 @@ use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\ImportExport\Model\Import;
 use Magento\ImportExport\Model\Import\ErrorProcessing\ProcessingErrorAggregatorInterface;
 use Magento\ImportExport\Model\Import\AbstractSource;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Indexer\IndexerRegistry;
 
 /**
  * Customer entity import
@@ -125,7 +127,7 @@ class Customer extends AbstractCustomer
     protected $_resourceHelper;
 
     /**
-     * @var \Magento\Framework\Indexer\IndexerRegistry
+     * @var IndexerRegistry
      */
     protected $_indexerRegistry;
 
@@ -184,6 +186,7 @@ class Customer extends AbstractCustomer
      * @param \Magento\CustomerImportExport\Model\ResourceModel\Import\Customer\StorageFactory $storageFactory
      * @param \Magento\Customer\Model\ResourceModel\Attribute\CollectionFactory $attrCollectionFactory
      * @param \Magento\Customer\Model\CustomerFactory $customerFactory
+     * @param IndexerRegistry $indexerRegistry
      * @param array $data
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
@@ -200,7 +203,7 @@ class Customer extends AbstractCustomer
         \Magento\CustomerImportExport\Model\ResourceModel\Import\Customer\StorageFactory $storageFactory,
         \Magento\Customer\Model\ResourceModel\Attribute\CollectionFactory $attrCollectionFactory,
         \Magento\Customer\Model\CustomerFactory $customerFactory,
-        \Magento\Framework\Indexer\IndexerRegistry $indexerRegistry,
+        IndexerRegistry $indexerRegistry = null,
         array $data = []
     ) {
         $this->_resourceHelper = $resourceHelper;
@@ -255,7 +258,7 @@ class Customer extends AbstractCustomer
         $this->_initStores(true)->_initAttributes();
 
         $this->_customerModel = $customerFactory->create();
-        $this->_indexerRegistry = $indexerRegistry;
+        $this->_indexerRegistry = $indexerRegistry ?: ObjectManager::getInstance()->get(IndexerRegistry::class);
         /** @var $customerResource \Magento\Customer\Model\ResourceModel\Customer */
         $customerResource = $this->_customerModel->getResource();
         $this->_entityTable = $customerResource->getEntityTable();


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes the customer grid not updating after a customer Import is run

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19741: Customer import do not reindex customer grid
2. magento/magento2#10829: New customers not shown on backend. Seems indexer customer_grid not re-indexing.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run a customer import using Import tool in Magento admin
2. The customers imported are now in the customer grid, prior to this they would not be there until a full customer grid reindex was run in the CLI

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
