### PR TITLE
Fix Issue 22743

### DIFF
--- a/app/code/Magento/Sales/Model/Service/InvoiceService.php
+++ b/app/code/Magento/Sales/Model/Service/InvoiceService.php
@@ -3,13 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Sales\Model\Service;
 
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Serialize\Serializer\Json as JsonSerializer;
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Api\Data\InvoiceItemInterface;
+use Magento\Sales\Api\Data\OrderItemInterface;
 use Magento\Sales\Api\InvoiceManagementInterface;
 use Magento\Sales\Model\Order;
-use Magento\Framework\App\ObjectManager;
-use Magento\Framework\Serialize\Serializer\Json;
-use Magento\Catalog\Model\Product\Type;
+use Magento\Sales\Model\Order\Invoice;
 
 /**
  * Class InvoiceService
@@ -19,36 +24,26 @@ use Magento\Catalog\Model\Product\Type;
 class InvoiceService implements InvoiceManagementInterface
 {
     /**
-     * Repository
-     *
      * @var \Magento\Sales\Api\InvoiceRepositoryInterface
      */
     protected $repository;
 
     /**
-     * Repository
-     *
      * @var \Magento\Sales\Api\InvoiceCommentRepositoryInterface
      */
     protected $commentRepository;
 
     /**
-     * Search Criteria Builder
-     *
      * @var \Magento\Framework\Api\SearchCriteriaBuilder
      */
     protected $criteriaBuilder;
 
     /**
-     * Filter Builder
-     *
      * @var \Magento\Framework\Api\FilterBuilder
      */
     protected $filterBuilder;
 
     /**
-     * Invoice Notifier
-     *
      * @var \Magento\Sales\Model\Order\InvoiceNotifier
      */
     protected $invoiceNotifier;
@@ -64,15 +59,11 @@ class InvoiceService implements InvoiceManagementInterface
     protected $orderConverter;
 
     /**
-     * Serializer interface instance.
-     *
-     * @var Json
+     * @var JsonSerializer
      */
     private $serializer;
 
     /**
-     * Constructor
-     *
      * @param \Magento\Sales\Api\InvoiceRepositoryInterface $repository
      * @param \Magento\Sales\Api\InvoiceCommentRepositoryInterface $commentRepository
      * @param \Magento\Framework\Api\SearchCriteriaBuilder $criteriaBuilder
@@ -80,7 +71,7 @@ class InvoiceService implements InvoiceManagementInterface
      * @param \Magento\Sales\Model\Order\InvoiceNotifier $notifier
      * @param \Magento\Sales\Api\OrderRepositoryInterface $orderRepository
      * @param \Magento\Sales\Model\Convert\Order $orderConverter
-     * @param Json|null $serializer
+     * @param JsonSerializer $serializer
      */
     public function __construct(
         \Magento\Sales\Api\InvoiceRepositoryInterface $repository,
@@ -90,7 +81,7 @@ class InvoiceService implements InvoiceManagementInterface
         \Magento\Sales\Model\Order\InvoiceNotifier $notifier,
         \Magento\Sales\Api\OrderRepositoryInterface $orderRepository,
         \Magento\Sales\Model\Convert\Order $orderConverter,
-        Json $serializer = null
+        JsonSerializer $serializer
     ) {
         $this->repository = $repository;
         $this->commentRepository = $commentRepository;
@@ -99,7 +90,7 @@ class InvoiceService implements InvoiceManagementInterface
         $this->invoiceNotifier = $notifier;
         $this->orderRepository = $orderRepository;
         $this->orderConverter = $orderConverter;
-        $this->serializer = $serializer ?: ObjectManager::getInstance()->get(Json::class);
+        $this->serializer = $serializer;
     }
 
     /**
@@ -140,40 +131,53 @@ class InvoiceService implements InvoiceManagementInterface
     }
 
     /**
-     * Creates an invoice based on the order and quantities provided
+     * Creates an invoice based on the order and quantities provided.
+     *
+     * Explanation for `if` statements:
+     * - using qty defined in `$preparedItemsQty` is prioritized
+     * - if qty is not defined and item is dummy, get ordered qty
+     * - if qty is not defined, get qty to invoice
+     * - else qty is 0
      *
      * @param Order $order
-     * @param array $qtys
-     * @return \Magento\Sales\Model\Order\Invoice
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @param array $orderItemsQtyToInvoice
+     * @return Invoice
+     * @throws LocalizedException
+     * @throws \Exception
      */
