### PR TITLE
Fixed 23230 : Sticky header floating under top when there is no buttons in the toolbar

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/toolbar.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/toolbar.js
@@ -271,6 +271,7 @@ define([
          */
         show: function () {
             this.visible = true;
+            //Check admin grid button has addedr not
             if($('.page-main-actions').length === 0) {
                 this.$sticky.style.top = 0;
             }

--- a/app/code/Magento/Ui/view/base/web/js/grid/toolbar.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/toolbar.js
@@ -271,7 +271,9 @@ define([
          */
         show: function () {
             this.visible = true;
-
+            if($('.page-main-actions').length === 0) {
+                this.$sticky.style.top = 0;
+            }
             this.$sticky.style.display = '';
             this.$toolbar.style.visibility = 'hidden';
 

--- a/app/code/Magento/Ui/view/base/web/js/grid/toolbar.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/toolbar.js
@@ -272,7 +272,7 @@ define([
         show: function () {
             this.visible = true;
             //Check admin grid button has addedr not
-            if($('.page-main-actions').length === 0) {
+            if ($('.page-main-actions').length === 0) {
                 this.$sticky.style.top = 0;
             }
             this.$sticky.style.display = '';


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Admin grid Sticky header is not showing properly when we remove the primary button from the admin grid 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23230: Sticky header floating under top when there is no buttons in the toolbar

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.Create listing grid without "button" node:
```
<listing ...>
    <settings>
        <!--<buttons></buttons>-->
    </settings>
</listing>
```
2.Set listingToolbar Sticky value:
```
<listing>
    <listingToolbar>
        <settings>
            <sticky>true</sticky>
        </settings>
    </listingToolbar>
</listing>
```
3. Open admin grid page and scroll down for toolbar sticking to top

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
