### PR TITLE
Do an empty check instead of isset check on image removed

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
@@ -231,7 +231,7 @@ class MediaGalleryProcessor
     private function processMediaAttributes(ProductInterface $product, array $images): void
     {
         foreach ($images as $image) {
-            if (!isset($image['removed']) && !empty($image['types'])) {
+            if (empty($image['removed']) && !empty($image['types'])) {
                 $this->processor->setMediaAttribute($product, $image['types'], $image['file']);
             }
         }


### PR DESCRIPTION
In some cases the 'removed' tag on the image is already set to an empty
string in the data which will be loaded. Therefore the isset check fails
which clears the image roles.

On all other cases where this 'removed' tag is being validated with an
empty or !empty. Therefor it seems safe to apply this here also.

### Manual testing scenarios (*)
1. Upload an image for a product
2. Set the image roles
3. See that the image roles still work
4. Try step 2 and 3 with different combination of image roles.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
