### PR TITLE
Adds module:config:status command which checks if the module config i…

### DIFF
--- a/setup/src/Magento/Setup/Console/Command/ModuleConfigStatusCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ModuleConfigStatusCommand.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Setup\Console\Command;
+
+use Magento\Framework\App\DeploymentConfig\Reader as ConfigReader;
+use Magento\Framework\Config\ConfigOptionsListConstants;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Console\Cli;
+use Magento\Framework\Setup\ConsoleLogger;
+use Magento\Setup\Model\InstallerFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Command to check if the modules config in app/etc/config.php matches with how Magento interprets it
+ */
+class ModuleConfigStatusCommand extends Command
+{
+    /**
+     * Deployment config reader
+     *
+     * @var ConfigReader
+     */
+    private $configReader;
+
+    /**
+     * Installer service factory.
+     *
+     * @var InstallerFactory
+     */
+    private $installerFactory;
+
+    /**
+     * @param ConfigReader     $configReader
+     * @param InstallerFactory $installerFactory
+     */
+    public function __construct(
+        ConfigReader     $configReader,
+        InstallerFactory $installerFactory
+    ) {
+        $this->configReader     = $configReader;
+        $this->installerFactory = $installerFactory;
+
+        parent::__construct();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $this->setName('module:config:status')
+             ->setDescription('Checks the modules configuration in the \'app/etc/config.php\' file and reports if they are up to date or not');
+
+        parent::configure();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            // the config as currently in app/etc/config.php
+            $currentConfig = $this->configReader->load(ConfigFilePool::APP_CONFIG);
+            if (!array_key_exists(ConfigOptionsListConstants::KEY_MODULES, $currentConfig)) {
+                throw new \Exception('Can\'t find the modules configuration in the \'app/etc/config.php\' file.');
+            }
+
+            $currentModuleConfig = $currentConfig[ConfigOptionsListConstants::KEY_MODULES];
+
+            $installer = $this->installerFactory->create(new ConsoleLogger($output));
+
+            // the module config as Magento calculated it
+            $correctModuleConfig = $installer->getModulesConfig();
+
+            if ($currentModuleConfig !== $correctModuleConfig) {
+                throw new \Exception(
+                    'The modules configuration in the \'app/etc/config.php\' file is outdated. Run \'setup:upgrade\' to fix it.'
+                );
+            }
+
+            $output->writeln(
+                '<info>The modules configuration is up to date.</info>'
+            );
+        } catch (\Exception $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+
+            return Cli::RETURN_FAILURE;
+        }
+
+        return Cli::RETURN_SUCCESS;
+    }
+}

--- a/setup/src/Magento/Setup/Console/Command/ModuleConfigStatusCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ModuleConfigStatusCommand.php
@@ -56,8 +56,12 @@ class ModuleConfigStatusCommand extends Command
      */
     protected function configure()
     {
-        $this->setName('module:config:status')
-             ->setDescription('Checks the modules configuration in the \'app/etc/config.php\' file and reports if they are up to date or not');
+        $this
+            ->setName('module:config:status')
+            ->setDescription(
+                'Checks the modules configuration in the \'app/etc/config.php\' file '
+                . 'and reports if they are up to date or not'
+            );
 
         parent::configure();
     }
@@ -71,6 +75,7 @@ class ModuleConfigStatusCommand extends Command
             // the config as currently in app/etc/config.php
             $currentConfig = $this->configReader->load(ConfigFilePool::APP_CONFIG);
             if (!array_key_exists(ConfigOptionsListConstants::KEY_MODULES, $currentConfig)) {
+                // phpcs:ignore Magento2.Exceptions.DirectThrow
                 throw new \Exception('Can\'t find the modules configuration in the \'app/etc/config.php\' file.');
             }
 
@@ -82,14 +87,17 @@ class ModuleConfigStatusCommand extends Command
             $correctModuleConfig = $installer->getModulesConfig();
 
             if ($currentModuleConfig !== $correctModuleConfig) {
+                // phpcs:ignore Magento2.Exceptions.DirectThrow
                 throw new \Exception(
-                    'The modules configuration in the \'app/etc/config.php\' file is outdated. Run \'setup:upgrade\' to fix it.'
+                    'The modules configuration in the \'app/etc/config.php\' file is outdated. '
+                    . 'Run \'setup:upgrade\' to fix it.'
                 );
             }
 
             $output->writeln(
                 '<info>The modules configuration is up to date.</info>'
             );
+            // phpcs:disable Magento2.Exceptions.ThrowCatch
         } catch (\Exception $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
 

--- a/setup/src/Magento/Setup/Console/CommandList.php
+++ b/setup/src/Magento/Setup/Console/CommandList.php
@@ -92,6 +92,7 @@ class CommandList
             if (class_exists($class)) {
                 $commands[] = $this->serviceManager->get($class);
             } else {
+                // phpcs:ignore Magento2.Exceptions.DirectThrow
                 throw new \Exception('Class ' . $class . ' does not exist');
             }
         }

--- a/setup/src/Magento/Setup/Console/CommandList.php
+++ b/setup/src/Magento/Setup/Console/CommandList.php
@@ -66,6 +66,7 @@ class CommandList
             \Magento\Setup\Console\Command\ModuleDisableCommand::class,
             \Magento\Setup\Console\Command\ModuleStatusCommand::class,
             \Magento\Setup\Console\Command\ModuleUninstallCommand::class,
+            \Magento\Setup\Console\Command\ModuleConfigStatusCommand::class,
             \Magento\Setup\Console\Command\MaintenanceAllowIpsCommand::class,
             \Magento\Setup\Console\Command\MaintenanceDisableCommand::class,
             \Magento\Setup\Console\Command\MaintenanceEnableCommand::class,

