### PR TITLE
fix qty calculation for the sold product reports

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Product/Sold/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Product/Sold/Collection.php
@@ -14,6 +14,8 @@ namespace Magento\Reports\Model\ResourceModel\Product\Sold;
 use Magento\Framework\DB\Select;
 
 /**
+ * Class Collection
+ *
  * @SuppressWarnings(PHPMD.DepthOfInheritance)
  * @api
  * @since 100.0.2
@@ -118,6 +120,8 @@ class Collection extends \Magento\Reports\Model\ResourceModel\Order\Collection
     }
 
     /**
+     * Get count request
+     *
      * @return Select
      * @since 100.2.0
      */

--- a/app/code/Magento/Reports/Model/ResourceModel/Product/Sold/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Product/Sold/Collection.php
@@ -66,7 +66,7 @@ class Collection extends \Magento\Reports\Model\ResourceModel\Order\Collection
         $this->getSelect()->reset()->from(
             ['order_items' => $this->getTable('sales_order_item')],
             [
-                'ordered_qty' => 'order_items.qty_ordered',
+                'ordered_qty' => 'SUM(order_items.qty_ordered)',
                 'order_items_name' => 'order_items.name',
                 'order_items_sku' => 'order_items.sku'
             ]
@@ -76,8 +76,10 @@ class Collection extends \Magento\Reports\Model\ResourceModel\Order\Collection
             []
         )->where(
             'order_items.parent_item_id IS NULL'
+        )->group(
+            ['order_items.sku', 'order_items.name']
         )->having(
-            'order_items.qty_ordered > ?',
+            'ordered_qty > ?',
             0
         );
         return $this;

--- a/app/code/Magento/Reports/Model/ResourceModel/Product/Sold/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Product/Sold/Collection.php
@@ -14,7 +14,7 @@ namespace Magento\Reports\Model\ResourceModel\Product\Sold;
 use Magento\Framework\DB\Select;
 
 /**
- * Class Collection
+ * Report Sold Products collection
  *
  * @SuppressWarnings(PHPMD.DepthOfInheritance)
  * @api


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
without the "group by" I'm adding in this commit, report has the same
products several times. So to get proper total qty one need to manually
sum all the qtys for the product.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. go to Reports > Products > Ordered
2. select dateFrom = 01/01/2018 and dateTo = 05/05/2019
3. select Show By = Year and Submit
4. make sure there are no duplicates in the table (each product exists in a single example and its qty summed)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
