### PR TITLE
Fix MySQL syntax error on indexation with certain attribute codes

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
@@ -365,7 +365,7 @@ class FlatTableBuilder
                         []
                     )->columns(
                         [$columnName => $this->_connection->getIfNullSql('ts.value', 't0.value')]
-                    )->where($attributeCode . ' IS NOT NULL');
+                    )->where($columnName . ' IS NOT NULL');
                     if (!empty($changedIds)) {
                         $select->where($this->_connection->quoteInto('et.entity_id IN (?)', $changedIds));
                     }

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
@@ -355,6 +355,7 @@ class FlatTableBuilder
                 //Update not simple attributes (eg. dropdown)
                 $columnName = $attributeCode . $valueFieldSuffix;
                 if (isset($flatColumns[$columnName])) {
+                    $columnValue = $this->_connection->getIfNullSql('ts.value', 't0.value');
                     $select = $this->_connection->select();
                     $select->joinLeft(
                         ['t0' => $this->_productIndexerHelper->getTable('eav_attribute_option_value')],
@@ -365,8 +366,8 @@ class FlatTableBuilder
                         'ts.option_id = et.' . $attributeCode . ' AND ts.store_id = ' . $storeId,
                         []
                     )->columns(
-                        [$columnName => $this->_connection->getIfNullSql('ts.value', 't0.value')]
-                    )->where($columnName . ' IS NOT NULL');
+                        [$columnName => $columnValue]
+                    )->where($columnValue . ' IS NOT NULL');
                     if (!empty($changedIds)) {
                         $select->where($this->_connection->quoteInto('et.entity_id IN (?)', $changedIds));
                     }

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
@@ -11,6 +11,7 @@ use Magento\Framework\EntityManager\MetadataPool;
 
 /**
  * Class FlatTableBuilder
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class FlatTableBuilder
@@ -389,7 +390,7 @@ class FlatTableBuilder
     }
 
     /**
-     * Get MetadataPool
+     * Get metadata pool
      *
      * @return \Magento\Framework\EntityManager\MetadataPool
      */


### PR DESCRIPTION
### Description
Fixes an issue where the category flat indexer would throw an MySQL syntax error if an attribute_code was equal to a MySQL function.

If you have a attribute with a code called "group" the following would occur when the catalog flat data indexer tries to run:
```SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'group IS NOT NULL)' at line 5, query was: UPDATE `catalog_product_flat_1_tmp_indexer` AS `et`
 LEFT JOIN `eav_attribute_option_value` AS `t0` ON t0.option_id = et.group AND t0.store_id = 0
 LEFT JOIN `eav_attribute_option_value` AS `ts` ON ts.option_id = et.group AND ts.store_id = 1
SET `et`.`group_value` = IFNULL(ts.value, t0.value)
WHERE (group IS NOT NULL)```

### Manual testing scenarios
Before patch:
1. Create attribute with attribute code group.
2. Add attribute to attribute set of products.
3. Run Catalog Flat Data indexer. `php bin/magento indexer:reindex catalog_category_flat`
4. See the error appear.

After patch:
1. Create attribute with attribute code group.
2. Add attribute to attribute set of products.
3. Run Catalog Flat Data indexer. `php bin/magento indexer:reindex catalog_category_flat`
4. Everything should have been successfully rebuilt.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
