### PR TITLE
Ignores allure-results in git.

### DIFF
--- a/dev/tests/integration/.gitignore
+++ b/dev/tests/integration/.gitignore
@@ -2,3 +2,4 @@
 !/etc/integration-tests-config.xml
 /var/
 /etc/*.php
+/framework/tests/unit/var/allure-results/

--- a/dev/tests/static/.gitignore
+++ b/dev/tests/static/.gitignore
@@ -1,4 +1,6 @@
 /*.xml
-framework/tests/unit/*.xml
-report/
-tmp/
+/framework/tests/unit/*.xml
+/framework/tests/unit/var/allure-results/
+/report/
+/tmp/
+/var/allure-results/

--- a/dev/tests/unit/.gitignore
+++ b/dev/tests/unit/.gitignore
@@ -1,1 +1,2 @@
 /phpunit.xml
+/var/allure-results/


### PR DESCRIPTION
### Description (*)
When running unit tests on a clone of this repo, it generates some files which should be ignored in git.

I'm not sure if we would need to ignore the entire `dev/tests/unit/var/` directory, or only `dev/tests/unit/var/allure-results`? I've opted for the latter here.

### Fixed Issues (if relevant)
None that I could find.

### Manual testing scenarios (*)
1. Clone this repo (2.3-develop branch)
2. Run `composer install`
3. Run `cd dev/tests/unit`
4. Run `../../../vendor/bin/phpunit ../../../setup/src/Magento/Setup/Test/Unit/`
5. Run `cd ../../../`
5. Run `git status`
6. It is expected that nothing shows up, but the directory `dev/tests/unit/var/allure-results` shows up containing a whole bunch of generated xml files.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
