### PR TITLE
[Backport] Fix negative subtotal when full discount applied with tax calculation #10790

### DIFF
--- a/app/code/Magento/SalesRule/Model/Utility.php
+++ b/app/code/Magento/SalesRule/Model/Utility.php
@@ -189,6 +189,8 @@ class Utility
     ) {
         $discountAmount = $discountData->getAmount();
         $baseDiscountAmount = $discountData->getBaseAmount();
+        $rowTotalInclTax = $item->getRowTotalInclTax();
+        $baseRowTotalInclTax = $item->getBaseRowTotalInclTax();
 
         //TODO Seems \Magento\Quote\Model\Quote\Item\AbstractItem::getDiscountPercent() returns float value
         //that can not be used as array index
@@ -203,6 +205,23 @@ class Utility
             $this->_roundingDeltas[$percentKey] = $discountAmount - $this->priceCurrency->round($discountAmount);
             $this->_baseRoundingDeltas[$percentKey] = $baseDiscountAmount
                 - $this->priceCurrency->round($baseDiscountAmount);
+        }
+
+        /**
+         * When we have 100% discount check if totals will not be negative
+         */
+
+        if ($percentKey == 100) {
+            $discountDelta = $rowTotalInclTax - $discountAmount;
+            $baseDiscountDelta = $baseRowTotalInclTax - $baseDiscountAmount;
+
+            if ($discountDelta < 0) {
+                $discountAmount += $discountDelta;
+            }
+
+            if ($baseDiscountDelta < 0) {
+                $baseDiscountAmount += $baseDiscountDelta;
+            }
         }
 
         $discountData->setAmount($this->priceCurrency->round($discountAmount));

--- a/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
@@ -154,12 +154,6 @@ abstract class AbstractAggregateCalculator extends AbstractCalculator
             $priceInclTax = $this->calculationTool->round($priceInclTax);
         }
 
-        $pricePerItemInclTax = $rowTotalInclTax / $quantity;
-
-        if (($pricePerItemInclTax - $priceInclTax) < 0) {
-            $priceInclTax = $pricePerItemInclTax;
-        }
-
         return $this->taxDetailsItemDataObjectFactory->create()
             ->setCode($item->getCode())
             ->setType($item->getType())

--- a/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
@@ -149,9 +149,6 @@ abstract class AbstractAggregateCalculator extends AbstractCalculator
         $rowTaxBeforeDiscount = array_sum($rowTaxesBeforeDiscount);
         $rowTotalInclTax = $rowTotal + $rowTaxBeforeDiscount;
         $priceInclTax = $rowTotalInclTax / $quantity;
-        if ($round) {
-            $priceInclTax = $this->calculationTool->round($priceInclTax);
-        }
 
         return $this->taxDetailsItemDataObjectFactory->create()
             ->setCode($item->getCode())

--- a/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
@@ -150,6 +150,16 @@ abstract class AbstractAggregateCalculator extends AbstractCalculator
         $rowTotalInclTax = $rowTotal + $rowTaxBeforeDiscount;
         $priceInclTax = $rowTotalInclTax / $quantity;
 
+        if ($round) {
+            $priceInclTax = $this->calculationTool->round($priceInclTax);
+        }
+
+        $pricePerItemInclTax = $rowTotalInclTax / $quantity;
+
+        if (($pricePerItemInclTax - $priceInclTax) < 0) {
+            $priceInclTax = $pricePerItemInclTax;
+        }
+
         return $this->taxDetailsItemDataObjectFactory->create()
             ->setCode($item->getCode())
             ->setType($item->getType())

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/Sales/Total/Quote/TaxTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/Sales/Total/Quote/TaxTest.php
@@ -11,6 +11,7 @@ use Magento\TestFramework\Helper\Bootstrap;
 
 require_once __DIR__ . '/SetupUtil.php';
 require_once __DIR__ . '/../../../../_files/tax_calculation_data_aggregated.php';
