### PR TITLE
Add filter index for ID column in adminhtml user grid

### DIFF
--- a/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_grid_block.xml
+++ b/app/code/Magento/User/view/adminhtml/layout/adminhtml_user_grid_block.xml
@@ -36,6 +36,7 @@
                             <argument name="index" xsi:type="string">user_id</argument>
                             <argument name="column_css_class" xsi:type="string">col-id</argument>
                             <argument name="header_css_class" xsi:type="string">col-id</argument>
+                            <argument name="filter_index" xsi:type="string">main_table.user_id</argument>
                         </arguments>
                     </block>
                     <block class="Magento\Backend\Block\Widget\Grid\Column" name="permission.user.grid.columnSet.username" as="username">


### PR DESCRIPTION
### Description (*)
Add filter index for ID column in adminhtml user grid.

### Fixed Issues (if relevant)
1. magento/magento2#23266: Cannot filter admin user by ID

### Manual testing scenarios (*)
1. Filter admin user grid (System > All Users) by ID.

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
