### PR TITLE
hide or show the select for regions instead of enabling/disabling in customer registration

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
@@ -157,7 +157,7 @@ define([
                 regionInput = $(this.options.regionInputId),
                 postcode = $(this.options.postcodeId),
                 label = regionList.parent().siblings('label'),
-                requiredLabel = regionList.parents('div.field');
+                container = regionList.parents('div.field');
 
             this._clearError();
             this._checkRegionRequired(country);
@@ -181,15 +181,16 @@ define([
 
                 if (this.options.isRegionRequired) {
                     regionList.addClass('required-entry').removeAttr('disabled');
-                    requiredLabel.addClass('required');
+                    container.addClass('required').show();
                 } else {
                     regionList.removeClass('required-entry validate-select').removeAttr('data-validate');
-                    requiredLabel.removeClass('required');
+                    container.removeClass('required');
 
                     if (!this.options.optionalRegionAllowed) { //eslint-disable-line max-depth
-                        regionList.attr('disabled', 'disabled');
+                        regionList.hide();
+                        container.hide();
                     } else {
-                        regionList.removeAttr('disabled');
+                        regionList.show();
                     }
                 }
 
@@ -201,12 +202,13 @@ define([
 
                 if (this.options.isRegionRequired) {
                     regionInput.addClass('required-entry').removeAttr('disabled');
-                    requiredLabel.addClass('required');
+                    container.addClass('required').show();
                 } else {
                     if (!this.options.optionalRegionAllowed) { //eslint-disable-line max-depth
                         regionInput.attr('disabled', 'disabled');
+                        container.hide();
                     }
-                    requiredLabel.removeClass('required');
+                    container.removeClass('required');
                     regionInput.removeClass('required-entry');
                 }
 


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
If you set the state options in Stores -> Configuration -> General -> General -> State Options and enable  the address fields for customer registration the behaviour in the frontend differs from the behaviour in the checkout. 
In the checkout the options are hidden if state is not required and not optional on the customer registration the dropdown is displayed but disabled.
This change should bring the customer registration more inline with the checkout behaviour.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. enable address input in customer registration:

`mytheme/src/Magento_Customer/layout/customer_account_create.xml`

    <?xml version="1.0"?>
    <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
        <body>
            <referenceBlock name="customer_form_register">
                <arguments>
                    <argument name="show_address_fields" xsi:type="boolean">true</argument>
                </arguments>
            </referenceBlock>
        </body>
    </page>

2. Go to customer registration `https://example.com/customer/account/create/`
Use country select to swap between countries that have states required and states that have not
The dropdown for regions will swap between enabled and disabled state. 

Do the same in checkout, there the dropdown hides / shows

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
