### PR TITLE
Previous scrolling to invalid form element is not being canceled on h…

### DIFF
--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -1958,7 +1958,7 @@
             }
 
             if (firstActive.length) {
-                $('html, body').animate({
+                $('html, body').stop().animate({
                     scrollTop: firstActive.offset().top
                 });
                 firstActive.focus();


### PR DESCRIPTION
…itting submit multiple times #21715

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

This issue was caused because of adding new jQuery animation every validation error of the QTY field without stopping the previous animation so I've added stopping the previous animation.

### Fixed Issues (if relevant)

1. magento/magento2#21715: Previous scrolling to invalid form element is not being canceled on hitting submit multiple times 

### Manual testing scenarios (*)

1. Go to a product page
2. Enter an invalid value like -1
3. Hit 'Add to cart' several times
4. When you get scrolled to the qty input try scrolling away
5. When scrolling is finished, the form will let you scroll away, no matter how many times you hit the add to cart button

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
