### PR TITLE
Consider entity type for Elasticsearch batch data mapper

### DIFF
--- a/app/code/Magento/Elasticsearch/Model/Adapter/Elasticsearch.php
+++ b/app/code/Magento/Elasticsearch/Model/Adapter/Elasticsearch.php
@@ -145,15 +145,19 @@ class Elasticsearch
      *
      * @param array $documentData
      * @param int $storeId
+     * @param string $mappedIndexerId
      * @return array
      */
-    public function prepareDocsPerStore(array $documentData, $storeId)
+    public function prepareDocsPerStore(array $documentData, $storeId, $mappedIndexerId)
     {
         $documents = [];
         if (count($documentData)) {
             $documents = $this->batchDocumentDataMapper->map(
                 $documentData,
-                $storeId
+                $storeId,
+                [
+                    'entityType' => $mappedIndexerId,
+                ]
             );
         }
         return $documents;

--- a/app/code/Magento/Elasticsearch/Model/Adapter/Elasticsearch.php
+++ b/app/code/Magento/Elasticsearch/Model/Adapter/Elasticsearch.php
@@ -207,7 +207,7 @@ class Elasticsearch
         // prepare new index name and increase version
         $indexPattern = $this->indexNameResolver->getIndexPattern($storeId, $mappedIndexerId);
         $version = (int)(str_replace($indexPattern, '', $indexName));
-        $newIndexName = $indexPattern . ++$version;
+        $newIndexName = $indexPattern . (++$version);
 
         // remove index if already exists
         if ($this->client->indexExists($newIndexName)) {

--- a/app/code/Magento/Elasticsearch/Model/Indexer/IndexerHandler.php
+++ b/app/code/Magento/Elasticsearch/Model/Indexer/IndexerHandler.php
@@ -92,7 +92,11 @@ class IndexerHandler implements IndexerInterface
         $dimension = current($dimensions);
         $scopeId = $this->scopeResolver->getScope($dimension->getValue())->getId();
         foreach ($this->batch->getItems($documents, $this->batchSize) as $documentsBatch) {
-            $docs = $this->adapter->prepareDocsPerStore($documentsBatch, $scopeId);
+            $docs = $this->adapter->prepareDocsPerStore(
+                $documentsBatch,
+                $scopeId,
+                $this->getIndexerId()
+            );
             $this->adapter->addDocs($docs, $scopeId, $this->getIndexerId());
         }
         $this->adapter->updateAlias($scopeId, $this->getIndexerId());

--- a/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/ElasticsearchTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/ElasticsearchTest.php
@@ -206,7 +206,7 @@ class ElasticsearchTest extends \PHPUnit\Framework\TestCase
      */
     public function testPrepareDocsPerStoreEmpty()
     {
-        $this->assertEquals([], $this->model->prepareDocsPerStore([], 1));
+        $this->assertEquals([], $this->model->prepareDocsPerStore([], 1, 'product'));
     }
 
     /**
@@ -227,7 +227,8 @@ class ElasticsearchTest extends \PHPUnit\Framework\TestCase
                         'name' => 'Product Name',
                     ],
                 ],
-                1
+                1,
+                'product'
             )
         );
     }


### PR DESCRIPTION


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

A DataMapperResolver allowing a separate data mapper class per entity type has been implemented into Magento as `Magento\Elasticsearch\Model\Adapter\BatchDataMapper\DataMapperResolver`, but without this change the entity type cannot be passed to the resolver from the Elasticsearch adapter (`Magento\Elasticsearch\Model\Adapter\Elasticsearch`), and the entity type will always default to `\Magento\Elasticsearch\Model\Config::ELASTICSEARCH_TYPE_DEFAULT`.



### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

It's quite tedious to reproduce, and I'm not able to paste all the indexing details to this PR, but hopefully you understand the gist of it.

1. Register & implement a new search indexer. In my case, I needed to index Drupal pages. For example, in `MyCompany/DrupalSearch/etc/indexer.xml`
```
<indexer id="drupal_page_search_fulltext" view_id="drupal_page_search_fulltext" class="MyCompany\DrupalSearch\Model\Page\Indexer\FulltextPageIndexer">
    <title translate="true">Drupal Page Search</title>
    <description translate="true">Rebuild Drupal page fulltext search index</description>
</indexer>
```
2. Implement an indexer handler factory based on `Magento\CatalogSearch\Model\Indexer\IndexerHandlerFactory`, and a ES field mapper based on `Magento\Elasticsearch\Elasticsearch5\Model\Adapter\FieldMapper\ProductFieldMapper`. Related `di.xml` changes as an example:
```
<type name="MyCompany\DrupalSearch\Model\IndexerHandlerFactory">
    <arguments>
        <argument name="handlers" xsi:type="array">
            <item name="elasticsearch" xsi:type="string">Magento\Elasticsearch\Model\Indexer\IndexerHandler</item>
            <item name="elasticsearch5" xsi:type="string">Magento\Elasticsearch\Model\Indexer\IndexerHandler</item>
            <item name="elasticsearch6" xsi:type="string">Magento\Elasticsearch\Model\Indexer\IndexerHandler</item>
        </argument>
    </arguments>
</type>

<type name="Magento\Elasticsearch\Model\Adapter\FieldMapper\FieldMapperResolver">
    <arguments>
        <argument name="fieldMappers" xsi:type="array">
            <item name="drupal_page_search_fulltext" xsi:type="string">MyCompany\DrupalSearch\Model\Elasticsearch\Adapter\FieldMapper\DrupalPageFieldMapper</item>
        </argument>
    </arguments>
</type>
```
3. Implement an ES batch data mapper based on `Magento\Elasticsearch\Model\Adapter\BatchDataMapper\ProductDataMapper`. Related `di.xml` changes as an example:
```
<type name="Magento\Elasticsearch\Model\Adapter\BatchDataMapper\DataMapperFactory">
    <arguments>
        <argument name="dataMappers" xsi:type="array">
            <item name="drupal_page_search_fulltext" xsi:type="string">MyCompany\DrupalSearch\Model\Elasticsearch\Adapter\BatchDataMapper\DrupalPageDataMapper</item>
        </argument>
    </arguments>
</type>
```
4. Run `magento indexer:reindex drupal_page_search_fulltext`.
5. Query the new ES index. **You will notice product data among the Drupal page data, eg. Magento is erroneously using the product batch data mapper for Drupal page search indexing.**

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
