### PR TITLE
FS/23038 Decimal qty with Increment is with specific values are not adding in cart

### DIFF
--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -1654,7 +1654,7 @@
                 result = isQtyIncrementsValid;
 
                 if (result === false) {
-                    validator.itemQtyErrorMessage = $.mage.__('You can buy this product only in quantities of fanis %1 at a time.').replace('%1', params.qtyIncrements);//eslint-disable-line max-len
+                    validator.itemQtyErrorMessage = $.mage.__('You can buy this product only in quantities of %1 at a time.').replace('%1', params.qtyIncrements);//eslint-disable-line max-len
 
                     return result;
                 }

--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -205,6 +205,21 @@
     }
 
     /**
+     *
+     * @param {float} qty
+     * @param {float} qtyIncrements
+     * @returns {float}
+     */
+    function resolveModulo(qty, qtyIncrements) {
+        while (qtyIncrements < 1) {
+            qty *= 10;
+            qtyIncrements *= 10;
+        }
+
+        return qty % qtyIncrements;
+    }
+
+    /**
      * Collection of validation rules including rules from additional-methods.js
      * @type {Object}
      */
@@ -1610,7 +1625,7 @@
                     isMaxAllowedValid = typeof params.maxAllowed === 'undefined' ||
                         qty <= $.mage.parseNumber(params.maxAllowed),
                     isQtyIncrementsValid = typeof params.qtyIncrements === 'undefined' ||
-                        qty % $.mage.parseNumber(params.qtyIncrements) === 0;
+                        resolveModulo(qty, $.mage.parseNumber(params.qtyIncrements)) === 0.0;
 
                 result = qty > 0;
 
@@ -1639,7 +1654,7 @@
                 result = isQtyIncrementsValid;
 
                 if (result === false) {
-                    validator.itemQtyErrorMessage = $.mage.__('You can buy this product only in quantities of %1 at a time.').replace('%1', params.qtyIncrements);//eslint-disable-line max-len
+                    validator.itemQtyErrorMessage = $.mage.__('You can buy this product only in quantities of fanis %1 at a time.').replace('%1', params.qtyIncrements);//eslint-disable-line max-len
 
                     return result;
                 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
### **Preconditions (*)**
- Product with Any Decimal Quantity should be added in Cart If Decimal "Qty Uses Decimals" and 
  option is "Yes"
- Product is not adding in cart with qty decimal, qty increment is enabled and minimum qty assigned.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1 Create simple product enable "Qty Uses Decimal" and Assign "Minimum Qty" to 0.5 then enable "Enable Qty Increments" and assign 0.1 to "Qty Increments"
Here is the case Minimum Qty in Cart 0.5, Qty Increment Is 0.1

2 Try to add it on Cart
"You can buy this product only in quantities of 0.1 at a time" error message


