### PR TITLE
#22063 Category link store id fix

### DIFF
--- a/app/code/Magento/Catalog/Model/CategoryLinkRepository.php
+++ b/app/code/Magento/Catalog/Model/CategoryLinkRepository.php
@@ -38,7 +38,7 @@ class CategoryLinkRepository implements \Magento\Catalog\Api\CategoryLinkReposit
      */
     public function save(\Magento\Catalog\Api\Data\CategoryProductLinkInterface $productLink)
     {
-        $category = $this->categoryRepository->get($productLink->getCategoryId());
+        $category = $this->categoryRepository->get($productLink->getCategoryId(), 0);
         $product = $this->productRepository->get($productLink->getSku());
         $productPositions = $category->getProductsPosition();
         $productPositions[$product->getId()] = $productLink->getPosition();
@@ -72,7 +72,7 @@ class CategoryLinkRepository implements \Magento\Catalog\Api\CategoryLinkReposit
      */
     public function deleteByIds($categoryId, $sku)
     {
-        $category = $this->categoryRepository->get($categoryId);
+        $category = $this->categoryRepository->get($categoryId, 0);
         $product = $this->productRepository->get($sku);
         $productPositions = $category->getProductsPosition();
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When there is a loop going through a few products and linking those products to categories. Some categories get data copied from another store.

Load a category from the default store instead of taking the last cached from CategoryRepository.

I think it would also be better to save the category via its repository. Unfortunately the CategoryRepository ignores posted products `$category->setPostedProducts($productPositions);`.
(probably a case for another bug)

### Fixed Issues (if relevant)

1. https://github.com/magento/magento2/issues/22063

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create many stores 
2. Give different descriptions and short descriptions to a category in each store.
3. Loop through different stores e.g. with emulation or just load categories based on product store id
4. Link a product to a category.
5. Category has correct data (data was not copied from the category instance that loaded in different store)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
