### PR TITLE
SenderBuilder now implements TransportBuilder as a factory

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Email/SenderBuilder.php
+++ b/app/code/Magento/Sales/Model/Order/Email/SenderBuilder.php
@@ -50,7 +50,9 @@ class SenderBuilder
         $this->templateContainer = $templateContainer;
         $this->identityContainer = $identityContainer;
         $this->transportBuilder = $transportBuilder;
-        $this->transportBuilderFactory = $transportBuilderFactory ? $transportBuilderFactory : \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Framework\Mail\Template\TransportBuilderFactory::class);
+        $this->transportBuilderFactory = $transportBuilderFactory
+          ? $transportBuilderFactory
+          : \Magento\Framework\App\ObjectManager::getInstance()->get(TransportBuilderFactory::class);
     }
 
     /**
@@ -72,7 +74,7 @@ class SenderBuilder
     public function send()
     {
         $this->resetTransportBuilder();
-
+        
         $this->configureEmailTemplate();
 
         $this->transportBuilder->addTo(
@@ -104,7 +106,7 @@ class SenderBuilder
         if (!empty($copyTo) && $this->identityContainer->getCopyMethod() == 'copy') {
             foreach ($copyTo as $email) {
                 $this->resetTransportBuilder();
-                
+
                 $this->configureEmailTemplate();
 
                 $this->transportBuilder->addTo($email);


### PR DESCRIPTION
### Description (*)
The SenderBuilder class now implements the TransportBuilder as a factory rather than a singleton to prevent the possibility of customer data persisting and leaking, as it was previously reliant on a specific execution path to reset the state in between uses.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23122 : Error handling causes customer data leak

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
