### PR TITLE
Fixed #22052 Customer account confirmation is overwritten by backend customer save

### DIFF
--- a/app/code/Magento/Customer/Model/Customer/DataProviderWithDefaultAddresses.php
+++ b/app/code/Magento/Customer/Model/Customer/DataProviderWithDefaultAddresses.php
@@ -39,7 +39,6 @@ class DataProviderWithDefaultAddresses extends \Magento\Ui\DataProvider\Abstract
     private static $forbiddenCustomerFields = [
         'password_hash',
         'rp_token',
-        'confirmation',
     ];
 
     /**

--- a/app/code/Magento/Customer/Test/Unit/Model/Customer/DataProviderWithDefaultAddressesTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Customer/DataProviderWithDefaultAddressesTest.php
@@ -339,7 +339,6 @@ class DataProviderWithDefaultAddressesTest extends \PHPUnit\Framework\TestCase
             'default_shipping' => 2,
             'password_hash' => 'password_hash',
             'rp_token' => 'rp_token',
-            'confirmation' => 'confirmation',
         ];
 
         $address = $this->getMockBuilder(\Magento\Customer\Model\Address::class)

--- a/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
+++ b/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
@@ -74,6 +74,17 @@
                 <visible>false</visible>
             </settings>
         </field>
+        <field name="confirmation" formElement="input">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">customer</item>
+                </item>
+            </argument>
+            <settings>
+                <dataType>text</dataType>
+                <visible>false</visible>
+            </settings>
+        </field>
         <field name="created_in" formElement="input">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">


### PR DESCRIPTION
Fixed #22052 Customer account confirmation is overwritten by backend customer save


### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Clean Magento setup 2.3.1
2. Set the account confirmation to **"Yes"** by visiting store > configuration > Customers > Customer Configuration > Create New Account Options > Require Emails Confirmation 

![cuonfig](https://user-images.githubusercontent.com/17308601/55266757-dab28400-527e-11e9-9c85-4e13700b3e4e.png)


### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Create a new customer account on frontend by visiting "Create a new account" link from header
2. Open Magento backend with valid credentials
3. Go to Customer > All Customers
4. Open the newly created customer and please notice the value of "Confirmed email:" is "Confirmation Required"
5. Now click on "Save and continue"
6. Now Please notice the value of "Confirmed email:" is "Confirmed"

**Customer account while opening customer**
![require](https://user-images.githubusercontent.com/17308601/55267005-0c781a80-5280-11e9-98ad-18e733e71226.png)

**After saving customer**

![confirm](https://user-images.githubusercontent.com/17308601/55267037-2b76ac80-5280-11e9-9b85-8f2673f1668c.png)


### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. Customer account should confirm by email link not from by saving customer from backend

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Customer account is getting confirmed even customer did not click on email activation link


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
