### PR TITLE
22127: check that products is set

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Type/Configurable/Product/Collection.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Type/Configurable/Product/Collection.php
@@ -12,6 +12,7 @@ namespace Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configura
  *
  * @api
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  * @since 100.0.2
  */
 class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection

--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Type/Configurable/Product/Collection.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Type/Configurable/Product/Collection.php
@@ -26,7 +26,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
     /**
      * @var \Magento\Catalog\Model\Product[]
      */
-    private $products;
+    private $products = [];
 
     /**
      * Assign link table name


### PR DESCRIPTION
Magento 2.3.0: getSize call on configurable collection leads to exception, if no product filters are applied

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The newrelic cron tries to get the amount of configurable products (or at least the given children) calling the getCount function of the ConfigurableProductManagementInterface.
In this process a configurable collection object is created (magento/module-configurable-product/Model/ResourceModel/Product/Type/Configurable/Product/Collection.php).
There the getSize function (in AbstractDB parent class) is called and as a consequence the _renderFilters function in the magento/module-configurable-product/Model/ResourceModel/Product/Type/Configurable/Product/Collection.php class.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/magento2/issues/22127

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run magento_newrelicreporting_cron cron job

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
