### PR TITLE
Fix undefined methods 'addClass' and `removeClass` on a PrototypeJS Element

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
@@ -45,11 +45,11 @@ function checkOptionsPanelVisibility(){
 
         if($('frontend_input') && ($('frontend_input').value=='select' || $('frontend_input').value=='multiselect')){
             panel.show();
-            panel.addClass(activePanelClass);
+            jQuery(panel).addClass(activePanelClass);
         }
         else {
             panel.hide();
-            panel.removeClass(activePanelClass);
+            jQuery(panel).removeClass(activePanelClass);
         }
     }
 }


### PR DESCRIPTION
### Description
This problem was caused by 5a283e3ff9 and reported in #20843. The mentioned commit adds two lines in `js.phtml` with non existing methods: `panel.addClass(activePanelClass);` and `panel.removeClass(activePanelClass);`. Both methods do not exist in PrototypeJS and should have been `addClassName()` and `removeClassName()` respectively.

The incorrect method names cause a Javascript error 'Uncaught TypeError: panel.addClass is not a function' in the console and prevents the Edit Attribute form from saving.

Enabling the Swatches module, as mentioned in the issue, only solves the issue because it replaces the phtml file with its own file.

### Fixed Issues (if relevant)
1. magento/magento2#20843: Uncaught TypeError: panel.addClass is not a function when Swatches are disabled

### Manual testing scenarios
1. Disable Swatches modules (otherwise, the mentioned phtml file will not be used)
2. In admin, go to Stores > Attributes > Product
3. Click any attribute
4. Try to save the attribute
5. Nothing happens without the code change, but the attribute saves fine with the code change

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
