### PR TITLE
Fixed Magento is no refreshing the cart page if you delete a product from cart side block

### DIFF
--- a/app/code/Magento/Checkout/Test/Mftf/Test/NoErrorCartCheckoutForProductsDeletedFromMiniCartTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/NoErrorCartCheckoutForProductsDeletedFromMiniCartTest.xml
@@ -47,7 +47,8 @@
         <see selector="{{StoreFrontRemoveItemModalSection.message}}" userInput="Are you sure you would like to remove this item from the shopping cart?" stepKey="seeDeleteConfirmationMessage"/>
         <click selector="{{StoreFrontRemoveItemModalSection.ok}}" stepKey="confirmDelete"/>
         <waitForPageLoad stepKey="waitForDeleteToFinish"/>
-        <click selector="{{CheckoutCartProductSection.RemoveItem}}" stepKey="deleteProductFromCheckoutCart"/>
+        <dontSeeElement selector="{{CheckoutCartProductSection.RemoveItem}}" stepKey="dontSeeDeleteProductFromCheckoutCart"/>
+        <click selector="{{StorefrontMinicartSection.showCart}}" stepKey="clickCart"/>
         <waitForPageLoad stepKey="WaitForPageLoad3"/>
         <see userInput="You have no items in your shopping cart." stepKey="seeNoItemsInShoppingCart"/>
     </test>

--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -311,7 +311,7 @@ define([
                     if (response.success) {
                         callback.call(this, elem, response);
                         var currentURL = window.location.pathname;
-                        if (url.includes("/checkout/cart/")) {
+                        if (currentURL.includes("/checkout/cart/")) {
                             location.reload();
                         }
                     } else {

--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -312,7 +312,7 @@ define([
                         callback.call(this, elem, response);
                         currentURL = window.location.pathname;
                         if (currentURL.includes("/checkout/cart/")) {
-                            $("#shopping-cart-table").trigger('contentUpdated');
+                            location.reload();
                         }
                     } else {
                         msg = response['error_message'];

--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -310,6 +310,10 @@ define([
 
                     if (response.success) {
                         callback.call(this, elem, response);
+                        var currentURL = window.location.pathname;
+                        if (url.includes("/checkout/cart/")) {
+                            location.reload();
+                        }
                     } else {
                         msg = response['error_message'];
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -306,13 +306,13 @@ define([
                 }
             })
                 .done(function (response) {
-                    var msg;
+                    var msg, currentURL;
 
                     if (response.success) {
                         callback.call(this, elem, response);
-                        var currentURL = window.location.pathname;
+                        currentURL = window.location.pathname;
                         if (currentURL.includes("/checkout/cart/")) {
-                            location.reload();
+                            $("#shopping-cart-table").trigger('contentUpdated');
                         }
                     } else {
                         msg = response['error_message'];

--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -261,7 +261,7 @@ define([
                 $(document).trigger('ajax:removeFromCart', {
                     productIds: [productData['product_id']]
                 });
-                if (window.location.href === this.shoppingCartUrl) {
+                if (window.location.href.indexOf(this.shoppingCartUrl) === 0) {
                     window.location.reload();
                 }
             }

--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -262,7 +262,7 @@ define([
                     productIds: [productData['product_id']]
                 });
                 if (window.location.href === this.shoppingCartUrl) {
-                    location.reload();
+                    window.location.reload();
                 }
             }
         },

--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -261,6 +261,7 @@ define([
                 $(document).trigger('ajax:removeFromCart', {
                     productIds: [productData['product_id']]
                 });
+
                 if (window.location.href.indexOf(this.shoppingCartUrl) === 0) {
                     window.location.reload();
                 }

--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -261,6 +261,9 @@ define([
                 $(document).trigger('ajax:removeFromCart', {
                     productIds: [productData['product_id']]
                 });
+                if (window.location.href === this.shoppingCartUrl) {
+                    location.reload();
+                }
             }
         },
 
@@ -306,14 +309,10 @@ define([
                 }
             })
                 .done(function (response) {
-                    var msg, currentURL;
+                    var msg;
 
                     if (response.success) {
                         callback.call(this, elem, response);
-                        currentURL = window.location.pathname;
-                        if (currentURL.includes("/checkout/cart/")) {
-                            location.reload();
-                        }
                     } else {
                         msg = response['error_message'];
 


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed Magento is no refreshing the cart page if you delete a product from cart side block
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#11292: Magento is no refreshing the cart page if you delete a product from cart side block

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add a product to cart
2.  Go to cart page
3.  Delete the product from cart side block

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
