### PR TITLE
Fixed  #22459

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ListProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/ListProduct.php
@@ -472,7 +472,7 @@ class ListProduct extends AbstractProduct implements IdentityInterface
         foreach ($layer->getState()->getFilters() as $filterItem) {
             $attributeToSelect[] = $filterItem->getFilter()->getRequestVar();
         }
-        foreach ($prodCollcetion as $ke => $product) {
+        foreach ($prodCollcetion as $product) {
             if (in_array($product->getTypeId(), ['configurable', 'group', 'bundle'])) {
                 $_children = $product->getTypeInstance()->getUsedProductCollection($product)
                                     ->addAttributeToSelect($attributeToSelect);


### PR DESCRIPTION
Magento 2.2.8 Filtered search shows out-of-stock subproducts when multiple filters are chosen #22459

<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento 2.2.8
2. Sample data installed

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->

1. In the admin, set all the size S simple products of the Leah Yoga Top to 0.
2. In the frontend, choose Women>Tops.
3. Select Size: S and Color: Purple from the filters.

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. The Leah Yoga Top should not be part of the search results.

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. The Leah Yoga Top should not be is part of the search results, with the S swatch missing. This is immediately confusing for a customer who only wants size S products.

![Capture](https://user-images.githubusercontent.com/730188/56527928-6cc74880-651c-11e9-9f43-366cde3cd614.PNG)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
