### PR TITLE
#22562: Fix price getting populated on child item for configurable item in order JSON

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Item/Processor.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/Processor.php
@@ -12,6 +12,8 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\DataObject;
 use Magento\Quote\Api\Data\CartItemInterface;
+use Magento\Catalog\Model\Product\Type as ProductType;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableType;
 
 /**
  * Class Processor
@@ -95,9 +97,14 @@ class Processor
             $item->setData(CartItemInterface::KEY_QTY, 0);
         }
         $item->addQty($candidate->getCartQty());
-
+        $parentItem = $item->getParentItem();
+        if ($parentItem && $item->getProductType() == ProductType::TYPE_SIMPLE
+            && $parentItem->getProductType() == ConfigurableType::TYPE_CODE) {
+            $item->setPrice(0);
+        } else {
+            $item->setPrice($candidate->getFinalPrice());
+        }
         $customPrice = $request->getCustomPrice();
-        $item->setPrice($candidate->getFinalPrice());
         if (!empty($customPrice)) {
             $item->setCustomPrice($customPrice);
             $item->setOriginalCustomPrice($customPrice);

--- a/app/code/Magento/Quote/composer.json
+++ b/app/code/Magento/Quote/composer.json
@@ -17,7 +17,8 @@
         "magento/module-eav": "101.0.*",
         "magento/module-tax": "100.2.*",
         "magento/module-catalog-inventory": "100.2.*",
-        "magento/framework": "101.0.*"
+        "magento/framework": "101.0.*",
+        "magento/module-configurable-product": "100.2.*"
     },
     "suggest": {
         "magento/module-webapi": "100.2.*"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22562: Price getting populated on child item in order JSON
2. magento/magento2#18685: Quote Item Prices are NULL in cart related events

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create Configurable item
2. Create order using the configurable item
3. get order JSON using order API
Rest Endpoint Url: WEBSITE_URL/rest/V1/orders/{$orderId}
Method: GET

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
