### PR TITLE
Fixed REST API issue

### DIFF
--- a/app/code/Magento/Eav/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor.php
+++ b/app/code/Magento/Eav/Model/Api/SearchCriteria/CollectionProcessor/FilterProcessor.php
@@ -65,22 +65,17 @@ class FilterProcessor implements CollectionProcessorInterface
             $isApplied = false;
             $customFilter = $this->getCustomFilterForField($filter->getField());
             if ($customFilter) {
-                if( $filter->getConditionType() == "eq" ) {
-                    $isApplied = true;
-
-                    if( !empty($customFilterArr[$filter->getField()]) && !empty($customFilterArr[$filter->getField()]['filter']) && isset($customFilterArr[$filter->getField()]['value']) ){
-                        $customFilterArr[$filter->getField()]['value'][] = $filter->getValue();
-                        $newFilter = clone $customFilterArr[$filter->getField()]['filter'];
-                        $newFilter->setValue($customFilterArr[$filter->getField()]['value']);
-                        $newFilter->setConditionType('in');
-                        $customFilterArr[$filter->getField()]['filter'] = $newFilter;
-                    } else {
-                        $customFilterArr[$filter->getField()]['filter'] = $filter;
-                        $customFilterArr[$filter->getField()]['value'][] = $filter->getValue();
-                    }
-                }else {
-                    $isApplied = $customFilter->apply($filter, $collection);
+                if ($filter->getConditionType() == "eq") {
+                    $customFilterArr[$filter->getField()]['value'][] = $filter->getValue();
+                    /** @var \Magento\Framework\Api\Filter $newFilter */
+                    $newFilter = clone $filter;
+                    $newFilter->setValue($customFilterArr[$filter->getField()]['value']);
+                    $newFilter->setConditionType('in');
+                    $customFilterArr[$filter->getField()]['filter'] = $newFilter;
+                    continue;
                 }
+
+                $isApplied = $customFilter->apply($filter, $collection);
             }
 
             if (!$isApplied) {
@@ -88,16 +83,11 @@ class FilterProcessor implements CollectionProcessorInterface
                 $condition = $filter->getConditionType() ? $filter->getConditionType() : 'eq';
                 $fields[] = ['attribute' => $field, $condition => $filter->getValue()];
             }
-
         }
 
-        if( !empty($customFilterArr) ){
-            foreach( $customFilterArr as $field => $val ){
-                $customFilter = $this->getCustomFilterForField($field);
-                if ($customFilter) {
-                    $customFilter->apply($val['filter'], $collection);
-                }
-            }
+        foreach ($customFilterArr as $field => $val) {
+            $customFilter = $this->getCustomFilterForField($field);
+            $customFilter->apply($val['filter'], $collection);
         }
 
         if ($fields) {


### PR DESCRIPTION
Fixed the issue of  OR Condition in searchCriteria (REST API) .

### Description (*)
Changed the FilterProcessor.php file to allow "OR" operation when a custom field is provided in unique "filterGroups" and one "filter" foreach custom field value

### Fixed Issues (if relevant)
1. magento/magento2#16425: OR Condition in searchCriteria (REST API) dosn't work

### Manual testing scenarios (*)

  1.  Create some categories (two or tre)
  2.  Create come products foreach category
  3.  Enable a REST API token
  4.  Make a call to resource "/V1/products" with a search parameter like this:

["searchCriteria"]=>
  array(1) {
    ["filterGroups"]=>
    array(1) {
      [1]=>
      array(1) {
        ["filters"]=>
        array(2) {
          [0]=>
          array(3) {
            ["field"]=>
            string(11) "category_id"
            ["value"]=>
            string(3) "{id category 1}"
          }
          [1]=>
          array(3) {
            ["field"]=>
            string(11) "category_id"
            ["value"]=>
            string(3) "{id category 2}"
          }
        }
      }
    }
  }
5. This condition should be able to return all products in category {id category 1} OR {id category 2}

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [] All automated tests passed successfully (all builds on Travis CI are green)
