### PR TITLE
Issue #22662 fixed

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/Collection.php
@@ -33,4 +33,22 @@ class Collection extends \Magento\Framework\View\Element\UiComponent\DataProvide
     ) {
         parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $mainTable, $resourceModel);
     }
+
+    /**
+     * Join table sales_order_grid to select order currency  code.
+     *
+     * @return $this
+     */
+    protected function _renderFiltersBefore()
+    {
+        $joinTable = $this->getTable('sales_order_grid');
+        $this->getSelect()->join(
+            $joinTable.' as cgf',
+            'main_table.order_id = cgf.entity_id',
+            [
+                'order_currency_code'=>'order_currency_code'
+            ]
+        );
+        parent::_renderFiltersBefore();
+    }
 }

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/Collection.php
@@ -35,9 +35,7 @@ class Collection extends \Magento\Framework\View\Element\UiComponent\DataProvide
     }
 
     /**
-     * Join table sales_order_grid to select order currency  code.
-     *
-     * @return $this
+     * @inheritdoc
      */
     protected function _renderFiltersBefore()
     {

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/Collection.php
@@ -35,7 +35,9 @@ class Collection extends \Magento\Framework\View\Element\UiComponent\DataProvide
     }
 
     /**
-     * @inheritdoc
+     * Join table sales_order_grid to select order currency code.
+     *
+     * @return void
      */
     protected function _renderFiltersBefore()
     {
@@ -47,6 +49,5 @@ class Collection extends \Magento\Framework\View\Element\UiComponent\DataProvide
                 'order_currency_code'=>'order_currency_code'
             ]
         );
-        parent::_renderFiltersBefore();
     }
 }

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/Collection.php
@@ -42,7 +42,7 @@ class Collection extends \Magento\Framework\View\Element\UiComponent\DataProvide
     protected function _renderFiltersBefore()
     {
         $this->getSelect()->join(
-            ['cgf' => $this->getTable('sales_order_grid')]
+            ['cgf' => $this->getTable('sales_order_grid')],
             'main_table.order_id = cgf.entity_id',
             [
                 'order_currency_code'=>'order_currency_code'

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/Collection.php
@@ -41,9 +41,8 @@ class Collection extends \Magento\Framework\View\Element\UiComponent\DataProvide
      */
     protected function _renderFiltersBefore()
     {
-        $joinTable = $this->getTable('sales_order_grid');
         $this->getSelect()->join(
-            $joinTable.' as cgf',
+            ['cgf' => $this->getTable('sales_order_grid')]
             'main_table.order_id = cgf.entity_id',
             [
                 'order_currency_code'=>'order_currency_code'

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Order/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Order/Grid/Collection.php
@@ -33,4 +33,23 @@ class Collection extends \Magento\Framework\View\Element\UiComponent\DataProvide
     ) {
         parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $mainTable, $resourceModel);
     }
+
+
+    /**
+     * Join table sales_order_grid to select order currency  code.
+     *
+     * @return $this
+     */
+    protected function _renderFiltersBefore()
+    {
+        $joinTable = $this->getTable('sales_order_grid');
+        $this->getSelect()->join(
+            $joinTable.' as cgf',
+            'main_table.order_id = cgf.entity_id',
+            [
+                'order_currency_code'=>'order_currency_code'
+            ]
+        );
+        parent::_renderFiltersBefore();
+    }
 }

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Order/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Order/Grid/Collection.php
@@ -34,9 +34,10 @@ class Collection extends \Magento\Framework\View\Element\UiComponent\DataProvide
         parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $mainTable, $resourceModel);
     }
 
-
     /**
-     * @inheritdoc
+     * Join table sales_order_grid to select order currency code.
+     *
+     * @return void
      */
     protected function _renderFiltersBefore()
     {
@@ -48,6 +49,5 @@ class Collection extends \Magento\Framework\View\Element\UiComponent\DataProvide
                 'order_currency_code'=>'order_currency_code'
             ]
         );
-        parent::_renderFiltersBefore();
     }
 }

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Order/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Order/Grid/Collection.php
@@ -36,9 +36,7 @@ class Collection extends \Magento\Framework\View\Element\UiComponent\DataProvide
 
 
     /**
-     * Join table sales_order_grid to select order currency  code.
-     *
-     * @return $this
+     * @inheritdoc
      */
     protected function _renderFiltersBefore()
     {

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Order/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Order/Grid/Collection.php
@@ -41,9 +41,8 @@ class Collection extends \Magento\Framework\View\Element\UiComponent\DataProvide
      */
     protected function _renderFiltersBefore()
     {
-        $joinTable = $this->getTable('sales_order_grid');
         $this->getSelect()->join(
-            $joinTable.' as cgf',
+            ['cgf' => $this->getTable('sales_order_grid')],
             'main_table.order_id = cgf.entity_id',
             [
                 'order_currency_code'=>'order_currency_code'

--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_creditmemo_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_creditmemo_grid.xml
@@ -194,14 +194,14 @@
                 <visible>false</visible>
             </settings>
         </column>
-        <column name="subtotal" class="Magento\Sales\Ui\Component\Listing\Column\Price">
+        <column name="subtotal" class="Magento\Sales\Ui\Component\Listing\Column\PurchasedPrice">
             <settings>
                 <filter>textRange</filter>
                 <label translate="true">Subtotal</label>
                 <visible>false</visible>
             </settings>
         </column>
-        <column name="shipping_and_handling" class="Magento\Sales\Ui\Component\Listing\Column\Price">
+        <column name="shipping_and_handling" class="Magento\Sales\Ui\Component\Listing\Column\PurchasedPrice">
             <settings>
                 <filter>textRange</filter>
                 <label translate="true">Shipping &amp; Handling</label>

--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_view_creditmemo_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_view_creditmemo_grid.xml
@@ -207,14 +207,14 @@
                 <visible>false</visible>
             </settings>
         </column>
-        <column name="subtotal" class="Magento\Sales\Ui\Component\Listing\Column\Price">
+        <column name="subtotal" class="Magento\Sales\Ui\Component\Listing\Column\PurchasedPrice">
             <settings>
                 <filter>textRange</filter>
                 <label translate="true">Subtotal</label>
                 <visible>false</visible>
             </settings>
         </column>
-        <column name="shipping_and_handling" class="Magento\Sales\Ui\Component\Listing\Column\Price">
+        <column name="shipping_and_handling" class="Magento\Sales\Ui\Component\Listing\Column\PurchasedPrice">
             <settings>
                 <filter>textRange</filter>
                 <label translate="true">Shipping &amp; Handling</label>


### PR DESCRIPTION
Wrong currency symbol in creditmemo_grid & sales_order_view > creditmemo grid

Description (*)
 For Column subtotal & Shipping and Handling fee in creditmemo_grid & sales_order_view > credit memo grid if the order is placed with the different currency.

Fixed Issues (if relevant)
1. magento/magento2 #22662: Wrong currency symbol in creditmemo_grid & sales_order_view > credit memo grid for subtotal & Shipping and Handling fee

Manual testing scenarios (*)
1. Set USD as Base Currency
2. Set INR currency for different store
3. Place an order from INR Currency store.
4. Go to Backend > SALES > Credit Memos, create Credit Memo
5. Check Subtotal & Shipping and Handling fee column on Credit Memo grid (sales_creditmemo_index) & sales_order_view > credit memo grid.

Finally, Subtotal & Shipping and Handling fee column value is showing correctly currency symbol.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
