### PR TITLE
Fix #12256 #13263 - add Serbian Latin language and change language lists to show script

### DIFF
--- a/lib/internal/Magento/Framework/Locale/Config.php
+++ b/lib/internal/Magento/Framework/Locale/Config.php
@@ -91,7 +91,8 @@ class Config implements \Magento\Framework\Locale\ConfigInterface
         'sk_SK', /*Slovak (Slovakia)*/
         'sl_SI', /*Slovenian (Slovenia)*/
         'sq_AL', /*Albanian (Albania)*/
-        'sr_Cyrl_RS', /*Serbian (Serbia)*/
+        'sr_Cyrl_RS', /*Serbian (Cyrillic, Serbia)*/
+        'sr_Latn_RS', /*Serbian (Latin, Serbia)*/
         'sv_SE', /*Swedish (Sweden)*/
         'sv_FI', /*Swedish (Finland)*/
         'sw_KE', /*Swahili (Kenya)*/

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/ConfigTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/ConfigTest.php
@@ -15,7 +15,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         'es_MX', 'eu_ES', 'es_PE', 'et_EE', 'fa_IR', 'fi_FI', 'fil_PH', 'fr_CA', 'fr_FR', 'gu_IN',
         'he_IL', 'hi_IN', 'hr_HR', 'hu_HU', 'id_ID', 'is_IS', 'it_CH', 'it_IT', 'ja_JP', 'ka_GE',
         'km_KH', 'ko_KR', 'lo_LA', 'lt_LT', 'lv_LV', 'mk_MK', 'mn_Cyrl_MN', 'ms_Latn_MY', 'nl_NL', 'nb_NO',
-        'nn_NO', 'pl_PL', 'pt_BR', 'pt_PT', 'ro_RO', 'ru_RU', 'sk_SK', 'sl_SI', 'sq_AL', 'sr_Cyrl_RS',
+        'nn_NO', 'pl_PL', 'pt_BR', 'pt_PT', 'ro_RO', 'ru_RU', 'sk_SK', 'sl_SI', 'sq_AL', 'sr_Cyrl_RS', 'sr_Latn_RS',
         'sv_SE', 'sw_KE', 'th_TH', 'tr_TR', 'uk_UA', 'vi_VN', 'zh_Hans_CN', 'zh_Hant_HK', 'zh_Hant_TW', 'es_CL',
         'lo_LA', 'es_VE', 'en_IE',
     ];

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/TranslatedListsTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/TranslatedListsTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Framework\Locale\Test\Unit;
 
@@ -17,23 +18,62 @@ class TranslatedListsTest extends TestCase
     /**
      * @var TranslatedLists
      */
-    protected $listsModel;
+    private $listsModel;
 
     /**
-     * @var  MockObject | ConfigInterface
+     * @var MockObject | ConfigInterface
      */
-    protected $mockConfig;
+    private $mockConfig;
 
     /**
-     * @var  MockObject | ResolverInterface
+     * @var MockObject | ResolverInterface
      */
