### PR TITLE
Fixed #22004 can't update attribute for all product

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/massactions.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/massactions.js
@@ -153,11 +153,6 @@ define([
             var itemsType = data.excludeMode ? 'excluded' : 'selected',
                 selections = {};
 
-            if (itemsType === 'excluded' && data.selected && data.selected.length) {
-                itemsType = 'selected';
-                data[itemsType] = _.difference(data.selected, data.excluded);
-            }
-
             selections[itemsType] = data[itemsType];
 
             if (!selections[itemsType].length) {


### PR DESCRIPTION
Fixed #22004 can't update attribute for all product

<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. ce2.3.1
2. Create at least 2 store view

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Go to Catalog > Product
2. Select All Product http://prntscr.com/n429o3
3. Select mass action = Update Attribute
4, In Website tab, tick Add Product To Websites > Main Website http://prntscr.com/n42ank
5. Click Save

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. Update all Product. Both store views will have exactly the same products
http://prntscr.com/n42hsr


### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Only update 20 product http://prntscr.com/n42b9f

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
