### PR TITLE
sales_order_item.qty_backordered Should not be null

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/ToOrderItem.php
@@ -93,6 +93,12 @@ class ToOrderItem
             \Magento\Sales\Api\Data\OrderItemInterface::class
         );
         $orderItem->setProductOptions($options);
+        $stockItem = $item->getProduct()->getExtensionAttributes()->getStockItem();
+        if(($orderItemData[OrderItemInterface::QTY_ORDERED] - $stockItem->getQty()) > 0 && $stockItem->getBackorders() > 0) {
+            $orderItem->setQtyBackordered(
+                $orderItemData[OrderItemInterface::QTY_ORDERED] - $stockItem->getQty()
+            );
+        }
         if ($item->getParentItem()) {
             $orderItem->setQtyOrdered(
                 $orderItemData[OrderItemInterface::QTY_ORDERED] * $item->getParentItem()->getQty()


### PR DESCRIPTION
### Description (*)
There are no backorders column in quote_item table.
So the qty_backordered column not update from quote.
Doing this update direct in sales_order_item table.

### Fixed Issues (#10079)
1. magento/magento2#10079: sales_order_item.qty_backordered should not be NULL

### Manual testing scenarios (*)
1. Enable backorders in store configuration (for example Enable Backorders and notify customers)
2. Set some product to have low quantity (for example 2)
3. Order "more than stock" qty (for example 3 if product has 2 items in stock)
3.1 Can be done via frontend or admin order creation.
4. Observe order in admin
5. Observe order in database

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
