### PR TITLE
fatalErrorHandler returns 500 only on fatal errors

### DIFF
--- a/pub/health_check.php
+++ b/pub/health_check.php
@@ -70,7 +70,7 @@ if ($cacheConfigs) {
 function fatalErrorHandler()
 {
     $error = error_get_last();
-    if ($error !== null) {
+    if ($error !== null && $error['type'] === E_ERROR) {
         http_response_code(500);
     }
 }


### PR DESCRIPTION
fatalogErrorHandler should return 500 only on fatal errors - otherwise, even a simple deprecation warning on the page triggers internal server error, which is invalid.

Fixes issue #22199 