### PR TITLE
Fixed #6955 Admin: While product which has images deleted. It's not deleting from Folder

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
@@ -12,7 +12,7 @@ use Magento\Backend\App\Action\Context;
 use Magento\Ui\Component\MassAction\Filter;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Catalog\Api\ProductRepositoryInterface;
-
+use Magento\Catalog\Model\ProductFactory;
 class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product implements HttpPostActionInterface
 {
     /**
@@ -31,6 +31,11 @@ class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product implement
      * @var ProductRepositoryInterface
      */
     private $productRepository;
+    
+     /**
+     * @var ProductFactory
+     */
+    private $productFactory;
 
     /**
      * @param Context $context
@@ -38,18 +43,21 @@ class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product implement
      * @param Filter $filter
      * @param CollectionFactory $collectionFactory
      * @param ProductRepositoryInterface $productRepository
+     * @param ProductFactory $productFactory
      */
     public function __construct(
         Context $context,
         Builder $productBuilder,
         Filter $filter,
         CollectionFactory $collectionFactory,
-        ProductRepositoryInterface $productRepository = null
+        ProductRepositoryInterface $productRepository = null,
+        ProductFactory $productFactory
     ) {
         $this->filter = $filter;
         $this->collectionFactory = $collectionFactory;
         $this->productRepository = $productRepository
             ?: \Magento\Framework\App\ObjectManager::getInstance()->create(ProductRepositoryInterface::class);
+        $this->productFactory = $productFactory;
         parent::__construct($context, $productBuilder);
     }
 
@@ -62,6 +70,7 @@ class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product implement
         $productDeleted = 0;
         /** @var \Magento\Catalog\Model\Product $product */
         foreach ($collection->getItems() as $product) {
+            $this->productFactory->create()->load($product->getId())->deleteMediaGalleryImages();
             $this->productRepository->delete($product);
             $productDeleted++;
         }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
@@ -11,6 +11,8 @@ use Magento\Backend\App\Action\Context;
 use Magento\Ui\Component\MassAction\Filter;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\ProductFactory;
+
 class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product implements HttpPostActionInterface
 {
     /**
@@ -23,28 +25,33 @@ class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product implement
      * @var CollectionFactory
      */
     protected $collectionFactory;
+    
     /**
-     * @var ProductRepositoryInterface
+     * @var \Magento\Catalog\Model\ProductFactory
      */
-    private $productRepository;
+    protected $productFactory;
+
     /**
      * @param Context $context
      * @param Builder $productBuilder
      * @param Filter $filter
      * @param CollectionFactory $collectionFactory
      * @param ProductRepositoryInterface $productRepository
+     * @param ProductFactory $productFactory
      */
     public function __construct(
         Context $context,
         Builder $productBuilder,
         Filter $filter,
         CollectionFactory $collectionFactory,
-        ProductRepositoryInterface $productRepository = null
+        ProductRepositoryInterface $productRepository = null,
+        ProductFactory $productFactory
     ) {
         $this->filter = $filter;
         $this->collectionFactory = $collectionFactory;
         $this->productRepository = $productRepository
             ?: \Magento\Framework\App\ObjectManager::getInstance()->create(ProductRepositoryInterface::class);
+        $this->productFactory = $productFactory;
         parent::__construct($context, $productBuilder);
     }
     /**
@@ -56,7 +63,7 @@ class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product implement
         $productDeleted = 0;
         /** @var \Magento\Catalog\Model\Product $product */
         foreach ($collection->getItems() as $product) {
-            $this->productRepository->delete($product);
+            $this->productFactory->create()->load($product->getId())->delete();
             $productDeleted++;
         }
         if ($productDeleted) {

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassDelete.php
@@ -5,14 +5,12 @@
  * See COPYING.txt for license details.
  */
 namespace Magento\Catalog\Controller\Adminhtml\Product;
-
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Backend\App\Action\Context;
 use Magento\Ui\Component\MassAction\Filter;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\Catalog\Model\ProductFactory;
 class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product implements HttpPostActionInterface
 {
     /**
@@ -21,46 +19,34 @@ class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product implement
      * @var Filter
      */
     protected $filter;
-
     /**
      * @var CollectionFactory
      */
     protected $collectionFactory;
-
     /**
      * @var ProductRepositoryInterface
      */
     private $productRepository;
-    
-     /**
-     * @var ProductFactory
-     */
-    private $productFactory;
-
     /**
      * @param Context $context
      * @param Builder $productBuilder
      * @param Filter $filter
      * @param CollectionFactory $collectionFactory
      * @param ProductRepositoryInterface $productRepository
-     * @param ProductFactory $productFactory
      */
     public function __construct(
         Context $context,
         Builder $productBuilder,
         Filter $filter,
         CollectionFactory $collectionFactory,
-        ProductRepositoryInterface $productRepository = null,
-        ProductFactory $productFactory
+        ProductRepositoryInterface $productRepository = null
     ) {
         $this->filter = $filter;
         $this->collectionFactory = $collectionFactory;
         $this->productRepository = $productRepository
             ?: \Magento\Framework\App\ObjectManager::getInstance()->create(ProductRepositoryInterface::class);
-        $this->productFactory = $productFactory;
         parent::__construct($context, $productBuilder);
     }
-
     /**
      * @return \Magento\Backend\Model\View\Result\Redirect
      */
@@ -70,17 +56,14 @@ class MassDelete extends \Magento\Catalog\Controller\Adminhtml\Product implement
         $productDeleted = 0;
         /** @var \Magento\Catalog\Model\Product $product */
         foreach ($collection->getItems() as $product) {
-            $this->productFactory->create()->load($product->getId())->deleteMediaGalleryImages();
             $this->productRepository->delete($product);
             $productDeleted++;
         }
-
         if ($productDeleted) {
             $this->messageManager->addSuccessMessage(
                 __('A total of %1 record(s) have been deleted.', $productDeleted)
             );
         }
-
         return $this->resultFactory->create(ResultFactory::TYPE_REDIRECT)->setPath('catalog/*/index');
     }
 }

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -352,6 +352,11 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
      * @var FilterProductCustomAttribute|null
      */
     private $filterCustomAttribute;
+        
+    /**
+     * @var \Magento\Catalog\Model\Product\Gallery\CreateHandler
+     */
+    protected $mediaGalleryHandler;
 
     /**
      * @param \Magento\Framework\Model\Context $context
@@ -2775,6 +2780,40 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
     public function setStockData($stockData)
     {
         $this->setData('stock_data', $stockData);
+        return $this;
+    }
+        
+
+    /**
+     * @return Product\Gallery\CreateHandler
+     */
+    private function getMediaGalleryHandler()
+    {
+        if (null === $this->mediaGalleryHandler) {
+            $this->mediaGalleryHandler = \Magento\Framework\App\ObjectManager::getInstance()
+                ->get(\Magento\Catalog\Model\Product\Gallery\CreateHandler::class);
+        }
+        return $this->mediaGalleryHandler;
+    }
+     
+    /**
+     * @return $this
+     */
+    public function deleteMediaGalleryImages() {
+        $attrCode = $this->getMediaGalleryHandler()->getAttribute()->getAttributeCode();
+        
+        $mediaGalleryData = $this->getData($attrCode);
+
+        if (!isset($mediaGalleryData['images']) || !is_array($mediaGalleryData['images'])) {
+            return $this;
+        }
+
+        foreach ($mediaGalleryData['images'] as &$image) {
+            $image['removed'] = 1;
+        }
+
+        $this->setData($attrCode, $mediaGalleryData);
+        $this->getMediaGalleryHandler()->execute($this)->save();
         return $this;
     }
 }

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -352,11 +352,6 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
      * @var FilterProductCustomAttribute|null
      */
     private $filterCustomAttribute;
-        
-    /**
-     * @var \Magento\Catalog\Model\Product\Gallery\CreateHandler
-     */
-    protected $mediaGalleryHandler;
 
     /**
      * @param \Magento\Framework\Model\Context $context
@@ -2780,40 +2775,6 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
     public function setStockData($stockData)
     {
         $this->setData('stock_data', $stockData);
-        return $this;
-    }
-        
-
-    /**
-     * @return Product\Gallery\CreateHandler
-     */
-    private function getMediaGalleryHandler()
-    {
-        if (null === $this->mediaGalleryHandler) {
-            $this->mediaGalleryHandler = \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(\Magento\Catalog\Model\Product\Gallery\CreateHandler::class);
-        }
-        return $this->mediaGalleryHandler;
-    }
-     
-    /**
-     * @return $this
-     */
-    public function deleteMediaGalleryImages() {
-        $attrCode = $this->getMediaGalleryHandler()->getAttribute()->getAttributeCode();
-        
-        $mediaGalleryData = $this->getData($attrCode);
-
-        if (!isset($mediaGalleryData['images']) || !is_array($mediaGalleryData['images'])) {
-            return $this;
-        }
-
-        foreach ($mediaGalleryData['images'] as &$image) {
-            $image['removed'] = 1;
-        }
-
-        $this->setData($attrCode, $mediaGalleryData);
-        $this->getMediaGalleryHandler()->execute($this)->save();
         return $this;
     }
 }

