### PR TITLE
[Backport] Use proper variables for tooltip styles on tablet devices

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
@@ -169,10 +169,10 @@
         width: 0;
     }
     .field-tooltip .field-tooltip-content::before {
-        border-bottom-color: @color-gray40;
+        .lib-css(border-bottom-color, @checkout-tooltip-content__border-color);
     }
     .field-tooltip .field-tooltip-content::after {
-        border-bottom-color: @color-gray-light01;
+        .lib-css(border-bottom-color, @checkout-tooltip-content__background-color);
         top: 1px;
     }
 }


### PR DESCRIPTION
Original Pull Request
magento#22258

Description
There are variables available for tooltip customization. This commit fixes an issue
on tablet devices when trying to use them.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less file and change the values of the tooltip variables as follows (Usually we do this via theme, but it's for testing purpose only):
`@checkout-tooltip-content__background-color: #fff;
@checkout-tooltip-content__border-color: #f2f5f7;
@checkout-tooltip-content__active__border-color: @checkout-tooltip-content__border-color;`

2. Navigate to checkout and chec the new styles of field tooltips

3. Set the width to 768px and check them again:

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
