### PR TITLE
Fix for item quantity value in transactional emails when partially or fully canceled

### DIFF
--- a/app/code/Magento/Sales/view/frontend/templates/email/items/order/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/order/default.phtml
@@ -32,7 +32,7 @@ $_order = $_item->getOrder();
         <?php endif; ?>
         <?= $block->escapeHtml($_item->getDescription()) ?>
     </td>
-    <td class="item-qty"><?= /* @escapeNotVerified */  $_item->getQtyOrdered() * 1 ?></td>
+    <td class="item-qty"><?= /* @escapeNotVerified */  ($_item->getQtyOrdered() * 1) - ($_item->getQtyCanceled() * 1) ?></td>
     <td class="item-price">
         <?= /* @escapeNotVerified */  $block->getItemPrice($_item) ?>
     </td>


### PR DESCRIPTION
### Description (*)
When you partially or fully cancel items from order then the wrong item quantity is shown in transactionals emails. The price is correct but the quantity is not. This fix adjust item quantity to correct amount in all transactional emails that uses layout handle "sales_email_order_items".

### Manual testing scenarios (*)
1. Create order with multiple items with 1 or more quantity
2. Cancel some items fully or cancel some items partially
3. Send order email from admin (or programatically) and you'll get original item quantity despite being canceled.

### Questions or comments
Affected line is 35 changed from 
`<td class="item-qty"><?= /* @escapeNotVerified */  $_item->getQtyOrdered() * 1) ?></td>`
to
`<td class="item-qty"><?= /* @escapeNotVerified */  ($_item->getQtyOrdered() * 1) - ($_item->getQtyCanceled() * 1) ?></td>`

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)