### PR TITLE
Fixed Issue in 2.2-develop : Fixed Ui Bookmark field created_at and updated_at fields issue

### DIFF
--- a/app/code/Magento/Ui/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Ui/Setup/UpgradeSchema.php
@@ -25,21 +25,21 @@ class UpgradeSchema implements UpgradeSchemaInterface
         $setup->startSetup();
         if (version_compare($context->getVersion(), '2.0.2') < 0) {
             $setup->getConnection()->modifyColumn(
-                $setup->getTable('ui_bookmark'), 
-                'created_at', 
+                $setup->getTable('ui_bookmark'),
+                'created_at',
                 [
                 'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
-                'nullable' => false, 
+                'nullable' => false,
                 'default' => \Magento\Framework\DB\Ddl\Table::TIMESTAMP_INIT_UPDATE
                 ],
                 'Bookmark created at'
             );
             $setup->getConnection()->modifyColumn(
-                $setup->getTable('ui_bookmark'), 
-                'updated_at', 
+                $setup->getTable('ui_bookmark'),
+                'updated_at',
                 [
                 'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
-                'nullable' => false, 
+                'nullable' => false,
                 'default' => \Magento\Framework\DB\Ddl\Table::TIMESTAMP_INIT_UPDATE
                 ],
                 'Bookmark updated at'
@@ -47,5 +47,4 @@ class UpgradeSchema implements UpgradeSchemaInterface
         }
         $setup->endSetup();
     }
-
 }

--- a/app/code/Magento/Ui/Setup/UpgradeSchema.php
+++ b/app/code/Magento/Ui/Setup/UpgradeSchema.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Ui\Setup;
+
+use Magento\Framework\Setup\InstallSchemaInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+
+/**
+ * @codeCoverageIgnore
+ */
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+
+    /**
+     * @inheritdoc
+     */
+    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $setup->startSetup();
+        if (version_compare($context->getVersion(), '2.0.2') < 0) {
+            $setup->getConnection()->modifyColumn(
+                $setup->getTable('ui_bookmark'), 
+                'created_at', 
+                [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
+                'nullable' => false, 
+                'default' => \Magento\Framework\DB\Ddl\Table::TIMESTAMP_INIT_UPDATE
+                ],
+                'Bookmark created at'
+            );
+            $setup->getConnection()->modifyColumn(
+                $setup->getTable('ui_bookmark'), 
+                'updated_at', 
+                [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
+                'nullable' => false, 
+                'default' => \Magento\Framework\DB\Ddl\Table::TIMESTAMP_INIT_UPDATE
+                ],
+                'Bookmark updated at'
+            );
+        }
+        $setup->endSetup();
+    }
+
+}

--- a/app/code/Magento/Ui/etc/module.xml
+++ b/app/code/Magento/Ui/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_Ui" setup_version="2.0.0">
+    <module name="Magento_Ui" setup_version="2.0.1">
         <sequence>
             <module name="Magento_Backend"/>
             <module name="Magento_Directory"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed Ui Bookmark field created_at and updated_at fields issue
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
2. magento/magento2#18557: Value of created_at and updated_at columns not updating in ui_bookmark table #18557

### Note:
PR #22340 fix using db_schema.xml which not working for the 2.2.X version.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. check ui_bookmark table you will see created_at and updated_at fields value is '0000-00-00 00:00:00' for all grids.

### Expected result
<!--- Tell us what should happen -->
1.There would time `timestamp [CURRENT_TIMESTAMP]` or magento should save date time while add or update data. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
