### PR TITLE
#22266 Allow GET method for products alerts

### DIFF
--- a/app/code/Magento/ProductAlert/Controller/Add/Price.php
+++ b/app/code/Magento/ProductAlert/Controller/Add/Price.php
@@ -6,6 +6,7 @@
 
 namespace Magento\ProductAlert\Controller\Add;
 
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\ProductAlert\Controller\Add as AddController;
 use Magento\Framework\App\Action\Context;
@@ -20,7 +21,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 /**
  * Controller for notifying about price.
  */
-class Price extends AddController implements HttpPostActionInterface
+class Price extends AddController implements HttpPostActionInterface, HttpGetActionInterface
 {
     /**
      * @var \Magento\Store\Model\StoreManagerInterface

--- a/app/code/Magento/ProductAlert/Controller/Add/Stock.php
+++ b/app/code/Magento/ProductAlert/Controller/Add/Stock.php
@@ -6,6 +6,7 @@
 
 namespace Magento\ProductAlert\Controller\Add;
 
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\ProductAlert\Controller\Add as AddController;
 use Magento\Framework\App\Action\Context;
@@ -19,7 +20,7 @@ use Magento\Store\Model\StoreManagerInterface;
 /**
  * Controller for notifying about stock.
  */
-class Stock extends AddController implements HttpPostActionInterface
+class Stock extends AddController implements HttpPostActionInterface, HttpGetActionInterface
 {
     /**
      * @var \Magento\Catalog\Api\ProductRepositoryInterface


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The classes
`\Magento\ProductAlert\Controller\Add\Stock`
`\Magento\ProductAlert\Controller\Add\Price`

Has been marked with `\Magento\Framework\App\Action\HttpPostActionInterface`
that caused 404 page issue after a redirect in `\Magento\Customer\Controller\Account\LoginPost`
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/magento2/issues/22266

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Click subscribe for stock alert on product page
2. Log in
3. See product page and message about successful subscription for notification

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
