### PR TITLE
URL Key already exist error coming if we give same name for two produ…

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlPathGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlPathGenerator.php
@@ -43,7 +43,7 @@ class ProductUrlPathGenerator
     /**
      * @var CategoryUrlPathGenerator
      */
-    protected $categoryUrlPathGenerator;
+    protected $catUrlPathGenerator;
 
     /**
      * @var ProductRepositoryInterface
@@ -53,18 +53,18 @@ class ProductUrlPathGenerator
     /**
      * @param StoreManagerInterface $storeManager
      * @param ScopeConfigInterface $scopeConfig
-     * @param CategoryUrlPathGenerator $categoryUrlPathGenerator
+     * @param CategoryUrlPathGenerator $catUrlPathGenerator
      * @param ProductRepositoryInterface $productRepository
      */
     public function __construct(
         StoreManagerInterface $storeManager,
         ScopeConfigInterface $scopeConfig,
-        CategoryUrlPathGenerator $categoryUrlPathGenerator,
+        CategoryUrlPathGenerator $catUrlPathGenerator,
         ProductRepositoryInterface $productRepository
     ) {
         $this->storeManager = $storeManager;
         $this->scopeConfig = $scopeConfig;
-        $this->categoryUrlPathGenerator = $categoryUrlPathGenerator;
+        $this->catUrlPathGenerator = $catUrlPathGenerator;
         $this->productRepository = $productRepository;
     }
 
@@ -86,7 +86,7 @@ class ProductUrlPathGenerator
         }
         return $category === null
             ? $path
-            : $this->categoryUrlPathGenerator->getUrlPath($category) . '/' . $path;
+            : $this->catUrlPathGenerator->getUrlPath($category) . '/' . $path;
     }
 
     /**


### PR DESCRIPTION
…cts. #21860

### Description (*)
Creating unique URL key for the new product.  
When a new product is creating and the admin has not filled the URL key field in the product edit form the unique URL key will be created.

### Fixed Issues (if relevant)

1.#21860: URL Key already exists error coming if we give the same name for two products. 

### Manual testing scenarios (*)

1.  Create a Product from Magento Admin and set visibility to catalog & search or catalog or search.
2.  Create another product with the same name. And select visibility catalog & search or catalog or search.
3. The second product has a unique URL key(it's modified like SKU)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
