### PR TITLE
Fix cms block save for specified store view, when another block with same ID is saved for 'All Store Views'

### DIFF
--- a/app/code/Magento/Cms/Model/ResourceModel/Block.php
+++ b/app/code/Magento/Cms/Model/ResourceModel/Block.php
@@ -185,12 +185,10 @@ class Block extends AbstractDb
         $entityMetadata = $this->metadataPool->getMetadata(BlockInterface::class);
         $linkField = $entityMetadata->getLinkField();
 
-        $stores = (array)$object->getData('store_id');
-        $isDefaultStore = $this->_storeManager->isSingleStoreMode()
-            || array_search(Store::DEFAULT_STORE_ID, $stores) !== false;
-
-        if (!$isDefaultStore) {
-            $stores[] = Store::DEFAULT_STORE_ID;
+        if ($this->_storeManager->isSingleStoreMode()) {
+            $stores = [Store::DEFAULT_STORE_ID];
+        } else {
+            $stores = (array)$object->getData('store_id');
         }
 
         $select = $this->getConnection()->select()
@@ -200,11 +198,8 @@ class Block extends AbstractDb
                 'cb.' . $linkField . ' = cbs.' . $linkField,
                 []
             )
-            ->where('cb.identifier = ?  ', $object->getData('identifier'));
-
-        if (!$isDefaultStore) {
-            $select->where('cbs.store_id IN (?)', $stores);
-        }
+            ->where('cb.identifier = ?', $object->getData('identifier'))
+            ->where('cbs.store_id IN (?)', $stores);
 
         if ($object->getId()) {
             $select->where('cb.' . $entityMetadata->getIdentifierField() . ' <> ?', $object->getId());


### PR DESCRIPTION
### Description

Since Magento 2.3.1 I'm not able to save CMS block when another block with the same ID is saved for 'All store views'.

### Manual testing scenarios
1. Create a CMS block `test` for 'All Store Views'
2. Try to create another one `test` for specific store view only
3. An error will be shown: "A block identifier with the same properties already exists in the selected store."

### Questions or comments

This PR is just a git revert of the following commit: https://github.com/magento/magento2/commit/1f743bd7fdf8147a80630fbd8f37a2cd53ee4d49

If someone knows what was this commit about I'll be glad to fix it properly.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
