### PR TITLE
Fixed #23238 Apply button act like remove button while create new order from admin

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/coupons/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/coupons/form.phtml
@@ -17,8 +17,10 @@
 <div class="admin__field field-apply-coupon-code">
     <label class="admin__field-label"><span><?= /* @escapeNotVerified */ __('Apply Coupon Code') ?></span></label>
     <div class="admin__field-control">
+        <?php if (!$block->getCouponCode()): ?>
         <input type="text" class="admin__control-text" id="coupons:code" value="" name="coupon_code" />
         <?= $block->getButtonHtml(__('Apply'), 'order.applyCoupon($F(\'coupons:code\'))') ?>
+        <?php endif; ?>
         <?php if ($block->getCouponCode()): ?>
         <p class="added-coupon-code">
             <span><?= $block->escapeHtml($block->getCouponCode()) ?></span>


### PR DESCRIPTION
Fixed #23238 Apply button act like remove button while create new order from admin

### Preconditions (*)
magento 2.3

### Steps to reproduce (*)
1. Go to Admin -> Create New Order 
3. Select customer and add product
4. Apply valid coupon
5. Now click apply button again

### Expected result (*)
Coupon should not be removed.

### Actual result (*)
![apply button issue](https://user-images.githubusercontent.com/50658701/59430556-301f1b80-8e00-11e9-9404-7db0df5d5116.jpg)