### PR TITLE
Fix > Exception #0 (BadMethodCallException): Missing required argument $msrpPriceCalculators of Magento\Msrp\Pricing\MsrpPriceCalculator.

### DIFF
--- a/app/code/Magento/Msrp/Pricing/MsrpPriceCalculator.php
+++ b/app/code/Magento/Msrp/Pricing/MsrpPriceCalculator.php
@@ -23,7 +23,7 @@ class MsrpPriceCalculator implements MsrpPriceCalculatorInterface
     /**
      * @param array $msrpPriceCalculators
      */
-    public function __construct(array $msrpPriceCalculators)
+    public function __construct(array $msrpPriceCalculators = [])
     {
         $this->msrpPriceCalculators = $this->getMsrpPriceCalculators($msrpPriceCalculators);
     }


### PR DESCRIPTION
### Description (*)
Fix > Exception #0 (BadMethodCallException): Missing required argument $msrpPriceCalculators of Magento\Msrp\Pricing\MsrpPriceCalculator.

The possible solution is a workaround for the case of modules Magento_MsrpConfigurableProduct and Magento_MsrpGroupedProduct are disabled.

### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/22090 MsrpPriceCalculator exception after upgrade to 2.3.1

magento/magento2#22190: Exception (BadMethodCallException): Missing required argument $msrpPriceCalculators of Magento\Msrp\Pricing\MsrpPriceCalculator.

### Manual testing scenarios (*)
1. Disable Magento_MsrpConfigurableProduct and Magento_MsrpGroupedProduct modules, Magento_Msrp should work properly.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
