### PR TITLE
Varnish health check failing due to presence of id_prefix in env.php

### DIFF
--- a/pub/health_check.php
+++ b/pub/health_check.php
@@ -43,7 +43,10 @@ foreach ($deploymentConfig->get(ConfigOptionsListConstants::CONFIG_PATH_DB_CONNE
 $cacheConfigs = $deploymentConfig->get(ConfigOptionsListConstants::KEY_CACHE_FRONTEND);
 if ($cacheConfigs) {
     foreach ($cacheConfigs as $cacheConfig) {
-        if (!isset($cacheConfig[ConfigOptionsListConstants::CONFIG_PATH_BACKEND]) ||
+        // allow config if only available "id_prefix"
+        if (count($cacheConfig) === 1 && isset($cacheConfig['id_prefix'])) {
+            continue;
+        } elseif (!isset($cacheConfig[ConfigOptionsListConstants::CONFIG_PATH_BACKEND]) ||
             !isset($cacheConfig[ConfigOptionsListConstants::CONFIG_PATH_BACKEND_OPTIONS])) {
             http_response_code(500);
             $logger->error("Cache configuration is invalid");


### PR DESCRIPTION

### Description (*)
The root of the issue has to do with the fix for GitHub-15828 and how pub/health_check.php works. In the release notes for 2.3.1 it says

Magento now sets the id_prefix option on prefix cache keys for the cache frontend during installation. If this option is not set, Magento uses the first 12 bits of the md5 hash of the absolute path to the Magento app/etc directory. But if this value is not exactly the same on all web servers, cache invalidation will not work.

### Fixed Issues (if relevant)

1. magento/magento2#22143: Issue title


### Manual testing scenarios (*)

1. Install a fresh copy of Magento 2.3.1
2. Configure the frontend cache to use Redis
3. Export varnish.vcl from admin panel and configure Varnish to sit in front of Apache per instructions at https://devdocs.magento.com/guides/v2.3/config-guide/varnish/config-varnish-configure.html
4. Try to load the site

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
