### PR TITLE
fix customer data race condition when bundling is enabled

### DIFF
--- a/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
@@ -11,12 +11,13 @@ define([
     'underscore',
     'ko',
     'Magento_Customer/js/section-config',
+    'mage/url',
     'mage/storage',
     'jquery/jquery-storageapi'
-], function ($, _, ko, sectionConfig) {
+], function ($, _, ko, sectionConfig, url) {
     'use strict';
 
-    var options,
+    var options = {},
         storage,
         storageInvalidation,
         invalidateCacheBySessionTimeOut,
@@ -24,6 +25,9 @@ define([
         dataProvider,
         buffer,
         customerData;
+
+    url.setBaseUrl(window.BASE_URL);
+    options.sectionLoadUrl = url.build('customer/section/load');
 
     //TODO: remove global change, in this case made for initNamespaceStorage
     $.cookieStorage.setConf({


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
when using advanced bundling there is a race condition leading to an error where options.sectionLoadUrl is undefined when customer data tries to retrieve sections from the server.

This has already lead to several issues with mostly different context but the same base problem: the options object is initialized as x-magento-init script in a phtml file which is not always executed fast enough (for example if you use the advanced bundling).

A fix for that will also be mandatory for tools that automate an advanced bundling mechanism (/cc @DrewML )

some related tickets that have been closed:
https://github.com/magento/magento2/issues?q=is%3Aissue+sectionLoadUrl+is%3Aclosed


related issue in m2-devtools project:
https://github.com/magento/m2-devtools/issues/56



### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. enable production mode
2. implement advanced bundling (maybe it also happens with magento default bundling)
 -> For example by using: https://github.com/magento/m2-devtools

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
