### PR TITLE
Add a MessageFormatter Phrase renderer

### DIFF
--- a/app/code/Magento/Translation/etc/di.xml
+++ b/app/code/Magento/Translation/etc/di.xml
@@ -43,6 +43,7 @@
         <arguments>
             <argument name="renderers" xsi:type="array">
                 <item name="translation" xsi:type="object">Magento\Framework\Phrase\Renderer\Translate</item>
+                <item name="messageFormatter" xsi:type="object">Magento\Framework\Phrase\Renderer\MessageFormatter</item>
                 <item name="placeholder" xsi:type="object">Magento\Framework\Phrase\Renderer\Placeholder</item>
                 <item name="inline" xsi:type="object">Magento\Framework\Phrase\Renderer\Inline</item>
             </argument>

--- a/lib/internal/Magento/Framework/Phrase/Renderer/MessageFormatter.php
+++ b/lib/internal/Magento/Framework/Phrase/Renderer/MessageFormatter.php
@@ -4,6 +4,8 @@
  * See COPYING.txt for license details.
  */
 
+declare(strict_types=1);
+
 namespace Magento\Framework\Phrase\Renderer;
 
 use Magento\Framework\Phrase\RendererInterface;
@@ -26,7 +28,7 @@ class MessageFormatter implements RendererInterface
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     public function render(array $source, array $arguments)
     {

--- a/lib/internal/Magento/Framework/Phrase/Renderer/MessageFormatter.php
+++ b/lib/internal/Magento/Framework/Phrase/Renderer/MessageFormatter.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Phrase\Renderer;
+
+use Magento\Framework\Phrase\RendererInterface;
+use Magento\Framework\TranslateInterface;
+
+/**
+ * Process texts to resolve ICU MessageFormat
+ */
+class MessageFormatter implements RendererInterface
+{
+    /** @var TranslateInterface */
+    private $translate;
+
+    /**
+     * @param TranslateInterface $translate
+     */
+    public function __construct(TranslateInterface $translate)
+    {
+        $this->translate = $translate;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function render(array $source, array $arguments)
+    {
+        $text = end($source);
+
+        if (strpos($text, '{') === false) {
+            // About 5x faster for non-MessageFormatted strings
+            // Only slightly slower for MessageFormatted strings (~0.3x)
+            return $text;
+        }
+
+        $result = \MessageFormatter::formatMessage($this->translate->getLocale(), $text, $arguments);
+        return $result !== false ? $result : $text;
+    }
+}

--- a/lib/internal/Magento/Framework/Phrase/Test/Unit/Renderer/MessageFormatterTest.php
+++ b/lib/internal/Magento/Framework/Phrase/Test/Unit/Renderer/MessageFormatterTest.php
@@ -4,24 +4,30 @@
  * See COPYING.txt for license details.
  */
 
+declare(strict_types=1);
+
 namespace Magento\Framework\Phrase\Test\Unit\Renderer;
 
 use Magento\Framework\Phrase\Renderer\MessageFormatter;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\Translate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests that messages sent through the MessageFormatter phrase renderer result in what would be expected when sent
  * through PHP's native MessageFormatter, and that the locale is pulled from the Translate dependency
  */
-class MessageFormatterTest extends \PHPUnit\Framework\TestCase
+class MessageFormatterTest extends TestCase
 {
     /** @var ObjectManager */
     private $objectManager;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp()
     {
-        $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $this->objectManager = new ObjectManager($this);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Phrase/Test/Unit/Renderer/MessageFormatterTest.php
+++ b/lib/internal/Magento/Framework/Phrase/Test/Unit/Renderer/MessageFormatterTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Phrase\Test\Unit\Renderer;
+
+use Magento\Framework\Phrase\Renderer\MessageFormatter;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\Translate;
+
+/**
+ * Tests that messages sent through the MessageFormatter phrase renderer result in what would be expected when sent
+ * through PHP's native MessageFormatter, and that the locale is pulled from the Translate dependency
+ */
+class MessageFormatterTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var ObjectManager */
+    private $objectManager;
+
+    protected function setUp()
+    {
+        $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+    }
+
+    /**
+     * Retrieve test cases
+     *
+     * @return array [Raw Phrase, Locale, Arguments, Expected Result]
+     * @throws \Exception
+     */
+    public function renderMessageFormatterDataProvider(): array
+    {
+        $twentynineteenJuneTwentyseven = new \DateTime('2019-06-27');
+
+        return [
+            [
+                'A table has {legs, plural, =0 {no legs} =1 {one leg} other {# legs}}.',
+                'en_US',
+                ['legs' => 4],
+                'A table has 4 legs.'
+            ],
+            [
+                'A table has {legs, plural, =0 {no legs} =1 {one leg} other {# legs}}.',
+                'en_US',
+                ['legs' => 0],
+                'A table has no legs.'
+            ],
+            [
+                'A table has {legs, plural, =0 {no legs} =1 {one leg} other {# legs}}.',
+                'en_US',
+                ['legs' => 1],
+                'A table has one leg.'
+            ],
+            ['The table costs {price, number, currency}.', 'en_US', ['price' => 23.4], 'The table costs $23.40.'],
+            [
+                'Today is {date, date, long}.',
+                'en_US',
+                ['date' => $twentynineteenJuneTwentyseven],
+                'Today is June 27, 2019.'
+            ],
+            [
+                'Today is {date, date, long}.',
+                'ja_JP',
+                ['date' => $twentynineteenJuneTwentyseven],
+                'Today is 2019年6月27日.'
+            ],
+        ];
+    }
+
+    /**
+     * Test MessageFormatter
+     *
+     * @param string $text The text with MessageFormat markers
+     * @param string $locale
+     * @param array $arguments The arguments supplying values for the variables
+     * @param string $result The expected result of Phrase rendering
+     *
+     * @dataProvider renderMessageFormatterDataProvider
+     */
+    public function testRenderMessageFormatter(string $text, string $locale, array $arguments, string $result): void
+    {
+        $renderer = $this->getMessageFormatter($locale);
+
+        $this->assertEquals($result, $renderer->render([$text], $arguments));
+    }
+
+    /**
+     * Create a MessageFormatter object provided a locale
+     *
+     * Automatically sets up the Translate dependency to return the provided locale and returns a MessageFormatter
+     * that has been provided that dependency
+     *
+     * @param string $locale
+     * @return MessageFormatter
+     */
+    private function getMessageFormatter(string $locale): MessageFormatter
+    {
+        $translateMock = $this->getMockBuilder(Translate::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getLocale'])
+            ->getMock();
+        $translateMock->method('getLocale')
+            ->willReturn($locale);
+
+        return $this->objectManager->getObject(MessageFormatter::class, ['translate' => $translateMock]);
+    }
+}

--- a/lib/internal/Magento/Framework/composer.json
+++ b/lib/internal/Magento/Framework/composer.json
@@ -16,6 +16,7 @@
         "ext-gd": "*",
         "ext-hash": "*",
         "ext-iconv": "*",
+        "ext-intl": "*",
         "ext-openssl": "*",
         "ext-simplexml": "*",
         "ext-spl": "*",


### PR DESCRIPTION
This gives us the ability to use ICU MessageFormatter formatting strings (inc. placeholders) for better support of internationalization.

MessageFormatter provides this by essentially giving a massive amount of flexibility to translatable strings, for example, consider a phrase describing how many orders there are.  In English, you might create:

* There are no orders.
* There is 1 order.
* There are x orders.

Or maybe

* There are x order(s).

These work fine for english, but the first one creates three phrases for the same string (and falls apart for languages such as Arabic and Ukranian) - and the second one falls apart in foreign languages.

With MessageFormatter:

* There are {orders, plural, =0 {no orders} =1 {1 order} other {# orders}}

This can then be mapped however necessary in foreign languages.  Japanese for example:

* 注文が{orders, plural, =0 {ない} other {#つある}}

This is just a small, quick example of the flexibility MessageFormatter provides over the current system.  Because of this form of processing, it also adds support for plurals and ordinal selection.  It also provides support for locale based date and currency formatting, but Magento's built-ins may be preferred for such functionality.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
