### PR TITLE
Backport Magento 2.2 Set cache id prefix on installation

### DIFF
--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
@@ -27,12 +27,14 @@ class Cache implements ConfigOptionsListInterface
     const INPUT_KEY_CACHE_BACKEND_REDIS_DATABASE = 'cache-backend-redis-db';
     const INPUT_KEY_CACHE_BACKEND_REDIS_PORT = 'cache-backend-redis-port';
     const INPUT_KEY_CACHE_BACKEND_REDIS_PASSWORD = 'cache-backend-redis-password';
+    const INPUT_KEY_CACHE_ID_PREFIX = 'cache-id-prefix';
 
     const CONFIG_PATH_CACHE_BACKEND = 'cache/frontend/default/backend';
     const CONFIG_PATH_CACHE_BACKEND_SERVER = 'cache/frontend/default/backend_options/server';
     const CONFIG_PATH_CACHE_BACKEND_DATABASE = 'cache/frontend/default/backend_options/database';
     const CONFIG_PATH_CACHE_BACKEND_PORT = 'cache/frontend/default/backend_options/port';
     const CONFIG_PATH_CACHE_BACKEND_PASSWORD = 'cache/frontend/default/backend_options/password';
+    const CONFIG_PATH_CACHE_ID_PREFIX = 'cache/frontend/default/id_prefix';
 
     /**
      * @var array
@@ -112,6 +114,12 @@ class Cache implements ConfigOptionsListInterface
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
                 self::CONFIG_PATH_CACHE_BACKEND_PASSWORD,
                 'Redis server password'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_CACHE_ID_PREFIX,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_CACHE_ID_PREFIX,
+                'ID prefix for cache keys'
             )
         ];
     }
@@ -122,6 +130,11 @@ class Cache implements ConfigOptionsListInterface
     public function createConfig(array $options, DeploymentConfig $deploymentConfig)
     {
         $configData = new ConfigData(ConfigFilePool::APP_ENV);
+        if (isset($options[self::INPUT_KEY_CACHE_ID_PREFIX])) {
+            $configData->set(self::CONFIG_PATH_CACHE_ID_PREFIX, $options[self::INPUT_KEY_CACHE_ID_PREFIX]);
+        } else {
+            $configData->set(self::CONFIG_PATH_CACHE_ID_PREFIX, $this->generateCachePrefix());
+        }
 
         if (isset($options[self::INPUT_KEY_CACHE_BACKEND])) {
             if ($options[self::INPUT_KEY_CACHE_BACKEND] == self::INPUT_VALUE_CACHE_REDIS) {
@@ -240,5 +253,15 @@ class Cache implements ConfigOptionsListInterface
         } else {
             return '';
         }
+    }
+
+    /**
+     * Generate default cache ID prefix based on installation dir
+     *
+     * @return string
+     */
+    private function generateCachePrefix(): string
+    {
+        return substr(\md5(dirname(__DIR__, 6)), 0, 3) . '_';
     }
 }

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php
@@ -28,6 +28,7 @@ class PageCache implements ConfigOptionsListInterface
     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PORT = 'page-cache-redis-port';
     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_COMPRESS_DATA = 'page-cache-redis-compress-data';
     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_PASSWORD = 'page-cache-redis-password';
+    const INPUT_KEY_PAGE_CACHE_ID_PREFIX = 'page-cache-id-prefix';
 
     const CONFIG_PATH_PAGE_CACHE_BACKEND = 'cache/frontend/page_cache/backend';
     const CONFIG_PATH_PAGE_CACHE_BACKEND_SERVER = 'cache/frontend/page_cache/backend_options/server';
@@ -35,6 +36,7 @@ class PageCache implements ConfigOptionsListInterface
     const CONFIG_PATH_PAGE_CACHE_BACKEND_PORT = 'cache/frontend/page_cache/backend_options/port';
     const CONFIG_PATH_PAGE_CACHE_BACKEND_COMPRESS_DATA = 'cache/frontend/page_cache/backend_options/compress_data';
     const CONFIG_PATH_PAGE_CACHE_BACKEND_PASSWORD = 'cache/frontend/page_cache/backend_options/password';
