### PR TITLE
Magento Catalog - fix custom option type text price conversion for mu…

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Option.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Option.php
@@ -172,7 +172,8 @@ class Option extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                     foreach ($storeIds as $storeId) {
                         if ($object->getPriceType() == 'fixed') {
                             $storeCurrency = $this->_storeManager->getStore($storeId)->getBaseCurrencyCode();
-                            $rate = $this->_currencyFactory->create()->load($websiteBaseCurrency)->getRate($storeCurrency);
+                            $rate = $this->_currencyFactory->create()->load($websiteBaseCurrency)
+                                ->getRate($storeCurrency);
                             if (!$rate) {
                                 $rate = 1;
                             }

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Option.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Option.php
@@ -6,6 +6,7 @@
 namespace Magento\Catalog\Model\ResourceModel\Product;
 
 use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Store\Model\ScopeInterface;
 
 /**
  * Catalog product custom option resource model
@@ -154,21 +155,24 @@ class Option extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 
             $scope = (int)$this->_config->getValue(
                 \Magento\Store\Model\Store::XML_PATH_PRICE_SCOPE,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                ScopeInterface::SCOPE_STORE
             );
 
             if ($object->getStoreId() != '0' && $scope == \Magento\Store\Model\Store::PRICE_SCOPE_WEBSITE) {
-                $baseCurrency = $this->_config->getValue(
+                $website  = $this->_storeManager->getStore($object->getStoreId())->getWebsite();
+
+                $websiteBaseCurrency = $this->_config->getValue(
                     \Magento\Directory\Model\Currency::XML_PATH_CURRENCY_BASE,
-                    'default'
+                    ScopeInterface::SCOPE_WEBSITE,
+                    $website
                 );
 
-                $storeIds = $this->_storeManager->getStore($object->getStoreId())->getWebsite()->getStoreIds();
+                $storeIds = $website->getStoreIds();
                 if (is_array($storeIds)) {
                     foreach ($storeIds as $storeId) {
                         if ($object->getPriceType() == 'fixed') {
                             $storeCurrency = $this->_storeManager->getStore($storeId)->getBaseCurrencyCode();
-                            $rate = $this->_currencyFactory->create()->load($baseCurrency)->getRate($storeCurrency);
+                            $rate = $this->_currencyFactory->create()->load($websiteBaseCurrency)->getRate($storeCurrency);
                             if (!$rate) {
                                 $rate = 1;
                             }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Previously I already fixed similar issue in the PR https://github.com/magento/magento2/pull/18225, but the fix doesn't cover all the custom option types, e.g. type "Field" still has that issue with price conversion. 

_It's reproduced on the following Magento setup with multi-currency configuration:_
1. There are 2 websites configured: US and CA (or another one).
2. Base Currency is configured in the next way: default level - USD; CA - CAD.
3. And if you try to update product with custom options type "Field" (or another without option values) with non zero price on CA website level.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
No related issues found.

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
**Steps to reproduce**
1. Create 2 websites on Magento: US website and CA website.
2. Set up Base Currency to USD (or any other) on default scope.
3. Set up Base Currency to CAD on CA website scope.
4. Create product with custom option type "Field" (or another without option values) and set up non zero price for option.
5. Save the product.
6. Change configuration scope on CA website.
7. Save product.

**Expected result**
Custom option price is not changed, because no actual changes were done.

**Actual result**
Custom option price is updated according to USD/CAD currency rate.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
