### PR TITLE
Fixed #22407 Top menu cache issue - 2.3.1

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -394,4 +394,17 @@ class Topmenu extends Template implements IdentityInterface
         }
         return $this->_menu;
     }
+    
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     * @since 100.1.0
+     */
+    public function getCacheKeyInfo()
+    {
+        $keyInfo = parent::getCacheKeyInfo();
+        $keyInfo[] = $this->getUrl('*/*/*', ['_current' => true, '_query' => '']);
+        return $keyInfo;
+    }
 }

--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -399,7 +399,6 @@ class Topmenu extends Template implements IdentityInterface
      * Get cache key informative items
      *
      * @return array
-     * @since 100.1.0
      */
     public function getCacheKeyInfo()
     {


### PR DESCRIPTION
Fixed #22407 Top menu cache issue - 2.3.1

<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1.Magento 2.3.1 with all cache types enabled


### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Create 2-3 categories, set include in menu = Yes
2. On frontend click on any category page in top menu
3. Flush magento cache
4. Open the same category page
5. Open any other category page

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
Just opened category is marked as active in top menu


### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
Both categories in top menu are marked as active
![test](https://user-images.githubusercontent.com/8502721/56359465-5488be00-61ea-11e9-9794-3df7b3015aa3.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
