### PR TITLE
Fix the invalid currency error in credit card payment of PayPal Payflow Pro or Payments Pro

### DIFF
--- a/app/code/Magento/Paypal/Model/Payflow/Service/Request/SecureToken.php
+++ b/app/code/Magento/Paypal/Model/Payflow/Service/Request/SecureToken.php
@@ -64,6 +64,7 @@ class SecureToken
         $request->setTrxtype(Payflowpro::TRXTYPE_AUTH_ONLY);
         $request->setVerbosity('HIGH');
         $request->setAmt(0);
+        $request->setCurrency($quote->getBaseCurrencyCode());
         $request->setCreatesecuretoken('Y');
         $request->setSecuretokenid($this->mathRandom->getUniqueHash());
         $request->setReturnurl($this->url->getUrl('paypal/transparent/response'));


### PR DESCRIPTION
Needs to provide the currency code explicitly in the $0.00 verification call, otherwise the payment would fail when store's default currency is not USD.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

When the store default currency is not USD, the credit card payment with Payflow Pro or Payments Pro would fail with an error complaining "invalid currency code"

My store's default currency is set to CAD, the Payflow Pro payment didn't go through. By PayPal support team's investigation, they found the "$0.00 verification call" is with USD currency, but the following non zero call was with CAD currency, in which condition PayPal doesn't accept the payment.

But I don't find our API calls to PayPal ever explicitly added USD, so that I can guess without a currency code is actually default to USD.

Back to the two calls from Magento to PayPal, the second one is using store default for currency code, so the change is to also add store default currency code to the first one. And by changing that, my transaction went through successfully.

Here is the original comments from PayPal support guys:

```
Thanks for reaching out today. Happy to help.

It looks as though this is an issue with the currency code you're passing. Right now it appears you're trying to pass USD in on the $0.00 verification call, but CAD on the actual 2.20 transaction itself. When you verify a card, the transaction you attempt against that verification must use the same currency. Try passing the subsequent transaction with USD, or create the verification in CAD and then run the transaction against it using CAD. See https://developer.paypal.com/docs/classic/payflow/integration-guide/#submitting-account-verifications for more on verifications. That's a great resource for Payflow in general as well.

That should resolve the issue you're seeing, but please let us know if you run into any other issues.

I hope that helps. Let us know if you have any questions.

Regards,
Eric B.
```




### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
n/a

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Setup PayPal Payflow payment for credit card
2. Set store default currency to CAD
3. Credit card payment fails

### Contribution checklist (*)
 - [*] Pull request has a meaningful description of its purpose
 - [*] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
