### PR TITLE
Disabling "Display on Product Details Page" the button is shown anyway.

### DIFF
--- a/app/code/Magento/Paypal/Model/SmartButtonConfig.php
+++ b/app/code/Magento/Paypal/Model/SmartButtonConfig.php
@@ -67,7 +67,8 @@ class SmartButtonConfig
             'locale' => $this->localeResolver->getLocale(),
             'allowedFunding' => $this->getAllowedFunding($page),
             'disallowedFunding' => $this->getDisallowedFunding(),
-            'styles' => $this->getButtonStyles($page)
+            'styles' => $this->getButtonStyles($page),
+            'isVisibleOnProductPage'  => (int)$this->config->getValue('visible_on_product')
         ];
     }
 

--- a/app/code/Magento/Paypal/Test/Unit/Model/_files/expected_config.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/_files/expected_config.php
@@ -31,7 +31,8 @@ return [
                 'shape' => 'pillow',
                 'label' => 'installment',
                 'installmentperiod' => 0
-            ]
+            ],
+            'isVisibleOnProductPage' => 0
         ]
     ],
     'checkout' => [
@@ -59,7 +60,8 @@ return [
                 'shape' => 'pillow',
                 'label' => 'installment',
                 'installmentperiod' => 0
-            ]
+            ],
+            'isVisibleOnProductPage' => 0
         ]
     ],
     'mini_cart' => [
@@ -86,7 +88,8 @@ return [
                 'color' => 'gold',
                 'shape' => 'rect',
                 'label' => 'paypal'
-            ]
+            ],
+            'isVisibleOnProductPage' => 0
         ]
     ],
     'mini_cart' => [
@@ -113,7 +116,8 @@ return [
                 'color' => 'gold',
                 'shape' => 'rect',
                 'label' => 'paypal'
-            ]
+            ],
+            'isVisibleOnProductPage' => 0
         ]
     ],
     'product' => [
@@ -140,7 +144,8 @@ return [
                 'color' => 'gold',
                 'shape' => 'rect',
                 'label' => 'paypal',
-            ]
+            ],
+            'isVisibleOnProductPage' => 0
         ]
     ]
 ];

--- a/app/code/Magento/Paypal/view/frontend/web/js/in-context/product-express-checkout.js
+++ b/app/code/Magento/Paypal/view/frontend/web/js/in-context/product-express-checkout.js
@@ -24,7 +24,11 @@ define([
                 customer = customerData.get('customer');
 
             this._super();
-            this.renderPayPalButtons(element);
+
+            if (config.clientConfig.isVisibleOnProductPage) {
+                this.renderPayPalButtons(element);
+            }
+
             this.declinePayment = !customer().firstname && !cart().isGuestCheckoutAllowed;
 
             return this;


### PR DESCRIPTION
### Description (*)
With a well working Paypal Express Checkout, Configure magento settings as follow:

set yes to "Display on Product Details Page" (>configuration>sales>payment methods>paypal>express checkout)

### Fixed Issues (if relevant)
1. magento/magento2#22045: Issue title
2. magento/magento2#22134 Paypal buttons disable issue - Magento 2.3.1

### Manual testing scenarios (*)
set yes to "Display on Product Details Page" (>configuration>sales>payment methods>paypal>express checkout)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
