### PR TITLE
Date column ui component locale date format

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
@@ -25,8 +25,8 @@ define([
          */
         initConfig: function () {
             this._super();
-
-            this.dateFormat = utils.normalizeDate(this.dateFormat);
+            
+            this.dateFormat = utils.normalizeDate(this.dateFormat ? this.dateFormat : this.options.dateFormat);
 
             return this;
         },

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
@@ -25,7 +25,7 @@ define([
          */
         initConfig: function () {
             this._super();
-            
+
             this.dateFormat = utils.normalizeDate(this.dateFormat ? this.dateFormat : this.options.dateFormat);
 
             return this;


### PR DESCRIPTION

<!--- Please provide a general summary of the Pull Request in the Title above -->
### Description (*)
added option to fallback to locale date format configuration. 
So in case lets say in ui component xml you pass empty value you can automatically fallback to locale date format. 
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Fixes issue where ui component have hardcoded date format and when having multi site with different date formats it adds option to fallback to locale settings. 
example: Have this issue with requisition lists grid in B2B in storefront.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
By default it doesn't change anything but if you change passed settings in component level and send empty value you can use locale specific settings. 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
