### PR TITLE
fixed issue #7299 V1/carts/mine/billing-address returning %fieldName is a required field.

### DIFF
--- a/app/code/Magento/Quote/Api/BillingAddressManagementInterface.php
+++ b/app/code/Magento/Quote/Api/BillingAddressManagementInterface.php
@@ -15,7 +15,7 @@ interface BillingAddressManagementInterface
     /**
      * Assigns a specified billing address to a specified cart.
      *
-     * @param int $cartId The cart ID.
+     * @param string $cartId The cart ID.
      * @param \Magento\Quote\Api\Data\AddressInterface $address Billing address data.
      * @param bool $useForShipping
      * @return int Address ID.

--- a/app/code/Magento/Quote/etc/webapi.xml
+++ b/app/code/Magento/Quote/etc/webapi.xml
@@ -372,7 +372,7 @@
             <resource ref="self" />
         </resources>
         <data>
-            <parameter name="cartId" force="true">%cart_id%</parameter>
+            <parameter name="cartId" force="true">%cartId%</parameter>
         </data>
     </route>
 


### PR DESCRIPTION
fixed issue #7299 V1/carts/mine/billing-address returning %fieldName is a required field.


### Description (*)
fixed issue #7299 V1/carts/mine/billing-address returning %fieldName is a required field.

### Fixed Issues (if relevant)
fixed issue #7299 V1/carts/mine/billing-address returning %fieldName is a required field.

1. magento/magento2#7299: fixed issue #7299 V1/carts/mine/billing-address returning %fieldName is a required field.


### Manual testing scenarios (*)

Preconditions

   Magento EE 2.1.1
   PHP 7.0.12
   Mysql Ver 14.14 Distrib 5.6.33-79.0, for Linux (x86_64) using 6.2

Steps to reproduce

 Go to the checkout after adding something to the basket
Send a request to the REST endpoint V1/carts/mine/billing-address using the payload below

{"cartId":"190488","address":{"countryId":"GB","regionId":"0","region":"","street":["54 Carnegie Court",""],"company":"","telephone":"0165 4569 8754","fax":"","postcode":"AB1C 2DF","city":"SomeCity","firstname":"Bob","lastname":"White","save_in_address_book":1,"saveInAddressBook":null}}


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
