### PR TITLE
[Backport] [Fixed] Checkout Section: Shipping step is getting skipped when customer hitting direct payment step URL

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/payment.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/payment.js
@@ -66,7 +66,7 @@ define([
         navigate: function () {
             var self = this;
 
-            if(!self.hasShippingMethod()) {
+            if (!self.hasShippingMethod()) {
                 this.isVisible(false);
                 stepNavigator.setHash('shipping');
             } else {

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/payment.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/payment.js
@@ -66,9 +66,21 @@ define([
         navigate: function () {
             var self = this;
 
-            getPaymentInformation().done(function () {
-                self.isVisible(true);
-            });
+            if(!self.hasShippingMethod()) {
+                this.isVisible(false);
+                stepNavigator.setHash('shipping');
+            } else {
+                getPaymentInformation().done(function () {
+                    self.isVisible(true);
+                });
+            }
+        },
+
+        /**
+         * @return {Boolean}
+         */
+        hasShippingMethod: function () {
+            return window.checkoutConfig.selectedShippingMethod !== null;
         },
 
         /**


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22405
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Checkout Section: Shipping step is getting skipped when customer hitting direct payment step URL

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21596: Checkout Section: Shipping step is getting skipped when customer hitting direct payment step URL

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Product Add To Cart and go to checkout page
2. hit payment url without adding shipping address

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
