### PR TITLE
Fix template paths on Windows

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
+++ b/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
@@ -135,7 +135,8 @@ class Validator
         if (!is_array($directories)) {
             $directories = (array)$directories;
         }
-        $realPath = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? str_replace('\\', '/', $this->fileDriver->getRealPath($path)) : $this->fileDriver->getRealPath($path);
+        $realPath = $this->fileDriver->getRealPath($path);
+        $realPath = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? str_replace('\\', '/', $realPath) : $realPath;
         foreach ($directories as $directory) {
             if (0 === strpos($realPath, $directory)) {
                 return true;

--- a/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
+++ b/lib/internal/Magento/Framework/View/Element/Template/File/Validator.php
@@ -135,7 +135,7 @@ class Validator
         if (!is_array($directories)) {
             $directories = (array)$directories;
         }
-        $realPath = $this->fileDriver->getRealPath($path);
+        $realPath = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? str_replace('\\', '/', $this->fileDriver->getRealPath($path)) : $this->fileDriver->getRealPath($path);
         foreach ($directories as $directory) {
             if (0 === strpos($realPath, $directory)) {
                 return true;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

When using Valet on Windows templates do not properly load because windows uses a backslash `\` for paths and magento is looking for `/`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Install Magento 2.3 (without this change) on Windows 10 using Valet
2. Visit magento2.test and you'll see template errors (in developer mode)
3. Install this change
4. Visit magento2.test again and you'll see the default theme working as it should.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
