### PR TITLE
[Backport]Magento should create log if an observer not implement ObserverInterface

### DIFF
--- a/lib/internal/Magento/Framework/Event/Test/Unit/Invoker/InvokerDefaultTest.php
+++ b/lib/internal/Magento/Framework/Event/Test/Unit/Invoker/InvokerDefaultTest.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\Framework\Event\Test\Unit\Invoker;
 
+/**
+ * Test for Magento\Framework\Event\Invoker\InvokerDefault.
+ */
 class InvokerDefaultTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -32,6 +35,11 @@ class InvokerDefaultTest extends \PHPUnit\Framework\TestCase
      */
     protected $_invokerDefault;
 
+    /**
+     * @var |Psr\Log|LoggerInterface
+     */
+    private $loggerMock;
+
     protected function setUp()
     {
         $this->_observerFactoryMock = $this->createMock(\Magento\Framework\Event\ObserverFactory::class);
@@ -41,10 +49,12 @@ class InvokerDefaultTest extends \PHPUnit\Framework\TestCase
             ['execute']
         );
         $this->_appStateMock = $this->createMock(\Magento\Framework\App\State::class);
+        $this->loggerMock = $this->createMock(\Psr\Log\LoggerInterface::class);
 
         $this->_invokerDefault = new \Magento\Framework\Event\Invoker\InvokerDefault(
             $this->_observerFactoryMock,
-            $this->_appStateMock
+            $this->_appStateMock,
+            $this->loggerMock
         );
     }
 
@@ -166,12 +176,14 @@ class InvokerDefaultTest extends \PHPUnit\Framework\TestCase
             $this->returnValue($notObserver)
         );
         $this->_appStateMock->expects(
-            $this->once()
+            $this->exactly(1)
         )->method(
             'getMode'
         )->will(
             $this->returnValue(\Magento\Framework\App\State::MODE_PRODUCTION)
         );
+
+        $this->loggerMock->expects($this->once())->method('warning');
 
         $this->_invokerDefault->dispatch(
             [


### PR DESCRIPTION
### Description (*)
In developer mode, if an observer does not implement ObserverInterface, Magento throws an exception. This is the expected behavior.

What I don't understand is that it does not do anything for other deploy modes (default and production). It silently discards the observer without even putting an entry to logs.
### Original PR #21767 
### Fixed Issues (if relevant)

1. magento/magento2#21755: Magento should create a log entry if an observer does not implement ObserverInterface 

### Manual testing scenarios (*)

1. Create an Observer class wich not implements ObserverInterface
2. Check Log sytem.log

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
