### PR TITLE
unregister phar only when appropriate

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -8,7 +8,9 @@
  * Environment initialization
  */
 error_reporting(E_ALL);
-stream_wrapper_unregister('phar');
+if (in_array('phar', \stream_get_wrappers())) {
+    stream_wrapper_unregister('phar');
+}
 #ini_set('display_errors', 1);
 
 /* PHP version validation */


### PR DESCRIPTION
Calling stream_wrapper_unregister('phar') without checking if it's registered will trigger a warning

Link issue : [#21973](https://github.com/magento/magento2/issues/21973)