### PR TITLE
[Backport] #22686 Shipment view fixed for Fatal error.

### DIFF
--- a/app/code/Magento/Shipping/view/adminhtml/templates/view/items.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/view/items.phtml
@@ -14,14 +14,16 @@
         </thead>
         <?php $_items = $block->getShipment()->getAllItems() ?>
         <?php $_i = 0; foreach ($_items as $_item) :
-            if ($_item->getOrderItem()->getParentItem()) :
-                continue;
-            endif;
-            $_i++ ?>
-            <tbody class="<?= /* @noEscape */ $_i%2 ? 'odd' : 'even' ?>">
-                <?= $block->getItemHtml($_item) ?>
-                <?= $block->getItemExtraInfoHtml($_item->getOrderItem()) ?>
-            </tbody>
+            if (!empty($_item->getOrderItem())) :
+                if ($_item->getOrderItem()->getParentItem()) :
+                    continue;
+                endif;
+                $_i++ ?>
+                <tbody class="<?= /* @noEscape */ $_i%2 ? 'odd' : 'even' ?>">
+                    <?= $block->getItemHtml($_item) ?>
+                    <?= $block->getItemExtraInfoHtml($_item->getOrderItem()) ?>
+                </tbody>
+            <?php endif; ?>
         <?php endforeach; ?>
     </table>
 </div>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22687
### Description (*)
Shipment Create via API salesShipmentRepositoryV1 throw Fatal error in Admin Order -> Shipment -> View

### Fixed Issues (if relevant)
1. magento/magento2#22686: Shipment Create via API salesShipmentRepositoryV1 throw Fatal error in Admin Order -> Shipment -> View

### Manual testing scenarios (*)
1. see magento/magento2#22686

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
