### PR TITLE
[Backport] mt_rand() function is a drop-in replacement for the older rand()

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/file.phtml
@@ -15,7 +15,7 @@
 <?php $_fieldNameAction = $_fileName . '_action'; ?>
 <?php $_fieldValueAction = $_fileExists ? 'save_old' : 'save_new'; ?>
 <?php $_fileNamed = $_fileName . '_name'; ?>
-<?php $_rand = rand(); ?>
+<?php $_rand = mt_rand(); ?>
 
 <script>
 require(['prototype'], function(){

--- a/app/code/Magento/GroupedProduct/Test/Unit/Pricing/Price/ConfiguredPriceTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Pricing/Price/ConfiguredPriceTest.php
@@ -93,7 +93,7 @@ class ConfiguredPriceTest extends \PHPUnit\Framework\TestCase
 
     public function testGetValueNoItem()
     {
-        $resultPrice = rand(1, 9);
+        $resultPrice = mt_rand(1, 9);
 
         $this->price->expects($this->once())
             ->method('getValue')
@@ -109,9 +109,9 @@ class ConfiguredPriceTest extends \PHPUnit\Framework\TestCase
 
     public function testGetValue()
     {
-        $resultPrice = rand(1, 9);
-        $customOptionOneQty = rand(1, 9);
-        $customOptionTwoQty = rand(1, 9);
+        $resultPrice = mt_rand(1, 9);
+        $customOptionOneQty = mt_rand(1, 9);
+        $customOptionTwoQty = mt_rand(1, 9);
 
         $priceInfoBase = $this->getMockBuilder(\Magento\Framework\Pricing\PriceInfo\Base::class)
             ->disableOriginalConstructor()
@@ -203,7 +203,7 @@ class ConfiguredPriceTest extends \PHPUnit\Framework\TestCase
 
     public function testGetAmount()
     {
-        $resultPrice = rand(1, 9);
+        $resultPrice = mt_rand(1, 9);
 
         $this->price->expects($this->exactly(4))
             ->method('getValue')

--- a/app/code/Magento/ProductVideo/Test/Unit/Block/Adminhtml/Product/Edit/NewVideoTest.php
+++ b/app/code/Magento/ProductVideo/Test/Unit/Block/Adminhtml/Product/Edit/NewVideoTest.php
@@ -77,14 +77,14 @@ class NewVideoTest extends \PHPUnit\Framework\TestCase
 
     public function testGetHtmlId()
     {
-        $this->mathRandom->expects($this->any())->method('getUniqueHash')->with('id_')->willReturn('id_' . rand());
+        $this->mathRandom->expects($this->any())->method('getUniqueHash')->with('id_')->willReturn('id_' . mt_rand());
         $result = $this->block->getHtmlId();
         $this->assertNotNull($result);
     }
 
     public function testGetWidgetOptions()
     {
-        $rand = rand();
+        $rand = mt_rand();
         $this->mathRandom->expects($this->any())->method('getUniqueHash')->with('id_')->willReturn('id_' . $rand);
         $saveVideoUrl = 'http://host/index.php/admin/catalog/product_gallery/upload/key/';
         $saveRemoteVideoUrl = 'http://host/index.php/admin/product_video/product_gallery/retrieveImage/';

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/grid.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/grid.phtml
@@ -8,7 +8,7 @@
 
 ?>
 <div class="grid">
-    <?php $randomId = rand(); ?>
+    <?php $randomId = mt_rand(); ?>
     <div class="admin__table-wrapper">
         <table class="data-grid">
             <thead>

--- a/lib/internal/Magento/Framework/Cache/Test/Unit/Backend/Decorator/CompressionTest.php
+++ b/lib/internal/Magento/Framework/Cache/Test/Unit/Backend/Decorator/CompressionTest.php
@@ -105,7 +105,7 @@ class CompressionTest extends \PHPUnit\Framework\TestCase
 
     public function testSaveLoad()
     {
-        $cacheId = 'cacheId' . rand(1, 100);
+        $cacheId = 'cacheId' . mt_rand(1, 100);
 
         $backend = $this->createPartialMock(\Zend_Cache_Backend_File::class, ['save', 'load']);
         $backend->expects($this->once())->method('save')->will($this->returnCallback([__CLASS__, 'mockSave']));


### PR DESCRIPTION
### Original Pull Request (*)
https://github.com/magento/magento2/pull/22203

### Description (*)
According to PHP documentation:

https://www.php.net/manual/en/function.mt-rand.php

Many random number generators of older libcs have **dubious or unknown characteristics and are slow**. 

The mt_rand() function is a drop-in replacement for the older rand(). 

It uses a random number generator with known characteristics using the » Mersenne Twister, which will produce random numbers **four times faster** than what the average libc rand() provides.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
