### PR TITLE
Catch throwables in mview updating

### DIFF
--- a/lib/internal/Magento/Framework/Mview/View.php
+++ b/lib/internal/Magento/Framework/Mview/View.php
@@ -277,12 +277,19 @@ class View extends DataObject implements ViewInterface
                 ? View\StateInterface::STATUS_SUSPENDED
                 : View\StateInterface::STATUS_IDLE;
             $this->getState()->setVersionId($currentVersionId)->setStatus($statusToRestore)->save();
-        } catch (Exception $exception) {
+        } catch (\Throwable $exception) {
             $this->getState()->loadByView($this->getId());
             $statusToRestore = $this->getState()->getStatus() === View\StateInterface::STATUS_SUSPENDED
                 ? View\StateInterface::STATUS_SUSPENDED
                 : View\StateInterface::STATUS_IDLE;
             $this->getState()->setStatus($statusToRestore)->save();
+            if (!$exception instanceof \Exception) {
+                $exception = new \RuntimeException(
+                    'Error when updating an mview',
+                    0,
+                    $exception
+                );
+            }
             throw $exception;
         }
     }

--- a/lib/internal/Magento/Framework/Mview/View.php
+++ b/lib/internal/Magento/Framework/Mview/View.php
@@ -4,6 +4,8 @@
  * See COPYING.txt for license details.
  */
 
+declare(strict_types=1);
+
 namespace Magento\Framework\Mview;
 
 use InvalidArgumentException;
@@ -254,23 +256,7 @@ class View extends DataObject implements ViewInterface
         try {
             $this->getState()->setStatus(View\StateInterface::STATUS_WORKING)->save();
 
-            $versionBatchSize = self::$maxVersionQueryBatch;
-            $batchSize = isset($this->changelogBatchSize[$this->getChangelog()->getViewId()])
-                ? $this->changelogBatchSize[$this->getChangelog()->getViewId()]
-                : self::DEFAULT_BATCH_SIZE;
-
-            for ($vsFrom = $lastVersionId; $vsFrom < $currentVersionId; $vsFrom += $versionBatchSize) {
-                // Don't go past the current version for atomicy.
-                $versionTo = min($currentVersionId, $vsFrom + $versionBatchSize);
-                $ids = $this->getChangelog()->getList($vsFrom, $versionTo);
-
-                // We run the actual indexer in batches.
-                // Chunked AFTER loading to avoid duplicates in separate chunks.
-                $chunks = array_chunk($ids, $batchSize);
-                foreach ($chunks as $ids) {
-                    $action->execute($ids);
-                }
-            }
+            $this->executeAction($action, $lastVersionId, $currentVersionId);
 
             $this->getState()->loadByView($this->getId());
             $statusToRestore = $this->getState()->getStatus() === View\StateInterface::STATUS_SUSPENDED
@@ -291,6 +277,36 @@ class View extends DataObject implements ViewInterface
                 );
             }
             throw $exception;
+        }
+    }
+
+    /**
+     * Execute action from last version to current version, by batches
+     *
+     * @param ActionInterface $action
+     * @param int $lastVersionId
+     * @param int $currentVersionId
+     * @return void
+     * @throws \Exception
+     */
+    private function executeAction(ActionInterface $action, int $lastVersionId, int $currentVersionId)
+    {
+        $versionBatchSize = self::$maxVersionQueryBatch;
+        $batchSize = isset($this->changelogBatchSize[$this->getChangelog()->getViewId()])
+            ? $this->changelogBatchSize[$this->getChangelog()->getViewId()]
+            : self::DEFAULT_BATCH_SIZE;
+
+        for ($vsFrom = $lastVersionId; $vsFrom < $currentVersionId; $vsFrom += $versionBatchSize) {
+            // Don't go past the current version for atomicity.
+            $versionTo = min($currentVersionId, $vsFrom + $versionBatchSize);
+            $ids = $this->getChangelog()->getList($vsFrom, $versionTo);
+
+            // We run the actual indexer in batches.
+            // Chunked AFTER loading to avoid duplicates in separate chunks.
+            $chunks = array_chunk($ids, $batchSize);
+            foreach ($chunks as $ids) {
+                $action->execute($ids);
+            }
         }
     }
 


### PR DESCRIPTION
2.2 : https://github.com/magento/magento2/pull/23124
2.3 : https://github.com/magento/magento2/pull/23125

### Description
Certain type of runtime exception weren't caught during mview updating, which caused some mview to be stuck in "processing" mode.
Refer to https://github.com/magento/magento2/issues/23054 for more detail about the issue.

This modification is very similar to the one made here : https://github.com/magento/magento2/commit/5927a75169aa5eb7a978847d22dbde5dbe3cc5a2

### Fixed Issues
https://github.com/magento/magento2/issues/23054

### Manual testing scenarios
make an mview updating crash with a Throwable (not an Exception)
process ends, mview is still in 'processing' in database
it is never picked up again

### Questions or comments
This does not prevent against all types of crashes (like process out of memory or server stop abruptly, so it is only a step in making indexing crons more resilient

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
