### PR TITLE
Show converted value for validateForRefund error message

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1785,6 +1785,17 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     }
 
     /**
+     * Retrieve text formatted base price value
+     *
+     * @param float $price
+     * @return string
+     */
+    public function formatBasePriceTxt($price)
+    {
+        return $this->getBaseCurrency()->formatTxt($price);
+    }
+
+    /**
      * Is currency different
      *
      * @return bool

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1503,7 +1503,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * Get item by quote item id
      *
      * @param mixed $quoteItemId
-     * @return \Magento\Framework\DataObject|null
+     * @return  \Magento\Framework\DataObject|null
      */
     public function getItemByQuoteItemId($quoteItemId)
     {
@@ -1782,17 +1782,6 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     public function formatBasePricePrecision($price, $precision)
     {
         return $this->getBaseCurrency()->formatPrecision($price, $precision);
-    }
-
-    /**
-     * Retrieve text formatted base price value
-     *
-     * @param float $price
-     * @return string
-     */
-    public function formatBasePriceTxt($price)
-    {
-        return $this->getBaseCurrency()->formatTxt($price);
     }
 
     /**

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1503,7 +1503,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * Get item by quote item id
      *
      * @param mixed $quoteItemId
-     * @return  \Magento\Framework\DataObject|null
+     * @return \Magento\Framework\DataObject|null
      */
     public function getItemByQuoteItemId($quoteItemId)
     {

--- a/app/code/Magento/Sales/Model/Service/CreditmemoService.php
+++ b/app/code/Magento/Sales/Model/Service/CreditmemoService.php
@@ -202,7 +202,7 @@ class CreditmemoService implements \Magento\Sales\Api\CreditmemoManagementInterf
             throw new \Magento\Framework\Exception\LocalizedException(
                 __(
                     'The most money available to refund is %1.',
-                    $creditmemo->getOrder()->formatPriceTxt($baseAvailableRefund)
+                    $creditmemo->getOrder()->formatBasePriceTxt($baseAvailableRefund)
                 )
             );
         }

--- a/app/code/Magento/Sales/Model/Service/CreditmemoService.php
+++ b/app/code/Magento/Sales/Model/Service/CreditmemoService.php
@@ -196,13 +196,13 @@ class CreditmemoService implements \Magento\Sales\Api\CreditmemoManagementInterf
             $creditmemo->getOrder()->getBaseTotalRefunded() + $creditmemo->getBaseGrandTotal()
         );
         if ($baseOrderRefund > $this->priceCurrency->round($creditmemo->getOrder()->getBaseTotalPaid())) {
-            $availableRefund = $creditmemo->getOrder()->getTotalPaid()
-                - $creditmemo->getOrder()->getTotalRefunded();
+            $baseAvailableRefund = $creditmemo->getOrder()->getBaseTotalPaid()
+                - $creditmemo->getOrder()->getBaseTotalRefunded();
 
             throw new \Magento\Framework\Exception\LocalizedException(
                 __(
                     'The most money available to refund is %1.',
-                    $creditmemo->getOrder()->formatPriceTxt($availableRefund)
+                    $creditmemo->getOrder()->formatPriceTxt($baseAvailableRefund)
                 )
             );
         }

--- a/app/code/Magento/Sales/Model/Service/CreditmemoService.php
+++ b/app/code/Magento/Sales/Model/Service/CreditmemoService.php
@@ -196,13 +196,13 @@ class CreditmemoService implements \Magento\Sales\Api\CreditmemoManagementInterf
             $creditmemo->getOrder()->getBaseTotalRefunded() + $creditmemo->getBaseGrandTotal()
         );
         if ($baseOrderRefund > $this->priceCurrency->round($creditmemo->getOrder()->getBaseTotalPaid())) {
-            $baseAvailableRefund = $creditmemo->getOrder()->getBaseTotalPaid()
-                - $creditmemo->getOrder()->getBaseTotalRefunded();
+            $availableRefund = $creditmemo->getOrder()->getTotalPaid()
+                - $creditmemo->getOrder()->getTotalRefunded();
 
             throw new \Magento\Framework\Exception\LocalizedException(
                 __(
                     'The most money available to refund is %1.',
-                    $creditmemo->getOrder()->formatPriceTxt($baseAvailableRefund)
+                    $creditmemo->getOrder()->formatPriceTxt($availableRefund)
                 )
             );
         }

