### PR TITLE
Add store id to retrieve localized content from category repository

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/Product/AnchorUrlRewriteGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Product/AnchorUrlRewriteGenerator.php
@@ -61,7 +61,7 @@ class AnchorUrlRewriteGenerator
             $anchorCategoryIds = $category->getAnchorsAbove();
             if ($anchorCategoryIds) {
                 foreach ($anchorCategoryIds as $anchorCategoryId) {
-                    $anchorCategory = $this->categoryRepository->get($anchorCategoryId);
+                    $anchorCategory = $this->categoryRepository->get($anchorCategoryId, $storeId);
                     $urls[] = $this->urlRewriteFactory->create()
                         ->setEntityType(ProductUrlRewriteGenerator::ENTITY_TYPE)
                         ->setEntityId($product->getId())


### PR DESCRIPTION
### Description
This commit solves an issue with the anchor category url generation.
To generate the anchor category url, data is retrieved by category repository without specifying  proper store id. Doing so, the generated url does not use the localized category name into request path.

### Manual testing scenarios
1. We assume we are working with Magento with one website and (at least) two storeviews:
  - store ID: 1 (default)
  - store ID: 2
2. Create an **anchor** category "test" (let say it has id 456) under Default Category with different url key for the storeviews:
  - url_key for store 1 : test-foo
  - url_key for store 2 : test-bar
3. Create a child category of "test" named "test child" and assign one product whose url_key is for exaple: "my-product" (let say id 123)

Expected result:
In the url_rewrite table we exepct to find the following rows:

```
entity_type|entity_id|target_path                             |request_path            |store_id|
-----------|---------|----------------------------------------|------------------------|--------|
product    |123      |catalog/product/view/id/123/category/456|test-foo/my-product.html|1       |
product    |123      |catalog/product/view/id/123/category/456|test-bar/my-product.html|2       |
```


Actual result:

```
entity_type|entity_id|target_path                             |request_path            |store_id|
-----------|---------|----------------------------------------|------------------------|--------|
product    |123      |catalog/product/view/id/123/category/456|test-foo/my-product.html|1       |
product    |123      |catalog/product/view/id/123/category/456|test-foo/my-product.html|2       |

```
as we can see the request_path value for the second row (store_id 2) is not as expected 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
