### PR TITLE
[Backport] Turn on edit mode for product repository when adding children

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/LinkManagement.php
+++ b/app/code/Magento/ConfigurableProduct/Model/LinkManagement.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -10,6 +9,9 @@ use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\StateException;
 
+/**
+ * Configurable product link management.
+ */
 class LinkManagement implements \Magento\ConfigurableProduct\Api\LinkManagementInterface
 {
     /**
@@ -67,7 +69,7 @@ class LinkManagement implements \Magento\ConfigurableProduct\Api\LinkManagementI
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getChildren($sku)
     {
@@ -106,7 +108,7 @@ class LinkManagement implements \Magento\ConfigurableProduct\Api\LinkManagementI
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function addChild($sku, $childSku)
     {
@@ -144,7 +146,7 @@ class LinkManagement implements \Magento\ConfigurableProduct\Api\LinkManagementI
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function removeChild($sku, $childSku)
     {

--- a/app/code/Magento/ConfigurableProduct/Model/LinkManagement.php
+++ b/app/code/Magento/ConfigurableProduct/Model/LinkManagement.php
@@ -110,7 +110,7 @@ class LinkManagement implements \Magento\ConfigurableProduct\Api\LinkManagementI
      */
     public function addChild($sku, $childSku)
     {
-        $product = $this->productRepository->get($sku);
+        $product = $this->productRepository->get($sku, true);
         $child = $this->productRepository->get($childSku);
 
         $childrenIds = array_values($this->configurableType->getChildrenIds($product->getId())[0]);

--- a/app/code/Magento/ConfigurableProduct/Model/LinkManagement.php
+++ b/app/code/Magento/ConfigurableProduct/Model/LinkManagement.php
@@ -11,6 +11,8 @@ use Magento\Framework\Exception\StateException;
 
 /**
  * Configurable product link management.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class LinkManagement implements \Magento\ConfigurableProduct\Api\LinkManagementInterface
 {
@@ -109,6 +111,10 @@ class LinkManagement implements \Magento\ConfigurableProduct\Api\LinkManagementI
 
     /**
      * @inheritdoc
+     * @throws InputException
+     * @throws NoSuchEntityException
+     * @throws StateException
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
      */
     public function addChild($sku, $childSku)
     {
@@ -147,6 +153,10 @@ class LinkManagement implements \Magento\ConfigurableProduct\Api\LinkManagementI
 
     /**
      * @inheritdoc
+     * @throws InputException
+     * @throws NoSuchEntityException
+     * @throws StateException
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
      */
     public function removeChild($sku, $childSku)
     {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21083
### Description (*)
This should fix the issue with the configurable products not having any options with Bulk and Async API. The product was being cached and its extension attributes were empty when trying to add children to a product via Bulk API.

### Fixed Issues (if relevant)
1. magento/magento2#20366: The parent product doesn't have configurable product options

### Manual testing scenarios (*)
1. Install Magento 2.3 with RabbitMQ
2. Add Sample data
3. Follow https://devdocs.magento.com/guides/v2.3/rest/tutorials/bulk-configurable-product/config-product-intro.html
4. If this fix is not there, when you do the step to add the product children, an error is produced saying that the product does not contain any configurable options.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
