### PR TITLE
magento/magento2#22568: Add an extension point to RateRequest in Magento\Quote\Model\Quote\Address::requestShippingRates

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -1021,6 +1021,8 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress implements
         $baseSubtotalInclTax = $this->getBaseSubtotalTotalInclTax();
         $request->setBaseSubtotalInclTax($baseSubtotalInclTax);
 
+        $this->_eventManager->dispatch($this->_eventPrefix . '_collect_rates_before', ['request' => $request]);
+
         $result = $this->_rateCollector->create()->collectRates($request)->getResult();
 
         $found = false;


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

PR fixes a problem described in issue https://github.com/magento/magento2/issues/22568.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22568: Add an extension point to RateRequest in requestShippingRates


Thank you!
