### PR TITLE
Fix layout xml and page layout caching issue on redis cluster under high load

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/View/Layout/MergeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Layout/MergeTest.php
@@ -42,6 +42,11 @@ class MergeTest extends \PHPUnit\Framework\TestCase
     protected $_cache;
 
     /**
+     * @var \Magento\Framework\Serialize\SerializerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $_serializer;
+
+    /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
     protected $_theme;
@@ -74,7 +79,8 @@ class MergeTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $files = [];
-        foreach (glob(__DIR__ . '/_mergeFiles/layout/*.xml') as $filename) {
+        $fileDriver = new \Magento\Framework\Filesystem\Driver\File();
+        foreach ($fileDriver->readDirectory(__DIR__ . '/_mergeFiles/layout/') as $filename) {
             $files[] = new \Magento\Framework\View\File($filename, 'Magento_Widget');
         }
         $fileSource = $this->getMockForAbstractClass(\Magento\Framework\View\File\CollectorInterface::class);
@@ -99,6 +105,8 @@ class MergeTest extends \PHPUnit\Framework\TestCase
         $this->_layoutValidator = $this->createMock(\Magento\Framework\View\Model\Layout\Update\Validator::class);
 
         $this->_cache = $this->getMockForAbstractClass(\Magento\Framework\Cache\FrontendInterface::class);
+
+        $this->_serializer = $this->getMockForAbstractClass(\Magento\Framework\Serialize\SerializerInterface::class);
 
         $this->_theme = $this->createMock(\Magento\Theme\Model\Theme::class);
         $this->_theme->expects($this->any())->method('isPhysical')->will($this->returnValue(true));
@@ -140,6 +148,7 @@ class MergeTest extends \PHPUnit\Framework\TestCase
                 'resource' => $this->_resource,
                 'appState' => $this->_appState,
                 'cache' => $this->_cache,
+                'serializer' => $this->_serializer,
                 'theme' => $this->_theme,
                 'validator' => $this->_layoutValidator,
                 'logger' => $this->_logger,
@@ -276,9 +285,16 @@ class MergeTest extends \PHPUnit\Framework\TestCase
 
     public function testLoadCache()
     {
+        $cacheValue = [
+            "pageLayout" => "1column",
+            "layout"     => self::FIXTURE_LAYOUT_XML
+        ];
+
         $this->_cache->expects($this->at(0))->method('load')
-            ->with('LAYOUT_area_STORE20_100c6a4ccd050e33acef0553f24ef399961')
-            ->will($this->returnValue(self::FIXTURE_LAYOUT_XML));
+            ->with('LAYOUT_area_STORE20_100c6a4ccd050e33acef0553f24ef399961_page_layout_merged')
+            ->will($this->returnValue(json_encode($cacheValue)));
+
+        $this->_serializer->expects($this->once())->method('unserialize')->willReturn($cacheValue);
 
         $this->assertEmpty($this->_model->getHandles());
         $this->assertEmpty($this->_model->asString());
@@ -424,8 +440,10 @@ class MergeTest extends \PHPUnit\Framework\TestCase
             ->method('isValid')
             ->willThrowException(new \Exception('Layout is invalid.'));
 
+        // phpcs:ignore Magento2.Security.InsecureFunction
         $suffix = md5(implode('|', $this->_model->getHandles()));
-        $cacheId = "LAYOUT_{$this->_theme->getArea()}_STORE{$this->scope->getId()}_{$this->_theme->getId()}{$suffix}";
+        $cacheId = "LAYOUT_{$this->_theme->getArea()}_STORE{$this->scope->getId()}"
+            . "_{$this->_theme->getId()}{$suffix}_page_layout_merged";
         $messages = $this->_layoutValidator->getMessages();
 
         // Testing error message is logged with logger

--- a/lib/internal/Magento/Framework/View/Test/Unit/Model/Layout/MergeTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Model/Layout/MergeTest.php
@@ -11,6 +11,11 @@ use Magento\Framework\Phrase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\View\Layout\LayoutCacheKeyInterface;
 
+/**
+ * Class MergeTest
+ *
+ * @package Magento\Framework\View\Test\Unit\Model\Layout
+ */
 class MergeTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -29,9 +34,19 @@ class MergeTest extends \PHPUnit\Framework\TestCase
     private $scope;
 
     /**
+     * @var \Magento\Framework\Cache\FrontendInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $cache;
+
+    /**
      * @var \Magento\Framework\View\Model\Layout\Update\Validator|\PHPUnit_Framework_MockObject_MockObject
      */
     private $layoutValidator;
