### PR TITLE
Handling Currency Converter API Error Responses

### DIFF
--- a/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
@@ -86,6 +86,8 @@ class CurrencyConverterApi extends AbstractImport
                     if (empty($response)) {
                         $this->_messages[] = __('We can\'t retrieve a rate from %1 for %2.', $url, $to);
                         $data[$currencyFrom][$to] = null;
+                    } elseif (array_key_exists('error', $response) && $response['error']) {
+                        $this->_messages[] = $response['error'];
                     } else {
                         $data[$currencyFrom][$to] = $this->_numberFormat(
                             (double)$response[$currencyFrom . '_' . $to]

--- a/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
@@ -86,7 +86,7 @@ class CurrencyConverterApi extends AbstractImport
                     if (empty($response)) {
                         $this->_messages[] = __('We can\'t retrieve a rate from %1 for %2.', $url, $to);
                         $data[$currencyFrom][$to] = null;
-                    } elseif (array_key_exists('error', $response) && $response['error']) {
+                    } elseif (!empty($response['error'])) {
                         $this->_messages[] = $response['error'];
                     } else {
                         $data[$currencyFrom][$to] = $this->_numberFormat(


### PR DESCRIPTION
### Description (*)
The issue #22468 happened because the Currency Converter API throws the error "API Key is required" with status 400. This particular issue has been already handled and fixed in the pull request #22461 by @hailong.

However, if the API throws different errors, which was not handled in the code and that will end up in throwing **Key Errors** or **Undefined Index Errors** like issue #22468. To avoid this in the future, this pull request has been created.

Now the user will be provided with the original error, instead of unidentified index errors.

### Fixed Issues (if relevant)
1. magento/magento2#22468: Error in pulling currency exchange rates from Currency Converter API

### Manual testing scenarios (*)
1. Set store default currency to CAD, and add CAD and USD as allowed currencies.
2. Navigate to Stores -> Currency Rates
3. Select Currency Converter API as Import Service and click Import.
4. It will throw the actual error "API Key is required" instead of an unhandled exception.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
