### PR TITLE
Handle the error properly when LESS source file is empty or having compilation error, and make the error message clear and clean.

### DIFF
--- a/app/code/Magento/Deploy/Package/Package.php
+++ b/app/code/Magento/Deploy/Package/Package.php
@@ -150,6 +150,8 @@ class Package
     }
 
     /**
+     * Get area.
+     *
      * @return string
      */
     public function getArea()
@@ -158,6 +160,8 @@ class Package
     }
 
     /**
+     * Get parent.
+     *
      * @return Package
      */
     public function getParent()
@@ -166,6 +170,8 @@ class Package
     }
 
     /**
+     * Get theme.
+     *
      * @return string
      */
     public function getTheme()
@@ -174,6 +180,8 @@ class Package
     }
 
     /**
+     * Get locale.
+     *
      * @return string
      */
     public function getLocale()
@@ -204,6 +212,8 @@ class Package
     }
 
     /**
+     * Get param.
+     *
      * @param string $name
      * @return mixed|null
      */
@@ -213,6 +223,8 @@ class Package
     }
 
     /**
+     * Set param.
+     *
      * @param string $name
      * @param mixed $value
      * @return bool
@@ -351,6 +363,8 @@ class Package
     }
 
     /**
+     * Set parent.
+     *
      * @param Package $parent
      * @return bool
      */
@@ -371,6 +385,8 @@ class Package
     }
 
     /**
+     * Get state.
+     *
      * @return int
      */
     public function getState()
@@ -379,6 +395,8 @@ class Package
     }
 
     /**
+     * Set state.
+     *
      * @param int $state
      * @return bool
      */
@@ -389,6 +407,8 @@ class Package
     }
 
     /**
+     * Get inheritance level.
+     *
      * @return int
      */
     public function getInheritanceLevel()
@@ -425,6 +445,7 @@ class Package
     {
         $map = [];
         foreach ($this->getParentPackages() as $parentPackage) {
+            // phpcs:ignore Magento2.Performance.ForeachArrayMerge.ForeachArrayMerge
             $map = array_merge($map, $parentPackage->getMap());
         }
         return $map;
@@ -441,8 +462,10 @@ class Package
         $files = [];
         foreach ($this->getParentPackages() as $parentPackage) {
             if ($type === null) {
+                // phpcs:ignore Magento2.Performance.ForeachArrayMerge.ForeachArrayMerge
                 $files = array_merge($files, $parentPackage->getFiles());
             } else {
+                // phpcs:ignore Magento2.Performance.ForeachArrayMerge.ForeachArrayMerge
                 $files = array_merge($files, $parentPackage->getFilesByType($type));
             }
         }
@@ -480,6 +503,8 @@ class Package
     }
 
     /**
+     * Get pre processors.
+     *
      * @return Processor\ProcessorInterface[]
      */
     public function getPreProcessors()
@@ -488,6 +513,8 @@ class Package
     }
 
     /**
+     * Get post processors.
+     *
      * @return Processor\ProcessorInterface[]
      */
     public function getPostProcessors()

