### PR TITLE
Fixes Issue #20125. Set sortOrder of product_has_weight component in product form

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/General.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/General.php
@@ -218,6 +218,12 @@ class General extends AbstractModifier
 
             $hasWeightPath = $this->arrayManager->slicePath($weightPath, 0, -1) . '/'
                 . ProductAttributeInterface::CODE_HAS_WEIGHT;
+
+            $sortOrder = $this->arrayManager->get(
+                $this->arrayManager->findPath('sortOrder', $meta, $weightPath),
+                $meta
+            );
+
             $meta = $this->arrayManager->set(
                 $hasWeightPath . static::META_CONFIG_PATH,
                 $meta,
@@ -228,6 +234,7 @@ class General extends AbstractModifier
                     'componentType' => Form\Field::NAME,
                     'dataScope' => 'product_has_weight',
                     'label' => '',
+                    'sortOrder' => $sortOrder + 1,
                     'options' => [
                         [
                             'label' => __('This item has weight'),


### PR DESCRIPTION
Set sortOrder of product_has_weight component in product form

### Description (*)
Set sortOrder of product_has_weight component in product form to one greater than weight field, so that the layout is not disrupted.

### Fixed Issues (if relevant)
1. magento/magento2#20125: Design issue in product creation form

### Manual testing scenarios (*)

1. Login to admin panel
2. On left navigation goto Stores-> Attributes-> Attribute Set
3. Create a new attribute set on based on default attribute
4. Now Stores-> Attributes -> Product
5. Create an attribute of the text field
6. Now assign created attribute to previously created attribute set on step 3.
7. Now try to create a product with the above-created attribute set
8. The product form design should not be disrupted

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
