### PR TITLE
[Backport] Fixed issue #18337

### DIFF
--- a/app/code/Magento/Search/view/frontend/templates/form.mini.phtml
+++ b/app/code/Magento/Search/view/frontend/templates/form.mini.phtml
@@ -35,7 +35,8 @@ $helper = $this->helper(\Magento\Search\Helper\Data::class);
                            role="combobox"
                            aria-haspopup="false"
                            aria-autocomplete="both"
-                           autocomplete="off"/>
+                           autocomplete="off"
+                           aria-expanded="false"/>
                     <div id="search_autocomplete" class="search-autocomplete"></div>
                     <?= $block->getChildHtml() ?>
                 </div>

--- a/app/code/Magento/Search/view/frontend/web/js/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/js/form-mini.js
@@ -69,9 +69,11 @@ define([
                 media: '(max-width: 768px)',
                 entry: function () {
                     this.isExpandable = true;
+                    this.element.attr('aria-expanded', false);
                 }.bind(this),
                 exit: function () {
                     this.isExpandable = true;
+                    this.element.attr('aria-expanded', false);
                 }.bind(this)
             });
 

--- a/app/code/Magento/Search/view/frontend/web/js/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/js/form-mini.js
@@ -71,8 +71,7 @@ define([
                     this.isExpandable = true;
                 }.bind(this),
                 exit: function () {
-                    this.isExpandable = false;
-                    this.element.removeAttr('aria-expanded');
+                    this.isExpandable = true;
                 }.bind(this)
             });
 

--- a/app/code/Magento/Search/view/frontend/web/js/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/js/form-mini.js
@@ -69,11 +69,9 @@ define([
                 media: '(max-width: 768px)',
                 entry: function () {
                     this.isExpandable = true;
-                    this.element.attr('aria-expanded', false);
                 }.bind(this),
                 exit: function () {
                     this.isExpandable = true;
-                    this.element.attr('aria-expanded', false);
                 }.bind(this)
             });
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22942
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
**Search input is missing required attribute aria-expanded:** For this issue I have made changes in mediaCheck exit function because the exit function is using only for desktop vestion and it was using isExpandable=>false.   

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18337: Search input is missing required attribute aria-expanded.
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Check home page in W3C html validator or open home page check with inspect element 
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
