### PR TITLE
magento/magento2#23345: Creditmemo getOrder() method loads order incorrectly.

### DIFF
--- a/app/code/Magento/Sales/Test/Unit/Model/Order/CreditmemoTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/CreditmemoTest.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Sales\Test\Unit\Model\Order;
 
+use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\ResourceModel\OrderFactory;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Sales\Model\ResourceModel\Order\Creditmemo\Item\CollectionFactory;
@@ -20,9 +21,9 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 class CreditmemoTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var OrderFactory |\PHPUnit_Framework_MockObject_MockObject
+     * @var OrderRepositoryInterface |\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $orderFactory;
+    protected $orderRepository;
 
     /**
      * @var \Magento\Sales\Model\Order\Creditmemo
@@ -41,7 +42,7 @@ class CreditmemoTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $this->orderFactory = $this->createPartialMock(\Magento\Sales\Model\OrderFactory::class, ['create']);
+        $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
         $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
 
         $objectManagerHelper = new ObjectManagerHelper($this);
@@ -61,7 +62,6 @@ class CreditmemoTest extends \PHPUnit\Framework\TestCase
             'creditmemoConfig' => $this->createMock(
                 \Magento\Sales\Model\Order\Creditmemo\Config::class
             ),
-            'orderFactory' => $this->orderFactory,
             'cmItemCollectionFactory' => $this->cmItemCollectionFactoryMock,
             'calculatorFactory' => $this->createMock(\Magento\Framework\Math\CalculatorFactory::class),
             'storeManager' => $this->createMock(\Magento\Store\Model\StoreManagerInterface::class),
@@ -69,7 +69,8 @@ class CreditmemoTest extends \PHPUnit\Framework\TestCase
             'commentCollectionFactory' => $this->createMock(
                 \Magento\Sales\Model\ResourceModel\Order\Creditmemo\Comment\CollectionFactory::class
             ),
-            'scopeConfig' => $this->scopeConfigMock
+            'scopeConfig' => $this->scopeConfigMock,
+            'orderRepository' => $this->orderRepository,
         ];
         $this->creditmemo = $objectManagerHelper->getObject(
             \Magento\Sales\Model\Order\Creditmemo::class,
@@ -91,14 +92,10 @@ class CreditmemoTest extends \PHPUnit\Framework\TestCase
             ->method('setHistoryEntityName')
             ->with($entityName)
             ->will($this->returnSelf());
-        $order->expects($this->atLeastOnce())
-            ->method('load')
+        $this->orderRepository->expects($this->atLeastOnce())
+            ->method('get')
             ->with($orderId)
-            ->will($this->returnValue($order));
-
-        $this->orderFactory->expects($this->atLeastOnce())
-            ->method('create')
-            ->will($this->returnValue($order));
+            ->willReturn($order);
 
         $this->assertEquals($order, $this->creditmemo->getOrder());
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23345: Creditmemo getOrder() method loads order incorrectly.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create Order.
2. Create Credit Memo.
3.  Load creditmemo by Magento\Sales\Api\CreditmemoRepositoryInterface
4. Get order: $order = $creditmemo->getOrder();
5. Get extension attributes: $extension = $order->getExtensionAttributes();
6. Make sure extension attributes array is not empty.


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
