### PR TITLE
Prevented /Magento/Sales/Model/Service/InvoiceService.php incorrectly…

### DIFF
--- a/app/code/Magento/Sales/Model/Service/InvoiceService.php
+++ b/app/code/Magento/Sales/Model/Service/InvoiceService.php
@@ -149,6 +149,7 @@ class InvoiceService implements InvoiceManagementInterface
      */
     public function prepareInvoice(Order $order, array $qtys = [])
     {
+        $isQtysEmpty = empty($qtys);
         $invoice = $this->orderConverter->toInvoice($order);
         $totalQty = 0;
         $qtys = $this->prepareItemsQty($order, $qtys);
@@ -161,7 +162,7 @@ class InvoiceService implements InvoiceManagementInterface
                 $qty = (double) $qtys[$orderItem->getId()];
             } elseif ($orderItem->isDummy()) {
                 $qty = $orderItem->getQtyOrdered() ? $orderItem->getQtyOrdered() : 1;
-            } elseif (empty($qtys)) {
+            } elseif ($isQtysEmpty) {
                 $qty = $orderItem->getQtyToInvoice();
             } else {
                 $qty = 0;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When calling Magento\Sales\Model\Service\InvoiceService::prepareInvoice without a quantity specified, the function no longer (incorrectly) discards items when bundled items have been processed

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22246: Programatically created invoices miss items when both simple products and bundled products are mixed in an order

### Manual testing scenarios (*)
1. Create an order containing both a bundled product and a simple product
2. Check out with a payment method which does not automatically create an invoice
3. Programatically get an instance of the order, and then run the following code
```
$invoice = $order->prepareInvoice();
$invoice->getOrder()->setIsInProcess(true);
$invoice->register()->pay();
$invoice->save();
```
4. Simple products without a parent will no longer be missed from the invoice

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
