### PR TITLE
[Backport] Fix layout xml and page layout caching issue on redis cluster under high load

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/View/Layout/MergeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Layout/MergeTest.php
@@ -41,6 +41,11 @@ class MergeTest extends \PHPUnit\Framework\TestCase
     protected $_cache;
 
     /**
+     * @var \Magento\Framework\Serialize\SerializerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $_serializer;
+
+    /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
     protected $_theme;
@@ -94,6 +99,8 @@ class MergeTest extends \PHPUnit\Framework\TestCase
 
         $this->_cache = $this->getMockForAbstractClass(\Magento\Framework\Cache\FrontendInterface::class);
 
+        $this->_serializer = $this->getMockForAbstractClass(\Magento\Framework\Serialize\SerializerInterface::class);
+
         $this->_theme = $this->createMock(\Magento\Theme\Model\Theme::class);
         $this->_theme->expects($this->any())->method('isPhysical')->will($this->returnValue(true));
         $this->_theme->expects($this->any())->method('getArea')->will($this->returnValue('area'));
@@ -129,6 +136,7 @@ class MergeTest extends \PHPUnit\Framework\TestCase
                 'resource' => $this->_resource,
                 'appState' => $this->_appState,
                 'cache' => $this->_cache,
+                'serializer' => $this->_serializer,
                 'theme' => $this->_theme,
                 'validator' => $this->_layoutValidator,
                 'logger' => $this->_logger,
@@ -264,9 +272,16 @@ class MergeTest extends \PHPUnit\Framework\TestCase
 
     public function testLoadCache()
     {
+        $cacheValue = [
+            "pageLayout" => "1column",
+            "layout"     => self::FIXTURE_LAYOUT_XML
+        ];
+
         $this->_cache->expects($this->at(0))->method('load')
-            ->with('LAYOUT_area_STORE20_100c6a4ccd050e33acef0553f24ef399961')
-            ->will($this->returnValue(self::FIXTURE_LAYOUT_XML));
+            ->with('LAYOUT_area_STORE20_100c6a4ccd050e33acef0553f24ef399961_page_layout_merged')
+            ->will($this->returnValue(json_encode($cacheValue)));
+
+        $this->_serializer->expects($this->once())->method('unserialize')->willReturn($cacheValue);
 
         $this->assertEmpty($this->_model->getHandles());
         $this->assertEmpty($this->_model->asString());
@@ -413,7 +428,8 @@ class MergeTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('Layout is invalid.'));
 
         $suffix = md5(implode('|', $this->_model->getHandles()));
-        $cacheId = "LAYOUT_{$this->_theme->getArea()}_STORE{$this->scope->getId()}_{$this->_theme->getId()}{$suffix}";
+        $cacheId = "LAYOUT_{$this->_theme->getArea()}_STORE{$this->scope->getId()}"
+            . "_{$this->_theme->getId()}{$suffix}_page_layout_merged";
         $messages = $this->_layoutValidator->getMessages();
 
         // Testing error message is logged with logger


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/22766

### Description (*)
Bugs which were fixed:
 - $this->pageLayout was not checked after reading from cache, but was used as is
 - two cache items were used in once place instead of one (performance impact)

Changes:
 - replace 2 cache items by 1 - it should improve performance
 - add "_MERGED" to cache key suffix to have compatibility with old cache keys during deployment of new version

### Fixed Issues (if relevant)
1. magento/magento2#6942 Layout corruption (Title is wrong, but issue is real)
2. magento/magento2#22976 Corrupt layout cache causes white page on customer account login

### Manual testing scenarios (*)
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
