### PR TITLE
#22479 - product required options prices considered in price index

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/CustomOptionPriceModifier.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/CustomOptionPriceModifier.php
@@ -394,6 +394,7 @@ class CustomOptionPriceModifier implements PriceModifierInterface
         );
         $select->columns(
             [
+                'price' => new ColumnValueExpression('i.min_price + io.min_price'),
                 'min_price' => new ColumnValueExpression('i.min_price + io.min_price'),
                 'max_price' => new ColumnValueExpression('i.max_price + io.max_price'),
                 'tier_price' => $connection->getCheckSql(


### PR DESCRIPTION
### Description (*)
When products has required options, their prices were summed up in min_price index column. Price take into account in sorting is min_price, thus on category page, products with options were sorted incorrectly.

### Fixed Issues (if relevant)
If product has required options, its price on category page is displayed with required additions. 
1. magento/magento2#22479: Sort by price is not working with custom options as expected in magento 2.3.0 product listing page

### Manual testing scenarios (*)
1. Valid path provided in linked [issue](https://github.com/magento/magento2/issues/22479)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
