### PR TITLE
Improve command catalog:images:resize

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Image.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Image.php
@@ -54,7 +54,7 @@ class Image
     }
 
     /**
-     * Returns product images
+     * Get all product images.
      *
      * @return \Generator
      */
@@ -75,7 +75,28 @@ class Image
     }
 
     /**
-     * Get the number of unique pictures of products
+     * Get used product images.
+     *
+     * @return \Generator
+     */
+    public function getUsedProductImages(): \Generator
+    {
+        $batchSelectIterator = $this->batchQueryGenerator->generate(
+            'value_id',
+            $this->getUsedImagesSelect(),
+            $this->batchSize,
+            \Magento\Framework\DB\Query\BatchIteratorInterface::NON_UNIQUE_FIELD_ITERATOR
+        );
+
+        foreach ($batchSelectIterator as $select) {
+            foreach ($this->connection->fetchAll($select) as $key => $value) {
+                yield $key => $value;
+            }
+        }
+    }
+
+    /**
+     * Get the number of unique images of products.
      *
      * @return int
      */
@@ -92,7 +113,24 @@ class Image
     }
 
     /**
-     * Return Select to fetch all products images
+     * Get the number of unique and used images of products.
+     *
+     * @return int
+     */
+    public function getCountUsedProductImages(): int
+    {
+        $select = $this->getUsedImagesSelect()
+            ->reset('columns')
+            ->reset('distinct')
+            ->columns(
+                new \Zend_Db_Expr('count(distinct value)')
+            );
+
+        return (int) $this->connection->fetchOne($select);
+    }
+
+    /**
+     * Return select to fetch all products images.
      *
      * @return Select
      */
