### PR TITLE
Fixed issue #22640

### DIFF
--- a/app/code/Magento/Tax/view/adminhtml/templates/rule/rate/form.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/rule/rate/form.phtml
@@ -10,7 +10,7 @@
     <div class="grid-loader"></div>
 </div>
 
-<div class="form-inline" id="<?= /* @escapeNotVerified */ $block->getNameInLayout() ?>" style="display:none">
+<div class="form-inline admin__scope-old" id="<?= /* @escapeNotVerified */ $block->getNameInLayout() ?>" style="display:none">
     <?= $block->getFormHtml() ?>
     <?= $block->getChildHtml('form_after') ?>
 </div>


### PR DESCRIPTION
Fixed issue #22640

### Description (*)
Add tax rule form checkbox design is not as per the magento admin panel checkbox design, It is showing default design

### Manual testing scenarios (*)

   1. Go to Tax rules in Admin panel.
   2. Open Add New Tax Rule Form and click Add New Tax Rate Button.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
