### PR TITLE
Fixed #22808 php bin/magento catalog:image:resize error if image is missing

### DIFF
--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -159,16 +159,24 @@ class ImageResize
 
         $productImages = $this->productImage->getAllProductImages();
         $viewImages = $this->getViewImages($themes ?? $this->getThemesInUse());
-
+        $notFoundImages = [];
         foreach ($productImages as $image) {
             $originalImageName = $image['filepath'];
             $originalImagePath = $this->mediaDirectory->getAbsolutePath(
                 $this->imageConfig->getMediaPath($originalImageName)
             );
-            foreach ($viewImages as $viewImage) {
-                $this->resize($viewImage, $originalImagePath, $originalImageName);
+            try {
+                foreach ($viewImages as $viewImage) {
+                    $this->resize($viewImage, $originalImagePath, $originalImageName);
+                }
+                yield $originalImageName => $count;
+            } catch (\Exception $e) {
+                $notFoundImages[] = $originalImagePath;
             }
-            yield $originalImageName => $count;
+        }
+        
+        if (!empty($notFoundImages)) {
+            throw new \Exception(PHP_EOL.__("These files does not exists.").PHP_EOL . implode(PHP_EOL, $notFoundImages) );
         }
     }
 

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -176,7 +176,7 @@ class ImageResize
         }
         
         if (!empty($notFoundImages)) {
-            throw new \Exception(PHP_EOL.__("These files does not exists.").PHP_EOL . implode(PHP_EOL, $notFoundImages) );
+            throw new \Exception(PHP_EOL.__('The following files do not exist:').PHP_EOL . implode(PHP_EOL, $notFoundImages) );
         }
     }
 

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -165,18 +165,18 @@ class ImageResize
             $originalImagePath = $this->mediaDirectory->getAbsolutePath(
                 $this->imageConfig->getMediaPath($originalImageName)
             );
-            try {
+            if (file_exists($originalImagePath)) {
                 foreach ($viewImages as $viewImage) {
                     $this->resize($viewImage, $originalImagePath, $originalImageName);
                 }
                 yield $originalImageName => $count;
-            } catch (\Exception $e) {
+            } else {
                 $notFoundImages[] = $originalImagePath;
             }
         }
         
         if (!empty($notFoundImages)) {
-            throw new \Exception(PHP_EOL.__('The following files do not exist:').PHP_EOL . implode(PHP_EOL, $notFoundImages) );
+            throw new NotFoundException(__(PHP_EOL . 'The following files do not exist:'. PHP_EOL . implode(PHP_EOL, $notFoundImages)));
         }
     }
 

--- a/app/code/Magento/MediaStorage/i18n/en_US.csv
+++ b/app/code/Magento/MediaStorage/i18n/en_US.csv
@@ -23,3 +23,4 @@ Database,Database
 "Select Media Database","Select Media Database"
 "After selecting a new media storage location, press the Synchronize button to transfer all media to that location. Media will not be available in the new location until the synchronization process is complete.","After selecting a new media storage location, press the Synchronize button to transfer all media to that location. Media will not be available in the new location until the synchronization process is complete."
 "Environment Update Time","Environment Update Time"
+"The following files do not exist:","The following files do not exist:"


### PR DESCRIPTION
Fixed #22808 php bin/magento catalog:image:resize error if image is missing

### Preconditions (*)
1. Magento 2.3.1 

### Steps to reproduce (*)
1. Delete manually a product image from pub/media/catalog folder 
2. Execute catalog:image:resize 

### Expected result (*)
1. The system creates the resized images for all products that the images exist and lists the errors.

### Actual result (*)
1. The execution halts immediately at the first missing image. 

![image](https://user-images.githubusercontent.com/20220341/57453750-d7dc8300-726f-11e9-9a9b-f40b3784830c.png)

This doesn't affect on the fly generation of images when browsing the products but it's good to be able to execute and test. 