### PR TITLE
Mview Indexers getList should return integer values of id's and not strings

### DIFF
--- a/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
+++ b/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
@@ -215,10 +215,10 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
         $this->connectionMock->expects($this->once())
             ->method('fetchCol')
             ->with($selectMock)
-            ->will($this->returnValue(['some_data']));
+            ->will($this->returnValue([1]));
 
         $this->model->setViewId('viewIdtest');
-        $this->assertEquals(['some_data'], $this->model->getList(1, 2));
+        $this->assertEquals([1], $this->model->getList(1, 2));
     }
 
     public function testGetListWithException()

--- a/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
+++ b/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
@@ -6,6 +6,11 @@
 
 namespace Magento\Framework\Mview\Test\Unit\View;
 
+/**
+ * Class ChangelogTest
+ *
+ * @package Magento\Framework\Mview\Test\Unit\View
+ */
 class ChangelogTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
+++ b/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
@@ -7,10 +7,9 @@
 namespace Magento\Framework\Mview\Test\Unit\View;
 
 /**
- * Test Changelog View Class
+ * Test Coverage for Changelog View.
  *
  * @see \Magento\Framework\Mview\View\Changelog
- * @package Magento\Framework\Mview\Test\Unit\View
  */
 class ChangelogTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
+++ b/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
@@ -7,8 +7,9 @@
 namespace Magento\Framework\Mview\Test\Unit\View;
 
 /**
- * Class ChangelogTest
+ * Test Changelog View Class
  *
+ * @see \Magento\Framework\Mview\View\Changelog
  * @package Magento\Framework\Mview\Test\Unit\View
  */
 class ChangelogTest extends \PHPUnit\Framework\TestCase

--- a/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
+++ b/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
@@ -50,7 +50,7 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException \Exception
+     * @expectedException \Magento\Framework\DB\Adapter\ConnectionException
      * @expectedExceptionMessage The write connection to the database isn't available. Please try again later.
      */
     public function testCheckConnectionException()
@@ -79,7 +79,7 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException \Exception
+     * @expectedException \DomainException
      * @expectedExceptionMessage View's identifier is not set
      */
     public function testGetNameWithException()
@@ -106,6 +106,10 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(10, $this->model->getVersion());
     }
 
+    /**
+     * @expectedException \Magento\Framework\Exception\RuntimeException
+     * @expectedExceptionMessage Table status for viewIdtest_cl is incorrect. Can`t fetch version id.
+     */
     public function testGetVersionWithExceptionNoAutoincrement()
     {
         $changelogTableName = 'viewIdtest_cl';
@@ -116,8 +120,6 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
             ->method('fetchRow')
             ->will($this->returnValue([]));
 
-        $this->expectException('Exception');
-        $this->expectExceptionMessage("Table status for {$changelogTableName} is incorrect. Can`t fetch version id.");
         $this->model->setViewId('viewIdtest');
         $this->model->getVersion();
     }

--- a/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
+++ b/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
@@ -118,7 +118,9 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue([]));
 
         $this->expectException('Exception');
-        $this->expectExceptionMessage("Table status for `{$changelogTableName}` is incorrect. Can`t fetch version id.");
+        $this->expectExceptionMessage(
+            __("Table status for %1 is incorrect. Can`t fetch version id.", [$changelogTableName])
+        );
         $this->model->setViewId('viewIdtest');
         $this->model->getVersion();
     }
@@ -130,7 +132,7 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
         $this->mockGetTableName();
 
         $this->expectException('Exception');
-        $this->expectExceptionMessage("Table {$changelogTableName} does not exist");
+        $this->expectExceptionMessage(__("Table %1 does not exist", [$changelogTableName]));
         $this->model->setViewId('viewIdtest');
         $this->model->getVersion();
     }
@@ -142,7 +144,7 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
         $this->mockGetTableName();
 
         $this->expectException('Exception');
-        $this->expectExceptionMessage("Table {$changelogTableName} does not exist");
+        $this->expectExceptionMessage(__("Table %1 does not exist", [$changelogTableName]));
         $this->model->setViewId('viewIdtest');
         $this->model->drop();
     }
@@ -234,7 +236,7 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
         $this->mockGetTableName();
 
         $this->expectException('Exception');
-        $this->expectExceptionMessage("Table {$changelogTableName} does not exist");
+        $this->expectExceptionMessage(__("Table %1 does not exist", [$changelogTableName]));
         $this->model->setViewId('viewIdtest');
         $this->model->getList(mt_rand(1, 200), mt_rand(201, 400));
     }
@@ -246,7 +248,7 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
         $this->mockGetTableName();
 
         $this->expectException('Exception');
