### PR TITLE
Mark Elasticsearch 6 support for synonyms

### DIFF
--- a/app/code/Magento/Elasticsearch/etc/search_engine.xml
+++ b/app/code/Magento/Elasticsearch/etc/search_engine.xml
@@ -9,4 +9,7 @@
     <engine name="elasticsearch">
         <feature name="synonyms" support="true" />
     </engine>
+    <engine name="elasticsearch5">
+        <feature name="synonyms" support="true" />
+    </engine>
 </engines>

--- a/app/code/Magento/Elasticsearch6/etc/search_engine.xml
+++ b/app/code/Magento/Elasticsearch6/etc/search_engine.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<engines xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Search/etc/search_engine.xsd">
+    <engine name="elasticsearch6">
+        <feature name="synonyms" support="true" />
+    </engine>
+</engines>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Elasticsearch 6 supports search synonyms in Magento just like previous Elasticsearch versions. Flagging synonyms as supported removes the following warning from Marketing > SEO & Search > Search Synonyms:

> Search synonyms are not supported by the elasticsearch6 search engine. Any synonyms you enter won't be used.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Go to Marketing > SEO & Search > Search Synonyms in the admin panel.
2. Notice the warning message about missing support for synonyms in Elasticsearch 6. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
