### PR TITLE
[Backport] [Shipping] Adjusting the Contact Us Xpath

### DIFF
--- a/app/code/Magento/Shipping/Block/Tracking/Popup.php
+++ b/app/code/Magento/Shipping/Block/Tracking/Popup.php
@@ -11,6 +11,8 @@ namespace Magento\Shipping\Block\Tracking;
 use Magento\Framework\Stdlib\DateTime\DateTimeFormatterInterface;
 
 /**
+ * Tracking popup
+ *
  * @api
  * @since 100.0.2
  */
@@ -107,13 +109,15 @@ class Popup extends \Magento\Framework\View\Element\Template
      */
     public function getContactUsEnabled()
     {
-        return (bool)$this->_scopeConfig->getValue(
-            'contacts/contacts/enabled',
+        return $this->_scopeConfig->isSetFlag(
+            'contact/contact/enabled',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
     }
 
     /**
+     * Get support email
+     *
      * @return string
      */
     public function getStoreSupportEmail()
@@ -125,6 +129,8 @@ class Popup extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Get contact us url
+     *
      * @return string
      */
     public function getContactUs()


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22823

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR adjusts the Xpath for the contact us on shipping details block, as result we should see the contact us link in the tracking information, if the shipping carrier won't be available.

### Fixed Issues (if relevant)
1. magento/magento2#22822: [Shipping] The contact us link isn't showing on order tracking page
2. ...

### Manual testing scenarios (*)
1. Make sure you have enabled the **Contact Us**
`Stores / Configuration / Contacts [General] / Contact Us`
2. Create a new order
3. Create a shipment for the order
3.1 Add the Tracking Number by using **USPS** carrier
4. Click on the _Track Order_ link (from Order page)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
