### PR TITLE
[TASK] Fixed undefined shipping method name in checkout summary

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/shipping-information.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/shipping-information.js
@@ -29,8 +29,13 @@ define([
          */
         getShippingMethodTitle: function () {
             var shippingMethod = quote.shippingMethod();
+            var shippingMethodTitle = '';
 
-            return shippingMethod ? shippingMethod['carrier_title'] + ' - ' + shippingMethod['method_title'] : '';
+            if (typeof(shippingMethod['method_title']) !== 'undefined') {
+                shippingMethodTitle = ' - ' + shippingMethod['method_title'];
+            }
+
+            return shippingMethod ? shippingMethod['carrier_title'] + shippingMethodTitle : '';
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In checkout on the last step, the shipping method is displayed as 'undefined' when no name is set. The code in this PR makes sure the name is only displayed when it's defined.

There is a merged PR related to this, which didn't solve the issue completely (https://github.com/magento/magento2/pull/17697)

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17492: "- undefined" displayed in checkout summary when shipping method name is not set

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add new or edit any existing shipping methods with Method name field left as a blank field.
2. Add any product to the cart and go through the checkout to the last step.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