-        $this->expectExceptionMessage("Table {$changelogTableName} does not exist");
+        $this->expectExceptionMessage(__("Table %1 does not exist", [$changelogTableName]));
         $this->model->setViewId('viewIdtest');
         $this->model->clear(mt_rand(1, 200));
     }

--- a/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
+++ b/lib/internal/Magento/Framework/Mview/Test/Unit/View/ChangelogTest.php
@@ -118,9 +118,7 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue([]));
 
         $this->expectException('Exception');
-        $this->expectExceptionMessage(
-            __("Table status for %1 is incorrect. Can`t fetch version id.", [$changelogTableName])
-        );
+        $this->expectExceptionMessage("Table status for {$changelogTableName} is incorrect. Can`t fetch version id.");
         $this->model->setViewId('viewIdtest');
         $this->model->getVersion();
     }
@@ -132,7 +130,7 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
         $this->mockGetTableName();
 
         $this->expectException('Exception');
-        $this->expectExceptionMessage(__("Table %1 does not exist", [$changelogTableName]));
+        $this->expectExceptionMessage("Table {$changelogTableName} does not exist");
         $this->model->setViewId('viewIdtest');
         $this->model->getVersion();
     }
@@ -144,7 +142,7 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
         $this->mockGetTableName();
 
         $this->expectException('Exception');
-        $this->expectExceptionMessage(__("Table %1 does not exist", [$changelogTableName]));
+        $this->expectExceptionMessage("Table {$changelogTableName} does not exist");
         $this->model->setViewId('viewIdtest');
         $this->model->drop();
     }
@@ -236,7 +234,7 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
         $this->mockGetTableName();
 
         $this->expectException('Exception');
-        $this->expectExceptionMessage(__("Table %1 does not exist", [$changelogTableName]));
+        $this->expectExceptionMessage("Table {$changelogTableName} does not exist");
         $this->model->setViewId('viewIdtest');
         $this->model->getList(mt_rand(1, 200), mt_rand(201, 400));
     }
@@ -248,7 +246,7 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
         $this->mockGetTableName();
 
         $this->expectException('Exception');
-        $this->expectExceptionMessage(__("Table %1 does not exist", [$changelogTableName]));
+        $this->expectExceptionMessage("Table {$changelogTableName} does not exist");
         $this->model->setViewId('viewIdtest');
         $this->model->clear(mt_rand(1, 200));
     }

--- a/lib/internal/Magento/Framework/Mview/View.php
+++ b/lib/internal/Magento/Framework/Mview/View.php
@@ -285,7 +285,7 @@ class View extends \Magento\Framework\DataObject implements ViewInterface
                 for ($vsFrom = $lastVersionId; $vsFrom < $currentVersionId; $vsFrom += $versionBatchSize) {
                     // Don't go past the current version for atomicy.
                     $versionTo = min($currentVersionId, $vsFrom + $versionBatchSize);
-                    $ids = array_map('intval', $this->getChangelog()->getList($vsFrom, $versionTo));
+                    $ids = $this->getChangelog()->getList($vsFrom, $versionTo);
 
                     // We run the actual indexer in batches.
                     // Chunked AFTER loading to avoid duplicates in separate chunks.

--- a/lib/internal/Magento/Framework/Mview/View/Changelog.php
+++ b/lib/internal/Magento/Framework/Mview/View/Changelog.php
@@ -8,6 +8,11 @@ namespace Magento\Framework\Mview\View;
 
 use Magento\Framework\Phrase;
 
+/**
+ * Class Changelog
+ *
+ * @package Magento\Framework\Mview\View
+ */
 class Changelog implements ChangelogInterface
 {
     /**
@@ -159,6 +164,7 @@ class Changelog implements ChangelogInterface
 
     /**
      * Get maximum version_id from changelog
+     *
      * @return int
      * @throws ChangelogTableNotExistsException
      * @throws \Exception
@@ -216,6 +222,8 @@ class Changelog implements ChangelogInterface
     }
 
     /**
+     * Get view's identifier
+     *
      * @return string
      */
     public function getViewId()

--- a/lib/internal/Magento/Framework/Mview/View/Changelog.php
+++ b/lib/internal/Magento/Framework/Mview/View/Changelog.php
@@ -154,7 +154,7 @@ class Changelog implements ChangelogInterface
             (int)$toVersionId
         );
 
-        return $this->connection->fetchCol($select);
+        return array_map('intval', $this->connection->fetchCol($select));
     }
 
     /**

--- a/lib/internal/Magento/Framework/Mview/View/Changelog.php
+++ b/lib/internal/Magento/Framework/Mview/View/Changelog.php
@@ -6,6 +6,8 @@
 
 namespace Magento\Framework\Mview\View;
 
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\SessionException;
 use Magento\Framework\Phrase;
 
 /**
@@ -58,12 +60,14 @@ class Changelog implements ChangelogInterface
      * Check DB connection
      *
      * @return void
-     * @throws \Exception
+     * @throws \Magento\Framework\Exception\SessionException
      */
     protected function checkConnection()
     {
         if (!$this->connection) {
-            throw new \Exception("The write connection to the database isn't available. Please try again later.");
+            throw new SessionException(
+                new Phrase("The write connection to the database isn't available. Please try again later.")
+            );
         }
     }
 
