### PR TITLE
[BUGFIX] Set correct cron instance for catalog_product_frontend_actio…

### DIFF
--- a/app/code/Magento/Catalog/etc/crontab.xml
+++ b/app/code/Magento/Catalog/etc/crontab.xml
@@ -16,7 +16,7 @@
         <job name="catalog_product_outdated_price_values_cleanup" instance="Magento\Catalog\Cron\DeleteOutdatedPriceValues" method="execute">
             <schedule>* * * * *</schedule>
         </job>
-        <job name="catalog_product_frontend_actions_flush" instance="Magento\Catalog\Cron\DeleteOutdatedPriceValues" method="execute">
+        <job name="catalog_product_frontend_actions_flush" instance="Magento\Catalog\Cron\FrontendActionsFlush" method="execute">
             <schedule>* * * * *</schedule>
         </job>
         <job name="catalog_product_attribute_value_synchronize" instance="Magento\Catalog\Cron\SynchronizeWebsiteAttributes" method="execute">


### PR DESCRIPTION
…ns_flush

previously:
Magento\Catalog\Cron\DeleteOutdatedPriceValues

new:
Magento\Catalog\Cron\FrontendActionsFlush

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The cron instance of catalog_product_outdated_price_values_cleanup was previously set for catalog_product_frontend_actions_flush


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
