### PR TITLE
Fix "Invalid template file" error on Windows

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
+++ b/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
@@ -137,6 +137,7 @@ class Validator
         }
         $realPath = $this->fileDriver->getRealPath($path);
         foreach ($directories as $directory) {
+            $directory = $this->fileDriver->getRealPath($directory);
             if (0 === strpos($realPath, $directory)) {
                 return true;
             }


### PR DESCRIPTION
ensure both sides of the comparison use the same directory separator
previous implementation did cause Issues in a Windows environment

Issue: Windows was not able to load templates but did log a lot "Invalid template file..." lines


### Manual testing scenarios (*)
1. have a magento setup running on native windows php 
2. open any frontend page which uses templates

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
