### PR TITLE
[Backport] Fix unexpected diff between builds in generated/metadata directory

### DIFF
--- a/setup/src/Magento/Setup/Module/Di/App/Task/Operation/Area.php
+++ b/setup/src/Magento/Setup/Module/Di/App/Task/Operation/Area.php
@@ -85,6 +85,8 @@ class Area implements OperationInterface
             }
         }
 
+        $this->sortDefinitions($definitionsCollection);
+
         $areaCodes = array_merge([App\Area::AREA_GLOBAL], $this->areaList->getCodes());
         foreach ($areaCodes as $areaCode) {
             $config = $this->configReader->generateCachePerScope($definitionsCollection, $areaCode);
@@ -120,5 +122,19 @@ class Area implements OperationInterface
     public function getName()
     {
         return 'Area configuration aggregation';
+    }
+
+    /**
+     * Sort definitions to make reproducible result
+     *
+     * @param DefinitionsCollection $definitionsCollection
+     */
+    private function sortDefinitions(DefinitionsCollection $definitionsCollection): void
+    {
+        $definitions = $definitionsCollection->getCollection();
+
+        ksort($definitions);
+
+        $definitionsCollection->initialize($definitions);
     }
 }


### PR DESCRIPTION
### Original Pull Request
https://github.com/magento/magento2/pull/23325

### Description (*)
Sort all path definitions before generating config and writing it to generated/metadata directory

This issue caused by using RecursiveDirectoryIterator object for generating list of all classes and all their arguments and [it could return not sorted result](https://www.php.net/manual/en/class.recursivedirectoryiterator.php#120971). As result files between builds are different just because files were found in different sort order.

### Fixed Issues (if relevant)
1. magento/magento2#23324: [Reproducible Builds] Diff in generated/metadata between the builds

### Manual testing scenarios (*)
1. See #23324 for details

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
