### PR TITLE
Fix the compatibility issue introduced by the change of catalog product view layout.

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Details.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Details.php
@@ -15,7 +15,7 @@ namespace Magento\Catalog\Block\Product\View;
  *
  * @api
  */
-class Details extends \Magento\Framework\View\Element\Template
+class Details extends Description
 {
     /**
      * Get sorted child block names.


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Layout change of the Magento_Catalog::catalog_product_view.xml breaks legacy templates in which uses the $block->getProduct() function calls. Problem is the new introduced block class doesn't support this.

To avoid incompatibility problem. it's better to have the new class extends from the legacy class.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
<!--


-->
1. magento/magento2#22036: $block->getProduct() in catalog product view template failed after upgrading from 2.3.0 to 2.3.1
### Manual testing scenarios (*)

<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Install Magento 2.3.0.
2. Install [Porto Theme](https://www.portotheme.com)
3. Product page is broken.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)