### PR TITLE
magento/magento-2#23222: setup:upgrade should return failure when app…

### DIFF
--- a/setup/src/Magento/Setup/Console/Command/UpgradeCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/UpgradeCommand.php
@@ -126,7 +126,10 @@ class UpgradeCommand extends AbstractSetupCommand
                 $importConfigCommand = $this->getApplication()->find(ConfigImportCommand::COMMAND_NAME);
                 $arrayInput = new ArrayInput([]);
                 $arrayInput->setInteractive($input->isInteractive());
-                $importConfigCommand->run($arrayInput, $output);
+                $result = $importConfigCommand->run($arrayInput, $output);
+                if ($result === \Magento\Framework\Console\Cli::RETURN_FAILURE) {
+                    throw new \Magento\Framework\Exception\RuntimeException(__(ConfigImportCommand::COMMAND_NAME . ' failed. See previous output.'));
+                }
             }
 
             if (!$keepGenerated && $this->appState->getMode() === AppState::MODE_PRODUCTION) {


### PR DESCRIPTION
app:config:import failed: Added logic to throw RuntimeException if app:config:import returns failure error code

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
This PR adds logic which detects if the return code of the app:config:import command returns an error code greater than zero and if so, throws a RuntimeException.

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
These CLI commands are used for deployments. If there is an error on deployment, the command should stop. But without an error code we cannot stop. This PR adds the error code.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23222: setup:upgrade should return failure when app:config:import failed 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add an Exception to Magento\Deploy\Console\Command\App\ConfigImport\Processor
after Line 114
```php
 if (!$importers || !$this->changeDetector->hasChanges()) {
              throw new \Exception('Test'); // added line
```
2. Run `bin/magento setup:upgrade`
3. Verify that the `bin/magento setup:upgrade` command is terminated by the `RuntimeException`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
