### PR TITLE
#16445 - getRegionHtmlSelect does not have configuration - resolved

### DIFF
--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Directory\Block;
 
 /**
@@ -173,10 +175,33 @@ class Data extends \Magento\Framework\View\Element\Template
      * Returns region html select
      *
      * @return string
+     * @deprecated
+     * @see getRegionSelect() method for more configurations
      */
     public function getRegionHtmlSelect()
     {
+        return $this->getRegionSelect();
+    }
+
+    /**
+     * Returns region html select
+     *
+     * @param null|int $value
+     * @param string $name
+     * @param string $id
+     * @param string $title
+     * @return string
+     */
+    public function getRegionSelect(
+        ?int $value = null,
+        string $name = 'region',
+        string $id = 'state',
+        string $title = 'State/Province'
+    ): string {
         \Magento\Framework\Profiler::start('TEST: ' . __METHOD__, ['group' => 'TEST', 'method' => __METHOD__]);
+        if ($value === null) {
+            $value = (int)$this->getRegionId();
+        }
         $cacheKey = 'DIRECTORY_REGION_SELECT_STORE' . $this->_storeManager->getStore()->getId();
         $cache = $this->_configCacheType->load($cacheKey);
         if ($cache) {
@@ -188,15 +213,15 @@ class Data extends \Magento\Framework\View\Element\Template
         $html = $this->getLayout()->createBlock(
             \Magento\Framework\View\Element\Html\Select::class
         )->setName(
-            'region'
+            $name
         )->setTitle(
-            __('State/Province')
+            __($title)
         )->setId(
-            'state'
+            $id
         )->setClass(
             'required-entry validate-state'
         )->setValue(
-            (int)$this->getRegionId()
+            $value
         )->setOptions(
             $options
         )->getHtml();


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
To give region field a name like array Ex. name="somearray[region]"  and getting data as array value. 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#16445: IgetRegionHtmlSelect does not have configuration

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ... create form with getRegionHtmlSelect() you will get a static name 'region'. developer can not pass any other value.
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
