### PR TITLE
magento/magento2#14971: Improper Handling of Pagination SEO

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Pager.php
+++ b/app/code/Magento/Theme/Block/Html/Pager.php
@@ -450,9 +450,7 @@ class Pager extends \Magento\Framework\View\Element\Template
      */
     public function getPageUrl($page)
     {
-        return $this->getPagerUrl([
-            $this->getPageVarName() => $page > 1 ? $page : null,
-        ]);
+        return $this->getPagerUrl([$this->getPageVarName() => $page > 1 ? $page : null]);
     }
 
     /**

--- a/app/code/Magento/Theme/Block/Html/Pager.php
+++ b/app/code/Magento/Theme/Block/Html/Pager.php
@@ -450,7 +450,9 @@ class Pager extends \Magento\Framework\View\Element\Template
      */
     public function getPageUrl($page)
     {
-        return $this->getPagerUrl([$this->getPageVarName() => $page]);
+        return $this->getPagerUrl([
+            $this->getPageVarName() => $page > 1 ? $page : null,
+        ]);
     }
 
     /**


### PR DESCRIPTION
This removes the p= query string parameter in pagination for the first page, when navigating back to page 1, to avoid duplicate content SEO issues.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
First page pagination links will still include the pagination query string (for example `p=1`) which causes a duplicate content SEO issue. 

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14971: Improper Handling of Pagination SEO

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Visit a category with more than 1 page
2. Use pagination to go to page 2
3. Return to page 1 via pagination and verify that the pagination query string parameter is not present in the URL

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
