### PR TITLE
Fix Exception While Creating an Order in the Admin

### DIFF
--- a/app/code/Magento/SalesRule/Model/Quote/Address/Total/ShippingDiscount.php
+++ b/app/code/Magento/SalesRule/Model/Quote/Address/Total/ShippingDiscount.php
@@ -89,7 +89,7 @@ class ShippingDiscount extends \Magento\Quote\Model\Quote\Address\Total\Abstract
         $amount = $total->getDiscountAmount();
 
         if ($amount != 0) {
-            $description = $total->getDiscountDescription() ?: '';
+            $description = (string)$total->getDiscountDescription() ?: '';
             $result = [
                 'code' => DiscountCollector::COLLECTOR_TYPE_CODE,
                 'title' => strlen($description) ? __('Discount (%1)', $description) : __('Discount'),


### PR DESCRIPTION
Changes:
- $total->getDiscountDescription() returns a Phrase, but strlen expects a string
- $total->getDiscountDescription()->getText() will return a string