### PR TITLE
Magento_SendFriend module change suggestion

### DIFF
--- a/app/code/Magento/SendFriend/Helper/Data.php
+++ b/app/code/Magento/SendFriend/Helper/Data.php
@@ -33,6 +33,24 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const CHECK_IP = 1;
 
     const CHECK_COOKIE = 0;
+    
+    const XML_PATH_SENDER_EMAIL = 'trans_email/ident_support/email';
+
+ /**
+    * Get Sender Email
+    *
+    * @param int $store
+    * @return string
+    */
+
+    public function getSenderEmail($store = null)
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_SENDER_EMAIL,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
 
     /**
      * Check is enabled Module

--- a/app/code/Magento/SendFriend/Model/SendFriend.php
+++ b/app/code/Magento/SendFriend/Model/SendFriend.php
@@ -180,8 +180,8 @@ class SendFriend extends \Magento\Framework\Model\AbstractModel
 
         $message = nl2br(htmlspecialchars($this->getSender()->getMessage()));
         $sender = [
-            'name' => $this->_escaper->escapeHtml($this->getSender()->getName()),
-            'email' => $this->_escaper->escapeHtml($this->getSender()->getEmail()),
+            'name' => $this->_escaper->escapeHtml($this->getSender()->getEmail()),
+            'email' => $this->_sendfriendData->getSenderEmail(),
         ];
 
         foreach ($this->getRecipients()->getEmails() as $k => $email) {


### PR DESCRIPTION
The Magento_SendFriend implements the functionality behind the “Email to a Friend” link on a product page, which allows sharing favorite products with others by clicking the link. One of the major bottlenecks here is that Magento recommends the use of the SMTP module to successfully send and inbox inviting email, but that never works. Simply, the module-send-friend is designed to place the FROM with the Customer account or Guest account (if enabled) details. Even with all valid SMTP settings (details) this is most likely going to fail when sending emails to any popular email exchange provider like Google, Yahoo, Hotmail, Yandex or similar. At the end we don't need an SMTP module installed to make this work, just Magento module itself tweaked.

### Description (*)
I've figured that these two lines are controlling this module:
$sender = [
'name' => $this->_escaper->escapeHtml($this->getSender()->getName()),  
'email' => $this->_escaper->escapeHtml($this->getSender()->getEmail()),  
        ];

To explain. I've swapped the 'name' and 'email' places since it is not necessary to have Name field repeated twice. You can freely test this functionality of my adjusted code on my Demo/Test page https://magentocommand.ml/hanna-sweater.html by clicking on the Email icon

### Fixed Issues (if relevant)
To fix this I've updated app/code/Magento/SendFriend/Helper/Data.php and app/code/Magento/SendFriend/Model/SendFriend.php to pull the FROM record properly from the trans_email/ident_support/email (Stores --> Configuration --> Contact Address) section.

### Manual testing scenarios (*)
You can freely test this functionality of my adjusted code on my Demo/Test page https://magentocommand.ml/hanna-sweater.html by clicking on the Email icon

### Questions or comments
If you are using AmazonSES or any other popular service which enforce the policy that the FROM sender needs to be used as a domain name used this would be extremely helpful to avoid usage of the SMTP module. As I've explained previously mostly SMTP module part fails because SPF/DKIM/DMARC fails.

Sample error: 
2019-06-05 17:41:29 1hYZuj-00003b-PW ** x@xxx.xxx R=sendviases T=sessmtp H=xxxxx.com X=TLS1.2:ECDHERSAAES256GCMSHA384:256 CV=no: SMTP error from remote mail server after MAIL FROM:<> SIZE=3446: 501 Invalid MAIL FROM address provided

Once module tweak is added: 
2019-06-05 17:49:32 1hYa2W-00003k-Fp => xx@xxx.com R=sendviases T=sessmtp H=xxxx.com X=TLS1.2:ECDHERSAAES256GCMSHA384:256 CV=no A=ses_login C="250 Ok 0100016b28c2a272-2250b0bf-d310-4e2a-b8c6-615259231294-000000" 
2019-06-05 17:49:32 1hYa2W-00003k-Fp Completed

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
