### PR TITLE
Showing Message for adding Out of stock product to wishlist

### DIFF
--- a/app/code/Magento/Wishlist/Controller/Index/Add.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Add.php
@@ -50,8 +50,7 @@ class Add extends \Magento\Wishlist\Controller\AbstractIndex
         \Magento\Wishlist\Controller\WishlistProviderInterface $wishlistProvider,
         ProductRepositoryInterface $productRepository,
         Validator $formKeyValidator
-    )
-    {
+    ) {
         $this->_customerSession = $customerSession;
         $this->wishlistProvider = $wishlistProvider;
         $this->productRepository = $productRepository;
@@ -115,6 +114,7 @@ class Add extends \Magento\Wishlist\Controller\AbstractIndex
             $resultRedirect->setUrl($this->_redirect->getRefererUrl());
             return $resultRedirect;
         }
+
         try {
             $buyRequest = new \Magento\Framework\DataObject($requestParams);
 

--- a/app/code/Magento/Wishlist/Controller/Index/Add.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Add.php
@@ -11,7 +11,6 @@ use Magento\Framework\Data\Form\FormKey\Validator;
 use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Controller\ResultFactory;
-use Magento\GraphQl\CatalogInventory\ProductStockStatusTest;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -39,32 +38,24 @@ class Add extends \Magento\Wishlist\Controller\AbstractIndex
     protected $formKeyValidator;
 
     /**
-     * @var ProductStockStatusTest
-     */
-    protected $_stockItemRepository;
-
-    /**
      * @param Action\Context $context
      * @param \Magento\Customer\Model\Session $customerSession
      * @param \Magento\Wishlist\Controller\WishlistProviderInterface $wishlistProvider
      * @param ProductRepositoryInterface $productRepository
      * @param Validator $formKeyValidator
-     * @param \Magento\CatalogInventory\Model\Stock\StockItemRepository $stockItemRepository
      */
     public function __construct(
         Action\Context $context,
         \Magento\Customer\Model\Session $customerSession,
         \Magento\Wishlist\Controller\WishlistProviderInterface $wishlistProvider,
         ProductRepositoryInterface $productRepository,
-        Validator $formKeyValidator,
-        \Magento\CatalogInventory\Model\Stock\StockItemRepository $stockItemRepository
+        Validator $formKeyValidator
     )
     {
         $this->_customerSession = $customerSession;
         $this->wishlistProvider = $wishlistProvider;
         $this->productRepository = $productRepository;
         $this->formKeyValidator = $formKeyValidator;
-        $this->_stockItemRepository = $stockItemRepository;
         parent::__construct($context);
     }
 
@@ -116,13 +107,14 @@ class Add extends \Magento\Wishlist\Controller\AbstractIndex
             $resultRedirect->setPath('*/');
             return $resultRedirect;
         }
-        $productStock = $this->_stockItemRepository->get($productId);
-        if (!$productStock->getIsInStock() || $productStock->getIsInStock() == 0) {
+
+        $stockItem = $product->getExtensionAttributes()->getStockItem();
+        $stockData = $stockItem->getIsInStock();
+        if (!$stockData || $stockData == 0) {
             $this->messageManager->addErrorMessage(__('Out of stock items can not be added to wishlist.'));
             $resultRedirect->setUrl($this->_redirect->getRefererUrl());
             return $resultRedirect;
         }
-
         try {
             $buyRequest = new \Magento\Framework\DataObject($requestParams);
 

--- a/app/code/Magento/Wishlist/Controller/Index/Add.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Add.php
@@ -3,7 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\Wishlist\Controller\Index;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
@@ -117,8 +116,6 @@ class Add extends \Magento\Wishlist\Controller\AbstractIndex
             $resultRedirect->setPath('*/');
             return $resultRedirect;
         }
-
-        $this->_objectManager->get(\Magento\Wishlist\Helper\Data::class)->calculate();
         $productStock = $this->_stockItemRepository->get($productId);
         if (!$productStock->getIsInStock() || $productStock->getIsInStock() == 0) {
             $this->messageManager->addErrorMessage(__('Out of stock items can not be added to wishlist.'));
@@ -149,6 +146,7 @@ class Add extends \Magento\Wishlist\Controller\AbstractIndex
             }
 
             $this->_objectManager->get(\Magento\Wishlist\Helper\Data::class)->calculate();
+
             $this->messageManager->addComplexSuccessMessage(
                 'addProductSuccessMessage',
                 [


### PR DESCRIPTION
### Description (*)
If user adds out of stock product to wishlist message has been shown "Out of Stock products can't be added to wishlist". If admin configuration is enabled to show Out Of Stock products, then this functionality will work.

Fixed Issues (if relevant)
#21519 - Adding out of stock items to wishlist shows success message but fails

### Manual testing scenarios (*)
1. Enable to Show Out Of Stock from Admin Configuration
2. In Frontend, Add the Product to Wishlist. Message "Out of Stock products can't be added to wishlist" will be shown.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
