### PR TITLE
magento/magento2#22317: PR#22321 fix.

### DIFF
--- a/dev/tests/static/framework/Magento/Sniffs/Annotation/AnnotationFormatValidator.php
+++ b/dev/tests/static/framework/Magento/Sniffs/Annotation/AnnotationFormatValidator.php
@@ -22,7 +22,7 @@ class AnnotationFormatValidator
      * @param int $commentEndPtr
      * @return int
      */
-    private function getShortDescriptionEndPosition(File $phpcsFile, int $shortPtr, $commentEndPtr) : int
+    private function getShortDescriptionEndPosition(File $phpcsFile, int $shortPtr, $commentEndPtr): int
     {
         $tokens = $phpcsFile->getTokens();
         $shortPtrEnd = $shortPtr;
@@ -49,22 +49,22 @@ class AnnotationFormatValidator
         File $phpcsFile,
         int $shortPtr,
         int $commentEndPtr
-    ) : void {
+    ): void {
         $tokens = $phpcsFile->getTokens();
         $shortPtrEnd = $this->getShortDescriptionEndPosition(
             $phpcsFile,
-            (int) $shortPtr,
+            (int)$shortPtr,
             $commentEndPtr
         );
         $shortPtrEndContent = $tokens[$shortPtrEnd]['content'];
         if (preg_match('/^[a-z]/', $shortPtrEndContent)
             && $shortPtrEnd != $shortPtr
             && !preg_match('/\bSee\b/', $shortPtrEndContent)
-            && $tokens[$shortPtr]['line']+1 === $tokens[$shortPtrEnd]['line']
+            && $tokens[$shortPtr]['line'] + 1 === $tokens[$shortPtrEnd]['line']
             && $tokens[$shortPtrEnd]['code'] !== T_DOC_COMMENT_TAG
         ) {
             $error = 'Short description should not be in multi lines';
-            $phpcsFile->addFixableError($error, $shortPtrEnd+1, 'MethodAnnotation');
+            $phpcsFile->addFixableError($error, $shortPtrEnd + 1, 'MethodAnnotation');
         }
     }
 
@@ -81,17 +81,17 @@ class AnnotationFormatValidator
         int $shortPtr,
         int $commentEndPtr,
         array $emptyTypeTokens
