### PR TITLE
For Issue #22500: Change currentTime calculation to public method to make Observer clea…

### DIFF
--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -192,6 +192,15 @@ class ProcessCronQueueObserver implements ObserverInterface
     }
 
     /**
+     * return currentTime
+     * @return current timestamp
+    **/
+    public function getCurrentTime()
+    {
+        return $this->dateTime->gmtTimestamp() ;
+    }
+
+    /**
      * Process cron queue
      * Generate tasks schedule
      * Cleanup tasks schedule
@@ -205,7 +214,7 @@ class ProcessCronQueueObserver implements ObserverInterface
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
 
-        $currentTime = $this->dateTime->gmtTimestamp();
+        $currentTime = $this->getCurrentTime();
         $jobGroupsRoot = $this->_config->getJobs();
         // sort jobs groups to start from used in separated process
         uksort(
@@ -546,7 +555,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      */
     protected function saveSchedule($jobCode, $cronExpression, $timeInterval, $exists)
     {
-        $currentTime = $this->dateTime->gmtTimestamp();
+        $currentTime = $this->getCurrentTime();
         $timeAhead = $currentTime + $timeInterval;
         for ($time = $currentTime; $time < $timeAhead; $time += self::SECONDS_IN_MINUTE) {
             $scheduledAt = strftime('%Y-%m-%d %H:%M:00', $time);


### PR DESCRIPTION
…nly extendable.

 On branch 2.3-develop
 Your branch is up to date with 'origin/2.3-develop'.

 Changes to be committed:
	modified:   ProcessCronQueueObserver.php

<!--- Please provide a general summary of the Pull Request in the Title above -->
Make Cron/Observer/ProcessCronQueueObserver.php cleanly extendable for changing time, when job runs to some other (e.g. local timezone) time.

### Description (*)
Bay introducing public method for currentTime calculation, one can develop clean extension to run jobs at specific timezone instead 'UTC'. 
And in the process there is also more clean OOP way to specify local property ...

<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22500: Cron Observer currentTime calculation change to make it cleanly extendable

<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
On issue #22500 will put github link to example extension using  this pull request changes.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
