### PR TITLE
Fixed typo issue and added missing header in customer sales order grid

### DIFF
--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Orders.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Orders.php
@@ -107,7 +107,7 @@ class Orders extends \Magento\Backend\Block\Widget\Grid\Extended
      */
     protected function _prepareColumns()
     {
-        $this->addColumn('increment_id', ['header' => __('Order'), 'width' => '100', 'index' => 'increment_id']);
+        $this->addColumn('increment_id', ['header' => __('Order #'), 'width' => '100', 'index' => 'increment_id']);
 
         $this->addColumn(
             'created_at',
@@ -140,7 +140,7 @@ class Orders extends \Magento\Backend\Block\Widget\Grid\Extended
             $this->addColumn(
                 'action',
                 [
-                    'header' => ' ',
+                    'header' => 'Action',
                     'filter' => false,
                     'sortable' => false,
                     'width' => '100px',

--- a/app/code/Magento/Customer/i18n/en_US.csv
+++ b/app/code/Magento/Customer/i18n/en_US.csv
@@ -47,7 +47,7 @@ Sending,Sending
 Paused,Paused
 View,View
 Unknown,Unknown
-Order,Order
+"Order #","Order #"
 Purchased,Purchased
 "Bill-to Name","Bill-to Name"
 "Ship-to Name","Ship-to Name"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed Typo issue as well as added header title for Last Action Column
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22641: Typo Issue and Missing header title at Customer Sales order grid

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to Magento admin
2. Open Customer > All Customers > Edit any customer
3. Check header title of Order column and header title of last column.

Before Fixed: 
![magento_customer_order_grid](https://user-images.githubusercontent.com/38535982/57174533-21873100-6e5e-11e9-94f8-c46c8b5e3b18.jpg)

After Fixed: 
![magento_customer_order_grid_fixed](https://user-images.githubusercontent.com/38535982/57174535-251ab800-6e5e-11e9-80c5-52e1c5d6e244.jpg)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
