### PR TITLE
Issue fix #18264: Wrong special_price in indexer database tables for bundle products.

### DIFF
--- a/app/code/Magento/Bundle/Model/ResourceModel/Indexer/Price.php
+++ b/app/code/Magento/Bundle/Model/ResourceModel/Indexer/Price.php
@@ -316,7 +316,7 @@ class Price implements DimensionalIndexerInterface
         $specialFromExpr = "{$specialFrom} IS NULL OR {$specialFromDate} <= {$currentDate}";
         $specialToExpr = "{$specialTo} IS NULL OR {$specialToDate} >= {$currentDate}";
         $specialExpr = "{$specialPrice} IS NOT NULL AND {$specialPrice} > 0 AND {$specialPrice} < 100"
-            . " AND {$specialFromExpr} AND {$specialToExpr}";
+            . " AND ({$specialFromExpr}) AND ({$specialToExpr})";
         $tierExpr = new \Zend_Db_Expr('tp.min_price');
 
         if ($priceType == \Magento\Bundle\Model\Product\Price::PRICE_TYPE_FIXED) {


### PR DESCRIPTION
### Description (*)
Issue was already fixed in M2.2.8 but only for Configurable products. Same situation relates to Bundle product prices and it's indexer (SQL). All conditions there are correct, but are not grouped which results with wrong special_price data populating in indexer database tables.  

### Fixed Issues (if relevant)
1. magento/magento2#18264: M2.2.6 : "Order by price" not working in product listing

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set same regular price for 2-3 bundle products
2. Set same special_price on above products
3. Set different dates in fields `special_price_from` and `special_price_to`, but having one product with special date valid for the day of testing.
4. Assign above products to the same category
5. Open that category page and watch results

#### Results: 
Products are sorted as if they have same (special) price, but displayed price is correct according to dates set in  `special_price_from` and `special_price_to` fields. 
In `catalog_product_index_price` table all three products have set special_price.

### Questions or comments
As I checked the issue is presenting in M2.3-develop as well. 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
