### PR TITLE
Use DateTime::createFromFormat when creating a date with a specific format

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/DateTime/DateTime.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/DateTime.php
@@ -97,7 +97,7 @@ class DateTime
     /**
      * Forms GMT timestamp
      *
-     * @param  int|string|\DateTimeInterface $input date in current timezone
+     * @param int|string|\DateTimeInterface $input date in current timezone
      * @return int
      */
     public function gmtTimestamp($input = null)
@@ -125,8 +125,7 @@ class DateTime
      * Converts input date into timestamp with timezone offset
      * Input date must be in GMT timezone
      *
-     * @param  int|string $input date in GMT timezone
-     * @param  null|string $format
+     * @param int|string $input date in GMT timezone
      *
      * @return int
      */
@@ -135,6 +134,14 @@ class DateTime
         $this->convertToTimestamp($input);
     }
 
+    /**
+     * Converts input date into timestamp with corresponded format
+     *
+     * @param int|string $input date in GMT timezone
+     * @param null|string $format
+     *
+     * @return int
+     */
     private function convertToTimestamp($input = null, $format = null)
     {
         switch (true) {
@@ -148,11 +155,7 @@ class DateTime
                 $result = $input->getTimestamp();
                 break;
             default:
-                {
-                    $result = $format ?
-                        \DateTime::createFromFormat($format, $input)
-                        : strtotime($input);
-                }
+                $result = $format ? \DateTime::createFromFormat($format, $input) : strtotime($input);
         }
 
         $date = $this->_localeDate->date($result);

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/DateTime.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/DateTime.php
@@ -90,7 +90,7 @@ class DateTime
         if ($format === null) {
             $format = 'Y-m-d H:i:s';
         }
-        $result = date($format, $this->timestamp($input, $format));
+        $result = date($format, $this->convertToTimestamp($input, $format));
         return $result;
     }
 
@@ -130,7 +130,12 @@ class DateTime
      *
      * @return int
      */
-    public function timestamp($input = null, $format = null)
+    public function timestamp($input = null)
+    {
+        $this->convertToTimestamp($input);
+    }
+
+    private function convertToTimestamp($input = null, $format = null)
     {
         switch (true) {
             case ($input === null):

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/DateTime.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/DateTime.php
@@ -90,7 +90,7 @@ class DateTime
         if ($format === null) {
             $format = 'Y-m-d H:i:s';
         }
-        $result = date($format, $this->timestamp($input));
+        $result = date($format, $this->timestamp($input, $format));
         return $result;
     }
 
@@ -126,9 +126,11 @@ class DateTime
      * Input date must be in GMT timezone
      *
      * @param  int|string $input date in GMT timezone
+     * @param  null|string $format
+     *
      * @return int
      */
-    public function timestamp($input = null)
+    public function timestamp($input = null, $format = null)
     {
         switch (true) {
             case ($input === null):
@@ -141,7 +143,11 @@ class DateTime
                 $result = $input->getTimestamp();
                 break;
             default:
-                $result = strtotime($input);
+                {
+                    $result = $format ?
+                        \DateTime::createFromFormat($format, $input)
+                        : strtotime($input);
+                }
         }
 
         $date = $this->_localeDate->date($result);


### PR DESCRIPTION
strtotime can't accept a format. So instead of using this, use DateTime::createFromFormat instead, which can.

Before:
\Magento\Framework\Stdlib\DateTime\DateTime->date("d/m/y", "15/08/2016") returns 'now'.

After:
\Magento\Framework\Stdlib\DateTime\DateTime->date("d/m/y", "15/08/2016") returns "15/08/2016".

I've left the default strtotime implementation if $format is not specified, which should reduce the chance of a regression issue.

magento/magento2#6187 Date creation not consistent with Magento/DateTime with french format
