### PR TITLE
Fix 19293 & 20434 - Create URL rewrites for all product visibilities

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/Products/AdaptUrlRewritesToVisibilityAttribute.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Products/AdaptUrlRewritesToVisibilityAttribute.php
@@ -18,7 +18,9 @@ use Magento\UrlRewrite\Model\UrlPersistInterface;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 
 /**
- *  Save/Delete UrlRewrites by Product ID's and visibility
+ * Save/Delete UrlRewrites by Product ID's and visibility
+ *
+ * @deprecated
  */
 class AdaptUrlRewritesToVisibilityAttribute
 {

--- a/app/code/Magento/CatalogUrlRewrite/Model/Products/AdaptUrlRewritesToVisibilityAttribute.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Products/AdaptUrlRewritesToVisibilityAttribute.php
@@ -20,7 +20,7 @@ use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 /**
  * Save/Delete UrlRewrites by Product ID's and visibility
  *
- * @deprecated
+ * @deprecated URL rewrites will be created for all products.
  */
 class AdaptUrlRewritesToVisibilityAttribute
 {

--- a/app/code/Magento/CatalogUrlRewrite/Observer/ProcessUrlRewriteOnChangeProductVisibilityObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/ProcessUrlRewriteOnChangeProductVisibilityObserver.php
@@ -15,6 +15,8 @@ use Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException;
 
 /**
  * Consider URL rewrites on change product visibility via mass action
+ *
+ * @deprecated
  */
 class ProcessUrlRewriteOnChangeProductVisibilityObserver implements ObserverInterface
 {

--- a/app/code/Magento/CatalogUrlRewrite/Observer/ProcessUrlRewriteOnChangeProductVisibilityObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/ProcessUrlRewriteOnChangeProductVisibilityObserver.php
@@ -16,7 +16,7 @@ use Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException;
 /**
  * Consider URL rewrites on change product visibility via mass action
  *
- * @deprecated
+ * @deprecated URL rewrites will be created for all products.
  */
 class ProcessUrlRewriteOnChangeProductVisibilityObserver implements ObserverInterface
 {

--- a/app/code/Magento/CatalogUrlRewrite/Observer/ProductProcessUrlRewriteSavingObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/ProductProcessUrlRewriteSavingObserver.php
@@ -63,13 +63,10 @@ class ProductProcessUrlRewriteSavingObserver implements ObserverInterface
         if ($product->dataHasChangedFor('url_key')
             || $product->getIsChangedCategories()
             || $product->getIsChangedWebsites()
-            || $product->dataHasChangedFor('visibility')
         ) {
-            if ($product->isVisibleInSiteVisibility()) {
-                $product->unsUrlPath();
-                $product->setUrlPath($this->productUrlPathGenerator->getUrlPath($product));
-                $this->urlPersist->replace($this->productUrlRewriteGenerator->generate($product));
-            }
+            $product->unsUrlPath();
+            $product->setUrlPath($this->productUrlPathGenerator->getUrlPath($product));
+            $this->urlPersist->replace($this->productUrlRewriteGenerator->generate($product));
         }
     }
 }

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/ProductProcessUrlRewriteSavingObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/ProductProcessUrlRewriteSavingObserverTest.php
@@ -99,72 +99,44 @@ class ProductProcessUrlRewriteSavingObserverTest extends \PHPUnit\Framework\Test
         return [
             'url changed' => [
                 'isChangedUrlKey'       => true,
-                'isChangedVisibility'   => false,
                 'isChangedWebsites'     => false,
                 'isChangedCategories'   => false,
-                'visibilityResult'      => true,
                 'expectedReplaceCount'  => 1,
 
             ],
-            'no chnages' => [
+            'no changes' => [
                 'isChangedUrlKey'       => false,
-                'isChangedVisibility'   => false,
                 'isChangedWebsites'     => false,
                 'isChangedCategories'   => false,
-                'visibilityResult'      => true,
                 'expectedReplaceCount'  => 0
-            ],
-            'visibility changed' => [
-                'isChangedUrlKey'       => false,
-                'isChangedVisibility'   => true,
-                'isChangedWebsites'     => false,
-                'isChangedCategories'   => false,
-                'visibilityResult'      => true,
-                'expectedReplaceCount'  => 1
             ],
             'websites changed' => [
                 'isChangedUrlKey'       => false,
-                'isChangedVisibility'   => false,
                 'isChangedWebsites'     => true,
                 'isChangedCategories'   => false,
-                'visibilityResult'      => true,
                 'expectedReplaceCount'  => 1
             ],
             'categories changed' => [
                 'isChangedUrlKey'       => false,
-                'isChangedVisibility'   => false,
                 'isChangedWebsites'     => false,
                 'isChangedCategories'   => true,
-                'visibilityResult'      => true,
                 'expectedReplaceCount'  => 1
-            ],
-            'url changed invisible' => [
-                'isChangedUrlKey'       => true,
-                'isChangedVisibility'   => false,
-                'isChangedWebsites'     => false,
-                'isChangedCategories'   => false,
-                'visibilityResult'      => false,
-                'expectedReplaceCount'  => 0
-            ],
+            ]
         ];
     }
 
     /**
      * @param bool $isChangedUrlKey
-     * @param bool $isChangedVisibility
      * @param bool $isChangedWebsites
      * @param bool $isChangedCategories
-     * @param bool $visibilityResult
      * @param int $expectedReplaceCount
      *
      * @dataProvider urlKeyDataProvider
      */
     public function testExecuteUrlKey(
         $isChangedUrlKey,
-        $isChangedVisibility,
         $isChangedWebsites,
         $isChangedCategories,
-        $visibilityResult,
         $expectedReplaceCount
     ) {
         $this->product->expects($this->any())->method('getStoreId')->will($this->returnValue(12));
@@ -173,7 +145,6 @@ class ProductProcessUrlRewriteSavingObserverTest extends \PHPUnit\Framework\Test
             ->method('dataHasChangedFor')
             ->will($this->returnValueMap(
                 [
-                    ['visibility', $isChangedVisibility],
                     ['url_key', $isChangedUrlKey]
                 ]
             ));
@@ -185,10 +156,6 @@ class ProductProcessUrlRewriteSavingObserverTest extends \PHPUnit\Framework\Test
         $this->product->expects($this->any())
             ->method('getIsChangedCategories')
             ->will($this->returnValue($isChangedCategories));
-
-        $this->product->expects($this->any())
-            ->method('isVisibleInSiteVisibility')
-            ->will($this->returnValue($visibilityResult));
 
         $this->urlPersist->expects($this->exactly($expectedReplaceCount))
             ->method('replace')

--- a/app/code/Magento/CatalogUrlRewrite/etc/events.xml
+++ b/app/code/Magento/CatalogUrlRewrite/etc/events.xml
@@ -27,9 +27,6 @@
     <event name="catalog_product_save_after">
         <observer name="process_url_rewrite_saving" instance="Magento\CatalogUrlRewrite\Observer\ProductProcessUrlRewriteSavingObserver"/>
     </event>
-    <event name="catalog_product_attribute_update_before">
-        <observer name="process_url_rewrite_on_change_product_visibility" instance="Magento\CatalogUrlRewrite\Observer\ProcessUrlRewriteOnChangeProductVisibilityObserver"/>
-    </event>
     <event name="catalog_category_save_before">
         <observer name="category_url_path_autogeneration" instance="Magento\CatalogUrlRewrite\Observer\CategoryUrlPathAutogeneratorObserver"/>
     </event>


### PR DESCRIPTION
### Description

- Add URL rewrites when a product is saved, even if the product is set to "Not visible individually".
- Removed mass attribute event, since this is not longer necessary when all URL rewrites are generated for visible and invisible products.
- Deprecated related classes, to be removed in next major release.

### Fixed Issues 
1. magento/magento2#19293: Invisible products do not update url_rewrite properly
2. magento/magento2#20434: Product URL duplicate when changing visibility via mass action

### Manual testing scenarios
1. Add product with visibility "Not visible individually"
2. URL rewrites should be generated and stored in the url_rewrite table

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
