### PR TITLE
Fixed issue #22875 Billing Agreements page title need to be improved

### DIFF
--- a/app/code/Magento/Paypal/Controller/Billing/Agreement/Index.php
+++ b/app/code/Magento/Paypal/Controller/Billing/Agreement/Index.php
@@ -6,7 +6,12 @@
  */
 namespace Magento\Paypal\Controller\Billing\Agreement;
 
-class Index extends \Magento\Paypal\Controller\Billing\Agreement
+use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+
+/**
+ * Index Controller.
+ */
+class Index extends \Magento\Paypal\Controller\Billing\Agreement implements HttpGetActionInterface
 {
     /**
      * View billing agreements

--- a/app/code/Magento/Paypal/Controller/Billing/Agreement/Index.php
+++ b/app/code/Magento/Paypal/Controller/Billing/Agreement/Index.php
@@ -16,7 +16,7 @@ class Index extends \Magento\Paypal\Controller\Billing\Agreement
     public function execute()
     {
         $this->_view->loadLayout();
-        $this->_view->getPage()->getConfig()->getTitle()->prepend(__('Billing Agreements'));
+        $this->_view->getPage()->getConfig()->getTitle()->set(__('Billing Agreements'));
         $this->_view->renderLayout();
     }
 }


### PR DESCRIPTION
Fixed #22875 Billing Agreements page title need to be improved

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento 2.3.x
2. Customer must be logged in.

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Login as customer in frontend
2. Now go to Billing Agreements tab

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1.Page title must be only : Billing Agreements

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Page title is showing: Billing Agreements / My Account
