### PR TITLE
Fixed issue of product_type attribute creation from installer as this is fixed in controller level

### DIFF
--- a/app/code/Magento/Eav/Setup/EavSetup.php
+++ b/app/code/Magento/Eav/Setup/EavSetup.php
@@ -1547,5 +1547,10 @@ class EavSetup
 
             throw new LocalizedException(__($errorMessage));
         }
+        if($attributeCode=="product_type"){
+        	$errorMessage = __("Attribute Code Already Exist"
+        	);
+        	throw new LocalizedException($errorMessage);
+        }
     }
 }


### PR DESCRIPTION
Fixed issue of product_type attribute creation from installer as this is fixed in controller level

### Description (*)
Fixed issue of product_type attribute creation from installer as this is fixed in controller level

### Fixed Issues (if relevant)
Fixed issue of product_type attribute creation from installer as this is fixed in controller level

### Manual testing scenarios (*)

1. Magento 2.3.1

2. product_type attribute should not be created from installer as this attribute is restricted from creating in product attribute section in admin side.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
