### PR TITLE
magento/magento2#23074: update correct product URL rewrites after changing category url key

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Observer/UrlRewriteHandler.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/UrlRewriteHandler.php
@@ -138,15 +138,19 @@ class UrlRewriteHandler
         $mergeDataProvider = clone $this->mergeDataProviderPrototype;
         $this->isSkippedProduct[$category->getEntityId()] = [];
         $saveRewriteHistory = (bool)$category->getData('save_rewrites_history');
+        $storeId = (int)$category->getStoreId();
 
-        foreach ($this->getCategoryStoreIds($category) as $storeId) {
-            if ($category->getChangedProductIds()) {
-                $this->generateChangedProductUrls($mergeDataProvider, $category, (int)$storeId, $saveRewriteHistory);
-            } else {
+        if ($category->getChangedProductIds()) {
+            $this->generateChangedProductUrls($mergeDataProvider, $category, $storeId, $saveRewriteHistory);
+        } else {
+            $categoryStoreIds = $this->getCategoryStoreIds($category);
+
+            foreach ($categoryStoreIds as $categoryStoreId) {
+                $this->isSkippedProduct[$category->getEntityId()] = [];
                 $mergeDataProvider->merge(
                     $this->getCategoryProductsUrlRewrites(
                         $category,
-                        (int)$storeId,
+                        $categoryStoreId,
                         $saveRewriteHistory,
                         $category->getEntityId()
                     )

--- a/app/code/Magento/CatalogUrlRewrite/Observer/UrlRewriteHandler.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/UrlRewriteHandler.php
@@ -139,7 +139,7 @@ class UrlRewriteHandler
         $this->isSkippedProduct[$category->getEntityId()] = [];
         $saveRewriteHistory = (bool)$category->getData('save_rewrites_history');
 
-        foreach ($category->getStoreIds() as $storeId) {
+        foreach ($this->getCategoryStoreIds($category) as $storeId) {
             if ($category->getChangedProductIds()) {
                 $this->generateChangedProductUrls($mergeDataProvider, $category, (int)$storeId, $saveRewriteHistory);
             } else {

--- a/app/code/Magento/CatalogUrlRewrite/Observer/UrlRewriteHandler.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/UrlRewriteHandler.php
@@ -246,7 +246,7 @@ class UrlRewriteHandler
         $productCollection = $this->productCollectionFactory->create();
 
         $productCollection->addCategoriesFilter(['eq' => [$category->getEntityId()]])
-            ->setStoreId($storeId)
+            ->addStoreFilter($storeId)
             ->addAttributeToSelect('name')
             ->addAttributeToSelect('visibility')
             ->addAttributeToSelect('url_key')

--- a/app/code/Magento/CatalogUrlRewrite/Observer/UrlRewriteHandler.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/UrlRewriteHandler.php
@@ -138,19 +138,20 @@ class UrlRewriteHandler
         $mergeDataProvider = clone $this->mergeDataProviderPrototype;
         $this->isSkippedProduct[$category->getEntityId()] = [];
         $saveRewriteHistory = (bool)$category->getData('save_rewrites_history');
-        $storeId = (int)$category->getStoreId();
 
-        if ($category->getChangedProductIds()) {
-            $this->generateChangedProductUrls($mergeDataProvider, $category, $storeId, $saveRewriteHistory);
-        } else {
-            $mergeDataProvider->merge(
-                $this->getCategoryProductsUrlRewrites(
-                    $category,
-                    $storeId,
-                    $saveRewriteHistory,
-                    $category->getEntityId()
-                )
-            );
+        foreach ($category->getStoreIds() as $storeId) {
+            if ($category->getChangedProductIds()) {
+                $this->generateChangedProductUrls($mergeDataProvider, $category, (int)$storeId, $saveRewriteHistory);
+            } else {
+                $mergeDataProvider->merge(
+                    $this->getCategoryProductsUrlRewrites(
+                        $category,
+                        (int)$storeId,
+                        $saveRewriteHistory,
+                        $category->getEntityId()
+                    )
+                );
+            }
         }
 
         foreach ($this->childrenCategoriesProvider->getChildren($category, true) as $childCategory) {

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/UrlRewriteHandlerTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/UrlRewriteHandlerTest.php
@@ -138,8 +138,14 @@ class UrlRewriteHandlerTest extends \PHPUnit\Framework\TestCase
             ->willReturn(1);
         $category->expects($this->any())
             ->method('getData')
-            ->with('save_rewrites_history')
-            ->willReturn(true);
+            ->withConsecutive(
+                [$this->equalTo('save_rewrites_history')],
+                [$this->equalTo('initial_setup_flag')]
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                null
+            );
 
         /* @var \Magento\Catalog\Model\Category|\PHPUnit_Framework_MockObject_MockObject $childCategory1 */
         $childCategory1 = $this->getMockBuilder(\Magento\Catalog\Model\Category::class)
@@ -175,6 +181,7 @@ class UrlRewriteHandlerTest extends \PHPUnit\Framework\TestCase
             ->method('addIdFilter')
             ->willReturnSelf();
         $productCollection->expects($this->any())->method('setStoreId')->willReturnSelf();
+        $productCollection->expects($this->any())->method('addStoreFilter')->willReturnSelf();
         $productCollection->expects($this->any())->method('addAttributeToSelect')->willReturnSelf();
         $iterator = new \ArrayIterator([]);
         $productCollection->expects($this->any())->method('getIterator')->will($this->returnValue($iterator));


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In a multi-store website, when a category URL key is updated, we will try to update related product URL rewrites in addition to the category's own URL. However sometimes we are not updating all the rewrite rules for all the stores that products belong to.

The problem is that if we simply look up the store id from the `$category`, we will get the store id from the last loop [here](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/CatalogUrlRewrite/Model/CategoryUrlRewriteGenerator.php#L127) and miss all the other store ids that the category (and the product) may belong to. Hence we need to once again loop through category store ids when regenerating product rewrite urls.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23074: Magento 2.3.1 - URL rewrite rules are not creating for product after update url key

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set up a multi-store instance
2. Create a category with one product
3. Go to the category in the admin
4. Update the URL key of category
5. Save the category

URL rewrites will be regenerated for all the stores that the product belongs to.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
