### PR TITLE
Improve ComponentRegistrar with new register methods

### DIFF
--- a/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
+++ b/lib/internal/Magento/Framework/Component/ComponentRegistrar.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Framework\Component;
 
 /**
@@ -15,7 +17,7 @@ namespace Magento\Framework\Component;
 class ComponentRegistrar implements ComponentRegistrarInterface
 {
     /**#@+
-     * Different types of components
+     * Available component types.
      */
     const MODULE = 'module';
     const LIBRARY = 'library';
@@ -34,7 +36,7 @@ class ComponentRegistrar implements ComponentRegistrarInterface
     ];
 
     /**
-     * Sets the location of a component.
+     * Register a component.
      *
      * @param string $type component type
      * @param string $componentName Fully-qualified component name
@@ -42,7 +44,7 @@ class ComponentRegistrar implements ComponentRegistrarInterface
      * @throws \LogicException
      * @return void
      */
-    public static function register($type, $componentName, $path)
+    public static function register(string $type, string $componentName, string $path): void
     {
         self::validateType($type);
         if (isset(self::$paths[$type][$componentName])) {
@@ -56,34 +58,96 @@ class ComponentRegistrar implements ComponentRegistrarInterface
     }
 
     /**
+     * Register a module component.
+     *
+     * @param string $componentName
+     * @param string $path
+     * @return void
+     */
+    public static function registerModule(string $componentName, string $path): void
+    {
+        self::register(self::MODULE, $componentName, $path);
+    }
+
+    /**
+     * Register a library component.
+     *
+     * @param string $componentName
+     * @param string $path
+     * @return void
+     */
+    public static function registerLibrary(string $componentName, string $path): void
+    {
+        self::register(self::LIBRARY, $componentName, $path);
+    }
+
+    /**
+     * Register a theme component.
+     *
+     * @param string $componentName
+     * @param string $path
+     * @return void
+     */
+    public static function registerTheme(string $componentName, string $path): void
+    {
+        self::register(self::THEME, $componentName, $path);
+    }
+
+    /**
+     * Register a language component.
+     *
+     * @param string $componentName
+     * @param string $path
+     * @return void
+     */
+    public static function registerLanguage(string $componentName, string $path): void
+    {
+        self::register(self::LANGUAGE, $componentName, $path);
+    }
+
+    /**
+     * Register a setup component.
+     *
+     * @param string $componentName
+     * @param string $path
+     * @return void
+     */
+    public static function registerSetup(string $componentName, string $path): void
+    {
+        self::register(self::SETUP, $componentName, $path);
+    }
+
+    /**
      * {@inheritdoc}
      */
-    public function getPaths($type)
+    public function getPaths(string $type): array
     {
         self::validateType($type);
+
         return self::$paths[$type];
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getPath($type, $componentName)
+    public function getPath(string $type, string $componentName): ?string
     {
         self::validateType($type);
+
         return self::$paths[$type][$componentName] ?? null;
     }
 
     /**
-     * Checks if type of component is valid
+     * Check if component type is valid.
      *
      * @param string $type
      * @return void
      * @throws \LogicException
      */
-    private static function validateType($type)
+    private static function validateType(string $type): void
     {
         if (!isset(self::$paths[$type])) {
-            throw new \LogicException('\'' . $type . '\' is not a valid component type');
+            throw new \LogicException(sprintf("'%s' is not a valid component type", $type));
         }
     }
 }

--- a/lib/internal/Magento/Framework/Component/ComponentRegistrarInterface.php
+++ b/lib/internal/Magento/Framework/Component/ComponentRegistrarInterface.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Framework\Component;
 
 /**
@@ -11,21 +13,21 @@ namespace Magento\Framework\Component;
 interface ComponentRegistrarInterface
 {
     /**
-     * Get list of registered Magento components
+     * Get list of registered Magento components.
      *
      * Returns an array where key is fully-qualified component name and value is absolute path to component
      *
      * @param string $type
      * @return array
      */
-    public function getPaths($type);
+    public function getPaths(string $type): array;
 
     /**
-     * Get path of a component if it is already registered
+     * Get path of a component if it is already registered.
      *
      * @param string $type
      * @param string $componentName
      * @return null|string
      */
-    public function getPath($type, $componentName);
+    public function getPath(string $type, string $componentName): ?string;
 }


### PR DESCRIPTION
- Add register methods for each component type
- Add strict types

### Description (*)
To improve developer experience and code readability, I added register methods for each component type to the `ComponentRegistrar`.

Now people can register modules as following:
``` php
<?php

use \Magento\Framework\Component\ComponentRegistrar;

ComponentRegistrar::registerModule('Acme_SampleModule', __DIR__);
```

Just a simple addition to make things easier. 

Aside from that, I also added strict types to all the methods in `ComponentRegistrar` and `ComponentRegistrarInterface`

### Manual testing scenarios (*)
1. Create a module and register it using `registerModule`.
2. It should be loaded.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
