### PR TITLE
[Backport] Fixed magento text swatch switches product image even if attribute feature is disabled

### DIFF
--- a/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
+++ b/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
@@ -179,6 +179,9 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
                     $attributeDataArray
                 );
             }
+            if (isset($attributeDataArray['additional_data'])) {
+                $config[$attributeId]['additional_data'] = $attributeDataArray['additional_data'];
+            }
         }
 
         return $this->jsonEncoder->encode($config);

--- a/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
+++ b/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
@@ -462,6 +462,7 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
 
     /**
      * @return string
+     * @SuppressWarnings(PHPMD.RequestAwareBlockMethod)
      */
     public function getMediaCallback()
     {

--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -785,7 +785,11 @@ define([
                     $widget.options.jsonConfig.optionPrices
                 ]);
 
-            $widget._loadMedia(eventName);
+            var checkAdditionalData = JSON.parse(this.options.jsonSwatchConfig[attributeId]['additional_data']);
+
+             if (1 == checkAdditionalData['update_product_preview_image']) {
+                $widget._loadMedia(eventName);
+            }
             $input.trigger('change');
         },
 

--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -745,7 +745,8 @@ define([
                 $wrapper = $this.parents('.' + $widget.options.classes.attributeOptionsWrapper),
                 $label = $parent.find('.' + $widget.options.classes.attributeSelectedOptionLabelClass),
                 attributeId = $parent.attr('attribute-id'),
-                $input = $parent.find('.' + $widget.options.classes.attributeInput);
+                $input = $parent.find('.' + $widget.options.classes.attributeInput),
+                checkAdditionalData = JSON.parse(this.options.jsonSwatchConfig[attributeId]['additional_data']);
 
             if ($widget.inProductList) {
                 $input = $widget.productForm.find(
@@ -785,9 +786,7 @@ define([
                     $widget.options.jsonConfig.optionPrices
                 ]);
 
-            var checkAdditionalData = JSON.parse(this.options.jsonSwatchConfig[attributeId]['additional_data']);
-
-             if (1 == checkAdditionalData['update_product_preview_image']) {
+            if (checkAdditionalData['update_product_preview_image'] === '1') {
                 $widget._loadMedia(eventName);
             }
             $input.trigger('change');


### PR DESCRIPTION

### Original Pull Request 
https://github.com/magento/magento2/pull/19184
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed magento text swatch switches product image even if attribute feature is disabled #16446
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#16446: Fixed magento text swatch switches product image even if attribute feature is disabled 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
N/A
### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