+    const CONFIG_PATH_PAGE_CACHE_ID_PREFIX = 'cache/frontend/page_cache/id_prefix';
 
     /**
      * @var array
@@ -122,6 +124,12 @@ class PageCache implements ConfigOptionsListInterface
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
                 self::CONFIG_PATH_PAGE_CACHE_BACKEND_PASSWORD,
                 'Redis server password'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_PAGE_CACHE_ID_PREFIX,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH_PAGE_CACHE_ID_PREFIX,
+                'ID prefix for cache keys'
             )
         ];
     }
@@ -132,6 +140,11 @@ class PageCache implements ConfigOptionsListInterface
     public function createConfig(array $options, DeploymentConfig $deploymentConfig)
     {
         $configData = new ConfigData(ConfigFilePool::APP_ENV);
+        if (isset($options[self::INPUT_KEY_PAGE_CACHE_ID_PREFIX])) {
+            $configData->set(self::CONFIG_PATH_PAGE_CACHE_ID_PREFIX, $options[self::INPUT_KEY_PAGE_CACHE_ID_PREFIX]);
+        } else {
+            $configData->set(self::CONFIG_PATH_PAGE_CACHE_ID_PREFIX, $this->generateCachePrefix());
+        }
 
         if (isset($options[self::INPUT_KEY_PAGE_CACHE_BACKEND])) {
             if ($options[self::INPUT_KEY_PAGE_CACHE_BACKEND] == self::INPUT_VALUE_PAGE_CACHE_REDIS) {
@@ -251,5 +264,15 @@ class PageCache implements ConfigOptionsListInterface
         } else {
             return '';
         }
+    }
+
+    /**
+     * Generate default cache ID prefix based on installation dir
+     *
+     * @return string
+     */
+    private function generateCachePrefix(): string
+    {
+        return substr(\md5(dirname(__DIR__, 6)), 0, 3) . '_';
     }
 }

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
@@ -28,6 +28,9 @@ class CacheTest extends \PHPUnit\Framework\TestCase
      */
     private $deploymentConfigMock;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp()
     {
         $this->validatorMock = $this->createMock(RedisConnectionValidator::class);
@@ -122,11 +125,6 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedConfigData, $configData->getData());
     }
 
-<<<<<<< HEAD
-=======
-    /**
-     * testCreateConfigCacheRedis
-     */
     public function testCreateConfigWithFileCache()
     {
         $this->deploymentConfigMock->method('get')->willReturn('');
@@ -146,9 +144,6 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedConfigData, $configData->getData());
     }
 
-    /**
-     * testCreateConfigCacheRedis
-     */
     public function testCreateConfigWithIdPrefix()
     {
         $this->deploymentConfigMock->method('get')->willReturn('');
@@ -172,10 +167,6 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedConfigData, $configData->getData());
     }
 
-    /**
-     * testValidateWithValidInput
-     */
->>>>>>> 12b7e08c2f26... Set cache id prefix on installation
     public function testValidateWithValidInput()
     {
         $options = [

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
@@ -39,7 +39,7 @@ class CacheTest extends \PHPUnit\Framework\TestCase
     public function testGetOptions()
     {
         $options = $this->configOptionsList->getOptions();
-        $this->assertCount(5, $options);
+        $this->assertCount(6, $options);
 
         $this->assertArrayHasKey(0, $options);
         $this->assertInstanceOf(SelectConfigOption::class, $options[0]);
@@ -60,6 +60,10 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey(4, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[4]);
         $this->assertEquals('cache-backend-redis-password', $options[4]->getName());
+
+        $this->assertArrayHasKey(5, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[5]);
+        $this->assertEquals('cache-id-prefix', $options[5]->getName());
     }
 
     public function testCreateConfigCacheRedis()
@@ -76,7 +80,8 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                             'port' => '',
                             'database' => '',
                             'password' => ''
-                        ]
+                        ],
+                        'id_prefix' => $this->expectedIdPrefix(),
                     ]
                 ]
             ]
