### PR TITLE
Magento admin store configuration general web Base url place holder c…

### DIFF
--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -503,22 +503,22 @@
                 <field id="base_url" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Secure Base URL</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Baseurl</backend_model>
-                    <comment>Specify URL or {{base_url}}, or {{unsecure_base_url}} placeholder.</comment>
+                    <comment>Specify URL or {{base_url}}{{unsecure_base_url}} placeholder.</comment>
                 </field>
                 <field id="base_link_url" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Secure Base Link URL</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Baseurl</backend_model>
-                    <comment>May start with {{secure_base_url}} or {{unsecure_base_url}} placeholder.</comment>
+                    <comment>May start with {{secure_base_url}}{{unsecure_base_url}} placeholder.</comment>
                 </field>
                 <field id="base_static_url" translate="label comment" type="text" sortOrder="25" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Secure Base URL for Static View Files</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Baseurl</backend_model>
-                    <comment>May be empty or start with {{secure_base_url}}, or {{unsecure_base_url}} placeholder.</comment>
+                    <comment>May be empty or start with {{secure_base_url}}{{unsecure_base_url}} placeholder.</comment>
                 </field>
                 <field id="base_media_url" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Secure Base URL for User Media Files</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Baseurl</backend_model>
-                    <comment>May be empty or start with {{secure_base_url}}, or {{unsecure_base_url}} placeholder.</comment>
+                    <comment>May be empty or start with {{secure_base_url}}{{unsecure_base_url}} placeholder.</comment>
                 </field>
                 <field id="use_in_frontend" translate="label comment" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Use Secure URLs on Storefront</label>


### PR DESCRIPTION
### Description (*)
There are typo errors found on the Magento admin panel. Please review Base url (secure) . You will find typo error for the place holder comment. In the Base url, the comment should be
Specify URL or placeholder instead of Specify URL or , or placeholder.

### Fixed Issues (if relevant)
1. magento/magento2#22169: Typo issue:Magento admin store configuration general web Base url place holder comment spelling mistake

### Manual testing scenarios (*)
1. Login to Magento admin
2. stores > configuration > general > web > Base Urls(secure)
3. observe the typo changes for hint text in 'Secure Base URL,Secure Base Link URL,Secure Base URL for Static View Files,Secure Base URL for User Media Files'
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
