### PR TITLE
Fixed issue  #22409 Configurable products are shown on Select Associated Product modal

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Type.php
+++ b/app/code/Magento/Catalog/Model/Product/Type.php
@@ -24,6 +24,9 @@ class Type implements OptionSourceInterface
     const TYPE_BUNDLE = 'bundle';
 
     const TYPE_VIRTUAL = 'virtual';
+    
+    const TYPE_DOWNLOADABLE = 'downloadable';
+    
     /**#@-*/
 
     /**

--- a/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Associated/AssociatedDataProvider.php
+++ b/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Associated/AssociatedDataProvider.php
@@ -60,10 +60,10 @@ class AssociatedDataProvider extends \Magento\Catalog\Ui\DataProvider\Product\Pr
      * @param LocatorInterface $locator
      * @param StoreRepositoryInterface $storeRepository
      * @param RequestInterface $request
-     * @param \Magento\Ui\DataProvider\AddFieldToCollectionInterface[] $addFieldStrategies
-     * @param \Magento\Ui\DataProvider\AddFilterToCollectionInterface[] $addFilterStrategies
      * @param array $meta
      * @param array $data
+     * @param \Magento\Ui\DataProvider\AddFieldToCollectionInterface[] $addFieldStrategies
+     * @param \Magento\Ui\DataProvider\AddFilterToCollectionInterface[] $addFilterStrategies
      */
     public function __construct(
         $name,
@@ -79,8 +79,7 @@ class AssociatedDataProvider extends \Magento\Catalog\Ui\DataProvider\Product\Pr
         array $data = [],
         array $addFieldStrategies = [],
         array $addFilterStrategies = []
-    )
-    {
+    ) {
         $this->_configurableType = $configurableType;
         $this->productData = $productFactory;
         $this->locator = $locator;
@@ -96,36 +95,36 @@ class AssociatedDataProvider extends \Magento\Catalog\Ui\DataProvider\Product\Pr
             $meta,
             $data
         );
-
     }
 
-
     /**
+     * Filtered Collection
+     *
      * @return Collection|\Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function getCollection()
     {
-        /** @var Collection $collection */
         $collection = parent::getCollection();
         $collection->addAttributeToSelect('status');
-
 
         if ($this->getStore()) {
             $collection->setStore($this->getStore());
         }
 
-        $collection->addFieldToFilter('type_id',
+        $collection->addFieldToFilter(
+            'type_id',
             ['in' => [
                 \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE,
                 \Magento\Catalog\Model\Product\Type::TYPE_VIRTUAL,
                 \Magento\Catalog\Model\Product\Type::TYPE_DOWNLOADABLE
-            ]]);
+            ]]
+        );
 
         $product = $this->_getProduct();
         foreach ((array)$this->_configurableType->getConfigurableAttributesAsArray($product) as $attribute) {
             $collection->addAttributeToSelect($attribute['attribute_code']);
-            $collection->addAttributeToFilter($attribute['attribute_code'], array('notnull' => 1));
+            $collection->addAttributeToFilter($attribute['attribute_code'], ['notnull' => 1]);
         }
 
         return $collection;

