### PR TITLE
Resolved Cart form default action is to empty cart #22597

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
@@ -54,19 +54,19 @@
         <?php endif; ?>
         <button type="submit"
                 name="update_cart_action"
-                data-cart-empty=""
-                value="empty_cart"
-                title="<?= $block->escapeHtml(__('Clear Shopping Cart')) ?>"
-                class="action clear" id="empty_cart_button">
-            <span><?= /* @escapeNotVerified */ __('Clear Shopping Cart') ?></span>
-        </button>
-        <button type="submit"
-                name="update_cart_action"
                 data-cart-item-update=""
                 value="update_qty"
                 title="<?= $block->escapeHtml(__('Update Shopping Cart')) ?>"
                 class="action update">
             <span><?= /* @escapeNotVerified */ __('Update Shopping Cart') ?></span>
+        </button>
+        <button type="submit"
+                name="update_cart_action"
+                data-cart-empty=""
+                value="empty_cart"
+                title="<?= $block->escapeHtml(__('Clear Shopping Cart')) ?>"
+                class="action clear" id="empty_cart_button">
+            <span><?= /* @escapeNotVerified */ __('Clear Shopping Cart') ?></span>
         </button>
         <input type="hidden" value="" id="update_cart_action_container" data-cart-item-update=""/>
     </div>


### PR DESCRIPTION
Resolved Cart form default action is to empty cart #22597

<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento 2.3.1
2. Firefox, Chrome, Safari


### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Add a product to cart
2. Go to cart page
3. Edit the quantity
4. Press enter inside quantity input box

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. Quantity must be updated

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Cart gets empty

### More info:
It happens in:
`vendor/magento/module-checkout/view/frontend/templates/cart/form.phtml`
Where there are two submit buttons in a form:
```
        <button type="submit"
                name="update_cart_action"
                data-cart-empty=""
                value="empty_cart"
                title="<?= $block->escapeHtml(__('Clear Shopping Cart')) ?>"
                class="action clear" id="empty_cart_button">
            <span><?= /* @escapeNotVerified */ __('Clear Shopping Cart') ?></span>
        </button>
        <button type="submit"
                name="update_cart_action"
                data-cart-item-update=""
                value="update_qty"
                title="<?= $block->escapeHtml(__('Update Shopping Cart')) ?>"
                class="action update">
            <span><?= /* @escapeNotVerified */ __('Update Shopping Cart') ?></span>
        </button>
```
When the `Enter` key is pressed inside quantity input box, the browser automatically chooses the first submit button which is to `empty_cart`. Order of these buttons should be reversed or a javascript added to define the default behavior when `Enter` key is pressed.

### Additional Information (*)

FYI: This issue is only reproduced on **magento 2.3.1**  not in 2.3 nor in 2.2

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
