### PR TITLE
[Backport] #22899 Fix the issue with Incorrect return type at getListByCustomerId in PaymentTokenManagementInterface

### DIFF
--- a/app/code/Magento/Vault/Api/PaymentTokenManagementInterface.php
+++ b/app/code/Magento/Vault/Api/PaymentTokenManagementInterface.php
@@ -56,6 +56,8 @@ interface PaymentTokenManagementInterface
     public function getByPublicHash($hash, $customerId);
 
     /**
+     * Save token with payment link
+     *
      * @param PaymentTokenInterface $token
      * @param OrderPaymentInterface $payment
      * @return bool

--- a/app/code/Magento/Vault/Api/PaymentTokenManagementInterface.php
+++ b/app/code/Magento/Vault/Api/PaymentTokenManagementInterface.php
@@ -20,7 +20,7 @@ interface PaymentTokenManagementInterface
      * Lists payment tokens that match specified search criteria.
      *
      * @param int $customerId Customer ID.
-     * @return \Magento\Vault\Api\Data\PaymentTokenSearchResultsInterface Payment token search result interface.
+     * @return \Magento\Vault\Api\Data\PaymentTokenSearchResultsInterface[] Payment token search result interface.
      * @since 100.1.0
      */
     public function getListByCustomerId($customerId);


### PR DESCRIPTION
### Original PR
https://github.com/magento/magento2/pull/22914

### Description (*)
Fix the issue with Incorrect return type at getListByCustomerId in PaymentTokenManagementInterface.
The Magento\Vault\Model\PaymentTokenManagement implements this interface and this class actually return the list of PaymentTokenSearchResultsInterface interfaces.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22899: Incorrect return type at getListByCustomerId in PaymentTokenManagementInterface

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. call getListByCustomerId() method of PaymentTokenManagementInterface interface and you will see that array with PaymentTokenSearchResultsInterface interfaces is returned.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
