### PR TITLE
MFTF: Use AdminLoginActionGroup for AdminLoginTest - easiest use of ActionGroup

### DIFF
--- a/app/code/Magento/Backend/Test/Mftf/Test/AdminLoginTest.xml
+++ b/app/code/Magento/Backend/Test/Mftf/Test/AdminLoginTest.xml
@@ -21,7 +21,6 @@
         </annotations>
 
         <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
-        <closeAdminNotification stepKey="closeAdminNotification"/>
         <seeInCurrentUrl url="{{AdminLoginPage.url}}" stepKey="seeAdminLoginUrl"/>
         <actionGroup ref="logout" stepKey="logoutFromAdmin"/>
     </test>

--- a/app/code/Magento/Backend/Test/Mftf/Test/AdminLoginTest.xml
+++ b/app/code/Magento/Backend/Test/Mftf/Test/AdminLoginTest.xml
@@ -20,11 +20,9 @@
             <group value="login"/>
         </annotations>
 
-        <amOnPage url="{{AdminLoginPage.url}}" stepKey="amOnAdminLoginPage"/>
-        <fillField selector="{{AdminLoginFormSection.username}}" userInput="{{_ENV.MAGENTO_ADMIN_USERNAME}}" stepKey="fillUsername"/>
-        <fillField selector="{{AdminLoginFormSection.password}}" userInput="{{_ENV.MAGENTO_ADMIN_PASSWORD}}" stepKey="fillPassword"/>
-        <click selector="{{AdminLoginFormSection.signIn}}" stepKey="clickOnSignIn"/>
+        <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
         <closeAdminNotification stepKey="closeAdminNotification"/>
         <seeInCurrentUrl url="{{AdminLoginPage.url}}" stepKey="seeAdminLoginUrl"/>
+        <actionGroup ref="logout" stepKey="logoutFromAdmin"/>
     </test>
 </tests>


### PR DESCRIPTION
### Description (*)
I found it annoying that the easiest example of ActionGroup usage is incorrectly implemented. Decided to use AdminLoginActionGroup to AdminLoginTest case.

What is more - for me successful Admin Login should end up with successful logout, so that I added logout verification.

### Fixed Issues (if relevant)
Irrelevant

### Manual testing scenarios (*)
1. Run MFTF on AdminLoginTest

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
