### PR TITLE
Checkout Totals Sort Order fields can't be empty and should be a number.

### DIFF
--- a/app/code/Magento/Sales/etc/adminhtml/system.xml
+++ b/app/code/Magento/Sales/etc/adminhtml/system.xml
@@ -27,18 +27,23 @@
                 <label>Checkout Totals Sort Order</label>
                 <field id="discount" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Discount</label>
+                    <validate>required-number validate-number</validate>
                 </field>
                 <field id="grand_total" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Grand Total</label>
+                    <validate>required-number validate-number</validate>
                 </field>
                 <field id="shipping" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Shipping</label>
+                    <validate>required-number validate-number</validate>
                 </field>
                 <field id="subtotal" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Subtotal</label>
+                    <validate>required-number validate-number</validate>
                 </field>
                 <field id="tax" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Tax</label>
+                    <validate>required-number validate-number</validate>
                 </field>
             </group>
             <group id="reorder" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/app/code/Magento/Weee/etc/adminhtml/system.xml
+++ b/app/code/Magento/Weee/etc/adminhtml/system.xml
@@ -44,6 +44,7 @@
             <group id="totals_sort">
                 <field id="weee" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Fixed Product Tax</label>
+                    <validate>required-number validate-number</validate>
                 </field>
             </group>
         </section>


### PR DESCRIPTION
Same fix than magento/magento2#22411 on 2.3.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

If, for some reason, a backend user deletes the content of one or all Configuration -> Sales -> Sales -> Checkout Totals Sort Order fields, the checkout won't work and you won't see an error and no exceptions seems to be logged.

### Description (*)

Now, field Subtotal, Discount, Shipping, Tax, Fixed Product Tax and Grand Total; inside Configuration -> Sales -> Sales -> Checkout Totals Sort Order, are required and can't be empty anymore.

### Manual testing scenarios (*)

Exactly the same steps than magento/magento2#22411.
I'm just applying the fix for 2.2.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
