### PR TITLE
Fixed downloadable product save exception

### DIFF
--- a/app/code/Magento/Downloadable/Model/Link/ContentValidator.php
+++ b/app/code/Magento/Downloadable/Model/Link/ContentValidator.php
@@ -49,7 +49,7 @@ class ContentValidator
             throw new InputException(__('Link price must have numeric positive value.'));
         }
         if (filter_var((int) $link->getNumberOfDownloads(), FILTER_VALIDATE_INT) === false
-            || $link->getNumberOfDownloads() < 0) {
+            || (int) $link->getNumberOfDownloads() < 0) {
             throw new InputException(__('Number of downloads must be a positive integer.'));
         }
         if (filter_var($link->getSortOrder(), FILTER_VALIDATE_INT) === false

--- a/app/code/Magento/Downloadable/Model/Link/ContentValidator.php
+++ b/app/code/Magento/Downloadable/Model/Link/ContentValidator.php
@@ -49,10 +49,10 @@ class ContentValidator
             throw new InputException(__('Link price must have numeric positive value.'));
         }
         if (filter_var((int) $link->getNumberOfDownloads(), FILTER_VALIDATE_INT) === false
-            || (int) $link->getNumberOfDownloads() < 0) {
+            || $link->getNumberOfDownloads() < 0) {
             throw new InputException(__('Number of downloads must be a positive integer.'));
         }
-        if (filter_var($link->getSortOrder(), FILTER_VALIDATE_INT) === false
+        if (filter_var((int) $link->getSortOrder(), FILTER_VALIDATE_INT) === false
             || $link->getSortOrder() < 0) {
             throw new InputException(__('Sort order must be a positive integer.'));
         }

--- a/app/code/Magento/Downloadable/Model/Link/ContentValidator.php
+++ b/app/code/Magento/Downloadable/Model/Link/ContentValidator.php
@@ -48,7 +48,7 @@ class ContentValidator
         if (!is_numeric($link->getPrice()) || $link->getPrice() < 0) {
             throw new InputException(__('Link price must have numeric positive value.'));
         }
-        if (filter_var($link->getNumberOfDownloads(), FILTER_VALIDATE_INT) === false
+        if (filter_var((int) $link->getNumberOfDownloads(), FILTER_VALIDATE_INT) === false
             || $link->getNumberOfDownloads() < 0) {
             throw new InputException(__('Number of downloads must be a positive integer.'));
         }

--- a/app/code/Magento/Downloadable/Model/Link/ContentValidator.php
+++ b/app/code/Magento/Downloadable/Model/Link/ContentValidator.php
@@ -52,7 +52,7 @@ class ContentValidator
             || $link->getNumberOfDownloads() < 0) {
             throw new InputException(__('Number of downloads must be a positive integer.'));
         }
-        if (filter_var((int) $link->getSortOrder(), FILTER_VALIDATE_INT) === false
+        if (filter_var($link->getSortOrder(), FILTER_VALIDATE_INT) === false
             || $link->getSortOrder() < 0) {
             throw new InputException(__('Sort order must be a positive integer.'));
         }

--- a/app/code/Magento/Downloadable/Test/Unit/Model/Link/ContentValidatorTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Model/Link/ContentValidatorTest.php
@@ -203,9 +203,7 @@ class ContentValidatorTest extends \PHPUnit\Framework\TestCase
     {
         return [
             [-1],
-            [2.71828],
-            ['string'],
-        ];
+            ];
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions
1. Magento 2.3.x
2. Magento 2.2.x

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
While admin insert positive integer number into "Max. Downloads" fields it will not allowed the integer number.


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Admin >> Catalog >> Products >> Add Products select Downloadable Products
2. Insert information into "Downloadable Information >> Max. Downloads" like "021" "010". 
3. Try to Save the Product.

### Expected Result
1. Downloadable product must be saved.

### Actual Result
1. While try to save the product it will give the exception "Number of downloads must be a positive integer".
![actual](https://user-images.githubusercontent.com/43463281/55858887-6a650600-5b8e-11e9-8ce0-92a92d000782.gif)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
