### PR TITLE
fix "/catalog/Adminhtml_category/"

### DIFF
--- a/lib/internal/Magento/Framework/App/Router/Base.php
+++ b/lib/internal/Magento/Framework/App/Router/Base.php
@@ -291,7 +291,7 @@ class Base implements \Magento\Framework\App\RouterInterface
         $action = null;
         $actionInstance = null;
 
-        $actionPath = $this->matchActionPath($request, $params['actionPath']);
+        $actionPath = strtolower($this->matchActionPath($request, $params['actionPath']));
         $action = $request->getActionName() ?: ($params['actionName'] ?: $this->_defaultPath->getPart('action'));
         $this->_checkShouldBeSecure($request, '/' . $moduleFrontName . '/' . $actionPath . '/' . $action);
 


### PR DESCRIPTION
Steps to reproduce
1. Use a web browser and go to "/catalog/Adminhtml_category/" in a magento website.
2. Example: "https://example.com/catalog/Adminhtml_category/"
3. More urls with same problem
* cms/Adminhtml_block
* cms/Adminhtml_block/index
* cms/Adminhtml_block/edit
* cms/Adminhtml_page
* customer/Adminhtml_index
* customer/Adminhtml_group

(/) Expected Result
1. Browser is redirected to magento client side "404" "not found page" : "https://example.com/catalog/Adminhtml_category/" = "Ups the page you are looking for is not found!"
2. Custom admin url not exposed
3. No more actions from attacker

(x) Actual result
1. Browser is redirected to admin login page: "https://example.com/example_custom_url/admin/index/index/key/".
2. Custom admin url is exposed
3. Attacker then tries to find exploits 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
