### PR TITLE
#22998 : failing order creation with api when no address email is provided

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Address.php
+++ b/app/code/Magento/Sales/Model/Order/Address.php
@@ -730,5 +730,16 @@ class Address extends AbstractModel implements OrderAddressInterface, AddressMod
         return $this->_setExtensionAttributes($extensionAttributes);
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function beforeSave()
+    {
+        if ($this->getEmail() === null) {
+            $this->setEmail($this->getOrder()->getCustomerEmail());
+        }
+        return parent::beforeSave();
+    }
+
     //@codeCoverageIgnoreEnd
 }


### PR DESCRIPTION
### Description (*)
When billing address data is before customer data in order create api JSON payload, the billing address email is not populated. see https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Sales/Model/Order.php#L997 . Order is empty, so customer email is nowhere to be brought from.

### Fixed Issues (if relevant)
1. magento/magento2#22998 : POST on /orders fails when properties in the body are out of sequence

### Manual testing scenarios (*)
1. use provided JSON payloads but fill it with your data
2. to fail, simply put billing address as first node.

### Questions or comments
I am not sure whether this is the best solution.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
