### PR TITLE
Alignment Issue While Editing Order Data containing Downlodable Products with "Links can be purchased separately" enabled in Admin Section

### DIFF
--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/composite/fieldset/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/composite/fieldset/downloadable.phtml
@@ -29,7 +29,7 @@
                            value="<?= /* @escapeNotVerified */ $_link->getId() ?>" <?= /* @escapeNotVerified */ $block->getLinkCheckedValue($_link) ?>
                            price="<?= /* @escapeNotVerified */ $block->getCurrencyPrice($_link->getPrice()) ?>"/>
                     <?php endif; ?>
-                    <label for="links_<?= /* @escapeNotVerified */ $_link->getId() ?>" class="label">
+                    <label for="links_<?= /* @escapeNotVerified */ $_link->getId() ?>" class="label admin__field-label">
                         <?= $block->escapeHtml($_link->getTitle()) ?>
                         <?php if ($_link->getSampleFile() || $_link->getSampleUrl()): ?>
                             &nbsp;(<a href="<?= /* @escapeNotVerified */ $block->getLinkSampleUrl($_link) ?>" <?= $block->getIsOpenInNewWindow()?'onclick="this.target=\'_blank\'"':'' ?>><?= /* @escapeNotVerified */ __('sample') ?></a>)


### PR DESCRIPTION
Alignment Issue While Editing Order Data containing Downlodable Products with "Links can be purchased separately" enabled in Admin Section
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Magento 2.3.x
Magento 2.2.x

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20917: Alignment Issue While Editing Order Data containing Downlodable Products in Admin Section


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login into admin panel
2. go to Order grid section from Sales > Orders
3. Reorder any order containing downladable product with "Links can be purchased separately" enabled.
4. now click on configure button : https://prnt.sc/navb8m
5. A modal will display an alignment issue : https://prnt.sc/navble

### Actual result (*)
https://prnt.sc/navble

### Expected result (*)
https://prnt.sc/navc9o

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
