### PR TITLE
[Performance] Fix array merge in loop to speed up static content deploy

### DIFF
--- a/app/code/Magento/Deploy/Package/Processor/PreProcessor/Css.php
+++ b/app/code/Magento/Deploy/Package/Processor/PreProcessor/Css.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Deploy\Package\Processor\PreProcessor;
 
 use Magento\Deploy\Console\DeployStaticOptions;
@@ -92,8 +93,7 @@ class Css implements ProcessorInterface
     }
 
     /**
-     * Checks if there are imports of CSS files or images within the given CSS file
-     * which exists in the current package
+     * Checks if there are imports of CSS files or images within the given CSS file which exists in the current package.
      *
      * @param PackageFile $parentFile
      * @param Package $package

--- a/app/code/Magento/Deploy/Package/Processor/PreProcessor/Css.php
+++ b/app/code/Magento/Deploy/Package/Processor/PreProcessor/Css.php
@@ -180,11 +180,13 @@ class Css implements ProcessorInterface
      */
     private function collectFileMap($fileName)
     {
-        $result = isset($this->map[$fileName]) ? $this->map[$fileName] : [];
+        $result = [$this->map[$fileName] ?? []];
+
         foreach ($result as $path) {
-            $result = array_merge($result, $this->collectFileMap($path));
+            $result[] = $this->collectFileMap($path);
         }
-        return array_unique($result);
+
+        return array_unique(array_merge(...$result));
     }
 
     /**


### PR DESCRIPTION
### Description (*)
This PR improving static content deploy speed.

For instance i tried to compile Magento/blank theme for 6 different locales (I have all these language packs installed).
```bash
php bin/magento setup:static-content:deploy -f --jobs=2 --area frontend en_US locale2 locale3 locale4 locale5 locale6 --theme Magento/blank
```

Before applying this patch: 109 seconds on my machine.
After applying this patch: 93 seconds on my machine.

If we'll execute for SCD for multiple theme - results should be bigger.

More info about array_merge in loop:
https://github.com/kalessil/phpinspectionsea/blob/master/docs/performance.md#slow-array-function-used-in-loop

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
