### PR TITLE
Fix for update products via csv file (fix for 22028)

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/Query/BaseFinalPrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/Query/BaseFinalPrice.php
@@ -221,11 +221,8 @@ class BaseFinalPrice
         $select->where("e.type_id = ?", $productType);
 
         if ($entityIds !== null) {
-            if (count($entityIds) > 1) {
-                $select->where(sprintf('e.entity_id BETWEEN %s AND %s', min($entityIds), max($entityIds)));
-            } else {
-                $select->where('e.entity_id = ?', $entityIds);
-            }
+            $select->where(sprintf('e.entity_id BETWEEN %s AND %s', min($entityIds), max($entityIds)));
+            $select->where('e.entity_id IN(?)', $entityIds);
         }
 
         /**


### PR DESCRIPTION
### Description (*)
It is fix for issue #22028

In query for selecting ids to indexing after import products, I changed "between" into "in",
Before change, when products were updated via csv file import in Admin panel, to indexing process were selected all products from range between the smallest and the biggest products id from csv file. When the ids were from wide range, it caused selecting a huge amount of data and attempt to inserting them to catalog_product_index_price_temp. If data amount was to big, it caused error
After change, for indexing process are selected only products from csv file.

Example:
Before change, when we try to update two products with id 30 and 31, only two products were selected to indexing. 
When products have ids 30 and 50, it caused, that 21 products were selected to indexing (All products with ids between 30 and 50.

After change, in both cases described above, only two products will be selected to indexing.

### Fixed Issues (if relevant)
No related issues found.

### Manual testing scenarios (*)
The same scenario can be applied to reproduce bug and check fix:
1. Prepare csv file to update products (2 products or more). (This csv should contain products with the lowest and the highest id - 1 and 6000)
2. In Admin panel go to: System->Import and choose Product and Add/Update
3. Upload file
4. Check Data
5. Import csv file (error should be displayed now)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)