### PR TITLE
#23053 : sendfriend verifies product visibility instead of status

### DIFF
--- a/app/code/Magento/SendFriend/Controller/Product.php
+++ b/app/code/Magento/SendFriend/Controller/Product.php
@@ -102,7 +102,7 @@ abstract class Product extends \Magento\Framework\App\Action\Action
         }
         try {
             $product = $this->productRepository->getById($productId);
-            if (!$product->isVisibleInCatalog()) {
+            if (!$product->isVisibleInSiteVisibility() || !$product->isVisibleInCatalog()) {
                 return false;
             }
         } catch (NoSuchEntityException $noEntityException) {

--- a/app/code/Magento/SendFriend/Controller/Product.php
+++ b/app/code/Magento/SendFriend/Controller/Product.php
@@ -61,6 +61,7 @@ abstract class Product extends \Magento\Framework\App\Action\Action
 
     /**
      * Check if module is enabled
+     *
      * If allow only for customer - redirect to login page
      *
      * @param RequestInterface $request

--- a/dev/tests/integration/testsuite/Magento/SendFriend/Controller/SendmailTest.php
+++ b/dev/tests/integration/testsuite/Magento/SendFriend/Controller/SendmailTest.php
@@ -86,11 +86,37 @@ class SendmailTest extends AbstractController
     }
 
     /**
+     * Share the product invisible in catalog to friend as guest customer
+     *
+     * @magentoDbIsolation enabled
+     * @magentoAppIsolation enabled
+     * @magentoConfigFixture default_store sendfriend/email/enabled 1
+     * @magentoConfigFixture default_store sendfriend/email/allow_guest 1
+     * @magentoDataFixture Magento/Catalog/_files/simple_products_not_visible_individually.php
+     */
+    public function testSendInvisibleProduct()
+    {
+        $product = $this->getInvisibleProduct();
+        $this->prepareRequestData();
+
+        $this->dispatch('sendfriend/product/sendmail/id/' . $product->getId());
+        $this->assert404NotFound();
+    }
+
+    /**
      * @return ProductInterface
      */
     private function getProduct()
     {
         return $this->_objectManager->get(ProductRepositoryInterface::class)->get('custom-design-simple-product');
+    }
+
+    /**
+     * @return ProductInterface
+     */
+    private function getInvisibleProduct()
+    {
+        return $this->_objectManager->get(ProductRepositoryInterface::class)->get('simple_not_visible_1');
     }
 
     /**


### PR DESCRIPTION
### Description (*)
Sendfriend feature was verifying product status only. This could cause sending a link for enabled product invisible in catalog and/or search. 

### Fixed Issues (if relevant)
1. magento/magento2#23053: Sendfriend works for products with visibility not visible individually

### Manual testing scenarios (*)
Follow steps provided in #23053

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
