### PR TITLE
Fixes magento#22087, products sold report grouped by product with total quantity

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Product/Sold/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Product/Sold/Collection.php
@@ -66,7 +66,7 @@ class Collection extends \Magento\Reports\Model\ResourceModel\Order\Collection
         $this->getSelect()->reset()->from(
             ['order_items' => $this->getTable('sales_order_item')],
             [
-                'ordered_qty' => 'order_items.qty_ordered',
+                'ordered_qty' => 'SUM(order_items.qty_ordered)',
                 'order_items_name' => 'order_items.name',
                 'order_items_sku' => 'order_items.sku'
             ]
@@ -76,8 +76,10 @@ class Collection extends \Magento\Reports\Model\ResourceModel\Order\Collection
             []
         )->where(
             'order_items.parent_item_id IS NULL'
+        )->group(
+            'order_items.product_id'
         )->having(
-            'order_items.qty_ordered > ?',
+            'SUM(order_items.qty_ordered) > ?',
             0
         );
         return $this;


### PR DESCRIPTION
### Summary
     - Fixes bug with products sold report to group by product and show total quantity
     - Fixes issue #22087

### Description
Fixes an issue with Products Ordered report where they are not grouped by product. This PR fixes this issue by grouping the report results by product and providing a total quantity.

### Fixed Issues
1. magento/magento2#22087: Products Ordered Report - Not grouped by product

### Manual testing scenarios (*)

#### Preconditions (*)
1. Magento 2.2.3

#### Steps to reproduce (*)
1. In the Magento 2 admin go to Reports -> Products -> Ordered
2. Select a date range where you know you have sold products spanning across multiple orders
3. Select 'Show By' year
4. Hit refresh

#### Expected result (*)
1. I would expect to see a list of products sold per year, grouped by product with a total quantity

#### Actual result (*)
1. I see a list of products sold per year, with multiple entries for a single product on a per order basis
