### PR TITLE
Fix for sitemap directory folder path

### DIFF
--- a/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Save.php
+++ b/app/code/Magento/Sitemap/Controller/Adminhtml/Sitemap/Save.php
@@ -120,7 +120,7 @@ class Save extends \Magento\Sitemap\Controller\Adminhtml\Sitemap implements Http
     protected function clearSiteMap(\Magento\Sitemap\Model\Sitemap $model)
     {
         /** @var \Magento\Framework\Filesystem $directory */
-        $directory = $this->filesystem->getDirectoryWrite(DirectoryList::ROOT);
+        $directory = $this->filesystem->getDirectoryWrite(DirectoryList::PUB);
 
         if ($this->getRequest()->getParam('sitemap_id')) {
             $model->load($this->getRequest()->getParam('sitemap_id'));


### PR DESCRIPTION
Fix for sitemap directory folder path

### Description (*)
changed the directory path to 'pub/' folder for saving sitemap.xml and will be accessible using browser.

### Fixed Issues (if relevant)
1. magento/magento2 #1146: A few issues when you use /pub as DocumentRoot

### Manual testing scenarios (*)

1. Make sure the Magento docroot is set to the pub directory
2. In the backend, go to Marketing => Site Map
3. Click 'Add Sitemap' (small inconsistency between, no space here)
4. Enter 'sitemap.xml' into the Filename field, enter '/' into the Path field
5. Click 'Save & generate'.

Problem: sitemap.xml is created in the pub directory, but the column 'Link for Google' now says: http://example.com/pub/sitemap.xml, which is also incorrect

In this case a solution with a redirect/rewrite in the .htaccess/nginx config file isn't really possible as the path and filename of the sitemap are dynamic.

Solution: with given fix we have made sure that only sitemap.xml in pub folder is accessible directly or nested folder in pub as mentioned in sitemap path while generating from admin.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
