### PR TITLE
Catch throwables in mview updating

### DIFF
--- a/lib/internal/Magento/Framework/Mview/View.php
+++ b/lib/internal/Magento/Framework/Mview/View.php
@@ -299,12 +299,19 @@ class View extends \Magento\Framework\DataObject implements ViewInterface
                     ? View\StateInterface::STATUS_SUSPENDED
                     : View\StateInterface::STATUS_IDLE;
                 $this->getState()->setVersionId($currentVersionId)->setStatus($statusToRestore)->save();
-            } catch (\Exception $exception) {
+            } catch (\Throwable $exception) {
                 $this->getState()->loadByView($this->getId());
                 $statusToRestore = $this->getState()->getStatus() == View\StateInterface::STATUS_SUSPENDED
                     ? View\StateInterface::STATUS_SUSPENDED
                     : View\StateInterface::STATUS_IDLE;
                 $this->getState()->setStatus($statusToRestore)->save();
+                if (!$exception instanceof \Exception) {
+                    $exception = new \RuntimeException(
+                        'Error when updating an mview',
+                        0,
+                        $exception
+                    );
+                }
                 throw $exception;
             }
         }


### PR DESCRIPTION
2.2 : https://github.com/magento/magento2/pull/23124
2.3 : https://github.com/magento/magento2/pull/23125

### Description (*)
Certain type of runtime exception weren't caught during mview updating, which caused some mview to be stuck in "processing" mode.
Refer to https://github.com/magento/magento2/issues/23054 for more detail about the issue.

This modification is very similar to the one made here : https://github.com/magento/magento2/commit/5927a75169aa5eb7a978847d22dbde5dbe3cc5a2

### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/23054 

### Manual testing scenarios (*)
- make an mview updating crash with a Throwable (not an Exception)
- process ends, mview is still in 'processing' in database
- it is never picked up again 

### Questions or comments
This does not prevent against all types of crashes (like process out of memory or server stop abruptly, so it is only a step in making indexing crons more resilient 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