--- a/app/code/Magento/Sales/Model/Service/CreditmemoService.php
+++ b/app/code/Magento/Sales/Model/Service/CreditmemoService.php
@@ -202,7 +202,7 @@ class CreditmemoService implements \Magento\Sales\Api\CreditmemoManagementInterf
             throw new \Magento\Framework\Exception\LocalizedException(
                 __(
                     'The most money available to refund is %1.',
-                    $creditmemo->getOrder()->formatBasePriceTxt($baseAvailableRefund)
+                    $creditmemo->getOrder()->getBaseCurrency()->formatTxt($baseAvailableRefund)
                 )
             );
         }

--- a/app/code/Magento/Sales/Test/Unit/Model/Service/CreditmemoServiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Service/CreditmemoServiceTest.php
@@ -343,71 +343,17 @@ class CreditmemoServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn($order);
         $creditMemo->method('getBaseGrandTotal')
             ->willReturn($baseGrandTotal);
-        $creditMemo->method('getGrandTotal')
-            ->willReturn($baseGrandTotal);
         $order->method('getBaseTotalRefunded')
-            ->willReturn($baseTotalRefunded);
-        $order->method('getTotalRefunded')
             ->willReturn($baseTotalRefunded);
         $this->priceCurrency->method('round')
             ->withConsecutive([$baseTotalRefunded + $baseGrandTotal], [$baseTotalPaid])
             ->willReturnOnConsecutiveCalls($baseTotalRefunded + $baseGrandTotal, $baseTotalPaid);
         $order->method('getBaseTotalPaid')
-            ->willReturn($baseTotalPaid);
-        $order->method('getTotalPaid')
             ->willReturn($baseTotalPaid);
         $baseAvailableRefund = $baseTotalPaid - $baseTotalRefunded;
         $order->method('formatPriceTxt')
             ->with($baseAvailableRefund)
             ->willReturn($baseAvailableRefund);
