### PR TITLE
Add display items to bestsellers report

### DIFF
--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Bestsellers/Grid.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Bestsellers/Grid.php
@@ -40,7 +40,7 @@ class Grid extends \Magento\Reports\Block\Adminhtml\Grid\AbstractGrid
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function _addCustomFilter($collection, $filterData)
     {

--- a/app/code/Magento/Reports/Block/Adminhtml/Sales/Bestsellers/Grid.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Sales/Bestsellers/Grid.php
@@ -42,6 +42,15 @@ class Grid extends \Magento\Reports\Block\Adminhtml\Grid\AbstractGrid
     /**
      * {@inheritdoc}
      */
+    protected function _addCustomFilter($collection, $filterData)
+    {
+        $collection->setRatingLimit($filterData->getRatingLimit());
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function _prepareColumns()
     {
         $this->addColumn(

--- a/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_bestsellers.xml
+++ b/app/code/Magento/Reports/view/adminhtml/layout/reports_report_sales_bestsellers.xml
@@ -23,7 +23,7 @@
         </referenceContainer>
         <referenceContainer name="content">
             <block class="Magento\Reports\Block\Adminhtml\Sales\Bestsellers" template="Magento_Reports::report/grid/container.phtml" name="sales.report.grid.container">
-                <block class="Magento\Sales\Block\Adminhtml\Report\Filter\Form" name="grid.filter.form">
+                <block class="Magento\Sales\Block\Adminhtml\Report\Bestsellers\Filter\Form" name="grid.filter.form">
                     <action method="setFieldVisibility">
                         <argument name="field" xsi:type="string">report_type</argument>
                         <argument name="visibility" xsi:type="string">0</argument>

--- a/app/code/Magento/Sales/Block/Adminhtml/Report/Bestsellers/Filter/Form.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Report/Bestsellers/Filter/Form.php
@@ -8,15 +8,13 @@ namespace Magento\Sales\Block\Adminhtml\Report\Bestsellers\Filter;
 /**
  * Sales Adminhtml report bestseller filter form
  *
- * @api
  * @author     Magento Core Team <core@magentocommerce.com>
  * @SuppressWarnings(PHPMD.DepthOfInheritance)
- * @since 100.1.0
  */
 class Form extends \Magento\Sales\Block\Adminhtml\Report\Filter\Form
 {
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function _prepareForm()
     {

--- a/app/code/Magento/Sales/Block/Adminhtml/Report/Bestsellers/Filter/Form.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Report/Bestsellers/Filter/Form.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Sales\Block\Adminhtml\Report\Bestsellers\Filter;
+
+/**
+ * Sales Adminhtml report bestseller filter form
+ *
+ * @api
+ * @author     Magento Core Team <core@magentocommerce.com>
+ * @SuppressWarnings(PHPMD.DepthOfInheritance)
+ * @since 100.1.0
+ */
+class Form extends \Magento\Sales\Block\Adminhtml\Report\Filter\Form
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function _prepareForm()
+    {
+        parent::_prepareForm();
+        /** @var \Magento\Framework\Data\Form\Element\Fieldset $fieldset */
+        $fieldset = $this->getForm()->getElement('base_fieldset');
+
+        if (is_object($fieldset) && $fieldset instanceof \Magento\Framework\Data\Form\Element\Fieldset) {
+            $fieldset->addField(
+                'rating_limit',
+                'select',
+                [
+                    'name' => 'rating_limit',
+                    'label' => __('Display items'),
+                    'options' => array_combine($i = [5, 10, 20, 50, 100], $i),
+                ],
+                'to'
+            );
+        }
+
+        return $this;
+    }
+}

--- a/app/code/Magento/Sales/Model/ResourceModel/Report/Bestsellers/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Report/Bestsellers/Collection.php
@@ -57,6 +57,18 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Report\Collection\Ab
     }
 
     /**
+     * Set rating limit
+     *
+     * @param int $ratingLimit
+     * @return $this
+     */
+    public function setRatingLimit($ratingLimit)
+    {
+        $this->_ratingLimit = $ratingLimit;
+        return $this;
+    }
+
+    /**
      * Return ordered filed
      *
      * @return string

--- a/app/code/Magento/Sales/i18n/en_US.csv
+++ b/app/code/Magento/Sales/i18n/en_US.csv
@@ -797,3 +797,4 @@ Created,Created
 Refunds,Refunds
 "Allow Zero GrandTotal for Creditmemo","Allow Zero GrandTotal for Creditmemo"
 "Allow Zero GrandTotal","Allow Zero GrandTotal"
+"Display items","Display items"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
As of now Magento Bestsellers report only shows 5 lines, this values is hardcoded into the code. The idea here is to create a new "Display items" field in the Bestsellers report form, this way the admin user can select if he wants to see more than 5 rows. It was used pre-defined values (5, 10, 20, 50), to prevent the admin user to accidentally request all rows and have some performance issues.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21361: Bestsellers collection is using ratingLimit as sql select limit

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Have a Magento installation set up
2. Have completed orders with more than 5 different products
3. Log in into the admin panel
4. Go to Reports > Bestsellers
5. Fill in from and to date (needs to encapsulate the orders)
6. Select a Display items value
7. Click on Show report
8. The report needs to show the exact quantity selected at the Display items field, or all the rows if the selected value is greater than the number of bestsellers products

### Observations
- I didn't write any automated tests for this feature yet, would be nice to have some sort of help in this part
- In this Magento\Sales\Block\Adminhtml\Report\Bestsellers\Filter\Form i wasn't sure if i needed to use `@api` and `@since`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
