### PR TITLE
[Backport] Add argument to show filter text in URL rewrite grid after click on back button

### DIFF
--- a/app/code/Magento/UrlRewrite/view/adminhtml/layout/adminhtml_url_rewrite_index.xml
+++ b/app/code/Magento/UrlRewrite/view/adminhtml/layout/adminhtml_url_rewrite_index.xml
@@ -14,8 +14,8 @@
                         <argument name="id" xsi:type="string">urlrewriteGrid</argument>
                         <argument name="dataSource" xsi:type="object">Magento\UrlRewrite\Model\ResourceModel\UrlRewriteCollection</argument>
                         <argument name="default_sort" xsi:type="string">url_rewrite_id</argument>
-			<!-- Add below argument to save session parameter in URL rewrite grid -->
-			<argument name="save_parameters_in_session" xsi:type="string">1</argument>
+                        <!-- Add below argument to save session parameter in URL rewrite grid -->
+                        <argument name="save_parameters_in_session" xsi:type="string">1</argument>
                     </arguments>
                     <block class="Magento\Backend\Block\Widget\Grid\ColumnSet" as="grid.columnSet" name="adminhtml.url_rewrite.grid.columnSet">
                         <arguments>

--- a/app/code/Magento/UrlRewrite/view/adminhtml/layout/adminhtml_url_rewrite_index.xml
+++ b/app/code/Magento/UrlRewrite/view/adminhtml/layout/adminhtml_url_rewrite_index.xml
@@ -14,6 +14,7 @@
                         <argument name="id" xsi:type="string">urlrewriteGrid</argument>
                         <argument name="dataSource" xsi:type="object">Magento\UrlRewrite\Model\ResourceModel\UrlRewriteCollection</argument>
                         <argument name="default_sort" xsi:type="string">url_rewrite_id</argument>
+						<argument name="save_parameters_in_session" xsi:type="string">1</argument>
                     </arguments>
                     <block class="Magento\Backend\Block\Widget\Grid\ColumnSet" as="grid.columnSet" name="adminhtml.url_rewrite.grid.columnSet">
                         <arguments>

--- a/app/code/Magento/UrlRewrite/view/adminhtml/layout/adminhtml_url_rewrite_index.xml
+++ b/app/code/Magento/UrlRewrite/view/adminhtml/layout/adminhtml_url_rewrite_index.xml
@@ -14,8 +14,8 @@
                         <argument name="id" xsi:type="string">urlrewriteGrid</argument>
                         <argument name="dataSource" xsi:type="object">Magento\UrlRewrite\Model\ResourceModel\UrlRewriteCollection</argument>
                         <argument name="default_sort" xsi:type="string">url_rewrite_id</argument>
-						<!-- Add below argument to save session parameter in URL rewrite grid -->
-						<argument name="save_parameters_in_session" xsi:type="string">1</argument>
+			<!-- Add below argument to save session parameter in URL rewrite grid -->
+			<argument name="save_parameters_in_session" xsi:type="string">1</argument>
                     </arguments>
                     <block class="Magento\Backend\Block\Widget\Grid\ColumnSet" as="grid.columnSet" name="adminhtml.url_rewrite.grid.columnSet">
                         <arguments>

--- a/app/code/Magento/UrlRewrite/view/adminhtml/layout/adminhtml_url_rewrite_index.xml
+++ b/app/code/Magento/UrlRewrite/view/adminhtml/layout/adminhtml_url_rewrite_index.xml
@@ -14,6 +14,7 @@
                         <argument name="id" xsi:type="string">urlrewriteGrid</argument>
                         <argument name="dataSource" xsi:type="object">Magento\UrlRewrite\Model\ResourceModel\UrlRewriteCollection</argument>
                         <argument name="default_sort" xsi:type="string">url_rewrite_id</argument>
+						<!-- Add below argument to save session parameter in URL rewrite grid -->
 						<argument name="save_parameters_in_session" xsi:type="string">1</argument>
                     </arguments>
                     <block class="Magento\Backend\Block\Widget\Grid\ColumnSet" as="grid.columnSet" name="adminhtml.url_rewrite.grid.columnSet">


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21834
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
    Changes are related to URL grid issue (i.e. https://github.com/magento/magento2/issues/21805)
    Argument i.e. "save_parameters_in_session" is not available in below xml file.
	XML file: adminhtml_logging_block.xml

### Fixed Issues (if relevant)
1. magento/magento2#21805: Filter in url rewrites table in backend isn't being remembered

### Manual testing scenarios (*)
	In Magento backend, go to Marketing > URL Rewrites
	Put a filter in one of the columns (like in the Request Path column) and apply it
	Click on one of the filtered results
	Click on the Back button

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
