### PR TITLE
issue #22745 fixed: Wrong discount amount calculating for cart price rules if cart rule set to fixed amount 

### DIFF
--- a/app/code/Magento/SalesRule/Model/Rule/Action/Discount/ByFixed.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Action/Discount/ByFixed.php
@@ -18,9 +18,12 @@ class ByFixed extends AbstractDiscount
         /** @var \Magento\SalesRule\Model\Rule\Action\Discount\Data $discountData */
         $discountData = $this->discountFactory->create();
 
+        $itemPrice = $this->validator->getItemPrice($item);
+        $baseItemPrice = $this->validator->getItemBasePrice($item);
+
         $quoteAmount = $this->priceCurrency->convert($rule->getDiscountAmount(), $item->getQuote()->getStore());
-        $discountData->setAmount($qty * $quoteAmount);
-        $discountData->setBaseAmount($qty * $rule->getDiscountAmount());
+        $discountData->setAmount(min($itemPrice * $qty, $quoteAmount));
+        $discountData->setBaseAmount(min($baseItemPrice * $qty, $rule->getDiscountAmount()));
 
         return $discountData;
     }

--- a/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateFixedAmountDiscountTest.xml
+++ b/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateFixedAmountDiscountTest.xml
@@ -58,7 +58,7 @@
         <actionGroup ref="VerifyDiscountAmount" stepKey="verifyStorefront">
             <argument name="productUrl" value="{{_defaultProduct.urlKey}}.html"/>
             <argument name="quantity" value="2"/>
-            <argument name="expectedDiscount" value="-$20.00"/>
+            <argument name="expectedDiscount" value="-$10.00"/>
         </actionGroup>
     </test>
 </tests>

