### PR TITLE
Fix swatches for new product widget

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_widget_new_product_list.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_widget_new_product_list.xml
@@ -5,8 +5,8 @@
 
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Magento\Framework\View\Element\RendererList" name="category.product.type.widget.details.renderers">
-            <block class="Magento\Framework\View\Element\Template" name="category.product.type.details.renderers.default" as="default"/>
+        <block class="Magento\Framework\View\Element\RendererList" name="category.new.product.type.widget.details.renderers">
+            <block class="Magento\Framework\View\Element\Template" name="category.new.product.type.details.renderers.default" as="default"/>
         </block>
     </body>
 </page>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
+use Magento\Framework\App\Action\Action;
 // @codingStandardsIgnoreFile
 
 ?>
@@ -53,36 +53,32 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                         <?= $block->escapeHtml($_item->getName()) ?>
                                     </a>
                                 </strong>
-                                <?php
-                                echo $block->getProductPriceHtml($_item, $type);
-                                ?>
 
                                 <?php if ($templateType): ?>
                                     <?= $block->getReviewsSummaryHtml($_item, $templateType) ?>
                                 <?php endif; ?>
 
+                                <?= $block->getProductPriceHtml($_item, $type) ?>
+
+                                <?= $block->getProductDetailsHtml($_item) ?>
+
                                 <?php if ($showWishlist || $showCompare || $showCart): ?>
+                                <div class="product-item-inner">
                                     <div class="product-item-actions">
                                         <?php if ($showCart): ?>
                                             <div class="actions-primary">
                                                 <?php if ($_item->isSaleable()): ?>
-                                                    <?php if (!$_item->getTypeInstance()->isPossibleBuyFromList($_item)): ?>
-                                                        <button class="action tocart primary"
-                                                                data-mage-init='{"redirectUrl":{"url":"<?= /* @escapeNotVerified */ $block->getAddToCartUrl($_item) ?>"}}'
-                                                                type="button" title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>">
+                                                    <?php $postParams = $block->getAddToCartPostParams($_item); ?>
+                                                    <form data-role="tocart-form" data-product-sku="<?= $block->escapeHtml($_item->getSku()) ?>" action="<?= /* @NoEscape */ $postParams['action'] ?>" method="post">
+                                                        <input type="hidden" name="product" value="<?= /* @escapeNotVerified */ $postParams['data']['product'] ?>">
+                                                        <input type="hidden" name="<?= /* @escapeNotVerified */ Action::PARAM_NAME_URL_ENCODED ?>" value="<?= /* @escapeNotVerified */ $postParams['data'][Action::PARAM_NAME_URL_ENCODED] ?>">
+                                                        <?= $block->getBlockHtml('formkey') ?>
+                                                        <button type="submit"
+                                                                title="<?= $block->escapeHtml(__('Add to Cart')) ?>"
+                                                                class="action tocart primary">
                                                             <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
                                                         </button>
-                                                    <?php else: ?>
-                                                        <?php
-                                                            $postDataHelper = $this->helper('Magento\Framework\Data\Helper\PostHelper');
-                                                            $postData = $postDataHelper->getPostData($block->getAddToCartUrl($_item), ['product' => $_item->getEntityId()])
-                                                        ?>
-                                                        <button class="action tocart primary"
-                                                                data-post='<?= /* @escapeNotVerified */ $postData ?>'
-                                                                type="button" title="<?= /* @escapeNotVerified */ __('Add to Cart') ?>">
-                                                            <span><?= /* @escapeNotVerified */ __('Add to Cart') ?></span>
-                                                        </button>
-                                                    <?php endif; ?>
+                                                    </form>
                                                 <?php else: ?>
                                                     <?php if ($_item->getIsSalable()): ?>
                                                         <div class="stock available"><span><?= /* @escapeNotVerified */ __('In stock') ?></span></div>
@@ -113,6 +109,7 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                             </div>
                                         <?php endif; ?>
                                     </div>
+                                </div>
                                 <?php endif; ?>
                             </div>
                         </div>

--- a/app/code/Magento/Swatches/view/frontend/layout/catalog_widget_new_product_list.xml
+++ b/app/code/Magento/Swatches/view/frontend/layout/catalog_widget_new_product_list.xml
@@ -1,0 +1,12 @@
+<!--
+  ~ Copyright © Magento, Inc. All rights reserved.
+  ~ See COPYING.txt for license details.
+  -->
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="category.new.product.type.widget.details.renderers">
+            <block class="Magento\Swatches\Block\Product\Renderer\Listing\Configurable" name="category.new.product.type.details.renderers.configurable" as="configurable" template="Magento_Swatches::product/listing/renderer.phtml" ifconfig="catalog/frontend/show_swatches_in_product_list"/>
+        </referenceBlock>
+    </body>
+</page>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14134: Swatches not showing on homepage New products widget

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a new **Catalog New Products List** widget and call that widget on HomPage
2. Add any of configurable product in widget

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
