### PR TITLE
[Backport] Root exception not logged on QuoteManagement::submitQuote

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -529,28 +529,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
             );
             $this->quoteRepository->save($quote);
         } catch (\Exception $e) {
-            try {
-                if (!empty($this->addressesToSync)) {
-                    foreach ($this->addressesToSync as $addressId) {
-                        $this->addressRepository->deleteById($addressId);
-                    }
-                }
-                $this->eventManager->dispatch(
-                    'sales_model_service_quote_submit_failure',
-                    [
-                        'order' => $order,
-                        'quote' => $quote,
-                        'exception' => $e,
-                    ]
-                );
-            } catch (\Exception $consecutiveException) {
-                $message = sprintf(
-                    "An exception occurred on 'sales_model_service_quote_submit_failure' event: %s",
-                    $consecutiveException->getMessage()
-                );
-
-                throw new \Exception($message, 0, $e);
-            }
+            $this->rollbackAddresses($quote, $order, $e);
             throw $e;
         }
         return $order;
@@ -615,6 +594,43 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
         }
         if ($shipping && !$shipping->getCustomerId() && !$hasDefaultBilling) {
             $shipping->setIsDefaultBilling(true);
+        }
+    }
+
+    /**
+     * Remove related to order and quote addresses and submit exception to further processing.
+     *
+     * @param Quote $quote
+     * @param \Magento\Sales\Api\Data\OrderInterface $order
+     * @param \Exception $e
+     * @throws \Exception
+     */
+    private function rollbackAddresses(
+        QuoteEntity $quote,
+        \Magento\Sales\Api\Data\OrderInterface $order,
+        \Exception $e
+    ): void {
+        try {
+            if (!empty($this->addressesToSync)) {
+                foreach ($this->addressesToSync as $addressId) {
+                    $this->addressRepository->deleteById($addressId);
+                }
+            }
+            $this->eventManager->dispatch(
+                'sales_model_service_quote_submit_failure',
+                [
+                    'order' => $order,
+                    'quote' => $quote,
+                    'exception' => $e,
+                ]
+            );
+        } catch (\Exception $consecutiveException) {
+            $message = sprintf(
+                "An exception occurred on 'sales_model_service_quote_submit_failure' event: %s",
+                $consecutiveException->getMessage()
+            );
+
+            throw new \Exception($message, 0, $e);
         }
     }
 }

--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -12,7 +12,6 @@ use Magento\Framework\Event\ManagerInterface as EventManager;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\StateException;
-use Magento\Framework\Phrase;
 use Magento\Quote\Api\Data\PaymentInterface;
 use Magento\Quote\Model\Quote\Address\ToOrder as ToOrderConverter;
 use Magento\Quote\Model\Quote\Address\ToOrderAddress as ToOrderAddressConverter;
@@ -545,15 +544,12 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
                     ]
                 );
             } catch (\Exception $consecutiveException) {
-                $message = new Phrase(
-                    "An exception occurred on 'sales_model_service_quote_submit_failure' event: %1\n%2",
-                    [
-                        $consecutiveException->getMessage(),
-                        $consecutiveException->getTraceAsString()
-                    ]
+                $message = sprintf(
+                    "An exception occurred on 'sales_model_service_quote_submit_failure' event: %s",
+                    $consecutiveException->getMessage()
                 );
 
-                throw new LocalizedException($message, $e);
+                throw new \Exception($message, 0, $e);
             }
             throw $e;
         }

--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -12,6 +12,7 @@ use Magento\Framework\Event\ManagerInterface as EventManager;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\StateException;
+use Magento\Framework\Phrase;
 use Magento\Quote\Api\Data\PaymentInterface;
 use Magento\Quote\Model\Quote\Address\ToOrder as ToOrderConverter;
 use Magento\Quote\Model\Quote\Address\ToOrderAddress as ToOrderAddressConverter;