-    ) : void {
+    ): void {
         $tokens = $phpcsFile->getTokens();
         $shortPtrEnd = $this->getShortDescriptionEndPosition(
             $phpcsFile,
-            (int) $shortPtr,
+            (int)$shortPtr,
             $commentEndPtr
         );
         $shortPtrEndContent = $tokens[$shortPtrEnd]['content'];
         if (preg_match('/^[A-Z]/', $shortPtrEndContent)
             && !preg_match('/\bSee\b/', $shortPtrEndContent)
-            && $tokens[$shortPtr]['line']+1 === $tokens[$shortPtrEnd]['line']
+            && $tokens[$shortPtr]['line'] + 1 === $tokens[$shortPtrEnd]['line']
             && $tokens[$shortPtrEnd]['code'] !== T_DOC_COMMENT_TAG
         ) {
             $error = 'There must be exactly one blank line between lines';
@@ -119,7 +119,7 @@ class AnnotationFormatValidator
         int $stackPtr,
         int $commentEndPtr,
         array $emptyTypeTokens
-    ) : void {
+    ): void {
         $tokens = $phpcsFile->getTokens();
         if ($tokens[$shortPtr]['line'] !== $tokens[$stackPtr]['line'] + 1) {
             $error = 'No blank lines are allowed before short description';
@@ -166,7 +166,7 @@ class AnnotationFormatValidator
         int $shortPtrEnd,
         int $commentEndPtr,
         array $emptyTypeTokens
-    ) : void {
+    ): void {
         $tokens = $phpcsFile->getTokens();
         $longPtr = $phpcsFile->findNext($emptyTypeTokens, $shortPtrEnd + 1, $commentEndPtr - 1, true);
         if (strtolower($tokens[$longPtr]['content']) === '@inheritdoc') {
@@ -192,7 +192,7 @@ class AnnotationFormatValidator
      * @param int $commentStartPtr
      * @param array $emptyTypeTokens
      */
-    public function validateTagsSpacingFormat(File $phpcsFile, int $commentStartPtr, array $emptyTypeTokens) : void
+    public function validateTagsSpacingFormat(File $phpcsFile, int $commentStartPtr, array $emptyTypeTokens): void
     {
         $tokens = $phpcsFile->getTokens();
         if (isset($tokens[$commentStartPtr]['comment_tags'][0])) {
@@ -214,7 +214,7 @@ class AnnotationFormatValidator
      * @param File $phpcsFile
      * @param int $commentStartPtr
      */
-    public function validateTagGroupingFormat(File $phpcsFile, int $commentStartPtr) : void
+    public function validateTagGroupingFormat(File $phpcsFile, int $commentStartPtr): void
     {
         $tokens = $phpcsFile->getTokens();
         $tagGroups = [];
@@ -256,7 +256,7 @@ class AnnotationFormatValidator
      * @param File $phpcsFile
      * @param int $commentStartPtr
      */
-    public function validateTagAligningFormat(File $phpcsFile, int $commentStartPtr) : void
+    public function validateTagAligningFormat(File $phpcsFile, int $commentStartPtr): void
     {
         $tokens = $phpcsFile->getTokens();
         $noAlignmentPositions = [];
@@ -287,7 +287,7 @@ class AnnotationFormatValidator
      * @param array $actualPositions
      * @return bool
      */
-    private function allTagsAligned(array $actualPositions)
+    private function allTagsAligned(array $actualPositions): bool
     {
         return count(array_unique($actualPositions)) === 1;
     }
@@ -299,7 +299,7 @@ class AnnotationFormatValidator
      * @param array $noAlignmentPositions
      * @return bool
      */
-    private function noneTagsAligned(array $actualPositions, array $noAlignmentPositions)
+    private function noneTagsAligned(array $actualPositions, array $noAlignmentPositions): bool
     {
         return $actualPositions === $noAlignmentPositions;
     }
@@ -317,7 +317,7 @@ class AnnotationFormatValidator
         int $commentStartPtr,
         int $commentEndPtr,
         array $emptyTypeTokens
-    ) : void {
+    ): void {
         $tokens = $phpcsFile->getTokens();
         $prevPtr = $phpcsFile->findPrevious($emptyTypeTokens, $commentEndPtr - 1, $commentStartPtr, true);
         if ($tokens[$prevPtr]['line'] < ($tokens[$commentEndPtr]['line'] - 1)) {
@@ -341,7 +341,7 @@ class AnnotationFormatValidator
         int $shortPtr,
         int $commentEndPtr,
         array $emptyTypeTokens
-    ) : void {
+    ): void {
         $tokens = $phpcsFile->getTokens();
         if (isset($tokens[$commentStartPtr]['comment_tags'][0])
         ) {
@@ -355,7 +355,7 @@ class AnnotationFormatValidator
             } else {
                 $this->validateShortDescriptionFormat(
                     $phpcsFile,
-                    (int) $shortPtr,
+                    (int)$shortPtr,
                     (int)$commentStartPtr,
                     (int)$commentEndPtr,
                     $emptyTypeTokens
@@ -364,7 +364,7 @@ class AnnotationFormatValidator
         } else {
             $this->validateShortDescriptionFormat(
                 $phpcsFile,
-                (int) $shortPtr,
+                (int)$shortPtr,
                 $commentStartPtr,
                 $commentEndPtr,
                 $emptyTypeTokens

--- a/dev/tests/static/framework/Magento/Sniffs/Annotation/MethodAnnotationStructureSniff.php
+++ b/dev/tests/static/framework/Magento/Sniffs/Annotation/MethodAnnotationStructureSniff.php
@@ -4,10 +4,11 @@
  * See COPYING.txt for license details.
  */
 declare(strict_types=1);
+
 namespace Magento\Sniffs\Annotation;
 
-use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
  * Sniff to validate structure of public, private, protected method annotations
@@ -46,7 +47,7 @@ class MethodAnnotationStructureSniff implements Sniff
         $commentStartPtr = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, ($stackPtr), 0);
         $commentEndPtr = $phpcsFile->findPrevious(T_DOC_COMMENT_CLOSE_TAG, ($stackPtr), 0);
         $commentCloserPtr = $tokens[$commentStartPtr]['comment_closer'];
-        $functionPtrContent = $tokens[$stackPtr+2]['content'] ;
+        $functionPtrContent = $tokens[$stackPtr + 2]['content'];
         if (preg_match('/(?i)__construct/', $functionPtrContent)) {
             return;
         }
@@ -62,7 +63,7 @@ class MethodAnnotationStructureSniff implements Sniff
             $this->annotationFormatValidator->validateDescriptionFormatStructure(
                 $phpcsFile,
                 $commentStartPtr,
-                (int) $shortPtr,
+                (int)$shortPtr,
                 $commentEndPtr,
                 $emptyTypeTokens
             );

--- a/dev/tests/static/framework/Magento/Sniffs/Annotation/MethodArgumentsSniff.php
+++ b/dev/tests/static/framework/Magento/Sniffs/Annotation/MethodArgumentsSniff.php
@@ -3,7 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 declare(strict_types=1);
 
 namespace Magento\Sniffs\Annotation;
@@ -124,10 +123,9 @@ class MethodArgumentsSniff implements Sniff
     private function getMethodParameters(array $paramDefinitions): array
     {
         $paramName = [];
-        $paramCount = count($paramDefinitions);
-        for ($i = 0; $i < $paramCount; $i++) {
-            if (isset($paramDefinitions[$i]['paramName'])) {
-                $paramName[] = $paramDefinitions[$i]['paramName'];
+        foreach ($paramDefinitions as $paramDefinition) {
+            if (isset($paramDefinition['paramName'])) {
+                $paramName[] = $paramDefinition['paramName'];
             }
         }
         return $paramName;
@@ -372,13 +370,12 @@ class MethodArgumentsSniff implements Sniff
         $parametersCount = count($paramPointers);
         if ($argumentsCount <= $parametersCount && $argumentsCount > 0) {
             $duplicateParameters = [];
-            $paramCount = count($paramDefinitions);
-            for ($i = 0; $i < $paramCount; $i++) {
-                if (isset($paramDefinitions[$i]['paramName'])) {
-                    $parameterContent = $paramDefinitions[$i]['paramName'];
-                    for ($j = $i + 1; $j < $paramCount; $j++) {
-                        if (isset($paramDefinitions[$j]['paramName'])
-                            && $parameterContent === $paramDefinitions[$j]['paramName']
+            foreach ($paramDefinitions as $i => $paramDefinition) {
+                if (isset($paramDefinition['paramName'])) {
+                    $parameterContent = $paramDefinition['paramName'];
+                    foreach (array_slice($paramDefinitions, $i + 1) as $nextParamDefinition) {
+                        if (isset($nextParamDefinition['paramName'])
+                            && $parameterContent === $nextParamDefinition['paramName']
                         ) {
                             $duplicateParameters[] = $parameterContent;
                         }
@@ -473,6 +470,8 @@ class MethodArgumentsSniff implements Sniff
      * @param array $methodArguments
      * @param int $previousCommentOpenPtr
      * @param int $previousCommentClosePtr
+     *
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
     private function validateMethodParameterAnnotations(
         int $stackPtr,
@@ -519,7 +518,8 @@ class MethodArgumentsSniff implements Sniff
             $paramPointers
         );
         $tokens = $phpcsFile->getTokens();
-        for ($ptr = 0; $ptr < $argumentCount; $ptr++) {
+
+        foreach ($methodArguments as $ptr => $methodArgument) {
             if (isset($paramPointers[$ptr])) {
                 $this->validateArgumentNameInParameterAnnotationExists(
                     $stackPtr,
@@ -605,6 +605,8 @@ class MethodArgumentsSniff implements Sniff
      * @param File $phpcsFile
      * @param array $paramPointers
      *
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     *
      * @see https://devdocs.magento.com/guides/v2.3/coding-standards/docblock-standard-general.html#format-consistency
      */
     private function validateFormattingConsistency(
@@ -616,20 +618,19 @@ class MethodArgumentsSniff implements Sniff
         $argumentPositions = [];
         $commentPositions = [];
         $tokens = $phpcsFile->getTokens();
-        $argumentCount = count($methodArguments);
-        for ($ptr = 0; $ptr < $argumentCount; $ptr++) {
+        foreach ($methodArguments as $ptr => $methodArgument) {
             if (isset($paramPointers[$ptr])) {
                 $paramContent = $tokens[$paramPointers[$ptr] + 2]['content'];
                 $paramDefinition = $paramDefinitions[$ptr];
                 $argumentPositions[] = strpos($paramContent, $paramDefinition['paramName']);
                 $commentPositions[] = $paramDefinition['comment']
-                    ? strpos($paramContent, $paramDefinition['comment']) : null;
+                    ? strrpos($paramContent, $paramDefinition['comment']) : null;
             }
         }
         if (!$this->allParamsAligned($argumentPositions, $commentPositions)
             && !$this->noneParamsAligned($argumentPositions, $commentPositions, $paramDefinitions)) {
             $phpcsFile->addFixableError(
-                'Visual alignment must be consistent',
+                'Method arguments visual alignment must be consistent',
                 $paramPointers[0],
                 'MethodArguments'
             );


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
magento/magento2#22321 was merged before it was finished.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22317: CodeSniffer should not mark correctly aligned DocBlock elements as code style violation.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Edit any Magento 2 class - align method params like shown here.
2. Create two aligned param comments for one method (one of them should be a substring of relevant param name).
3. Run static tests.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
