### PR TITLE
Customer Account Forgot Password page title fix

### DIFF
--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_forgotpassword.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_forgotpassword.xml
@@ -7,7 +7,7 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
-        <title>Forgot Your Password</title>
+        <title>Forgot Your Password?</title>
     </head>
     <body>
         <referenceBlock name="root">


### PR DESCRIPTION
Missing question mark in Customer Account Forgot Password page title, because of this it was missing the translated string.