### PR TITLE
Set timezone on DateTime object not in constructor

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
@@ -196,7 +196,8 @@ class Timezone implements TimezoneInterface
     public function scopeDate($scope = null, $date = null, $includeTime = false)
     {
         $timezone = $this->_scopeConfig->getValue($this->getDefaultTimezonePath(), $this->_scopeType, $scope);
-        $date = new \DateTime(is_numeric($date) ? '@' . $date : $date, new \DateTimeZone($timezone));
+        $date = new \DateTime(is_numeric($date) ? '@' . $date : $date);
+        $date->setTimezone(new \DateTimeZone($timezone));
         if (!$includeTime) {
             $date->setTime(0, 0, 0);
         }

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
@@ -248,13 +248,8 @@ class Timezone implements TimezoneInterface
             $toTimeStamp += 86400;
         }
 
-        $result = false;
-        if (!$this->_dateTime->isEmptyDate($dateFrom) && $scopeTimeStamp < $fromTimeStamp) {
-        } elseif (!$this->_dateTime->isEmptyDate($dateTo) && $scopeTimeStamp > $toTimeStamp) {
-        } else {
-            $result = true;
-        }
-        return $result;
+        return !(!$this->_dateTime->isEmptyDate($dateFrom) && $scopeTimeStamp < $fromTimeStamp ||
+               !$this->_dateTime->isEmptyDate($dateTo) && $scopeTimeStamp > $toTimeStamp);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/TimezoneTest.php
+++ b/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/TimezoneTest.php
@@ -253,4 +253,15 @@ class TimezoneTest extends \PHPUnit\Framework\TestCase
     {
         $this->scopeConfig->method('getValue')->with('', '', null)->willReturn($configuredTimezone);
     }
+
+    public function testCheckIfScopeDateSetsTimeZone()
+    {
+        $scopeDate = new \DateTime('now', new \DateTimeZone('America/Vancouver'));
+        $this->scopeConfig->method('getValue')->willReturn('America/Vancouver');
+
+        $this->assertEquals(
+            $scopeDate->getTimezone(),
+            $this->getTimezone()->scopeDate(0, $scopeDate->getTimestamp())->getTimezone()
+        );
+    }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Passing in the DateTimeZone object via the DateTime constructor defines what timezone the passed date string is and not converting the time. This causes issues where UTC time does not get converted to local timezone.

Changing `Timezone.php` to set the timezone after the constructor is called will convert the original DateTime string passed into the correct timezone. See https://www.php.net/manual/en/datetime.settimezone.php for more information on this function

### Manual testing scenarios (*)

See: https://github.com/magento/partners-magento2ee/issues/20

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
