### PR TITLE
Optimized dev:urn-catalog:generate for PHPStorm

### DIFF
--- a/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
+++ b/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
@@ -18,8 +18,8 @@ use Magento\Framework\Filesystem\File\WriteFactory;
  */
 class PhpStorm implements FormatInterface
 {
-    const PROJECT_PATH_IDENTIFIER = '$PROJECT_DIR$';
-    const IDEA_PATH = '.idea';
+    private const PROJECT_PATH_IDENTIFIER = '$PROJECT_DIR$';
+    private const IDEA_PATH = '.idea';
 
     /**
      * @var ReadInterface
@@ -141,7 +141,7 @@ class PhpStorm implements FormatInterface
      * @param string $configFilePath
      * @return string
      */
-    public function resolveProjectPath($configFilePath): string
+    private function resolveProjectPath($configFilePath): string
     {
         return \str_replace('/' . self::IDEA_PATH, '', realpath(dirname($configFilePath)));
     }
@@ -153,7 +153,7 @@ class PhpStorm implements FormatInterface
      * @param string $xsdPath
      * @return string
      */
-    public function getFileLocationInProject(string $ideaDir, string $xsdPath): string
+    private function getFileLocationInProject(string $ideaDir, string $xsdPath): string
     {
         return \str_replace($ideaDir, self::PROJECT_PATH_IDENTIFIER, $xsdPath);
     }

--- a/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
+++ b/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
@@ -22,6 +22,11 @@ class PhpStorm implements FormatInterface
     const IDEA_PATH = '.idea';
 
     /**
+     * @var ReadInterface
+     */
+    private $currentDirRead;
+
+    /**
      * @var WriteFactory
      */
     private $fileWriteFactory;
@@ -37,9 +42,11 @@ class PhpStorm implements FormatInterface
      * @param DomDocumentFactory $domDocumentFactory
      */
     public function __construct(
+        ReadFactory $readFactory,
         WriteFactory $fileWriteFactory,
         DomDocumentFactory $domDocumentFactory = null
     ) {
+        $this->currentDirRead = $readFactory->create(getcwd());
         $this->fileWriteFactory = $fileWriteFactory;
         $this->domDocumentFactory = $domDocumentFactory ?: ObjectManager::getInstance()->get(DomDocumentFactory::class);
     }

--- a/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
+++ b/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
@@ -18,10 +18,6 @@ use Magento\Framework\Filesystem\File\WriteFactory;
  */
 class PhpStorm implements FormatInterface
 {
-    /**
-     * @var ReadInterface
-     */
-    private $currentDirRead;
 
     /**
      * @var WriteFactory
@@ -39,11 +35,9 @@ class PhpStorm implements FormatInterface
      * @param DomDocumentFactory $domDocumentFactory
      */
     public function __construct(
-        ReadFactory $readFactory,
         WriteFactory $fileWriteFactory,
         DomDocumentFactory $domDocumentFactory = null
     ) {
-        $this->currentDirRead = $readFactory->create(getcwd());
         $this->fileWriteFactory = $fileWriteFactory;
         $this->domDocumentFactory = $domDocumentFactory ?: ObjectManager::getInstance()->get(DomDocumentFactory::class);
     }

--- a/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
+++ b/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
@@ -19,7 +19,6 @@ use Magento\Framework\Filesystem\File\WriteFactory;
 class PhpStorm implements FormatInterface
 {
     private const PROJECT_PATH_IDENTIFIER = '$PROJECT_DIR$';
-    private const IDEA_PATH = '.idea';
 
     /**
      * @var ReadInterface
@@ -63,8 +62,6 @@ class PhpStorm implements FormatInterface
         $componentNode = null;
         $projectNode = null;
 
-        $ideaDir = $this->resolveProjectPath($configFilePath);
-
         try {
             $file = $this->fileWriteFactory->create(
                 $configFilePath,
@@ -100,7 +97,7 @@ class PhpStorm implements FormatInterface
         foreach ($dictionary as $urn => $xsdPath) {
             $node = $dom->createElement('resource');
             $node->setAttribute('url', $urn);
-            $node->setAttribute('location', $this->getFileLocationInProject($ideaDir, $xsdPath));
+            $node->setAttribute('location', $this->getFileLocationInProject($xsdPath));
             $componentNode->appendChild($node);
         }
         $dom->formatOutput = true;
@@ -136,25 +133,13 @@ class PhpStorm implements FormatInterface
     }
 
     /**
-     * Resolve PhpStorm Project Path
-     *
-     * @param string $configFilePath
-     * @return string
-     */
-    private function resolveProjectPath($configFilePath): string
-    {
-        return \str_replace('/' . self::IDEA_PATH, '', realpath(dirname($configFilePath)));
-    }
-
-    /**
      * Resolve xsdpath to xml project path
      *
-     * @param string $ideaDir
      * @param string $xsdPath
      * @return string
      */
-    private function getFileLocationInProject(string $ideaDir, string $xsdPath): string
+    private function getFileLocationInProject(string $xsdPath): string
     {
-        return \str_replace($ideaDir, self::PROJECT_PATH_IDENTIFIER, $xsdPath);
+        return self::PROJECT_PATH_IDENTIFIER . DIRECTORY_SEPARATOR . $this->currentDirRead->getRelativePath($xsdPath);
     }
 }

--- a/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
+++ b/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
@@ -10,6 +10,7 @@ use Magento\Framework\App\ObjectManager;
 use Magento\Framework\DomDocument\DomDocumentFactory;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Filesystem\Directory\ReadFactory;
+use Magento\Framework\Filesystem\Directory\ReadInterface;
 use Magento\Framework\Filesystem\File\WriteFactory;
 
 /**
@@ -31,6 +32,7 @@ class PhpStorm implements FormatInterface
     private $domDocumentFactory;
 
     /**
+     * @param ReadFactory $readFactory
      * @param WriteFactory $fileWriteFactory
      * @param DomDocumentFactory $domDocumentFactory
      */

--- a/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
+++ b/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
@@ -10,7 +10,6 @@ use Magento\Framework\App\ObjectManager;
 use Magento\Framework\DomDocument\DomDocumentFactory;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Filesystem\Directory\ReadFactory;
-use Magento\Framework\Filesystem\Directory\ReadInterface;
 use Magento\Framework\Filesystem\File\WriteFactory;
 
 /**
@@ -32,7 +31,6 @@ class PhpStorm implements FormatInterface
     private $domDocumentFactory;
 
     /**
-     * @param ReadFactory $readFactory
      * @param WriteFactory $fileWriteFactory
      * @param DomDocumentFactory $domDocumentFactory
      */

--- a/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
+++ b/app/code/Magento/Developer/Model/XmlCatalog/Format/PhpStorm.php
@@ -18,6 +18,8 @@ use Magento\Framework\Filesystem\File\WriteFactory;
  */
 class PhpStorm implements FormatInterface
 {
+    const PROJECT_PATH_IDENTIFIER = '$PROJECT_DIR$';
+    const IDEA_PATH = '.idea';
 
     /**
      * @var WriteFactory
@@ -54,6 +56,8 @@ class PhpStorm implements FormatInterface
         $componentNode = null;
         $projectNode = null;
 
+        $ideaDir = $this->resolveProjectPath($configFilePath);
+
         try {
             $file = $this->fileWriteFactory->create(
                 $configFilePath,
@@ -89,7 +93,7 @@ class PhpStorm implements FormatInterface
         foreach ($dictionary as $urn => $xsdPath) {
             $node = $dom->createElement('resource');
             $node->setAttribute('url', $urn);
-            $node->setAttribute('location', $xsdPath);
+            $node->setAttribute('location', $this->getFileLocationInProject($ideaDir, $xsdPath));
             $componentNode->appendChild($node);
         }
         $dom->formatOutput = true;
@@ -122,5 +126,28 @@ class PhpStorm implements FormatInterface
         $rootComponentNode->setAttribute('name', 'ProjectRootManager');
         $projectNode->appendChild($rootComponentNode);
         return $projectNode;
+    }
+
+    /**
+     * Resolve PhpStorm Project Path
+     *
+     * @param string $configFilePath
+     * @return string
+     */
+    public function resolveProjectPath($configFilePath): string
+    {
+        return \str_replace('/' . self::IDEA_PATH, '', realpath(dirname($configFilePath)));
+    }
+
+    /**
+     * Resolve xsdpath to xml project path
+     *
+     * @param string $ideaDir
+     * @param string $xsdPath
+     * @return string
+     */
+    public function getFileLocationInProject(string $ideaDir, string $xsdPath): string
+    {
+        return \str_replace($ideaDir, self::PROJECT_PATH_IDENTIFIER, $xsdPath);
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

When generating the `urn-catalog` from within any docker setup with path mappings this isn't reflected correctly to PHPStorm because the path's won't match up. This is no problem for people running local php instances.

### Description (*)
This change resolves the project directory and replaces all paths to `$PROJECT_DIR$`,  this also makes moving your project possible. The change does a compare from the realpath for the given `.idea/misc.xml` to resolve the projectdir.

### Fixed Issues (if relevant)
I didn't find any, so it only bothered me.

### Manual testing scenarios (*)
Run in any console `bin/magento dev:urn-catalog:generate test.xml` this will replace the absolute paths to `$PROJECT_DIR/path/to/file.xsd` in the location attribute.

### Questions or comments
No Unittests because there weren't any to optimize.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
