### PR TITLE
[Backport] Fix condition Safe-NULL condition on Update Trigger

### DIFF
--- a/lib/internal/Magento/Framework/Mview/View/Subscription.php
+++ b/lib/internal/Magento/Framework/Mview/View/Subscription.php
@@ -213,7 +213,7 @@ class Subscription implements SubscriptionInterface
                         $columns = [];
                         foreach ($columnNames as $columnName) {
                             $columns[] = sprintf(
-                                'NEW.%1$s <=> OLD.%1$s',
+                                'NOT NEW.%1$s <=> OLD.%1$s',
                                 $this->connection->quoteIdentifier($columnName)
                             );
                         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Safe-NULL in the Update Trigger created by View is used in the wrong way. As we are using an external integration system using INSERT INTO ... ON DUPLICATE KEY UPDATE `value`= ... on most on our product ( for example stock, prices, varchar attribute) each integration is followed by a reindex of most of our products that are not really updated. And impact a lot the performances of our database.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#15939: Duplicated product is out of stock when index set to UPDATE BY SCHEDULE
2. magento/magento2#23077: Triggers created by MView are triggered all the time

### Manual testing scenarios (*)
To understand the condition used before and after the commit magento/magento2@df5597a2e and the solution proposed in this Pull Request.

I'm doing this benchmark playground :

```sql
CREATE TABLE `test_trigger_cond1` (
  `value` VARCHAR(255) DEFAULT NULL
) ENGINE=INNODB DEFAULT CHARSET=utf8;

CREATE TABLE `test_trigger_cond2` (
  `value` VARCHAR(255) DEFAULT NULL
) ENGINE=INNODB DEFAULT CHARSET=utf8;

INSERT INTO `test_trigger_cond1` (`value`)
VALUES
    ('Magento'),
    (NULL),
    ('1');

INSERT INTO `test_trigger_cond2` (`value`)
VALUES
    ('Magento'),
    (NULL),
    ('1');


SELECT
a.value "Value A",
b.value "Value B",
a.value != b.value "before commit df5597a2e4",
a.value <=> b.value "after commit df5597a2e4",
NOT a.value <=> b.value "Suggested Trigger Comparison"
FROM test_trigger_cond1 a, test_trigger_cond2 b;
```

here the result of the last query:

| Value A | Value B | before commit magento/magento2@df5597a2e4 | after commit magento/magento2@df5597a2e4 | Suggested Trigger Comparison |
|-------|---------|----|------|-------|
| Magento | Magento | 0 | 1 | 0 |
| NULL | Magento | NULL | 0 | 1 |
| 1 | Magento | 1 | 0 | 1 |
| Magento | NULL | NULL | 0 | 1 |
| NULL | NULL | NULL | 1 | 0 |
| 1 | NULL | NULL | 0 | 1 |
| Magento | 1 | 1 | 0 | 1 |
| NULL | 1 | NULL | 0 | 1 |
| 1 | 1 | 0 | 1 | 0 |

### Before
as we can see before the commit the NULL condition could cause a lot of trouble if for example a previous attribute were NULL or become NULL as change the 

### After
Only if the both value are the same we got `true`.

if we look a classic line in a trigger for example : `trg_catalog_product_entity_int_after_update `
```sql
BEGIN
SET @entity_id = (SELECT `entity_id` FROM `catalog_product_entity` WHERE `row_id` = NEW.`row_id`);
...
IF (
NEW.`value_id` <=> OLD.`value_id` OR 
NEW.`attribute_id` <=> OLD.`attribute_id` OR 
NEW.`store_id` <=> OLD.`store_id` OR 
NEW.`row_id` <=> OLD.`row_id` OR 
NEW.`value` <=> OLD.`value`
) THEN 
INSERT IGNORE INTO `catalog_product_flat_cl` (`entity_id`) values(@entity_id); END IF;
...
END
```

if at least one of these fields (`value_id`, `attribute_id`, `store_id`, `row_id`, `value`) didn't change we will always insert a new row inside `catalog_product_flat_cl`. And this is always the case.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)