### PR TITLE
Removed redundant Gallery subscription for catalog rules

### DIFF
--- a/app/code/Magento/CatalogRule/etc/mview.xml
+++ b/app/code/Magento/CatalogRule/etc/mview.xml
@@ -16,11 +16,8 @@
             <table name="catalog_product_entity" entity_column="entity_id" />
             <table name="catalog_product_entity_datetime" entity_column="entity_id" />
             <table name="catalog_product_entity_decimal" entity_column="entity_id" />
-            <table name="catalog_product_entity_gallery" entity_column="entity_id" />
             <table name="catalog_product_entity_int" entity_column="entity_id" />
-            <table name="catalog_product_entity_text" entity_column="entity_id" />
             <table name="catalog_product_entity_tier_price" entity_column="entity_id" />
-            <table name="catalog_product_entity_varchar" entity_column="entity_id" />
             <table name="catalog_category_product" entity_column="product_id" />
         </subscriptions>
     </view>

--- a/app/code/Magento/CatalogRule/etc/mview.xml
+++ b/app/code/Magento/CatalogRule/etc/mview.xml
@@ -17,7 +17,9 @@
             <table name="catalog_product_entity_datetime" entity_column="entity_id" />
             <table name="catalog_product_entity_decimal" entity_column="entity_id" />
             <table name="catalog_product_entity_int" entity_column="entity_id" />
+            <table name="catalog_product_entity_text" entity_column="entity_id" />
             <table name="catalog_product_entity_tier_price" entity_column="entity_id" />
+            <table name="catalog_product_entity_varchar" entity_column="entity_id" />
             <table name="catalog_category_product" entity_column="product_id" />
         </subscriptions>
     </view>


### PR DESCRIPTION
### Description (*)
Hi @magento-engcom-team 

I suggest removing  'catalog_product_entity_gallery' subscription table which is not related to price/price-rules from CatalogRule mview. 
Listening 'catalog_product_entity_gallery'   causing a huge amount of records to changelog when saving the product with applied price rule in case the product has many product images.
Gallery attribute does not contain data related to pricing framework and can't be utilized creating price rule condition, so, I don't see a reason to listen to that table for the partial reindex changelog. 

Thank you!

### Manual testing scenarios (*)
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