@@ -529,19 +530,31 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
             );
             $this->quoteRepository->save($quote);
         } catch (\Exception $e) {
-            if (!empty($this->addressesToSync)) {
-                foreach ($this->addressesToSync as $addressId) {
-                    $this->addressRepository->deleteById($addressId);
+            try {
+                if (!empty($this->addressesToSync)) {
+                    foreach ($this->addressesToSync as $addressId) {
+                        $this->addressRepository->deleteById($addressId);
+                    }
                 }
+                $this->eventManager->dispatch(
+                    'sales_model_service_quote_submit_failure',
+                    [
+                        'order' => $order,
+                        'quote' => $quote,
+                        'exception' => $e,
+                    ]
+                );
+            } catch (\Exception $consecutiveException) {
+                $message = new Phrase(
+                    "An exception occurred on 'sales_model_service_quote_submit_failure' event: %1\n%2",
+                    [
+                        $consecutiveException->getMessage(),
+                        $consecutiveException->getTraceAsString()
+                    ]
+                );
+
+                throw new LocalizedException($message, $e);
             }
-            $this->eventManager->dispatch(
-                'sales_model_service_quote_submit_failure',
-                [
-                    'order'     => $order,
-                    'quote'     => $quote,
-                    'exception' => $e
-                ]
-            );
             throw $e;
         }
         return $order;


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21697
### Description
If an exceptions happens in `\Magento\Sales\Api\OrderManagementInterface::place` or an `sales_model_service_quote_submit_success` observer, the catch block itself fires an event. As you can not know, what these observers do, it should be wrapped in a try catch block itself.

With the Magento core this will currently happen, for example if saving the order throws an exception. This causes a rollback in `\Magento\Framework\Model\ResourceModel\Db\AbstractDb::save`. The `catch` in the order management triggers via an observer the method `\Magento\CatalogInventory\Model\ResourceModel\Stock::correctItemsQty`. In this method the stock modification is secured in a transaction - as the connection is already in rollback mode, the exception with the message _Rolled back transaction has not been completed correctly._ is thrown.

The problem is, that only the second exception is logged in `exception.log` - the preceding exception is very hard to find.

To handle this I wrapped the catch block itself in a try catch and merge the information in a new exception. This new exception is handled as before and finds its way to the `exception.log`.

### Fixed Issues
1. magento/magento2#18752: Rolled back transaction has not been completed correctly" on Magento 2.1.15
1. magento/magento2#14926: "Rolled back transaction has not been completed correctly" on Magento 2.2.3

### Manual testing scenarios
I do not know another (simple) way of reproducing this bug, than introducing an exception in placement of order. In a real life scenario this exception may happen because of some runtime conditions (invalid credit card data - depending on PSP). It has to be either a rollback triggered in the try block of `\Magento\Sales\Api\OrderManagementInterface::place` or an exception in a `sales_model_service_quote_submit_failure` observers.
1. Add this to the method `\Magento\Sales\Model\ResourceModel\Order::_beforeSave`:
`throw new \Exception('root of all evil');`
1. watch the exception log: `tail -f <magento_root>/var/log/excption.log`
1. add products to cart
1. proceed to checkout
1. try to place the order
    1. the message 'An error occurred. Try to place the order again.' shows up in store front
    1. the log entry contains the message of the consecutive exception ('Rolled back transaction has not been completed correctly')
    1. the log entry contains the message of the preceding exception ('root of all evil').

### Example
#### Log message without fix
```
report.CRITICAL: Rolled back transaction has not been completed correctly. {"exception":"[object]
(Exception(code: 0): Rolled back transaction has not been completed correctly. at
/Users/fuehrd/sources/magento2ce/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php:277)"} []
```

#### Log message with fix
```
report.CRITICAL: An exception occurred on 'sales_model_service_quote_submit_failure' event: Rolled
back transaction has not been completed correctly. {"exception":"[object] (Exception(code: 0): An
exception occurred on 'sales_model_service_quote_submit_failure' event: Rolled back transaction has
not been completed correctly. at
/Users/fuehrd/sources/magento2ce/app/code/Magento/Quote/Model/QuoteManagement.php:555,
Exception(code: 0): root of all evil at
/Users/fuehrd/sources/magento2ce/app/code/Magento/Sales/Model/ResourceModel/Order.php:144)"}
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
