### PR TITLE
[fixed] Rest API Magento 2.3.1 update product attribute not working as expected / documented

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
@@ -113,7 +113,11 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
                 ->getEntityType(\Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE)
                 ->getId()
         );
-        if ($attribute->getAttributeId()) {
+        $existingAttributeModel = $this->eavConfig->getAttribute(
+            \Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE,
+            $attribute->getAttributeCode()
+        );
+        if ($attribute->getAttributeId() || $existingAttributeModel->getAttributeId()) {
             $existingModel = $this->get($attribute->getAttributeCode());
 
             if (!$existingModel->getAttributeId()) {

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
@@ -113,11 +113,22 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
                 ->getEntityType(\Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE)
                 ->getId()
         );
-        $existingAttributeModel = $this->eavConfig->getAttribute(
+        $attributeIdFlag = false;
+
+        if ($attribute->getAttributeId()) {
+           $attributeIdFlag = true; 
+        } elseif ($attribute->getAttributeCode()) {
+           $existAttrModel = $this->eavConfig->getAttribute(
             \Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE,
             $attribute->getAttributeCode()
-        );
-        if ($attribute->getAttributeId() || $existingAttributeModel->getAttributeId()) {
+            );
+
+           if ($existAttrModel->getAttributeId()) {
+                $attributeIdFlag = true; 
+           }
+        }
+
+        if ($attributeIdFlag) {
             $existingModel = $this->get($attribute->getAttributeCode());
 
             if (!$existingModel->getAttributeId()) {

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
@@ -116,16 +116,16 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
         $attributeIdFlag = false;
 
         if ($attribute->getAttributeId()) {
-           $attributeIdFlag = true; 
+            $attributeIdFlag = true; 
         } elseif ($attribute->getAttributeCode()) {
-           $existAttrModel = $this->eavConfig->getAttribute(
-            \Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE,
-            $attribute->getAttributeCode()
+            $existAttrModel = $this->eavConfig->getAttribute(
+                \Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE,
+                $attribute->getAttributeCode()
             );
 
-           if ($existAttrModel->getAttributeId()) {
+            if ($existAttrModel->getAttributeId()) {
                 $attributeIdFlag = true; 
-           }
+            }
         }
 
         if ($attributeIdFlag) {


### PR DESCRIPTION
### Preconditions (*)
1. Magento 2.3.1
2. Product attribute with attribute code "test_attribute" exists with the default frontend label "Test"

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22391: Rest API Magento 2.3.1 update product attribute not working as expected/documented

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Manual Testing

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
