### PR TITLE
magento/magento2#21232: Custom select attribute code container breaks…

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/Attributes.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Action/Attribute/Tab/Attributes.php
@@ -87,6 +87,7 @@ class Attributes extends \Magento\Catalog\Block\Adminhtml\Form implements
          * for using it in elements generation
          */
         $form->setDataObject($this->_productFactory->create());
+        $form->setHtmlIdPrefix('attributes_');
         $this->_setFieldset($attributes, $fieldset, $this->getFormExcludedFieldList());
         $form->setFieldNameSuffix('attributes');
         $this->setForm($form);
@@ -127,7 +128,7 @@ class Attributes extends \Magento\Catalog\Block\Adminhtml\Form implements
     {
         // Add name attribute to checkboxes that correspond to multiselect elements
         $nameAttributeHtml = $element->getExtType() === 'multiple' ? 'name="' . $element->getId() . '_checkbox"' : '';
-        $elementId = $element->getId();
+        $elementId = $element->getHtmlId();
         $dataAttribute = "data-disable='{$elementId}'";
         $dataCheckboxName = "toggle_" . "{$elementId}";
         $checkboxLabel = __('Change');

--- a/app/code/Magento/Catalog/Test/Mftf/Data/ProductAttributeData.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Data/ProductAttributeData.xml
@@ -320,4 +320,25 @@
         <data key="option1_admin" unique="suffix">opt1'Admin</data>
         <data key="option1_frontend" unique="suffix">opt1'Front</data>
     </entity>
+    <entity name="productAttributeWithCodeContainer" type="ProductAttribute">
+        <data key="attribute_code">container</data>
+        <data key="frontend_input">select</data>
+        <data key="scope">global</data>
+        <data key="is_required">false</data>
+        <data key="is_unique">false</data>
+        <data key="is_searchable">true</data>
+        <data key="is_visible">true</data>
+        <data key="is_visible_in_advanced_search">true</data>
+        <data key="is_visible_on_front">true</data>
+        <data key="is_filterable">true</data>
+        <data key="is_filterable_in_search">true</data>
+        <data key="used_in_product_listing">true</data>
+        <data key="is_used_for_promo_rules">true</data>
+        <data key="is_comparable">true</data>
+        <data key="is_used_in_grid">true</data>
+        <data key="is_visible_in_grid">true</data>
+        <data key="is_filterable_in_grid">true</data>
+        <data key="used_for_sort_by">true</data>
+        <requiredEntity type="FrontendLabel">ProductAttributeFrontendLabel</requiredEntity>
+    </entity>
 </entities>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminEditProductAttributesSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminEditProductAttributesSection.xml
@@ -12,14 +12,14 @@
         <element name="AttributeName" type="text" selector=".field-name .input-text"/>
         <element name="AttributeNameDisabled" type="text" selector=".field-name .input-text[disabled]"/>
         <element name="ChangeAttributeNameToggle" type="checkbox" selector=".field-name .attribute-change-checkbox .checkbox"/>
-        <element name="AttributeContainer" type="select" selector=".field-container .select-select"/>
-        <element name="AttributeContainerDisabled" type="select" selector=".field-container .select-select[disabled]"/>
+        <element name="AttributeContainer" type="select" selector=".field-container select.select"/>
+        <element name="AttributeContainerDisabled" type="select" selector=".field-container select.select[disabled]"/>
         <element name="ChangeAttributeContainerToggle" type="checkbox" selector=".field-container .attribute-change-checkbox .checkbox"/>
         <element name="NameError" type="text" selector=".field-name .mage-error"/>
         <element name="AttributePrice" type="text" selector=".field-price .input-text"/>
         <element name="ChangeAttributePriceToggle" type="checkbox" selector=".field-price .attribute-change-checkbox .checkbox"/>
         <element name="PriceError" type="text" selector=".field-price .mage-error"/>
-        <element name="AttributeDescription" type="text" selector=".field-description .input-text"/>
+        <element name="AttributeDescription" type="text" selector=".field-description .textarea"/>
         <element name="ChangeAttributeDescriptionToggle" type="checkbox" selector=".field-description .attribute-change-checkbox .checkbox"/>
         <element name="Save" type="button" selector="button.save.primary" timeout="30"/>
         <element name="ProductDataMayBeLostModal" type="button" selector="//aside[contains(@class,'_show')]//header[contains(.,'Product data may be lost')]"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminEditProductAttributesSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminEditProductAttributesSection.xml
@@ -9,15 +9,19 @@
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="AdminEditProductAttributesSection">
-        <element name="AttributeName" type="text" selector="#name"/>
-        <element name="ChangeAttributeNameToggle" type="checkbox" selector="#toggle_name"/>
-        <element name="NameError" type="text" selector="#name-error"/>
-        <element name="AttributePrice" type="text" selector="#price"/>
-        <element name="ChangeAttributePriceToggle" type="checkbox" selector="#toggle_price"/>
-        <element name="PriceError" type="text" selector="#price-error"/>
-        <element name="AttributeDescription" type="text" selector="#description"/>
-        <element name="ChangeAttributeDescriptionToggle" type="checkbox" selector="#toggle_description"/>
-        <element name="Save" type="button" selector="button[title=Save]" timeout="30"/>
+        <element name="AttributeName" type="text" selector=".field-name .input-text"/>
+        <element name="AttributeNameDisabled" type="text" selector=".field-name .input-text[disabled]"/>
+        <element name="ChangeAttributeNameToggle" type="checkbox" selector=".field-name .attribute-change-checkbox .checkbox"/>
+        <element name="AttributeContainer" type="select" selector=".field-container .select-select"/>
+        <element name="AttributeContainerDisabled" type="select" selector=".field-container .select-select[disabled]"/>
+        <element name="ChangeAttributeContainerToggle" type="checkbox" selector=".field-container .attribute-change-checkbox .checkbox"/>
+        <element name="NameError" type="text" selector=".field-name .mage-error"/>
+        <element name="AttributePrice" type="text" selector=".field-price .input-text"/>
+        <element name="ChangeAttributePriceToggle" type="checkbox" selector=".field-price .attribute-change-checkbox .checkbox"/>
+        <element name="PriceError" type="text" selector=".field-price .mage-error"/>
+        <element name="AttributeDescription" type="text" selector=".field-description .input-text"/>
+        <element name="ChangeAttributeDescriptionToggle" type="checkbox" selector=".field-description .attribute-change-checkbox .checkbox"/>
+        <element name="Save" type="button" selector="button.save.primary" timeout="30"/>
         <element name="ProductDataMayBeLostModal" type="button" selector="//aside[contains(@class,'_show')]//header[contains(.,'Product data may be lost')]"/>
         <element name="ProductDataMayBeLostConfirmButton" type="button" selector="//aside[contains(@class,'_show')]//button[.='Change Input Type']"/>
         <element name="defaultLabel" type="text" selector="//td[contains(text(), '{{attributeName}}')]/following-sibling::td[contains(@class, 'col-frontend_label')]" parameterized="true"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminUpdateAttributesSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminUpdateAttributesSection.xml
@@ -11,32 +11,32 @@
     <section name="AdminUpdateAttributesSection">
         <element name="saveButton" type="button" selector="button[title='Save']" timeout="30"/>
 
-        <element name="toggleCountryOfManufacture" type="checkbox" selector="#toggle_country_of_manufacture"/>
-        <element name="toggleCustomDesign" type="checkbox" selector="#toggle_custom_design"/>
-        <element name="toggleCustomDesignFrom" type="checkbox" selector="#toggle_custom_design_from"/>
-        <element name="toggleCustomDesignTo" type="checkbox" selector="#toggle_custom_design_to"/>
-        <element name="toggleCustomLayout" type="checkbox" selector="#toggle_custom_layout"/>
-        <element name="toggleCustomLayoutUpdate" type="checkbox" selector="#toggle_custom_layout_update"/>
-        <element name="toggleDescription" type="checkbox" selector="#toggle_description"/>
-        <element name="toggleMetaDescription" type="checkbox" selector="#toggle_meta_description"/>
-        <element name="toggleMetaKeyword" type="checkbox" selector="#toggle_meta_keyword"/>
-        <element name="toggleMetaTitle" type="checkbox" selector="#toggle_meta_title"/>
-        <element name="toggleName" type="checkbox" selector="#toggle_name"/>
-        <element name="toggleNewsFromDate" type="checkbox" selector="#toggle_news_from_date"/>
-        <element name="toggleNewsToDate" type="checkbox" selector="#toggle_news_to_date"/>
-        <element name="toggleOptionsContainer" type="checkbox" selector="#toggle_options_container"/>
-        <element name="togglePageLayout" type="checkbox" selector="#toggle_page_layout"/>
-        <element name="togglePrice" type="checkbox" selector="#toggle_price"/>
-        <element name="toggleShortDescription" type="checkbox" selector="#toggle_short_description"/>
-        <element name="toggleSpecialFromDate" type="checkbox" selector="#toggle_special_from_date"/>
-        <element name="toggleSpecialPrice" type="checkbox" selector="#toggle_special_price"/>
-        <element name="toggleSpecialToDate" type="checkbox" selector="#toggle_special_to_date"/>
-        <element name="toggleTaxClass" type="checkbox" selector="#toggle_tax_class_id"/>
-        <element name="toggleVisibility" type="checkbox" selector="#toggle_visibility"/>
-        <element name="toggleWeight" type="checkbox" selector="#toggle_weight"/>
-        <element name="toggleColor" type="checkbox" selector="#toggle_color"/>
+        <element name="toggleCountryOfManufacture" type="checkbox" selector="#toggle_attributes_country_of_manufacture"/>
+        <element name="toggleCustomDesign" type="checkbox" selector="#toggle_attributes_custom_design"/>
+        <element name="toggleCustomDesignFrom" type="checkbox" selector="#toggle_attributes_custom_design_from"/>
+        <element name="toggleCustomDesignTo" type="checkbox" selector="#toggle_attributes_custom_design_to"/>
+        <element name="toggleCustomLayout" type="checkbox" selector="#toggle_attributes_custom_layout"/>
+        <element name="toggleCustomLayoutUpdate" type="checkbox" selector="#toggle_attributes_custom_layout_update"/>
+        <element name="toggleDescription" type="checkbox" selector="#toggle_attributes_description"/>
+        <element name="toggleMetaDescription" type="checkbox" selector="#toggle_attributes_meta_description"/>
+        <element name="toggleMetaKeyword" type="checkbox" selector="#toggle_attributes_meta_keyword"/>
+        <element name="toggleMetaTitle" type="checkbox" selector="#toggle_attributes_meta_title"/>
+        <element name="toggleName" type="checkbox" selector="#toggle_attributes_name"/>
+        <element name="toggleNewsFromDate" type="checkbox" selector="#toggle_attributes_news_from_date"/>
+        <element name="toggleNewsToDate" type="checkbox" selector="#toggle_attributes_news_to_date"/>
+        <element name="toggleOptionsContainer" type="checkbox" selector="#toggle_attributes_options_container"/>
+        <element name="togglePageLayout" type="checkbox" selector="#toggle_attributes_page_layout"/>
+        <element name="togglePrice" type="checkbox" selector="#toggle_attributes_price"/>
+        <element name="toggleShortDescription" type="checkbox" selector="#toggle_attributes_short_description"/>
+        <element name="toggleSpecialFromDate" type="checkbox" selector="#toggle_attributes_special_from_date"/>
+        <element name="toggleSpecialPrice" type="checkbox" selector="#toggle_attributes_special_price"/>
+        <element name="toggleSpecialToDate" type="checkbox" selector="#toggle_attributes_special_to_date"/>
+        <element name="toggleTaxClass" type="checkbox" selector="#toggle_attributes_tax_class_id"/>
+        <element name="toggleVisibility" type="checkbox" selector="#toggle_attributes_visibility"/>
+        <element name="toggleWeight" type="checkbox" selector="#toggle_attributes_weight"/>
+        <element name="toggleColor" type="checkbox" selector="#toggle_attributes_color"/>
 
-        <element name="description" type="input" selector="#description"/>
+        <element name="description" type="textarea" selector="#attributes_description"/>
     </section>
     <section name="AdminUpdateAttributesWebsiteSection">
         <element name="website" type="button" selector="#attributes_update_tabs_websites"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassUpdateProductAttributesMissingRequiredFieldTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminMassUpdateProductAttributesMissingRequiredFieldTest.xml
@@ -28,12 +28,17 @@
             <createData entity="ApiSimpleProduct" stepKey="createProductTwo">
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
+            <createData entity="productAttributeWithCodeContainer" stepKey="createAttributeWithCodeContainer"/>
+            <createData entity="AddToDefaultSet" stepKey="createAttributeWithCodeContainerAddToAttributeSet">
+                <requiredEntity createDataKey="createAttributeWithCodeContainer"/>
+            </createData>
         </before>
         <after>
             <amOnPage url="{{AdminLogoutPage.url}}" stepKey="amOnLogoutPage"/>
             <deleteData createDataKey="createProductOne" stepKey="deleteProductOne"/>
             <deleteData createDataKey="createProductTwo" stepKey="deleteProductTwo"/>
             <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <deleteData createDataKey="createAttributeWithCodeContainer" stepKey="deleteAttributeWithCodeContainer"/>
         </after>
 
         <!-- Search and select products -->
@@ -50,6 +55,10 @@
         <waitForPageLoad stepKey="waitForBulkUpdatePage"/>
         <seeInCurrentUrl stepKey="seeInUrl" url="catalog/product_action_attribute/edit/"/>
         <click selector="{{AdminEditProductAttributesSection.ChangeAttributeNameToggle}}" stepKey="toggleToChangeName"/>
+        <seeElement stepKey="seeDisabled" selector="{{AdminEditProductAttributesSection.AttributeContainerDisabled}}"/>
+        <click selector="{{AdminEditProductAttributesSection.ChangeAttributeContainerToggle}}" stepKey="toggleToEnableContainerAttribute"/>
+        <seeElement stepKey="seeEnabled" selector="{{AdminEditProductAttributesSection.AttributeContainer}}"/>
+        <click selector="{{AdminEditProductAttributesSection.ChangeAttributeContainerToggle}}" stepKey="toggleToDisableContainerAttribute"/>
         <click selector="{{AdminEditProductAttributesSection.Save}}" stepKey="save"/>
         <see stepKey="seeError" selector="{{AdminEditProductAttributesSection.NameError}}" userInput="This is a required field"/>
     </test>


### PR DESCRIPTION
… javascript on update attributes.

Description
Added "attributes_" prefiix to id of input fields of attributes in Mass Update Products Attributes page

Fixed Issues
#21232: Custom select attribute code "container" breaks javascript on update attributes

Manual testing scenarios
1. Create a custom select attribute with a code of "container"
2. Go to the Catalog->Products and check the box next to at least one product.
3. Click the Action dropdown and select "Update Attributes"
4. Scroll down until you see your container attribute and you will see that it is not disabled

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
