### PR TITLE
Fix typehint for ButtonList::update parameter

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Button/ButtonList.php
+++ b/app/code/Magento/Backend/Block/Widget/Button/ButtonList.php
@@ -81,7 +81,7 @@ class ButtonList
      *
      * @param string $buttonId
      * @param string|null $key
-     * @param string $data
+     * @param mixed $data
      * @return void
      */
     public function update($buttonId, $key, $data)


### PR DESCRIPTION
Magento\Backend\Block\Widget\Button\Item::setData accepts mixed value parameter, so should Magento\Backend\Block\Widget\Button\ButtonList::update. 

Found this issue while experimenting with phpstan.
