### PR TITLE
[Backport] PUT /V1/products/:sku/media/:entryId does not change the file

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Gallery/GalleryManagement.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/GalleryManagement.php
@@ -68,8 +68,10 @@ class GalleryManagement implements \Magento\Catalog\Api\ProductAttributeMediaGal
         $product->setMediaGalleryEntries($existingMediaGalleryEntries);
         try {
             $product = $this->productRepository->save($product);
+            // phpcs:ignore Magento2.Exceptions.ThrowCatch
         } catch (InputException $inputException) {
             throw $inputException;
+            // phpcs:ignore Magento2.Exceptions.ThrowCatch
         } catch (\Exception $e) {
             throw new StateException(__('Cannot save product.'));
         }
@@ -100,7 +102,10 @@ class GalleryManagement implements \Magento\Catalog\Api\ProductAttributeMediaGal
 
             if ($existingEntry->getId() == $entry->getId()) {
                 $found = true;
-                if ($entry->getFile()) {
+
+                $file = $entry->getContent();
+
+                if ($file && $file->getBase64EncodedData() || $entry->getFile()) {
                     $entry->setId(null);
                 }
                 $existingMediaGalleryEntries[$key] = $entry;


### PR DESCRIPTION
### Original Pull Request 
https://github.com/magento/magento2/pull/22424
### Description (*)
When update product image via Api image not replaced because $entry->getFile() return null.

### Fixed Issues (if relevant)

1. magento/magento2#22402: Issue title

### Manual testing scenarios (*)
1. Send the following PUT request to "/V1/products/24-WG080/media/52"
base64_encoded_data is empty as this would bloat the issue-text

`{"entry":{"media_type":"image","label":"Label for my Image":1,"disabled":false,"types":["image","small_image","thumbnail"],"content":{"base64_encoded_data":"...","type":"image/jpeg","name":"luma-yoga-kit-2"},"id":52}}`

1. Everything provided by the request is updated for the media entity
2. The actual file-content is replaced with what is provided in the base64_encoded_data
3. The endpoint returns true

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
