### PR TITLE
Fix negative credit memo total when setting shipping refund to 0 where a shipping discount exists

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Discount.php
@@ -100,8 +100,9 @@ class Discount extends AbstractTotal
      */
     private function getBaseShippingAmount(\Magento\Sales\Model\Order\Creditmemo $creditmemo): float
     {
-        $baseShippingAmount = (float)$creditmemo->getBaseShippingAmount();
-        if (!$baseShippingAmount) {
+        if ($creditmemo->hasBaseShippingAmount()) {
+            $baseShippingAmount = (float)$creditmemo->getBaseShippingAmount();
+        } else {
             $baseShippingInclTax = (float)$creditmemo->getBaseShippingInclTax();
             $baseShippingTaxAmount = (float)$creditmemo->getBaseShippingTaxAmount();
             $baseShippingAmount = $baseShippingInclTax - $baseShippingTaxAmount;

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Total/DiscountTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Total/DiscountTest.php
@@ -48,8 +48,9 @@ class DiscountTest extends \PHPUnit\Framework\TestCase
             ]);
         $this->creditmemoMock = $this->createPartialMock(\Magento\Sales\Model\Order\Creditmemo::class, [
                 'setBaseCost', 'getAllItems', 'getOrder', 'getBaseShippingAmount', 'roundPrice',
-                'setDiscountAmount', 'setBaseDiscountAmount', 'getBaseShippingInclTax', 'getBaseShippingTaxAmount'
-            ]);
+                'setDiscountAmount', 'setBaseDiscountAmount', 'getBaseShippingInclTax', 'getBaseShippingTaxAmount',
+            'hasBaseShippingAmount'
+        ]);
         $this->creditmemoItemMock = $this->createPartialMock(\Magento\Sales\Model\Order\Creditmemo\Item::class, [
                 'getHasChildren', 'getBaseCost', 'getQty', 'getOrderItem', 'setDiscountAmount',
                 'setBaseDiscountAmount', 'isLast'
@@ -59,6 +60,9 @@ class DiscountTest extends \PHPUnit\Framework\TestCase
 
     public function testCollect()
     {
+        $this->creditmemoMock->expects($this->exactly(1))
+            ->method('hasBaseShippingAmount')
+            ->willReturn(true);
         $this->creditmemoMock->expects($this->exactly(2))
             ->method('setDiscountAmount')
             ->willReturnSelf();
@@ -129,6 +133,9 @@ class DiscountTest extends \PHPUnit\Framework\TestCase
 
     public function testCollectNoBaseShippingAmount()
     {
+        $this->creditmemoMock->expects($this->exactly(1))
+            ->method('hasBaseShippingAmount')
+            ->willReturn(false);
         $this->creditmemoMock->expects($this->exactly(2))
             ->method('setDiscountAmount')
             ->willReturnSelf();
@@ -138,7 +145,7 @@ class DiscountTest extends \PHPUnit\Framework\TestCase
         $this->creditmemoMock->expects($this->once())
             ->method('getOrder')
             ->willReturn($this->orderMock);
-        $this->creditmemoMock->expects($this->once())
+        $this->creditmemoMock->expects($this->never())
             ->method('getBaseShippingAmount')
             ->willReturn(0);
         $this->creditmemoMock->expects($this->once())
@@ -205,6 +212,9 @@ class DiscountTest extends \PHPUnit\Framework\TestCase
 
     public function testCollectZeroShipping()
     {
+        $this->creditmemoMock->expects($this->exactly(1))
+            ->method('hasBaseShippingAmount')
+            ->willReturn(true);
         $this->creditmemoMock->expects($this->exactly(2))
             ->method('setDiscountAmount')
             ->willReturnSelf();
@@ -276,6 +286,9 @@ class DiscountTest extends \PHPUnit\Framework\TestCase
      */
     public function testCollectNonZeroShipping()
     {
+        $this->creditmemoMock->expects($this->exactly(1))
+            ->method('hasBaseShippingAmount')
+            ->willReturn(true);
         $this->creditmemoMock->expects($this->once())
             ->method('setDiscountAmount')
             ->willReturnSelf();


### PR DESCRIPTION
### Description (*)
1. In Discount total collector, ensure we check for existence of shipping amount using hasBaseShipping Discount so that we match the same check inside Shipping total collector (https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Shipping.php#L66)

### Fixed Issues (if relevant)
When an order has a shipping discount applied, if you create credit memo against that order's only invoice, and then set the refund shipping amount to 0, you will end up refunding less than the requested amount because the Shipping Discount is still populated, but the Shipping is 0 - meaning total is reduced by the Shipping Discount. This is because the Shipping total sees the 0 shipping and obeys it. However, the Discount total does a boolean check on shipping amount so sees 0 as the same as not present, and thus leaves the shipping discount present when it should've been removed.

### Manual testing scenarios (*)
1. Create new order with shipping discount applied to a positive value shipping and have it fully invoiced
2. View the invoice and create credit memo, set refund shipping to 0 and verify the totals - they are wrong and less than they should be by a value equivalent to the shipping discount
3. Furthermore, set all item quantities to 0 as if you were refunding shipping only, then set shipping refund to 0, and update totals, instead of grand total 0 you will get a negative total.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
