### PR TITLE
Removing incorrect less selector '.abs-cleafix', it has a typo + it i…

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
@@ -470,8 +470,6 @@ label.mage-error {
     }
 
     .admin__data-grid-header-row {
-        &:extend(.abs-cleafix);
-
         .action-select-multiselect {
             -webkit-appearance: menulist-button;
             appearance: menulist-button;


### PR DESCRIPTION
…s already used correctly in a different less file (_data-grid-header.less).

### Description (*)
This was discovered by using a different less compiler then what Magento ships with.

There is a typo in the [`_temp.less` file](https://github.com/magento/magento2/blob/2.3.1/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less#L473) where it says `.abs-cleafix` instead of `.abs-clearfix`
After some further research, it looks like the same extends is already correctly added in a different place to the same selector `.admin__data-grid-header-row` [over here](https://github.com/magento/magento2/blob/2.3.1/app/design/adminhtml/Magento/backend/Magento_Ui/web/css/source/module/data-grid/_data-grid-header.less#L27), so we don't need to fix the incorrect selector, but can just remove it.

More details:
- `.abs_clearfix` [references](https://github.com/magento/magento2/blob/2.3.1/app/design/adminhtml/Magento/backend/web/css/source/_extends.less#L73-L75) the `.lib-clearfix()` mixin.
- The `.lib-clearfix()` mixin is defined [over here](https://github.com/magento/magento2/blob/2.3.1/lib/web/css/source/lib/_utilities.less#L54-L64).
- So this means that the `.admin__data-grid-header-row` selector's `::before` & `::after` pseudo-elements get the properties as defined by the `.lib-clearfix()` mixin. And this stays the case after removing the line in this PR since it's also being applied [over here](https://github.com/magento/magento2/blob/2.3.1/app/design/adminhtml/Magento/backend/Magento_Ui/web/css/source/module/data-grid/_data-grid-header.less#L27).


### Fixed Issues (if relevant)
None that I could find.

### Manual testing scenarios (*)
1. Having nodejs v8 installed
2. Setting up vanilla Magento installation using composer
3. Running `npm install less@2.7.3`
4. Open Magento's backend in the browser, so static files for the admin theme are being generated
5. Re-compile less, now using the less.js compiler: `node_modules/.bin/lessc --no-color var/view_preprocessed/pub/static/adminhtml/Magento/backend/en_US/css/styles.less | head`
6. Notice that without this fix the first line says: `extend ' .abs-cleafix' has no matches`, with this fix that error is gone.
7. In the backend, go to the product grid, look in your inspector and search for elements having the `admin__data-grid-header-row` class, and look at their `::before` & `::after` pseudo-elements.
8. With and without this fix, it is expected to see that those pseudo-elements have the css properties:
```
content: '';
display: table;
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
