### PR TITLE
fix date calculation for report's years interval

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Report/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Report/Collection.php
@@ -12,6 +12,8 @@
 namespace Magento\Reports\Model\ResourceModel\Report;
 
 /**
+ * Class Collection
+ *
  * @api
  * @since 100.0.2
  */
@@ -100,6 +102,7 @@ class Collection extends \Magento\Framework\Data\Collection
 
     /**
      * Set period
+     *
      * @codeCoverageIgnore
      *
      * @param int $period
@@ -113,6 +116,7 @@ class Collection extends \Magento\Framework\Data\Collection
 
     /**
      * Set interval
+     *
      * @codeCoverageIgnore
      *
      * @param \DateTimeInterface $fromDate
@@ -275,6 +279,7 @@ class Collection extends \Magento\Framework\Data\Collection
 
     /**
      * Set store ids
+     *
      * @codeCoverageIgnore
      *
      * @param array $storeIds
@@ -288,6 +293,7 @@ class Collection extends \Magento\Framework\Data\Collection
 
     /**
      * Get store ids
+     *
      * @codeCoverageIgnore
      *
      * @return array
@@ -309,6 +315,7 @@ class Collection extends \Magento\Framework\Data\Collection
 
     /**
      * Set page size
+     *
      * @codeCoverageIgnore
      *
      * @param int $size
@@ -322,6 +329,7 @@ class Collection extends \Magento\Framework\Data\Collection
 
     /**
      * Get page size
+     *
      * @codeCoverageIgnore
      *
      * @return int

--- a/app/code/Magento/Reports/Model/ResourceModel/Report/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Report/Collection.php
@@ -248,7 +248,7 @@ class Collection extends \Magento\Framework\Data\Collection
             ? $this->_localeDate->convertConfigTimeToUtc($dateStart->format('Y-m-d 00:00:00'))
             : $this->_localeDate->convertConfigTimeToUtc($dateStart->format('Y-01-01 00:00:00'));
 
-        $interval['end'] = $dateStart->diff($dateEnd)->y == 0
+        $interval['end'] = $dateStart->format('Y') == $dateEnd->format('Y')
             ? $this->_localeDate->convertConfigTimeToUtc(
                 $dateStart->setDate($dateStart->format('Y'), $dateEnd->format('m'), $dateEnd->format('d'))
                     ->format('Y-m-d 23:59:59')

--- a/app/code/Magento/Reports/Model/ResourceModel/Report/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Report/Collection.php
@@ -252,7 +252,7 @@ class Collection extends \Magento\Framework\Data\Collection
             ? $this->_localeDate->convertConfigTimeToUtc($dateStart->format('Y-m-d 00:00:00'))
             : $this->_localeDate->convertConfigTimeToUtc($dateStart->format('Y-01-01 00:00:00'));
 
-        $interval['end'] = $dateStart->format('Y') == $dateEnd->format('Y')
+        $interval['end'] = $dateStart->format('Y') === $dateEnd->format('Y')
             ? $this->_localeDate->convertConfigTimeToUtc(
                 $dateStart->setDate($dateStart->format('Y'), $dateEnd->format('m'), $dateEnd->format('d'))
                     ->format('Y-m-d 23:59:59')


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Date->diff returns amount of full years between dates, so when
dateStart = 2018-12-25 and dateEnd = 2019-01-25
$dateStart->diff($dateEnd)->y will be 0, that does not match the code's
logic which expects 1 when year 'from' is not eq to year 'to'

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. go to Reports > Products > Ordered
2. select dateFrom = 12/1/2018 and dateTo =  01/31/2019
3. select Show By = Month and Submit
4. check Total Qty value in the table footer
5. select Show By = Year and Submit
4. check Total Qty value in the table footer, it should be the same as it was on step 4.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
