### PR TITLE
Sku uniqueness

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
@@ -3,13 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\Catalog\Model\Product\Attribute\Backend;
 
 use Magento\Catalog\Model\Product;
 
 /**
- * Catalog product SKU backend attribute model.
+ * Catalog product SKU backend attribute model
+ *
+ * @author     Magento Core Team <core@magentocommerce.com>
  */
 class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
 {

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
@@ -71,6 +71,31 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
     }
 
     /**
+     * Generate and set unique SKU to product
+     *
+     * @param Product $object
+     * @return void
+     */
+    protected function _generateUniqueSku($object)
+    {
+        $attribute = $this->getAttribute();
+        $entity = $attribute->getEntity();
+        $attributeValue = $object->getData($attribute->getAttributeCode());
+        $increment = null;
+        while (!$entity->checkAttributeUniqueValue($attribute, $object)) {
+            if ($increment === null) {
+                $increment = $this->_getLastSimilarAttributeValueIncrement($attribute, $object);
+            }
+            $sku = trim($attributeValue);
+            if (strlen($sku . '-' . ++$increment) > self::SKU_MAX_LENGTH) {
+                $sku = substr($sku, 0, -strlen($increment) - 1);
+            }
+            $sku = $sku . '-' . $increment;
+            $object->setData($attribute->getAttributeCode(), $sku);
+        }
+    }
+
+    /**
      * Make SKU unique before save
      *
      * @param Product $object
@@ -78,6 +103,37 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      */
     public function beforeSave($object)
     {
+        if ($object->getIsDuplicate()) {
+            $this->_generateUniqueSku($object);
+        }
         return parent::beforeSave($object);
+    }
+
+    /**
+     * Return increment needed for SKU uniqueness
+     *
+     * @param \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute
+     * @param Product $object
+     * @return int
+     */
+    protected function _getLastSimilarAttributeValueIncrement($attribute, $object)
+    {
+        $connection = $this->getAttribute()->getEntity()->getConnection();
+        $select = $connection->select();
+        $value = $object->getData($attribute->getAttributeCode());
+        $bind = ['attribute_code' => trim($value) . '-%'];
+
+        $select->from(
+            $this->getTable(),
+            $attribute->getAttributeCode()
+        )->where(
+            $attribute->getAttributeCode() . ' LIKE :attribute_code'
+        )->order(
+            ['entity_id DESC', $attribute->getAttributeCode() . ' ASC']
+        )->limit(
+            1
+        );
+        $data = $connection->fetchOne($select, $bind);
+        return abs((int)str_replace($value, '', $data));
     }
 }

--- a/dev/tests/functional/tests/app/Magento/CatalogUrlRewrite/Test/Constraint/AssertProductUrlDuplicateErrorMessage.php
+++ b/dev/tests/functional/tests/app/Magento/CatalogUrlRewrite/Test/Constraint/AssertProductUrlDuplicateErrorMessage.php
@@ -19,7 +19,7 @@ class AssertProductUrlDuplicateErrorMessage extends AbstractConstraint
     /**
      * Text title of the error message to be checked.
      */
-    const ERROR_MESSAGE_TITLE = 'The value specified in the URL Key field would generate a URL that already exists.';
+    const ERROR_MESSAGE_TITLE = 'SKU is already in use.';
 
     /**
      * Assert that success message is displayed after product save.

--- a/dev/tests/functional/tests/app/Magento/CatalogUrlRewrite/Test/Constraint/AssertProductUrlDuplicateErrorMessage.php
+++ b/dev/tests/functional/tests/app/Magento/CatalogUrlRewrite/Test/Constraint/AssertProductUrlDuplicateErrorMessage.php
@@ -19,7 +19,7 @@ class AssertProductUrlDuplicateErrorMessage extends AbstractConstraint
     /**
      * Text title of the error message to be checked.
      */
-    const ERROR_MESSAGE_TITLE = 'SKU is already in use.';
+    const ERROR_MESSAGE_TITLE = 'The value specified in the URL Key field would generate a URL that already exists.';
 
     /**
      * Assert that success message is displayed after product save.

--- a/dev/tests/functional/tests/app/Magento/CatalogUrlRewrite/Test/TestCase/CreateDuplicateUrlProductEntity.php
+++ b/dev/tests/functional/tests/app/Magento/CatalogUrlRewrite/Test/TestCase/CreateDuplicateUrlProductEntity.php
@@ -68,6 +68,7 @@ class CreateDuplicateUrlProductEntity extends Injectable
      * Run create product simple entity test.
      *
      * @param CatalogProductSimple $product
+     * @param CatalogProductSimple $product2
      * @param Category $category
      * @param CatalogProductIndex $productGrid
      * @param CatalogProductNew $newProductPage
@@ -77,6 +78,7 @@ class CreateDuplicateUrlProductEntity extends Injectable
      */
     public function testCreate(
         CatalogProductSimple $product,
+        CatalogProductSimple $product2,
         Category $category,
         CatalogProductIndex $productGrid,
         CatalogProductNew $newProductPage,
@@ -92,13 +94,15 @@ class CreateDuplicateUrlProductEntity extends Injectable
             ['configData' => $this->configData, 'flushCache' => $this->flushCache]
         )->run();
 
