### PR TITLE
Fixed: wrong argument passing \DateTimeInterval to strtotime instead …

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
@@ -241,8 +241,18 @@ class Timezone implements TimezoneInterface
         }
 
         $scopeTimeStamp = $this->scopeTimeStamp($scope);
+
+        if ($dateFrom instanceof \DateTimeInterface) {
+            $dateFrom = $dateFrom->format('Y-m-d H:i:s');
+        }
+
+        if ($dateTo instanceof \DateTimeInterface) {
+            $dateTo = $dateTo->format('Y-m-d H:i:s');
+        }
+
         $fromTimeStamp = strtotime($dateFrom);
         $toTimeStamp = strtotime($dateTo);
+
         if ($dateTo) {
             // fix date YYYY-MM-DD 00:00:00 to YYYY-MM-DD 23:59:59
             $toTimeStamp += 86400;

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/TimezoneInterface.php
@@ -117,8 +117,8 @@ interface TimezoneInterface
      * Checks if current date of the given scope (in the scope timezone) is within the range
      *
      * @param int|string|\Magento\Framework\App\ScopeInterface $scope
-     * @param string|null $dateFrom
-     * @param string|null $dateTo
+     * @param string|\DateTimeInterface|null $dateFrom
+     * @param string|\DateTimeInterface|null $dateTo
      * @return bool
      */
     public function isScopeDateInInterval($scope, $dateFrom = null, $dateTo = null);


### PR DESCRIPTION
### Description
1) `strtotime` receives `string` as the argument
2) `strtotime` functions on `Magento\Framework\Stdlib\DateTime\Timezone:isScopeDateInInterval()` are handling `$dateFrom` and `$dateTo` **ONLY** as `string`. So the assumption here is that **ALL** `$dateFrom` and `$dateTo` will be passed as string.
3) *Issue:* There are certain contexts on Magento where it passes `$dateFrom` and `$dateTo` as `\DateTimeInterface` instead.
4) PHP throws a warning looking like this: `Warning: strtotime() expects parameter 1 to be string, object given in /vendor/magento/framework/Stdlib/DateTime/Timezone.php on line 273`

Solution:

```
if ($dateFrom instanceof \DateTimeInterface) {
    $dateFrom = $dateFrom->format('Y-m-d H:i:s');
}

if ($dateTo instanceof \DateTimeInterface) {
    $dateTo = $dateTo->format('Y-m-d H:i:s');
}
```

Very simple: check if it's a `\DateTimeInterface`, and if it is, convert into a string.
You can also check on the very same class (`Magento\Framework\Stdlib\DateTime\Timezone`) other methods have this `\DateTimeInterface` checking. In case the data type is already a `string` nothing will be done.

### Manual testing scenarios (*)
Stand alone way to reproduce:
```
$timezone = $om->get('Magento\Framework\Stdlib\DateTime\Timezone');

// works
$timezone->isScopeDateInInterval(0, '2019-01-01 00:00:00', '2019-12-31 23:59:59');


// does NOT work
$dateFrom = \DateTime::createFromFormat('Y-m-d H:i:s', '2019-01-01 00:00:00');
$dateTo   = \DateTime::createFromFormat('Y-m-d H:i:s', '2019-12-31 00:00:00');
$timezone->isScopeDateInInterval(0, $dateFrom, $dateTo);

// result: PHP Warning:  strtotime() expects parameter 1 to be string, object given in /var/www/magento2/vendor/magento/framework/Stdlib/DateTime/Timezone.php
```
