### PR TITLE
fix clean_cache plugin flush mode

### DIFF
--- a/lib/internal/Magento/Framework/App/Test/Unit/Cache/FlushCacheByTagsTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Cache/FlushCacheByTagsTest.php
@@ -3,9 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Framework\App\Test\Unit\Cache;
 
+use Magento\Framework\App\Cache\FlushCacheByTags;
+use Magento\Framework\App\Cache\StateInterface;
+use Magento\Framework\App\Cache\Tag\Resolver;
+use Magento\Framework\App\Cache\Type\FrontendPool;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+
+/**
+ * Unit tests for the \Magento\Framework\App\Cache\FlushCacheByTags class.
+ */
 class FlushCacheByTagsTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -28,13 +39,16 @@ class FlushCacheByTagsTest extends \PHPUnit\Framework\TestCase
      */
     private $plugin;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp()
     {
-        $this->cacheState = $this->getMockForAbstractClass(\Magento\Framework\App\Cache\StateInterface::class);
-        $this->frontendPool = $this->createMock(\Magento\Framework\App\Cache\Type\FrontendPool::class);
-        $this->tagResolver = $this->createMock(\Magento\Framework\App\Cache\Tag\Resolver::class);
+        $this->cacheState = $this->getMockForAbstractClass(StateInterface::class);
+        $this->frontendPool = $this->createMock(FrontendPool::class);
+        $this->tagResolver = $this->createMock(Resolver::class);
 
-        $this->plugin = new \Magento\Framework\App\Cache\FlushCacheByTags(
+        $this->plugin = new FlushCacheByTags(
             $this->frontendPool,
             $this->cacheState,
             ['test'],
@@ -42,14 +56,19 @@ class FlushCacheByTagsTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testAroundSave()
+    /**
+     * @return void
+     */
+    public function testAroundSave(): void
     {
-        $resource = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\AbstractResource::class)
+        $resource = $this->getMockBuilder(AbstractResource::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-        $model = $this->getMockBuilder(\Magento\Framework\Model\AbstractModel::class)
+        $model = $this->getMockBuilder(AbstractModel::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
+        $this->tagResolver->expects($this->atLeastOnce())->method('getTags')->with($model)->willReturn([]);
+
         $result = $this->plugin->aroundSave(
             $resource,
             function () use ($resource) {
@@ -57,17 +76,23 @@ class FlushCacheByTagsTest extends \PHPUnit\Framework\TestCase
             },
             $model
         );
+
         $this->assertSame($resource, $result);
     }
 
-    public function testAroundDelete()
+    /**
+     * @return void
+     */
+    public function testAroundDelete(): void
     {
-        $resource = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\AbstractResource::class)
+        $resource = $this->getMockBuilder(AbstractResource::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-        $model = $this->getMockBuilder(\Magento\Framework\Model\AbstractModel::class)
+        $model = $this->getMockBuilder(AbstractModel::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
+        $this->tagResolver->expects($this->atLeastOnce())->method('getTags')->with($model)->willReturn([]);
+
         $result = $this->plugin->aroundDelete(
             $resource,
             function () use ($resource) {
@@ -75,25 +100,7 @@ class FlushCacheByTagsTest extends \PHPUnit\Framework\TestCase
             },
             $model
         );
-        $this->assertSame($resource, $result);
-    }
 
-    public function testAroundSaveWithInterface()
-    {
-        $resource = $this->getMockBuilder(\Magento\Framework\Model\ResourceModel\AbstractResource::class)
-
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
-        $model = $this->getMockBuilder(\Magento\Framework\Model\AbstractModel::class)
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
-        $result = $this->plugin->aroundSave(
-            $resource,
-            function () use ($resource) {
-                return $resource;
-            },
-            $model
-        );
         $this->assertSame($resource, $result);
     }
 }


### PR DESCRIPTION
Previous PR: https://github.com/magento/magento2/pull/20228

The following plugin is used to clean the "block_html" and "collections" cache types by tags.
This plugin is not really used in the native Magento app, so I guess no one didn't really had issue with it (unless for eav resource models).

The `\Zend_Cache::CLEANING_MODE_MATCHING_TAG` is too restrictive as all entity tags must match with the stored data tags.

### Description (*)
- introduce strict types
- fix clean cache mode to match any tags

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
