### PR TITLE
Don't create a new account-nav block - use existing instead.

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Customer/layout/customer_account.xml
+++ b/app/design/frontend/Magento/luma/Magento_Customer/layout/customer_account.xml
@@ -7,52 +7,12 @@
 -->
 <page layout="2columns-left" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="sidebar.main">
-            <block class="Magento\Framework\View\Element\Template" name="customer_account_navigation_block" template="Magento_Theme::html/collapsible.phtml" before="-">
-                <arguments>
-                    <argument name="block_title" translate="true" xsi:type="string">My Account</argument>
-                    <argument name="block_css" xsi:type="string">block-collapsible-nav</argument>
-                </arguments>
-                <block class="Magento\Customer\Block\Account\Navigation" name="customer_account_navigation" before="-">
-                    <arguments>
-                        <argument name="css_class" xsi:type="string">nav items</argument>
-                    </arguments>
-                    <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-account-link">
-                        <arguments>
-                            <argument name="label" xsi:type="string" translate="true">My Account</argument>
-                            <argument name="path" xsi:type="string">customer/account</argument>
-                            <argument name="sortOrder" xsi:type="number">250</argument>
-                        </arguments>
-                    </block>
-                    <block class="Magento\Customer\Block\Account\Delimiter" name="customer-account-navigation-delimiter-1"
-                           template="Magento_Customer::account/navigation-delimiter.phtml">
-                        <arguments>
-                            <argument name="sortOrder" xsi:type="number">200</argument>
-                        </arguments>
-                    </block>
-                    <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-address-link">
-                        <arguments>
-                            <argument name="label" xsi:type="string" translate="true">Address Book</argument>
-                            <argument name="path" xsi:type="string">customer/address</argument>
-                            <argument name="sortOrder" xsi:type="number">190</argument>
-                        </arguments>
-                    </block>
-                    <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-account-edit-link">
-                        <arguments>
-                            <argument name="label" xsi:type="string" translate="true">Account Information</argument>
-                            <argument name="path" xsi:type="string">customer/account/edit</argument>
-                            <argument name="sortOrder" xsi:type="number">180</argument>
-                        </arguments>
-                    </block>
-                    <block class="Magento\Customer\Block\Account\Delimiter" name="customer-account-navigation-delimiter-2"
-                           template="Magento_Customer::account/navigation-delimiter.phtml">
-                        <arguments>
-                            <argument name="sortOrder" xsi:type="number">130</argument>
-                        </arguments>
-                    </block>
-                </block>
-            </block>
-        </referenceContainer>
+        <referenceBlock name="sidebar.main.account_nav">
+            <arguments>
+                <argument name="block_title" translate="true" xsi:type="string">My Account</argument>
+                <argument name="block_css" xsi:type="string">block-collapsible-nav</argument>
+            </arguments>
+        </referenceBlock>
         <move element="page.main.title" destination="content.top" before="-"/>
     </body>
 </page>


### PR DESCRIPTION
### Description
Account navigation block is already created by Magento_Customer module in
[Magento/Customer/view/frontend/layout/customer_account.xml](https://github.com/magento/magento2/blob/2.3-develop/app/design/frontend/Magento/luma/Magento_Customer/layout/customer_account.xml#L16) layout update file.
So instead of creating a new block that will contain another one, we can
use the same block.

### Manual testing scenarios (*)
1. Navigate into customer account page and inspect sidebar with browser dev tools
2. You'll see an empty block below `block-collapsible-nav` block:

   ![image](https://user-images.githubusercontent.com/306080/58539241-96504f80-81ff-11e9-9f82-3a2e0cacf8e5.png)

3. Apply the patch and empty block will disappear.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