-        $this->creditmemoService->refund($creditMemo, true);
-    }
-
-    /**
-     * @expectedExceptionMessage The most money available to refund is €0.88.
-     * @expectedException \Magento\Framework\Exception\LocalizedException
-     */
-    public function testMultiCurrencyRefundExpectsMoneyAvailableToReturn()
-    {
-        $baseGrandTotal = 10.00;
-        $baseTotalRefunded = 9.00;
-        $baseTotalPaid = 10;
-
-        $grandTotal = 8.81;
-        $totalRefunded = 7.929;
-        $totalPaid = 8.81;
-
-        /** @var CreditmemoInterface|MockObject $creditMemo */
-        $creditMemo = $this->getMockBuilder(CreditmemoInterface::class)
-            ->setMethods(['getId', 'getOrder'])
-            ->getMockForAbstractClass();
-        $creditMemo->method('getId')
-            ->willReturn(null);
-        /** @var Order|MockObject $order */
-        $order = $this->getMockBuilder(Order::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $creditMemo->method('getOrder')
-            ->willReturn($order);
-        $creditMemo->method('getBaseGrandTotal')
-            ->willReturn($baseGrandTotal);
-        $creditMemo->method('getGrandTotal')
-            ->willReturn($grandTotal);
-        $order->method('getBaseTotalRefunded')
-            ->willReturn($baseTotalRefunded);
-        $order->method('getTotalRefunded')
-            ->willReturn($totalRefunded);
-        $this->priceCurrency->method('round')
-            ->withConsecutive([$baseTotalRefunded + $baseGrandTotal], [$baseTotalPaid])
-            ->willReturnOnConsecutiveCalls($baseTotalRefunded + $baseGrandTotal, $baseTotalPaid);
-        $order->method('getBaseTotalPaid')
-            ->willReturn($baseTotalPaid);
-        $order->method('getTotalPaid')
-            ->willReturn($totalPaid);
-        $availableRefund = $totalPaid - $totalRefunded;
-        $order->method('formatPriceTxt')
-            ->with($availableRefund)
-            ->willReturn(sprintf('€%.2f', $availableRefund));
         $this->creditmemoService->refund($creditMemo, true);
     }
 

--- a/app/code/Magento/Sales/Test/Unit/Model/Service/CreditmemoServiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Service/CreditmemoServiceTest.php
@@ -343,17 +343,71 @@ class CreditmemoServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn($order);
         $creditMemo->method('getBaseGrandTotal')
             ->willReturn($baseGrandTotal);
+        $creditMemo->method('getGrandTotal')
+            ->willReturn($baseGrandTotal);
         $order->method('getBaseTotalRefunded')
+            ->willReturn($baseTotalRefunded);
+        $order->method('getTotalRefunded')
             ->willReturn($baseTotalRefunded);
         $this->priceCurrency->method('round')
             ->withConsecutive([$baseTotalRefunded + $baseGrandTotal], [$baseTotalPaid])
             ->willReturnOnConsecutiveCalls($baseTotalRefunded + $baseGrandTotal, $baseTotalPaid);
         $order->method('getBaseTotalPaid')
             ->willReturn($baseTotalPaid);
+        $order->method('getTotalPaid')
+            ->willReturn($baseTotalPaid);
         $baseAvailableRefund = $baseTotalPaid - $baseTotalRefunded;
         $order->method('formatPriceTxt')
             ->with($baseAvailableRefund)
             ->willReturn($baseAvailableRefund);
+        $this->creditmemoService->refund($creditMemo, true);
+    }
+
+    /**
+     * @expectedExceptionMessage The most money available to refund is €0.88.
+     * @expectedException \Magento\Framework\Exception\LocalizedException
+     */
+    public function testMultiCurrencyRefundExpectsMoneyAvailableToReturn()
+    {
+        $baseGrandTotal = 10.00;
+        $baseTotalRefunded = 9.00;
+        $baseTotalPaid = 10;
+
+        $grandTotal = 8.81;
+        $totalRefunded = 7.929;
+        $totalPaid = 8.81;
+
+        /** @var CreditmemoInterface|MockObject $creditMemo */
+        $creditMemo = $this->getMockBuilder(CreditmemoInterface::class)
+            ->setMethods(['getId', 'getOrder'])
+            ->getMockForAbstractClass();
+        $creditMemo->method('getId')
+            ->willReturn(null);
+        /** @var Order|MockObject $order */
+        $order = $this->getMockBuilder(Order::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $creditMemo->method('getOrder')
+            ->willReturn($order);
+        $creditMemo->method('getBaseGrandTotal')
+            ->willReturn($baseGrandTotal);
+        $creditMemo->method('getGrandTotal')
+            ->willReturn($grandTotal);
+        $order->method('getBaseTotalRefunded')
+            ->willReturn($baseTotalRefunded);
+        $order->method('getTotalRefunded')
+            ->willReturn($totalRefunded);
+        $this->priceCurrency->method('round')
+            ->withConsecutive([$baseTotalRefunded + $baseGrandTotal], [$baseTotalPaid])
+            ->willReturnOnConsecutiveCalls($baseTotalRefunded + $baseGrandTotal, $baseTotalPaid);
+        $order->method('getBaseTotalPaid')
+            ->willReturn($baseTotalPaid);
+        $order->method('getTotalPaid')
+            ->willReturn($totalPaid);
+        $availableRefund = $totalPaid - $totalRefunded;
+        $order->method('formatPriceTxt')
+            ->with($availableRefund)
+            ->willReturn(sprintf('€%.2f', $availableRefund));
         $this->creditmemoService->refund($creditMemo, true);
     }
 

--- a/app/code/Magento/Sales/Test/Unit/Model/Service/CreditmemoServiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Service/CreditmemoServiceTest.php
@@ -351,7 +351,7 @@ class CreditmemoServiceTest extends \PHPUnit\Framework\TestCase
         $order->method('getBaseTotalPaid')
             ->willReturn($baseTotalPaid);
         $baseAvailableRefund = $baseTotalPaid - $baseTotalRefunded;
-        $order->method('formatPriceTxt')
+        $order->method('formatBasePriceTxt')
             ->with($baseAvailableRefund)
             ->willReturn($baseAvailableRefund);
         $this->creditmemoService->refund($creditMemo, true);
@@ -368,5 +368,52 @@ class CreditmemoServiceTest extends \PHPUnit\Framework\TestCase
             ->getMockForAbstractClass();
         $creditMemoMock->expects($this->once())->method('getId')->willReturn(444);
         $this->creditmemoService->refund($creditMemoMock, true);
+    }
+
+    /**
+     * @expectedExceptionMessage The most money available to refund is $1.00.
+     * @expectedException \Magento\Framework\Exception\LocalizedException
+     */
+    public function testMultiCurrencyRefundExpectsMoneyAvailableToReturn()
+    {
+        $baseGrandTotal = 10.00;
+        $baseTotalRefunded = 9.00;
+        $baseTotalPaid = 10;
+        $grandTotal = 8.81;
+        $totalRefunded = 7.929;
+        $totalPaid = 8.81;
+
+        /** @var CreditmemoInterface|MockObject $creditMemo */
+        $creditMemo = $this->getMockBuilder(CreditmemoInterface::class)
+            ->setMethods(['getId', 'getOrder'])
+            ->getMockForAbstractClass();
+        $creditMemo->method('getId')
+            ->willReturn(null);
+        /** @var Order|MockObject $order */
+        $order = $this->getMockBuilder(Order::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $creditMemo->method('getOrder')
+            ->willReturn($order);
+        $creditMemo->method('getBaseGrandTotal')
+            ->willReturn($baseGrandTotal);
+        $creditMemo->method('getGrandTotal')
+            ->willReturn($grandTotal);
+        $order->method('getBaseTotalRefunded')
+            ->willReturn($baseTotalRefunded);
+        $order->method('getTotalRefunded')
+            ->willReturn($totalRefunded);
+        $this->priceCurrency->method('round')
+            ->withConsecutive([$baseTotalRefunded + $baseGrandTotal], [$baseTotalPaid])
+            ->willReturnOnConsecutiveCalls($baseTotalRefunded + $baseGrandTotal, $baseTotalPaid);
+        $order->method('getBaseTotalPaid')
+            ->willReturn($baseTotalPaid);
+        $order->method('getTotalPaid')
+            ->willReturn($totalPaid);
+        $baseAvailableRefund = $baseTotalPaid - $baseTotalRefunded;
+        $order->method('formatBasePriceTxt')
+            ->with($baseAvailableRefund)
+            ->willReturn(sprintf('$%.2f', $baseAvailableRefund));
+        $this->creditmemoService->refund($creditMemo, true);
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/Service/CreditmemoServiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Service/CreditmemoServiceTest.php
@@ -351,9 +351,14 @@ class CreditmemoServiceTest extends \PHPUnit\Framework\TestCase
         $order->method('getBaseTotalPaid')
             ->willReturn($baseTotalPaid);
         $baseAvailableRefund = $baseTotalPaid - $baseTotalRefunded;
-        $order->method('formatBasePriceTxt')
+        $baseCurrency = $this->createMock(\Magento\Directory\Model\Currency::class);
+        $baseCurrency->expects($this->once())
+            ->method('formatTxt')
             ->with($baseAvailableRefund)
             ->willReturn($baseAvailableRefund);
+        $order->expects($this->once())
+            ->method('getBaseCurrency')
+            ->willReturn($baseCurrency);
         $this->creditmemoService->refund($creditMemo, true);
     }
 
@@ -411,9 +416,14 @@ class CreditmemoServiceTest extends \PHPUnit\Framework\TestCase
         $order->method('getTotalPaid')
             ->willReturn($totalPaid);
         $baseAvailableRefund = $baseTotalPaid - $baseTotalRefunded;
-        $order->method('formatBasePriceTxt')
+        $baseCurrency = $this->createMock(\Magento\Directory\Model\Currency::class);
+        $baseCurrency->expects($this->once())
+            ->method('formatTxt')
             ->with($baseAvailableRefund)
             ->willReturn(sprintf('$%.2f', $baseAvailableRefund));
+        $order->expects($this->once())
+            ->method('getBaseCurrency')
+            ->willReturn($baseCurrency);
         $this->creditmemoService->refund($creditMemo, true);
     }
 }


### PR DESCRIPTION
### Description

When refunding an order placed in a different currency than the default one (via admin), the refund validation is not taking into account this difference when showing the error message. The message is formatted with the correct currency, but the amount is wrong.

In my tests, with a product of $1.00 and exchange rate for USD-EUR of 0.88, I was getting `The most money available to refund is €1.00.` instead of `The most money available to refund is €0.88.`

### Manual testing scenarios

1. Place an order with at least 2 units of a product via Admin using a different currency than the default one;
2. Partially invoice this order (1 item only);
3. Create a credit memo for the entire order;

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
