### PR TITLE
Fix buttonId for credit memo button on admin invoice view

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Invoice/View.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Invoice/View.php
@@ -113,8 +113,8 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
                 $orderPayment->canRefund() && !$this->getInvoice()->getIsUsedForRefund()
             ) {
                 $this->buttonList->add(
-                    'capture',
-                    [ // capture?
+                    'credit-memo',
+                    [
                         'label' => __('Credit Memo'),
                         'class' => 'credit-memo',
                         'onclick' => 'setLocation(\'' . $this->getCreditMemoUrl() . '\')'


### PR DESCRIPTION
### Description

Credit Memo button has the wrong `buttonId`, so it is not possible to customise those buttons in a reliable way.

### Manual testing scenarios

1. Create a plugin that hides/overwrites/changes the `capture` button in the admin invoice view;
2. The creditmemo button is affected when it shouldn't.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