--- a/app/code/Magento/Deploy/Package/Package.php
+++ b/app/code/Magento/Deploy/Package/Package.php
@@ -320,7 +320,10 @@ class Package
      */
     public function deleteFile($fileId)
     {
+        $file = $this->files[$fileId];
+        $deployedFileId = $file->getDeployedFileId();
         unset($this->files[$fileId]);
+        unset($this->map[$deployedFileId]);
     }
 
     /**

--- a/app/code/Magento/Deploy/Service/DeployPackage.php
+++ b/app/code/Magento/Deploy/Service/DeployPackage.php
@@ -134,9 +134,10 @@ class DeployPackage
             } catch (ContentProcessorException $exception) {
                 $errorMessage = __('Compilation from source: ')
                     . $file->getSourcePath()
-                    . PHP_EOL . $exception->getMessage();
+                    . PHP_EOL . $exception->getMessage() . PHP_EOL;
                 $this->errorsCount++;
                 $this->logger->critical($errorMessage);
+                $package->deleteFile($file->getFileId());
             } catch (\Exception $exception) {
                 $this->logger->critical(
                     'Compilation from source ' . $file->getSourcePath() . ' failed' . PHP_EOL . (string)$exception

--- a/dev/tests/integration/testsuite/Magento/Email/Model/Template/FilterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/Template/FilterTest.php
@@ -408,10 +408,12 @@ class FilterTest extends \PHPUnit\Framework\TestCase
     protected function setUpDesignParams()
     {
         $themeCode = 'Vendor_EmailTest/custom_theme';
-        $this->model->setDesignParams([
-            'area' => Area::AREA_FRONTEND,
-            'theme' => $themeCode,
-            'locale' => Locale::DEFAULT_SYSTEM_LOCALE,
-        ]);
+        $this->model->setDesignParams(
+            [
+                'area' => Area::AREA_FRONTEND,
+                'theme' => $themeCode,
+                'locale' => Locale::DEFAULT_SYSTEM_LOCALE,
+            ]
+        );
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Email/Model/Template/FilterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/Template/FilterTest.php
@@ -9,6 +9,7 @@ use Magento\Framework\App\Area;
 use Magento\Framework\App\State;
 use Magento\Framework\App\TemplateTypesInterface;
 use Magento\Framework\Phrase;
+use Magento\Framework\View\Asset\ContentProcessorInterface;
 use Magento\Setup\Module\I18n\Locale;
 use Magento\Theme\Block\Html\Footer;
 
@@ -267,7 +268,7 @@ class FilterTest extends \PHPUnit\Framework\TestCase
             'Empty or missing file' => [
                 TemplateTypesInterface::TYPE_HTML,
                 'file="css/non-existent-file.css"',
-                '/* Contents of the specified CSS file could not be loaded or is empty */'
+                '/*' . PHP_EOL . ContentProcessorInterface::ERROR_MESSAGE_PREFIX . 'LESS file is empty: ',
             ],
             'File with compilation error results in error message' => [
                 TemplateTypesInterface::TYPE_HTML,

--- a/lib/internal/Magento/Framework/Css/PreProcessor/Adapter/Less/Processor.php
+++ b/lib/internal/Magento/Framework/Css/PreProcessor/Adapter/Less/Processor.php
@@ -77,7 +77,7 @@ class Processor implements ContentProcessorInterface
             $content = $this->assetSource->getContent($asset);
 
             if (trim($content) === '') {
-                return '';
+                throw new ContentProcessorException(new Phrase(ContentProcessorInterface::ERROR_MESSAGE_PREFIX . 'LESS file is empty: ' . $path));
             }
 
             $tmpFilePath = $this->temporaryFile->createFile($path, $content);
@@ -88,8 +88,7 @@ class Processor implements ContentProcessorInterface
             gc_enable();
 
             if (trim($content) === '') {
-                $this->logger->warning('Parsed less file is empty: ' . $path);
-                return '';
+                throw new ContentProcessorException(new Phrase(ContentProcessorInterface::ERROR_MESSAGE_PREFIX . 'LESS file is empty: ' . $path));
             } else {
                 return $content;
             }

--- a/lib/internal/Magento/Framework/Css/PreProcessor/Adapter/Less/Processor.php
+++ b/lib/internal/Magento/Framework/Css/PreProcessor/Adapter/Less/Processor.php
@@ -61,7 +61,6 @@ class Processor implements ContentProcessorInterface
 
     /**
      * @inheritdoc
-     * @throws ContentProcessorException
      */
     public function processContent(File $asset)
     {
@@ -77,7 +76,9 @@ class Processor implements ContentProcessorInterface
             $content = $this->assetSource->getContent($asset);
 
             if (trim($content) === '') {
-                throw new ContentProcessorException(new Phrase(ContentProcessorInterface::ERROR_MESSAGE_PREFIX . 'LESS file is empty: ' . $path));
+                throw new ContentProcessorException(
+                    new Phrase('Compilation from source: LESS file is empty: ' . $path)
+                );
             }
 
             $tmpFilePath = $this->temporaryFile->createFile($path, $content);
@@ -88,7 +89,9 @@ class Processor implements ContentProcessorInterface
             gc_enable();
 
             if (trim($content) === '') {
-                throw new ContentProcessorException(new Phrase(ContentProcessorInterface::ERROR_MESSAGE_PREFIX . 'LESS file is empty: ' . $path));
+                throw new ContentProcessorException(
+                    new Phrase('Compilation from source: LESS file is empty: ' . $path)
+                );
             } else {
                 return $content;
             }

--- a/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/Adapter/Less/ProcessorTest.php
+++ b/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/Adapter/Less/ProcessorTest.php
@@ -111,6 +111,9 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test for processContent method (empty content)
+     *
+     * @expectedException \Magento\Framework\View\Asset\ContentProcessorException
+     * @expectedExceptionMessageRegExp (Compilation from source: LESS file is empty: test-path)
      */
     public function testProcessContentEmpty()
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Sometimes developer may want to put a `<css src=...` reference in the layout xml file first to get it ready, while leave an empty LESS source file (or with some comments) there to work later on.

Now the `setup:static-content:deploy` command would fail and print a full callstack of exception, while the callstack doesn't really show the real problem. Moreover, the deployment is actually moving on, until it gets a PHP error that failed to open CSS file, which it should never try since its LESS source is empty already.

This fix is to address such issue, print a clear error message, and to avoid the final PHP open file error. It covers the following two conditions:

1. LESS file is empty.
2. LESS file has compilation errors.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.


2. ...
-->
1. magento/magento2#22183: Empty LESS source file causes setup:static-content:deploy command fail
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Clone the 2.3-develop branch, and install a new site.
2. Add a LESS file to `app/design/frontend/Magento/blank/web/css/test-empty.less`, which has NO content or just some comments.
3. Add `<css src="css/test-empty.css"/>` to `app/design/frontend/Magento/blank/Magento_Theme/layout/default_head_blocks.xml`
4. Now run the `setup:static-content:deploy` command to compile.
5. We should be able to see the error message, and the compilation should complete with no other errors.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)