### PR TITLE
Remove direct use of object manager

### DIFF
--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/Index.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/Index.php
@@ -7,6 +7,8 @@ namespace Magento\Cms\Controller\Adminhtml\Page;
 
 use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\Request\DataPersistorInterface;
 use Magento\Framework\View\Result\PageFactory;
 
 /**
@@ -27,15 +29,23 @@ class Index extends \Magento\Backend\App\Action implements HttpGetActionInterfac
     protected $resultPageFactory;
 
     /**
+     * @var DataPersistorInterface
+     */
+    private $dataPersistor;
+
+    /**
      * @param Context $context
      * @param PageFactory $resultPageFactory
+     * @param DataPersistorInterface $dataPersistor
      */
     public function __construct(
         Context $context,
-        PageFactory $resultPageFactory
+        PageFactory $resultPageFactory,
+        DataPersistorInterface $dataPersistor = null
     ) {
         parent::__construct($context);
         $this->resultPageFactory = $resultPageFactory;
+        $this->dataPersistor = $dataPersistor ?: ObjectManager::getInstance()->get(DataPersistorInterface::class);
     }
 
     /**
@@ -52,8 +62,7 @@ class Index extends \Magento\Backend\App\Action implements HttpGetActionInterfac
         $resultPage->addBreadcrumb(__('Manage Pages'), __('Manage Pages'));
         $resultPage->getConfig()->getTitle()->prepend(__('Pages'));
 
-        $dataPersistor = $this->_objectManager->get(\Magento\Framework\App\Request\DataPersistorInterface::class);
-        $dataPersistor->clear('cms_page');
+        $this->dataPersistor->clear('cms_page');
 
         return $resultPage;
     }


### PR DESCRIPTION
### Description (*)
Remove the direct use of object manager and replace it with the dependency injection.

### Manual testing scenarios (*)
1. Tried accessing the cms grid listing page and got success.
2. Ran unit tests for cms module.
