### PR TITLE
Fixes a less compilation error: '.no-link a' isn't defined when .emai…

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Sales/web/css/source/_email.less
+++ b/app/design/frontend/Magento/blank/Magento_Sales/web/css/source/_email.less
@@ -68,8 +68,10 @@
 }
 
 //  Remove address and phone number link color on iOS
-.address-details a {
-    &:extend(.no-link a);
+.email-non-inline() {
+    .address-details a {
+        &:extend(.no-link a);
+    }
 }
 
 .media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__xs) {

--- a/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_email.less
+++ b/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_email.less
@@ -76,8 +76,10 @@
 }
 
 //  Remove address and phone number link color on iOS
-.address-details a {
-    &:extend(.no-link a);
+.email-non-inline() {
+    .address-details a {
+        &:extend(.no-link a);
+    }
 }
 
 .media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__xs) {


### PR DESCRIPTION
…l-non-inline() isn't active, so when using '.no-link a', it should be wrapped inside .email-non-inline().

### Description (*)
This was discovered by using a different less compiler then what Magento ships with.

The selector `.no-link a` only exists when `.email-non-inline()` is active, see:
https://github.com/magento/magento2/blob/2.3.1/app/design/frontend/Magento/blank/web/css/source/_email-base.less#L136-L140

However, it gets used in the Magento/blank & Magento/luma themes without being wrapped in `.email-non-inline()`.

This throws an error when using [less.js compiler](http://lesscss.org/) v2.7.3 when compiling the `email-inline.less` file. Error message: `extend ' .no-link a' has no matches`.

See https://github.com/magento/magento2/issues/22330 for more details.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/22330: Error "extend ' .no-link a' has no matches" when compiling email-inline css using an alternative less compiler

### Manual testing scenarios (*)
1. Having nodejs v8 installed
2. Setting up vanilla Magento installation using composer
3. Run `npm install less@2.7.3`
4. Run `bin/magento setup:static-content:deploy -f -t Magento/luma en_US`
5. Run `node_modules/.bin/lessc --no-color var/view_preprocessed/pub/static/frontend/Magento/luma/en_US/css/email-inline.less | head`
6. Notice that without this fix the first line says: `extend ' .no-link a' has no matches`, with this fix that error is gone.
7. When sending an order confirmation email, verify that the styling of the phone number should be without underline and in color `#333333`, not in `#006bb4`.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
