### PR TITLE
Fixes issue - #21824. "save_parameters_in_session" set to true for admin user grid

### DIFF
--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_grid_block.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_grid_block.xml
@@ -16,6 +16,7 @@
                     <argument name="default_sort" xsi:type="string">username</argument>
                     <argument name="default_dir" xsi:type="string">asc</argument>
                     <argument name="grid_url" xsi:type="url" path="*/*/roleGrid"/>
+                    <argument name="save_parameters_in_session" xsi:type="boolean">true</argument>
                 </arguments>
                 <block class="Magento\Backend\Block\Widget\Grid\ColumnSet" as="grid.columnSet" name="permission.user.grid.columnSet">
                     <arguments>


### PR DESCRIPTION

### Description (*)
Fixes issue - #21824. "save_parameters_in_session" set to true for admin user grid through xml

### Fixed Issues (if relevant)

1. magento/magento2#21824: Filter in admin users grid in backend isn't being remembered

### Manual testing scenarios (*)
1. Go to Admin >> System >> Permissions >> All Users
2. Filter grid by "User Name", "First Name" or "Last Name"
3. Click to any admin user
4. Come back to the "All Users" grid.
5. The applied filter should stay

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
