### PR TITLE
Fixed #22266: 404 message for product alerts when not logged in

### DIFF
--- a/app/code/Magento/ProductAlert/Controller/Add/Price.php
+++ b/app/code/Magento/ProductAlert/Controller/Add/Price.php
@@ -6,7 +6,7 @@
 
 namespace Magento\ProductAlert\Controller\Add;
 
-use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\ProductAlert\Controller\Add as AddController;
 use Magento\Framework\App\Action\Context;
 use Magento\Customer\Model\Session as CustomerSession;
@@ -20,7 +20,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 /**
  * Controller for notifying about price.
  */
-class Price extends AddController implements HttpPostActionInterface
+class Price extends AddController implements HttpGetActionInterface
 {
     /**
      * @var \Magento\Store\Model\StoreManagerInterface

--- a/app/code/Magento/ProductAlert/Controller/Add/Stock.php
+++ b/app/code/Magento/ProductAlert/Controller/Add/Stock.php
@@ -6,7 +6,7 @@
 
 namespace Magento\ProductAlert\Controller\Add;
 
-use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\ProductAlert\Controller\Add as AddController;
 use Magento\Framework\App\Action\Context;
 use Magento\Customer\Model\Session as CustomerSession;
@@ -19,7 +19,7 @@ use Magento\Store\Model\StoreManagerInterface;
 /**
  * Controller for notifying about stock.
  */
-class Stock extends AddController implements HttpPostActionInterface
+class Stock extends AddController implements HttpGetActionInterface
 {
     /**
      * @var \Magento\Catalog\Api\ProductRepositoryInterface

--- a/app/code/Magento/ProductAlert/view/frontend/templates/product/view.phtml
+++ b/app/code/Magento/ProductAlert/view/frontend/templates/product/view.phtml
@@ -6,7 +6,7 @@
 ?>
 <?php /* @var $block \Magento\ProductAlert\Block\Product\View */?>
 <div class="product alert <?= $block->getHtmlClass() ?>">
-    <a href="#" data-post='<?= /* @noEscape */ $block->getPostAction() ?>'
+    <a href="<?= $block->escapeUrl($block->getSignupUrl()) ?>"
        title="<?= $block->escapeHtml(__($block->getSignupLabel())) ?>" class="action alert">
         <?= $block->escapeHtml(__($block->getSignupLabel())) ?>
     </a>


### PR DESCRIPTION
### Description (*)
When the user isn't logged in and presses the product alert link
(either stock or price), the user has to login and gets redirected
to a 404 page. This is because the redirect done by the login page
is a `GET` call. The fix done is to change the used interface for
the product alerts from `POST` to `GET`, as this is the easy fix and
there's no reason to use `POST` here at this moment, as all parameters
for the call are all in get URL parameters.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22266: Product Alert after login shows 404 page

### Manual testing scenarios (*)
1. Create a product in the Magento backend and ensure it's not in stock
2. Make sure you enable stock and/or price alerts in the configuration and clean the config and full page cache
3. Go to the frontend of the webshop and ensure you're not logged in
4. Go to the newly created product
5. Click the stock alert link and/or the price alert link
6. Login or create an account here
7. Ensure the product is added to the stock/price alerts of the current customer account

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