-        for ($index = 0; $index < 2; $index++) {
-            // Duplicate product
-            $productGrid->open();
-            $productGrid->getGridPageActionBlock()->addProduct('simple');
-            $newProductPage->getProductForm()->fill($product, null, $category);
-            $newProductPage->getFormPageActions()->save();
-        }
+        $productGrid->open();
+        $productGrid->getGridPageActionBlock()->addProduct('simple');
+        $newProductPage->getProductForm()->fill($product, null, $category);
+        $newProductPage->getFormPageActions()->save();
+
+        $productGrid->open();
+        $productGrid->getGridPageActionBlock()->addProduct('simple');
+        $newProductPage->getProductForm()->fill($product2, null, $category);
+        $newProductPage->getFormPageActions()->save();
 
         return ['product' => $product];
     }

--- a/dev/tests/functional/tests/app/Magento/CatalogUrlRewrite/Test/TestCase/CreateDuplicateUrlProductEntity.xml
+++ b/dev/tests/functional/tests/app/Magento/CatalogUrlRewrite/Test/TestCase/CreateDuplicateUrlProductEntity.xml
@@ -8,13 +8,19 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../vendor/magento/mtf/etc/variations.xsd">
     <testCase name="Magento\CatalogUrlRewrite\Test\TestCase\CreateDuplicateUrlProductEntity" summary="Create Simple Product" ticketId="MAGETWO-69427">
         <variation name="CreateDuplicateUrlProductEntityTestVariation1" summary="Create Duplicate Url Product">
-            <data name="tag" xsi:type="string">test_type:acceptance_test, test_type:extended_acceptance_test, severity:S1, mftf_migrated:yes</data>
-            <data name="product/data/url_key" xsi:type="string">simple-product-%isolation%</data>
+            <data name="tag" xsi:type="string">test_type:acceptance_test, test_type:extended_acceptance_test, severity:S1</data>
+            <data name="product/data/url_key" xsi:type="string">simple-product-samekey</data>
             <data name="product/data/name" xsi:type="string">Simple Product %isolation%</data>
             <data name="product/data/sku" xsi:type="string">simple_sku_%isolation%</data>
             <data name="product/data/price/value" xsi:type="string">10000</data>
             <data name="product/data/weight" xsi:type="string">50</data>
             <data name="product/data/quantity_and_stock_status/qty" xsi:type="string">657</data>
+            <data name="product2/data/url_key" xsi:type="string">simple-product-samekey</data>
+            <data name="product2/data/name" xsi:type="string">Simple Product %isolation%</data>
+            <data name="product2/data/sku" xsi:type="string">simple_sku_%isolation%</data>
+            <data name="product2/data/price/value" xsi:type="string">10000</data>
+            <data name="product2/data/weight" xsi:type="string">50</data>
+            <data name="product2/data/quantity_and_stock_status/qty" xsi:type="string">657</data>
             <constraint name="Magento\CatalogUrlRewrite\Test\Constraint\AssertProductUrlDuplicateErrorMessage" />
         </variation>
     </testCase>

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/SkuTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/SkuTest.php
@@ -64,7 +64,7 @@ class SkuTest extends \PHPUnit\Framework\TestCase
             \Magento\Catalog\Model\ProductRepository::class
         );
         $product = $repository->get('simple');
-        $product->setSku('0123456789012345678901234567890123456789012345678901234567890123');
+        $product->setSku('0123456789012345678901234567890123456789012345678901234567890123')->save();
 
         /** @var \Magento\Catalog\Model\Product\Copier $copier */
         $copier = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
@@ -72,12 +72,7 @@ class SkuTest extends \PHPUnit\Framework\TestCase
         );
         $copy = $copier->copy($product);
         $this->assertEquals('0123456789012345678901234567890123456789012345678901234567890123', $product->getSku());
-        $product->getResource()->getAttribute('sku')->getBackend()->beforeSave($product);
-        $this->assertEquals('0123456789012345678901234567890123456789012345678901234567890123', $product->getSku());
         $this->assertEquals('01234567890123456789012345678901234567890123456789012345678901-1', $copy->getSku());
