### PR TITLE
[Backport] Fixed:#22395

### DIFF
--- a/app/code/Magento/Config/Console/Command/ConfigSetCommand.php
+++ b/app/code/Magento/Config/Console/Command/ConfigSetCommand.php
@@ -139,8 +139,10 @@ class ConfigSetCommand extends Command
     /**
      * Creates and run appropriate processor, depending on input options.
      *
-     * {@inheritdoc}
+     * @param InputInterface $input
+     * @param OutputInterface $output
      * @since 100.2.0
+     * @return int|null
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/app/code/Magento/Config/Console/Command/ConfigSetCommand.php
+++ b/app/code/Magento/Config/Console/Command/ConfigSetCommand.php
@@ -114,13 +114,13 @@ class ConfigSetCommand extends Command
                 ),
                 new InputOption(
                     static::OPTION_LOCK_ENV,
-                    'le',
+                    'e',
                     InputOption::VALUE_NONE,
                     'Lock value which prevents modification in the Admin (will be saved in app/etc/env.php)'
                 ),
                 new InputOption(
                     static::OPTION_LOCK_CONFIG,
-                    'lc',
+                    'c',
                     InputOption::VALUE_NONE,
                     'Lock and share value with other installations, prevents modification in the Admin '
                     . '(will be saved in app/etc/config.php)'


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22720
Fixed  #22395: config:set -le and -lc short form options don't work
Note : updated short command lc to c and le to e as symfony takes single character as a short option.
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. 2.3.1

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. bin/magento config:set --scope default -lc <path> <value>

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. -lc option is applied

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Error message appears:

`The "-c" option does not exist.`

The long form versions (--lock-env, --lock-config) of those options work fine


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
