### PR TITLE
#13227 Wrong product url (with category path) was fixed.

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Url.php
+++ b/app/code/Magento/Catalog/Model/Product/Url.php
@@ -162,9 +162,9 @@ class Url extends \Magento\Framework\DataObject
                     \Magento\Store\Model\ScopeInterface::SCOPE_STORE
                 );
 
-                if ($categoryId) {
+                if ($useCategories && $categoryId) {
                     $filterData[UrlRewrite::METADATA]['category_id'] = $categoryId;
-                } elseif (!$useCategories) {
+                } else {
                     $filterData[UrlRewrite::METADATA]['category_id'] = '';
                 }
 


### PR DESCRIPTION
### Description
Knockout Recently Viewed contains wrong product url (with category path), also not correct url <meta property="og:url"> on product view page.
There is a problem with a condition in model "\Magento\Catalog\Model\Product\Url".
This problem was fixed.

### Fixed Issues (if relevant)
1. magento/magento2#13227: Knockout Recently Viewed contains wrong product url (with category path), also not correct url <meta property="og:url"> on product view page.

### Manual testing scenarios
1. Magento 2.2.2
2. PHP 7

I added "Recently Viewed" to the product page. Using  xml layout
```
 <referenceContainer name="content.aside">
            <block class="Magento\Catalog\Block\Widget\RecentlyViewed" name="recently_viewed" template="Magento_Catalog::product/widget/viewed/grid.phtml" after="-">
                <arguments>
                    <argument name="uiComponent" xsi:type="string">widget_recently_viewed</argument>
                    <argument name="page_size" xsi:type="number">4</argument>
                    <argument name="show_attributes" xsi:type="string">name,image,price</argument>
                    <argument name="show_buttons" xsi:type="string">add_to_cart,add_to_compare,add_to_wishlist</argument>
                </arguments>
            </block>
        </referenceContainer>
```

### Steps to reproduce
<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1. Site use product configuration "Use Categories Path for Product URLs" = NO
2. Open several products to fill history of the products viewed
3. On any page of the site, open  page inspector(web developer utility)  and see the local storage cache "product_data_storage", find product contain url with category path (http://take.ms/ukxAM).
Or   open  source code html of product view page, and find the next code  js component "Magento_Catalog/js/product/view/provider".

Example:
```
<script type="text/x-magento-init">
    {
        "*": {
                "Magento_Catalog/js/product/view/provider": {
                    "data": {"items":{"720" , ... {"url":"http:\/\/m2-sample.dev\/catalog\/product\/view\/id\/720\/s\/tiberius-gym-tank\/category\/13\/","id":720,"name":"Tiberius Gym Tank" ....    }
        }
    }
</script>
```


UPD:
Another way to proset the error:
1. open product view page
2. open source html page
3) find tag <meta property="og:url" content="
4) my result
page url - http://m2-sample.dev/montana-wind-jacket.html, tag - `<meta property="og:url" content="http://m2-sample.dev/men/tops-men/jackets-men/montana-wind-jacket.html" />`

### Expected result
<!--- Tell us what should happen -->
1. URL should not contain a category path (http://m2-sample.dev/tiberius-gym-tank.html)

### Actual result
<!--- Tell us what happens instead -->
1. ![image](https://user-images.githubusercontent.com/971021/35011272-385f0ce6-fb0e-11e7-8983-d72207454c1e.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
