### PR TITLE
fixed issue #22379 Fetching child products of configurable product only returns salable products

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
@@ -1306,7 +1306,7 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
         if (!$product->hasData($dataFieldName)) {
             $usedProducts = $this->readUsedProductsCacheData($cacheKey);
             if ($usedProducts === null) {
-                $collection = $this->getConfiguredUsedProductCollection($product, false);
+                $collection = $this->getConfiguredUsedProductCollection($product, !$salableOnly);
                 if ($salableOnly) {
                     $collection = $this->salableProcessor->process($collection);
                 }


### PR DESCRIPTION
fixed issue #22379 Fetching child products of configurable product only returns salable products

### Description (*)
fixed issue #22379 Fetching child products of configurable product only returns salable products

### Fixed Issues (if relevant)

1. magento/magento2 #22379: Fetching child products of configurable product only returns salable products

### Manual testing scenarios (*)

Preconditions (*)
    2.3.1

Steps to reproduce (*)

Fetch child products for configurable product using:
$childProducts = $product->getTypeInstance()->getUsedProducts($product);

Expected result (*)

This should return a collection of all child products of a configurable product

Actual result (*)

 Only child products that have stock status "In Stock" are returned.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
