### PR TITLE
phpcs error on rule classes - must be of the type integer

### DIFF
--- a/dev/tests/static/framework/Magento/Sniffs/Annotation/ClassAnnotationStructureSniff.php
+++ b/dev/tests/static/framework/Magento/Sniffs/Annotation/ClassAnnotationStructureSniff.php
@@ -97,8 +97,12 @@ class ClassAnnotationStructureSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
         $previousCommentClosePtr = $phpcsFile->findPrevious(T_DOC_COMMENT_CLOSE_TAG, $stackPtr - 1, 0);
-        $this->validateAnnotationBlockExists($phpcsFile, (int)$previousCommentClosePtr, (int)$stackPtr);
-        $commentStartPtr = (int)$phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr - 1, 0);
+        if (!$previousCommentClosePtr) {
+            $phpcsFile->addError('Comment block is missing', $stackPtr -1, 'MethodArguments');
+            return;
+        }
+        $this->validateAnnotationBlockExists($phpcsFile, $previousCommentClosePtr, $stackPtr);
+        $commentStartPtr = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr - 1, 0);
         $commentCloserPtr = $tokens[$commentStartPtr]['comment_closer'];
         $emptyTypeTokens = [
             T_DOC_COMMENT_WHITESPACE,
@@ -111,7 +115,7 @@ class ClassAnnotationStructureSniff implements Sniff
         } else {
             $this->annotationFormatValidator->validateDescriptionFormatStructure(
                 $phpcsFile,
-                (int)$commentStartPtr,
+                $commentStartPtr,
                 (int) $shortPtr,
                 $previousCommentClosePtr,
                 $emptyTypeTokens

--- a/dev/tests/static/framework/Magento/Sniffs/Annotation/MethodAnnotationStructureSniff.php
+++ b/dev/tests/static/framework/Magento/Sniffs/Annotation/MethodAnnotationStructureSniff.php
@@ -45,6 +45,10 @@ class MethodAnnotationStructureSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
         $commentStartPtr = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, ($stackPtr), 0);
         $commentEndPtr = $phpcsFile->findPrevious(T_DOC_COMMENT_CLOSE_TAG, ($stackPtr), 0);
+        if (!$commentStartPtr) {
+            $phpcsFile->addError('Comment block is missing', $stackPtr, 'MethodArguments');
+            return;
+        }
         $commentCloserPtr = $tokens[$commentStartPtr]['comment_closer'];
         $functionPtrContent = $tokens[$stackPtr+2]['content'] ;
         if (preg_match('/(?i)__construct/', $functionPtrContent)) {

--- a/dev/tests/static/framework/Magento/Sniffs/Annotation/MethodArgumentsSniff.php
+++ b/dev/tests/static/framework/Magento/Sniffs/Annotation/MethodArgumentsSniff.php
@@ -550,8 +550,12 @@ class MethodArgumentsSniff implements Sniff
         $numTokens = count($tokens);
         $previousCommentOpenPtr = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr - 1, 0);
         $previousCommentClosePtr = $phpcsFile->findPrevious(T_DOC_COMMENT_CLOSE_TAG, $stackPtr - 1, 0);
-        if (!$this->validateCommentBlockExists($phpcsFile, $previousCommentClosePtr, $stackPtr)) {
-            $phpcsFile->addError('Comment block is missing', $stackPtr, 'MethodArguments');
+        if ($previousCommentClosePtr && $previousCommentOpenPtr) {
+            if (!$this->validateCommentBlockExists($phpcsFile, $previousCommentClosePtr, $stackPtr)) {
+                $phpcsFile->addError('Comment block is missing', $stackPtr, 'MethodArguments');
+                return;
+            }
+        } else {
             return;
         }
         $openParenthesisPtr = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr + 1, $numTokens);
@@ -663,6 +667,9 @@ class MethodArgumentsSniff implements Sniff
         foreach ($argumentPositions as $index => $argumentPosition) {
             $commentPosition = $commentPositions[$index];
             $type = $paramDefinitions[$index]['type'];
+            if ($type === null) {
+                continue;
+            }
             $paramName = $paramDefinitions[$index]['paramName'];
             if (($argumentPosition !== strlen($type) + 1) ||
                 (isset($commentPosition) && ($commentPosition !== $argumentPosition + strlen($paramName) + 1))) {


### PR DESCRIPTION
### Description (*)
Unfortunately https://github.com/magento/magento2/pull/22081 does in no way fix the real issue in the Sniff, but pushes the problem a few lines down in the code.

The issue is that the `PHP_CodeSniffer\Files\File::findPrevious` method returns either a pointer to the previous token of a type **or `false` if none is found**. This case is triggered when the CodeSniffer is running on a file with no closing comment tags.

Earlier the issue was because this `false` was passed to a function which expected an `int` instead. What  https://github.com/magento/magento2/pull/22081 does is to cast the boolean into an integer, **which obviously is not correct** (as the Sniff now treats the code like there is a comment closing token at position 0 when in fact there is none in the file).

Now the Sniff returns a new error as it's trying to get the closing comment from the token list:
```
An error occurred during processing; checking has been aborted.
The error message was: Undefined index: comment_closer in
dev/tests/static/framework/Magento/Sniffs/Annotation/ClassAnnotationStructureSniff.php on line 102
```

### Fixed Issues (if relevant)
magento/magento2#20186: Issue title

### Manual testing scenarios (*)

1. clean Magento installation on 2.3-develop branch
2. create a Foo.php file with the following contents

```php
<?php

class Foo{}
```

3. run the phpcs on that file with the Magento ruleset `./vendor/bin/phpcs --standard=./dev/tests/static/framework/Magento/ Foo.php`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
