### PR TITLE
[Backport] Non existing file, when adding image to gallery with move option. Fix for #21978

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Gallery/Processor.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/Processor.php
@@ -191,7 +191,7 @@ class Processor
         $mediaGalleryData = $product->getData($attrCode);
         $position = 0;
 
-        $absoluteFilePath = $this->mediaDirectory->getAbsolutePath($file);
+        $absoluteFilePath = $this->mediaDirectory->getAbsolutePath($destinationFile);
         $imageMimeType = $this->mime->getMimeType($absoluteFilePath);
         $imageContent = $this->mediaDirectory->readFile($absoluteFilePath);
         $imageBase64 = base64_encode($imageContent);

--- a/app/code/Magento/Catalog/Model/Product/Gallery/Processor.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/Processor.php
@@ -489,7 +489,7 @@ class Processor
     /**
      * Retrieve data for update attribute
      *
-     * @param  \Magento\Catalog\Model\Product $object
+     * @param \Magento\Catalog\Model\Product $object
      * @return array
      * @since 101.0.0
      */


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22020
### Description (*)
1. Fix for throwing error "File not exist" when adding image to product via `addImageToMediaGallery` method with `$move`.

### Fixed Issues (if relevant)
1. magento/magento2#21978: Adding product image: File doesn't exist #21978

### Manual testing scenarios (*)
1. Add image via above method programatically.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
