### PR TITLE
Fixed cart redirection url with parameters issue

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/web/js/catalog-add-to-cart.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/catalog-add-to-cart.js
@@ -61,7 +61,7 @@ define([
             locationParts = window.location.href.split('#');
             forceReload = urlParts[0] === locationParts[0];
 
-            window.location.assign(url);
+            window.location.assign(urlParts[0]);
 
             if (forceReload) {
                 window.location.reload();


### PR DESCRIPTION
### Description (*)
After adding a configurable product to cart with cart redirection enable, Magento adds the configurable attributes in the cart URL as parameters and redirects to the cart page.

### Fixed Issues (if relevant)
1. magento/magento2#21450: Magento 2.3 adding attributes value in URL if onestep checkout is enabled.


### Manual testing scenarios (*)
1. Enable **After Adding a Product Redirect to Shopping Cart** setting from store >> configuration >> sales >> checkout >> Shopping Cart >> After Adding a Product Redirect to Shopping Cart.
2. Add any configurable product from the product detail page.
3. After adding a product it will redirect to checkout/cart page and URL will be generated like
checkout/cart/#size=169&color=56

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
