### PR TITLE
issue-22007

### DIFF
--- a/lib/internal/Magento/Framework/Model/AbstractExtensibleModel.php
+++ b/lib/internal/Magento/Framework/Model/AbstractExtensibleModel.php
@@ -128,8 +128,8 @@ abstract class AbstractExtensibleModel extends AbstractModel implements
                     $customAttributes[$customAttributeCode] = $customAttribute;
                 }
             }
-            $this->_data[self::CUSTOM_ATTRIBUTES] = $customAttributes;
             $this->customAttributesChanged = false;
+            return $customAttributes;
         }
     }
 
@@ -140,9 +140,9 @@ abstract class AbstractExtensibleModel extends AbstractModel implements
      */
     public function getCustomAttributes()
     {
-        $this->initializeCustomAttributes();
+        $data = $this->initializeCustomAttributes();
         // Returning as a sequential array (instead of stored associative array) to be compatible with the interface
-        return array_values($this->_data[self::CUSTOM_ATTRIBUTES]);
+        return array_values($data);
     }
 
     /**
@@ -153,8 +153,8 @@ abstract class AbstractExtensibleModel extends AbstractModel implements
      */
     public function getCustomAttribute($attributeCode)
     {
-        $this->initializeCustomAttributes();
-        return $this->_data[self::CUSTOM_ATTRIBUTES][$attributeCode] ?? null;
+        $data = $this->initializeCustomAttributes();
+        return $data[$attributeCode] ?? null;
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
If the function `getCustomAttribute` called on model in `catalog_product_save_before` then the multiselect custom attribute data was not saving previously. 
Using a local variable instead of overridden global `$this->_data` was eleminated in `initializeCustomAttributes` function.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22007: Issue 2.3.0 Product attribute not saving if getCustomAttribute / getCustomAttributes is called


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.Magento 2.3
2.Make sure getCustomAttribute or getCustomAttributes() is called on the model before Magento\Framework\EntityManager\Operation\Update is executed (for example in a catalog_product_save_before observer)



### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
