### PR TITLE
Revert "Magento backend catalog cost without currency symbol" as Cost…

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
@@ -192,13 +192,6 @@
                 <label translate="true">Websites</label>
             </settings>
         </column>
-        <column name="cost" class="Magento\Catalog\Ui\Component\Listing\Columns\Price" sortOrder="120">
-            <settings>
-                <addField>true</addField>
-                <filter>textRange</filter>
-                <label translate="true">Cost</label>
-            </settings>
-        </column>
         <actionsColumn name="actions" class="Magento\Catalog\Ui\Component\Listing\Columns\ProductActions" sortOrder="200">
             <settings>
                 <indexField>entity_id</indexField>


### PR DESCRIPTION
… column must not be added to grid by default

This reverts commit 85beeec61b061f9494df14cad448753bd9e75c8b.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open product grid and make sure Cost column is absent by default
2. https://github.com/magento/magento2/issues/20906 should be still reproducible

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
