### PR TITLE
Fixed #23213 Static content deploy showing percentage symbol two times in progress bar

### DIFF
--- a/app/code/Magento/Deploy/Console/ConsoleLogger.php
+++ b/app/code/Magento/Deploy/Console/ConsoleLogger.php
@@ -271,7 +271,7 @@ class ConsoleLogger extends AbstractLogger
         return "{$title}{$titlePad}"
         . "{$count}{$countPad}"
         . "{$this->renderBar($output, $process)} "
-        . "{$percent}%{$percentPad}"
+        . "{$percent}{$percentPad}"
         . "{$process['elapsed']}   ";
     }
 


### PR DESCRIPTION
### Fixed Issues (if relevant)
Fixed #23213 Static content deploy showing percentage(%) two times in progress bar

### Preconditions (*)
1. Magento version -> 2.2.x / 2.3.x

### Steps to reproduce (*)
. Run static deploy command -> php bin/magento setup:static-content:deploy -f

### Expected result (*)
1. Only one percentage(%) sign must be shown in progress bar.

### Actual result (*)
1.See screenshot
 ![Screenshot](https://user-images.githubusercontent.com/25526499/59307152-7e76d200-8cbb-11e9-9dba-412044a7cecb.png)
2. Percentage(%) sign is showing two times in progress bar.
