### PR TITLE
[Backport] [Fixed] Full Tax Summary missing calculation Admin create order

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/tax.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/tax.phtml
@@ -33,7 +33,6 @@ $taxAmount = $block->getTotal()->getValue();
                 <?php $percent = $info['percent']; ?>
                 <?php $amount = $info['amount']; ?>
                 <?php $rates = $info['rates']; ?>
-                <?php $isFirst = 1; ?>
 
                 <?php foreach ($rates as $rate): ?>
                 <tr class="summary-details-<?= /* @escapeNotVerified */ $taxIter ?> summary-details<?php if ($isTop): echo ' summary-details-first'; endif; ?>" style="display:none;">
@@ -44,13 +43,10 @@ $taxAmount = $block->getTotal()->getValue();
                         <?php endif; ?>
                         <br />
                     </td>
-                    <?php if ($isFirst): ?>
-                        <td style="<?= /* @escapeNotVerified */ $block->getTotal()->getStyle() ?>" class="admin__total-amount" rowspan="<?= count($rates) ?>">
-                            <?= /* @escapeNotVerified */ $block->formatPrice($amount) ?>
-                        </td>
-                    <?php endif; ?>
+                    <td style="<?= /* @escapeNotVerified */ $block->getTotal()->getStyle() ?>" class="admin__total-amount">
+                        <?= /* @escapeNotVerified */ $block->formatPrice(($amount*(float)$rate['percent'])/$percent) ?>
+                    </td>
                 </tr>
-                <?php $isFirst = 0; ?>
                 <?php $isTop = 0; ?>
                 <?php endforeach; ?>
         <?php endforeach; ?>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22233
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
### Preconditions:
1. Magento 2.3.x
2. Mangento 2.2.x
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The full tax summary is displaying total tax, instead of showing individual tax value.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Steps to reproduce: 
1. Set Display Full Tax Summary to Yes From Store Configuration > Sales > Tax
2. Set up 2 tax rule to apply 2 taxes.
3. Create an order with 2 taxes from magento 2 admin.
4. Scroll Down to Total and Subtotal Check and expand TAX. Tax summary display tax total not display sepereate tax calulated amount.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Manual Testing 

### Expected result
Tax should have a different value calculated by tax percentage.

![expected](https://user-images.githubusercontent.com/44108490/55778771-6cad5e80-5ac1-11e9-89bb-9e725b3f1cb8.png)

### Actual Result
Tax have a totaled value instead of separate calculated Value.

![actual](https://user-images.githubusercontent.com/44108490/55778781-7040e580-5ac1-11e9-9e36-e1a624b9322e.png)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
