### PR TITLE
[Backport] Fix missing whitespace in mobile navigation for non-English websites

### DIFF
--- a/lib/web/mage/menu.js
+++ b/lib/web/mage/menu.js
@@ -464,7 +464,7 @@ define([
 
                 this.categoryLink = $('<a>')
                     .attr('href', categoryUrl)
-                    .text($.mage.__('All ') + category);
+                    .text($.mage.__('All %1').replace('%1', category));
 
                 this.categoryParent = $('<li>')
                     .addClass('ui-menu-item all-category')


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/23081
These changes fixes issue with missing whitespace  which happens on websites that using non-default (en_US) locale. 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #23080


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
