### PR TITLE
Fixed #22396 config:set fails with JSON values

### DIFF
--- a/app/code/Magento/CatalogInventory/Helper/Minsaleqty.php
+++ b/app/code/Magento/CatalogInventory/Helper/Minsaleqty.php
@@ -95,7 +95,7 @@ class Minsaleqty
             }
             return $this->serializer->serialize($data);
         } else {
-            return '';
+            return $value;
         }
     }
 

--- a/app/code/Magento/CatalogInventory/Test/Unit/Helper/MinsaleqtyTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Helper/MinsaleqtyTest.php
@@ -216,7 +216,7 @@ class MinsaleqtyTest extends \PHPUnit\Framework\TestCase
     public function makeStorableArrayFieldValueDataProvider()
     {
         return [
-            'invalid bool' => [false, ''],
+            'invalid bool' => [false, false],
             'invalid empty string' => ['', ''],
             'valid numeric' => ['22', '22'],
             'valid empty array' => [[], '[]', 1],
@@ -240,7 +240,8 @@ class MinsaleqtyTest extends \PHPUnit\Framework\TestCase
                 '[1]',
                 1,
                 [0 => 1.0]
-            ]
+            ],
+            'json value' => ['{"32000":2,"0":1}', '{"32000":2,"0":1}'],
         ];
     }
 }


### PR DESCRIPTION
Fixed #22396 config:set fails with JSON values

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. 2.3.1

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Try to set a config value for a config option that uses JSON values via the command line cli
2. i.e.: php bin/magento config:sataloginventory/item_options/min_sale_qty "{"32000":2,"0":2}"


### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. Config is set to provided value


### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Config is set to empty value.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
