### PR TITLE
Fixed Issue #22087

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Product/Sold/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Product/Sold/Collection.php
@@ -79,6 +79,10 @@ class Collection extends \Magento\Reports\Model\ResourceModel\Order\Collection
         )->having(
             'order_items.qty_ordered > ?',
             0
+        )->columns(
+            'SUM(order_items.qty_ordered) as ordered_qty'
+        )->group(
+            'order_items.product_id'
         );
         return $this;
     }

--- a/app/code/Magento/Reports/Model/ResourceModel/Product/Sold/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Product/Sold/Collection.php
@@ -14,6 +14,8 @@ namespace Magento\Reports\Model\ResourceModel\Product\Sold;
 use Magento\Framework\DB\Select;
 
 /**
+ * Data collection.
+ *
  * @SuppressWarnings(PHPMD.DepthOfInheritance)
  * @api
  * @since 100.0.2
@@ -21,7 +23,7 @@ use Magento\Framework\DB\Select;
 class Collection extends \Magento\Reports\Model\ResourceModel\Order\Collection
 {
     /**
-     * Set Date range to collection
+     * Set Date range to collection.
      *
      * @param int $from
      * @param int $to
@@ -120,6 +122,8 @@ class Collection extends \Magento\Reports\Model\ResourceModel\Order\Collection
     }
 
     /**
+     * @inheritdoc
+     *
      * @return Select
      * @since 100.2.0
      */


### PR DESCRIPTION
Fixed Issue #22087

### Description (*)
  Products Ordered Report - Not grouped by product 


### Manual testing scenarios (*)
   1. In the Magento 2 admin go to Reports -> Products -> Ordered
   2. Select a date range where you know you have sold products spanning across multiple orders
   3. Select 'Show By' year
   4. Hit refresh


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
