### PR TITLE
Billing address remains old after going back from Payment step #20364 - fix

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
@@ -247,8 +247,7 @@ define([
          */
         setShippingInformation: function () {
             if (this.validateShippingInformation()) {
-                quote.billingAddress(null);
-                checkoutDataResolver.resolveBillingAddress();
+                quote.billingAddress(quote.shippingAddress());
                 setShippingInformationAction().done(
                     function () {
                         stepNavigator.next();


### PR DESCRIPTION
**Description (*)**

Fix for Default Billing Address Persisted when changing shipping Address after moving from payment step to shipping step

**Cause for the issue:**
     1) Whenever user moves from payment step to shipping step, always default billing address is set in quote's billing Address. 
    2) So when a different shipping Address apart from a default one is selected and moved to payment step, default Billing Address will only be shown and same as shipping checkbox will be unchecked.
   
Note:
Same as shipping checkbox will only be checked when 
quote's shipping Address == quote's billing Address(this check is done with the help of cache key)

So in this case always default billing address will be selected from 1st step to 2nd step. So whenever a different address is selected which is not a default one, this checkbox will always be unchecked as a result only the default billing address displays.

**Fix for the issue: **
Since we always want billing address to be same as shipping in all cases except while adding a new address in billing. The fix is to 

- Set Shipping Address as Quote's Billing Address on the setShippingInformation  function() [This function internally sets default billing address in quote through the line checkoutDataResolver.resolveBillingAddress())

- And Removed checkoutDataResolver.resolveBillingAddress() line from the function setShippingInformation() because, we have already set Billing Address directly using quote's Shipping Address.

- For the case when new billing Address is added, same as shipping will be unchecked, this will happen because while setting payment Method, internally it agains calls checkoutDataResolver.resolveBillingAddress() which will now have the new billing address and thereby billing Address will not replaced with shipping Address selected in 1st step in this scenario alone.


**Fixed Issues (if relevant)**
1. magento2#20364 : Billing address remains old after going back from Payment step and changing the shipping 


 **Contribution checklist (*)**
 - [X] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
