### PR TITLE
In edge cases product url rewrites got generated starting with a forw…

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlPathGenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ProductUrlPathGenerator.php
@@ -70,9 +70,15 @@ class ProductUrlPathGenerator
                 ? $this->prepareProductUrlKey($product)
                 : $this->prepareProductDefaultUrlKey($product);
         }
-        return $category === null
-            ? $path
-            : $this->categoryUrlPathGenerator->getUrlPath($category) . '/' . $path;
+
+        if ($category !== null) {
+            $categoryUrlPath = $this->categoryUrlPathGenerator->getUrlPath($category);
+            if ($categoryUrlPath !== '') {
+                return $categoryUrlPath . '/' . $path;
+            }
+        }
+
+        return $path;
     }
 
     /**

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/ProductUrlPathGeneratorTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/ProductUrlPathGeneratorTest.php
@@ -173,6 +173,22 @@ class ProductUrlPathGeneratorTest extends \PHPUnit\Framework\TestCase
     /**
      * @return void
      */
+    public function testGetUrlPathWithCategoryHavingAnEmptyUrlPath(): void
+    {
+        $this->product->expects($this->once())->method('getData')->with('url_path')
+            ->will($this->returnValue('product-path'));
+        $this->categoryUrlPathGenerator->expects($this->once())->method('getUrlPath')
+            ->will($this->returnValue(''));
+
+        $this->assertEquals(
+            'product-path',
+            $this->productUrlPathGenerator->getUrlPath($this->product, $this->category)
+        );
+    }
+
+    /**
+     * @return void
+     */
     public function testGetUrlPathWithSuffix(): void
     {
         $storeId = 1;


### PR DESCRIPTION
…ard slash. This edge case gets fixed here.

### Description (*)
Not sure if this will get accepted but bear with me here.

I found an instance of a Magento2 shop where certain product url rewrites got generated which started with a forward slash.
This was caused because a category the product was in, somehow return an empty string from its rewritten url path ([probably because its parent was a root category](https://github.com/magento/magento2/blob/d3fdecf0d0f89d6c38ddb8109e5542d1a7b483eb/app/code/Magento/CatalogUrlRewrite/Model/CategoryUrlPathGenerator.php#L73-L75)).
It is expected that url rewrites don't start with a forward slash.

I don't know how to reproduce this problem on a vanilla Magento installation though. This is just an extra check which gets added to avoid this issue. In our case it is most likely caused by some 3rd party plugin to regenerate url rewrites.

The unit test added demonstrates what is expected, without this fix the unit test would result in: `/product-path` instead of `product-path`.

### Fixed Issues (if relevant)
None I could find.

### Manual testing scenarios (*)
1. Manage to get the CategoryUrlPathGenerator->getUrlPath to return an empty string somehow.
2. Generate a url rewrite for one or multiple products in such a category somehow.
3. Expected url rewrite is `product-url-key.html`, but actual result was `/product-url-key.html`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
