### PR TITLE
Fix #21862 - allow to reuse previously used password

### DIFF
--- a/app/code/Magento/User/Model/Backend/Config/ObserverConfig.php
+++ b/app/code/Magento/User/Model/Backend/Config/ObserverConfig.php
@@ -80,4 +80,14 @@ class ObserverConfig
     {
         return (int)$this->backendConfig->getValue('admin/security/lockout_failures');
     }
+
+    /**
+     * Check whether password re-use is allowed
+     *
+     * @return bool
+     */
+    public function isPasswordReuseAllowed()
+    {
+        return (bool)(int)$this->backendConfig->getValue('admin/security/password_allow_reuse');
+    }
 }

--- a/app/code/Magento/User/etc/adminhtml/system.xml
+++ b/app/code/Magento/User/etc/adminhtml/system.xml
@@ -34,6 +34,10 @@
                     <label>Password Change</label>
                     <source_model>Magento\User\Model\System\Config\Source\Password</source_model>
                 </field>
+                <field id="password_allow_reuse" translate="label" sortOrder="140" type="select" showInDefault="1" canRestore="1">
+                    <label>Allow to Re-use Previous Passwords</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
     </system>

--- a/app/code/Magento/User/etc/config.xml
+++ b/app/code/Magento/User/etc/config.xml
@@ -20,6 +20,7 @@
                 <lockout_threshold>30</lockout_threshold>
                 <password_lifetime>90</password_lifetime>
                 <password_is_forced>1</password_is_forced>
+                <password_allow_reuse>0</password_allow_reuse>
             </security>
         </admin>
     </default>

--- a/app/code/Magento/User/i18n/en_US.csv
+++ b/app/code/Magento/User/i18n/en_US.csv
@@ -75,6 +75,7 @@ Permissions,Permissions
 Recommended,Recommended
 Forced,Forced
 "Sorry, but this password has already been used. Please create another.","Sorry, but this password has already been used. Please create another."
+"Sorry, but this password is being used now. Please create another.","Sorry, but this password is being used now. Please create another."
 email,email
 password,password
 username,username
@@ -130,6 +131,7 @@ Resources,Resources
 "Password Lifetime (days)","Password Lifetime (days)"
 "We will disable this feature if the value is empty. ","We will disable this feature if the value is empty. "
 "Password Change","Password Change"
+"Allow to Re-use Previous Passwords","Allow to Re-use Previous Passwords"
 Unlock,Unlock
 ID,ID
 Username,Username


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21862: Provide a setting to allow previously used passwords to be re-used when changing passwords

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to MBO
2. Change your password
3. Try to change password to previously used one - Error message appears
4. Go to Stores -> Configuration -> Advanced -> Admin -> Security
5. Change **Allow to Re-use Previous Passwords** to Yes
6. Try to change password to previously used one - Success

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