--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -1201,6 +1201,17 @@ class Installer
     }
 
     /**
+     * Get the modules config as Magento sees it
+     *
+     * @return array
+     * @throws \LogicException
+     */
+    public function getModulesConfig()
+    {
+        return $this->createModulesConfig([], true);
+    }
+
+    /**
      * Uninstall Magento application
      *
      * @return void

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/ModuleConfigStatusCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/ModuleConfigStatusCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Setup\Test\Unit\Console\Command;
+
+use Magento\Framework\Config\ConfigOptionsListConstants;
+use Magento\Setup\Console\Command\ModuleConfigStatusCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ModuleConfigStatusCommandTest extends TestCase
+{
+    /**
+     * @param array $currentConfig
+     * @param array $correctConfig
+     * @param string $expectedOutput
+     * @dataProvider executeDataProvider
+     */
+    public function testExecute(array $currentConfig, array $correctConfig, string $expectedOutput)
+    {
+        $configReader = $this->createMock(\Magento\Framework\App\DeploymentConfig\Reader::class);
+        $configReader->expects($this->once())
+                     ->method('load')
+                     ->willReturn([ConfigOptionsListConstants::KEY_MODULES => $currentConfig]);
+
+        $installer = $this->createMock(\Magento\Setup\Model\Installer::class);
+        $installer->expects($this->once())
+                  ->method('getModulesConfig')
+                  ->willReturn($correctConfig);
+
+        $installerFactory = $this->createMock(\Magento\Setup\Model\InstallerFactory::class);
+        $installerFactory->expects($this->once())
+                         ->method('create')
+                         ->willReturn($installer);
+
+        $command = new ModuleConfigStatusCommand($configReader, $installerFactory);
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $this->assertEquals($expectedOutput, $tester->getDisplay());
+    }
+
+    public function executeDataProvider()
+    {
+        $successMessage = 'The modules configuration is up to date.' . PHP_EOL;
+        $failureMessage = 'The modules configuration in the \'app/etc/config.php\' file is outdated. Run \'setup:upgrade\' to fix it.' . PHP_EOL;
+
+        return [
+            [
+                ['Magento_ModuleA' => 1, 'Magento_ModuleB' => 1],
+                ['Magento_ModuleA' => 1, 'Magento_ModuleB' => 1],
+                $successMessage,
+            ],
+            [
+                ['Magento_ModuleA' => 0, 'Magento_ModuleB' => 1],
+                ['Magento_ModuleA' => 0, 'Magento_ModuleB' => 1],
+                $successMessage,
+            ],
+            [
+                ['Magento_ModuleA' => 1, 'Magento_ModuleB' => 1],
+                ['Magento_ModuleB' => 1, 'Magento_ModuleA' => 1],
+                $failureMessage,
+            ],
+            [
+                ['Magento_ModuleA' => 0, 'Magento_ModuleB' => 1],
+                ['Magento_ModuleB' => 1, 'Magento_ModuleA' => 0],
+                $failureMessage,
+            ],
+            [
+                ['Magento_ModuleA' => 1],
+                ['Magento_ModuleB' => 1, 'Magento_ModuleA' => 1],
+                $failureMessage,
+            ],
+            [
+                ['Magento_ModuleA' => 1, 'Magento_ModuleB' => 1],
+                ['Magento_ModuleB' => 1],
+                $failureMessage,
+            ],
+        ];
+    }
+}

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/ModuleConfigStatusCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/ModuleConfigStatusCommandTest.php
@@ -13,6 +13,9 @@ use Magento\Setup\Console\Command\ModuleConfigStatusCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
+/**
+ * Tests for module config status command.
+ */
 class ModuleConfigStatusCommandTest extends TestCase
 {
     /**
@@ -49,7 +52,8 @@ class ModuleConfigStatusCommandTest extends TestCase
     public function executeDataProvider()
     {
         $successMessage = 'The modules configuration is up to date.' . PHP_EOL;
-        $failureMessage = 'The modules configuration in the \'app/etc/config.php\' file is outdated. Run \'setup:upgrade\' to fix it.' . PHP_EOL;
+        $failureMessage = 'The modules configuration in the \'app/etc/config.php\' '
+            . 'file is outdated. Run \'setup:upgrade\' to fix it.' . PHP_EOL;
 
         return [
             [


### PR DESCRIPTION
…n the app/etc/config.php file is correct or not.

### Description (*)
This adds a new command to `bin/magento`: `module:config:status`.
This command checks if the modules in the file `app/etc/config.php` are correct or not.

I've created this command since I'm getting a bit tired of seeing incorrect `app/etc/config.php` files being added to our git repo's whenever somebody adds a new module using composer and forgets to run `bin/magento setup:upgrade`, or when some branch get merged which has merge conflicts in the `config.php` file and the conflict gets solved incorrectly.
Having this new command, would allow us to have a pre-commit githook which can check for this problem and then tell the developer to fix the `config.php` file before committing.

Feel free to let me know if the command name or description needs to be changed. And also if the output messages need to be changed.

### Fixed Issues (if relevant)
None that I could find.

### Manual testing scenarios (*)
1. Have a correct Magento installation
2. Run `bin/magento module:config:status`, it should say: `The modules configuration is up to date.`
3. Edit the file `app/etc/config.php` and remove or add a module. Or just switch the sort order of 2 modules.
4. Run `bin/magento module:config:status`, it should say: `The modules configuration in the 'app/etc/config.php' file is outdated. Run 'setup:upgrade' to fix it.`
5. Run `bin/magento setup:upgrade`
6. Run `bin/magento module:config:status`, it should say: `The modules configuration is up to date.`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