--- a/app/code/Magento/Catalog/Observer/CategoryProductMediaDelete.php
+++ b/app/code/Magento/Catalog/Observer/CategoryProductMediaDelete.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Catalog\Observer;
+
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Catalog\Model\Product\Media\ConfigInterface as MediaConfig;
+use Magento\Framework\Filesystem;
+use Magento\Framework\App\Filesystem\DirectoryList;
+
+class CategoryProductMediaDelete implements ObserverInterface
+{
+    /**
+     * @var MediaConfig
+     */
+
+    private $imageConfig;
+    /**
+     * @var Filesystem
+     */
+
+    private $mediaDirectory;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * Product constructor.
+     * @param MediaConfig $imageConfig
+     * @param Filesystem $filesystem
+     */
+    public function __construct(
+        MediaConfig $imageConfig,
+        Filesystem $filesystem
+    ) {
+        $this->imageConfig = $imageConfig;
+        $this->mediaDirectory = $filesystem->getDirectoryWrite(DirectoryList::MEDIA);
+    }
+
+    /**
+     * Process event on 'catalog_product_delete_after_done' event
+     *
+     * @param \Magento\Framework\Event\Observer $observer
+     * @return void
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        /** @var $product \Magento\Catalog\Model\Product */
+        $product = $observer->getEvent()->getProduct();
+
+        if ($product->getId()) {
+            $mediaGallery = $product->getData('media_gallery');
+            $productImages = !empty($mediaGallery['images']) ? array_column($mediaGallery['images'], 'file') : [];
+
+            foreach ($productImages as $image) {
+                $originalImagePath = $this->mediaDirectory->getAbsolutePath(
+                    $this->imageConfig->getMediaPath($image)
+                );
+
+                if (file_exists($originalImagePath)) {
+                    unlink($originalImagePath);
+                }
+            }
+        }
+    }
+}

