### PR TITLE
Fixed #21684 Currency sign for "Layered Navigation Price Step" is not according to default settings

### DIFF
--- a/app/code/Magento/Catalog/Model/Category/DataProvider.php
+++ b/app/code/Magento/Catalog/Model/Category/DataProvider.php
@@ -350,6 +350,11 @@ class DataProvider extends \Magento\Ui\DataProvider\ModifierPoolDataProvider
 
             $meta[$code]['scopeLabel'] = $this->getScopeLabel($attribute);
             $meta[$code]['componentType'] = Field::NAME;
+            
+            if($code == "filter_price_range"){
+                $meta[$code]['addbefore'] = $this->storeManager->getStore()
+                ->getBaseCurrency()->getCurrencySymbol();
+            }
         }
 
         $result = [];

--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/category_form.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/category_form.xml
@@ -353,7 +353,6 @@
                     <additionalClasses>
                         <class name="admin__field-small">true</class>
                     </additionalClasses>
-                    <addBefore>$</addBefore>
                     <label translate="true">Layered Navigation Price Step</label>
                 </settings>
             </field>


### PR DESCRIPTION
Fixed #21684 Currency sign for "Layered Navigation Price Step" is not according to default settings

### Preconditions (*)

1. Magento CE 2.7 or 2.3
2. Please set Base Currency = Euro
3. Please set Default Currency = Euro
4. Please set Allow Currency = Euro

### Steps to reproduce (*)

1. Go to catalog --> Categories --> Add Sub Category
2. Expand Display Settings
3. Check currency symbol in Layered Navigation Price Step 
 
### Expected result (*)

With these settings the currency displayed in Layered Navigation Price Step must be euro sign (€).

### Actual result (*)

With these settings the currency displayed in  Layered Navigation Price Step is incorrect: displays dollar sign ($), but expected euro sign (€):
![image](https://user-images.githubusercontent.com/366965/54115609-10391f80-43ed-11e9-987c-881f21caa891.png)

### Note (*) 

currency displayed in product (Price, Customizable Options → Option → Price) are correct.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
