### PR TITLE
issues #22647 fixed, In customer account create page word not readable, should use '-' after break to new line In mobile view 

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
@@ -80,7 +80,7 @@
     .page-main {
         > .page-title-wrapper {
             .page-title {
-                word-break: break-all;
+                hyphens: auto;
             }
         }
     }


### PR DESCRIPTION
issue #22647 fixed

### Description (*)
In customer account create page word not readable, should use '-' after break to new line In mobile view 

### Manual testing scenarios (*)
1. Open customer account create page in mobile view

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
