### PR TITLE
[Backport] Fix #12802 - allow to override preference over CartInterface and return correct object from QuoteRepository

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteRepository.php
+++ b/app/code/Magento/Quote/Model/QuoteRepository.php
@@ -5,25 +5,28 @@
  */
 namespace Magento\Quote\Model;
 
-use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
-use Magento\Framework\App\ObjectManager;
-use Magento\Framework\Api\SortOrder;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Quote\Api\Data\CartInterface;
-use Magento\Quote\Model\Quote;
-use Magento\Store\Model\StoreManagerInterface;
-use Magento\Framework\Api\Search\FilterGroup;
-use Magento\Quote\Model\ResourceModel\Quote\Collection as QuoteCollection;
-use Magento\Quote\Model\ResourceModel\Quote\CollectionFactory as QuoteCollectionFactory;
-use Magento\Framework\Exception\InputException;
 use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
+use Magento\Framework\Api\Search\FilterGroup;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessor;
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Api\Data\CartInterfaceFactory;
+use Magento\Quote\Api\Data\CartSearchResultsInterfaceFactory;
 use Magento\Quote\Model\QuoteRepository\SaveHandler;
 use Magento\Quote\Model\QuoteRepository\LoadHandler;
+use Magento\Quote\Model\ResourceModel\Quote\Collection as QuoteCollection;
+use Magento\Quote\Model\ResourceModel\Quote\CollectionFactory as QuoteCollectionFactory;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class QuoteRepository implements \Magento\Quote\Api\CartRepositoryInterface
+class QuoteRepository implements CartRepositoryInterface
 {
     /**
      * @var Quote[]
@@ -37,6 +40,7 @@ class QuoteRepository implements \Magento\Quote\Api\CartRepositoryInterface
 
     /**
      * @var QuoteFactory
+     * @deprecated
      */
     protected $quoteFactory;
 
@@ -46,13 +50,13 @@ class QuoteRepository implements \Magento\Quote\Api\CartRepositoryInterface
     protected $storeManager;
 
     /**
-     * @var \Magento\Quote\Model\ResourceModel\Quote\Collection
+     * @var QuoteCollection
      * @deprecated 100.2.0
      */
     protected $quoteCollection;
 
     /**
-     * @var \Magento\Quote\Api\Data\CartSearchResultsInterfaceFactory
+     * @var CartSearchResultsInterfaceFactory
      */
     protected $searchResultsDataFactory;
 
@@ -77,39 +81,47 @@ class QuoteRepository implements \Magento\Quote\Api\CartRepositoryInterface
     private $collectionProcessor;
 
     /**
-     * @var \Magento\Quote\Model\ResourceModel\Quote\CollectionFactory
+     * @var QuoteCollectionFactory
      */
     private $quoteCollectionFactory;
+
+    /**
+     * @var CartInterfaceFactory
+     */
+    private $cartFactory;
 
     /**
      * Constructor
      *
      * @param QuoteFactory $quoteFactory
      * @param StoreManagerInterface $storeManager
-     * @param \Magento\Quote\Model\ResourceModel\Quote\Collection $quoteCollection
-     * @param \Magento\Quote\Api\Data\CartSearchResultsInterfaceFactory $searchResultsDataFactory
+     * @param QuoteCollection $quoteCollection
+     * @param CartSearchResultsInterfaceFactory $searchResultsDataFactory
      * @param JoinProcessorInterface $extensionAttributesJoinProcessor
      * @param CollectionProcessorInterface|null $collectionProcessor
-     * @param \Magento\Quote\Model\ResourceModel\Quote\CollectionFactory|null $quoteCollectionFactory
+     * @param QuoteCollectionFactory|null $quoteCollectionFactory
+     * @param CartInterfaceFactory|null $cartFactory
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
         QuoteFactory $quoteFactory,
         StoreManagerInterface $storeManager,
-        \Magento\Quote\Model\ResourceModel\Quote\Collection $quoteCollection,
-        \Magento\Quote\Api\Data\CartSearchResultsInterfaceFactory $searchResultsDataFactory,
+        QuoteCollection $quoteCollection,
+        CartSearchResultsInterfaceFactory $searchResultsDataFactory,
         JoinProcessorInterface $extensionAttributesJoinProcessor,
         CollectionProcessorInterface $collectionProcessor = null,
-        \Magento\Quote\Model\ResourceModel\Quote\CollectionFactory $quoteCollectionFactory = null
+        QuoteCollectionFactory $quoteCollectionFactory = null,
+        CartInterfaceFactory $cartFactory = null
     ) {
         $this->quoteFactory = $quoteFactory;
         $this->storeManager = $storeManager;
         $this->searchResultsDataFactory = $searchResultsDataFactory;
         $this->extensionAttributesJoinProcessor = $extensionAttributesJoinProcessor;
-        $this->collectionProcessor = $collectionProcessor ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Api\SearchCriteria\CollectionProcessor::class);
-        $this->quoteCollectionFactory = $quoteCollectionFactory ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Quote\Model\ResourceModel\Quote\CollectionFactory::class);
+        $this->collectionProcessor = $collectionProcessor ?: ObjectManager::getInstance()
+            ->get(CollectionProcessor::class);
+        $this->quoteCollectionFactory = $quoteCollectionFactory ?: ObjectManager::getInstance()
+            ->get(QuoteCollectionFactory::class);
+        $this->cartFactory = $cartFactory ?: ObjectManager::getInstance()->get(CartInterfaceFactory::class);
     }
 
     /**
@@ -166,7 +178,7 @@ class QuoteRepository implements \Magento\Quote\Api\CartRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function save(\Magento\Quote\Api\Data\CartInterface $quote)
+    public function save(CartInterface $quote)
     {
         if ($quote->getId()) {
             $currentQuote = $this->get($quote->getId(), [$quote->getStoreId()]);
@@ -186,7 +198,7 @@ class QuoteRepository implements \Magento\Quote\Api\CartRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function delete(\Magento\Quote\Api\Data\CartInterface $quote)
+    public function delete(CartInterface $quote)
     {
         $quoteId = $quote->getId();
         $customerId = $quote->getCustomerId();
@@ -203,13 +215,13 @@ class QuoteRepository implements \Magento\Quote\Api\CartRepositoryInterface
      * @param int $identifier
      * @param int[] $sharedStoreIds
      * @throws NoSuchEntityException
-     * @return Quote
+     * @return CartInterface
      */
     protected function loadQuote($loadMethod, $loadField, $identifier, array $sharedStoreIds = [])
     {
-        /** @var Quote $quote */
-        $quote = $this->quoteFactory->create();
-        if ($sharedStoreIds) {
+        /** @var CartInterface $quote */
+        $quote = $this->cartFactory->create();
+        if ($sharedStoreIds && method_exists($quote, 'setSharedStoreIds')) {
             $quote->setSharedStoreIds($sharedStoreIds);
         }
         $quote->setStoreId($this->storeManager->getStore()->getId())->$loadMethod($identifier);
@@ -222,7 +234,7 @@ class QuoteRepository implements \Magento\Quote\Api\CartRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria)
+    public function getList(SearchCriteriaInterface $searchCriteria)
     {
         $this->quoteCollection = $this->quoteCollectionFactory->create();
         /** @var \Magento\Quote\Api\Data\CartSearchResultsInterface $searchData */

--- a/app/code/Magento/Quote/Model/QuoteRepository.php
+++ b/app/code/Magento/Quote/Model/QuoteRepository.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Quote\Model;
 
 use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
@@ -24,6 +25,8 @@ use Magento\Quote\Model\ResourceModel\Quote\CollectionFactory as QuoteCollection
 use Magento\Store\Model\StoreManagerInterface;
 
 /**
+ * Quote repository.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class QuoteRepository implements CartRepositoryInterface
@@ -125,7 +128,7 @@ class QuoteRepository implements CartRepositoryInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function get($cartId, array $sharedStoreIds = [])
     {
@@ -138,7 +141,7 @@ class QuoteRepository implements CartRepositoryInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getForCustomer($customerId, array $sharedStoreIds = [])
     {
@@ -152,7 +155,7 @@ class QuoteRepository implements CartRepositoryInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getActive($cartId, array $sharedStoreIds = [])
     {
@@ -164,7 +167,7 @@ class QuoteRepository implements CartRepositoryInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getActiveForCustomer($customerId, array $sharedStoreIds = [])
     {
@@ -176,7 +179,7 @@ class QuoteRepository implements CartRepositoryInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function save(CartInterface $quote)
     {
@@ -196,7 +199,7 @@ class QuoteRepository implements CartRepositoryInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function delete(CartInterface $quote)
     {
@@ -232,7 +235,7 @@ class QuoteRepository implements CartRepositoryInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getList(SearchCriteriaInterface $searchCriteria)
     {
@@ -277,6 +280,7 @@ class QuoteRepository implements CartRepositoryInterface
 
     /**
      * Get new SaveHandler dependency for application code.
+     *
      * @return SaveHandler
      * @deprecated 100.1.0
      */
@@ -289,6 +293,8 @@ class QuoteRepository implements CartRepositoryInterface
     }
 
     /**
+     * Get load handler instance.
+     *
      * @return LoadHandler
      * @deprecated 100.1.0
      */


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22149

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This is fix for #12802 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#12802: QuoteRepository get methods won't return CartInterface but Quote model

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Steps are described in #12802 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
