### PR TITLE
Fixed #22841 Telephone, Company & Fax fields does not display on Customer Registration Page

### DIFF
--- a/app/code/Magento/Customer/Block/Form/Register.php
+++ b/app/code/Magento/Customer/Block/Form/Register.php
@@ -217,13 +217,18 @@ class Register extends \Magento\Directory\Block\Data
     
     /**
      * Address fields availability
-     *
-     * @return bool
      */
     public function getShowAddressFields(){
-        $_company = $this->getLayout()->createBlock('Magento\Customer\Block\Widget\Company');
-        $_telephone = $this->getLayout()->createBlock('Magento\Customer\Block\Widget\Telephone');
-        $_fax = $this->getLayout()->createBlock('Magento\Customer\Block\Widget\Fax');
-        return ($this->getData('show_address_fields') || $_company->isEnabled() || $_telephone->isEnabled() || $_fax->isEnabled())?true:false;
+        $_company = $this->getLayout()->createBlock(
+            \Magento\Customer\Block\Widget\Company::class
+        );
+        $_telephone = $this->getLayout()->createBlock(
+            \Magento\Customer\Block\Widget\Telephone::class
+        );
+        $_fax = $this->getLayout()->createBlock(
+            \Magento\Customer\Block\Widget\Fax::class
+        );
+        return ($this->getData('show_address_fields') || 
+            $_company->isEnabled() || $_telephone->isEnabled() || $_fax->isEnabled())?true:false;
     }
 }

--- a/app/code/Magento/Customer/Block/Form/Register.php
+++ b/app/code/Magento/Customer/Block/Form/Register.php
@@ -218,7 +218,8 @@ class Register extends \Magento\Directory\Block\Data
     /**
      * Address fields availability
      */
-    public function getShowAddressFields(){
+    public function getShowAddressFields()
+    {
         $_company = $this->getLayout()->createBlock(
             \Magento\Customer\Block\Widget\Company::class
         );
@@ -228,7 +229,8 @@ class Register extends \Magento\Directory\Block\Data
         $_fax = $this->getLayout()->createBlock(
             \Magento\Customer\Block\Widget\Fax::class
         );
-        return ($this->getData('show_address_fields') || 
-            $_company->isEnabled() || $_telephone->isEnabled() || $_fax->isEnabled())?true:false;
+        
+        return ($this->getData('show_address_fields') ||
+            $_company->isEnabled() || $_telephone->isEnabled() || $_fax->isEnabled())? true : false;
     }
 }

--- a/app/code/Magento/Customer/Block/Form/Register.php
+++ b/app/code/Magento/Customer/Block/Form/Register.php
@@ -214,4 +214,16 @@ class Register extends \Magento\Directory\Block\Data
     {
         return $this->_scopeConfig->getValue(AccountManagement::XML_PATH_REQUIRED_CHARACTER_CLASSES_NUMBER);
     }
+    
+    /**
+     * Address fields availability
+     *
+     * @return bool
+     */
+    public function getShowAddressFields(){
+        $_company = $this->getLayout()->createBlock('Magento\Customer\Block\Widget\Company');
+        $_telephone = $this->getLayout()->createBlock('Magento\Customer\Block\Widget\Telephone');
+        $_fax = $this->getLayout()->createBlock('Magento\Customer\Block\Widget\Fax');
+        return ($this->getData('show_address_fields') || $_company->isEnabled() || $_telephone->isEnabled() || $_fax->isEnabled())?true:false;
+    }
 }


### PR DESCRIPTION
Fixed #22841 Telephone, Company & Fax fields does not display on Customer Registration Page
## Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento 2.2.6
2. Backend Store configuration->Customer Configuration-> Name & Address Options
3. Frontend Customer Registration page

Base on the Magento documentation, it is clearly stated that the settings determine the information that is collection during customer registration. 
https://docs.magento.com/m2/ce/user_guide/customers/customer-account-configuration.html

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Admin Backend: store > configuration > customer configuration 
Under **Name and Address Options**, set S_how Prefix, Show Middle Name, Show Suffix, Show Date of Birth, Show Tax/VAT Number. Show Gender, Show Telephone, Show Company & Show Fax_ to "Yes" or "Optional" or "Required".

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. On the frontend customer registration page, all the fields that are Yes, Optional or Required should be displayed 

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Prefix, Middle Name, Suffix, Date of Birth, Tax/VAT Number and Gender fields are displayed correctly. But Telephone, Company and Fax fields are missing.
![image](https://user-images.githubusercontent.com/22439364/57582056-bb03b200-74f2-11e9-9006-8df8f6e56260.png)