### PR TITLE
Store view specific labels cut in left navigation menu #22406

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/_store-scope.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/_store-scope.less
@@ -37,7 +37,7 @@
 .store-scope {
     .admin__legend {
         .admin__field-tooltip {
-            margin-left: -@indent__base;
+            margin-left: 0;
             margin-top: .5rem;
         }
     }

--- a/app/design/adminhtml/Magento/backend/web/css/styles-old.less
+++ b/app/design/adminhtml/Magento/backend/web/css/styles-old.less
@@ -1366,7 +1366,7 @@
         font-size: 14px;
         font-weight: 600;
         line-height: 3.2rem;
-        padding: 0 30px 0 0;
+        padding: 0 30px 0 30px;
         white-space: nowrap;
         word-wrap: break-word;
 


### PR DESCRIPTION
Store view specific labels cut in left navigation menu in cart price rule.

### Preconditions (*)

Magento 2.3.x

### Steps to reproduce (*)
#22406
1. Go to Admin
2. Marketing >> Cart Price rule
3. Labels >> Store View Specific Labels 
4. Review the Main Websites and Main Website Store labels

### Expected result (*)

https://www.screencast.com/t/kQG9Kmwk

### Actual result (*)

https://www.screencast.com/t/ECiEKvkHS