### PR TITLE
[Backport]Layered Navigation: “Equalize product count” not working as expected

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/Layer/Filter/Decimal.php
+++ b/app/code/Magento/CatalogSearch/Model/Layer/Filter/Decimal.php
@@ -111,12 +111,9 @@ class Decimal extends AbstractFilter
                 $from = '';
             }
             if ($to == '*') {
-                $to = '';
+                $to = null;
             }
-            $label = $this->renderRangeLabel(
-                empty($from) ? 0 : $from,
-                empty($to) ? 0 : $to
-            );
+            $label = $this->renderRangeLabel(empty($from) ? 0 : $from, $to);
             $value = $from . '-' . $to;
 
             $data[] = [
@@ -141,7 +138,7 @@ class Decimal extends AbstractFilter
     protected function renderRangeLabel($fromPrice, $toPrice)
     {
         $formattedFromPrice = $this->priceCurrency->format($fromPrice);
-        if ($toPrice === '') {
+        if ($toPrice === null) {
             return __('%1 and above', $formattedFromPrice);
         } else {
             if ($fromPrice != $toPrice) {


### PR DESCRIPTION
### Description (*)
Create a custom attribute of type price.
Got to Stores > Configuration > Catalog > Layered Navigation and set “price navigation step calculation” to “Automatic (equalize product counts)”

issue comes from -> https://github.com/magento/magento2/issues/6715 
where Someone says that **"Both parts of ternary operators are equals."** 

### Original PR #21968

I would expect ten ranges with equalized product counts (as the name suggests).
### Fixed Issues (if relevant)

1. magento/magento2#21960: Issue title
2. ...

### Manual testing scenarios (*)

Create a custom attribute of type price.
Got to Stores > Configuration > Catalog > Layered Navigation and set “price navigation step calculation” to “Automatic (equalize product counts)”

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
