### PR TITLE
[Backport] [Widget] Fixing the multidimensional array as value for the widget's parameter

### DIFF
--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
@@ -165,7 +165,7 @@ class Options extends \Magento\Backend\Block\Widget\Form\Generic
 
         if (is_array($data['value'])) {
             foreach ($data['value'] as &$value) {
-                if (!is_array($value)) {
+                if (is_string($value)) {
                     $value = html_entity_decode($value);
                 }
             }

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
@@ -165,7 +165,9 @@ class Options extends \Magento\Backend\Block\Widget\Form\Generic
 
         if (is_array($data['value'])) {
             foreach ($data['value'] as &$value) {
-                $value = html_entity_decode($value);
+                if (!is_array($value)) {
+                    $value = html_entity_decode($value);
+                }
             }
         } else {
             $data['value'] = html_entity_decode($data['value']);

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
@@ -158,7 +158,7 @@ class Options extends \Magento\Backend\Block\Widget\Form\Generic
             $data['value'] = $parameter->getValue();
             //prepare unique id value
             if ($fieldName == 'unique_id' && $data['value'] == '') {
-                $data['value'] = md5(microtime(1));
+                $data['value'] = hash('sha256', microtime(1));
             }
         }
 

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php
@@ -91,7 +91,7 @@ class Options extends \Magento\Backend\Block\Widget\Form\Generic
         if ($this->_getData('main_fieldset') instanceof \Magento\Framework\Data\Form\Element\Fieldset) {
             return $this->_getData('main_fieldset');
         }
-        $mainFieldsetHtmlId = 'options_fieldset' . md5($this->getWidgetType());
+        $mainFieldsetHtmlId = 'options_fieldset' . hash('sha256', $this->getWidgetType());
         $this->setMainFieldsetHtmlId($mainFieldsetHtmlId);
         $fieldset = $this->getForm()->addFieldset(
             $mainFieldsetHtmlId,
@@ -141,7 +141,6 @@ class Options extends \Magento\Backend\Block\Widget\Form\Generic
     {
         $form = $this->getForm();
         $fieldset = $this->getMainFieldset();
-        //$form->getElement('options_fieldset');
 
         // prepare element data with values (either from request of from default values)
         $fieldName = $parameter->getKey();
@@ -166,10 +165,12 @@ class Options extends \Magento\Backend\Block\Widget\Form\Generic
         if (is_array($data['value'])) {
             foreach ($data['value'] as &$value) {
                 if (is_string($value)) {
+                    // phpcs:ignore Magento2.Functions.DiscouragedFunction
                     $value = html_entity_decode($value);
                 }
             }
         } else {
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
             $data['value'] = html_entity_decode($data['value']);
         }
 

--- a/lib/internal/Magento/Framework/Data/Form/Element/Label.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Label.php
@@ -37,12 +37,11 @@ class Label extends \Magento\Framework\Data\Form\Element\AbstractElement
     public function getElementHtml()
     {
         $html = $this->getBold() ? '<div class="control-value special">' : '<div class="control-value">';
-        if (is_array($this->getValue())) {
-            $html .= '</div>';
-        } else {
-            $html .= $this->getEscapedValue() . '</div>';
+        if (!is_array($this->getValue())) {
+            $html .= $this->getEscapedValue();
         }
 
+        $html .= '</div>';
         $html .= $this->getAfterElementHtml();
 
         return $html;

--- a/lib/internal/Magento/Framework/Data/Form/Element/Label.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Label.php
@@ -37,7 +37,7 @@ class Label extends \Magento\Framework\Data\Form\Element\AbstractElement
     public function getElementHtml()
     {
         $html = $this->getBold() ? '<div class="control-value special">' : '<div class="control-value">';
-        if (!is_array($this->getValue())) {
+        if (is_string($this->getValue())) {
             $html .= $this->getEscapedValue();
         }
 

--- a/lib/internal/Magento/Framework/Data/Form/Element/Label.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Label.php
@@ -37,8 +37,14 @@ class Label extends \Magento\Framework\Data\Form\Element\AbstractElement
     public function getElementHtml()
     {
         $html = $this->getBold() ? '<div class="control-value special">' : '<div class="control-value">';
-        $html .= $this->getEscapedValue() . '</div>';
+        if (is_array($this->getValue())) {
+            $html .= '</div>';
+        } else {
+            $html .= $this->getEscapedValue() . '</div>';
+        }
+
         $html .= $this->getAfterElementHtml();
+
         return $html;
     }
 }

--- a/lib/internal/Magento/Framework/Data/Form/Element/Label.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Label.php
@@ -4,13 +4,13 @@
  * See COPYING.txt for license details.
  */
 
-/**
- * Data form abstract class
- *
- * @author      Magento Core Team <core@magentocommerce.com>
- */
 namespace Magento\Framework\Data\Form\Element;
 
+use Magento\Framework\Phrase;
+
+/**
+ * Label form element.
+ */
 class Label extends \Magento\Framework\Data\Form\Element\AbstractElement
 {
     /**
@@ -37,7 +37,7 @@ class Label extends \Magento\Framework\Data\Form\Element\AbstractElement
     public function getElementHtml()
     {
         $html = $this->getBold() ? '<div class="control-value special">' : '<div class="control-value">';
-        if (is_string($this->getValue())) {
+        if (is_string($this->getValue()) || $this->getValue() instanceof Phrase) {
             $html .= $this->getEscapedValue();
         }
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21008
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR gives the possibility to use a multi row field as a parameter for a widget. 
```xml
<parameter name="conditions" xsi:type="block" visible="true" sort_order="30">
    <label translate="true">Tabs</label>
    <block class="Atwix\Tabs\Block\Adminhtml\Widget\Form\Element" />
</parameter>
```

After saving the widget, or opening, you'll have 2 exceptions thrown:
`Warning: html_entity_decode() expects parameter 1 to be string, array given in /home/dev/sites/mage23/app/code/Magento/Widget/Block/Adminhtml/Widget/Options.php on line 170`

`Warning: htmlspecialchars() expects parameter 1 to be string, array given in /home/dev/sites/mage23/lib/internal/Magento/Framework/Data/Form/Element/AbstractElement.php on line 290`

As a result, you should are able to save and open the widget:
![xnip2019-02-06_09-59-09](https://user-images.githubusercontent.com/15868188/52327897-6255e200-29f6-11e9-8dce-768f1f870970.jpg)


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19909: Not possible to use multidimensional arrays in widget parameters
2. ...

### Manual testing scenarios (*)
1. ...
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