--- a/app/code/Magento/Catalog/etc/adminhtml/events.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/events.xml
@@ -12,4 +12,7 @@
     <event name="catalog_category_change_products">
         <observer name="category_product_indexer" instance="Magento\Catalog\Observer\CategoryProductIndexer"/>
     </event>
+    <event name="catalog_product_delete_after_done">
+        <observer name="category_product_media_delete" instance="Magento\Catalog\Observer\CategoryProductMediaDelete"/>
+    </event>
 </config>


### PR DESCRIPTION
Fixed #6955 Admin: While product which has images deleted. It's not deleting from Folder
### Preconditions

<!--- Provide a more detailed information of environment you use -->

<!--- Magento version, tag, HEAD, etc., PHP & MySQL version, etc.. -->
1. I'm using Magento 2 CE Version 2.1.1
### Steps to reproduce

<!--- Provide a set of unambiguous steps to reproduce this bug include code, if relevant  -->
1.  Go to Admin -> Products -> Catalog
2.  When Product has image & if you delete from listing.
3.  It will not delete product images from Folder.
### Expected result

<!--- Tell us what should happen -->
1.  When product is deleted, It should delete all product images from Folder as well.
### Actual result

<!--- Tell us what happens instead -->
1. Currently it's not deleting product Images.
2. Due to Image Not Deleted, there will be lots of space on server will be used.
3. This is the only case for Products, May be we have same issue of other Admin module as well where image is uploaded.
4. Need to check whole Admin where image is related while Delete.

<!--- (This may be platform independent comment) -->
