### PR TITLE
Update the contributing.md to match the new beginners guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,18 +1,23 @@
 # Contributing to Magento 2 code
 
 Contributions to the Magento 2 codebase are done using the fork & pull model.
-This contribution model has contributors maintaining their own copy of the forked codebase (which can easily be synced with the main copy). The forked repository is then used to submit a request to the base repository to “pull” a set of changes. For more information on pull requests please refer to [GitHub Help](https://help.github.com/articles/about-pull-requests/).
+This contribution model has contributors maintaining their own fork of the Magento 2 repository.
+The forked repository is then used to submit a request to the base repository to “pull” a set of changes.
+For more information on pull requests please refer to [GitHub Help](https://help.github.com/articles/about-pull-requests/).
 
 Contributions can take the form of new components or features, changes to existing features, tests, documentation (such as developer guides, user guides, examples, or specifications), bug fixes or optimizations.
 
-The Magento 2 development team will review all issues and contributions submitted by the community of developers in the first in, first out order. During the review we might require clarifications from the contributor. If there is no response from the contributor within two weeks, the pull request will be closed.
+The Magento 2 development team or community maintainers will review all issues and contributions submitted by the community of developers in the first in, first out order.
+During the review we might require clarifications from the contributor.
+If there is no response from the contributor within two weeks, the pull request will be closed.
 
+For more detialed information on contribution please read our [beginners guide](https://github.com/magento/magento2/wiki/Getting-Started).
 
 ## Contribution requirements
 
-1. Contributions must adhere to the [Magento coding standards](https://devdocs.magento.com/guides/v2.2/coding-standards/bk-coding-standards.html).
+1. Contributions must adhere to the [Magento coding standards](https://devdocs.magento.com/guides/v2.3/coding-standards/bk-coding-standards.html).
 2. Pull requests (PRs) must be accompanied by a meaningful description of their purpose. Comprehensive descriptions increase the chances of a pull request being merged quickly and without additional clarification requests.
-3. Commits must be accompanied by meaningful commit messages. Please see the [Magento Pull Request Template](https://github.com/magento/magento2/blob/2.2-develop/.github/PULL_REQUEST_TEMPLATE.md) for more information.
+3. Commits must be accompanied by meaningful commit messages. Please see the [Magento Pull Request Template](https://github.com/magento/magento2/blob/2.3-develop/.github/PULL_REQUEST_TEMPLATE.md) for more information.
 4. PRs which include bug fixes must be accompanied with a step-by-step description of how to reproduce the bug.
 3. PRs which include new logic or new features must be submitted along with:
 * Unit/integration test coverage
@@ -22,15 +27,22 @@ The Magento 2 development team will review all issues and contributions submitte
 
 ## Contribution process
 
-If you are a new GitHub user, we recommend that you create your own [free github account](https://github.com/signup/free). This will allow you to collaborate with the Magento 2 development team, fork the Magento 2 project and send pull requests.
+If you are a new GitHub user, we recommend that you create your own [free github account](https://github.com/signup/free).
+This will allow you to collaborate with the Magento 2 development team, fork the Magento 2 project and send pull requests.
 
 1. Search current [listed issues](https://github.com/magento/magento2/issues) (open or closed) for similar proposals of intended contribution before starting work on a new contribution.
 2. Review the [Contributor License Agreement](https://magento.com/legaldocuments/mca) if this is your first time contributing.
 3. Create and test your work.
-4. Fork the Magento 2 repository according to the [Fork A Repository instructions](https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html#fork) and when you are ready to send us a pull request – follow the [Create A Pull Request instructions](https://devdocs.magento.com/guides/v2.2/contributor-guide/contributing.html#pull_request).
+4. Fork the Magento 2 repository according to the [Fork A Repository instructions](https://devdocs.magento.com/guides/v2.3/contributor-guide/contributing.html#fork) and when you are ready to send us a pull request – follow the [Create A Pull Request instructions](https://devdocs.magento.com/guides/v2.3/contributor-guide/contributing.html#pull_request).
 5. Once your contribution is received the Magento 2 development team will review the contribution and collaborate with you as needed.
 
 ## Code of Conduct
 
 Please note that this project is released with a Contributor Code of Conduct. We expect you to agree to its terms when participating in this project.
 The full text is available in the repository [Wiki](https://github.com/magento/magento2/wiki/Magento-Code-of-Conduct).
+
+## Connecting with Community!
+
+If you have any questions, join us in [#beginners](https://magentocommeng.slack.com/messages/CH8BGFX9D) Slack chat. If you are not on our slack, [click here](http://tinyurl.com/engcom-slack) to join.
+
+Need to find a project? Check out the [Slack Channels](https://github.com/magento/magento2/wiki/Slack-Channels) (with listed project info) and the [Open Source Portal](https://opensource.magento.com/).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,4 +45,4 @@ The full text is available in the repository [Wiki](https://github.com/magento/m
 
 If you have any questions, join us in [#beginners](https://magentocommeng.slack.com/messages/CH8BGFX9D) Slack chat. If you are not on our slack, [click here](http://tinyurl.com/engcom-slack) to join.
 
-Need to find a project? Check out the [Slack Channels](https://github.com/magento/magento2/wiki/Slack-Channels) (with listed project info) and the [Open Source Portal](https://opensource.magento.com/).
+Need to find a project? Check out the [Slack Channels](https://github.com/magento/magento2/wiki/Slack-Channels) (with listed project info) and the [Magento Community Portal](https://opensource.magento.com/).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,6 @@
     There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
 -->
 1. magento/magento2#<issue_number>: Issue title
-2. ...
 
 ### Manual testing scenarios (*)
 <!---
@@ -30,6 +29,12 @@
 -->
 1. ...
 2. ...
+
+### Questions or comments
+<!---
+	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
+	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
+-->
 
 ### Contribution checklist (*)
  - [ ] Pull request has a meaningful description of its purpose


### PR DESCRIPTION
### Description (*)
The aim of this pull request is to update the following files to make them more useful to people.

- contributing.md
- issue_template.md
- pull_request_template.md

### Questions and thoughts

- Should the contributing.md have more information from the beginners guides or is it ok just to link in but leave the information as is?
- After a bit of feedback and usage I can see that the issue and pull request templates are not too clear. I have removed some lines that I think are not needed and also added a new section for open questions as a few people have asked if it was ok to ask question on a PR you are writing.

I would be happy for any further thoughts or input on these changes.