### PR TITLE
Fixed #21581: Catalog Products List widget - wrong scope for prices

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/AbstractProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/AbstractProduct.php
@@ -245,10 +245,10 @@ class AbstractProduct extends \Magento\Framework\View\Element\Template
         \Magento\Catalog\Model\ResourceModel\Product\Collection $collection
     ) {
         return $collection
+            ->addAttributeToSelect($this->_catalogConfig->getProductAttributes())
             ->addMinimalPrice()
             ->addFinalPrice()
             ->addTaxPercents()
-            ->addAttributeToSelect($this->_catalogConfig->getProductAttributes())
             ->addUrlRewrite();
     }
 


### PR DESCRIPTION
Catalog Products List widget loads prices from EAV table and not from index table.

### Description (*)
Product prices in **Catalog Products List** widget should be loaded from _price index table_ `catalog_product_index_price`, but due to wrong order of method calls it loads prices from EAV or flat (if enabled) tables.
The problem is in `\Magento\Catalog\Block\Product\AbstractProduct::_addProductAttributesAndPrices()` method.
`addAttributeToSelect()` method is called later than `addFinalPrice()` and it overrides price column.

`\Magento\Catalog\Model\ResourceModel\Product\Collection::_productLimitationPrice()` already handles price override, but it is not called in the right order.

### Fixed Issues
magento/magento2#21581: Catalog Products List widget - prices are loaded from wrong source

### Manual testing scenarios (*)
1. Create widget "Catalog Products List", add product "A" to it.
2. Change price for product "A" in index table manually in the database (`catalog_product_index_price`).
3. Flush the cache
4. Make sure that price change is visible in widget

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
