### PR TITLE
[Backport] Tierprice can t save float percentage value 18651

### DIFF
--- a/app/code/Magento/Catalog/Pricing/Render/PriceBox.php
+++ b/app/code/Magento/Catalog/Pricing/Render/PriceBox.php
@@ -102,10 +102,16 @@ class PriceBox extends PriceBoxRender
      * Format percent
      *
      * @param float $percent
+     *
      * @return string
      */
     public function formatPercent(float $percent): string
     {
-        return rtrim(number_format($percent, 2), '.0');
+        /*First rtrim - trim zeros. So, 10.00 -> 10.*/
+        /*Second rtrim - trim dot. So, 10. -> 10*/
+        return rtrim(
+            rtrim(number_format($percent, 2), '0'),
+            '.'
+        );
     }
 }

--- a/app/code/Magento/Catalog/Pricing/Render/PriceBox.php
+++ b/app/code/Magento/Catalog/Pricing/Render/PriceBox.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Catalog\Pricing\Render;
 
 use Magento\Catalog\Model\Product;
@@ -69,7 +71,7 @@ class PriceBox extends PriceBoxRender
     /**
      * Get random string
      *
-     * @param int         $length
+     * @param int $length
      * @param string|null $chars
      *
      * @return string
@@ -97,11 +99,12 @@ class PriceBox extends PriceBoxRender
     }
 
     /**
-     * @param float $percent
+     * Format percent
      *
+     * @param float $percent
      * @return string
      */
-    public function formatPercent(float $percent):string
+    public function formatPercent(float $percent): string
     {
         return rtrim(number_format($percent, 2), '.0');
     }

--- a/app/code/Magento/Catalog/Pricing/Render/PriceBox.php
+++ b/app/code/Magento/Catalog/Pricing/Render/PriceBox.php
@@ -69,9 +69,11 @@ class PriceBox extends PriceBoxRender
     /**
      * Get random string
      *
-     * @param int $length
+     * @param int         $length
      * @param string|null $chars
+     *
      * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getRandomString($length, $chars = null)
     {
@@ -92,5 +94,15 @@ class PriceBox extends PriceBoxRender
             return false;
         }
         return true;
+    }
+
+    /**
+     * @param float $percent
+     *
+     * @return string
+     */
+    public function formatPercent(float $percent):string
+    {
+        return rtrim(number_format($percent, 2), '.0');
     }
 }

--- a/app/code/Magento/Catalog/view/base/templates/product/price/tier_prices.phtml
+++ b/app/code/Magento/Catalog/view/base/templates/product/price/tier_prices.phtml
@@ -77,7 +77,7 @@ $product = $block->getSaleableItem();
                             $price['price_qty'],
                             $priceAmountBlock,
                             $index,
-                            $tierPriceModel->getSavePercent($price['price'])
+                            $block->formatPercent($price['percentage_value'] ?? $tierPriceModel->getSavePercent($price['price']))
                         )
                         : __('Buy %1 for %2 each', $price['price_qty'], $priceAmountBlock);
                 ?>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19584
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
See #18651 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18651: Tierprice can't save float percentage value 

### Manual testing scenarios (*)
## Steps to reproduce (*)
1. Add new product
2. Add new tierprice with "discount" value "12.5"
3. Save the product

## Expected result (*)
1. Saving the tierprice as you set it "12.5"

## Actual result (*)
1. It's converted to INT then save it

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
