### PR TITLE
 Show exception message during SCD failure

### DIFF
--- a/app/code/Magento/Deploy/Service/DeployPackage.php
+++ b/app/code/Magento/Deploy/Service/DeployPackage.php
@@ -107,6 +107,8 @@ class DeployPackage
     }
 
     /**
+     * Execute package deploy procedure when area already emulated
+     *
      * @param Package $package
      * @param array $options
      * @param bool $skipLogging
@@ -136,7 +138,9 @@ class DeployPackage
                 $this->errorsCount++;
                 $this->logger->critical($errorMessage);
             } catch (\Exception $exception) {
-                $this->logger->critical($exception->getTraceAsString());
+                $this->logger->critical(
+                    'Compilation from source ' . $file->getSourcePath() . ' failed' . PHP_EOL . (string)$exception
+                );
                 $this->errorsCount++;
             }
         }
@@ -219,7 +223,9 @@ class DeployPackage
     private function checkFileSkip($filePath, array $options)
     {
         if ($filePath !== '.') {
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
             $ext = strtolower(pathinfo($filePath, PATHINFO_EXTENSION));
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
             $basename = pathinfo($filePath, PATHINFO_BASENAME);
             if ($ext === 'less' && strpos($basename, '_') === 0) {
                 return true;


### PR DESCRIPTION
### Description (*)
Add full exception message when SCD fails

### Fixed Issues (if relevant)
1. magento/magento2#22882: Static content deploy - Don't shows error message, just stack trace 

### Manual testing scenarios (*)
1. see magento/magento2#22882

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
