### PR TITLE
[Backport] Bug fix for #21753 (2.3-develop)

### DIFF
--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -9,6 +9,8 @@ use Magento\Framework\Event\ObserverInterface;
 use Magento\Store\Model\ScopeInterface;
 
 /**
+ * Saves data from order to purchased links.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class SaveDownloadableOrderItemObserver implements ObserverInterface
@@ -159,7 +161,7 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                             \Magento\Sales\Model\Order\Item::STATUS_PENDING == $orderStatusToEnableItem ?
                             \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE :
                             \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING
-                       )->setCreatedAt(
+                        )->setCreatedAt(
                             $orderItem->getCreatedAt()
                         )->setUpdatedAt(
                             $orderItem->getUpdatedAt()
@@ -173,6 +175,8 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
     }
 
     /**
+     * Create purchased model.
+     *
      * @return \Magento\Downloadable\Model\Link\Purchased
      */
     protected function _createPurchasedModel()
@@ -181,6 +185,8 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
     }
 
     /**
+     * Create product model.
+     *
      * @return \Magento\Catalog\Model\Product
      */
     protected function _createProductModel()
@@ -189,6 +195,8 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
     }
 
     /**
+     * Create purchased item model.
+     *
      * @return \Magento\Downloadable\Model\Link\Purchased\Item
      */
     protected function _createPurchasedItemModel()
@@ -197,6 +205,8 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
     }
 
     /**
+     * Create items collection.
+     *
      * @return \Magento\Downloadable\Model\ResourceModel\Link\Purchased\Item\Collection
      */
     protected function _createItemsCollection()

--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -92,14 +92,15 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
         if ($purchasedLink->getId()) {
             return $this;
         }
+        $storeId = $orderItem->getOrder()->getStoreId();
         $orderStatusToEnableItem = $this->_scopeConfig->getValue(
             \Magento\Downloadable\Model\Link\Purchased\Item::XML_PATH_ORDER_ITEM_STATUS,
             ScopeInterface::SCOPE_STORE,
-            $orderItem->getOrder()->getStoreId()
+            $storeId
         );
         if (!$product) {
             $product = $this->_createProductModel()->setStoreId(
-                $orderItem->getOrder()->getStoreId()
+                $storeId
             )->load(
                 $orderItem->getProductId()
             );

--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -92,7 +92,7 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
         if ($purchasedLink->getId()) {
             return $this;
         }
-        $statusToEnable = $this->_scopeConfig->getValue(
+        $orderStatusToEnableItem = $this->_scopeConfig->getValue(
             \Magento\Downloadable\Model\Link\Purchased\Item::XML_PATH_ORDER_ITEM_STATUS,
             ScopeInterface::SCOPE_STORE,
             $orderItem->getOrder()->getStoreId()
@@ -155,10 +155,10 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                         )->setNumberOfDownloadsBought(
                             $numberOfDownloads
                         )->setStatus(
-                            1 == $statusToEnable ?
+                            \Magento\Sales\Model\Order\Item::STATUS_PENDING == $orderStatusToEnableItem ?
                             \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE :
                             \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING
-                        )->setCreatedAt(
+                       )->setCreatedAt(
                             $orderItem->getCreatedAt()
                         )->setUpdatedAt(
                             $orderItem->getUpdatedAt()

--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -92,7 +92,7 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
         if ($purchasedLink->getId()) {
             return $this;
         }
-        $orderItemStatusToEnable = $this->_scopeConfig->getValue(
+        $statusToEnable = $this->_scopeConfig->getValue(
             \Magento\Downloadable\Model\Link\Purchased\Item::XML_PATH_ORDER_ITEM_STATUS,
             ScopeInterface::SCOPE_STORE,
             $orderItem->getOrder()->getStoreId()
@@ -155,7 +155,7 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                         )->setNumberOfDownloadsBought(
                             $numberOfDownloads
                         )->setStatus(
-                            1 == $orderItemStatusToEnable ?
+                            1 == $statusToEnable ?
                             \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE :
                             \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING
                         )->setCreatedAt(

--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -92,6 +92,11 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
         if ($purchasedLink->getId()) {
             return $this;
         }
+        $orderItemStatusToEnable = $this->_scopeConfig->getValue(
+            \Magento\Downloadable\Model\Link\Purchased\Item::XML_PATH_ORDER_ITEM_STATUS,
+            ScopeInterface::SCOPE_STORE,
+            $orderItem->getOrder()->getStoreId()
+        );
         if (!$product) {
             $product = $this->_createProductModel()->setStoreId(
                 $orderItem->getOrder()->getStoreId()
@@ -150,6 +155,8 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                         )->setNumberOfDownloadsBought(
                             $numberOfDownloads
                         )->setStatus(
+                            1 == $orderItemStatusToEnable ?
+                            \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE :
                             \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING
                         )->setCreatedAt(
                             $orderItem->getCreatedAt()


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22073
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fixes the issue raised in #21753 by setting the initial downloadable item status to Available if \Magento\Downloadable\Model\Link\Purchased\Item::XML_PATH_ORDER_ITEM_STATUS is set to 'Pending.'

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/magento2/issues/21753

### Manual testing scenarios (*)
1. Login to the admin and set Stores -> Configuration -> Catalog -> Downloadable Product Options -> Order Item Status to Enable Downloads to "Pending"
2. Create a downloadable product in the admin
3. Create a user account on the frontend and login
4. Purchase a downloadable product. The product should be placed in the "available" state after successful completion of payment.
5. Login to the admin and set Stores -> Configuration -> Catalog -> Downloadable Product Options -> Order Item Status to Enable Downloads to "Invoiced"
6. Purchase the product again and note the second ordered item is in the "pending" status.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
