### PR TITLE
Load product in default store before duplicating

### DIFF
--- a/app/code/Magento/Bundle/Controller/Adminhtml/Bundle/Product/Edit/Duplicate.php
+++ b/app/code/Magento/Bundle/Controller/Adminhtml/Bundle/Product/Edit/Duplicate.php
@@ -6,6 +6,9 @@
  */
 namespace Magento\Bundle\Controller\Adminhtml\Bundle\Product\Edit;
 
+/**
+ * @deprecated
+ */
 class Duplicate extends \Magento\Catalog\Controller\Adminhtml\Product\Duplicate
 {
 }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit.php
@@ -242,6 +242,7 @@ class Edit extends \Magento\Backend\Block\Widget
 
     /**
      * @return string
+     * @deprecated
      */
     public function getDuplicateUrl()
     {

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Duplicate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Duplicate.php
@@ -9,6 +9,9 @@ namespace Magento\Catalog\Controller\Adminhtml\Product;
 use Magento\Backend\App\Action;
 use Magento\Catalog\Controller\Adminhtml\Product;
 
+/**
+ * @deprecated
+ */
 class Duplicate extends \Magento\Catalog\Controller\Adminhtml\Product
 {
     /**

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
@@ -157,9 +157,19 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
                 );
 
                 if ($redirectBack === 'duplicate') {
-                    $product->unsetData('quantity_and_stock_status');
-                    $newProduct = $this->productCopier->copy($product);
-                    $this->checkUniqueAttributes($product);
+                    if ($product->getStoreId() === \Magento\Store\Model\Store::DEFAULT_STORE_ID) {
+                        $productToDuplicate = $product;
+                    } else {
+                        $productToDuplicate = $this->productRepository->get(
+                            $product->getSku(),
+                            false,
+                            \Magento\Store\Model\Store::DEFAULT_STORE_ID,
+                            true
+                        );
+                    }
+
+                    $productToDuplicate->unsetData('quantity_and_stock_status');
+                    $newProduct = $this->productCopier->copy($productToDuplicate);
                     $this->messageManager->addSuccessMessage(__('You duplicated the product.'));
                 }
             } catch (\Magento\Framework\Exception\LocalizedException $e) {

--- a/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/Duplicate.php
+++ b/app/code/Magento/Downloadable/Controller/Adminhtml/Downloadable/Product/Edit/Duplicate.php
@@ -6,6 +6,9 @@
  */
 namespace Magento\Downloadable\Controller\Adminhtml\Downloadable\Product\Edit;
 
+/**
+ * @deprecated
+ */
 class Duplicate extends \Magento\Catalog\Controller\Adminhtml\Product\Duplicate
 {
 }


### PR DESCRIPTION
### Description (*)
Duplicating a product will use the current scope data as default values instead of copying it from the original product.

### Fixed Issues (if relevant)
1. magento/magento2#15656: Duplicate product

### Manual testing scenarios (*)
1. Create product with different values in different StoreViews (e.g StoreView UK, NL, DE, ...)
2. Open product and select one StoreView (e.g. UK - not "All StoreViews"!)
3. Click on "Save product & duplicate"

### Questions or comments
Not really happy with reloading the product while we have it already as method parameter. Maybe deprecate the `copy()` method and create a `copyBySku()` method?

Will update tests if implementation is approved by Magento.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