+require_once __DIR__ . '/../../../../_files/full_discount_with_tax.php';
 
 /**
  * Class TaxTest
@@ -131,135 +132,16 @@ class TaxTest extends \Magento\TestFramework\Indexer\TestCase
      * This method will test the collector through $quote->collectTotals() method
      *
      * @see \Magento\SalesRule\Model\Utility::deltaRoundingFix
+     * @magentoDataFixture Magento/Tax/_files/full_discount_with_tax.php
      * @magentoDbIsolation enabled
      * @magentoAppIsolation enabled
      */
     public function testFullDiscountWithDeltaRoundingFix()
     {
-        $configData = [
-            'config_overrides' =>
-                [
-                    'tax/calculation/apply_after_discount' => 0,
-                    'tax/calculation/discount_tax' => 1,
-                    'tax/calculation/algorithm' => 'ROW_BASE_CALCULATION',
-                    'tax/classes/shipping_tax_class' => SetupUtil::SHIPPING_TAX_CLASS,
-                ],
-            'tax_rate_overrides' =>
-                [
-                    SetupUtil::TAX_RATE_TX => 18,
-                    SetupUtil::TAX_RATE_SHIPPING => 0,
-                ],
-            'tax_rule_overrides' =>
-                [
-                    [
-                            'code' => 'Product Tax Rule',
-                            'product_tax_class_ids' =>
-                                [
-                                    SetupUtil::PRODUCT_TAX_CLASS_1
-                                ],
-                        ],
-                    [
-                            'code' => 'Shipping Tax Rule',
-                            'product_tax_class_ids' =>
-                                [
-                                    SetupUtil::SHIPPING_TAX_CLASS
-                                ],
-                            'tax_rate_ids' =>
-                                [
-                                    SetupUtil::TAX_RATE_SHIPPING,
-                                ],
-                        ],
-                ],
-        ];
-
-        $quoteData = [
-            'billing_address' =>
-                [
-                    'region_id' => SetupUtil::REGION_TX,
-                ],
-            'shipping_address' =>
-                [
-                    'region_id' => SetupUtil::REGION_TX,
-                ],
-            'items' =>
-                [
-                    [
-                        'sku' => 'simple1',
-                        'price' => 2542.37,
-                        'qty' => 2,
-                    ]
-                ],
-            'shipping_method' => 'free',
-            'shopping_cart_rules' =>
-                [
-                    ['discount_amount' => 100],
-                ],
-        ];
-
-        $expectedResults = [
-            'address_data' =>
-                [
-                    'subtotal' => 5084.74,
-                    'base_subtotal' => 5084.74,
-                    'subtotal_incl_tax' => 5999.99,
-                    'base_subtotal_incl_tax' => 5999.99,
-                    'tax_amount' => 915.25,
-                    'base_tax_amount' => 915.25,
-                    'shipping_amount' => 0,
-                    'base_shipping_amount' => 0,
-                    'shipping_incl_tax' => 0,
-                    'base_shipping_incl_tax' => 0,
-                    'shipping_tax_amount' => 0,
-                    'base_shipping_tax_amount' => 0,
-                    'discount_amount' => -5999.99,
-                    'base_discount_amount' => -5999.99,
-                    'discount_tax_compensation_amount' => 0,
-                    'base_discount_tax_compensation_amount' => 0,
-                    'shipping_discount_tax_compensation_amount' => 0,
-                    'base_shipping_discount_tax_compensation_amount' => 0,
-                    'grand_total' => 0,
-                    'base_grand_total' => 0,
-                    'applied_taxes' =>
-                        [
-                            SetupUtil::TAX_RATE_TX =>
-                                [
-                                    'percent' => 18,
-                                    'amount' => 915.25,
-                                    'base_amount' => 915.25,
-                                    'rates' =>
-                                        [
-                                                [
-                                                    'code' => SetupUtil::TAX_RATE_TX,
-                                                    'title' => SetupUtil::TAX_RATE_TX,
-                                                    'percent' => 18,
-                                                ],
-                                        ],
-                                ]
-                        ],
-                ],
-            'items_data' =>
-                [
-                    'simple1' =>
-                        [
-                            'row_total' => 5084.74,
-                            'base_row_total' => 5084.74,
-                            'tax_percent' => 18,
-                            'price' => 2542.37,
-                            'base_price' => 2542.37,
-                            'price_incl_tax' => 3000,
-                            'base_price_incl_tax' => 3000,
-                            'row_total_incl_tax' => 5999.99,
-                            'base_row_total_incl_tax' => 5999.99,
-                            'tax_amount' => 915.25,
-                            'base_tax_amount' => 915.25,
-                            'discount_amount' => 5999.99,
-                            'base_discount_amount' => 5999.99,
-                            'discount_percent' => 100,
-                            'discount_tax_compensation_amount' => 0,
-                            'base_discount_tax_compensation_amount' => 0,
-                        ],
-                ],
-    ];
+        global $fullTaxDiscountWithTax;
+        $configData = $fullTaxDiscountWithTax['config_data'];
+        $quoteData = $fullTaxDiscountWithTax['quote_data'];
+        $expectedResults = $fullTaxDiscountWithTax['expected_result'];
 
         /** @var  \Magento\Framework\ObjectManagerInterface $objectManager */
         $objectManager = Bootstrap::getObjectManager();

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/Sales/Total/Quote/TaxTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/Sales/Total/Quote/TaxTest.php
@@ -138,10 +138,10 @@ class TaxTest extends \Magento\TestFramework\Indexer\TestCase
      */
     public function testFullDiscountWithDeltaRoundingFix()
     {
-        global $fullTaxDiscountWithTax;
-        $configData = $fullTaxDiscountWithTax['config_data'];
-        $quoteData = $fullTaxDiscountWithTax['quote_data'];
-        $expectedResults = $fullTaxDiscountWithTax['expected_result'];
+        global $fullDiscountIncTax;
+        $configData = $fullDiscountIncTax['config_data'];
+        $quoteData = $fullDiscountIncTax['quote_data'];
+        $expectedResults = $fullDiscountIncTax['expected_result'];
 
         /** @var  \Magento\Framework\ObjectManagerInterface $objectManager */
         $objectManager = Bootstrap::getObjectManager();

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/Sales/Total/Quote/TaxTest.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/Sales/Total/Quote/TaxTest.php
@@ -127,7 +127,7 @@ class TaxTest extends \Magento\TestFramework\Indexer\TestCase
     /**
      * Test taxes collection with full discount for quote.
      *
-     * Test tax calculation with certain configuration and price calculation of items when the discount may be bigger than total
+     * Test tax calculation and price when the discount may be bigger than total
      * This method will test the collector through $quote->collectTotals() method
      *
      * @see \Magento\SalesRule\Model\Utility::deltaRoundingFix
@@ -136,51 +136,51 @@ class TaxTest extends \Magento\TestFramework\Indexer\TestCase
      */
     public function testFullDiscountWithDeltaRoundingFix()
     {
-        $configData = array (
+        $configData = [
             'config_overrides' =>
-                array (
+                [
                     'tax/calculation/apply_after_discount' => 0,
                     'tax/calculation/discount_tax' => 1,
                     'tax/calculation/algorithm' => 'ROW_BASE_CALCULATION',
                     'tax/classes/shipping_tax_class' => SetupUtil::SHIPPING_TAX_CLASS,
-                ),
+                ],
             'tax_rate_overrides' =>
-                array (
+                [
                     SetupUtil::TAX_RATE_TX => 18,
                     SetupUtil::TAX_RATE_SHIPPING => 0,
-                ),
+                ],
             'tax_rule_overrides' =>
-                array (
-                        array (
+                [
+                    [
                             'code' => 'Product Tax Rule',
                             'product_tax_class_ids' =>
-                                array (
+                                [
                                     SetupUtil::PRODUCT_TAX_CLASS_1
-                                ),
-                        ),
-                        array (
+                                ],
+                        ],
+                    [
                             'code' => 'Shipping Tax Rule',
                             'product_tax_class_ids' =>
-                                array (
+                                [
                                     SetupUtil::SHIPPING_TAX_CLASS
-                                ),
+                                ],
                             'tax_rate_ids' =>
-                                array (
+                                [
                                     SetupUtil::TAX_RATE_SHIPPING,
-                                ),
-                        ),
-                ),
-        );
+                                ],
+                        ],
+                ],
+        ];
 
-        $quoteData = array (
+        $quoteData = [
             'billing_address' =>
-                array (
+                [
                     'region_id' => SetupUtil::REGION_TX,
-                ),
+                ],
             'shipping_address' =>
-                array (
+                [
                     'region_id' => SetupUtil::REGION_TX,
-                ),
+                ],
             'items' =>
                 [
                     [
@@ -191,16 +191,14 @@ class TaxTest extends \Magento\TestFramework\Indexer\TestCase
                 ],
             'shipping_method' => 'free',
             'shopping_cart_rules' =>
-                array (
-                        array (
-                            'discount_amount' => 100,
-                        ),
-                ),
-        );
+                [
+                    ['discount_amount' => 100],
+                ],
+        ];
 
-        $expectedResults = array (
+        $expectedResults = [
             'address_data' =>
-                array (
+                [
                     'subtotal' => 5084.74,
                     'base_subtotal' => 5084.74,
                     'subtotal_incl_tax' => 5999.99,
@@ -222,27 +220,27 @@ class TaxTest extends \Magento\TestFramework\Indexer\TestCase
                     'grand_total' => 0,
                     'base_grand_total' => 0,
                     'applied_taxes' =>
-                        array (
+                        [
                             SetupUtil::TAX_RATE_TX =>
-                                array (
+                                [
                                     'percent' => 18,
                                     'amount' => 915.25,
                                     'base_amount' => 915.25,
                                     'rates' =>
-                                        array (
-                                                array (
+                                        [
+                                                [
                                                     'code' => SetupUtil::TAX_RATE_TX,
                                                     'title' => SetupUtil::TAX_RATE_TX,
                                                     'percent' => 18,
-                                                ),
-                                        ),
-                                )
-                        ),
-                ),
+                                                ],
+                                        ],
+                                ]
+                        ],
+                ],
             'items_data' =>
-                array (
+                [
                     'simple1' =>
-                        array (
+                        [
                             'row_total' => 5084.74,
                             'base_row_total' => 5084.74,
                             'tax_percent' => 18,
@@ -259,9 +257,9 @@ class TaxTest extends \Magento\TestFramework\Indexer\TestCase
                             'discount_percent' => 100,
                             'discount_tax_compensation_amount' => 0,
                             'base_discount_tax_compensation_amount' => 0,
-                        ),
-                ),
-        );
+                        ],
+                ],
+    ];
 
         /** @var  \Magento\Framework\ObjectManagerInterface $objectManager */
         $objectManager = Bootstrap::getObjectManager();

--- a/dev/tests/integration/testsuite/Magento/Tax/_files/full_discount_with_tax.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/_files/full_discount_with_tax.php
@@ -8,125 +8,125 @@ use Magento\Tax\Model\Sales\Total\Quote\SetupUtil;
 
 $fullTaxDiscountWithTax = [
         'config_data' => [
-            'config_overrides' =>
-                [
-                    Config::CONFIG_XML_PATH_APPLY_AFTER_DISCOUNT => 0,
-                    Config::CONFIG_XML_PATH_DISCOUNT_TAX => 1,
-                    Config::XML_PATH_ALGORITHM => 'ROW_BASE_CALCULATION',
-                    Config::CONFIG_XML_PATH_SHIPPING_TAX_CLASS => SetupUtil::SHIPPING_TAX_CLASS,
-                ],
-            'tax_rate_overrides' =>
-                [
-                    SetupUtil::TAX_RATE_TX => 18,
-                    SetupUtil::TAX_RATE_SHIPPING => 0,
-                ],
-            'tax_rule_overrides' =>
-                [
+                'config_overrides' =>
                     [
-                        'code' => 'Product Tax Rule',
-                        'product_tax_class_ids' =>
-                            [
-                                SetupUtil::PRODUCT_TAX_CLASS_1
-                            ],
+                        Config::CONFIG_XML_PATH_APPLY_AFTER_DISCOUNT => 0,
+                        Config::CONFIG_XML_PATH_DISCOUNT_TAX => 1,
+                        Config::XML_PATH_ALGORITHM => 'ROW_BASE_CALCULATION',
+                        Config::CONFIG_XML_PATH_SHIPPING_TAX_CLASS => SetupUtil::SHIPPING_TAX_CLASS,
                     ],
+                'tax_rate_overrides' =>
                     [
-                        'code' => 'Shipping Tax Rule',
-                        'product_tax_class_ids' =>
-                            [
-                                SetupUtil::SHIPPING_TAX_CLASS
-                            ],
-                        'tax_rate_ids' =>
-                            [
-                                SetupUtil::TAX_RATE_SHIPPING,
-                            ],
+                        SetupUtil::TAX_RATE_TX => 18,
+                        SetupUtil::TAX_RATE_SHIPPING => 0,
                     ],
-                ],
+                'tax_rule_overrides' =>
+                    [
+                        [
+                            'code' => 'Product Tax Rule',
+                            'product_tax_class_ids' =>
+                                [
+                                    SetupUtil::PRODUCT_TAX_CLASS_1
+                                ],
+                        ],
+                        [
+                            'code' => 'Shipping Tax Rule',
+                            'product_tax_class_ids' =>
+                                [
+                                    SetupUtil::SHIPPING_TAX_CLASS
+                                ],
+                            'tax_rate_ids' =>
+                                [
+                                    SetupUtil::TAX_RATE_SHIPPING,
+                                ],
+                        ],
+                    ],
         ],
         'quote_data' => [
-            'billing_address' =>
-                [
-                    'region_id' => SetupUtil::REGION_TX,
-                ],
-            'shipping_address' =>
-                [
-                    'region_id' => SetupUtil::REGION_TX,
-                ],
-            'items' =>
-                [
+                'billing_address' =>
                     [
-                        'sku' => 'simple1',
-                        'price' => 2542.37,
-                        'qty' => 2,
-                    ]
-                ],
-            'shipping_method' => 'free',
-            'shopping_cart_rules' =>
-                [
-                    ['discount_amount' => 100],
-                ],
+                        'region_id' => SetupUtil::REGION_TX,
+                    ],
+                'shipping_address' =>
+                    [
+                        'region_id' => SetupUtil::REGION_TX,
+                    ],
+                'items' =>
+                    [
+                        [
+                            'sku' => 'simple1',
+                            'price' => 2542.37,
+                            'qty' => 2,
+                        ]
+                    ],
+                'shipping_method' => 'free',
+                'shopping_cart_rules' =>
+                    [
+                        ['discount_amount' => 100],
+                    ],
         ],
         'expected_result' => [
-            'address_data' =>
-                [
-                    'subtotal' => 5084.74,
-                    'base_subtotal' => 5084.74,
-                    'subtotal_incl_tax' => 5999.99,
-                    'base_subtotal_incl_tax' => 5999.99,
-                    'tax_amount' => 915.25,
-                    'base_tax_amount' => 915.25,
-                    'shipping_amount' => 0,
-                    'base_shipping_amount' => 0,
-                    'shipping_incl_tax' => 0,
-                    'base_shipping_incl_tax' => 0,
-                    'shipping_tax_amount' => 0,
-                    'base_shipping_tax_amount' => 0,
-                    'discount_amount' => -5999.99,
-                    'base_discount_amount' => -5999.99,
-                    'discount_tax_compensation_amount' => 0,
-                    'base_discount_tax_compensation_amount' => 0,
-                    'shipping_discount_tax_compensation_amount' => 0,
-                    'base_shipping_discount_tax_compensation_amount' => 0,
-                    'grand_total' => 0,
-                    'base_grand_total' => 0,
-                    'applied_taxes' =>
-                        [
-                            SetupUtil::TAX_RATE_TX =>
-                                [
-                                    'percent' => 18,
-                                    'amount' => 915.25,
-                                    'base_amount' => 915.25,
-                                    'rates' =>
-                                        [
+                'address_data' =>
+                    [
+                        'subtotal' => 5084.74,
+                        'base_subtotal' => 5084.74,
+                        'subtotal_incl_tax' => 5999.99,
+                        'base_subtotal_incl_tax' => 5999.99,
+                        'tax_amount' => 915.25,
+                        'base_tax_amount' => 915.25,
+                        'shipping_amount' => 0,
+                        'base_shipping_amount' => 0,
+                        'shipping_incl_tax' => 0,
+                        'base_shipping_incl_tax' => 0,
+                        'shipping_tax_amount' => 0,
+                        'base_shipping_tax_amount' => 0,
+                        'discount_amount' => -5999.99,
+                        'base_discount_amount' => -5999.99,
+                        'discount_tax_compensation_amount' => 0,
+                        'base_discount_tax_compensation_amount' => 0,
+                        'shipping_discount_tax_compensation_amount' => 0,
+                        'base_shipping_discount_tax_compensation_amount' => 0,
+                        'grand_total' => 0,
+                        'base_grand_total' => 0,
+                        'applied_taxes' =>
+                            [
+                                SetupUtil::TAX_RATE_TX =>
+                                    [
+                                        'percent' => 18,
+                                        'amount' => 915.25,
+                                        'base_amount' => 915.25,
+                                        'rates' =>
                                             [
-                                                'code' => SetupUtil::TAX_RATE_TX,
-                                                'title' => SetupUtil::TAX_RATE_TX,
-                                                'percent' => 18,
+                                                [
+                                                    'code' => SetupUtil::TAX_RATE_TX,
+                                                    'title' => SetupUtil::TAX_RATE_TX,
+                                                    'percent' => 18,
+                                                ],
                                             ],
-                                        ],
-                                ]
-                        ],
-                ],
-            'items_data' =>
-                [
-                    'simple1' =>
-                        [
-                            'row_total' => 5084.74,
-                            'base_row_total' => 5084.74,
-                            'tax_percent' => 18,
-                            'price' => 2542.37,
-                            'base_price' => 2542.37,
-                            'price_incl_tax' => 3000,
-                            'base_price_incl_tax' => 3000,
-                            'row_total_incl_tax' => 5999.99,
-                            'base_row_total_incl_tax' => 5999.99,
-                            'tax_amount' => 915.25,
-                            'base_tax_amount' => 915.25,
-                            'discount_amount' => 5999.99,
-                            'base_discount_amount' => 5999.99,
-                            'discount_percent' => 100,
-                            'discount_tax_compensation_amount' => 0,
-                            'base_discount_tax_compensation_amount' => 0,
-                        ],
-                ],
+                                    ]
+                            ],
+                    ],
+                'items_data' =>
+                    [
+                        'simple1' =>
+                            [
+                                'row_total' => 5084.74,
+                                'base_row_total' => 5084.74,
+                                'tax_percent' => 18,
+                                'price' => 2542.37,
+                                'base_price' => 2542.37,
+                                'price_incl_tax' => 3000,
+                                'base_price_incl_tax' => 3000,
+                                'row_total_incl_tax' => 5999.99,
+                                'base_row_total_incl_tax' => 5999.99,
+                                'tax_amount' => 915.25,
+                                'base_tax_amount' => 915.25,
+                                'discount_amount' => 5999.99,
+                                'base_discount_amount' => 5999.99,
+                                'discount_percent' => 100,
+                                'discount_tax_compensation_amount' => 0,
+                                'base_discount_tax_compensation_amount' => 0,
+                            ],
+                    ],
         ]
 ];

--- a/dev/tests/integration/testsuite/Magento/Tax/_files/full_discount_with_tax.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/_files/full_discount_with_tax.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+use Magento\Tax\Model\Config;
+use Magento\Tax\Model\Sales\Total\Quote\SetupUtil;
+
+$fullTaxDiscountWithTax = [
+    'config_data' => [
+        'config_overrides' =>
+            [
+                Config::CONFIG_XML_PATH_APPLY_AFTER_DISCOUNT => 0,
+                Config::CONFIG_XML_PATH_DISCOUNT_TAX => 1,
+                Config::XML_PATH_ALGORITHM => 'ROW_BASE_CALCULATION',
+                Config::CONFIG_XML_PATH_SHIPPING_TAX_CLASS => SetupUtil::SHIPPING_TAX_CLASS,
+            ],
+        'tax_rate_overrides' =>
+            [
+                SetupUtil::TAX_RATE_TX => 18,
+                SetupUtil::TAX_RATE_SHIPPING => 0,
+            ],
+        'tax_rule_overrides' =>
+            [
+                [
+                    'code' => 'Product Tax Rule',
+                    'product_tax_class_ids' =>
+                        [
+                            SetupUtil::PRODUCT_TAX_CLASS_1
+                        ],
+                ],
+                [
+                    'code' => 'Shipping Tax Rule',
+                    'product_tax_class_ids' =>
+                        [
+                            SetupUtil::SHIPPING_TAX_CLASS
+                        ],
+                    'tax_rate_ids' =>
+                        [
+                            SetupUtil::TAX_RATE_SHIPPING,
+                        ],
+                ],
+            ],
+    ],
+    'quote_data' => [
+        'billing_address' =>
+            [
+                'region_id' => SetupUtil::REGION_TX,
+            ],
+        'shipping_address' =>
+            [
+                'region_id' => SetupUtil::REGION_TX,
+            ],
+        'items' =>
+            [
+                [
+                    'sku' => 'simple1',
+                    'price' => 2542.37,
+                    'qty' => 2,
+                ]
+            ],
+        'shipping_method' => 'free',
+        'shopping_cart_rules' =>
+            [
+                ['discount_amount' => 100],
+            ],
+    ],
+    'expected_result' => [
+        'address_data' =>
+            [
+                'subtotal' => 5084.74,
+                'base_subtotal' => 5084.74,
+                'subtotal_incl_tax' => 5999.99,
+                'base_subtotal_incl_tax' => 5999.99,
+                'tax_amount' => 915.25,
+                'base_tax_amount' => 915.25,
+                'shipping_amount' => 0,
+                'base_shipping_amount' => 0,
+                'shipping_incl_tax' => 0,
+                'base_shipping_incl_tax' => 0,
+                'shipping_tax_amount' => 0,
+                'base_shipping_tax_amount' => 0,
+                'discount_amount' => -5999.99,
+                'base_discount_amount' => -5999.99,
+                'discount_tax_compensation_amount' => 0,
+                'base_discount_tax_compensation_amount' => 0,
+                'shipping_discount_tax_compensation_amount' => 0,
+                'base_shipping_discount_tax_compensation_amount' => 0,
+                'grand_total' => 0,
+                'base_grand_total' => 0,
+                'applied_taxes' =>
+                    [
+                        SetupUtil::TAX_RATE_TX =>
+                            [
+                                'percent' => 18,
+                                'amount' => 915.25,
+                                'base_amount' => 915.25,
+                                'rates' =>
+                                    [
+                                        [
+                                            'code' => SetupUtil::TAX_RATE_TX,
+                                            'title' => SetupUtil::TAX_RATE_TX,
+                                            'percent' => 18,
+                                        ],
+                                    ],
+                            ]
+                    ],
+            ],
+        'items_data' =>
+            [
+                'simple1' =>
+                    [
+                        'row_total' => 5084.74,
+                        'base_row_total' => 5084.74,
+                        'tax_percent' => 18,
+                        'price' => 2542.37,
+                        'base_price' => 2542.37,
+                        'price_incl_tax' => 3000,
+                        'base_price_incl_tax' => 3000,
+                        'row_total_incl_tax' => 5999.99,
+                        'base_row_total_incl_tax' => 5999.99,
+                        'tax_amount' => 915.25,
+                        'base_tax_amount' => 915.25,
+                        'discount_amount' => 5999.99,
+                        'base_discount_amount' => 5999.99,
+                        'discount_percent' => 100,
+                        'discount_tax_compensation_amount' => 0,
+                        'base_discount_tax_compensation_amount' => 0,
+                    ],
+            ],
+    ]
+];

--- a/dev/tests/integration/testsuite/Magento/Tax/_files/full_discount_with_tax.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/_files/full_discount_with_tax.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 use Magento\Tax\Model\Config;
 use Magento\Tax\Model\Sales\Total\Quote\SetupUtil;
 

--- a/dev/tests/integration/testsuite/Magento/Tax/_files/full_discount_with_tax.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/_files/full_discount_with_tax.php
@@ -6,7 +6,7 @@
 use Magento\Tax\Model\Config;
 use Magento\Tax\Model\Sales\Total\Quote\SetupUtil;
 
-$fullTaxDiscountWithTax = [
+$fullDiscountIncTax = [
         'config_data' => [
                 'config_overrides' => [
                         Config::CONFIG_XML_PATH_APPLY_AFTER_DISCOUNT => 0,

--- a/dev/tests/integration/testsuite/Magento/Tax/_files/full_discount_with_tax.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/_files/full_discount_with_tax.php
@@ -7,126 +7,126 @@ use Magento\Tax\Model\Config;
 use Magento\Tax\Model\Sales\Total\Quote\SetupUtil;
 
 $fullTaxDiscountWithTax = [
-    'config_data' => [
-        'config_overrides' =>
-            [
-                Config::CONFIG_XML_PATH_APPLY_AFTER_DISCOUNT => 0,
-                Config::CONFIG_XML_PATH_DISCOUNT_TAX => 1,
-                Config::XML_PATH_ALGORITHM => 'ROW_BASE_CALCULATION',
-                Config::CONFIG_XML_PATH_SHIPPING_TAX_CLASS => SetupUtil::SHIPPING_TAX_CLASS,
-            ],
-        'tax_rate_overrides' =>
-            [
-                SetupUtil::TAX_RATE_TX => 18,
-                SetupUtil::TAX_RATE_SHIPPING => 0,
-            ],
-        'tax_rule_overrides' =>
-            [
+        'config_data' => [
+            'config_overrides' =>
                 [
-                    'code' => 'Product Tax Rule',
-                    'product_tax_class_ids' =>
-                        [
-                            SetupUtil::PRODUCT_TAX_CLASS_1
-                        ],
+                    Config::CONFIG_XML_PATH_APPLY_AFTER_DISCOUNT => 0,
+                    Config::CONFIG_XML_PATH_DISCOUNT_TAX => 1,
+                    Config::XML_PATH_ALGORITHM => 'ROW_BASE_CALCULATION',
+                    Config::CONFIG_XML_PATH_SHIPPING_TAX_CLASS => SetupUtil::SHIPPING_TAX_CLASS,
                 ],
+            'tax_rate_overrides' =>
                 [
-                    'code' => 'Shipping Tax Rule',
-                    'product_tax_class_ids' =>
-                        [
-                            SetupUtil::SHIPPING_TAX_CLASS
-                        ],
-                    'tax_rate_ids' =>
-                        [
-                            SetupUtil::TAX_RATE_SHIPPING,
-                        ],
+                    SetupUtil::TAX_RATE_TX => 18,
+                    SetupUtil::TAX_RATE_SHIPPING => 0,
                 ],
-            ],
-    ],
-    'quote_data' => [
-        'billing_address' =>
-            [
-                'region_id' => SetupUtil::REGION_TX,
-            ],
-        'shipping_address' =>
-            [
-                'region_id' => SetupUtil::REGION_TX,
-            ],
-        'items' =>
-            [
+            'tax_rule_overrides' =>
                 [
-                    'sku' => 'simple1',
-                    'price' => 2542.37,
-                    'qty' => 2,
-                ]
-            ],
-        'shipping_method' => 'free',
-        'shopping_cart_rules' =>
-            [
-                ['discount_amount' => 100],
-            ],
-    ],
-    'expected_result' => [
-        'address_data' =>
-            [
-                'subtotal' => 5084.74,
-                'base_subtotal' => 5084.74,
-                'subtotal_incl_tax' => 5999.99,
-                'base_subtotal_incl_tax' => 5999.99,
-                'tax_amount' => 915.25,
-                'base_tax_amount' => 915.25,
-                'shipping_amount' => 0,
-                'base_shipping_amount' => 0,
-                'shipping_incl_tax' => 0,
-                'base_shipping_incl_tax' => 0,
-                'shipping_tax_amount' => 0,
-                'base_shipping_tax_amount' => 0,
-                'discount_amount' => -5999.99,
-                'base_discount_amount' => -5999.99,
-                'discount_tax_compensation_amount' => 0,
-                'base_discount_tax_compensation_amount' => 0,
-                'shipping_discount_tax_compensation_amount' => 0,
-                'base_shipping_discount_tax_compensation_amount' => 0,
-                'grand_total' => 0,
-                'base_grand_total' => 0,
-                'applied_taxes' =>
                     [
-                        SetupUtil::TAX_RATE_TX =>
+                        'code' => 'Product Tax Rule',
+                        'product_tax_class_ids' =>
                             [
-                                'percent' => 18,
-                                'amount' => 915.25,
-                                'base_amount' => 915.25,
-                                'rates' =>
-                                    [
-                                        [
-                                            'code' => SetupUtil::TAX_RATE_TX,
-                                            'title' => SetupUtil::TAX_RATE_TX,
-                                            'percent' => 18,
-                                        ],
-                                    ],
-                            ]
+                                SetupUtil::PRODUCT_TAX_CLASS_1
+                            ],
                     ],
-            ],
-        'items_data' =>
-            [
-                'simple1' =>
                     [
-                        'row_total' => 5084.74,
-                        'base_row_total' => 5084.74,
-                        'tax_percent' => 18,
-                        'price' => 2542.37,
-                        'base_price' => 2542.37,
-                        'price_incl_tax' => 3000,
-                        'base_price_incl_tax' => 3000,
-                        'row_total_incl_tax' => 5999.99,
-                        'base_row_total_incl_tax' => 5999.99,
-                        'tax_amount' => 915.25,
-                        'base_tax_amount' => 915.25,
-                        'discount_amount' => 5999.99,
-                        'base_discount_amount' => 5999.99,
-                        'discount_percent' => 100,
-                        'discount_tax_compensation_amount' => 0,
-                        'base_discount_tax_compensation_amount' => 0,
+                        'code' => 'Shipping Tax Rule',
+                        'product_tax_class_ids' =>
+                            [
+                                SetupUtil::SHIPPING_TAX_CLASS
+                            ],
+                        'tax_rate_ids' =>
+                            [
+                                SetupUtil::TAX_RATE_SHIPPING,
+                            ],
                     ],
-            ],
-    ]
+                ],
+        ],
+        'quote_data' => [
+            'billing_address' =>
+                [
+                    'region_id' => SetupUtil::REGION_TX,
+                ],
+            'shipping_address' =>
+                [
+                    'region_id' => SetupUtil::REGION_TX,
+                ],
+            'items' =>
+                [
+                    [
+                        'sku' => 'simple1',
+                        'price' => 2542.37,
+                        'qty' => 2,
+                    ]
+                ],
+            'shipping_method' => 'free',
+            'shopping_cart_rules' =>
+                [
+                    ['discount_amount' => 100],
+                ],
+        ],
+        'expected_result' => [
+            'address_data' =>
+                [
+                    'subtotal' => 5084.74,
+                    'base_subtotal' => 5084.74,
+                    'subtotal_incl_tax' => 5999.99,
+                    'base_subtotal_incl_tax' => 5999.99,
+                    'tax_amount' => 915.25,
+                    'base_tax_amount' => 915.25,
+                    'shipping_amount' => 0,
+                    'base_shipping_amount' => 0,
+                    'shipping_incl_tax' => 0,
+                    'base_shipping_incl_tax' => 0,
+                    'shipping_tax_amount' => 0,
+                    'base_shipping_tax_amount' => 0,
+                    'discount_amount' => -5999.99,
+                    'base_discount_amount' => -5999.99,
+                    'discount_tax_compensation_amount' => 0,
+                    'base_discount_tax_compensation_amount' => 0,
+                    'shipping_discount_tax_compensation_amount' => 0,
+                    'base_shipping_discount_tax_compensation_amount' => 0,
+                    'grand_total' => 0,
+                    'base_grand_total' => 0,
+                    'applied_taxes' =>
+                        [
+                            SetupUtil::TAX_RATE_TX =>
+                                [
+                                    'percent' => 18,
+                                    'amount' => 915.25,
+                                    'base_amount' => 915.25,
+                                    'rates' =>
+                                        [
+                                            [
+                                                'code' => SetupUtil::TAX_RATE_TX,
+                                                'title' => SetupUtil::TAX_RATE_TX,
+                                                'percent' => 18,
+                                            ],
+                                        ],
+                                ]
+                        ],
+                ],
+            'items_data' =>
+                [
+                    'simple1' =>
+                        [
+                            'row_total' => 5084.74,
+                            'base_row_total' => 5084.74,
+                            'tax_percent' => 18,
+                            'price' => 2542.37,
+                            'base_price' => 2542.37,
+                            'price_incl_tax' => 3000,
+                            'base_price_incl_tax' => 3000,
+                            'row_total_incl_tax' => 5999.99,
+                            'base_row_total_incl_tax' => 5999.99,
+                            'tax_amount' => 915.25,
+                            'base_tax_amount' => 915.25,
+                            'discount_amount' => 5999.99,
+                            'base_discount_amount' => 5999.99,
+                            'discount_percent' => 100,
+                            'discount_tax_compensation_amount' => 0,
+                            'base_discount_tax_compensation_amount' => 0,
+                        ],
+                ],
+        ]
 ];

--- a/dev/tests/integration/testsuite/Magento/Tax/_files/full_discount_with_tax.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/_files/full_discount_with_tax.php
@@ -8,51 +8,42 @@ use Magento\Tax\Model\Sales\Total\Quote\SetupUtil;
 
 $fullTaxDiscountWithTax = [
         'config_data' => [
-                'config_overrides' =>
-                    [
+                'config_overrides' => [
                         Config::CONFIG_XML_PATH_APPLY_AFTER_DISCOUNT => 0,
                         Config::CONFIG_XML_PATH_DISCOUNT_TAX => 1,
                         Config::XML_PATH_ALGORITHM => 'ROW_BASE_CALCULATION',
                         Config::CONFIG_XML_PATH_SHIPPING_TAX_CLASS => SetupUtil::SHIPPING_TAX_CLASS,
                     ],
-                'tax_rate_overrides' =>
-                    [
+                'tax_rate_overrides' => [
                         SetupUtil::TAX_RATE_TX => 18,
                         SetupUtil::TAX_RATE_SHIPPING => 0,
                     ],
-                'tax_rule_overrides' =>
-                    [
+                'tax_rule_overrides' => [
                         [
                             'code' => 'Product Tax Rule',
-                            'product_tax_class_ids' =>
-                                [
+                            'product_tax_class_ids' => [
                                     SetupUtil::PRODUCT_TAX_CLASS_1
                                 ],
                         ],
                         [
                             'code' => 'Shipping Tax Rule',
-                            'product_tax_class_ids' =>
-                                [
+                            'product_tax_class_ids' => [
                                     SetupUtil::SHIPPING_TAX_CLASS
                                 ],
-                            'tax_rate_ids' =>
-                                [
+                            'tax_rate_ids' => [
                                     SetupUtil::TAX_RATE_SHIPPING,
                                 ],
                         ],
                     ],
         ],
         'quote_data' => [
-                'billing_address' =>
-                    [
+                'billing_address' => [
                         'region_id' => SetupUtil::REGION_TX,
                     ],
-                'shipping_address' =>
-                    [
+                'shipping_address' => [
                         'region_id' => SetupUtil::REGION_TX,
                     ],
-                'items' =>
-                    [
+                'items' => [
                         [
                             'sku' => 'simple1',
                             'price' => 2542.37,
@@ -60,14 +51,14 @@ $fullTaxDiscountWithTax = [
                         ]
                     ],
                 'shipping_method' => 'free',
-                'shopping_cart_rules' =>
-                    [
-                        ['discount_amount' => 100],
+                'shopping_cart_rules' => [
+                        [
+                            'discount_amount' => 100
+                        ],
                     ],
         ],
         'expected_result' => [
-                'address_data' =>
-                    [
+                'address_data' => [
                         'subtotal' => 5084.74,
                         'base_subtotal' => 5084.74,
                         'subtotal_incl_tax' => 5999.99,
@@ -88,15 +79,12 @@ $fullTaxDiscountWithTax = [
                         'base_shipping_discount_tax_compensation_amount' => 0,
                         'grand_total' => 0,
                         'base_grand_total' => 0,
-                        'applied_taxes' =>
-                            [
-                                SetupUtil::TAX_RATE_TX =>
-                                    [
+                        'applied_taxes' => [
+                                SetupUtil::TAX_RATE_TX => [
                                         'percent' => 18,
                                         'amount' => 915.25,
                                         'base_amount' => 915.25,
-                                        'rates' =>
-                                            [
+                                        'rates' => [
                                                 [
                                                     'code' => SetupUtil::TAX_RATE_TX,
                                                     'title' => SetupUtil::TAX_RATE_TX,
@@ -106,10 +94,8 @@ $fullTaxDiscountWithTax = [
                                     ]
                             ],
                     ],
-                'items_data' =>
-                    [
-                        'simple1' =>
-                            [
+                'items_data' => [
+                        'simple1' => [
                                 'row_total' => 5084.74,
                                 'base_row_total' => 5084.74,
                                 'tax_percent' => 18,


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/14468
Added additional check for discount

### Description
Added additional check for full (100%) discount in 
app/code/Magento/SalesRule/Model/Utility.php:214
to see if delta (row total minus discount) is negative. In case of negative delta to decrease a discount on delta value.  

### Fixed Issues (if relevant)

1. magento/magento2#10790 Tax rate + 100% discount results in negative grand total

### Manual testing scenarios
1. Create product A with price = 2 762,71
2. Create product B with price = 2 542,37
3. Setup tax rule 18%
4. Create coupon code that adds 100% discount.
5. Add both products to the cart with qty = 2
6. Apply coupon code
7. Total Order should be 0

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
