### PR TITLE
Fixed issue with printing in firefox

### DIFF
--- a/app/design/frontend/Magento/blank/web/css/print.less
+++ b/app/design/frontend/Magento/blank/web/css/print.less
@@ -136,4 +136,8 @@
     .hidden-print {
         display: none !important;
     }
+
+    .page-wrapper, .columns {
+        display: block;
+    }
 }

--- a/app/design/frontend/Magento/blank/web/css/print.less
+++ b/app/design/frontend/Magento/blank/web/css/print.less
@@ -137,7 +137,8 @@
         display: none !important;
     }
 
-    .page-wrapper, .columns {
+    .page-wrapper,
+    .columns {
         display: block;
     }
 }


### PR DESCRIPTION
### Description (*)
Tested with order print page in Firefox and problem of only printing the first page is solved. Maybe also fixes print problems with other pages.
The `display` style for `.page-wrapper` and `.columns` is by default set to `flex`. This pull request sets them to `block` for printing therefore fixes the problem with printing in Firefox.
You can see the problem here:
http://demoshops.splendid-internet.de/magento/demoshop-magento2-daily/sales/order/print/order_id/4/
Only the second page contains the real print and its content is broken.

### Fixed Issues (if relevant)
#12464

1. magento/magento2#12464: Print layout broken in Firefox

### Manual testing scenarios (*)
1. Login
2. Go to order history
2.1. If history is empty place an order first
3. Print one of orders

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
