### PR TITLE
fixed issue - 20413

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/components/group.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/components/group.js
@@ -72,7 +72,7 @@ define([
 
             _.extend(this.additionalClasses, {
                 'admin__control-grouped': !this.breakLine,
-                'admin__control-fields': this.breakLine,
+                'admin__control-fields': !this.breakLine,
                 required:   this.required,
                 _error:     this.error,
                 _disabled:  this.disabled


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
admin__control-fields class should not add in Frontend -> **this has been resolved.**
![Screenshot from 2019-05-04 16-43-03](https://user-images.githubusercontent.com/50240169/57178350-42667b00-6e8c-11e9-9417-9c3a37ed5fdc.png)

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20413: admin__control-fields class should not add in Frontend ( in checkout page )

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open frontend
2. Add any product in cart
3. Go to checkout and see shipping address form > Street Address Label
4. And inspect html here added admin__control-fields in fieldset

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
