### PR TITLE
[Backport] 404 not found form validation url when updating quantity in cart page

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
@@ -14,7 +14,7 @@
           method="post"
           id="form-validate"
           data-mage-init='{"Magento_Checkout/js/action/update-shopping-cart":
-              {"validationURL" : "/checkout/cart/updateItemQty",
+              {"validationURL" : "<?= /* @escapeNotVerified */ $block->getUrl('checkout/cart/updateItemQty') ?>",
               "updateCartActionContainer": "#update_cart_action_container"}
           }'
           class="form form-cart">


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22657
404 not found form validation url when updating item quantity in cart page

### Description (*)
404 not found form validation url when updating item quantity in cart page

### Manual testing scenarios (*)
1. Add product to cart
2. Go to cart page
3. Edit any item quantity and click update shopping cart button.
4. Cart form validation request goes to 404 url

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
