### PR TITLE
Removed client preference from Magento\ReleaseNotification module

### DIFF
--- a/app/code/Magento/ReleaseNotification/etc/di.xml
+++ b/app/code/Magento/ReleaseNotification/etc/di.xml
@@ -6,7 +6,6 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <preference for="Magento\Framework\HTTP\ClientInterface" type="Magento\Framework\HTTP\Client\Curl" />
     <preference for="Magento\ReleaseNotification\Model\ContentProviderInterface" type="Magento\ReleaseNotification\Model\ContentProvider\Http\HttpContentProvider" />
     <type name="Magento\Config\Model\Config\TypePool">
         <arguments>

--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -210,6 +210,7 @@
     <preference for="Magento\Framework\MessageQueue\Bulk\ExchangeFactoryInterface" type="Magento\Framework\MessageQueue\Bulk\ExchangeFactory" />
     <preference for="Magento\Framework\MessageQueue\QueueFactoryInterface" type="Magento\Framework\MessageQueue\QueueFactory" />
     <preference for="Magento\Framework\Search\Request\IndexScopeResolverInterface" type="Magento\Framework\Indexer\ScopeResolver\IndexScopeResolver"/>
+    <preference for="Magento\Framework\HTTP\ClientInterface" type="Magento\Framework\HTTP\Client\Curl"/>
     <type name="Magento\Framework\Model\ResourceModel\Db\TransactionManager" shared="false" />
     <type name="Magento\Framework\Acl\Data\Cache">
         <arguments>


### PR DESCRIPTION
### Description (*)
A preference for `ClientInterface` was wrongly present in `Magento\ReleaseNotification` module. This fix is related to the MSI issue: https://github.com/magento-engcom/msi/issues/2128 and to the MSI pull request: https://github.com/magento-engcom/msi/pull/2144

### Fixed Issues (if relevant)
Related to MSI issue: https://github.com/magento-engcom/msi/issues/2128

### Manual testing scenarios (*)
Testable on MSI, see https://github.com/magento-engcom/msi/pull/2144

### Contribution checklist (*)
 - [x ] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
