### PR TITLE
Fix loss of page_cache cache_dir setting from di.xml

### DIFF
--- a/app/code/Magento/Catalog/Observer/FlushCategoryPagesCache.php
+++ b/app/code/Magento/Catalog/Observer/FlushCategoryPagesCache.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+/**
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Catalog\Observer;
+
+use Magento\Catalog\Model\Category;
+use Magento\Framework\Event\Observer as Event;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\PageCache\Model\Cache\Type as PageCache;
+use Magento\PageCache\Model\Config as CacheConfig;
+
+/**
+ * Flush the built in page cache when a category is moved
+ */
+class FlushCategoryPagesCache implements ObserverInterface
+{
+
+    /**
+     * @var CacheConfig
+     */
+    private $cacheConfig;
+
+    /**
+     *
+     * @var PageCache
+     */
+    private $pageCache;
+
+    /**
+     * FlushCategoryPagesCache constructor.
+     *
+     * @param CacheConfig $cacheConfig
+     * @param PageCache $pageCache
+     */
+    public function __construct(CacheConfig $cacheConfig, PageCache $pageCache)
+    {
+        $this->cacheConfig = $cacheConfig;
+        $this->pageCache = $pageCache;
+    }
+
+    /**
+     * Clean the category page cache if built in cache page cache is used.
+     *
+     * The built in cache requires cleaning all pages that contain the top category navigation menu when a
+     * category is moved. This is because the built in cache does not support ESI blocks.
+     *
+     * @param Event $event
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function execute(Event $event)
+    {
+        if ($this->cacheConfig->getType() == CacheConfig::BUILT_IN && $this->cacheConfig->isEnabled()) {
+            $this->pageCache->clean(\Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG, [Category::CACHE_TAG]);
+        }
+    }
+}

--- a/app/code/Magento/Catalog/etc/adminhtml/events.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/events.xml
@@ -12,4 +12,7 @@
     <event name="catalog_category_change_products">
         <observer name="category_product_indexer" instance="Magento\Catalog\Observer\CategoryProductIndexer"/>
     </event>
+    <event name="category_move">
+        <observer name="clean_cagegory_page_cache" instance="Magento\Catalog\Observer\FlushCategoryPagesCache" />
+    </event>
 </config>

--- a/dev/tests/integration/testsuite/Magento/Framework/App/Cache/Frontend/PoolTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Cache/Frontend/PoolTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\App\Cache\Frontend;
+
+use Magento\Framework\ObjectManager\ConfigInterface as ObjectManagerConfig;
+use Magento\TestFramework\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This superfluous comment can be removed as soon as the sniffs have been updated to match the coding guide lines.
+ */
+class PoolTest extends TestCase
+{
+    public function testPageCacheNotSameAsDefaultCacheDirectory(): void
+    {
+        /** @var ObjectManagerConfig $diConfig */
+        $diConfig = ObjectManager::getInstance()->get(ObjectManagerConfig::class);
+        $argumentConfig = $diConfig->getArguments(\Magento\Framework\App\Cache\Frontend\Pool::class);
+
+        $pageCacheDir = $argumentConfig['frontendSettings']['page_cache']['backend_options']['cache_dir'] ?? null;
+        $defaultCacheDir = $argumentConfig['frontendSettings']['default']['backend_options']['cache_dir'] ?? null;
+
+        $noPageCacheMessage = "No default page_cache directory set in di.xml: \n" . var_export($argumentConfig, true);
+        $this->assertNotEmpty($pageCacheDir, $noPageCacheMessage);
+
+        $sameCacheDirMessage = 'The page_cache and default cache storages share the same cache directory';
+        $this->assertNotSame($pageCacheDir, $defaultCacheDir, $sameCacheDirMessage);
+    }
+
+    /**
+     * @covers  \Magento\Framework\App\Cache\Frontend\Pool::_getCacheSettings
+     * @depends testPageCacheNotSameAsDefaultCacheDirectory
+     */
+    public function testCleaningDefaultCachePreservesPageCache()
+    {
+        $testData = 'test data';
+        $testKey = 'test-key';
+
+        /** @var \Magento\Framework\App\Cache\Frontend\Pool $cacheFrontendPool */
+        $cacheFrontendPool = ObjectManager::getInstance()->get(\Magento\Framework\App\Cache\Frontend\Pool::class);
+
+        $pageCache = $cacheFrontendPool->get('page_cache');
+        $pageCache->save($testData, $testKey);
+
+        $defaultCache = $cacheFrontendPool->get('default');
+        $defaultCache->clean();
+
+        $this->assertSame($testData, $pageCache->load($testKey));
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/AbstractGraphqlCacheTest.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/AbstractGraphqlCacheTest.php
@@ -7,9 +7,15 @@ declare(strict_types=1);
 
 namespace Magento\GraphQlCache\Controller;
 
-use PHPUnit\Framework\TestCase;
-use Magento\TestFramework\ObjectManager;
+use Magento\Framework\App\Request\Http as HttpRequest;
+use Magento\Framework\App\Response\HttpInterface as HttpResponse;
+use Magento\Framework\Registry;
+use Magento\GraphQl\Controller\GraphQl as GraphQlController;
+use Magento\GraphQlCache\Model\CacheableQuery;
+use Magento\PageCache\Model\Cache\Type as PageCache;
 use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\ObjectManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Abstract test class for Graphql cache tests
@@ -21,40 +27,114 @@ abstract class AbstractGraphqlCacheTest extends TestCase
      */
     protected $objectManager;
 
-    /**
-     * @inheritdoc
-     */
     protected function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
+        $this->enablePageCachePlugin();
+        $this->enableCachebleQueryTestProxy();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->disableCacheableQueryTestProxy();
+        $this->disablePageCachePlugin();
+        $this->flushPageCache();
+    }
+
+    protected function enablePageCachePlugin(): void
+    {
+        /** @var  $registry Registry */
+        $registry = $this->objectManager->get(Registry::class);
+        $registry->register('use_page_cache_plugin', true, true);
+    }
+
+    protected function disablePageCachePlugin(): void
+    {
+        /** @var  $registry Registry */
+        $registry = $this->objectManager->get(Registry::class);
+        $registry->unregister('use_page_cache_plugin');
+    }
+
+    protected function flushPageCache(): void
+    {
+        /** @var PageCache $fullPageCache */
+        $fullPageCache = $this->objectManager->get(PageCache::class);
+        $fullPageCache->clean();
     }
 
     /**
-     * Prepare a query and return a request to be used in the same test end to end
+     * Regarding the SuppressWarnings annotation below: the nested class below triggers a false rule match.
      *
-     * @param string $query
-     * @return \Magento\Framework\App\Request\Http
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
-    protected function prepareRequest(string $query) : \Magento\Framework\App\Request\Http
+    private function enableCachebleQueryTestProxy(): void
     {
-        $cacheableQuery = $this->objectManager->get(\Magento\GraphQlCache\Model\CacheableQuery::class);
-        $cacheableQueryReflection = new \ReflectionProperty(
-            $cacheableQuery,
-            'cacheTags'
-        );
-        $cacheableQueryReflection->setAccessible(true);
-        $cacheableQueryReflection->setValue($cacheableQuery, []);
+        $cacheableQueryProxy = new class($this->objectManager) extends CacheableQuery {
+            /** @var CacheableQuery */
+            private $delegate;
 
-        /** @var \Magento\Framework\UrlInterface $urlInterface */
-        $urlInterface = $this->objectManager->create(\Magento\Framework\UrlInterface::class);
-        //set unique URL
-        $urlInterface->setQueryParam('query', $query);
+            public function __construct(ObjectManager $objectManager)
+            {
+                $this->reset($objectManager);
+            }
 
-        $request = $this->objectManager->get(\Magento\Framework\App\Request\Http::class);
-        $request->setUri($urlInterface->getUrl('graphql'));
+            public function reset(ObjectManager $objectManager): void
+            {
+                $this->delegate = $objectManager->create(CacheableQuery::class);
+            }
+
+            public function getCacheTags(): array
+            {
+                return $this->delegate->getCacheTags();
+            }
+
+            public function addCacheTags(array $cacheTags): void
+            {
+                $this->delegate->addCacheTags($cacheTags);
+            }
+
+            public function isCacheable(): bool
+            {
+                return $this->delegate->isCacheable();
+            }
+
+            public function setCacheValidity(bool $cacheable): void
+            {
+                $this->delegate->setCacheValidity($cacheable);
+            }
+
+            public function shouldPopulateCacheHeadersWithTags(): bool
+            {
+                return $this->delegate->shouldPopulateCacheHeadersWithTags();
+            }
+        };
+        $this->objectManager->addSharedInstance($cacheableQueryProxy, CacheableQuery::class);
+    }
+
+    private function disableCacheableQueryTestProxy(): void
+    {
+        $this->resetQueryCacheTags();
+        $this->objectManager->removeSharedInstance(CacheableQuery::class);
+    }
+
+    protected function resetQueryCacheTags(): void
+    {
+        $this->objectManager->get(CacheableQuery::class)->reset($this->objectManager);
+    }
+
+    protected function dispatchGraphQlGETRequest(array $queryParams): HttpResponse
+    {
+        $this->resetQueryCacheTags();
+
+        /** @var HttpRequest $request */
+        $request = $this->objectManager->get(HttpRequest::class);
+        $request->setPathInfo('/graphql');
         $request->setMethod('GET');
-        //set the actual GET query
-        $request->setQueryValue('query', $query);
-        return $request;
+        $request->setParams($queryParams);
+
+        // required for \Magento\Framework\App\PageCache\Identifier to generate the correct cache key
+        $request->setUri(implode('?', [$request->getPathInfo(), http_build_query($queryParams)]));
+
+        return $this->objectManager->create(GraphQlController::class)->dispatch($request);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Catalog/CategoriesWithProductsCacheTest.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Catalog/CategoriesWithProductsCacheTest.php
@@ -9,8 +9,6 @@ namespace Magento\GraphQlCache\Controller\Catalog;
 
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\Framework\App\Request\Http;
-use Magento\GraphQl\Controller\GraphQl;
 use Magento\GraphQlCache\Controller\AbstractGraphqlCacheTest;
 
 /**
@@ -23,30 +21,11 @@ use Magento\GraphQlCache\Controller\AbstractGraphqlCacheTest;
 class CategoriesWithProductsCacheTest extends AbstractGraphqlCacheTest
 {
     /**
-     * @var GraphQl
-     */
-    private $graphqlController;
-
-    /**
-     * @var Http
-     */
-    private $request;
-
-    /**
-     * @inheritdoc
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->graphqlController = $this->objectManager->get(\Magento\GraphQl\Controller\GraphQl::class);
-        $this->request = $this->objectManager->create(Http::class);
-    }
-    /**
      * Test cache tags and debug header for category with products querying for products and category
      *
      * @magentoDataFixture Magento/Catalog/_files/category_product.php
      */
-    public function testToCheckRequestCacheTagsForCategoryWithProducts(): void
+    public function testRequestCacheTagsForCategoryWithProducts(): void
     {
         /** @var ProductRepositoryInterface $productRepository */
         $productRepository = $this->objectManager->get(ProductRepositoryInterface::class);
@@ -91,17 +70,7 @@ QUERY;
             'operationName' => 'GetCategoryWithProducts'
         ];
 
-        /** @var \Magento\Framework\UrlInterface $urlInterface */
-        $urlInterface = $this->objectManager->create(\Magento\Framework\UrlInterface::class);
-        //set unique URL
-        $urlInterface->setQueryParam('query', $queryParams['query']);
-        $urlInterface->setQueryParam('variables', $queryParams['variables']);
-        $urlInterface->setQueryParam('operationName', $queryParams['operationName']);
-        $this->request->setUri($urlInterface->getUrl('graphql'));
-        $this->request->setPathInfo('/graphql');
-        $this->request->setMethod('GET');
-        $this->request->setParams($queryParams);
-        $response = $this->graphqlController->dispatch($this->request);
+        $response = $this->dispatchGraphQlGETRequest($queryParams);
         $this->assertEquals('MISS', $response->getHeader('X-Magento-Cache-Debug')->getFieldValue());
         $expectedCacheTags = ['cat_c','cat_c_' . $categoryId,'cat_p','cat_p_' . $product->getId(),'FPC'];
         $actualCacheTags = explode(',', $response->getHeader('X-Magento-Tags')->getFieldValue());

--- a/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Catalog/CategoryCacheTest.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Catalog/CategoryCacheTest.php
@@ -7,8 +7,6 @@ declare(strict_types=1);
 
 namespace Magento\GraphQlCache\Controller\Catalog;
 
-use Magento\Framework\App\Request\Http;
-use Magento\GraphQl\Controller\GraphQl;
 use Magento\GraphQlCache\Controller\AbstractGraphqlCacheTest;
 
 /**
@@ -21,24 +19,11 @@ use Magento\GraphQlCache\Controller\AbstractGraphqlCacheTest;
 class CategoryCacheTest extends AbstractGraphqlCacheTest
 {
     /**
-     * @var GraphQl
-     */
-    private $graphqlController;
-
-    /**
-     * @inheritdoc
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->graphqlController = $this->objectManager->get(\Magento\GraphQl\Controller\GraphQl::class);
-    }
-    /**
      * Test cache tags and debug header for category and querying only for category
      *
      * @magentoDataFixture Magento/Catalog/_files/category_product.php
      */
-    public function testToCheckRequestCacheTagsForForCategory(): void
+    public function testRequestCacheTagsForCategory(): void
     {
         $categoryId ='333';
         $query
@@ -53,11 +38,10 @@ class CategoryCacheTest extends AbstractGraphqlCacheTest
            }
        }
 QUERY;
