### PR TITLE
module-media-storage throws type mismatch exception.

### DIFF
--- a/app/code/Magento/MediaStorage/Model/File/Validator/NotProtectedExtension.php
+++ b/app/code/Magento/MediaStorage/Model/File/Validator/NotProtectedExtension.php
@@ -78,6 +78,9 @@ class NotProtectedExtension extends \Zend_Validate_Abstract
     {
         if (!$this->_protectedFileExtensions) {
             $extensions = $this->getProtectedFileExtensions();
+            if (is_null($extensions)) {
+                $extensions = [];
+            }
             if (is_string($extensions)) {
                 $extensions = explode(',', $extensions);
             }
@@ -93,7 +96,7 @@ class NotProtectedExtension extends \Zend_Validate_Abstract
      * Return list with protected file extensions
      *
      * @param \Magento\Store\Model\Store|string|int $store
-     * @return string|string[]
+     * @return mixed
      */
     public function getProtectedFileExtensions($store = null)
     {

--- a/app/code/Magento/MediaStorage/Model/File/Validator/NotProtectedExtension.php
+++ b/app/code/Magento/MediaStorage/Model/File/Validator/NotProtectedExtension.php
@@ -96,7 +96,7 @@ class NotProtectedExtension extends \Zend_Validate_Abstract
      * Return list with protected file extensions
      *
      * @param \Magento\Store\Model\Store|string|int $store
-     * @return mixed
+     * @return string|null
      */
     public function getProtectedFileExtensions($store = null)
     {

--- a/app/code/Magento/MediaStorage/Model/File/Validator/NotProtectedExtension.php
+++ b/app/code/Magento/MediaStorage/Model/File/Validator/NotProtectedExtension.php
@@ -78,7 +78,7 @@ class NotProtectedExtension extends \Zend_Validate_Abstract
     {
         if (!$this->_protectedFileExtensions) {
             $extensions = $this->getProtectedFileExtensions();
-            if (is_null($extensions)) {
+            if ($extensions === null) {
                 $extensions = [];
             }
             if (is_string($extensions)) {


### PR DESCRIPTION
Added null check for function that uses "$this->_scopeConfig->getValue" that will return 'null' when no configuration is found.

When your table core_config_data does not have a configuration path: "general/file/protected_extensions". Then you get the next warning in your logging and add-to-cart does not work any more. Also you get a message, like: "Something went wrong".

[2019-05-20 13:42:57] report.CRITICAL: Warning: Invalid argument supplied for foreach() in /private/var/www/drinkies/vendor/magento/module-media-storage/Model/File/Validator/NotProtectedExtension.php on line 84 {"exception":"[object] (Exception(code: 0): Warning: Invalid argument supplied for foreach() in /private/var/www/drinkies/vendor/magento/module-media-storage/Model/File/Validator/NotProtectedExtension.php on line 84 at /private/var/www/drinkies/vendor/magento/framework/App/ErrorHandler.php:61)"}


### Description (*)

I added a simple null check.

