### PR TITLE
[Backport] Fix retrieving remote address when Magento behind reverse proxy

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -174,6 +174,13 @@
     <preference for="Magento\Framework\View\Element\Message\InterpretationStrategyInterface" type="Magento\Framework\View\Element\Message\InterpretationMediator" />
     <preference for="Magento\Framework\Indexer\Config\DependencyInfoProviderInterface" type="Magento\Framework\Indexer\Config\DependencyInfoProvider" />
     <preference for="Magento\Framework\Search\Request\IndexScopeResolverInterface" type="Magento\Framework\Indexer\ScopeResolver\IndexScopeResolver"/>
+    <type name="Magento\Framework\HTTP\PhpEnvironment\RemoteAddress">
+        <arguments>
+            <argument name="alternativeHeaders" xsi:type="array">
+                <item name="x-forwarded-for" xsi:type="string">HTTP_X_FORWARDED_FOR</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\Framework\Model\ResourceModel\Db\TransactionManager" shared="false" />
     <type name="Magento\Framework\Acl\Data\Cache">
         <arguments>


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/23219

### Description (*)
Add `X-Forwarded-For` header to list of alternate headers for getting remote address.
This is default header that common used by well known reverse proxies like nginx, apache, varnish and many services.

More info: https://dev98.de/2017/01/02/how-to-add-alternative-http-headers-to-magento-2/

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Setup Magento with reverse proxy, nginx for instance
2. Try to get client IP address using following method: `\Magento\Framework\HTTP\PhpEnvironment\RemoteAddress::getRemoteAddress`

**Actual result:**
Retrieved address - IP address of reverse proxy

**Expected result:**
Retrieved address - client's IP address

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