--- a/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Associated/AssociatedDataProvider.php
+++ b/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Associated/AssociatedDataProvider.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\ConfigurableProduct\Ui\DataProvider\Product\Associated;
+
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Ui\DataProvider\Modifier\ModifierInterface;
+use Magento\Ui\DataProvider\Modifier\PoolInterface;
+use Magento\Framework\App\RequestInterface;
+use Magento\Store\Api\StoreRepositoryInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Locator\LocatorInterface;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Catalog\Model\ProductFactory;
+
+/**
+* Class AssociatedDataProvider
+*
+* @api
+* @since 100.0.2
+*/
+class AssociatedDataProvider extends \Magento\Catalog\Ui\DataProvider\Product\ProductDataProvider
+{
+
+    /**
+     * @var Magento\Catalog\Model\ProductFactory
+     */
+    protected $productData;
+
+    /**
+     * @var ProductInterface
+     */
+    private $product;
+
+    /**
+     * Product collection
+     *
+     * @var \Magento\Catalog\Model\ResourceModel\Product\Collection
+     */
+    protected $collection;
+
+    /**
+     * @var \Magento\Ui\DataProvider\AddFieldToCollectionInterface[]
+     */
+    protected $addFieldStrategies;
+
+    /**
+     * @var \Magento\Ui\DataProvider\AddFilterToCollectionInterface[]
+     */
+    protected $addFilterStrategies;
+
+    /**
+     * @var PoolInterface
+     */
+    private $modifiersPool;
+
+    /**
+     * @var StoreInterface
+     */
+    private $store;
+
+    /**
+     * @param string $name
+     * @param string $primaryFieldName
+     * @param string $requestFieldName
+     * @param CollectionFactory $collectionFactory
+     * @param \Magento\Ui\DataProvider\AddFieldToCollectionInterface[] $addFieldStrategies
+     * @param \Magento\Ui\DataProvider\AddFilterToCollectionInterface[] $addFilterStrategies
+     * @param array $meta
+     * @param array $data
+     * @param PoolInterface|null $modifiersPool
+     */
+    public function __construct(
+        Configurable $configurableType,
+        ProductFactory $productFactory,
+        $name,
+        $primaryFieldName,
+        $requestFieldName,
+        CollectionFactory $collectionFactory,
+        \Magento\Framework\Registry $registry,
+        array $addFieldStrategies = [],
+        array $addFilterStrategies = [],
+        array $meta = [],
+        array $data = [],
+        LocatorInterface $locator,
+        PoolInterface $modifiersPool = null,
+        StoreRepositoryInterface $storeRepository,
+        ProductRepositoryInterface $productRepository,
+        RequestInterface $request
+    )
+    {
+        $this->_configurableType = $configurableType;
+        $this->productData = $productFactory;
+        $this->locator = $locator;
+        $this->_coreRegistry = $registry;
+        $this->request = $request;
+        $this->storeRepository = $storeRepository;
+        $this->productRepository = $productRepository;
+        parent::__construct($name, $primaryFieldName, $requestFieldName, $collectionFactory, $addFieldStrategies, $addFilterStrategies, $meta, $data);
+    }
+
+    /**
+     * {@inheritdoc}
+     * @since 101.0.0
+     */
+    public function getCollection()
+    {
+        /** @var Collection $collection */
+        $collection = parent::getCollection();
+        $collection->addAttributeToSelect('status');
+
+
+        if ($this->getStore()) {
+            $collection->setStore($this->getStore());
+        }
+
+        $collection->addFieldToFilter('type_id',
+            ['in' => [
+                \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE,
+                \Magento\Catalog\Model\Product\Type::TYPE_VIRTUAL,
+                \Magento\Catalog\Model\Product\Type::TYPE_DOWNLOADABLE
+            ]]);
+
+        $product = $this->_getProduct();
+        foreach ((array)$this->_configurableType->getConfigurableAttributesAsArray($product) as $attribute) {
+            $collection->addAttributeToSelect($attribute['attribute_code']);
+            $collection->addAttributeToFilter($attribute['attribute_code'], array('notnull' => 1));
+        }
+
+        return $collection;
+    }
+
+    /**
+     * Get product
+     *
+     * @return \Magento\Catalog\Model\Product
+     */
+    protected function _getProduct()
+    {
+        $product_id = (int) $this->request->getParam('id');
+        return $this->productData->create()->load($product_id);
+    }
+
+    /**
+     * Retrieve store
+     *
+     * @return StoreInterface|null
+     * @since 101.0.0
+     */
+    protected function getStore()
+    {
+        if (null !== $this->store) {
+            return $this->store;
+        }
+
+        if (!($storeId = $this->request->getParam('current_store_id'))) {
+            return null;
+        }
+
+        return $this->store = $this->storeRepository->getById($storeId);
+    }
+
+}

