### PR TITLE
Fixed #22545 Status downloadable product stays pending after succesfu…

### DIFF
--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -132,7 +132,7 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                     );
                 $linkPurchased->setLinkSectionTitle($linkSectionTitle)->save();
                 
-                $linkstatus =  \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING;
+                $linkStatus =  \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING;
                 if ($orderStatusToEnableItem == \Magento\Sales\Model\Order\Item::STATUS_PENDING
                     || $orderItem->getOrder()->getState() == \Magento\Sales\Model\Order::STATE_COMPLETE
                 ) {

--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -131,6 +131,13 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                         ScopeInterface::SCOPE_STORE
                     );
                 $linkPurchased->setLinkSectionTitle($linkSectionTitle)->save();
+                
+                $linkstatus =  \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING;
+               if( $orderStatusToEnableItem == \Magento\Sales\Model\Order\Item::STATUS_PENDING
+                    || $orderItem->getOrder()->getStatus() == \Magento\Sales\Model\Order::STATE_COMPLETE){
+                    $linkstatus =  \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE;  
+                }
+                
                 foreach ($linkIds as $linkId) {
                     if (isset($links[$linkId])) {
                         $linkPurchasedItem = $this->_createPurchasedItemModel()->setPurchasedId(
@@ -158,9 +165,7 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                         )->setNumberOfDownloadsBought(
                             $numberOfDownloads
                         )->setStatus(
-                            \Magento\Sales\Model\Order\Item::STATUS_PENDING == $orderStatusToEnableItem ?
-                            \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE :
-                            \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING
+                            $linkstatus
                         )->setCreatedAt(
                             $orderItem->getCreatedAt()
                         )->setUpdatedAt(

--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -133,9 +133,10 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                 $linkPurchased->setLinkSectionTitle($linkSectionTitle)->save();
                 
                 $linkstatus =  \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING;
-               if( $orderStatusToEnableItem == \Magento\Sales\Model\Order\Item::STATUS_PENDING
-                    || $orderItem->getOrder()->getStatus() == \Magento\Sales\Model\Order::STATE_COMPLETE){
-                    $linkstatus =  \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE;  
+                if ($orderStatusToEnableItem == \Magento\Sales\Model\Order\Item::STATUS_PENDING
+                    || $orderItem->getOrder()->getState() == \Magento\Sales\Model\Order::STATE_COMPLETE
+                ) {
+                    $linkStatus =  \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE;  
                 }
                 
                 foreach ($linkIds as $linkId) {
@@ -165,7 +166,7 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                         )->setNumberOfDownloadsBought(
                             $numberOfDownloads
                         )->setStatus(
-                            $linkstatus
+                            $linkStatus
                         )->setCreatedAt(
                             $orderItem->getCreatedAt()
                         )->setUpdatedAt(

--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -176,7 +176,6 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                 }
             }
         }
-
         return $this;
     }
 

--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -132,11 +132,11 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                     );
                 $linkPurchased->setLinkSectionTitle($linkSectionTitle)->save();
                 
-                $linkStatus =  \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING;
+                $linkStatus = \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_PENDING;
                 if ($orderStatusToEnableItem == \Magento\Sales\Model\Order\Item::STATUS_PENDING
                     || $orderItem->getOrder()->getState() == \Magento\Sales\Model\Order::STATE_COMPLETE
                 ) {
-                    $linkStatus =  \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE;  
+                    $linkStatus = \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE;  
                 }
                 
                 foreach ($linkIds as $linkId) {

--- a/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SaveDownloadableOrderItemObserver.php
@@ -136,7 +136,7 @@ class SaveDownloadableOrderItemObserver implements ObserverInterface
                 if ($orderStatusToEnableItem == \Magento\Sales\Model\Order\Item::STATUS_PENDING
                     || $orderItem->getOrder()->getState() == \Magento\Sales\Model\Order::STATE_COMPLETE
                 ) {
-                    $linkStatus = \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE;  
+                    $linkStatus = \Magento\Downloadable\Model\Link\Purchased\Item::LINK_STATUS_AVAILABLE;
                 }
                 
                 foreach ($linkIds as $linkId) {


### PR DESCRIPTION
Fixed #22545 Status downloadable product stays pending after succesfull payment
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->
When a downloadable product has been order and paid for download status should automatically become available. Status remains pending although order is invoiced and completed automatically by payment processor. When order is invoiced from admin it all works.

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento 2.3.1 CE
2. PHP 7.2

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Setup Magento site with demo contents
2. Order Item Status to Enable Downloads->Invoiced
3. Setup Payment for instance Paypal
4. Make purchase of downloadable product with payment method Paypal
5. Make sure payment is succesfull (Order status is completed) 

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. Download link should be available in customer account
2. Status of downloadable product should be available

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. In customer account order status is completed
2. In customer account downloadable product is pending

When an order is placed and in Magento admin the order is invoiced the it works as it should. So somehow downloadable status is not changed when an order is automatically set to completed when payment is succesfull.

This issue occured only after upgrading to Magento 2.3.1 in 2.3.0 it all worked like it should.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
