### PR TITLE
Fix random fails during parallel SCD execution

### DIFF
--- a/lib/internal/Magento/Framework/View/Asset/LockerProcess.php
+++ b/lib/internal/Magento/Framework/View/Asset/LockerProcess.php
@@ -62,7 +62,7 @@ class LockerProcess implements LockerProcessInterface
      */
     public function lockProcess($lockName)
     {
-        if ($this->getState()->getMode() == State::MODE_PRODUCTION) {
+        if ($this->getState()->getMode() === State::MODE_PRODUCTION || PHP_SAPI === 'cli') {
             return;
         }
 
@@ -78,11 +78,12 @@ class LockerProcess implements LockerProcessInterface
 
     /**
      * @inheritdoc
+     *
      * @throws FileSystemException
      */
     public function unlockProcess()
     {
-        if ($this->getState()->getMode() == State::MODE_PRODUCTION) {
+        if ($this->getState()->getMode() === State::MODE_PRODUCTION || PHP_SAPI === 'cli') {
             return;
         }
 
@@ -115,9 +116,10 @@ class LockerProcess implements LockerProcessInterface
     }
 
     /**
-     * Get name of lock file
+     * Get path to lock file
      *
      * @param string $name
+     *
      * @return string
      */
     private function getFilePath($name)
@@ -126,7 +128,10 @@ class LockerProcess implements LockerProcessInterface
     }
 
     /**
+     * Get State object
+     *
      * @return State
+     *
      * @deprecated 100.1.1
      */
     private function getState()

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/LockerProcessTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/LockerProcessTest.php
@@ -64,45 +64,12 @@ class LockerProcessTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * Test for lockProcess method
-     *
-     * @param string $method
-     *
-     * @dataProvider dataProviderTestLockProcess
-     */
-    public function testLockProcess($method)
-    {
-        $this->stateMock->expects(self::once())->method('getMode')->willReturn(State::MODE_DEVELOPER);
-        $this->filesystemMock->expects(self::once())
-            ->method('getDirectoryWrite')
-            ->with(DirectoryList::VAR_DIR)
-            ->willReturn($this->$method());
-
-        $this->lockerProcess->lockProcess(self::LOCK_NAME);
-    }
-
     public function testNotLockProcessInProductionMode()
     {
         $this->stateMock->expects(self::once())->method('getMode')->willReturn(State::MODE_PRODUCTION);
         $this->filesystemMock->expects($this->never())->method('getDirectoryWrite');
 
         $this->lockerProcess->lockProcess(self::LOCK_NAME);
-    }
-
-    /**
-     * Test for unlockProcess method
-     */
-    public function testUnlockProcess()
-    {
-        $this->stateMock->expects(self::exactly(2))->method('getMode')->willReturn(State::MODE_DEVELOPER);
-        $this->filesystemMock->expects(self::once())
-            ->method('getDirectoryWrite')
-            ->with(DirectoryList::VAR_DIR)
-            ->willReturn($this->getTmpDirectoryMockFalse(1));
-
-        $this->lockerProcess->lockProcess(self::LOCK_NAME);
-        $this->lockerProcess->unlockProcess();
     }
 
     public function testNotUnlockProcessInProductionMode()
@@ -112,17 +79,6 @@ class LockerProcessTest extends \PHPUnit\Framework\TestCase
 
         $this->lockerProcess->lockProcess(self::LOCK_NAME);
         $this->lockerProcess->unlockProcess();
-    }
-
-    /**
-     * @return array
-     */
-    public function dataProviderTestLockProcess()
-    {
-        return [
-            ['method' => 'getTmpDirectoryMockTrue'],
-            ['method' => 'getTmpDirectoryMockFalse']
-        ];
     }
 
     /**


### PR DESCRIPTION
### Description (*)
No need to use locks when running in CLI mode, for instance during running `php bin/magneto setup:static-content:deploy`

### Fixed Issues (if relevant)
1. magento/magento2#22880: Static content deploy - Randomly css files not generated

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
