### PR TITLE
[Backport] fixed issue #22736 - Cursor position not in right side of search keyword in mobile

### DIFF
--- a/app/code/Magento/Search/view/frontend/web/js/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/js/form-mini.js
@@ -130,14 +130,14 @@ define([
          */
         setActiveState: function (isActive) {
             var searchValue;
-            
+
             this.searchForm.toggleClass('active', isActive);
             this.searchLabel.toggleClass('active', isActive);
 
             if (this.isExpandable) {
                 this.element.attr('aria-expanded', isActive);
                 searchValue = this.element.val();
-                this.element.val("");
+                this.element.val('');
                 this.element.val(searchValue);
             }
         },

--- a/app/code/Magento/Search/view/frontend/web/js/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/js/form-mini.js
@@ -134,6 +134,9 @@ define([
 
             if (this.isExpandable) {
                 this.element.attr('aria-expanded', isActive);
+                let searchValue = this.element.val();
+                this.element.val("");
+                this.element.val(searchValue);
             }
         },
 

--- a/app/code/Magento/Search/view/frontend/web/js/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/js/form-mini.js
@@ -129,12 +129,13 @@ define([
          * @param {Boolean} isActive
          */
         setActiveState: function (isActive) {
+            var searchValue;
             this.searchForm.toggleClass('active', isActive);
             this.searchLabel.toggleClass('active', isActive);
 
             if (this.isExpandable) {
                 this.element.attr('aria-expanded', isActive);
-                let searchValue = this.element.val();
+                searchValue = this.element.val();
                 this.element.val("");
                 this.element.val(searchValue);
             }

--- a/app/code/Magento/Search/view/frontend/web/js/form-mini.js
+++ b/app/code/Magento/Search/view/frontend/web/js/form-mini.js
@@ -130,6 +130,7 @@ define([
          */
         setActiveState: function (isActive) {
             var searchValue;
+            
             this.searchForm.toggleClass('active', isActive);
             this.searchLabel.toggleClass('active', isActive);
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/22795
### Description (*)
For mobile view when search is focused I have set with only found solution https://www.google.com/search?q=jquery+set+cursor+at+end+of+input

### Fixed Issues (if relevant)
1. magento/magento2#22736: 
Cursor position not in right side of search keyword in search box when click on search again (Mobile issue)

### Manual testing scenarios (*)
1. Load website in mobile view
2. Search anything.
3. Click on search icon to focus search box
4. Check the cursor position

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
