### PR TITLE
Filter config values on testSuiteStart

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Isolation/DeploymentConfig.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Isolation/DeploymentConfig.php
@@ -40,7 +40,7 @@ class DeploymentConfig
     {
         if (null === $this->reader) {
             $this->reader = Bootstrap::getObjectManager()->get(\Magento\Framework\App\DeploymentConfig\Reader::class);
-            $this->config = $this->reader->load();
+            $this->config = $this->filterIgnoredConfigValues($this->reader->load()); 
         }
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22370: Filtering ignored config values in test framework causes error

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set `compiled_config => 1` in `app/etc/env.php` cache types. 
2. Then run the integration test suite. 

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
