### PR TITLE
#22929 Add Image not working if move true

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Gallery/Processor.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/Processor.php
@@ -174,6 +174,13 @@ class Processor
 
         $destinationFile = $this->mediaConfig->getTmpMediaPath($fileName);
 
+        // collecting image MimeType, Content, Base64, Name before move/copy file.
+        $absoluteFilePath = $this->mediaDirectory->getAbsolutePath($destinationFile);
+        $imageMimeType = $this->mime->getMimeType($absoluteFilePath);
+        $imageContent = $this->mediaDirectory->readFile($absoluteFilePath);
+        $imageBase64 = base64_encode($imageContent);
+        $imageName = $pathinfo['filename'];
+
         try {
             /** @var $storageHelper \Magento\MediaStorage\Helper\File\Storage\Database */
             $storageHelper = $this->fileStorageDb;
@@ -196,12 +203,6 @@ class Processor
         $attrCode = $this->getAttribute()->getAttributeCode();
         $mediaGalleryData = $product->getData($attrCode);
         $position = 0;
-
-        $absoluteFilePath = $this->mediaDirectory->getAbsolutePath($destinationFile);
-        $imageMimeType = $this->mime->getMimeType($absoluteFilePath);
-        $imageContent = $this->mediaDirectory->readFile($absoluteFilePath);
-        $imageBase64 = base64_encode($imageContent);
-        $imageName = $pathinfo['filename'];
 
         if (!is_array($mediaGalleryData)) {
             $mediaGalleryData = ['images' => []];


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
PR raise to fix issue of Add Image when we use image true. https://github.com/magento/magento2/issues/22929

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22929: Catalog Product Gallery Processor: Add Image not working if move true

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ... use \Magento\Catalog\Model\Product\Gallery\Processor:addImage function to test issue with move true/false
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