@@ -104,6 +142,25 @@ class Image
                 'value as filepath'
             )->where(
                 'disabled = 0'
+            );
+    }
+
+    /**
+     * Return select to fetch all used product images.
+     *
+     * @return Select
+     */
+    private function getUsedImagesSelect(): Select
+    {
+        return $this->connection->select()->distinct()
+            ->from(
+                ['images' => $this->resourceConnection->getTableName(Gallery::GALLERY_TABLE)],
+                'value as filepath'
+            )->joinInner(
+                ['image_value' => $this->resourceConnection->getTableName(Gallery::GALLERY_VALUE_TABLE)],
+                'images.value_id = image_value.value_id'
+            )->where(
+                'images.disabled = 0 AND image_value.disabled = 0'
             );
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
@@ -77,6 +77,37 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @return MockObject
+     */
+    protected function getUsedImagesSelectMock(): MockObject
+    {
+        $selectMock = $this->getMockBuilder(Select::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $selectMock->expects($this->once())
+            ->method('distinct')
+            ->willReturnSelf();
+        $selectMock->expects($this->once())
+            ->method('from')
+            ->with(
+                ['images' => Gallery::GALLERY_TABLE],
+                'value as filepath'
+            )->willReturnSelf();
+        $selectMock->expects($this->once())
+            ->method('joinInner')
+            ->with(
+                ['image_value' => Gallery::GALLERY_VALUE_TABLE],
+                'images.value_id = image_value.value_id'
+            )->willReturnSelf();
+        $selectMock->expects($this->once())
+            ->method('where')
+            ->with('images.disabled = 0 AND image_value.disabled = 0')
+            ->willReturnSelf();
+
+        return $selectMock;
+    }
+
+    /**
      * @param int $imagesCount
      * @dataProvider dataProvider
      */
@@ -118,13 +149,51 @@ class ImageTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @param int $imagesCount
+     * @dataProvider dataProvider
+     */
+    public function testGetCountUsedProductImages(int $imagesCount): void
+    {
+        $selectMock = $this->getUsedImagesSelectMock();
+        $selectMock->expects($this->exactly(2))
+            ->method('reset')
+            ->withConsecutive(
+                ['columns'],
+                ['distinct']
+            )->willReturnSelf();
+        $selectMock->expects($this->once())
+            ->method('columns')
+            ->with(new \Zend_Db_Expr('count(distinct value)'))
+            ->willReturnSelf();
+
+        $this->connectionMock->expects($this->once())
+            ->method('select')
+            ->willReturn($selectMock);
+        $this->connectionMock->expects($this->once())
+            ->method('fetchOne')
+            ->with($selectMock)
+            ->willReturn($imagesCount);
+
+        $imageModel = $this->objectManager->getObject(
+            Image::class,
+            [
+                'generator' => $this->generatorMock,
+                'resourceConnection' => $this->resourceMock
+            ]
+        );
+
+        $this->assertSame(
+            $imagesCount,
+            $imageModel->getCountUsedProductImages()
+        );
+    }
+
+    /**
+     * @param int $imagesCount
      * @param int $batchSize
      * @dataProvider dataProvider
      */
-    public function testGetAllProductImages(
-        int $imagesCount,
-        int $batchSize
-    ): void {
+    public function testGetAllProductImages(int $imagesCount, int $batchSize): void
+    {
         $this->connectionMock->expects($this->once())
             ->method('select')
             ->willReturn($this->getVisibleImagesSelectMock());
@@ -163,6 +232,54 @@ class ImageTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->assertCount($imagesCount, $imageModel->getAllProductImages());
+    }
+
+    /**
+     * @param int $imagesCount
+     * @param int $batchSize
+     * @dataProvider dataProvider
+     */
+    public function testGetUsedProductImages(int $imagesCount, int $batchSize): void
+    {
+        $this->connectionMock->expects($this->once())
+            ->method('select')
+            ->willReturn($this->getUsedImagesSelectMock());
+
+        $batchCount = (int)ceil($imagesCount / $batchSize);
+        $fetchResultsCallback = $this->getFetchResultCallbackForBatches($imagesCount, $batchSize);
+        $this->connectionMock->expects($this->exactly($batchCount))
+            ->method('fetchAll')
+            ->will($this->returnCallback($fetchResultsCallback));
+
+        /** @var Select | MockObject $selectMock */
+        $selectMock = $this->getMockBuilder(Select::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->generatorMock->expects($this->once())
+            ->method('generate')
+            ->with(
+                'value_id',
+                $selectMock,
+                $batchSize,
+                BatchIteratorInterface::NON_UNIQUE_FIELD_ITERATOR
+            )->will(
+                $this->returnCallback(
+                    $this->getBatchIteratorCallback($selectMock, $batchCount)
+                )
+            );
+
+        /** @var Image $imageModel */
+        $imageModel = $this->objectManager->getObject(
+            Image::class,
+            [
+                'generator' => $this->generatorMock,
+                'resourceConnection' => $this->resourceMock,
+                'batchSize' => $batchSize
+            ]
+        );
+
+        $this->assertCount($imagesCount, $imageModel->getUsedProductImages());
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ImageTest.php
@@ -16,6 +16,10 @@ use Magento\Catalog\Model\ResourceModel\Product\Gallery;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Magento\Framework\DB\Query\BatchIteratorInterface;
 
+/**
+ * Class ImageTest
+ * @package Magento\Catalog\Test\Unit\Model\ResourceModel\Product
+ */
 class ImageTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/code/Magento/MediaStorage/Console/Command/ImagesResizeCommand.php
+++ b/app/code/Magento/MediaStorage/Console/Command/ImagesResizeCommand.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\MediaStorage\Console\Command;
 
 use Magento\Framework\App\Area;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\State;
 use Magento\MediaStorage\Service\ImageResize;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -36,16 +37,19 @@ class ImagesResizeCommand extends \Symfony\Component\Console\Command\Command
      * @param State $appState
      * @param ImageResize $resize
      * @param ProgressBarFactory $progressBarFactory
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
         State $appState,
         ImageResize $resize,
-        ProgressBarFactory $progressBarFactory
+        $objectManager = null,
+        ProgressBarFactory $progressBarFactory = null
     ) {
         parent::__construct();
         $this->resize = $resize;
         $this->appState = $appState;
-        $this->progressBarFactory = $progressBarFactory;
+        $this->progressBarFactory = $progressBarFactory
+            ?: ObjectManager::getInstance()->get(ProgressBarFactory::class);
     }
 
     /**
@@ -92,5 +96,7 @@ class ImagesResizeCommand extends \Symfony\Component\Console\Command\Command
 
         $output->write(PHP_EOL);
         $output->writeln("<info>Product images resized successfully</info>");
+
+        return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
     }
 }

--- a/app/code/Magento/MediaStorage/Console/Command/ImagesResizeCommand.php
+++ b/app/code/Magento/MediaStorage/Console/Command/ImagesResizeCommand.php
@@ -16,6 +16,11 @@ use Symfony\Component\Console\Helper\ProgressBarFactory;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Resizes product images according to theme view definitions.
+ *
+ * @package Magento\MediaStorage\Console\Command
+ */
 class ImagesResizeCommand extends \Symfony\Component\Console\Command\Command
 {
     /**
@@ -53,7 +58,7 @@ class ImagesResizeCommand extends \Symfony\Component\Console\Command\Command
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function configure()
     {
@@ -62,7 +67,9 @@ class ImagesResizeCommand extends \Symfony\Component\Console\Command\Command
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
+     * @param InputInterface $input
+     * @param OutputInterface $output
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -71,10 +78,12 @@ class ImagesResizeCommand extends \Symfony\Component\Console\Command\Command
             $generator = $this->resize->resizeFromThemes();
 
             /** @var ProgressBar $progress */
-            $progress = $this->progressBarFactory->create([
-                'output' => $output,
-                'max' => $generator->current()
-            ]);
+            $progress = $this->progressBarFactory->create(
+                [
+                    'output' => $output,
+                    'max' => $generator->current()
+                ]
+            );
             $progress->setFormat(
                 "%current%/%max% [%bar%] %percent:3s%% %elapsed% %memory:6s% \t| <info>%message%</info>"
             );

--- a/app/code/Magento/MediaStorage/Console/Command/ImagesResizeCommand.php
+++ b/app/code/Magento/MediaStorage/Console/Command/ImagesResizeCommand.php
@@ -10,6 +10,7 @@ namespace Magento\MediaStorage\Console\Command;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\State;
+use Magento\Framework\ObjectManagerInterface;
 use Magento\MediaStorage\Service\ImageResize;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\ProgressBarFactory;
@@ -41,13 +42,14 @@ class ImagesResizeCommand extends \Symfony\Component\Console\Command\Command
     /**
      * @param State $appState
      * @param ImageResize $resize
+     * @param ObjectManagerInterface $objectManager
      * @param ProgressBarFactory $progressBarFactory
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
         State $appState,
         ImageResize $resize,
-        $objectManager = null,
+        ObjectManagerInterface $objectManager,
         ProgressBarFactory $progressBarFactory = null
     ) {
         parent::__construct();

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -152,12 +152,12 @@ class ImageResize
      */
     public function resizeFromThemes(array $themes = null): \Generator
     {
-        $count = $this->productImage->getCountAllProductImages();
+        $count = $this->productImage->getCountUsedProductImages();
         if (!$count) {
             throw new NotFoundException(__('Cannot resize images - product images not found'));
         }
 
-        $productImages = $this->productImage->getAllProductImages();
+        $productImages = $this->productImage->getUsedProductImages();
         $viewImages = $this->getViewImages($themes ?? $this->getThemesInUse());
 
         foreach ($productImages as $image) {

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -202,10 +202,12 @@ class ImageResize
         $viewImages = [];
         /** @var \Magento\Theme\Model\Theme $theme */
         foreach ($themes as $theme) {
-            $config = $this->viewConfig->getViewConfig([
-                'area' => Area::AREA_FRONTEND,
-                'themeModel' => $theme,
-            ]);
+            $config = $this->viewConfig->getViewConfig(
+                [
+                    'area' => Area::AREA_FRONTEND,
+                    'themeModel' => $theme,
+                ]
+            );
             $images = $config->getMediaEntities('Magento_Catalog', ImageHelper::MEDIA_TYPE_CONFIG_NODE);
             foreach ($images as $imageId => $imageData) {
                 $uniqIndex = $this->getUniqueImageIndex($imageData);

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -228,6 +228,7 @@ class ImageResize
     {
         ksort($imageData);
         unset($imageData['type']);
+        // phpcs:disable Magento2.Security.InsecureFunction
         return md5(json_encode($imageData));
     }
 


### PR DESCRIPTION
- Only resize images that are actually in use.
- Improve code on several places

### Description (*)
The resizer uses table `catalog_product_entity_media_gallery` as source table. These records contain the paths to the actual images. The problem is, these records can exist, even when they are not being used by any products. I added an inner join to table `catalog_product_entity_media_gallery_value`, to make sure that there's a link between the image and a product.

This improves performance and is less error prone, because the orphan images might not have a physical presence on the filesystem. Now the latter is an other issue, but hardening the resizer won't do any harm.

### Fixed Issues 
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. N/a
### Manual testing scenarios (*)
1. Create product with image.
2. Insert a dummy row into `catalog_product_entity_media_gallery`.
3. Run `bin/magento catalog:images:resize`.
4. Output should look like this:
```
Product images resized successfully

1/1 [============================] 100% < 1 sec 44.2 MiB 	| /t/e/testupload.jpg
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
