### PR TITLE
[Backport] Qty box visibility issue in wishlist when product is out of stock

### DIFF
--- a/app/code/Magento/Wishlist/view/frontend/templates/item/column/cart.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/column/cart.phtml
@@ -25,7 +25,7 @@ $allowedQty = $viewModel->setItem($item)->getMinMaxQty();
             <label class="label" for="qty[<?= $block->escapeHtmlAttr($item->getId()) ?>]"><span><?= $block->escapeHtml(__('Qty')) ?></span></label>
             <div class="control">
                 <input type="number" data-role="qty" id="qty[<?= $block->escapeHtmlAttr($item->getId()) ?>]" class="input-text qty" data-validate="{'required-number':true,'validate-greater-than-zero':true,'validate-item-quantity':{'minAllowed':<?= /* @noEscape */ $allowedQty['minAllowed'] ?>,'maxAllowed':<?= /* @noEscape */ $allowedQty['maxAllowed'] ?>}}"
-               name="qty[<?= $block->escapeHtmlAttr($item->getId()) ?>]" value="<?= /* @noEscape */ (int)($block->getAddToCartQty($item) * 1) ?>">
+               name="qty[<?= $block->escapeHtmlAttr($item->getId()) ?>]" value="<?= /* @noEscape */ (int)($block->getAddToCartQty($item) * 1) ?>" <?= $product->isSaleable() ? '' : 'disabled="disabled"' ?>>
             </div>
         </div>
     <?php endif; ?>

--- a/app/code/Magento/Wishlist/view/frontend/templates/item/column/comment.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/column/comment.phtml
@@ -17,6 +17,6 @@ $item = $block->getItem();
         <span><?= $block->escapeHtml(__('Comment')) ?></span>
     </label>
     <div class="control">
-        <textarea id="product-item-comment-<?= $block->escapeHtmlAttr($item->getWishlistItemId()) ?>" placeholder="<?= /* @noEscape */ $this->helper('Magento\Wishlist\Helper\Data')->defaultCommentString() ?>" name="description[<?= $block->escapeHtmlAttr($item->getWishlistItemId()) ?>]" title="<?= $block->escapeHtmlAttr(__('Comment')) ?>" class="product-item-comment"><?= ($block->escapeHtml($item->getDescription())) ?></textarea>
+        <textarea id="product-item-comment-<?= $block->escapeHtmlAttr($item->getWishlistItemId()) ?>" placeholder="<?= /* @noEscape */ $this->helper('Magento\Wishlist\Helper\Data')->defaultCommentString() ?>" name="description[<?= $block->escapeHtmlAttr($item->getWishlistItemId()) ?>]" title="<?= $block->escapeHtmlAttr(__('Comment')) ?>" class="product-item-comment" <?= $item->getProduct()->isSaleable() ? '' : 'disabled="disabled"' ?>><?= ($block->escapeHtml($item->getDescription())) ?></textarea>
     </div>
 </div>


### PR DESCRIPTION
### Original Pull Request 
https://github.com/magento/magento2/pull/22381
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Magento 2.3.x
Magento 2.2.x

Qty box should not be displayed in the wishlist if an added product is out of stock.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set out of stock product display as a front end from admin configuration by below steps
Stores >> Setting >> Configuration >> Catalog >> Inventory >> Display Out of Stock Products	 set Yes
2. Login as a customer in frontend
3. Add out of stock product into wishlist
4. Review the product in My Wish List section in frontend where qty box is displayed for out of stock product.
![Screenshot from 2019 04 17 11 50 01](https://user-images.githubusercontent.com/43400051/56265739-f7b4d700-6107-11e9-8b82-44bae54be820.png)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