@@ -99,7 +104,8 @@ class CacheTest extends \PHPUnit\Framework\TestCase
                             'port' => '1234',
                             'database' => '5',
                             'password' => ''
-                        ]
+                        ],
+                        'id_prefix' => $this->expectedIdPrefix(),
                     ]
                 ]
             ]
@@ -116,6 +122,60 @@ class CacheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedConfigData, $configData->getData());
     }
 
+<<<<<<< HEAD
+=======
+    /**
+     * testCreateConfigCacheRedis
+     */
+    public function testCreateConfigWithFileCache()
+    {
+        $this->deploymentConfigMock->method('get')->willReturn('');
+
+        $expectedConfigData = [
+            'cache' => [
+                'frontend' => [
+                    'default' => [
+                        'id_prefix' => $this->expectedIdPrefix(),
+                    ]
+                ]
+            ]
+        ];
+
+        $configData = $this->configOptionsList->createConfig([], $this->deploymentConfigMock);
+
+        $this->assertEquals($expectedConfigData, $configData->getData());
+    }
+
+    /**
+     * testCreateConfigCacheRedis
+     */
+    public function testCreateConfigWithIdPrefix()
+    {
+        $this->deploymentConfigMock->method('get')->willReturn('');
+
+        $explicitPrefix = 'XXX_';
+        $expectedConfigData = [
+            'cache' => [
+                'frontend' => [
+                    'default' => [
+                        'id_prefix' => $explicitPrefix,
+                    ]
+                ]
+            ]
+        ];
+
+        $configData = $this->configOptionsList->createConfig(
+            ['cache-id-prefix' => $explicitPrefix],
+            $this->deploymentConfigMock
+        );
+
+        $this->assertEquals($expectedConfigData, $configData->getData());
+    }
+
+    /**
+     * testValidateWithValidInput
+     */
+>>>>>>> 12b7e08c2f26... Set cache id prefix on installation
     public function testValidateWithValidInput()
     {
         $options = [
@@ -141,5 +201,15 @@ class CacheTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(1, $errors);
         $this->assertEquals("Invalid cache handler 'clay-tablet'", $errors[0]);
+    }
+
+    /**
+     * The default ID prefix, based on installation directory
+     *
+     * @return string
+     */
+    private function expectedIdPrefix(): string
+    {
+        return substr(\md5(dirname(__DIR__, 8)), 0, 3) . '_';
     }
 }

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
@@ -28,6 +28,9 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
      */
     private $deploymentConfigMock;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp()
     {
         $this->validatorMock = $this->createMock(RedisConnectionValidator::class, [], [], '', false);
@@ -130,11 +133,6 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedConfigData, $configData->getData());
     }
 
-<<<<<<< HEAD
-=======
-    /**
-     * testCreateConfigWithRedis
-     */
     public function testCreateConfigWithFileCache()
     {
         $this->deploymentConfigMock->method('get')->willReturn('');
@@ -154,10 +152,6 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedConfigData, $configData->getData());
     }
 
-
-    /**
-     * testCreateConfigCacheRedis
-     */
     public function testCreateConfigWithIdPrefix()
     {
         $this->deploymentConfigMock->method('get')->willReturn('');
@@ -181,10 +175,6 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedConfigData, $configData->getData());
     }
 