-    public function prepareInvoice(Order $order, array $qtys = [])
-    {
-        $isQtysEmpty = empty($qtys);
-        $invoice = $this->orderConverter->toInvoice($order);
+    public function prepareInvoice(
+        Order $order,
+        array $orderItemsQtyToInvoice = []
+    ): InvoiceInterface {
         $totalQty = 0;
-        $qtys = $this->prepareItemsQty($order, $qtys);
+        $invoice = $this->orderConverter->toInvoice($order);
+        $preparedItemsQty = $this->prepareItemsQty($order, $orderItemsQtyToInvoice);
+
         foreach ($order->getAllItems() as $orderItem) {
-            if (!$this->_canInvoiceItem($orderItem, $qtys)) {
+            if (!$this->canInvoiceItem($orderItem, $preparedItemsQty)) {
                 continue;
             }
-            $item = $this->orderConverter->itemToInvoiceItem($orderItem);
-            if (isset($qtys[$orderItem->getId()])) {
-                $qty = (double) $qtys[$orderItem->getId()];
+
+            if (isset($preparedItemsQty[$orderItem->getId()])) {
+                $qty = $preparedItemsQty[$orderItem->getId()];
             } elseif ($orderItem->isDummy()) {
                 $qty = $orderItem->getQtyOrdered() ? $orderItem->getQtyOrdered() : 1;
-            } elseif ($isQtysEmpty) {
+            } elseif (empty($orderItemsQtyToInvoice)) {
                 $qty = $orderItem->getQtyToInvoice();
             } else {
                 $qty = 0;
             }
+
+            $invoiceItem = $this->orderConverter->itemToInvoiceItem($orderItem);
+            $this->setInvoiceItemQuantity($invoiceItem, (float) $qty);
+            $invoice->addItem($invoiceItem);
             $totalQty += $qty;
-            $this->setInvoiceItemQuantity($item, $qty);
-            $invoice->addItem($item);
         }
+
         $invoice->setTotalQty($totalQty);
         $invoice->collectTotals();
         $order->getInvoiceCollection()->addItem($invoice);
+
         return $invoice;
     }
 
@@ -181,92 +185,77 @@ class InvoiceService implements InvoiceManagementInterface
      * Prepare qty to invoice for parent and child products if theirs qty is not specified in initial request.
      *
      * @param Order $order
-     * @param array $qtys
+     * @param array $orderItemsQtyToInvoice
      * @return array
      */
-    private function prepareItemsQty(Order $order, array $qtys = [])
-    {
+    private function prepareItemsQty(
+        Order $order,
+        array $orderItemsQtyToInvoice
+    ): array {
         foreach ($order->getAllItems() as $orderItem) {
-            if (empty($qtys[$orderItem->getId()])) {
-                if ($orderItem->getProductType() == Type::TYPE_BUNDLE && !$orderItem->isShipSeparately()) {
-                    $qtys[$orderItem->getId()] = $orderItem->getQtyOrdered() - $orderItem->getQtyInvoiced();
-                } else {
-                    $parentItem = $orderItem->getParentItem();
-                    $parentItemId = $parentItem ? $parentItem->getId() : null;
-                    if ($parentItemId && isset($qtys[$parentItemId])) {
-                        $qtys[$orderItem->getId()] = $qtys[$parentItemId];
-                    }
-                    continue;
+            if (isset($orderItemsQtyToInvoice[$orderItem->getId()])) {
+                if ($orderItem->isDummy() && $orderItem->getHasChildren()) {
+                    $orderItemsQtyToInvoice = $this->setChildItemsQtyToInvoice($orderItem, $orderItemsQtyToInvoice);
+                }
+            } else {
+                if (isset($orderItemsQtyToInvoice[$orderItem->getParentItemId()])) {
+                    $orderItemsQtyToInvoice[$orderItem->getId()] =
+                        $orderItemsQtyToInvoice[$orderItem->getParentItemId()];
                 }
             }
-
-            $this->prepareItemQty($orderItem, $qtys);
         }
 
-        return $qtys;
+        return $orderItemsQtyToInvoice;
     }
 
     /**
-     * Prepare qty_invoiced for order item
+     * Sets qty to invoice for children order items, if not set.
      *
-     * @param \Magento\Sales\Api\Data\OrderItemInterface $orderItem
-     * @param array $qtys
+     * @param OrderItemInterface $parentOrderItem
+     * @param array $orderItemsQtyToInvoice
+     * @return array
      */
-    private function prepareItemQty(\Magento\Sales\Api\Data\OrderItemInterface $orderItem, &$qtys)
-    {
-        $this->prepareBundleQty($orderItem, $qtys);
+    private function setChildItemsQtyToInvoice(
+        OrderItemInterface $parentOrderItem,
+        array $orderItemsQtyToInvoice
+    ): array {
+        /** @var OrderItemInterface $childOrderItem */
+        foreach ($parentOrderItem->getChildrenItems() as $childOrderItem) {
+            if (!isset($orderItemsQtyToInvoice[$childOrderItem->getItemId()])) {
+                $productOptions = $childOrderItem->getProductOptions();
 
-        if ($orderItem->isDummy()) {
-            if ($orderItem->getHasChildren()) {
-                foreach ($orderItem->getChildrenItems() as $child) {
-                    if (!isset($qtys[$child->getId()])) {
-                        $qtys[$child->getId()] = $child->getQtyToInvoice();
-                    }
-                    $parentId = $orderItem->getParentItemId();
-                    if ($parentId && array_key_exists($parentId, $qtys)) {
-                        $qtys[$orderItem->getId()] = $qtys[$parentId];
-                    } else {
-                        continue;
-                    }
-                }
-            } elseif ($orderItem->getParentItem()) {
-                $parent = $orderItem->getParentItem();
-                if (!isset($qtys[$parent->getId()])) {
-                    $qtys[$parent->getId()] = $parent->getQtyToInvoice();
+                if (isset($productOptions['bundle_selection_attributes'])) {
+                    $bundleSelectionAttributes = $this->serializer
+                        ->unserialize($productOptions['bundle_selection_attributes']);
+                    $orderItemsQtyToInvoice[$childOrderItem->getItemId()] =
+                        $bundleSelectionAttributes['qty'] * $orderItemsQtyToInvoice[$parentOrderItem->getItemId()];
                 }
             }
         }
+
+        return $orderItemsQtyToInvoice;
     }
 
     /**
-     * Prepare qty to invoice for bundle products
-     *
-     * @param \Magento\Sales\Api\Data\OrderItemInterface $orderItem
+     * @deprecated
+     * @param OrderItemInterface $item
      * @param array $qtys
+     * @return bool
      */
-    private function prepareBundleQty(\Magento\Sales\Api\Data\OrderItemInterface $orderItem, &$qtys)
+    protected function _canInvoiceItem(\Magento\Sales\Api\Data\OrderItemInterface $item, array $qtys = [])
     {
-        if ($orderItem->getProductType() == Type::TYPE_BUNDLE && !$orderItem->isShipSeparately()) {
-            foreach ($orderItem->getChildrenItems() as $childItem) {
-                $bundleSelectionAttributes = $childItem->getProductOptionByCode('bundle_selection_attributes');
-                if (is_string($bundleSelectionAttributes)) {
-                    $bundleSelectionAttributes = $this->serializer->unserialize($bundleSelectionAttributes);
-                }
-
-                $qtys[$childItem->getId()] = $qtys[$orderItem->getId()] * $bundleSelectionAttributes['qty'];
-            }
-        }
+        return $this->canInvoiceItem($item, $qtys);
     }
 
     /**
      * Check if order item can be invoiced.
      *
-     * @param \Magento\Sales\Api\Data\OrderItemInterface $item
+     * @param OrderItemInterface $item
      * @param array $qtys
      * @return bool
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    protected function _canInvoiceItem(\Magento\Sales\Api\Data\OrderItemInterface $item, array $qtys = [])
+    private function canInvoiceItem(OrderItemInterface $item, array $qtys): bool
     {
         if ($item->getLockedDoInvoice()) {
             return false;
@@ -299,14 +288,15 @@ class InvoiceService implements InvoiceManagementInterface
     }
 
     /**
-     * Set quantity to invoice item
+     * Set quantity to invoice item.
      *
-     * @param \Magento\Sales\Api\Data\InvoiceItemInterface $item
+     * @deprecated It will become private so it can not be used in customizations.
+     * @param InvoiceItemInterface $item
      * @param float $qty
-     * @return $this
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @return InvoiceManagementInterface
+     * @throws LocalizedException
      */
-    protected function setInvoiceItemQuantity(\Magento\Sales\Api\Data\InvoiceItemInterface $item, $qty)
+    protected function setInvoiceItemQuantity(InvoiceItemInterface $item, float $qty): InvoiceManagementInterface
     {
         $qty = ($item->getOrderItem()->getIsQtyDecimal()) ? (double) $qty : (int) $qty;
         $qty = $qty > 0 ? $qty : 0;
@@ -317,7 +307,7 @@ class InvoiceService implements InvoiceManagementInterface
         $qtyToInvoice = sprintf("%F", $item->getOrderItem()->getQtyToInvoice());
         $qty = sprintf("%F", $qty);
         if ($qty > $qtyToInvoice && !$item->getOrderItem()->isDummy()) {
-            throw new \Magento\Framework\Exception\LocalizedException(
+            throw new LocalizedException(
                 __('We found an invalid quantity to invoice item "%1".', $item->getName())
             );
         }


### PR DESCRIPTION
### Description (*)
New logic introduced in 2.3.1 https://github.com/magento/magento2/commit/2fb6b3b81ada22e1a172272a7eb5454a50a71a2d populates wrong quantity for the bundled products .

See  magento/magento2#22743
### Fixed Issues (if relevant)
1. magento/magento2#22743: M2.3.1: Unable to place order for bundle when child quantity > 1

### Manual testing scenarios (*)
1. Add Test bundle to the shopping cart, making sure to set the child quantity to a value > 1:
2. Proceed to Checkout
3. Select PayPal Express Checkout as the payment method.
Expected result (*)
Customer is redirected back to Magento's Order Success page
Actual result (*)
Error message We found an invalid quantity to invoice item "%1". is displayed.
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
