### PR TITLE
issue #22832 fixed Should not hide element in page as In customer account register page a element hide from css, But we should properly remove from html

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
@@ -167,9 +167,6 @@
         <div class="primary">
             <button type="submit" class="action submit primary" title="<?= $block->escapeHtmlAttr(__('Create an Account')) ?>"><span><?= $block->escapeHtml(__('Create an Account')) ?></span></button>
         </div>
-        <div class="secondary">
-            <a class="action back" href="<?= $block->escapeUrl($block->getBackUrl()) ?>"><span><?= $block->escapeHtml(__('Back')) ?></span></a>
-        </div>
     </div>
 </form>
 <script>


### PR DESCRIPTION
issue #22832 fixed Should not hide element in page as In customer account register page a element hide from css, But we should properly remove from html


### Description (*)
Should not hide element in page as In customer account register page a element hide from css, But we should properly remove from html

### Manual testing scenarios (*)
>> Open customer account register page
>> inspect element in create an account and look `<div class="actions-toolbar">` and inside this look `<div class="secondary">`
>> Content of this ( `<div class="secondary">` ) is hide from css.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
