### PR TITLE
[Backport] Fix configurable dropdown showing tax incorrectly in 2.3-develop

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
@@ -373,7 +373,7 @@ define([
                 allowedProducts,
                 i,
                 j,
-                basePrice = parseFloat(this.options.spConfig.prices.basePrice.amount),
+                finalPrice = parseFloat(this.options.spConfig.prices.finalPrice.amount),
                 optionFinalPrice,
                 optionPriceDiff,
                 optionPrices = this.options.spConfig.optionPrices,
@@ -410,7 +410,7 @@ define([
                             typeof optionPrices[allowedProducts[0]] !== 'undefined') {
                             allowedProductMinPrice = this._getAllowedProductWithMinPrice(allowedProducts);
                             optionFinalPrice = parseFloat(optionPrices[allowedProductMinPrice].finalPrice.amount);
-                            optionPriceDiff = optionFinalPrice - basePrice;
+                            optionPriceDiff = optionFinalPrice - finalPrice;
 
                             if (optionPriceDiff !== 0) {
                                 options[i].label = options[i].label + ' ' + priceUtils.formatPrice(


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22466
### Description (*)

This pull request addresses an issue described in #22270 and introduced in #17695.

The issue is that the price increase calculation was previously based upon the configurable basePrice vs the optionFinalPrice rather than the configurable finalPrice vs the optionFinalPrice. This meant that the tax amount was also been added to the price difference calculation for each of the configurable options incorrectly.

### Fixed Issues (if relevant)

1. magento/magento2#22270: 2.2.8 Configurable product option dropdown - price difference incorrect when catalog prices are entered excluding tax

### Manual testing scenarios (*)all Magento 2.

2. Set prices to be entered excluding tax in the configuration.
3. Apply product tax using tax rules.
4. Create a configurable product configurable by only one dropdown attribute (e.g colour or size)
5. Ensure that the product tax is not added for a second time in the dropdown attribute

### Contribution checklist (*)

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
