### PR TITLE
Resolved issue

### DIFF
--- a/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
+++ b/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
@@ -218,6 +218,13 @@ class Grouped extends \Magento\Catalog\Model\Product\Type\AbstractType
                 ['in' => $this->getStatusFilters($product)]
             );
 
+            $collection->getSelect()
+                ->joinInner(
+                    'cataloginventory_stock_item',
+                    'e.entity_id=cataloginventory_stock_item.product_id AND cataloginventory_stock_item.is_in_stock ="1"',
+                    ['is_in_stock']
+                );
+            
             foreach ($collection as $item) {
                 $associatedProducts[] = $item;
             }


### PR DESCRIPTION
Fixed issue #22304 [Grouped product] Can´t add simple products to cart if one other is out of stock.

### Description (*)
Fixed issue #22304 [Grouped product] Can´t add simple products to cart if one other is out of stock.

### Fixed Issues (if relevant)
Fixed issue #22304 [Grouped product] Can´t add simple products to cart if one other is out of stock.
1. #22304 :  [Grouped product] Can´t add simple products to cart if one other is out of stock.

### Manual testing scenarios (*)
1.enable the option allow to show products without stock
2.grouped product with more sub items
3.at least one sub items have to be without stock (quantity=0)
4.navigate to the PDS of the grouped product
5.add at least on item of any available sub item
6.if you add the item to the cart the message "Please specify the quantity of product(s)." apears

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
