### PR TITLE
Fixed assignment of the guest customer to the guest group when 'Automatic Assignment by VAT ID' is enabled

### DIFF
--- a/app/code/Magento/Quote/Observer/Frontend/Quote/Address/CollectTotalsObserver.php
+++ b/app/code/Magento/Quote/Observer/Frontend/Quote/Address/CollectTotalsObserver.php
@@ -7,6 +7,11 @@ namespace Magento\Quote\Observer\Frontend\Quote\Address;
 
 use Magento\Framework\Event\ObserverInterface;
 
+/**
+ * Handle customer VAT number on collect_totals_before event of quote address.
+ *
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
+ */
 class CollectTotalsObserver implements ObserverInterface
 {
     /**

--- a/app/code/Magento/Quote/Observer/Frontend/Quote/Address/CollectTotalsObserver.php
+++ b/app/code/Magento/Quote/Observer/Frontend/Quote/Address/CollectTotalsObserver.php
@@ -124,7 +124,7 @@ class CollectTotalsObserver implements ObserverInterface
             );
         }
 
-        if ($groupId) {
+        if ($groupId !== null) {
             $address->setPrevQuoteCustomerGroupId($quote->getCustomerGroupId());
             $quote->setCustomerGroupId($groupId);
             $this->customerSession->setCustomerGroupId($groupId);

--- a/app/code/Magento/Quote/Test/Unit/Observer/Frontend/Quote/Address/CollectTotalsObserverTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Observer/Frontend/Quote/Address/CollectTotalsObserverTest.php
@@ -199,7 +199,7 @@ class CollectTotalsObserverTest extends \PHPUnit\Framework\TestCase
             ->method('getNotLoggedInGroup')
             ->will($this->returnValue($this->groupInterfaceMock));
         $this->groupInterfaceMock->expects($this->once())
-            ->method('getId')->will($this->returnValue(0));
+            ->method('getId')->will($this->returnValue(null));
         $this->vatValidatorMock->expects($this->once())
             ->method('isEnabled')
             ->with($this->quoteAddressMock, $this->storeId)
@@ -220,9 +220,6 @@ class CollectTotalsObserverTest extends \PHPUnit\Framework\TestCase
             $this->returnValue(false)
         );
 
-        $groupMock = $this->getMockBuilder(\Magento\Customer\Api\Data\GroupInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $this->customerMock->expects($this->once())->method('getId')->will($this->returnValue(null));
 
         /** Assertions */


### PR DESCRIPTION
### Description
Current logic doesn't work for a guest group id since it's `0`.

This commit fixes the case when guest fills valid VAT number,
then returns to the shipping step and removes VAT from the address.

### Manual testing scenarios
1. Navigate to _Customers > Customer Groups_ and create two groups "Valid VAT", "Invalid VAT".
2. Navigate to _Stores > Configuration > Customers > Customer Configuration > Create New Account Options_ and enable "Enable Automatic Assignment to Customer Group". Use groups from the first step for valid and invalid vat id groups. Don't forget to enable "Show VAT Number on Storefront" option.
3. Open checkout as a guest and use "LU26375245" as a VAT number and "Luxembourg" as a country.
4. Proceed to the payment step.
5. Open `quote` DB table using adminer of phpmyadmin, find your quote and look at the `customer_group_id` column. You'll see id of valid group (`4`, for example).
6. Return to the shipping step, remove VAT number, and proceed to the payment step again.
7. Take a look and the `quote` table again. I'm expecting to see `0` here but it still has `4`.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