--- a/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Associated/AssociatedDataProvider.php
+++ b/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Associated/AssociatedDataProvider.php
@@ -6,22 +6,18 @@
 namespace Magento\ConfigurableProduct\Ui\DataProvider\Product\Associated;
 
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
-use Magento\Ui\DataProvider\Modifier\ModifierInterface;
-use Magento\Ui\DataProvider\Modifier\PoolInterface;
 use Magento\Framework\App\RequestInterface;
 use Magento\Store\Api\StoreRepositoryInterface;
-use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Locator\LocatorInterface;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Catalog\Model\ProductFactory;
 
 /**
-* Class AssociatedDataProvider
-*
-* @api
-* @since 100.0.2
-*/
+ * Class AssociatedDataProvider
+ *
+ * @api
+ * @since 100.0.2
+ */
 class AssociatedDataProvider extends \Magento\Catalog\Ui\DataProvider\Product\ProductDataProvider
 {
 
@@ -29,11 +25,6 @@ class AssociatedDataProvider extends \Magento\Catalog\Ui\DataProvider\Product\Pr
      * @var Magento\Catalog\Model\ProductFactory
      */
     protected $productData;
-
-    /**
-     * @var ProductInterface
-     */
-    private $product;
 
     /**
      * Product collection
@@ -53,58 +44,65 @@ class AssociatedDataProvider extends \Magento\Catalog\Ui\DataProvider\Product\Pr
     protected $addFilterStrategies;
 
     /**
-     * @var PoolInterface
-     */
-    private $modifiersPool;
-
-    /**
      * @var StoreInterface
      */
     private $store;
 
     /**
+     * Construct
+     *
      * @param string $name
      * @param string $primaryFieldName
      * @param string $requestFieldName
      * @param CollectionFactory $collectionFactory
+     * @param Configurable $configurableType
+     * @param ProductFactory $productFactory
+     * @param LocatorInterface $locator
+     * @param StoreRepositoryInterface $storeRepository
+     * @param RequestInterface $request
      * @param \Magento\Ui\DataProvider\AddFieldToCollectionInterface[] $addFieldStrategies
      * @param \Magento\Ui\DataProvider\AddFilterToCollectionInterface[] $addFilterStrategies
      * @param array $meta
      * @param array $data
-     * @param PoolInterface|null $modifiersPool
      */
     public function __construct(
-        Configurable $configurableType,
-        ProductFactory $productFactory,
         $name,
         $primaryFieldName,
         $requestFieldName,
         CollectionFactory $collectionFactory,
-        \Magento\Framework\Registry $registry,
-        array $addFieldStrategies = [],
-        array $addFilterStrategies = [],
+        Configurable $configurableType,
+        ProductFactory $productFactory,
+        LocatorInterface $locator,
+        StoreRepositoryInterface $storeRepository,
+        RequestInterface $request,
         array $meta = [],
         array $data = [],
-        LocatorInterface $locator,
-        PoolInterface $modifiersPool = null,
-        StoreRepositoryInterface $storeRepository,
-        ProductRepositoryInterface $productRepository,
-        RequestInterface $request
+        array $addFieldStrategies = [],
+        array $addFilterStrategies = []
     )
     {
         $this->_configurableType = $configurableType;
         $this->productData = $productFactory;
         $this->locator = $locator;
-        $this->_coreRegistry = $registry;
         $this->request = $request;
         $this->storeRepository = $storeRepository;
-        $this->productRepository = $productRepository;
-        parent::__construct($name, $primaryFieldName, $requestFieldName, $collectionFactory, $addFieldStrategies, $addFilterStrategies, $meta, $data);
+        parent::__construct(
+            $name,
+            $primaryFieldName,
+            $requestFieldName,
+            $collectionFactory,
+            $addFieldStrategies,
+            $addFilterStrategies,
+            $meta,
+            $data
+        );
+
     }
 
+
     /**
-     * {@inheritdoc}
-     * @since 101.0.0
+     * @return Collection|\Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function getCollection()
     {
@@ -147,8 +145,8 @@ class AssociatedDataProvider extends \Magento\Catalog\Ui\DataProvider\Product\Pr
     /**
      * Retrieve store
      *
-     * @return StoreInterface|null
-     * @since 101.0.0
+     * @return StoreInterface|\Magento\Store\Api\Data\StoreInterface|null
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     protected function getStore()
     {

--- a/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
+++ b/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
@@ -207,7 +207,7 @@ class ConfigurablePanel extends AbstractModifier
                                             . $this->associatedListingPrefix
                                             . static::ASSOCIATED_PRODUCT_LISTING . '.product_columns.ids',
                                         'ns' => $this->associatedListingPrefix . static::ASSOCIATED_PRODUCT_LISTING,
-                                        'render_url' => $this->urlBuilder->getUrl('mui/index/render'),
+                                        'render_url' => $this->urlBuilder->getUrl('mui/index/render', ['id' => $this->locator->getProduct()->getId()]),
                                         'realTimeLink' => true,
                                         'behaviourType' => 'simple',
                                         'externalFilterMode' => false,

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/ui_component/configurable_associated_product_listing.xml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/ui_component/configurable_associated_product_listing.xml
@@ -25,7 +25,7 @@
             <updateUrl path="mui/index/render"/>
         </settings>
         <aclResource>Magento_Catalog::products</aclResource>
-        <dataProvider class="Magento\Catalog\Ui\DataProvider\Product\ProductDataProvider" name="data_source">
+        <dataProvider class="Magento\ConfigurableProduct\Ui\DataProvider\Product\Associated\AssociatedDataProvider" name="data_source">
             <settings>
                 <requestFieldName>id</requestFieldName>
                 <primaryFieldName>entity_id</primaryFieldName>

--- a/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
+++ b/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
@@ -218,6 +218,13 @@ class Grouped extends \Magento\Catalog\Model\Product\Type\AbstractType
                 ['in' => $this->getStatusFilters($product)]
             );
 
+            $collection->getSelect()
+                ->joinInner(
+                    'cataloginventory_stock_item',
+                    'e.entity_id=cataloginventory_stock_item.product_id AND cataloginventory_stock_item.is_in_stock ="1"',
+                    ['is_in_stock']
+                );
+            
             foreach ($collection as $item) {
                 $associatedProducts[] = $item;
             }

--- a/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
+++ b/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
@@ -218,13 +218,6 @@ class Grouped extends \Magento\Catalog\Model\Product\Type\AbstractType
                 ['in' => $this->getStatusFilters($product)]
             );
 
-            $collection->getSelect()
-                ->joinInner(
-                    'cataloginventory_stock_item',
-                    'e.entity_id=cataloginventory_stock_item.product_id AND cataloginventory_stock_item.is_in_stock ="1"',
-                    ['is_in_stock']
-                );
-            
             foreach ($collection as $item) {
                 $associatedProducts[] = $item;
             }


### PR DESCRIPTION
Fixed issue  #22409 Configurable products are shown on Select Associated Product modal

### Description (*)
Fixed issue  #22409 Configurable products are shown on Select Associated Product modal

### Fixed Issues (if relevant)
Fixed issue  #22409 Configurable products are shown on Select Associated Product modal

1. magento/magento2#22409: Configurable products are shown on Select Associated Product modal

### Manual testing scenarios (*)
1.Create a configurable product Test 1 with 2 child products (color = red and color = black for the example)
2. Create a new simple product Test 2 with color = red
3. Open the last created product Test 2 in admin panel and convert it to configurable by adding child products (color = green, color = grey), do not change the value for color attribute while you edit product
4. Open the first configurable product Test 1, remove the child product with color = red, click on 'Add products manually' link in Configurations section

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