-    /**
-     * testValidationWithValidData
-     */
->>>>>>> 12b7e08c2f26... Set cache id prefix on installation
     public function testValidationWithValidData()
     {
         $this->validatorMock->expects($this->once())

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/PageCacheTest.php
@@ -39,7 +39,7 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
     public function testGetOptions()
     {
         $options = $this->configList->getOptions();
-        $this->assertCount(6, $options);
+        $this->assertCount(7, $options);
 
         $this->assertArrayHasKey(0, $options);
         $this->assertInstanceOf(SelectConfigOption::class, $options[0]);
@@ -64,6 +64,10 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey(5, $options);
         $this->assertInstanceOf(TextConfigOption::class, $options[5]);
         $this->assertEquals('page-cache-redis-password', $options[5]->getName());
+
+        $this->assertArrayHasKey(6, $options);
+        $this->assertInstanceOf(TextConfigOption::class, $options[6]);
+        $this->assertEquals('page-cache-id-prefix', $options[6]->getName());
     }
 
     public function testCreateConfigWithRedis()
@@ -81,7 +85,8 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
                             'database' => '',
                             'compress_data' => '',
                             'password' => ''
-                        ]
+                        ],
+                        'id_prefix' => $this->expectedIdPrefix(),
                     ]
                 ]
             ]
@@ -105,7 +110,8 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
                             'database' => '6',
                             'compress_data' => '1',
                             'password' => ''
-                        ]
+                        ],
+                        'id_prefix' => $this->expectedIdPrefix(),
                     ]
                 ]
             ]
@@ -124,6 +130,61 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedConfigData, $configData->getData());
     }
 
+<<<<<<< HEAD
+=======
+    /**
+     * testCreateConfigWithRedis
+     */
+    public function testCreateConfigWithFileCache()
+    {
+        $this->deploymentConfigMock->method('get')->willReturn('');
+
+        $expectedConfigData = [
+            'cache' => [
+                'frontend' => [
+                    'page_cache' => [
+                        'id_prefix' => $this->expectedIdPrefix(),
+                    ]
+                ]
+            ]
+        ];
+
+        $configData = $this->configList->createConfig([], $this->deploymentConfigMock);
+
+        $this->assertEquals($expectedConfigData, $configData->getData());
+    }
+
+
+    /**
+     * testCreateConfigCacheRedis
+     */
+    public function testCreateConfigWithIdPrefix()
+    {
+        $this->deploymentConfigMock->method('get')->willReturn('');
+
+        $explicitPrefix = 'XXX_';
+        $expectedConfigData = [
+            'cache' => [
+                'frontend' => [
+                    'page_cache' => [
+                        'id_prefix' => $explicitPrefix,
+                    ]
+                ]
+            ]
+        ];
+
+        $configData = $this->configList->createConfig(
+            ['page-cache-id-prefix' => $explicitPrefix],
+            $this->deploymentConfigMock
+        );
+
+        $this->assertEquals($expectedConfigData, $configData->getData());
+    }
+
+    /**
+     * testValidationWithValidData
+     */
+>>>>>>> 12b7e08c2f26... Set cache id prefix on installation
     public function testValidationWithValidData()
     {
         $this->validatorMock->expects($this->once())
@@ -150,5 +211,15 @@ class PageCacheTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(1, $errors);
         $this->assertEquals('Invalid cache handler \'foobar\'', $errors[0]);
+    }
+
+    /**
+     * The default ID prefix, based on installation directory
+     *
+     * @return string
+     */
+    private function expectedIdPrefix(): string
+    {
+        return substr(\md5(dirname(__DIR__, 8)), 0, 3) . '_';
     }
 }


### PR DESCRIPTION
Original Pull Request #18641

### Description (*)
The undocumented id_prefix option for the cache frontend is used to prefix cache keys. If it is not set, Magento uses the first 12 bits of the md5 hash of the absolute path to Magentos app/etc directory. But if this is not exactly the same on all web servers, cache invalidation does not work.

Source: https://github.com/magento/magento2/blob/2.3-develop/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php#L121-L130

To prevent this issue, the value shall be set on installation, so that the fall back on the fly does not happen anymore. Optionally, the value can be specified explicitly.

### Fixed Issues (if relevant)
#15828: Multisite installation, default website slow

### Manual testing scenarios (*)

1. Install Magento via CLI or Web Wizard
2. There should be new options "cache-id-prefix" and "page-cache-id-prefix"
3. The value is saved in env.php at cache/frontend/{default,page_cache}/id_prefix

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
