### PR TITLE
Fix issue with incorrect payment translation in sales emails

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Sender/EmailSender.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Sender/EmailSender.php
@@ -99,6 +99,8 @@ class EmailSender extends Sender implements SenderInterface
         $creditmemo->setSendEmail(true);
 
         if (!$this->globalConfig->getValue('sales_email/general/async_sending') || $forceSyncMode) {
+            $this->identityContainer->setStore($order->getStore());
+
             $transport = [
                 'order' => $order,
                 'creditmemo' => $creditmemo,

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoCommentSender.php
@@ -63,6 +63,8 @@ class CreditmemoCommentSender extends NotifySender
     public function send(Creditmemo $creditmemo, $notify = true, $comment = '')
     {
         $order = $creditmemo->getOrder();
+        $this->identityContainer->setStore($order->getStore());
+
         $transport = [
             'order' => $order,
             'creditmemo' => $creditmemo,

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoSender.php
@@ -103,6 +103,7 @@ class CreditmemoSender extends Sender
 
         if (!$this->globalConfig->getValue('sales_email/general/async_sending') || $forceSyncMode) {
             $order = $creditmemo->getOrder();
+            $this->identityContainer->setStore($order->getStore());
 
             $transport = [
                 'order' => $order,

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceCommentSender.php
@@ -63,6 +63,8 @@ class InvoiceCommentSender extends NotifySender
     public function send(Invoice $invoice, $notify = true, $comment = '')
     {
         $order = $invoice->getOrder();
+        $this->identityContainer->setStore($order->getStore());
+
         $transport = [
             'order' => $order,
             'invoice' => $invoice,

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceSender.php
@@ -103,6 +103,7 @@ class InvoiceSender extends Sender
 
         if (!$this->globalConfig->getValue('sales_email/general/async_sending') || $forceSyncMode) {
             $order = $invoice->getOrder();
+            $this->identityContainer->setStore($order->getStore());
 
             $transport = [
                 'order' => $order,

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/OrderCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/OrderCommentSender.php
@@ -61,6 +61,8 @@ class OrderCommentSender extends NotifySender
      */
     public function send(Order $order, $notify = true, $comment = '')
     {
+        $this->identityContainer->setStore($order->getStore());
+
         $transport = [
             'order' => $order,
             'comment' => $comment,

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentCommentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentCommentSender.php
@@ -63,6 +63,8 @@ class ShipmentCommentSender extends NotifySender
     public function send(Shipment $shipment, $notify = true, $comment = '')
     {
         $order = $shipment->getOrder();
+        $this->identityContainer->setStore($order->getStore());
+
         $transport = [
             'order' => $order,
             'shipment' => $shipment,

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentSender.php
@@ -103,6 +103,7 @@ class ShipmentSender extends Sender
 
         if (!$this->globalConfig->getValue('sales_email/general/async_sending') || $forceSyncMode) {
             $order = $shipment->getOrder();
+            $this->identityContainer->setStore($order->getStore());
 
             $transport = [
                 'order' => $order,

--- a/app/code/Magento/Sales/Model/Order/Invoice/Sender/EmailSender.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/Sender/EmailSender.php
@@ -99,6 +99,8 @@ class EmailSender extends Sender implements SenderInterface
         $invoice->setSendEmail(true);
 
         if (!$this->globalConfig->getValue('sales_email/general/async_sending') || $forceSyncMode) {
+            $this->identityContainer->setStore($order->getStore());
+
             $transport = [
                 'order' => $order,
                 'invoice' => $invoice,

--- a/app/code/Magento/Sales/Model/Order/Shipment/Sender/EmailSender.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Sender/EmailSender.php
@@ -99,6 +99,8 @@ class EmailSender extends Sender implements SenderInterface
         $shipment->setSendEmail(true);
 
         if (!$this->globalConfig->getValue('sales_email/general/async_sending') || $forceSyncMode) {
+            $this->identityContainer->setStore($order->getStore());
+
             $transport = [
                 'order' => $order,
                 'shipment' => $shipment,


### PR DESCRIPTION

### Description (*)
This changes fixes issue #23333.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23333: Incorrect payment method translation in order emails

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create website with different locale than en_US (for example: fr_FR)
2. Enable "Check / Money" order payment method for French website and translate it in into "Chèque / Argent"
3. Flush cache
4. Create new order in French store view
5. Create shipment for it and set checkbox "Email Copy of Shipment" checked
6. Create credit memo for it and set checkbox "Email Copy of Credit Memo" checked


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
