### PR TITLE
#5730 - config created for search result default sort by option

### DIFF
--- a/app/code/Magento/CatalogSearch/Block/Result.php
+++ b/app/code/Magento/CatalogSearch/Block/Result.php
@@ -143,7 +143,7 @@ class Result extends Template
         )->setDefaultDirection(
             'desc'
         )->setDefaultSortBy(
-            'relevance'
+            $this->catalogSearchData->getDefaultSearchSortBy()
         );
 
         return $this;

--- a/app/code/Magento/CatalogSearch/Helper/Data.php
+++ b/app/code/Magento/CatalogSearch/Helper/Data.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\CatalogSearch\Helper;
 
+use Magento\Store\Model\ScopeInterface;
+
 /**
  * Catalog search helper
  *
@@ -13,6 +15,8 @@ namespace Magento\CatalogSearch\Helper;
  */
 class Data extends \Magento\Search\Helper\Data
 {
+    const XML_PATH_SEARCH_DEFAULT_SORT_BY = 'catalog/search/default_sort_by';
+
     /**
      * Retrieve advanced search URL
      *
@@ -21,5 +25,15 @@ class Data extends \Magento\Search\Helper\Data
     public function getAdvancedSearchUrl()
     {
         return $this->_getUrl('catalogsearch/advanced');
+    }
+
+    /**
+     * Get config value for search results sort by option
+     *
+     * @return string
+     */
+    public function getDefaultSearchSortBy(): string
+    {
+        return $this->scopeConfig->getValue(self::XML_PATH_SEARCH_DEFAULT_SORT_BY, ScopeInterface::SCOPE_STORE);
     }
 }

--- a/app/code/Magento/CatalogSearch/Model/Config/Source/ListSort.php
+++ b/app/code/Magento/CatalogSearch/Model/Config/Source/ListSort.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\CatalogSearch\Model\Config\Source;
+
+/**
+ * Catalog Search Product List Sortable allowed sortable attributes source
+ *
+ * @author     Magento Core Team <core@magentocommerce.com>
+ */
+class ListSort implements \Magento\Framework\Data\OptionSourceInterface
+{
+    /**
+     * @var \Magento\Catalog\Model\Config
+     */
+    protected $catalogConfig;
+
+    /**
+     * @param \Magento\Catalog\Model\Config $catalogConfig
+     */
+    public function __construct(\Magento\Catalog\Model\Config $catalogConfig)
+    {
+        $this->catalogConfig = $catalogConfig;
+    }
+
+    /**
+     * Provide config options for dropdown
+     *
+     * @return array
+     */
+    public function toOptionArray(): array
+    {
+        $options = [];
+        $options[] = ['label' => __('Relevance'), 'value' => 'relevance'];
+        foreach ($this->catalogConfig->getAttributesUsedForSortBy() as $attribute) {
+            $options[] = ['label' => __($attribute['frontend_label']), 'value' => $attribute['attribute_code']];
+        }
+        return $options;
+    }
+}

--- a/app/code/Magento/CatalogSearch/etc/adminhtml/system.xml
+++ b/app/code/Magento/CatalogSearch/etc/adminhtml/system.xml
@@ -34,6 +34,11 @@
                     <comment>Number of popular search terms to be cached for faster response. Use “0” to cache all results after a term is searched for the second time.</comment>
                     <validate>validate-digits</validate>
                 </field>
+                <field id="default_sort_by" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Search Result Sort by</label>
+                    <comment>Applies to catalog search result pages</comment>
+                    <source_model>Magento\CatalogSearch\Model\Config\Source\ListSort</source_model>
+                </field>
                 <field id="autocomplete_limit" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Autocomplete Limit</label>
                     <validate>validate-digits</validate>

--- a/app/code/Magento/CatalogSearch/etc/config.xml
+++ b/app/code/Magento/CatalogSearch/etc/config.xml
@@ -16,6 +16,7 @@
                 <min_query_length>3</min_query_length>
                 <max_query_length>128</max_query_length>
                 <max_count_cacheable_search_terms>100</max_count_cacheable_search_terms>
+                <default_sort_by>relevance</default_sort_by>
                 <autocomplete_limit>8</autocomplete_limit>
                 <enable_eav_indexer>1</enable_eav_indexer>
             </search>


### PR DESCRIPTION
### Description (*)
Feature provides new catalog search config value. It is responsible for providing default sort order for catalog search result pages. Default is set 'relevance', as it was before. 

### Fixed Issues (if relevant)
1. [magento/magento2#5730](https://github.com/magento/magento2/issues/5730)

### Manual testing scenarios (*)
1. Check default behaviour by checking catalog search result page
2. Change sort by in Admin -> Stores-> Catalog -> Catalog Search -> Search Result Sort by
3. Clear cache
4. Check catalog search result page for predefined sort by

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