-
-        $copy->getResource()->getAttribute('sku')->getBackend()->beforeSave($copy);
-        $this->assertEquals('01234567890123456789012345678901234567890123456789012345678901-2', $copy->getSku());
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/SkuTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/SkuTest.php
@@ -14,7 +14,23 @@ class SkuTest extends \PHPUnit\Framework\TestCase
     /**
      * @magentoDataFixture Magento/Catalog/_files/product_simple.php
      */
-    public function testGenerateUniqueSkuExistingProduct()
+    public function testGenerateUniqueSkuExistingProductDuplication()
+    {
+        $repository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Catalog\Model\ProductRepository::class
+        );
+        $product = $repository->get('simple');
+        $product->setId(null);
+        $product->setIsDuplicate(true);
+        $this->assertEquals('simple', $product->getSku());
+        $product->getResource()->getAttribute('sku')->getBackend()->beforeSave($product);
+        $this->assertEquals('simple-1', $product->getSku());
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     */
+    public function testGenerateUniqueSkuExistingProductNoDuplication()
     {
         $repository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
             \Magento\Catalog\Model\ProductRepository::class
@@ -23,7 +39,7 @@ class SkuTest extends \PHPUnit\Framework\TestCase
         $product->setId(null);
         $this->assertEquals('simple', $product->getSku());
         $product->getResource()->getAttribute('sku')->getBackend()->beforeSave($product);
-        $this->assertEquals('simple-1', $product->getSku());
+        $this->assertEquals('simple', $product->getSku());
     }
 
     /**
@@ -54,10 +70,14 @@ class SkuTest extends \PHPUnit\Framework\TestCase
         $copier = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
             \Magento\Catalog\Model\Product\Copier::class
         );
-        $copier->copy($product);
+        $copy = $copier->copy($product);
         $this->assertEquals('0123456789012345678901234567890123456789012345678901234567890123', $product->getSku());
         $product->getResource()->getAttribute('sku')->getBackend()->beforeSave($product);
-        $this->assertEquals('01234567890123456789012345678901234567890123456789012345678901-1', $product->getSku());
+        $this->assertEquals('0123456789012345678901234567890123456789012345678901234567890123', $product->getSku());
+        $this->assertEquals('01234567890123456789012345678901234567890123456789012345678901-1', $copy->getSku());
+
+        $copy->getResource()->getAttribute('sku')->getBackend()->beforeSave($copy);
+        $this->assertEquals('01234567890123456789012345678901234567890123456789012345678901-2', $copy->getSku());
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/CatalogRule/Model/Indexer/IndexerBuilderTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogRule/Model/Indexer/IndexerBuilderTest.php
@@ -137,10 +137,11 @@ class IndexerBuilderTest extends \PHPUnit\Framework\TestCase
 
         $this->product->setStoreId(0)->setData('test_attribute', 'test_attribute_value')->save();
         $this->productSecond = clone $this->product;
-        $this->productSecond->setId(null)->setUrlKey('product-second')->save();
+        $this->productSecond->setId(null)->setUrlKey('product-second')->setIsDuplicate(true)->save();
         $this->productThird = clone $this->product;
         $this->productThird->setId(null)
             ->setUrlKey('product-third')
+            ->setIsDuplicate(true)
             ->setData('test_attribute', 'NO_test_attribute_value')
             ->save();
     }


### PR DESCRIPTION
This is a migration of the PR https://github.com/magento-engcom/import-export-improvements/pull/119 from the now closed import-export-improvements repo.

Originally by @federivo and @pogster 

**Description**

This PR may replace #102.
In contrast to the original PR I restored the SKU autogeneration in case a product is duplicated. The product copier will copy the original SKU and save the duplicate in a loop until a unique url key is found - if no SKU is autogenerated and no valid SKU is supplied it simply won't save the product.

Since the copier sets "isDuplicate" = true I thought it would be good simple solution to check for that entry before autogenerating a SKU.

**Fixed Issues (if relevant)**

https://github.com/magento-engcom/import-export-improvements/issues/101

**Manual testing scenarios**

- Create product with sku "TEST"
- Create another product with sku "TEST"
- You should receive an error saying that the sku already exists instead of getting your sku modified.
- "Save & Duplicate" the product with sku "TEST"
- The duplicate receives the SKU "TEST-1" and will already be saved.

**Contribution checklist**
- [ ]   Pull request has a meaningful description of its purpose
- [ ]   All commits are accompanied by meaningful commit messages
- [ ]   All new or changed code is covered with unit/integration tests (if applicable)
- [ ]   All automated tests passed successfully (all builds on Travis CI are green)