### PR TITLE
Use class name as type hint instead of self. 

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
@@ -152,7 +152,7 @@ class Full extends AbstractAction
      *
      * @return $this
      */
-    public function execute(): self
+    public function execute(): Full
     {
         $this->createTables();
         $this->clearReplicaTables();


### PR DESCRIPTION
### Description (*)
Use class name as type hint instead of `self`. `self` breaks code generator when a preference is defined.

### Fixed Issues (if relevant)

1. magento/magento2#22769: "Creating a preference for category product indexer breaks setup:di:compile"

### Manual testing scenarios (*)
1. Create a preference for \Magento\Catalog\Model\Indexer\Category\Product\Action\Full in a custom module
2. Run bin/magento setup:di:compile
3. There is no PHP fatal error anymore.

### Questions or comments
I am going to try and work out a solution to the real problem here which should allow us to still use the `self` keyword and use preferences/code generation at the same time. That would be in a different PR though.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
