### PR TITLE
[Backport] #21747 Fix catalog_product_flat_data attribute value for store during indexer

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilder.php
@@ -289,9 +289,12 @@ class TableBuilder
 
                 /** @var $attribute \Magento\Catalog\Model\ResourceModel\Eav\Attribute */
                 foreach ($columnsList as $columnName => $attribute) {
-                    $countTableName = 't' . $iterationNum++;
+                    $countTableName = 't' . ($iterationNum++);
                     $joinCondition = sprintf(
-                        'e.%3$s = %1$s.%3$s AND %1$s.attribute_id = %2$d AND (%1$s.store_id = %4$d OR %1$s.store_id = 0)',
+                        'e.%3$s = %1$s.%3$s' .
+                        ' AND %1$s.attribute_id = %2$d' .
+                        ' AND (%1$s.store_id = %4$d' .
+                        ' OR %1$s.store_id = 0)',
                         $countTableName,
                         $attribute->getId(),
                         $metadata->getLinkField(),

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilder.php
@@ -291,10 +291,11 @@ class TableBuilder
                 foreach ($columnsList as $columnName => $attribute) {
                     $countTableName = 't' . $iterationNum++;
                     $joinCondition = sprintf(
-                        'e.%3$s = %1$s.%3$s AND %1$s.attribute_id = %2$d AND %1$s.store_id = 0',
+                        'e.%3$s = %1$s.%3$s AND %1$s.attribute_id = %2$d AND (%1$s.store_id = %4$d OR %1$s.store_id = 0)',
                         $countTableName,
                         $attribute->getId(),
-                        $metadata->getLinkField()
+                        $metadata->getLinkField(),
+                        $storeId
                     );
 
                     $select->joinLeft(
@@ -308,9 +309,10 @@ class TableBuilder
                         $columnValueName = $attributeCode . $valueFieldSuffix;
                         if (isset($flatColumns[$columnValueName])) {
                             $valueJoinCondition = sprintf(
-                                'e.%1$s = %2$s.option_id AND %2$s.store_id = 0',
+                                'e.%1$s = %2$s.option_id AND (%2$s.store_id = %3$d OR %2$s.store_id = 0)',
                                 $attributeCode,
-                                $countTableName
+                                $countTableName,
+                                $storeId
                             );
                             $selectValue->joinLeft(
                                 [


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22318
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
Fix catalog_product_flat store tables values
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fix bin/magento indexer:reindex of catalog_product_flat for specified empty attribute value of exact store

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21747: catalog_product_flat_data for store view populated with default view data when it should be store view data 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create custom attribute with scope "Store" or "Website", add it to attribute set. 
2. Create a product and assign this attribute to Default scope.
3. Enable "Use Flat Catalog Product" settings.
4. Change scope to store-view of website and assign empty value, save product.
5. In database table catalog_product_flat_1 product has properly attribute value.
6. Run bin/magento indexer:reindex catalog_product_flat. In table catalog_product_flat_1 value or new attribute is set to default scope.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
