### PR TITLE
#22869 - defaulting customer storeId fix

### DIFF
--- a/app/code/Magento/Customer/Model/ResourceModel/CustomerRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/CustomerRepository.php
@@ -209,7 +209,7 @@ class CustomerRepository implements CustomerRepositoryInterface
         $customerModel->setId($customer->getId());
         $storeId = $customerModel->getStoreId();
         if ($storeId === null) {
-            $customerModel->setStoreId($this->storeManager->getStore()->getId());
+            $customerModel->setStoreId($prevCustomerData->getStoreId() ?? $this->storeManager->getStore()->getId());
         }
         // Need to use attribute set or future updates can cause data loss
         if (!$customerModel->getAttributeSetId()) {

--- a/app/code/Magento/Customer/Model/ResourceModel/CustomerRepository.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/CustomerRepository.php
@@ -209,7 +209,9 @@ class CustomerRepository implements CustomerRepositoryInterface
         $customerModel->setId($customer->getId());
         $storeId = $customerModel->getStoreId();
         if ($storeId === null) {
-            $customerModel->setStoreId($prevCustomerData->getStoreId() ?? $this->storeManager->getStore()->getId());
+            $customerModel->setStoreId(
+                $prevCustomerData ? $prevCustomerData->getStoreId() : $this->storeManager->getStore()->getId()
+            );
         }
         // Need to use attribute set or future updates can cause data loss
         if (!$customerModel->getAttributeSetId()) {
@@ -277,7 +279,6 @@ class CustomerRepository implements CustomerRepositoryInterface
                 'delegate_data' => $delegatedNewOperation ? $delegatedNewOperation->getAdditionalData() : [],
             ]
         );
-
         return $savedCustomer;
     }
 

--- a/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/CustomerRepositoryTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/CustomerRepositoryTest.php
@@ -107,7 +107,7 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
             $this->createMock(\Magento\Customer\Model\ResourceModel\Customer::class);
         $this->customerRegistry = $this->createMock(\Magento\Customer\Model\CustomerRegistry::class);
         $this->dataObjectHelper = $this->createMock(\Magento\Framework\Api\DataObjectHelper::class);
-        $this->customerFactory  =
+        $this->customerFactory =
             $this->createPartialMock(\Magento\Customer\Model\CustomerFactory::class, ['create']);
         $this->customerSecureFactory = $this->createPartialMock(
             \Magento\Customer\Model\Data\CustomerSecureFactory::class,
@@ -193,9 +193,10 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
     public function testSave()
     {
         $customerId = 1;
-        $storeId = 2;
 
-        $customerModel = $this->createPartialMock(\Magento\Customer\Model\Customer::class, [
+        $customerModel = $this->createPartialMock(
+            \Magento\Customer\Model\Customer::class,
+            [
                 'getId',
                 'setId',
                 'setStoreId',
@@ -210,7 +211,8 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
                 'setFirstFailure',
                 'setLockExpires',
                 'save',
-            ]);
+            ]
+        );
 
         $origCustomer = $this->customer;
 
@@ -229,14 +231,17 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
                 'setAddresses'
             ]
         );
-        $customerSecureData = $this->createPartialMock(\Magento\Customer\Model\Data\CustomerSecure::class, [
-                'getRpToken',
-                'getRpTokenCreatedAt',
-                'getPasswordHash',
-                'getFailuresNum',
-                'getFirstFailure',
-                'getLockExpires',
-            ]);
+        $customerSecureData = $this->createPartialMock(
+            \Magento\Customer\Model\Data\CustomerSecure::class,
+            [
+            'getRpToken',
+            'getRpTokenCreatedAt',
+            'getPasswordHash',
+            'getFailuresNum',
+            'getFirstFailure',
+            'getLockExpires',
+            ]
+        );
         $this->customer->expects($this->atLeastOnce())
             ->method('getId')
             ->willReturn($customerId);
@@ -268,17 +273,6 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
         $customerModel->expects($this->once())
             ->method('getStoreId')
             ->willReturn(null);
