### PR TITLE
Patch #22309: Remove "null" value of not passed name attribute

### DIFF
--- a/app/code/Magento/Catalog/Model/CategoryRepository.php
+++ b/app/code/Magento/Catalog/Model/CategoryRepository.php
@@ -80,6 +80,10 @@ class CategoryRepository implements \Magento\Catalog\Api\CategoryRepositoryInter
         $existingData = array_diff_key($existingData, array_flip(['path', 'level', 'parent_id']));
         $existingData['store_id'] = $storeId;
 
+        if (array_key_exists('name', $existingData) && $existingData['name'] === null) {
+            unset($existingData['name']);
+        }
+
         if ($category->getId()) {
             $metadata = $this->getMetadataPool()->getMetadata(
                 CategoryInterface::class


### PR DESCRIPTION
### Description

If a category is updated via REST API in the "all" scope and the
category name is not sent, Magento use "null" as value for the name,
This leads into a validation error, because the category name is
required.
In this case we remove the null value out of the automatically
generated default value array. Magento will then skip the category,
because there is no change.

### Fixed Issues 
1. magento/magento2#22309: Category Update without "name" cannot be saved in scope "all" with REST API

### Manual testing scenarios

1. Install demo data in Magento 2.3.x
2. Try to save an existing category without the name attribute via REST API in scope "all".

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
