### PR TITLE
Fix #18557 - set created_at and updated_at on save to ui_bookmark table

### DIFF
--- a/app/code/Magento/Ui/Model/ResourceModel/Bookmark.php
+++ b/app/code/Magento/Ui/Model/ResourceModel/Bookmark.php
@@ -5,7 +5,12 @@
  */
 namespace Magento\Ui\Model\ResourceModel;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Model\AbstractModel;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use Magento\Framework\Model\ResourceModel\Db\Context;
+use Magento\Framework\Stdlib\DateTime\DateTime;
+use Magento\Ui\Api\Data\BookmarkInterface;
 
 /**
  * Bookmark resource
@@ -13,14 +18,22 @@ use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 class Bookmark extends AbstractDb
 {
     /**
-     * @param \Magento\Framework\Model\ResourceModel\Db\Context $context
+     * @var DateTime
+     */
+    private $dateTime;
+
+    /**
+     * @param Context $context
      * @param string $connectionName
+     * @param DateTime|null $dateTime
      */
     public function __construct(
-        \Magento\Framework\Model\ResourceModel\Db\Context $context,
-        $connectionName = null
+        Context $context,
+        $connectionName = null,
+        DateTime $dateTime = null
     ) {
         parent::__construct($context, $connectionName);
+        $this->dateTime = $dateTime ?: ObjectManager::getInstance()->get(DateTime::class);
     }
 
     /**
@@ -31,5 +44,23 @@ class Bookmark extends AbstractDb
     protected function _construct()
     {
         $this->_init('ui_bookmark', 'bookmark_id');
+    }
+
+    /**
+     * Perform actions before object save
+     *
+     * @param AbstractModel|BookmarkInterface $object
+     * @return $this
+     */
+    protected function _beforeSave(AbstractModel $object)
+    {
+        $gmtDate = $this->dateTime->gmtDate();
+
+        $object->setUpdatedAt($gmtDate);
+        if ($object->isObjectNew()) {
+            $object->setCreatedAt($gmtDate);
+        }
+
+        return parent::_beforeSave($object);
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This is fix for #18557.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18557: Value of created_at and updated_at columns not updating in ui_bookmark table

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to some grid in MBO (i.e. sales orders grid)
2. Modify visible columns
3. Create new bookmark by saving new view
4. Check `created_at` and `updated_at` columns for chosen grid rows in `ui_bookmark` table.
5. Save same bookmark again
6. Check `updated_at` column

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
