### PR TITLE
[Backport] #22786 Add dependency for UPS required fields to avoid validation for these fields if UPS Shipping is not active

### DIFF
--- a/app/code/Magento/Ups/etc/adminhtml/system.xml
+++ b/app/code/Magento/Ups/etc/adminhtml/system.xml
@@ -13,6 +13,9 @@
                 <field id="access_license_number" translate="label" type="obscure" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Access License Number</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                    <depends>
+                        <field id="carriers/ups/active">1</field>
+                    </depends>
                 </field>
                 <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enabled for Checkout</label>
@@ -84,6 +87,9 @@
                 <field id="password" translate="label" type="obscure" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Password</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                    <depends>
+                        <field id="carriers/ups/active">1</field>
+                    </depends>
                 </field>
                 <field id="pickup" translate="label" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Pickup Method</label>
@@ -113,6 +119,9 @@
                 <field id="username" translate="label" type="obscure" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>User ID</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                    <depends>
+                        <field id="carriers/ups/active">1</field>
+                    </depends>
                 </field>
                 <field id="negotiated_active" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enable Negotiated Rates</label>


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/22787

### Description (*)
I have added the dependency on UPS active config for Access License Number, Password, User ID UPS configs.
It prevents validation for Access License Number, Password, User ID fields and hides them in the case when UPS is disabled.

### Fixed Issues
1. magento/magento2#22786: The validation for UPS configurations triggers even if UPS is disabled for checkout

### Manual testing scenarios (*)
1. Go to the Admin -> Stores -> Configuration -> Sales -> Shipping Methods
2. Click on Save Config button

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
