### PR TITLE
Made version compare logic work as documented for declarative patches

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Patch/PatchBackwardCompatability.php
+++ b/lib/internal/Magento/Framework/Setup/Patch/PatchBackwardCompatability.php
@@ -41,7 +41,7 @@ class PatchBackwardCompatability
     {
         $dbVersion = (string) $this->moduleResource->getDataVersion($moduleName);
         return in_array(PatchVersionInterface::class, class_implements($patchClassName)) &&
-            version_compare(call_user_func([$patchClassName, 'getVersion']), $dbVersion) <= 0;
+            version_compare(call_user_func([$patchClassName, 'getVersion']), $dbVersion) < 0;
     }
 
     /**
@@ -55,6 +55,6 @@ class PatchBackwardCompatability
     {
         $dbVersion = (string) $this->moduleResource->getDbVersion($moduleName);
         return in_array(PatchVersionInterface::class, class_implements($patchClassName)) &&
-            version_compare(call_user_func([$patchClassName, 'getVersion']), $dbVersion) <= 0;
+            version_compare(call_user_func([$patchClassName, 'getVersion']), $dbVersion) < 0;
     }
 }

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/Patch/PatchApplierTest.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/Patch/PatchApplierTest.php
@@ -200,7 +200,7 @@ class PatchApplierTest extends \PHPUnit\Framework\TestCase
                     \SomeDataPatch::class,
                     \OtherDataPatch::class
                 ],
-                'moduleVersionInDb' => null,
+                'moduleVersionInDb' => '2.0.0',
             ],
         ];
     }


### PR DESCRIPTION
### Description (*)
In the [documentation for declarative patches](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/declarative-schema/data-patches.html#will-old-scripts-work-in-newer-versions) it's mentioned that we can use `PatchVersionInterface` and the method `getVersion` to make sure a patch runs only when a matching module version is installed/upgraded to.

> This interface allows you to specify the setup version of the module in your database. If the version of the module is higher than the version specified in your patch, then the patch is skipped. If the version in the database is equal or lower, then the patch installs.

However, a patch is currently skipped if its version is equal to the module version which goes against what the documentation, quoted above, mentions.

To fix it I removed the `=` from the comparison operator.

### Manual testing scenarios (*)
1. Add a logger to `Magento\Framework\Setup\Patch\PatchApplier::applyDataPatch` on line 146 to check if the process reaches this line
2. In your/a module, create a data patch class that implements `Magento\Framework\Setup\Patch\PatchVersionInterface`
3. Add the `getVersion` method to your patch class and have it return a version equal to the current module version in your database
4. Run `bin/magento setup:upgrade`
5. The patch should pass over the if-statement on line 142 to allow it to be applied, and this can be confirmed by verifying that your added logger was called

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)