### PR TITLE
only trigger livereload by .css files

### DIFF
--- a/dev/tools/grunt/configs/watch.js
+++ b/dev/tools/grunt/configs/watch.js
@@ -11,11 +11,8 @@ var combo  = require('./combo'),
 
 var themeOptions = {};
 
-_.each(themes, function(theme, name) {
+_.each(themes, function (theme, name) {
     themeOptions[name] = {
-        'options': {
-            livereload: true
-        },
         'files': [
             '<%= combo.autopath(\''+name+'\', path.pub) %>/**/*.less'
         ],


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
- Reverted #10836
- Confirmed by https://github.com/magento/magento2/issues/19544#issuecomment-463170558_

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19544: Grunt watch triggers entire page reload

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run grunt watch and change a .less file
2. less changes triggers styles refresh without reloading entire page

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
