### PR TITLE
magento/magento2#23301: MethodArgumentsSniff works incorrect with arguments passed by reference.

### DIFF
--- a/dev/tests/static/framework/Magento/Sniffs/Annotation/MethodArgumentsSniff.php
+++ b/dev/tests/static/framework/Magento/Sniffs/Annotation/MethodArgumentsSniff.php
@@ -417,7 +417,7 @@ class MethodArgumentsSniff implements Sniff
                 );
                 break;
             case 1:
-                if (preg_match('/^\$.*/', $paramDefinitions[0])) {
+                if (preg_match('/^&?\$.*/', $paramDefinitions[0])) {
                     $phpcsFile->addError(
                         'Type is not specified',
                         $paramPointers[$ptr],
@@ -442,7 +442,7 @@ class MethodArgumentsSniff implements Sniff
                 );
                 break;
             default:
-                if (preg_match('/^\$.*/', $paramDefinitions[0])) {
+                if (preg_match('/^&?\$.*/', $paramDefinitions[0])) {
                     $phpcsFile->addError(
                         'Type is not specified',
                         $paramPointers[$ptr],
@@ -568,7 +568,7 @@ class MethodArgumentsSniff implements Sniff
                 $content = preg_replace('/\s+/', ' ', $tokens[$tempPtr + 2]['content'], 2);
                 $paramAnnotationParts = explode(' ', $content, 3);
                 if (count($paramAnnotationParts) === 1) {
-                    if ((preg_match('/^\$.*/', $paramAnnotationParts[0]))) {
+                    if ((preg_match('/^&?\$.*/', $paramAnnotationParts[0]))) {
                         $paramDefinitions[] = [
                             'type' => null,
                             'paramName' => rtrim(ltrim($tokens[$tempPtr + 2]['content'], '&'), ','),
@@ -626,7 +626,7 @@ class MethodArgumentsSniff implements Sniff
             if (isset($paramPointers[$ptr])) {
                 $paramContent = $tokens[$paramPointers[$ptr] + 2]['content'];
                 $paramDefinition = $paramDefinitions[$ptr];
-                $argumentPositions[] = strpos($paramContent, $paramDefinition['paramName']);
+                $argumentPositions[] = $this->getArgumentPosition($paramContent, $paramDefinition);
                 $commentPositions[] = $paramDefinition['comment']
                     ? strrpos($paramContent, $paramDefinition['comment']) : null;
             }
@@ -680,5 +680,18 @@ class MethodArgumentsSniff implements Sniff
         }
 
         return $flag;
+    }
+
+    /**
+     * Get argument name starting position in annotation string.
+     *
+     * @param string $paramContent
+     * @param array $paramDefinition
+     * @return int|bool
+     */
+    private function getArgumentPosition(string $paramContent, array $paramDefinition)
+    {
+        return strpos($paramContent, '&' . $paramDefinition['paramName']) ?:
+            strpos($paramContent, $paramDefinition['paramName']);
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1.magento/magento2#23301: MethodArgumentsSniff works incorrect with arguments passed by reference.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add any changes to \Magento\CatalogImportExport\Model\Import\Product\Option class.
2. Run \Magento\Test\Php\LiveCodeTest::testCodeStyle method.


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
