### PR TITLE
Add more descriptive exception when data patch fails to apply.

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Patch/PatchApplier.php
+++ b/lib/internal/Magento/Framework/Setup/Patch/PatchApplier.php
@@ -10,7 +10,7 @@ use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Module\ModuleList;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Phrase;
-use Magento\Framework\Setup\Exception;
+use Magento\Framework\Setup\Exception as SetupException;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 
 /**
@@ -129,8 +129,8 @@ class PatchApplier
     /**
      * Apply all patches for one module
      *
-     * @param null | string $moduleName
-     * @throws Exception
+     * @param null|string $moduleName
+     * @throws SetupException
      */
     public function applyDataPatch($moduleName = null)
     {
@@ -149,7 +149,7 @@ class PatchApplier
                 ['moduleDataSetup' => $this->moduleDataSetup]
             );
             if (!$dataPatch instanceof DataPatchInterface) {
-                throw new Exception(
+                throw new SetupException(
                     new Phrase("Patch %1 should implement DataPatchInterface", [get_class($dataPatch)])
                 );
             }
@@ -164,7 +164,7 @@ class PatchApplier
                     $this->moduleDataSetup->getConnection()->commit();
                 } catch (\Exception $e) {
                     $this->moduleDataSetup->getConnection()->rollBack();
-                    throw new Exception(
+                    throw new SetupException(
                         new Phrase(
                             'Unable to apply data patch %1 for module %2. Original exception message: %3',
                             [
@@ -183,8 +183,7 @@ class PatchApplier
     }
 
     /**
-     * Register all patches in registry in order to manipulate chains and dependencies of patches
-     * of patches
+     * Register all patches in registry in order to manipulate chains and dependencies of patches of patches
      *
      * @param string $moduleName
      * @param string $patchType
@@ -217,8 +216,8 @@ class PatchApplier
      *
      * Please note: that schema patches are not revertable
      *
-     * @param null | string $moduleName
-     * @throws Exception
+     * @param null|string $moduleName
+     * @throws SetupException
      */
     public function applySchemaPatch($moduleName = null)
     {
@@ -239,7 +238,7 @@ class PatchApplier
                 $schemaPatch->apply();
                 $this->patchHistory->fixPatch(get_class($schemaPatch));
             } catch (\Exception $e) {
-                throw new Exception(
+                throw new SetupException(
                     new Phrase(
                         'Unable to apply patch %1 for module %2. Original exception message: %3',
                         [
@@ -258,8 +257,8 @@ class PatchApplier
     /**
      * Revert data patches for specific module
      *
-     * @param null | string $moduleName
-     * @throws Exception
+     * @param null|string $moduleName
+     * @throws SetupException
      */
     public function revertDataPatches($moduleName = null)
     {
@@ -280,7 +279,7 @@ class PatchApplier
                     $adapter->commit();
                 } catch (\Exception $e) {
                     $adapter->rollBack();
-                    throw new Exception(new Phrase($e->getMessage()));
+                    throw new SetupException(new Phrase($e->getMessage()));
                 } finally {
                     unset($dataPatch);
                 }

--- a/lib/internal/Magento/Framework/Setup/Patch/PatchApplier.php
+++ b/lib/internal/Magento/Framework/Setup/Patch/PatchApplier.php
@@ -164,7 +164,17 @@ class PatchApplier
                     $this->moduleDataSetup->getConnection()->commit();
                 } catch (\Exception $e) {
                     $this->moduleDataSetup->getConnection()->rollBack();
-                    throw new Exception(new Phrase($e->getMessage()));
+                    throw new Exception(
+                        new Phrase(
+                            'Unable to apply data patch %1 for module %2. Original exception message: %3',
+                            [
+                                get_class($dataPatch),
+                                $moduleName,
+                                $e->getMessage()
+                            ]
+                        ),
+                        $e
+                    );
                 } finally {
                     unset($dataPatch);
                 }


### PR DESCRIPTION



<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

This PR adds a better exception message when a data patch cannot be applied due to an exception. Currently it does not contain any information about the patch that failed.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23045: Exceptions from data patches do not show root cause

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a patch that will throw an exception.
2. Run `bin/magento setup:upgrade`
3. See that exception message now contains the module name, and specific data patch class that failed. As well as the original exception.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
