### PR TITLE
Fix > Exception #0 (BadMethodCallException): Missing required argument $msrpPriceCalculators of Magento\Msrp\Pricing\MsrpPriceCalculator.

### DIFF
--- a/app/code/Magento/Msrp/Pricing/MsrpPriceCalculator.php
+++ b/app/code/Magento/Msrp/Pricing/MsrpPriceCalculator.php
@@ -23,9 +23,15 @@ class MsrpPriceCalculator implements MsrpPriceCalculatorInterface
     /**
      * @param array $msrpPriceCalculators
      */
-    public function __construct(array $msrpPriceCalculators)
+    public function __construct(?array $msrpPriceCalculators = null)
     {
-        $this->msrpPriceCalculators = $this->getMsrpPriceCalculators($msrpPriceCalculators);
+        /*
+         * This is a workaround for the case of modules Magento_MsrpConfigurableProduct and Magento_MsrpGroupedProduct
+         * are disabled.
+         */
+        if (\is_array($msrpPriceCalculators)) {
+            $this->msrpPriceCalculators = $this->getMsrpPriceCalculators($msrpPriceCalculators);
+        }
     }
 
     /**


### PR DESCRIPTION
### Description (*)
Fix > Exception #0 (BadMethodCallException): Missing required argument $msrpPriceCalculators of Magento\Msrp\Pricing\MsrpPriceCalculator.

### Fixed Issues (if relevant)
magento/magento2#22190: Exception (BadMethodCallException): Missing required argument $msrpPriceCalculators of Magento\Msrp\Pricing\MsrpPriceCalculator.

### Manual testing scenarios (*)
1. Modules Magento_MsrpConfigurableProduct or Magento_MsrpGroupedProduct must be enable for module Magento_Msrp works properly

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
