### PR TITLE
[Backport] #23053 : sendfriend verifies product visibility instead of status

### DIFF
--- a/app/code/Magento/SendFriend/Controller/Product.php
+++ b/app/code/Magento/SendFriend/Controller/Product.php
@@ -102,7 +102,7 @@ abstract class Product extends \Magento\Framework\App\Action\Action
         }
         try {
             $product = $this->productRepository->getById($productId);
-            if (!$product->isVisibleInCatalog()) {
+            if (!$product->isVisibleInSiteVisibility() || !$product->isVisibleInCatalog()) {
                 return false;
             }
         } catch (NoSuchEntityException $noEntityException) {

--- a/app/code/Magento/SendFriend/Test/Unit/Controller/Product/SendTest.php
+++ b/app/code/Magento/SendFriend/Test/Unit/Controller/Product/SendTest.php
@@ -104,7 +104,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
 
         /** @var \Magento\Catalog\Api\Data\ProductInterface|\PHPUnit_Framework_MockObject_MockObject $productMock */
         $productMock = $this->getMockBuilder(\Magento\Catalog\Api\Data\ProductInterface::class)
-            ->setMethods(['isVisibleInCatalog'])
+            ->setMethods(['isVisibleInCatalog', 'isVisibleInSiteVisibility'])
             ->getMockForAbstractClass();
 
         $this->productRepositoryMock->expects($this->once())
@@ -114,6 +114,10 @@ class SendTest extends \PHPUnit\Framework\TestCase
 
         $productMock->expects($this->once())
             ->method('isVisibleInCatalog')
+            ->willReturn(true);
+
+        $productMock->expects($this->once())
+            ->method('isVisibleInSiteVisibility')
             ->willReturn(true);
 
         $this->registryMock->expects($this->once())
@@ -193,7 +197,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
 
         /** @var \Magento\Catalog\Api\Data\ProductInterface|\PHPUnit_Framework_MockObject_MockObject $productMock */
         $productMock = $this->getMockBuilder(\Magento\Catalog\Api\Data\ProductInterface::class)
-            ->setMethods(['isVisibleInCatalog'])
+            ->setMethods(['isVisibleInCatalog', 'isVisibleInSiteVisibility'])
             ->getMockForAbstractClass();
 
         $this->productRepositoryMock->expects($this->once())
@@ -203,6 +207,10 @@ class SendTest extends \PHPUnit\Framework\TestCase
 
         $productMock->expects($this->once())
             ->method('isVisibleInCatalog')
+            ->willReturn(true);
+
+        $productMock->expects($this->once())
+            ->method('isVisibleInSiteVisibility')
             ->willReturn(true);
 
         $this->registryMock->expects($this->once())
@@ -269,7 +277,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
 
         /** @var \Magento\Catalog\Api\Data\ProductInterface|\PHPUnit_Framework_MockObject_MockObject $productMock */
         $productMock = $this->getMockBuilder(\Magento\Catalog\Api\Data\ProductInterface::class)
-            ->setMethods(['isVisibleInCatalog'])
+            ->setMethods(['isVisibleInCatalog', 'isVisibleInSiteVisibility'])
             ->getMockForAbstractClass();
 
         $this->productRepositoryMock->expects($this->once())
@@ -279,6 +287,10 @@ class SendTest extends \PHPUnit\Framework\TestCase
 
         $productMock->expects($this->once())
             ->method('isVisibleInCatalog')
+            ->willReturn(true);
+
+        $productMock->expects($this->once())
+            ->method('isVisibleInSiteVisibility')
             ->willReturn(true);
 
         $this->registryMock->expects($this->once())
@@ -391,7 +403,7 @@ class SendTest extends \PHPUnit\Framework\TestCase
 
         /** @var \Magento\Catalog\Api\Data\ProductInterface|\PHPUnit_Framework_MockObject_MockObject $productMock */
         $productMock = $this->getMockBuilder(\Magento\Catalog\Api\Data\ProductInterface::class)
-            ->setMethods(['isVisibleInCatalog'])
+            ->setMethods(['isVisibleInCatalog', 'isVisibleInSiteVisibility'])
             ->getMockForAbstractClass();
 
         $this->productRepositoryMock->expects($this->once())
@@ -402,6 +414,10 @@ class SendTest extends \PHPUnit\Framework\TestCase
         $productMock->expects($this->once())
             ->method('isVisibleInCatalog')
             ->willReturn(false);
+
+        $productMock->expects($this->once())
+            ->method('isVisibleInSiteVisibility')
+            ->willReturn(true);
 
         /** @var \Magento\Framework\Controller\Result\Forward|\PHPUnit_Framework_MockObject_MockObject $forwardMock */
         $forwardMock = $this->getMockBuilder(\Magento\Framework\Controller\Result\Forward::class)


### PR DESCRIPTION
### Description (*)
This is backport pull request.
Sendfriend feature was verifying product status only. This could cause sending a link for enabled product invisible in catalog and/or search. 

### Fixed Issues (if relevant)
1. magento/magento2#23053: Sendfriend works for products with visibility not visible individually

### Manual testing scenarios (*)
Follow steps provided in #23053

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
