### PR TITLE
Fixed issue #22788

### DIFF
--- a/app/code/Magento/Sales/view/frontend/templates/email/shipment/track.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/shipment/track.phtml
@@ -9,8 +9,9 @@
 ?>
 <?php $_shipment = $block->getShipment() ?>
 <?php $_order = $block->getOrder() ?>
+<?php if ($_shipment && $_order): ?>
 <?php $trackCollection = $_order->getTracksCollection($_shipment->getId()) ?>
-<?php if ($_shipment && $_order && $trackCollection): ?>
+<?php if ($trackCollection): ?>
     <br />
     <table class="shipment-track">
         <thead>
@@ -28,4 +29,5 @@
         <?php endforeach ?>
         </tbody>
     </table>
+<?php endif; ?>
 <?php endif; ?>


### PR DESCRIPTION
Fixed issue #22788  New Shipment emails do not generate
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento 2.3.1 Open Source
2. Ubuntu 16.04, PHP 7.2, Apache 2.4.18

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Go to Marketing > Email Templates
2. Add Template
3. Load magento_sales > New Shipment (Default Template with no custom changes)
4. Press Load
5. Preview Template

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. The Template Preview Tab loads with the default contents

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. The Template Preview Tab is blank. The only HTML source code is below
````
<html lang="en"><head>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
    <title>Email Preview</title>
</head>
<body>
    </body>
</html>
````

**Further Notes:** When you remove the below line from the Default Template, the Template Preview loads:

    {{block class='Magento\\Framework\\View\\Element\\Template' area='frontend' template='Magento_Sales::email/shipment/track.phtml' shipment=$shipment order=$order}}

![template-ok](https://user-images.githubusercontent.com/24552648/57377403-40f1c700-719a-11e9-9c88-11ec37be89c4.png)
