### PR TITLE
Payment methods source model is broken again

### DIFF
--- a/app/code/Magento/Payment/Helper/Data.php
+++ b/app/code/Magento/Payment/Helper/Data.php
@@ -150,7 +150,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             $res[] = $methodInstance;
         }
 
-        @uasort(
+        uasort(
             $res,
             function (MethodInterface $a, MethodInterface $b) {
                 return (int)$a->getConfigData('sort_order') <=> (int)$b->getConfigData('sort_order');
@@ -261,14 +261,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $groupRelations = [];
 
         foreach ($this->getPaymentMethods() as $code => $data) {
-            if (!empty($data['active'])) {
-                $storedTitle = $this->getMethodInstance($code)->getConfigData('title', $store);
-                if (isset($storedTitle)) {
-                    $methods[$code] = $storedTitle;
-                } elseif (isset($data['title'])) {
-                    $methods[$code] = $data['title'];
-                }
+            $storedTitle = $this->getMethodInstance($code)->getConfigData('title', $store);
+            if (isset($storedTitle)) {
+                $methods[$code] = $storedTitle;
+            } elseif (isset($data['title'])) {
+                $methods[$code] = $data['title'];
             }
+
             if ($asLabelValue && $withGroups && isset($data['group'])) {
                 $groupRelations[$code] = $data['group'];
             }

--- a/dev/tests/integration/testsuite/Magento/Payment/Helper/DataTest.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/Helper/DataTest.php
@@ -9,6 +9,11 @@
  */
 namespace Magento\Payment\Helper;
 
+use Magento\TestFramework\Helper\Bootstrap;
+
+/**
+ * Test for \Magento\Payment\Helper\Data class.
+ */
 class DataTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetInfoBlock()
@@ -20,5 +25,32 @@ class DataTest extends \PHPUnit\Framework\TestCase
         $paymentInfo->setMethod('checkmo');
         $result = $helper->getInfoBlock($paymentInfo);
         $this->assertInstanceOf(\Magento\OfflinePayments\Block\Info\Checkmo::class, $result);
+    }
+
+    /**
+     * Checking if payment available in getPaymentMethodList() with set active to 0.
+     *
+     * @magentoConfigFixture default_store payment/checkmo/active 0
+     */
+    public function testGetPaymentMethodListWithInactivePayments()
+    {
+        /** @var \Magento\Payment\Helper\Data $helper */
+        $helper = Bootstrap::getObjectManager()->get(\Magento\Payment\Helper\Data::class);
+        $paymentMethodsList =  $helper->getPaymentMethodList();
+        $this->assertArrayHasKey('checkmo', $paymentMethodsList);
+    }
+
+    /**
+     * Checking different title for payment method.
+     *
+     * @magentoConfigFixture default_store payment/checkmo/title New Title
+     */
+    public function testGetPaymentMethodListWithDifferentTitles()
+    {
+        /** @var \Magento\Payment\Helper\Data $helper */
+        $helper = Bootstrap::getObjectManager()->get(\Magento\Payment\Helper\Data::class);
+        $storedTitle = $helper->getMethodInstance('checkmo')->getConfigData('title', 'default');
+        $paymentMethodList = $helper->getPaymentMethodList();
+        $this->assertEquals($storedTitle, $paymentMethodList['checkmo']);
     }
 }


### PR DESCRIPTION
### Description (*)

The bug was introduced in 28c86be by testing the active flag of payment methods in \Magento\Payment\Helper\Data::getPaymentMethodList (where \Magento\Payment\Model\Config\Source\Allmethods::toOptionArray forwards to).

Because the source of the data is the default payment method configuration of a plain vanilla installation, no config setting changes (=activating additional methods) are taken into account.

This issue does not only affect the cart price rules. Every extension developer building upon this source model is affected:

### Fixed Issues (if relevant)
1. magento/magento2#22043: Payment methods source model is broken again
2. magento/magento2#22231: Payment Method Not Showing Admin Sales Grid only check method showing

### Manual testing scenarios (*)

Go to Marketing → Cart Price Rules.
Edit/Open a rule.
Under Conditions, add the Cart Attribute condition Payment Method.
Wait for the possible options to load..

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
