### PR TITLE
Removes usage of classes which don't exist from DB migration scripts.

### DIFF
--- a/app/code/Magento/Catalog/Setup/CategorySetup.php
+++ b/app/code/Magento/Catalog/Setup/CategorySetup.php
@@ -53,6 +53,8 @@ use Magento\Catalog\Model\Product\Type;
 use Magento\Theme\Model\Theme\Source\Theme;
 
 /**
+ * Setup category with default entities.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class CategorySetup extends EavSetup

--- a/app/code/Magento/Catalog/Setup/CategorySetup.php
+++ b/app/code/Magento/Catalog/Setup/CategorySetup.php
@@ -10,7 +10,6 @@ namespace Magento\Catalog\Setup;
 use Magento\Catalog\Block\Adminhtml\Category\Helper\Pricestep;
 use Magento\Catalog\Block\Adminhtml\Category\Helper\Sortby\Available;
 use Magento\Catalog\Block\Adminhtml\Category\Helper\Sortby\DefaultSortby;
-use Magento\Catalog\Block\Adminhtml\Product\Helper\Form\BaseImage;
 use Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Category as CategoryFormHelper;
 use Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Weight as WeightFormHelper;
 use Magento\Catalog\Model\Attribute\Backend\Customlayoutupdate;
@@ -593,7 +592,6 @@ class CategorySetup extends EavSetup
                         'label' => 'Base Image',
                         'input' => 'media_image',
                         'frontend' => ImageFrontendModel::class,
-                        'input_renderer' => BaseImage::class,
                         'required' => false,
                         'sort_order' => 0,
                         'global' => ScopedAttributeInterface::SCOPE_STORE,
@@ -626,7 +624,6 @@ class CategorySetup extends EavSetup
                         'type' => 'varchar',
                         'label' => 'Media Gallery',
                         'input' => 'gallery',
-                        'backend' => Media::class,
                         'required' => false,
                         'sort_order' => 4,
                         'group' => 'Images',

--- a/app/code/Magento/Customer/Setup/Patch/Data/MigrateStoresAllowedCountriesToWebsite.php
+++ b/app/code/Magento/Customer/Setup/Patch/Data/MigrateStoresAllowedCountriesToWebsite.php
@@ -8,7 +8,6 @@ namespace Magento\Customer\Setup\Patch\Data;
 
 use Magento\Directory\Model\AllowedCountries;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
-use Magento\Directory\Model\AllowedCountriesFactory;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
@@ -27,7 +26,7 @@ class MigrateStoresAllowedCountriesToWebsite implements DataPatchInterface, Patc
     private $storeManager;
 
     /**
-     * @var AllowedCountriesFactory
+     * @var AllowedCountries
      */
     private $allowedCountries;
 

--- a/app/code/Magento/Customer/Setup/Patch/Data/MigrateStoresAllowedCountriesToWebsite.php
+++ b/app/code/Magento/Customer/Setup/Patch/Data/MigrateStoresAllowedCountriesToWebsite.php
@@ -13,6 +13,9 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchVersionInterface;
 
+/**
+ * Migrate store allowed countries to website.
+ */
 class MigrateStoresAllowedCountriesToWebsite implements DataPatchInterface, PatchVersionInterface
 {
     /**
@@ -47,10 +50,11 @@ class MigrateStoresAllowedCountriesToWebsite implements DataPatchInterface, Patc
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function apply()
     {
+
         $this->moduleDataSetup->getConnection()->beginTransaction();
 
         try {
@@ -148,7 +152,7 @@ class MigrateStoresAllowedCountriesToWebsite implements DataPatchInterface, Patc
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public static function getDependencies()
     {
@@ -158,7 +162,7 @@ class MigrateStoresAllowedCountriesToWebsite implements DataPatchInterface, Patc
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public static function getVersion()
     {
@@ -166,7 +170,7 @@ class MigrateStoresAllowedCountriesToWebsite implements DataPatchInterface, Patc
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getAliases()
     {


### PR DESCRIPTION
### Description (*)
This PR was sparked after some research in https://github.com/magento/magento2/issues/22124
It might solve https://github.com/magento/magento2/issues/22124 but it wasn't determined yet how to reproduce that issue, so I'm not going to mention it in the Fixed Issues list for now (but please let me know if I need to edit my post to add it).

Other issues solved in this PR were discovered by executing [phpstan](https://github.com/phpstan/phpstan) with level 0 over the DB migration scripts:
```
➜ vendor/bin/phpstan analyze -l 0 app/code/Magento/*/Setup/
 145/145 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ --------------------------------------------------------------------------------
  Line   Catalog/Setup/CategorySetup.php
 ------ --------------------------------------------------------------------------------
  596    Class Magento\Catalog\Block\Adminhtml\Product\Helper\Form\BaseImage not found.
  629    Class Magento\Catalog\Setup\Media not found.
 ------ --------------------------------------------------------------------------------

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Customer/Setup/Patch/Data/MigrateStoresAllowedCountriesToWebsite.php
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  32     Property Magento\Customer\Setup\Patch\Data\MigrateStoresAllowedCountriesToWebsite::$allowedCountries has unknown class Magento\Directory\Model\AllowedCountriesFactory as its type.
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

(fun fact: phpstan reports around 214 violations of these non-existing classes in the entire code base, if somebody wants to go fix all of these, be my guest :))

#### Issue 1 - BaseImage
The `BaseImage` class was removed a long time ago in https://github.com/magento/magento2/commit/566be67f8902899b6744fc7fb7855d83d9f013a8#diff-6ab33404f7c9e2c38f69b1d172d923a9, but its usage wasn't removed from the DB Migration scripts.

#### Issue 2 - Media
The `Media` class was removed an even longer time ago in https://github.com/magento/magento2/commit/0f0063045b5#diff-7efc962fb113e767187c2ce8d5017415, and its usage was also not removed from the DB Migration script. Later on, in https://github.com/magento/magento2/commit/dcd8b323950b924db07ba7b37898a9c3a8b0f2fd#diff-7b8ac6c93b8d79968c8d4d8237621404L587, the `Media` class usage namespace was changed from `Magento\Catalog\Model\Product\Attribute\Backend` to `Magento\Catalog\Setup` without anyone noticing the class never existed at that point.

#### Issue 3 - AllowedCountriesFactory
The usage of class `AllowedCountriesFactory` was introduced in https://github.com/magento/magento2/commit/6368e1eda02#diff-eceb8134fbc63b4fd17610ab3a3c95cc and later reverted in https://github.com/magento/magento2/commit/8689dd7b0fa#diff-eceb8134fbc63b4fd17610ab3a3c95cc, but someone forgot to revert the changes to the docblock of the `$allowedCountries` variable.
(Btw: I've checked if it makes sense to use a Factory over here, and it doesn't make sense).

### Fixed Issues (if relevant)
1. ...

### Manual testing scenarios (*)
1. Clone 2.3-develop branch
2. Run `composer install`
3. Run `composer require --dev phpstan/phpstan`
4. Run `bin/magento setup:di:compile`
5. Run `composer dump-autoload`
6. Run `vendor/bin/phpstan analyze -l 0 app/code/Magento/*/Setup/`

To test if DB migrations still work fine, run `bin/magento setup:install ... --cleanup-database` command before and after these changes, the following end result should remain the same:
1. Check if the product attribute `media_gallery` (ID: 90) has the `backend_model` set to `NULL` in the table `eav_attribute`
2. Check if the product attribute `image` (ID: 87) has the `frontend_input_renderer` set to `NULL` in the table `catalog_eav_attribute`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
