### PR TITLE
show only current children categories

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/CategoryTree.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/CategoryTree.php
@@ -102,6 +102,7 @@ class CategoryTree
         $collection->addFieldToFilter('level', ['gt' => $level]);
         $collection->addFieldToFilter('level', ['lteq' => $level + $depth - self::DEPTH_OFFSET]);
         $collection->addAttributeToFilter('is_active', 1, "left");
+        $collection->addAttributeToFilter('parent_id', $rootCategoryId);
         $collection->setOrder('level');
         $collection->setOrder(
             'position',


### PR DESCRIPTION
Added check of parent_id, so that it will return the current categories of the called category id.
 
### Description (*)
 Currently, CategoryTree::getTree(..) returns all the enabled categories, so if the parent is disabled then it will also return the children of those parent categories, 
so I added a parent_id check so that it won't check and return the child categories of the disabled categories. 

### Fixed Issues (if relevant) 
 It was causing an issue in the PWA. It was returning the disabled categories index but values are null.

![image](https://user-images.githubusercontent.com/31412411/57178486-59a66800-6e8e-11e9-9ab2-d6db3a438394.png)

### Manual testing scenarios (*)
1. Disable any parent category.
2. In Graphql run the  PWA category list query.
<pre>
<code>
# TODO: get only active categories from graphql when it is ready
query categoryList($id: Int!) {
    category(id: $id) {
        id
        children {
            id
            name
            include_in_menu
            url_key
            url_path
            children_count
            path
            image
            productImagePreview: products(pageSize: 1) {
                items {
                    small_image {
                        url
                    }
                }
            }
        }
    }
}
</code>
</pre>
It will return the disabled category in index but the values are null(similar to pic).
 
### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
