### PR TITLE
magento2-22238: removed backward incompatible change from the options…

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Options/Type/Select.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options/Type/Select.php
@@ -59,7 +59,7 @@ class Select extends \Magento\Catalog\Block\Product\View\Options\AbstractOptions
      *
      * @return string
      */
-    public function getValuesHtml(): string
+    public function getValuesHtml()
     {
         $option = $this->getOption();
         $optionType = $option->getType();


### PR DESCRIPTION
### Fixed Issues (if relevant)
1. magento/magento2#22238: Backward-incompatible change between 2.2.7 and 2.2.8

### Manual testing scenarios (*)
1. Create a custom module with the following class:
**app/code/Vendor/Module/Block/Product/View/Options/Type/Swatch.php**

        <?php

        namespace Vendor\Module\Block\Product\View\Options\Type;

        use Magento\Catalog\Block\Product\View\Options\Type\Select;

        class Swatch extends Select
        {
            public function getValuesHtml()
            {
                $html = parent:getValuesHtml();
                // custom logic goes here
                return $html;
            }
        }
2. Check that this class doesn't cause PHP Fatal Error

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
