### PR TITLE
Use proper variables for tooltip styles on tablet devices

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
@@ -173,10 +173,10 @@
         width: 0;
     }
     .field-tooltip .field-tooltip-content::before {
-        border-bottom-color: @color-gray40;
+        border-bottom-color: @checkout-tooltip-content__border-color;
     }
     .field-tooltip .field-tooltip-content::after {
-        border-bottom-color: @color-gray-light01;
+        border-bottom-color: @checkout-tooltip-content__background-color;
         top: 1px;
     }
 }

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
@@ -173,10 +173,10 @@
         width: 0;
     }
     .field-tooltip .field-tooltip-content::before {
-        border-bottom-color: @checkout-tooltip-content__border-color;
+        .lib-css(border-bottom-color, @checkout-tooltip-content__border-color);
     }
     .field-tooltip .field-tooltip-content::after {
-        border-bottom-color: @checkout-tooltip-content__background-color;
+        .lib-css(border-bottom-color, @checkout-tooltip-content__background-color);
         top: 1px;
     }
 }


### PR DESCRIPTION
### Description
There are variables available for tooltip customization. This commit fixes an issue
on tablet devices when trying to use them.

### Manual testing scenarios
 1. Open `Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less` file and change the values of the tooltip variables as follows (Usually we do this via theme, but it's for testing purpose only):

    ```less
    @checkout-tooltip-content__background-color: #fff;
    @checkout-tooltip-content__border-color: #f2f5f7;
    @checkout-tooltip-content__active__border-color: @checkout-tooltip-content__border-color;
    ```
 2. Navigate to checkout and chec the new styles of field tooltips
 3. Set the width to `768px` and check them again:

    Without patch | With patch
    --------------|------------
    ![image](https://user-images.githubusercontent.com/306080/55861030-2f5ad680-5b7e-11e9-9f04-92afa963fd2a.png) | ![image](https://user-images.githubusercontent.com/306080/55861154-75179f00-5b7e-11e9-8cee-9935534421df.png)



### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
