### PR TITLE
[Backport] Fixed #22223 Missing/Wrong data display on downloadable report table …

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Product/Downloads/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Product/Downloads/Collection.php
@@ -97,4 +97,15 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
         }
         return $this;
     }
+    
+    /**
+     * Get SQL for get record count without left JOINs and group 
+     *
+     * @return \Magento\Framework\DB\Select
+     */
+    public function getSelectCountSql() {
+        $countSelect = parent::getSelectCountSql();
+        $countSelect->reset(\Zend\Db\Sql\Select::GROUP);
+        return $countSelect;
+    }
 }

--- a/app/code/Magento/Reports/Model/ResourceModel/Product/Downloads/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Product/Downloads/Collection.php
@@ -4,16 +4,16 @@
  * See COPYING.txt for license details.
  */
 
+namespace Magento\Reports\Model\ResourceModel\Product\Downloads;
+
 /**
  * Product Downloads Report collection
  *
  * @author      Magento Core Team <core@magentocommerce.com>
- */
-namespace Magento\Reports\Model\ResourceModel\Product\Downloads;
-
-/**
+ *
  * @api
  * @since 100.0.2
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  */
 class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
 {
@@ -97,13 +97,11 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
         }
         return $this;
     }
-    
+
     /**
-     * Get SQL for get record count without left JOINs and group 
-     *
-     * @return \Magento\Framework\DB\Select
+     * @inheritDoc
      */
-    public function getSelectCountSql() 
+    public function getSelectCountSql()
     {
         $countSelect = parent::getSelectCountSql();
         $countSelect->reset(\Zend\Db\Sql\Select::GROUP);

--- a/app/code/Magento/Reports/Model/ResourceModel/Product/Downloads/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Product/Downloads/Collection.php
@@ -103,7 +103,8 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
      *
      * @return \Magento\Framework\DB\Select
      */
-    public function getSelectCountSql() {
+    public function getSelectCountSql() 
+    {
         $countSelect = parent::getSelectCountSql();
         $countSelect->reset(\Zend\Db\Sql\Select::GROUP);
         return $countSelect;


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22291
Fixed #22223 Missing/Wrong data display on downloadable report table reports > downloads in BO

<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. At least Magento 2.1.11 to 2.3.1  are concerned

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1.Create 22 downloadable products
2.Order the 22 downloadable products
3. Complete the order in BO
3.Visit the downloadable links to download bought products (from frontend customer account)
4 Go go downloads reports table in the backoffice at *reports>downloads*

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. Should've found 22 records / products with their download count as well as a pagination  
2. 
![good_report_pagination_ok](https://user-images.githubusercontent.com/3765910/55741933-c44eba00-5a2e-11e9-8e2f-9530296861df.png)


### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Only 1 records found also the table only show the first 20 products with no pagination
2.
![only_first_20_product](https://user-images.githubusercontent.com/3765910/55742033-fbbd6680-5a2e-11e9-889b-8b19d0d339c1.png)



### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