-    protected $mockLocaleResolver;
+    private $mockLocaleResolver;
+
+    /**
+     * @var array
+     */
+    private $expectedCurrencies = [
+        'USD',
+        'EUR',
+        'UAH',
+        'GBP',
+    ];
+
+    /**
+     * @var array
+     */
+    private $expectedLocales = [
+        'en_US' => 'English (United States)',
+        'en_GB' => 'English (United Kingdom)',
+        'uk_UA' => 'Ukrainian (Ukraine)',
+        'de_DE' => 'German (Germany)',
+        'sr_Cyrl_RS' => 'Serbian (Cyrillic, Serbia)',
+        'sr_Latn_RS' => 'Serbian (Latin, Serbia)'
+    ];
+
+    /**
+     * @var array
+     */
+    private $expectedTranslatedLocales = [
+        'en_US' => 'English (United States) / English (United States)',
+        'en_GB' => 'English (United Kingdom) / English (United Kingdom)',
+        'uk_UA' => 'українська (Україна) / Ukrainian (Ukraine)',
+        'de_DE' => 'Deutsch (Deutschland) / German (Germany)',
+        'sr_Cyrl_RS' => 'српски (ћирилица, Србија) / Serbian (Cyrillic, Serbia)',
+        'sr_Latn_RS' => 'Srpski (latinica, Srbija) / Serbian (Latin, Serbia)'
+    ];
 
     protected function setUp()
     {
         $this->mockConfig = $this->getMockBuilder(ConfigInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->mockConfig->method('getAllowedLocales')
+            ->willReturn(array_keys($this->expectedLocales));
+        $this->mockConfig->method('getAllowedCurrencies')
+            ->willReturn($this->expectedCurrencies);
+
         $this->mockLocaleResolver = $this->getMockBuilder(ResolverInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -69,12 +109,6 @@ class TranslatedListsTest extends TestCase
 
     public function testGetOptionCurrencies()
     {
-        $allowedCurrencies = ['USD', 'EUR', 'GBP', 'UAH'];
-
-        $this->mockConfig->expects($this->once())
-            ->method('getAllowedCurrencies')
-            ->willReturn($allowedCurrencies);
-
         $expectedResults = ['USD', 'EUR', 'GBP', 'UAH'];
 
         $currencyList = $this->listsModel->getOptionCurrencies();
@@ -134,44 +168,34 @@ class TranslatedListsTest extends TestCase
 
     public function testGetOptionLocales()
     {
-        $this->setupForOptionLocales();
-
-        $expectedResults = ['en_US', 'uk_UA', 'de_DE'];
-
-        $list = $this->listsModel->getOptionLocales();
-        foreach ($expectedResults as $value) {
-            $found = false;
-            foreach ($list as $item) {
-                $found = $found || ($value == $item['value']);
-            }
-            $this->assertTrue($found);
-        }
+        $locales = array_intersect(
+            $this->expectedLocales,
+            $this->convertOptionLocales($this->listsModel->getOptionLocales())
+        );
+        $this->assertEquals($this->expectedLocales, $locales);
     }
 
     public function testGetTranslatedOptionLocales()
     {
-        $this->setupForOptionLocales();
-
-        $expectedResults = ['en_US', 'uk_UA', 'de_DE'];
-
-        $list = $this->listsModel->getOptionLocales();
-        foreach ($expectedResults as $value) {
-            $found = false;
-            foreach ($list as $item) {
-                $found = $found || ($value == $item['value']);
-            }
-            $this->assertTrue($found);
-        }
+        $locales = array_intersect(
+            $this->expectedTranslatedLocales,
+            $this->convertOptionLocales($this->listsModel->getTranslatedOptionLocales())
+        );
+        $this->assertEquals($this->expectedTranslatedLocales, $locales);
     }
 
     /**
-     * Setup for option locales
+     * @param array $optionLocales
+     * @return array
      */
-    protected function setupForOptionLocales()
+    private function convertOptionLocales($optionLocales): array
     {
-        $allowedLocales = ['en_US', 'uk_UA', 'de_DE'];
-        $this->mockConfig->expects($this->once())
-            ->method('getAllowedLocales')
-            ->willReturn($allowedLocales);
+        $result = [];
+
+        foreach ($optionLocales as $optionLocale) {
+            $result[$optionLocale['value']] = $optionLocale['label'];
+        }
+
+        return $result;
     }
 }

--- a/lib/internal/Magento/Framework/Locale/TranslatedLists.php
+++ b/lib/internal/Magento/Framework/Locale/TranslatedLists.php
@@ -81,17 +81,23 @@ class TranslatedLists implements ListsInterface
             }
             $language = \Locale::getPrimaryLanguage($locale);
             $country = \Locale::getRegion($locale);
+            $script = \Locale::getScript($locale);
+            $scriptTranslated = '';
             if (!$languages[$language] || !$countries[$country]) {
                 continue;
             }
+            if ($script !== '') {
+                $script = \Locale::getDisplayScript($locale) . ', ';
+                $scriptTranslated = \Locale::getDisplayScript($locale, $locale) . ', ';
+            }
             if ($translatedName) {
                 $label = ucwords(\Locale::getDisplayLanguage($locale, $locale))
-                    . ' (' . \Locale::getDisplayRegion($locale, $locale) . ') / '
+                    . ' (' . $scriptTranslated . \Locale::getDisplayRegion($locale, $locale) . ') / '
                     . $languages[$language]
-                    . ' (' . $countries[$country] . ')';
+                    . ' (' . $script . $countries[$country] . ')';
             } else {
                 $label = $languages[$language]
-                    . ' (' . $countries[$country] . ')';
+                    . ' (' . $script . $countries[$country] . ')';
             }
             $options[] = ['value' => $locale, 'label' => $label];
         }

--- a/lib/internal/Magento/Framework/Setup/Lists.php
+++ b/lib/internal/Magento/Framework/Setup/Lists.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Framework\Setup;
 
@@ -12,6 +13,9 @@ use Magento\Framework\Locale\Bundle\RegionBundle;
 use Magento\Framework\Locale\ConfigInterface;
 use Magento\Framework\Locale\Resolver;
 
+/**
+ * Retrieves lists of allowed locales and currencies
+ */
 class Lists
 {
     /**

--- a/lib/internal/Magento/Framework/Setup/Lists.php
+++ b/lib/internal/Magento/Framework/Setup/Lists.php
@@ -99,10 +99,14 @@ class Lists
             }
             $language = \Locale::getPrimaryLanguage($locale);
             $country = \Locale::getRegion($locale);
+            $script = \Locale::getScript($locale);
             if (!$languages[$language] || !$countries[$country]) {
                 continue;
             }
-            $list[$locale] = $languages[$language] . ' (' . $countries[$country] . ')';
+            if ($script !== '') {
+                $script = \Locale::getDisplayScript($locale) . ', ';
+            }
+            $list[$locale] = $languages[$language] . ' (' . $script . $countries[$country] . ')';
         }
         asort($list);
         return $list;

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/ListsTest.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/ListsTest.php
@@ -3,27 +3,31 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Framework\Setup\Test\Unit;
 
+use Magento\Framework\Locale\ConfigInterface;
 use Magento\Framework\Setup\Lists;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
-class ListsTest extends \PHPUnit\Framework\TestCase
+class ListsTest extends TestCase
 {
     /**
      * @var Lists
      */
-    protected $lists;
+    private $lists;
 
     /**
-     * @var  \PHPUnit_Framework_MockObject_MockObject | \Magento\Framework\Locale\ConfigInterface
+     * @var MockObject|ConfigInterface
      */
-    protected $mockConfig;
+    private $mockConfig;
 
     /**
      * @var array
      */
-    protected $expectedTimezones = [
+    private $expectedTimezones = [
         'Australia/Darwin',
         'America/Los_Angeles',
         'Europe/Kiev',
@@ -33,7 +37,7 @@ class ListsTest extends \PHPUnit\Framework\TestCase
     /**
      * @var array
      */
-    protected $expectedCurrencies = [
+    private $expectedCurrencies = [
         'USD',
         'EUR',
         'UAH',
@@ -43,23 +47,23 @@ class ListsTest extends \PHPUnit\Framework\TestCase
     /**
      * @var array
      */
-    protected $expectedLocales = [
-        'en_US',
-        'en_GB',
-        'uk_UA',
-        'de_DE',
+    private $expectedLocales = [
+        'en_US' => 'English (United States)',
+        'en_GB' => 'English (United Kingdom)',
+        'uk_UA' => 'Ukrainian (Ukraine)',
+        'de_DE' => 'German (Germany)',
+        'sr_Cyrl_RS' => 'Serbian (Cyrillic, Serbia)',
+        'sr_Latn_RS' => 'Serbian (Latin, Serbia)'
     ];
 
     protected function setUp()
     {
-        $this->mockConfig = $this->getMockBuilder(\Magento\Framework\Locale\ConfigInterface::class)
+        $this->mockConfig = $this->getMockBuilder(ConfigInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->mockConfig->expects($this->any())
-            ->method('getAllowedLocales')
-            ->willReturn($this->expectedLocales);
-        $this->mockConfig->expects($this->any())
-            ->method('getAllowedCurrencies')
+        $this->mockConfig->method('getAllowedLocales')
+            ->willReturn(array_keys($this->expectedLocales));
+        $this->mockConfig->method('getAllowedCurrencies')
             ->willReturn($this->expectedCurrencies);
 
         $this->lists = new Lists($this->mockConfig);
@@ -73,13 +77,10 @@ class ListsTest extends \PHPUnit\Framework\TestCase
 
     public function testGetLocaleList()
     {
-        $locales = array_intersect($this->expectedLocales, array_keys($this->lists->getLocaleList()));
+        $locales = array_intersect($this->expectedLocales, $this->lists->getLocaleList());
         $this->assertEquals($this->expectedLocales, $locales);
     }
 
-    /**
-     * Test Lists:getCurrencyList() considering allowed currencies config values.
-     */
     public function testGetCurrencyList()
     {
         $currencies = array_intersect($this->expectedCurrencies, array_keys($this->lists->getCurrencyList()));


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR adds Serbian Latin language and allows to distinguish which locale is Latin and which is Cyrillic.
Second change is to display script in locale name, so user can select correct language he wants. Before change both **sr_Cyrl_RS** and **sr_Latn_RS** would be displayed as **Serbian (Serbia)**. Now those are **Serbian (Cyrillic, Serbia)** and **Serbian (Latin, Serbia)**.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#12256: Option to select durring instalation Serbian Latin or Serbian Cyrilic
2. magento/magento2#13263: In the magenta (all versions) there is no option to choose Serbian-Latin

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to MBO
2. Go to Stores -> Configuration -> General -> General -> Locale Options -> Locale
3. See both **Serbian (Cyrillic, Serbia)** and **Serbian (Latin, Serbia)** locales

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
