### PR TITLE
Fixed wrong module name in no route handler

### DIFF
--- a/lib/internal/Magento/Framework/App/Router/NoRouteHandler.php
+++ b/lib/internal/Magento/Framework/App/Router/NoRouteHandler.php
@@ -7,23 +7,20 @@
  */
 namespace Magento\Framework\App\Router;
 
-use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\App\RequestInterface;
-
 /**
  * Default no route handler for frontend
  */
-class NoRouteHandler implements NoRouteHandlerInterface
+class NoRouteHandler implements \Magento\Framework\App\Router\NoRouteHandlerInterface
 {
     /**
-     * @var ScopeConfigInterface
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     protected $_config;
 
     /**
-     * @param ScopeConfigInterface $config
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $config
      */
-    public function __construct(ScopeConfigInterface $config)
+    public function __construct(\Magento\Framework\App\Config\ScopeConfigInterface $config)
     {
         $this->_config = $config;
     }
@@ -31,10 +28,11 @@ class NoRouteHandler implements NoRouteHandlerInterface
     /**
      * Check and process no route request
      *
-     * @param RequestInterface $request
+     * @param \Magento\Framework\App\RequestInterface $request
      * @return bool
+     * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function process(RequestInterface $request)
+    public function process(\Magento\Framework\App\RequestInterface $request)
     {
         $noRoutePath = $this->_config->getValue('web/default/no_route', 'default');
 
@@ -44,9 +42,9 @@ class NoRouteHandler implements NoRouteHandlerInterface
             $noRoute = [];
         }
 
-        $moduleName = $noRoute[0] ?? 'cms';
-        $actionPath = $noRoute[1] ?? 'index';
-        $actionName = $noRoute[2] ?? 'index';
+        $moduleName = isset($noRoute[0]) ? $noRoute[0] : 'cms';
+        $actionPath = isset($noRoute[1]) ? $noRoute[1] : 'index';
+        $actionName = isset($noRoute[2]) ? $noRoute[2] : 'index';
 
         $request->setModuleName($moduleName)->setControllerName($actionPath)->setActionName($actionName);
 

--- a/lib/internal/Magento/Framework/App/Router/NoRouteHandler.php
+++ b/lib/internal/Magento/Framework/App/Router/NoRouteHandler.php
@@ -7,17 +7,20 @@
  */
 namespace Magento\Framework\App\Router;
 
-class NoRouteHandler implements \Magento\Framework\App\Router\NoRouteHandlerInterface
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\RequestInterface;
+
+class NoRouteHandler implements NoRouteHandlerInterface
 {
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     * @var ScopeConfigInterface
      */
     protected $_config;
 
     /**
-     * @param \Magento\Framework\App\Config\ScopeConfigInterface $config
+     * @param ScopeConfigInterface $config
      */
-    public function __construct(\Magento\Framework\App\Config\ScopeConfigInterface $config)
+    public function __construct(ScopeConfigInterface $config)
     {
         $this->_config = $config;
     }
@@ -25,11 +28,10 @@ class NoRouteHandler implements \Magento\Framework\App\Router\NoRouteHandlerInte
     /**
      * Check and process no route request
      *
-     * @param \Magento\Framework\App\RequestInterface $request
+     * @param RequestInterface $request
      * @return bool
-     * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function process(\Magento\Framework\App\RequestInterface $request)
+    public function process(RequestInterface $request)
     {
         $noRoutePath = $this->_config->getValue('web/default/no_route', 'default');
 
@@ -39,9 +41,9 @@ class NoRouteHandler implements \Magento\Framework\App\Router\NoRouteHandlerInte
             $noRoute = [];
         }
 
-        $moduleName = isset($noRoute[0]) ? $noRoute[0] : 'core';
-        $actionPath = isset($noRoute[1]) ? $noRoute[1] : 'index';
-        $actionName = isset($noRoute[2]) ? $noRoute[2] : 'index';
+        $moduleName = $noRoute[0] ?? 'cms';
+        $actionPath = $noRoute[1] ?? 'index';
+        $actionName = $noRoute[2] ?? 'index';
 
         $request->setModuleName($moduleName)->setControllerName($actionPath)->setActionName($actionName);
 

--- a/lib/internal/Magento/Framework/App/Router/NoRouteHandler.php
+++ b/lib/internal/Magento/Framework/App/Router/NoRouteHandler.php
@@ -10,6 +10,9 @@ namespace Magento\Framework\App\Router;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\RequestInterface;
 
+/**
+ * Default no route handler for frontend
+ */
 class NoRouteHandler implements NoRouteHandlerInterface
 {
     /**

--- a/lib/internal/Magento/Framework/App/Test/Unit/Router/NoRouteHandlerTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Router/NoRouteHandlerTest.php
@@ -8,6 +8,9 @@
 
 namespace Magento\Framework\App\Test\Unit\Router;
 
+/**
+ * Test for default no route handler
+ */
 class NoRouteHandlerTest extends \Magento\Framework\TestFramework\Unit\BaseTestCase
 {
     /**

--- a/lib/internal/Magento/Framework/App/Test/Unit/Router/NoRouteHandlerTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Router/NoRouteHandlerTest.php
@@ -76,7 +76,7 @@ class NoRouteHandlerTest extends \Magento\Framework\TestFramework\Unit\BaseTestC
         // Set expectations
         $this->requestMock->expects($this->once())
             ->method('setModuleName')
-            ->with('core')
+            ->with('cms')
             ->willReturnSelf();
         $this->requestMock->expects($this->once())
             ->method('setControllerName')


### PR DESCRIPTION
### Fixed wrong module name in default no route handler
The PR fixes a bug in frontend no route handler, when configuration value **web/default/no_route** is empty.

### Manual testing scenarios
1. Clean **web/default/no_route** configuration value through backend: Stores -> Configuration -> General tab -> Web -> Default Pages -> Default No-route URL.
2. Try to request any nonexistent page on frontend.

### Expected result
The system does not find no route default value in configuration and forwards to homepage.

### Actual result
`Exception #0 (LogicException): Front controller reached 100 router match iterations`

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
