### PR TITLE
Fix for 404 after Login Redirect

### DIFF
--- a/app/code/Magento/ProductAlert/Controller/Add/Stock.php
+++ b/app/code/Magento/ProductAlert/Controller/Add/Stock.php
@@ -19,7 +19,7 @@ use Magento\Store\Model\StoreManagerInterface;
 /**
  * Controller for notifying about stock.
  */
-class Stock extends AddController implements HttpPostActionInterface
+class Stock extends AddController
 {
     /**
      * @var \Magento\Catalog\Api\ProductRepositoryInterface


### PR DESCRIPTION
### Description (*)
When a guest user adds a product to stock notification, they are redirected to Login, after which they are redirected to 404 page because login redirect is always a GET request. Since this controller does not use POST parametars, it should not implement the class I removed

### Manual testing scenarios (*)

1. Enable "Back in stock notifications"
2. As guest user, subscribe to a products "Back in stock Notifications"
3. You will be redirected to login page
4. Login

### Questions or comments
Why did this controller implement HttpPostActionInterface when POST parametars are not used? 
Should the same fix be applied to Price.php from the same folder?

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
