### PR TITLE
Fix-#22196-200 Response Code When Exception is Thrown During Bootstrap

### DIFF
--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -440,6 +440,7 @@ class Bootstrap
             }
             echo $message;
         }
+        header('HTTP/1.1 500 Internal Server Error', true, 500);
         exit(1);
     }
     // phpcs:enable

--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -109,6 +109,13 @@ class Bootstrap
     private $factory;
 
     /**
+     * Application Object
+     *
+     * @var ObjectManagerFactory
+     */
+    private $app;
+
+    /**
      * Static method so that client code does not have to create Object Manager Factory every time Bootstrap is called
      *
      * @param string $rootDir
@@ -235,6 +242,7 @@ class Bootstrap
             if (!($application instanceof AppInterface)) {
                 throw new \InvalidArgumentException("The provided class doesn't implement AppInterface: {$type}");
             }
+            $this->app = $application;
             return $application;
         } catch (\Exception $e) {
             $this->terminate($e);
@@ -440,7 +448,7 @@ class Bootstrap
             }
             echo $message;
         }
-        header('HTTP/1.1 500 Internal Server Error', true, 500);
+        $this->app->handleTerminateError();
         exit(1);
     }
     // phpcs:enable

--- a/lib/internal/Magento/Framework/App/Http.php
+++ b/lib/internal/Magento/Framework/App/Http.php
@@ -21,7 +21,7 @@ use Magento\Framework\ObjectManager\ConfigLoaderInterface;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Http implements \Magento\Framework\AppInterface
+class  Http implements \Magento\Framework\AppInterface
 {
     /**
      * @var \Magento\Framework\ObjectManagerInterface
@@ -359,6 +359,19 @@ class Http implements \Magento\Framework\AppInterface
         }
         // phpcs:ignore Magento2.Security.IncludeFile
         require $this->_filesystem->getDirectoryRead(DirectoryList::PUB)->getAbsolutePath('errors/report.php');
+        return true;
+    }
+
+    /**
+     * Error Handler for Application Termination
+     *
+     * @return bool
+     */
+    public function handleTerminateError()
+    {
+        $this->_response->setHttpResponseCode(500);
+        $this->_response->setHeader('Content-Type', 'text/html; charset=UTF-8');
+        $this->_response->sendResponse();
         return true;
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Now the application will throw a 500 error instead of 200 response when it terminates during the bootstrap process. 

So, now the error message will be displayed with the 500 response code.


<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Do any code change to throw an error during the bootstrap process. 
2. Refresh the page.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
