### PR TITLE
Fix 22085

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
@@ -16,6 +16,10 @@
 @swatch-option__hover__color: @color-gray20;
 @swatch-option__hover__outline: 1px solid @color-gray60;
 
+@swatch-more__hover__border: @border-width__base solid @color-white;
+@swatch-more__hover__color: @color-orange-red1;
+@swatch-more__hover__outline: 1px solid @color-gray60;
+
 @swatch-option__selected__border: @swatch-option__hover__border;
 @swatch-option__selected__color: @swatch-option__hover__color;
 @swatch-option__selected__outline: 2px solid @active__color;
@@ -318,8 +322,8 @@
         &-more {
             display: inline-block;
             margin: 2px 0;
+            padding: 2px;
             position: static;
-            text-decoration: none !important;
             z-index: 1;
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<22085>: Not focusable moreButton on Catalog page using Tab

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. You need to have a product with more than 3 swatches option
Option in
Stores -> Configuration -> Catalog / Catalog -> Swatches per Product set to 3
Show Swatches in Product List set to Yes
2.  In the products list hover on more link, now it is focusable  

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
