### PR TITLE
#22299: Cms block cache key does not contain the store id

### DIFF
--- a/app/code/Magento/Cms/Block/Block.php
+++ b/app/code/Magento/Cms/Block/Block.php
@@ -84,4 +84,14 @@ class Block extends AbstractBlock implements \Magento\Framework\DataObject\Ident
     {
         return [\Magento\Cms\Model\Block::CACHE_TAG . '_' . $this->getBlockId()];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCacheKeyInfo()
+    {
+        $cacheKeyInfo = parent::getCacheKeyInfo();
+        $cacheKeyInfo[] = $this->_storeManager->getStore()->getId();
+        return $cacheKeyInfo;
+    }
 }

--- a/app/code/Magento/Cms/Block/Block.php
+++ b/app/code/Magento/Cms/Block/Block.php
@@ -86,7 +86,7 @@ class Block extends AbstractBlock implements \Magento\Framework\DataObject\Ident
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getCacheKeyInfo()
     {


### PR DESCRIPTION
### Description (*)
This PR adds the current store id to the cms blocks cache key to avoid rendering the wrong cms block on different store views
### Fixed Issues (if relevant)
1. magento/magento2#22299: Cms block cache key does not contain the store id

### Manual testing scenarios (*)
Steps to reproduce are listed in the issue #22299 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
