### PR TITLE
[Backport] Fiexed 22152 - Click on search icon it does not working on admin grid sticky header

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/search/search.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/search/search.js
@@ -11,8 +11,9 @@ define([
     'uiLayout',
     'mage/translate',
     'mageUtils',
-    'uiElement'
-], function (_, layout, $t, utils, Element) {
+    'uiElement',
+    'jquery'
+], function (_, layout, $t, utils, Element, $) {
     'use strict';
 
     return Element.extend({
@@ -29,11 +30,13 @@ define([
             tracks: {
                 value: true,
                 previews: true,
-                inputValue: true
+                inputValue: true,
+                focused: true
             },
             imports: {
                 inputValue: 'value',
-                updatePreview: 'value'
+                updatePreview: 'value',
+                focused: false
             },
             exports: {
                 value: '${ $.provider }:params.search'
@@ -86,6 +89,18 @@ define([
             this.value = '';
 
             return this;
+        },
+
+        /**
+         * Click To ScrollTop.
+         */
+        scrollTo: function ($data) {
+            $('html, body').animate({
+                scrollTop: 0
+            }, 'slow', function () {
+                $data.focused = false;
+                $data.focused = true;
+            });
         },
 
         /**

--- a/app/code/Magento/Ui/view/base/web/templates/grid/search/search.html
+++ b/app/code/Magento/Ui/view/base/web/templates/grid/search/search.html
@@ -5,7 +5,7 @@
  */
 -->
 <div class="data-grid-search-control-wrap">
-    <label class="data-grid-search-label" attr="title: $t('Search'), for: index">
+    <label class="data-grid-search-label" attr="title: $t('Search'), for: index" data-bind="click: scrollTo">
         <span translate="'Search'"/>
     </label>
     <input class="admin__control-text data-grid-search-control" type="text"
@@ -16,6 +16,7 @@
                     placeholder: $t(placeholder)
                 },
                 textInput: inputValue,
+                hasFocus: focused,
                 keyboard: {
                     13: apply.bind($data, false),
                     27: cancel


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22154
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Click on search icon it does not working on admin grid sticky header

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22152: Click on search icon it does not working.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Manual Testing

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
