### PR TITLE
Fixed Issue #22702

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/template/variations/steps/summary-grid.html
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/template/variations/steps/summary-grid.html
@@ -5,7 +5,7 @@
  */
 -->
 
-<div class="admin__collapsible-block-wrapper opened">
+<div class="admin__collapsible-block-wrapper">
     <div class="fieldset-wrapper-title">
         <strong class="admin__collapsible-title" data-toggle="collapse" data-bind="attr:{'data-target': '#'+id}">
             <span data-bind="text: title"></span>

--- a/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/_collapsible-blocks.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/main/_collapsible-blocks.less
@@ -84,6 +84,12 @@
             content: '';
         }
     }
+
+    &.active {
+        &:before {
+            transform: rotate(180deg);
+        }
+    }
 }
 
 .__collapsible-sub-title-pattern() {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Toggle icon not working in create configuration Product creation Page

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22702: Toggle icon not working in create configuration Product creation Page

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Catalog > Products > New Product (Configurable) > Click Create Configuration.
2. Select Attributes > Attribute Values > Bulk Images & Price > Summary.
3. Associated Products's Toggle working properly

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
