### PR TITLE
Fixed wrong url redirect when edit product review from Customer view page

### DIFF
--- a/app/code/Magento/Review/Block/Adminhtml/Edit/Form.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Edit/Form.php
@@ -75,6 +75,17 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         $review = $this->_coreRegistry->registry('review_data');
         $product = $this->_productFactory->create()->load($review->getEntityPkValue());
 
+        $formActionParams = [
+            'id' => $this->getRequest()->getParam('id'),
+            'ret' => $this->_coreRegistry->registry('ret')
+        ];
+        if ($this->getRequest()->getParam('productId')) {
+            $formActionParams['productId'] = $this->getRequest()->getParam('productId');
+        }
+        if ($this->getRequest()->getParam('customerId')) {
+            $formActionParams['customerId'] = $this->getRequest()->getParam('customerId');
+        }
+
         /** @var \Magento\Framework\Data\Form $form */
         $form = $this->_formFactory->create(
             [
@@ -82,11 +93,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                     'id' => 'edit_form',
                     'action' => $this->getUrl(
                         'review/*/save',
-                        [
-                            'id' => $this->getRequest()->getParam('id'),
-                            'ret' => $this->_coreRegistry->registry('ret'),
-                            'productId' => $this->getRequest()->getParam('productId')
-                        ]
+                        $formActionParams
                     ),
                     'method' => 'post',
                 ],

--- a/app/code/Magento/Review/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Product/Save.php
@@ -77,6 +77,10 @@ class Save extends ProductController implements HttpPostActionInterface
             if ($productId) {
                 $resultRedirect->setPath("catalog/product/edit/id/$productId");
             }
+            $customerId = (int)$this->getRequest()->getParam('customerId');
+            if ($customerId) {
+                $resultRedirect->setPath("customer/index/edit/id/$customerId");
+            }
             return $resultRedirect;
         }
         $resultRedirect->setPath('review/*/');


### PR DESCRIPTION
Fixed wrong URL redirect when edit product review from the Customer view page
Fixed wrong URL redirect when edit product review from the view product page

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22425: wrong url redirect when edit product review from Customer view page

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Navigate to Customer for edit
2. CUSTOMER INFORMATION tab -> Product Reviews -> Edit Review 
3. After edit review -> click on save

1. Catalog-> product-> Product Reviews
2. edit any review -> click on save


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
