### PR TITLE
Directory-CountryCollection: loadByStore should reset previous added store-filter

### DIFF
--- a/app/code/Magento/Directory/Model/ResourceModel/Country/Collection.php
+++ b/app/code/Magento/Directory/Model/ResourceModel/Country/Collection.php
@@ -181,6 +181,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
             ->getAllowedCountries(ScopeInterface::SCOPE_STORE, $store);
 
         if (!empty($allowedCountries)) {
+            $this->getSelect()->reset(\Magento\Framework\DB\Select::WHERE);
             $this->addFieldToFilter("country_id", ['in' => $allowedCountries]);
         }
 

--- a/dev/tests/integration/testsuite/Magento/Directory/Model/ResourceModel/Country/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Directory/Model/ResourceModel/Country/CollectionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Magento\Directory\Model\ResourceModel\Country;
+
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Country Resource Collection Test
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class CollectionTest extends TestCase
+{
+    /**
+     * @var Collection
+     */
+    private $countryCollection;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->countryCollection = Bootstrap::getObjectManager()->get(Collection::class);
+        $this->storeManager = Bootstrap::getObjectManager()->get(StoreManagerInterface::class);
+    }
+
+    /**
+     * @covers \Magento\Directory\Model\ResourceModel\Country\Collection::loadByStore
+     *
+     * @magentoDataFixture Magento/Store/_files/second_store.php
+     * @magentoConfigFixture default_store general/country/allow US
+     * @magentoConfigFixture fixture_second_store_store general/country/allow DE
+     */
+    public function testLoadByStoreShouldResetPreviousStoreFilter()
+    {
+        $defaultStore = $this->storeManager->getDefaultStoreView();
+        $secondStore = $this->storeManager->getStore('fixture_second_store');
+
+        $this->assertEquals(['US'], $this->countryCollection->loadByStore($defaultStore)->getAllIds());
+        $this->assertEquals(['DE'], $this->countryCollection->loadByStore($secondStore)->getAllIds());
+    }
+}


### PR DESCRIPTION
### Description (*)

`\Magento\Directory\Model\ResourceModel\Country\Collection::loadByStore` does not reset previous added country-filters, only appends the given country-Id(s).
We recognize this behaviour in a cron job, that sync customers by using emulationMode. Only first website (Website A) works, next coming (Website B) breaks with an ["invalid countryId-Error"](https://github.com/magento/magento2/blob/0eb8677b0b4e35606032e856cc1ef7c80e68829f/app/code/Magento/Customer/Model/Address/Validator/Country.php#L75).

### Manual testing scenarios (*)
1. See Description. 
2. Having 2 stores with different allowed countries and each has at least one customer
3. Emulation-Mode first store, load a customer, modify something and save
4. Emulation-Mode second store, load other customer and modify something and save -> should breaks with the countyId-Error in description

### Contribution checklist (*)
 - [ X] Pull request has a meaningful description of its purpose
 - [ X] All commits are accompanied by meaningful commit messages
 - [ X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ X] All automated tests passed successfully (all builds on Travis CI are green)
