### PR TITLE
Fix for item quantity value in transactional emails when partially or fully canceled

### DIFF
--- a/app/code/Magento/Sales/view/frontend/templates/email/items/order/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/order/default.phtml
@@ -32,7 +32,7 @@ $_order = $_item->getOrder();
         <?php endif; ?>
         <?= $block->escapeHtml($_item->getDescription()) ?>
     </td>
-    <td class="item-qty"><?= /* @escapeNotVerified */  $_item->getQtyOrdered() * 1 ?></td>
+    <td class="item-qty"><?= /* @escapeNotVerified */  ($_item->getQtyOrdered() * 1) - ($_item->getQtyCanceled() * 1) ?></td>
     <td class="item-price">
         <?= /* @escapeNotVerified */  $block->getItemPrice($_item) ?>
     </td>

--- a/vendor/magento/module-sales/view/frontend/templates/email/items/order/default.phtml
+++ b/vendor/magento/module-sales/view/frontend/templates/email/items/order/default.phtml
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+// @codingStandardsIgnoreFile
+
+/** @var $block \Magento\Sales\Block\Order\Email\Items\DefaultItems */
+
+/** @var $_item \Magento\Sales\Model\Order\Item */
+$_item = $block->getItem();
+$_order = $_item->getOrder();
+?>
+<tr>
+    <td class="item-info<?php if ($block->getItemOptions()): ?> has-extra<?php endif; ?>">
+        <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
+        <p class="sku"><?= /* @escapeNotVerified */  __('SKU') ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
+        <?php if ($block->getItemOptions()): ?>
+            <dl class="item-options">
+                <?php foreach ($block->getItemOptions() as $option): ?>
+                    <dt><strong><em><?= /* @escapeNotVerified */  $option['label'] ?></em></strong></dt>
+                    <dd>
+                        <?= /* @escapeNotVerified */  nl2br($option['value']) ?>
+                    </dd>
+                <?php endforeach; ?>
+            </dl>
+        <?php endif; ?>
+        <?php $addInfoBlock = $block->getProductAdditionalInformationBlock(); ?>
+        <?php if ($addInfoBlock) :?>
+            <?= $addInfoBlock->setItem($_item)->toHtml() ?>
+        <?php endif; ?>
+        <?= $block->escapeHtml($_item->getDescription()) ?>
+    </td>
+    <td class="item-qty"><?= /* @escapeNotVerified */  ($_item->getQtyOrdered() * 1) - ($_item->getQtyCanceled() * 1) ?></td>
+    <td class="item-price">
+        <?= /* @escapeNotVerified */  $block->getItemPrice($_item) ?>
+    </td>
+</tr>
+<?php if ($_item->getGiftMessageId() && $_giftMessage = $this->helper('Magento\GiftMessage\Helper\Message')->getGiftMessage($_item->getGiftMessageId())): ?>
+    <tr>
+        <td colspan="3" class="item-extra">
+            <table class="message-gift">
+                <tr>
+                    <td>
+                        <h3><?= /* @escapeNotVerified */  __('Gift Message') ?></h3>
+                        <strong><?= /* @escapeNotVerified */  __('From:') ?></strong> <?= $block->escapeHtml($_giftMessage->getSender()) ?>
+                        <br /><strong><?= /* @escapeNotVerified */  __('To:') ?></strong> <?= $block->escapeHtml($_giftMessage->getRecipient()) ?>
+                        <br /><strong><?= /* @escapeNotVerified */  __('Message:') ?></strong>
+                        <br /><?= $block->escapeHtml($_giftMessage->getMessage()) ?>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+<?php endif; ?>


### PR DESCRIPTION
### Description (*)
When you partially or fully cancel items from order then the wrong item quantity is shown in transactionals emails. The price is correct but the quantity is not. This fix adjust item quantity to correct amount in all transactional emails that uses layout handle "sales_email_order_items".

### Manual testing scenarios (*)
1. Create order with multiple items with 1 or more quantity
2. Cancel some items fully or cancel some items partially
3. Send order email from admin (or programatically) and you'll get original item quantity despite being canceled.

### Questions or comments
Affected line is 35 changed from 
`<td class="item-qty"><?= /* @escapeNotVerified */  $_item->getQtyOrdered() * 1) ?></td>`
to
`<td class="item-qty"><?= /* @escapeNotVerified */  ($_item->getQtyOrdered() * 1) - ($_item->getQtyCanceled() * 1) ?></td>`

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