+
+    /**
+     * @var \Magento\Framework\Serialize\SerializerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $serializer;
 
     /**
      * @var \Psr\Log\LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
@@ -53,10 +68,12 @@ class MergeTest extends \PHPUnit\Framework\TestCase
         $this->objectManagerHelper = new ObjectManager($this);
 
         $this->scope = $this->getMockForAbstractClass(\Magento\Framework\Url\ScopeInterface::class);
+        $this->cache = $this->getMockForAbstractClass(\Magento\Framework\Cache\FrontendInterface::class);
         $this->layoutValidator = $this->getMockBuilder(\Magento\Framework\View\Model\Layout\Update\Validator::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->logger = $this->getMockForAbstractClass(\Psr\Log\LoggerInterface::class);
+        $this->serializer = $this->getMockForAbstractClass(\Magento\Framework\Serialize\SerializerInterface::class);
         $this->appState = $this->getMockBuilder(\Magento\Framework\App\State::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -70,10 +87,12 @@ class MergeTest extends \PHPUnit\Framework\TestCase
             \Magento\Framework\View\Model\Layout\Merge::class,
             [
                 'scope' => $this->scope,
+                'cache' => $this->cache,
                 'layoutValidator' => $this->layoutValidator,
                 'logger' => $this->logger,
                 'appState' => $this->appState,
                 'layoutCacheKey' => $this->layoutCacheKeyMock,
+                'serializer' => $this->serializer,
             ]
         );
     }
@@ -101,6 +120,35 @@ class MergeTest extends \PHPUnit\Framework\TestCase
         $this->appState->expects($this->once())
             ->method('getMode')
             ->willReturn(State::MODE_DEVELOPER);
+
+        $this->model->load();
+    }
+
+    /**
+     * Test that merged layout is saved to cache if it wasn't cached before.
+     */
+    public function testSaveToCache()
+    {
+        $this->scope->expects($this->once())->method('getId')->willReturn(1);
+        $this->cache->expects($this->once())->method('save');
+
+        $this->model->load();
+    }
+
+    /**
+     * Test that merged layout is not re-saved to cache when it was loaded from cache.
+     */
+    public function testNoSaveToCacheWhenCachePresent()
+    {
+        $cacheValue = [
+            "pageLayout" => "1column",
+            "layout"     => "<body></body>"
+        ];
+
+        $this->scope->expects($this->once())->method('getId')->willReturn(1);
+        $this->cache->expects($this->once())->method('load')->willReturn(json_encode($cacheValue));
+        $this->serializer->expects($this->once())->method('unserialize')->willReturn($cacheValue);
+        $this->cache->expects($this->never())->method('save');
 
         $this->model->load();
     }


### PR DESCRIPTION
### Description (*)
Bugs which were fixed:
 - $this->pageLayout was not checked after reading from cache, but was used as is
 - two cache items were used in once place instead of one (performance impact)

Changes:
 - replace 2 cache items by 1 - it should improve performance
 - add "_MERGED" to cache key suffix to have compatibility with old cache keys during deployment of new version

### Fixed Issues (if relevant)
1. magento/magento2#6942 Layout corruption (Title is wrong, but issue is real)
2. magento/magento2#22976 Corrupt layout cache causes white page on customer account login

### Manual testing scenarios (*)
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
