### PR TITLE
Fixed #22614 Magento 2.3.0 Admin grid using UI component sticky CSS is not working 

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/templates/pageactions.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/pageactions.phtml
@@ -7,7 +7,7 @@
 // @codingStandardsIgnoreFile
 
 ?>
-<?php if ($block->getChildHtml()):?>
+<?php if ($block->getChildHtml() || $block->getIsSticky()):?>
     <div data-mage-init='{"floatingHeader": {}}' class="page-actions floating-header" <?= /* @escapeNotVerified */ $block->getUiId('content-header') ?>>
         <?= $block->getChildHtml() ?>
     </div>

--- a/app/code/Magento/Ui/Component/AbstractComponent.php
+++ b/app/code/Magento/Ui/Component/AbstractComponent.php
@@ -114,6 +114,13 @@ abstract class AbstractComponent extends DataObject implements UiComponentInterf
 
         if ($this->hasData('buttons')) {
             $this->getContext()->addButtons($this->getData('buttons'), $this);
+        } else {
+            if (isset($this->_data['config']['sticky'])) {
+                $toolbar = $this->getContext()->getPageLayout()->getBlock('page.actions.toolbar');
+                if ($toolbar) {
+                    $toolbar->setData('is_sticky', $this->_data['config']['sticky']);
+                }
+            }
         }
         $this->context->getProcessor()->register($this);
         $this->getContext()->getProcessor()->notify($this->getComponentName());

--- a/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/_actions-bar.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/_actions-bar.less
@@ -24,6 +24,14 @@
     padding: @page-main-actions__padding;
 }
 
+.page-main-actions:not(button) {
+    background: unset !important;
+    border-bottom: unset !important;
+    border-top: unset !important;
+    margin: 0;
+    padding: 0 !important;
+}
+
 .page-main-actions {
     margin: 0 0 @indent__l;
 
@@ -144,6 +152,10 @@
             }
         }
     }
+}
+
+page-actions:not(button) {
+    padding: 1.68rem;
 }
 
 .page-actions-buttons {


### PR DESCRIPTION
Fixed #22614 Magento 2.3.0 Admin grid using UI component sticky CSS is not working 
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento version CE 2.3.0
2. PHP version 7.1.
3. Admin area

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Create admin grid using Ui-component Make sure Sticky true `<sticky>true</sticky>`
2. Display only grid don't add button `<buttons></buttons>` just above the grid. 
3. Because I just want to display the record in a grid I don't need any form so there is no need to display button in the grid page.

### Expected result (*)
<!--- Tell us what do you expect to happen. --> 
![without-sticky](https://user-images.githubusercontent.com/40203855/57120677-8f652700-6d90-11e9-957f-d674d958f637.png)

1. sticky is true and a button is not added then scroll down sticky CSS should be working.

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
![with sticky](https://user-images.githubusercontent.com/40203855/57120736-f1be2780-6d90-11e9-992c-c56ab8169be5.png)

1. Sticky is true and a button is not added then scroll down sticky CSS is not working.