--- a/dev/tests/integration/testsuite/Magento/SalesRule/Model/Rule/Action/Discount/ByFixedTest.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/Model/Rule/Action/Discount/ByFixedTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\SalesRule\Model\Rule\Action\Discount;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ProductRepository;
+use Magento\Quote\Api\Data\CartItemInterface;
+use Magento\Quote\Api\GuestCartItemRepositoryInterface;
+use Magento\Quote\Api\GuestCartManagementInterface;
+use Magento\Quote\Api\GuestCartTotalRepositoryInterface;
+use Magento\Quote\Api\GuestCouponManagementInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/**
+ * Tests for Magento\SalesRule\Model\Rule\Action\Discount\ByFixed.
+ */
+class ByFixedTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var GuestCartManagementInterface
+     */
+    private $cartManagement;
+
+    /**
+     * @var GuestCartItemRepositoryInterface
+     */
+    private $cartItemRepository;
+
+    /**
+     * @var GuestCouponManagementInterface
+     */
+    private $couponManagement;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->cartManagement = Bootstrap::getObjectManager()->create(GuestCartManagementInterface::class);
+        $this->couponManagement = Bootstrap::getObjectManager()->create(GuestCouponManagementInterface::class);
+        $this->cartItemRepository = Bootstrap::getObjectManager()->create(GuestCartItemRepositoryInterface::class);
+    }
+
+    /**
+     * Applies fixed discount amount
+     *
+     * @magentoDataFixture Magento/SalesRule/_files/coupon_by_fixed_amount.php
+     * @return void
+     */
+    public function testApplyFixedDiscount(): void
+    {
+        $expectedDiscount = '-15.00';
+        $couponCode = 'BY_FIXED_DISCOUNT_15';
+        $cartId = $this->cartManagement->createEmptyCart();
+        $product = $this->createProduct();
+        /** @var CartItemInterface $quoteItem */
+        $quoteItem = Bootstrap::getObjectManager()->create(CartItemInterface::class);
+        $quoteItem->setQuoteId($cartId);
+        $quoteItem->setProduct($product);
+        $quoteItem->setQty(3);
+        $this->cartItemRepository->save($quoteItem);
+        $this->couponManagement->set($cartId, $couponCode);
+        /** @var GuestCartTotalRepositoryInterface $cartTotalRepository */
+        $cartTotalRepository = Bootstrap::getObjectManager()->get(GuestCartTotalRepositoryInterface::class);
+        $total = $cartTotalRepository->get($cartId);
+
+        $this->assertEquals($expectedDiscount, $total->getBaseDiscountAmount());
+    }
+
+    /**
+     * Returns simple product with given price.
+     *
+     *
+     * @return ProductInterface
+     */
+    private function createProduct(): ProductInterface
+    {
+        $name = 'simple-' . time();
+        $productRepository = Bootstrap::getObjectManager()->get(ProductRepository::class);
+        $product = Bootstrap::getObjectManager()->create(Product::class);
+        $product->setTypeId('simple')
+            ->setAttributeSetId($product->getDefaultAttributeSetId())
+            ->setWebsiteIds([1])
+            ->setName($name)
+            ->setSku(uniqid($name))
+            ->setPrice('150')
+            ->setMetaTitle('meta title')
+            ->setMetaKeyword('meta keyword')
+            ->setMetaDescription('meta description')
+            ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+            ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
+            ->setStockData(['qty' => 3, 'is_in_stock' => 1])
+            ->setWeight(1);
+
+        return $productRepository->save($product);
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/SalesRule/_files/coupon_by_fixed_amount.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/_files/coupon_by_fixed_amount.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Customer\Model\GroupManagement;
+use Magento\SalesRule\Api\CouponRepositoryInterface;
+use Magento\SalesRule\Model\Coupon;
+use Magento\SalesRule\Model\Rule;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+$objectManager = Bootstrap::getObjectManager();
+
+/** @var Rule $salesRule */
+$salesRule = $objectManager->create(Rule::class);
+$salesRule->setData(
+    [
+        'name' => '15$ fixed discount amount',
+        'is_active' => 1,
+        'customer_group_ids' => [GroupManagement::NOT_LOGGED_IN_ID],
+        'coupon_type' => Rule::COUPON_TYPE_SPECIFIC,
+        'conditions' => [],
+        'simple_action' => Rule::BY_FIXED_ACTION,
+        'discount_amount' => 15,
+        'discount_step' => 0,
+        'stop_rules_processing' => 1,
+        'website_ids' => [
+            $objectManager->get(StoreManagerInterface::class)->getWebsite()->getId(),
+        ],
+    ]
+);
+$objectManager->get(\Magento\SalesRule\Model\ResourceModel\Rule::class)->save($salesRule);
+
+// Create coupon and assign "15$ fixed discount" rule to this coupon.
+$coupon = $objectManager->create(Coupon::class);
+$coupon->setRuleId($salesRule->getId())
+    ->setCode('BY_FIXED_DISCOUNT_15')
+    ->setType(0);
+$objectManager->get(CouponRepositoryInterface::class)->save($coupon);

--- a/dev/tests/integration/testsuite/Magento/SalesRule/_files/coupon_by_fixed_amount_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/_files/coupon_by_fixed_amount_rollback.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\SalesRule\Api\CouponRepositoryInterface;
+use Magento\SalesRule\Model\Coupon;
+use Magento\TestFramework\Helper\Bootstrap;
+
+$objectManager = Bootstrap::getObjectManager();
+
+
+$coupon = $objectManager->create(Coupon::class);
+$coupon->loadByCode('BY_FIXED_DISCOUNT_15');
+if ($coupon->getCouponId()) {
+    /** @var CouponRepositoryInterface $couponRepository */
+    $couponRepository = $objectManager->get(CouponRepositoryInterface::class);
+    $couponRepository->deleteById($coupon->getCouponId());
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Fixed: Wrong discount amount calculating for cart price rules if cart rule set to fixed amount  in this PR
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed: #22745 in this PR.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22745
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create cart price rule with Fixed amount discount.
2. Add products to shopping cart.
3. Add discount coupon to cart, click on apply discount button and check for cart totals.
4. Correct discount getting applied now.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