-        $request = $this->prepareRequest($query);
-        $response = $this->graphqlController->dispatch($request);
+        $response = $this->dispatchGraphQlGETRequest(['query' => $query]);
         $this->assertEquals('MISS', $response->getHeader('X-Magento-Cache-Debug')->getFieldValue());
         $actualCacheTags = explode(',', $response->getHeader('X-Magento-Tags')->getFieldValue());
-        $expectedCacheTags = ['cat_c','cat_c_' . $categoryId,'FPC'];
+        $expectedCacheTags = ['cat_c','cat_c_' . $categoryId, 'FPC'];
         $this->assertEquals($expectedCacheTags, $actualCacheTags);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Catalog/DeepNestedCategoriesAndProductsTest.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Catalog/DeepNestedCategoriesAndProductsTest.php
@@ -9,7 +9,6 @@ namespace Magento\GraphQlCache\Controller\Catalog;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Api\CategoryRepositoryInterface;
-use Magento\Framework\App\Request\Http;
 use Magento\GraphQlCache\Controller\AbstractGraphqlCacheTest;
 
 /**
@@ -20,24 +19,11 @@ use Magento\GraphQlCache\Controller\AbstractGraphqlCacheTest;
  */
 class DeepNestedCategoriesAndProductsTest extends AbstractGraphqlCacheTest
 {
-    /** @var \Magento\GraphQl\Controller\GraphQl */
-    private $graphql;
-
-    /**
-     * @inheritdoc
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->graphql = $this->objectManager->get(\Magento\GraphQl\Controller\GraphQl::class);
-    }
-
     /**
      * Test cache tags and debug header for deep nested queries involving category and products
      *
      * @magentoCache all enabled
      * @magentoDataFixture Magento/Catalog/_files/product_in_multiple_categories.php
-     *
      */
     public function testDispatchForCacheHeadersOnDeepNestedQueries(): void
     {
@@ -102,14 +88,13 @@ QUERY;
         $uniqueCategoryIds = array_unique($resolvedCategoryIds);
         $expectedCacheTags = ['cat_c', 'cat_p', 'FPC'];
         foreach ($uniqueProductIds as $uniqueProductId) {
-            $expectedCacheTags = array_merge($expectedCacheTags, ['cat_p_'.$uniqueProductId]);
+            $expectedCacheTags = array_merge($expectedCacheTags, ['cat_p_' . $uniqueProductId]);
         }
         foreach ($uniqueCategoryIds as $uniqueCategoryId) {
-            $expectedCacheTags = array_merge($expectedCacheTags, ['cat_c_'.$uniqueCategoryId]);
+            $expectedCacheTags = array_merge($expectedCacheTags, ['cat_c_' . $uniqueCategoryId]);
         }
 
-        $request = $this->prepareRequest($query);
-        $response = $this->graphql->dispatch($request);
+        $response = $this->dispatchGraphQlGETRequest(['query' => $query]);
         $this->assertEquals('MISS', $response->getHeader('X-Magento-Cache-Debug')->getFieldValue());
         $actualCacheTags = explode(',', $response->getHeader('X-Magento-Tags')->getFieldValue());
         $this->assertEmpty(

--- a/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Catalog/DeepNestedCategoriesAndProductsTest.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Catalog/DeepNestedCategoriesAndProductsTest.php
@@ -80,6 +80,7 @@ QUERY;
         $resolvedCategoryIds = array_merge($resolvedCategoryIds, [$baseCategoryId]);
         foreach ($resolvedCategoryIds as $categoryId) {
             $category = $categoryRepository->get($categoryId);
+            // phpcs:ignore Magento2.Performance.ForeachArrayMerge
             $productIdsFromCategory= array_merge(
                 $productIdsFromCategory,
                 $category->getProductCollection()->getAllIds()

--- a/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Catalog/DeepNestedCategoriesAndProductsTest.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Catalog/DeepNestedCategoriesAndProductsTest.php
@@ -69,12 +69,14 @@ QUERY;
 
         $productIdsFromCategory = $category->getProductCollection()->getAllIds();
         foreach ($productIdsFromCategory as $productId) {
+            // phpcs:ignore Magento2.Performance.ForeachArrayMerge
             $resolvedCategoryIds = array_merge(
                 $resolvedCategoryIds,
                 $productRepository->getById($productId)->getCategoryIds()
             );
         }
 
+        // phpcs:ignore Magento2.Performance.ForeachArrayMerge
         $resolvedCategoryIds = array_merge($resolvedCategoryIds, [$baseCategoryId]);
         foreach ($resolvedCategoryIds as $categoryId) {
             $category = $categoryRepository->get($categoryId);
@@ -88,9 +90,11 @@ QUERY;
         $uniqueCategoryIds = array_unique($resolvedCategoryIds);
         $expectedCacheTags = ['cat_c', 'cat_p', 'FPC'];
         foreach ($uniqueProductIds as $uniqueProductId) {
+            // phpcs:ignore Magento2.Performance.ForeachArrayMerge
             $expectedCacheTags = array_merge($expectedCacheTags, ['cat_p_' . $uniqueProductId]);
         }
         foreach ($uniqueCategoryIds as $uniqueCategoryId) {
+            // phpcs:ignore Magento2.Performance.ForeachArrayMerge
             $expectedCacheTags = array_merge($expectedCacheTags, ['cat_c_' . $uniqueCategoryId]);
         }
 

--- a/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Catalog/ProductsCacheTest.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Catalog/ProductsCacheTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace Magento\GraphQlCache\Controller\Catalog;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\GraphQl\Controller\GraphQl;
 use Magento\GraphQlCache\Controller\AbstractGraphqlCacheTest;
 
 /**
@@ -21,25 +20,11 @@ use Magento\GraphQlCache\Controller\AbstractGraphqlCacheTest;
 class ProductsCacheTest extends AbstractGraphqlCacheTest
 {
     /**
-     * @var GraphQl
-     */
-    private $graphqlController;
-
-    /**
-     * @inheritdoc
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->graphqlController = $this->objectManager->get(\Magento\GraphQl\Controller\GraphQl::class);
-    }
-
-    /**
      * Test request is dispatched and response is checked for debug headers and cache tags
      *
      * @magentoDataFixture Magento/Catalog/_files/product_simple_with_url_key.php
      */
-    public function testToCheckRequestCacheTagsForProducts(): void
+    public function testRequestCacheTagsForProducts(): void
     {
         /** @var ProductRepositoryInterface $productRepository */
         $productRepository = $this->objectManager->get(ProductRepositoryInterface::class);
@@ -63,8 +48,7 @@ class ProductsCacheTest extends AbstractGraphqlCacheTest
        }
 QUERY;
 
-        $request = $this->prepareRequest($query);
-        $response = $this->graphqlController->dispatch($request);
+        $response = $this->dispatchGraphQlGETRequest(['query' => $query]);
         $this->assertEquals('MISS', $response->getHeader('X-Magento-Cache-Debug')->getFieldValue());
         $actualCacheTags = explode(',', $response->getHeader('X-Magento-Tags')->getFieldValue());
         $expectedCacheTags = ['cat_p', 'cat_p_' . $product->getId(), 'FPC'];
@@ -74,7 +58,7 @@ QUERY;
     /**
      * Test request is checked for debug headers and no cache tags for not existing product
      */
-    public function testToCheckRequestNoTagsForProducts(): void
+    public function testRequestNoTagsForNonExistingProducts(): void
     {
         $query
             = <<<QUERY
@@ -93,11 +77,66 @@ QUERY;
        }
 
 QUERY;
-        $request = $this->prepareRequest($query);
-        $response = $this->graphqlController->dispatch($request);
+        $response = $this->dispatchGraphQlGETRequest(['query' => $query]);
         $this->assertEquals('MISS', $response->getHeader('X-Magento-Cache-Debug')->getFieldValue());
         $actualCacheTags = explode(',', $response->getHeader('X-Magento-Tags')->getFieldValue());
         $expectedCacheTags = ['FPC'];
         $this->assertEquals($expectedCacheTags, $actualCacheTags);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/product_simple_with_url_key.php
+     */
+    public function testConsecutiveRequestsAreServedFromThePageCache(): void
+    {
+        $query
+            = <<<QUERY
+{
+   products(filter: {sku: {eq: "simple1"}})
+   {
+       items {
+           id
+           name
+           sku
+           description {
+           html
+           }
+       }
+   }
+}
+QUERY;
+        $response1 = $this->dispatchGraphQlGETRequest(['query' => $query]);
+        $response2 = $this->dispatchGraphQlGETRequest(['query' => $query]);
+
+        $this->assertEquals('MISS', $response1->getHeader('X-Magento-Cache-Debug')->getFieldValue());
+        $this->assertEquals('HIT', $response2->getHeader('X-Magento-Cache-Debug')->getFieldValue());
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/product_simple_with_url_key.php
+     */
+    public function testDifferentProductsRequestsUseDifferentPageCacheRecords(): void
+    {
+        $queryTemplate
+            = <<<QUERY
+{
+   products(filter: {sku: {eq: "%s"}})
+   {
+       items {
+           id
+           name
+           sku
+           description {
+           html
+           }
+       }
+   }
+}
+QUERY;
+        $responseProduct1 = $this->dispatchGraphQlGETRequest(['query' => sprintf($queryTemplate, 'simple1')]);
+        $responseProduct2 = $this->dispatchGraphQlGETRequest(['query' => sprintf($queryTemplate, 'simple2')]);
+
+        $this->assertEquals('MISS', $responseProduct1->getHeader('X-Magento-Cache-Debug')->getFieldValue());
+        $this->assertEquals('MISS', $responseProduct2->getHeader('X-Magento-Cache-Debug')->getFieldValue());
     }
 }

--- a/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Cms/BlockCacheTest.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQlCache/Controller/Cms/BlockCacheTest.php
@@ -7,8 +7,9 @@ declare(strict_types=1);
 
 namespace Magento\GraphQlCache\Controller\Cms;
 
+use Magento\Cms\Api\Data\BlockInterface;
 use Magento\Cms\Model\BlockRepository;
-use Magento\GraphQl\Controller\GraphQl;
+use Magento\Framework\App\Response\HttpInterface as HttpResponse;
 use Magento\GraphQlCache\Controller\AbstractGraphqlCacheTest;
 
 /**
@@ -20,23 +21,27 @@ use Magento\GraphQlCache\Controller\AbstractGraphqlCacheTest;
  */
 class BlockCacheTest extends AbstractGraphqlCacheTest
 {
-    /**
-     * @var GraphQl
-     */
-    private $graphqlController;
-
-    /**
-     * @inheritdoc
-     */
-    protected function setUp(): void
+    private function assertPageCacheMissWithTagsForCmsBlock(HttpResponse $response, BlockInterface $block): void
     {
-        parent::setUp();
-        $this->graphqlController = $this->objectManager->get(\Magento\GraphQl\Controller\GraphQl::class);
+        $this->assertEquals('MISS', $response->getHeader('X-Magento-Cache-Debug')->getFieldValue());
+        $this->assertCmsBlockCacheTags($response, $block);
+    }
+
+    private function assertPageCacheHitWithTagsForCmsBlock(HttpResponse $response, BlockInterface $block): void
+    {
+        $this->assertEquals('HIT', $response->getHeader('X-Magento-Cache-Debug')->getFieldValue());
+        $this->assertCmsBlockCacheTags($response, $block);
+    }
+
+    private function assertCmsBlockCacheTags(HttpResponse $response, BlockInterface $block): void
+    {
+        $expectedCacheTags  = ['cms_b', 'cms_b_' . $block->getId(), 'cms_b_' . $block->getIdentifier(), 'FPC'];
+        $rawActualCacheTags = $response->getHeader('X-Magento-Tags')->getFieldValue();
+        $actualCacheTags    = explode(',', $rawActualCacheTags);
+        $this->assertEquals($expectedCacheTags, $actualCacheTags);
     }
 
     /**
-     * Test that the correct cache tags get added to request for cmsBlocks
-     *
      * @magentoDataFixture Magento/Cms/_files/block.php
      * @magentoDataFixture Magento/Cms/_files/blocks.php
      */
@@ -46,9 +51,9 @@ class BlockCacheTest extends AbstractGraphqlCacheTest
         $blockRepository = $this->objectManager->get(BlockRepository::class);
 
         $block1Identifier = 'fixture_block';
-        $block1 = $blockRepository->getById($block1Identifier);
+        $block1           = $blockRepository->getById($block1Identifier);
         $block2Identifier = 'enabled_block';
-        $block2 = $blockRepository->getById($block2Identifier);
+        $block2           = $blockRepository->getById($block2Identifier);
 
         $queryBlock1
             = <<<QUERY
@@ -77,60 +82,30 @@ QUERY;
 QUERY;
 
         // check to see that the first entity gets a MISS when called the first time
-        $request = $this->prepareRequest($queryBlock1);
-        $response = $this->graphqlController->dispatch($request);
-        $this->assertEquals('MISS', $response->getHeader('X-Magento-Cache-Debug')->getFieldValue());
-        $expectedCacheTags = ['cms_b', 'cms_b_' . $block1->getId(), 'cms_b_' . $block1->getIdentifier(), 'FPC'];
-        $rawActualCacheTags = $response->getHeader('X-Magento-Tags')->getFieldValue();
-        $actualCacheTags = explode(',', $rawActualCacheTags);
-        $this->assertEquals($expectedCacheTags, $actualCacheTags);
+        $response = $this->dispatchGraphQlGETRequest(['query' => $queryBlock1]);
+        $this->assertPageCacheMissWithTagsForCmsBlock($response, $block1);
 
-        // check to see that the second entity gets a miss when called the first time
-        $request = $this->prepareRequest($queryBlock2);
-        $response = $this->graphqlController->dispatch($request);
-        $this->assertEquals('MISS', $response->getHeader('X-Magento-Cache-Debug')->getFieldValue());
-        $expectedCacheTags = ['cms_b', 'cms_b_' . $block2->getId(), 'cms_b_' . $block2->getIdentifier(), 'FPC'];
-        $rawActualCacheTags = $response->getHeader('X-Magento-Tags')->getFieldValue();
-        $actualCacheTags = explode(',', $rawActualCacheTags);
-        $this->assertEquals($expectedCacheTags, $actualCacheTags);
+        // check to see that the second entity gets a MISS when called the first time
+        $response = $this->dispatchGraphQlGETRequest(['query' => $queryBlock2]);
+        $this->assertPageCacheMissWithTagsForCmsBlock($response, $block2);
 
         // check to see that the first entity gets a HIT when called the second time
-        $request = $this->prepareRequest($queryBlock1);
-        $response = $this->graphqlController->dispatch($request);
-        $this->assertEquals('HIT', $response->getHeader('X-Magento-Cache-Debug')->getFieldValue());
-        $expectedCacheTags = ['cms_b', 'cms_b_' . $block1->getId(), 'cms_b_' . $block1->getIdentifier(), 'FPC'];
-        $rawActualCacheTags = $response->getHeader('X-Magento-Tags')->getFieldValue();
-        $actualCacheTags = explode(',', $rawActualCacheTags);
-        $this->assertEquals($expectedCacheTags, $actualCacheTags);
+        $response = $this->dispatchGraphQlGETRequest(['query' => $queryBlock1]);
+        $this->assertPageCacheHitWithTagsForCmsBlock($response, $block1);
 
         // check to see that the second entity gets a HIT when called the second time
-        $request = $this->prepareRequest($queryBlock2);
-        $response = $this->graphqlController->dispatch($request);
-        $this->assertEquals('HIT', $response->getHeader('X-Magento-Cache-Debug')->getFieldValue());
-        $expectedCacheTags = ['cms_b', 'cms_b_' . $block2->getId(), 'cms_b_' . $block2->getIdentifier(), 'FPC'];
-        $rawActualCacheTags = $response->getHeader('X-Magento-Tags')->getFieldValue();
-        $actualCacheTags = explode(',', $rawActualCacheTags);
-        $this->assertEquals($expectedCacheTags, $actualCacheTags);
+        $response = $this->dispatchGraphQlGETRequest(['query' => $queryBlock2]);
+        $this->assertPageCacheHitWithTagsForCmsBlock($response, $block2);
 
         $block1->setTitle('something else that causes invalidation');
         $blockRepository->save($block1);
 
         // check to see that the first entity gets a MISS and it was invalidated
-        $request = $this->prepareRequest($queryBlock1);
-        $response = $this->graphqlController->dispatch($request);
-        $this->assertEquals('MISS', $response->getHeader('X-Magento-Cache-Debug')->getFieldValue());
-        $expectedCacheTags = ['cms_b', 'cms_b_' . $block1->getId(), 'cms_b_' . $block1->getIdentifier(), 'FPC'];
-        $rawActualCacheTags = $response->getHeader('X-Magento-Tags')->getFieldValue();
-        $actualCacheTags = explode(',', $rawActualCacheTags);
-        $this->assertEquals($expectedCacheTags, $actualCacheTags);
+        $response = $this->dispatchGraphQlGETRequest(['query' => $queryBlock1]);
+        $this->assertPageCacheMissWithTagsForCmsBlock($response, $block1);
 
         // check to see that the first entity gets a HIT when called the second time
-        $request = $this->prepareRequest($queryBlock1);
-        $response = $this->graphqlController->dispatch($request);
-        $this->assertEquals('HIT', $response->getHeader('X-Magento-Cache-Debug')->getFieldValue());
-        $expectedCacheTags = ['cms_b', 'cms_b_' . $block1->getId(), 'cms_b_' . $block1->getIdentifier(), 'FPC'];
-        $rawActualCacheTags = $response->getHeader('X-Magento-Tags')->getFieldValue();
-        $actualCacheTags = explode(',', $rawActualCacheTags);
-        $this->assertEquals($expectedCacheTags, $actualCacheTags);
+        $response = $this->dispatchGraphQlGETRequest(['query' => $queryBlock1]);
+        $this->assertPageCacheHitWithTagsForCmsBlock($response, $block1);
     }
 }

--- a/lib/internal/Magento/Framework/App/Cache/Frontend/Pool.php
+++ b/lib/internal/Magento/Framework/App/Cache/Frontend/Pool.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Framework\App\Cache\Frontend;
 
 use Magento\Framework\App\Cache\Type\FrontendPool;
@@ -55,6 +56,7 @@ class Pool implements \Iterator
 
     /**
      * Create instances of every cache frontend known to the system.
+     *
      * Method is to be used for delayed initialization of the iterator.
      *
      * @return void
@@ -77,18 +79,21 @@ class Pool implements \Iterator
     protected function _getCacheSettings()
     {
         /*
-         * Merging is intentionally implemented through array_merge() instead of array_replace_recursive()
-         * to avoid "inheritance" of the default settings that become irrelevant as soon as cache storage type changes
+         * Merging is intentionally implemented through array_replace_recursive() instead of array_merge(), because even
+         * though some settings may become irrelevant when the cache storage type is changed, they don't do any harm
+         * and can be overwritten when needed.
+         * Also array_merge leads to unexpected behavior, for for example by dropping the
+         * default cache_dir setting from di.xml when a cache id_prefix is configured in app/etc/env.php.
          */
         $cacheInfo = $this->deploymentConfig->getConfigData(FrontendPool::KEY_CACHE);
         if (null !== $cacheInfo) {
-            return array_merge($this->_frontendSettings, $cacheInfo[FrontendPool::KEY_FRONTEND_CACHE]);
+            return array_replace_recursive($this->_frontendSettings, $cacheInfo[FrontendPool::KEY_FRONTEND_CACHE]);
         }
         return $this->_frontendSettings;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      *
      * @return \Magento\Framework\Cache\FrontendInterface
      */
@@ -99,7 +104,7 @@ class Pool implements \Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function key()
     {
@@ -108,7 +113,7 @@ class Pool implements \Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function next()
     {
@@ -117,7 +122,7 @@ class Pool implements \Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function rewind()
     {
@@ -126,7 +131,7 @@ class Pool implements \Iterator
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function valid()
     {

--- a/lib/internal/Magento/Framework/App/Test/Unit/Cache/Frontend/PoolTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Cache/Frontend/PoolTest.php
@@ -8,6 +8,9 @@ namespace Magento\Framework\App\Test\Unit\Cache\Frontend;
 use Magento\Framework\App\Cache\Frontend\Pool;
 use Magento\Framework\App\Cache\Type\FrontendPool;
 
+/**
+ * And another docblock to make the sniff shut up.
+ */
 class PoolTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -111,25 +114,38 @@ class PoolTest extends \PHPUnit\Framework\TestCase
     public function initializationParamsDataProvider()
     {
         return [
-            'default frontend, default settings' => [
+            'no deployment config, default settings' => [
                 ['frontend' => []],
                 [Pool::DEFAULT_FRONTEND_ID => ['default_option' => 'default_value']],
                 ['default_option' => 'default_value'],
             ],
-            'default frontend, overridden settings' => [
+            'deployment config, default settings' => [
                 ['frontend' => [Pool::DEFAULT_FRONTEND_ID => ['configured_option' => 'configured_value']]],
-                [Pool::DEFAULT_FRONTEND_ID => ['ignored_option' => 'ignored_value']],
+                [Pool::DEFAULT_FRONTEND_ID => ['default_option' => 'default_value']],
+                ['configured_option' => 'configured_value', 'default_option' => 'default_value'],
+            ],
+            'deployment config, overridden settings' => [
+                ['frontend' => [Pool::DEFAULT_FRONTEND_ID => ['configured_option' => 'configured_value']]],
+                [Pool::DEFAULT_FRONTEND_ID => ['configured_option' => 'default_value']],
                 ['configured_option' => 'configured_value'],
             ],
-            'custom frontend, default settings' => [
-                ['frontend' => []],
-                ['custom' => ['default_option' => 'default_value']],
-                ['default_option' => 'default_value'],
+            'deployment config, default settings, overridden settings' => [
+                ['frontend' => [Pool::DEFAULT_FRONTEND_ID => ['configured_option' => 'configured_value']]],
+                [Pool::DEFAULT_FRONTEND_ID => [
+                    'configured_option' => 'default_value',
+                    'default_setting' => 'default_value'
+                ]],
+                ['configured_option' => 'configured_value', 'default_setting' => 'default_value'],
             ],
-            'custom frontend, overridden settings' => [
+            'custom deployent config, default settings' => [
                 ['frontend' => ['custom' => ['configured_option' => 'configured_value']]],
-                ['custom' => ['ignored_option' => 'ignored_value']],
-                ['configured_option' => 'configured_value'],
+                ['custom' => ['default_option' => 'default_value']],
+                ['configured_option' => 'configured_value', 'default_option' => 'default_value'],
+            ],
+            'custom deployent config, default settings, overridden settings' => [
+                ['frontend' => ['custom' => ['configured_option' => 'configured_value']]],
+                ['custom' => ['default_option' => 'default_value', 'configured_option' => 'default_value']],
+                ['configured_option' => 'configured_value', 'default_option' => 'default_value'],
             ]
         ];
     }


### PR DESCRIPTION
### Description

In a native Magento 2 installation both the page_cache and the default cache is stored in the `var/cache` directory. The `var/page_cache` directory is not used, even, though it is [configured in di.xml](https://github.com/magento/magento2/blob/2.3-develop/app/etc/di.xml#L771).

This makes it impossible to use `bin/magento cache:flush full_page` to only clear the FPC, as it will also flush the cache directory.

The reason is any cache options configured in `di.xml` are lost if any configuration for a cache frontend is present in `app/etc/env.php`.

During the Magento installation a cache id_prefix for both the [default](\Magento\Setup\Model\ConfigOptionsList\Cache::createConfig) and the [page_cache](\Magento\Setup\Model\ConfigOptionsList\PageCache) frontends are written to the `app/etc/env.php`.

The bug was introduced by the PR: https://github.com/magento/magento2/pull/18641  
(note: the issue that was solved by that PR is also relevant for non-filesystem cache backends.) 

In the method body of `\Magento\Framework\App\Cache\Frontend\Pool::_getCacheSettings` the original comment read:

```
Merging is intentionally implemented through array_merge() instead of array_replace_recursive()
to avoid "inheritance" of the default settings that become irrelevant as soon as cache storage type changes
```

This reasoning of the original comment applies only if the backend type is changed, but not if an option is added to be used with the default.

### Fixed Issues

This PR will merge the deployment configuration and the `di.xml` configuration using `array_replace_recursive` instead of `array_merge`, as cache settings that are not used by other cache backends don't do any harm, and still can be changed by overwriting them when needed. 

An alternative implementation of the solution checked if the `page_cache` backend was set to a different value of the `default` cache frontend, but that added a lot of additional coupling and in favor of simplicity I believe the solution in this PR is better.

The above fix revealed a bug that was masked before, namely that the when the built in page cache was is used, moving a category does not clean the appropriate cache records.
With varnish this issue does not occur because there the category top navigation is rendered as an ESI block, which is associated with all category ID cache tags (`cat_c_<ID>`).  
The page cache records however are only associated with the generic category cache tag (`cat_c`).  
Moving a category only cleans records that are associated with the category ID cache tag.  
The solution is implemented as an event observer for the `category_move` event, which cleans the generic category cache tag if the built in page cache is used.

### Manual testing scenarios

1. download source Magento (tarball or composer or github clone)
2. install Magento (ui or cli)
3. access a frontend or adminhtml page in the browser
4. With the bug: `var/page_cache` is empty and `var/cache` is not empty
5. Run `bin/magento cache:flush full_page`
6. Check `var/cache` is empty

After the patch is applied `var/page_cache` will no longer be empty after a page is accessed and `bin/magento cache:flush full_page` will only flush `var/page_cache`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
