### PR TITLE
Fixed Value of created_at and updated_at columns

### DIFF
--- a/app/code/Magento/Ui/etc/db_schema.xml
+++ b/app/code/Magento/Ui/etc/db_schema.xml
@@ -18,8 +18,8 @@
                 comment="Mark current bookmark per user and identifier"/>
         <column xsi:type="varchar" name="title" nullable="true" length="255" comment="Bookmark title"/>
         <column xsi:type="longtext" name="config" nullable="true" comment="Bookmark config"/>
-        <column xsi:type="datetime" name="created_at" on_update="false" nullable="false" comment="Bookmark created at"/>
-        <column xsi:type="datetime" name="updated_at" on_update="false" nullable="false" comment="Bookmark updated at"/>
+        <column xsi:type="datetime" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP" comment="Bookmark created at"/>
+        <column xsi:type="datetime" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP" comment="Bookmark updated at"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="bookmark_id"/>
         </constraint>


### PR DESCRIPTION
Fixed #18557 for Magento 2.3
Value of created_at and updated_at columns not updating in ui_bookmark table

**Preconditions (*)**
Magento 2.2.5 and above

**Steps to reproduce (*)**
Value of created_at and updated_at columns not updating in ui_bookmark table.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
