### PR TITLE
[Backport] Fix gallery event observer

### DIFF
--- a/lib/web/mage/gallery/gallery.js
+++ b/lib/web/mage/gallery/gallery.js
@@ -141,7 +141,7 @@ define([
             this.setupBreakpoints();
             this.initFullscreenSettings();
 
-            this.settings.$element.on('mousedown', '.fotorama__stage__frame', function () {
+            this.settings.$element.on('click', '.fotorama__stage__frame', function () {
                 if (
                     !$(this).parents('.fotorama__shadows--left, .fotorama__shadows--right').length &&
                     !$(this).hasClass('fotorama-video-container')


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
### Original PR
https://github.com/magento/magento2/pull/21790

### Description (*)
This PR fix issue of opening gallery if moving mouse to image when clicking to another element of page

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21789: [BUG] Product gallery opening by mistake

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open product page
2. Click to product qty move cursor to product image and up mouse button

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