@@ -167,7 +171,7 @@ class Changelog implements ChangelogInterface
      *
      * @return int
      * @throws ChangelogTableNotExistsException
-     * @throws \Exception
+     * @throws LocalizedException
      */
     public function getVersion()
     {
@@ -179,7 +183,9 @@ class Changelog implements ChangelogInterface
         if (isset($row['Auto_increment'])) {
             return (int)$row['Auto_increment'] - 1;
         } else {
-            throw new \Exception("Table status for `{$changelogTableName}` is incorrect. Can`t fetch version id.");
+            throw new LocalizedException(
+                new Phrase("Table status for `{$changelogTableName}` is incorrect. Can`t fetch version id.")
+            );
         }
     }
 
@@ -188,13 +194,15 @@ class Changelog implements ChangelogInterface
      *
      * Build a changelog name by concatenating view identifier and changelog name suffix.
      *
-     * @throws \Exception
+     * @throws \Magento\Framework\Exception\LocalizedException
      * @return string
      */
     public function getName()
     {
         if (strlen($this->viewId) == 0) {
-            throw new \Exception("View's identifier is not set");
+            throw new LocalizedException(
+                new Phrase("View's identifier is not set")
+            );
         }
         return $this->viewId . '_' . self::NAME_SUFFIX;
     }

--- a/lib/internal/Magento/Framework/Mview/View/Changelog.php
+++ b/lib/internal/Magento/Framework/Mview/View/Changelog.php
@@ -6,15 +6,12 @@
 
 namespace Magento\Framework\Mview\View;
 
-use DomainException;
 use Magento\Framework\DB\Adapter\ConnectionException;
 use Magento\Framework\Exception\RuntimeException;
 use Magento\Framework\Phrase;
 
 /**
- * Class Changelog for modifying the mview_state table
- *
- * @package Magento\Framework\Mview\View
+ * Class Changelog for manipulations with the mview_state table.
  */
 class Changelog implements ChangelogInterface
 {
@@ -48,8 +45,6 @@ class Changelog implements ChangelogInterface
     protected $resource;
 
     /**
-     * Changelog constructor
-     *
      * @param \Magento\Framework\App\ResourceConnection $resource
      * @throws ConnectionException
      */
@@ -70,8 +65,7 @@ class Changelog implements ChangelogInterface
     {
         if (!$this->connection) {
             throw new ConnectionException(
-                new Phrase("The write connection to the database isn't available. Please try again later."),
-                E_USER_ERROR
+                new Phrase("The write connection to the database isn't available. Please try again later.")
             );
         }
     }
@@ -199,15 +193,14 @@ class Changelog implements ChangelogInterface
      *
      * Build a changelog name by concatenating view identifier and changelog name suffix.
      *
-     * @throws DomainException
+     * @throws \DomainException
      * @return string
      */
     public function getName()
     {
         if (strlen($this->viewId) == 0) {
-            throw new DomainException(
-                new Phrase("View's identifier is not set"),
-                E_USER_ERROR
+            throw new \DomainException(
+                new Phrase("View's identifier is not set")
             );
         }
         return $this->viewId . '_' . self::NAME_SUFFIX;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When using Maria DB I have noticed that when the `indexer_update_all_views` cron job runs that some of the indexer queries have a mix of entity_id values that are strings and some that are integers.  When running a describe on the query I have confirmed that Maria DB will look at every row in the table and not use the entity_id values that are in the WHERE clause.  This does not seem to be an issue when using MySql but is in an issue when using Maria DB.


### Manual testing scenarios (*)
When reviewing the queries for the `catalog_product_attribute` indexer I saw a mix of string and integer id values.

1. Run a describe on the query, notice mix of string and integer
    DESC DELETE FROM `catalog_product_index_eav` WHERE (entity_id IN('2764369', 2766213));
    rows returned shows all rows in table: 9,133,650 and Extra shows "Using Where"

2. Run the same query but change the entity_ids to be integers
    DESC DELETE FROM `catalog_product_index_eav` WHERE (entity_id IN(2764369, 2766213));
    rows returned shows only 23 rows and Extran shows "Using Where"
    

Maria DB version tested on: 10.1.38-MariaDB-1~xenial mariadb.org binary distribution
