### PR TITLE
Set proper secure flag for JS based cookies

### DIFF
--- a/app/code/Magento/Theme/view/frontend/templates/js/cookie.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/js/cookie.phtml
@@ -19,7 +19,7 @@
                 "expires": null,
                 "path": "<?= /* @escapeNotVerified */ $block->getPath() ?>",
                 "domain": "<?= /* @escapeNotVerified */ $block->getDomain() ?>",
-                "secure": false,
+                "secure": <?= /* @escapeNotVerified */ $block->isSecure() ? 'true' : 'false' ?>,
                 "lifetime": "<?= /* @escapeNotVerified */ $block->getLifetime() ?>"
             }
         }

--- a/app/code/Magento/Theme/view/frontend/templates/js/cookie.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/js/cookie.phtml
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+// @codingStandardsIgnoreFile
 ?>
 <?php
 /**

--- a/lib/internal/Magento/Framework/View/Element/Js/Cookie.php
+++ b/lib/internal/Magento/Framework/View/Element/Js/Cookie.php
@@ -11,6 +11,7 @@ use Magento\Framework\View\Element\Template\Context;
 
 /**
  * @api
+ * @since 100.0.2
  */
 class Cookie extends Template
 {
@@ -80,5 +81,12 @@ class Cookie extends Template
     public function getLifetime()
     {
         return $this->sessionConfig->getCookieLifetime();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSecure() {
+        return $this->sessionConfig->getCookieSecure();
     }
 }

--- a/lib/internal/Magento/Framework/View/Element/Js/Cookie.php
+++ b/lib/internal/Magento/Framework/View/Element/Js/Cookie.php
@@ -11,7 +11,6 @@ use Magento\Framework\View\Element\Template\Context;
 
 /**
  * @api
- * @since 100.0.2
  */
 class Cookie extends Template
 {

--- a/lib/internal/Magento/Framework/View/Element/Js/Cookie.php
+++ b/lib/internal/Magento/Framework/View/Element/Js/Cookie.php
@@ -10,6 +10,8 @@ use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 
 /**
+ * Cookie template.
+ *
  * @api
  */
 class Cookie extends Template
@@ -75,6 +77,8 @@ class Cookie extends Template
     }
 
     /**
+     * Return cookie lifetime.
+     *
      * @return int
      */
     public function getLifetime()
@@ -83,9 +87,12 @@ class Cookie extends Template
     }
 
     /**
+     * Checks if cookie secure.
+     *
      * @return bool
      */
-    public function isSecure() {
+    public function isSecure()
+    {
         return $this->sessionConfig->getCookieSecure();
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Merge request replaces hardcoded `secure: false` property of Javascript cookie manager into dynamic one based on value returned by backend.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22272: Frontend cookies are not set with secure flag on https

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set up Magento with HTTPS enabled
2. Check if cookies set by Javascript contain secure flag

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
