### PR TITLE
[Backport] Translate comment tag in DHL config settings

### DIFF
--- a/app/code/Magento/Dhl/etc/adminhtml/system.xml
+++ b/app/code/Magento/Dhl/etc/adminhtml/system.xml
@@ -31,7 +31,7 @@
                 <field id="account" translate="label" type="text" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Account Number</label>
                 </field>
-                <field id="content_type" translate="label" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                <field id="content_type" translate="label comment" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Content Type (Non Domestic)</label>
                     <comment>Whether to use Documents or NonDocuments service for non domestic shipments. (Shipments within the EU are classed as domestic)</comment>
                     <source_model>Magento\Dhl\Model\Source\Contenttype</source_model>

--- a/app/code/Magento/Dhl/i18n/en_US.csv
+++ b/app/code/Magento/Dhl/i18n/en_US.csv
@@ -61,6 +61,7 @@ Title,Title
 Password,Password
 "Account Number","Account Number"
 "Content Type","Content Type"
+"Whether to use Documents or NonDocuments service for non domestic shipments. (Shipments within the EU are classed as domestic)","Whether to use Documents or NonDocuments service for non domestic shipments. (Shipments within the EU are classed as domestic)"
 "Calculate Handling Fee","Calculate Handling Fee"
 "Handling Applied","Handling Applied"
 """Per Order"" allows a single handling fee for the entire order. ""Per Package"" allows an individual handling fee for each package.","""Per Order"" allows a single handling fee for the entire order. ""Per Package"" allows an individual handling fee for each package."


### PR DESCRIPTION
### Original Pull Request 
https://github.com/magento/magento2/pull/22207

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Added translation for the `comment` tag of the following field
- `STORES > Settings > Configuration > SALES > Shipping Methods > DHL > Content Type (Non Domestic)`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. N/A

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
