### PR TITLE
Backport for Magento 2.2 - Fixes variables in configuration not being…

### DIFF
--- a/app/code/Magento/Config/Block/System/Config/Form.php
+++ b/app/code/Magento/Config/Block/System/Config/Form.php
@@ -423,6 +423,10 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 $backendModel = $field->getBackendModel();
                 // Backend models which implement ProcessorInterface are processed by ScopeConfigInterface
                 if (!$backendModel instanceof ProcessorInterface) {
+                    if (array_key_exists($path, $this->_configData)) {
+                        $data = $this->_configData[$path];
+                    }
+
                     $backendModel->setPath($path)
                         ->setValue($data)
                         ->setWebsite($this->getWebsiteCode())


### PR DESCRIPTION
… replaced with actual values in the backend form fields.

(cherry picked from commit a8f17290363aa157eb1ec77984b3df2201a97ea9)

### Description (*)
This is a backport of https://github.com/magento/magento2/pull/18067 for Magento 2.2

### Fixed Issues (if relevant)
1. #15972: Since Magento 2.2.1, certain variables in the configuration get resolved to their actual value

### Manual testing scenarios (*)
1. Setup a clean Magento from 2.2-develop branch
2. In the backend configuration go to: General > Web > Base URLs & Base URLs (Secure)
3. Enter `{{unsecure_base_url}}media/` in "Base URL for User Media Files" and 
`{{secure_base_url}}media/` in "Secure Base URL for User Media Files"
4. Save Config
5. Look at those two fields you just edited, they should remain unchanged

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