-        $store = $this->createMock(\Magento\Store\Model\Store::class);
-        $store->expects($this->once())
-            ->method('getId')
-            ->willReturn($storeId);
-        $this->storeManager
-            ->expects($this->once())
-            ->method('getStore')
-            ->willReturn($store);
-        $customerModel->expects($this->once())
-            ->method('setStoreId')
-            ->with($storeId);
         $customerModel->expects($this->once())
             ->method('setId')
             ->with($customerId);
@@ -310,16 +304,20 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
 
         $customerModel->expects($this->once())
             ->method('setRpToken')
-            ->willReturnMap([
+            ->willReturnMap(
+                [
                 ['rpToken', $customerModel],
                 [null, $customerModel],
-            ]);
+                ]
+            );
         $customerModel->expects($this->once())
             ->method('setRpTokenCreatedAt')
-            ->willReturnMap([
+            ->willReturnMap(
+                [
                 ['rpTokenCreatedAt', $customerModel],
                 [null, $customerModel],
-            ]);
+                ]
+            );
 
         $customerModel->expects($this->once())
             ->method('setPasswordHash')
@@ -371,32 +369,37 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
     public function testSaveWithPasswordHash()
     {
         $customerId = 1;
-        $storeId = 2;
         $passwordHash = 'ukfa4sdfa56s5df02asdf4rt';
 
-        $customerSecureData = $this->createPartialMock(\Magento\Customer\Model\Data\CustomerSecure::class, [
-                'getRpToken',
-                'getRpTokenCreatedAt',
-                'getPasswordHash',
-                'getFailuresNum',
-                'getFirstFailure',
-                'getLockExpires',
-            ]);
+        $customerSecureData = $this->createPartialMock(
+            \Magento\Customer\Model\Data\CustomerSecure::class,
+            [
+            'getRpToken',
+            'getRpTokenCreatedAt',
+            'getPasswordHash',
+            'getFailuresNum',
+            'getFirstFailure',
+            'getLockExpires',
+            ]
+        );
         $origCustomer = $this->customer;
 
-        $customerModel = $this->createPartialMock(\Magento\Customer\Model\Customer::class, [
-                'getId',
-                'setId',
-                'setStoreId',
-                'getStoreId',
-                'getAttributeSetId',
-                'setAttributeSetId',
-                'setRpToken',
-                'setRpTokenCreatedAt',
-                'getDataModel',
-                'setPasswordHash',
-                'save',
-            ]);
+        $customerModel = $this->createPartialMock(
+            \Magento\Customer\Model\Customer::class,
+            [
+            'getId',
+            'setId',
+            'setStoreId',
+            'getStoreId',
+            'getAttributeSetId',
+            'setAttributeSetId',
+            'setRpToken',
+            'setRpTokenCreatedAt',
+            'getDataModel',
+            'setPasswordHash',
+            'save',
+            ]
+        );
         $customerAttributesMetaData = $this->getMockForAbstractClass(
             \Magento\Framework\Api\CustomAttributesDataInterface::class,
             [],
@@ -447,7 +450,6 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
         $customerSecureData->expects($this->once())
             ->method('getLockExpires')
             ->willReturn('lockExpires');
-
         $this->customer->expects($this->atLeastOnce())
             ->method('getId')
             ->willReturn($customerId);
@@ -477,20 +479,6 @@ class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->with(['data' => ['customerData']])
             ->willReturn($customerModel);
-        $customerModel->expects($this->once())
-            ->method('getStoreId')
-            ->willReturn(null);
-        $store = $this->createMock(\Magento\Store\Model\Store::class);
-        $store->expects($this->once())
-            ->method('getId')
-            ->willReturn($storeId);
-        $this->storeManager
-            ->expects($this->once())
-            ->method('getStore')
-            ->willReturn($store);
-        $customerModel->expects($this->once())
-            ->method('setStoreId')
-            ->with($storeId);
         $customerModel->expects($this->once())
             ->method('setId')
             ->with($customerId);


### PR DESCRIPTION
### Description (*)
Fix prevent saving default customer storeId if one was not passed in rest request. StoreId is taken from previously loaded customer data if none is provided.

### Fixed Issues (if relevant)
1. magento/magento2#22869: REST: Updating a customer without store_id sets the store_id to default

### Manual testing scenarios (*)
1. use steps provided in issue [description](https://github.com/magento/magento2/issues/22869#issue-443427004)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
