### PR TITLE
#222249 configurable product images wrong sorting fix

### DIFF
--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -697,7 +697,7 @@ define([
          */
         _sortImages: function (images) {
             return _.sortBy(images, function (image) {
-                return image.position;
+                return parseInt(image.position, 10);
             });
         },
 


### PR DESCRIPTION
Configurable Product Gallery Images Out of Order when More than 10 images. Images sort order does not comply with that in admin panel for configurable product. 

### Description (*)
'position' argument was provided as string, thus result of sorting was like: 1, 10, 11, 2, 3, 4, ... .

### Fixed Issues (if relevant)
1. magento/magento2#22249: Configurable Product Gallery Images Out of Order when More than 10 images 

### Manual testing scenarios (*)
1. Exact steps to reproduce are extensively provided in related issue

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
