### PR TITLE
[Backport] [Validator] Fix wrong behaviour of validation scroll

### DIFF
--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -990,8 +990,8 @@
                         minValidRange = $.mage.parseNumber(validRange[1]);
                         maxValidRange = $.mage.parseNumber(validRange[2]);
                         result = result &&
-                        (isNaN(minValidRange) || minValue >= minValidRange) &&
-                        (isNaN(maxValidRange) || maxValue <= maxValidRange);
+                            (isNaN(minValidRange) || minValue >= minValidRange) &&
+                            (isNaN(maxValidRange) || maxValue <= maxValidRange);
                     }
                 }
 
@@ -1109,8 +1109,8 @@
                     options = p.find('input');
 
                 return options.map(function (el) {
-                        return $(el).val();
-                    }).length > 0;
+                    return $(el).val();
+                }).length > 0;
             },
             $.mage.__('Please select one of the options above.')
         ],
@@ -1922,15 +1922,15 @@
          * @param {jQuery.Event} event
          * @param {Object} validation
          */
-        listenFormValidateHandler:  function (event, validation) {
+        listenFormValidateHandler: function (event, validation) {
             var firstActive = $(validation.errorList[0].element || []),
                 lastActive = $(validation.findLastActive() ||
                     validation.errorList.length && validation.errorList[0].element || []),
-                parent, windowHeight, successList;
+                windowHeight = $(window).height(),
+                parent, successList;
 
             if (lastActive.is(':hidden')) {
                 parent = lastActive.parent();
-                windowHeight = $(window).height();
                 $('html, body').animate({
                     scrollTop: parent.offset().top - windowHeight / 2
                 });
@@ -1948,8 +1948,8 @@
             }
 
             if (firstActive.length) {
-                $('html, body').stop().animate({
-                    scrollTop: firstActive.offset().top
+                $('body').stop().animate({
+                    scrollTop: firstActive.offset().top - windowHeight / 2
                 });
                 firstActive.focus();
             }


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/23035
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
If page have validating elements page scrolling down and up instead of focusing on non valid element

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23034: Wrong behaviour of validation scroll

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open create order page in admin panel
2. Click Add Product button
3. Click Submit Order button

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
