### PR TITLE
Fotorama - disabling swipe on the item with class "disableSwipe"

### DIFF
--- a/lib/web/fotorama/fotorama.js
+++ b/lib/web/fotorama/fotorama.js
@@ -1399,12 +1399,13 @@ fotoramaVersion = '4.6.4';
             touchFLAG,
             targetIsSelectFLAG,
             targetIsLinkFlag,
+            isDisabledSwipe,
             tolerance,
             moved;
 
         function onStart(e) {
             $target = $(e.target);
-            tail.checked = targetIsSelectFLAG = targetIsLinkFlag = moved = false;
+            tail.checked = targetIsSelectFLAG = targetIsLinkFlag = isDisabledSwipe = moved = false;
 
             if (touchEnabledFLAG
                 || tail.flow
@@ -1415,6 +1416,7 @@ fotoramaVersion = '4.6.4';
 
             touchFLAG = e.type === 'touchstart';
             targetIsLinkFlag = $target.is('a, a *', el);
+            isDisabledSwipe = $target.hasClass('disableSwipe');
             controlTouch = tail.control;
 
             tolerance = (tail.noMove || tail.noSwipe || controlTouch) ? 16 : !tail.snap ? 4 : 0;
@@ -1428,7 +1430,7 @@ fotoramaVersion = '4.6.4';
 
             touchEnabledFLAG = tail.flow = true;
 
-            if (!touchFLAG || tail.go) stopEvent(e);
+            if (!isDisabledSwipe && (!touchFLAG || tail.go)) stopEvent(e);
         }
 
         function onMove(e) {
@@ -1438,6 +1440,13 @@ fotoramaVersion = '4.6.4';
                 || !touchEnabledFLAG) {
                 touchEnabledFLAG && onEnd();
                 (options.onTouchEnd || noop)();
+                return;
+            }
+
+            $target = $(e.target);
+            isDisabledSwipe = $target.hasClass('disableSwipe');
+
+            if (isDisabledSwipe) {
                 return;
             }
 

--- a/lib/web/fotorama/fotorama.js
+++ b/lib/web/fotorama/fotorama.js
@@ -1443,8 +1443,7 @@ fotoramaVersion = '4.6.4';
                 return;
             }
 
-            $target = $(e.target);
-            isDisabledSwipe = $target.hasClass('disableSwipe');
+            isDisabledSwipe = $(e.target).hasClass('disableSwipe');
 
             if (isDisabledSwipe) {
                 return;


### PR DESCRIPTION
### Description
This fix adds the ability to disable swipe on the item.
For example canvas where you can draw something. Currently, we can't interactive with it because when we try to rotate an object, fotorama will slide to the next image.
This fix will check the active element and if it has "disableSwipe" class, it disables swipe and we'll interact with this element.