### PR TITLE
magento/magento2:#23342 : Sort Orders not applied to Magento\Catalog\…

### DIFF
--- a/app/code/Magento/Catalog/Model/CategoryList.php
+++ b/app/code/Magento/Catalog/Model/CategoryList.php
@@ -77,15 +77,10 @@ class CategoryList implements CategoryListInterface
 
         $this->collectionProcessor->process($searchCriteria, $collection);
 
-        $items = [];
-        foreach ($collection->getAllIds() as $id) {
-            $items[] = $this->categoryRepository->get($id);
-        }
-
         /** @var CategorySearchResultsInterface $searchResult */
         $searchResult = $this->categorySearchResultsFactory->create();
         $searchResult->setSearchCriteria($searchCriteria);
-        $searchResult->setItems($items);
+        $searchResult->setItems($collection->getItems());
         $searchResult->setTotalCount($collection->getSize());
         return $searchResult;
     }

--- a/app/code/Magento/Catalog/Test/Unit/Model/CategoryListTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CategoryListTest.php
@@ -82,8 +82,6 @@ class CategoryListTest extends \PHPUnit\Framework\TestCase
     public function testGetList()
     {
         $totalCount = 2;
-        $categoryIdFirst = 1;
-        $categoryIdSecond = 2;
 
         $categoryFirst = $this->getMockBuilder(Category::class)->disableOriginalConstructor()->getMock();
         $categorySecond = $this->getMockBuilder(Category::class)->disableOriginalConstructor()->getMock();

--- a/app/code/Magento/Catalog/Test/Unit/Model/CategoryListTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CategoryListTest.php
@@ -93,7 +93,7 @@ class CategoryListTest extends \PHPUnit\Framework\TestCase
 
         $collection = $this->getMockBuilder(Collection::class)->disableOriginalConstructor()->getMock();
         $collection->expects($this->once())->method('getSize')->willReturn($totalCount);
-        $collection->expects($this->once())->method('getAllIds')->willReturn([$categoryIdFirst, $categoryIdSecond]);
+        $collection->expects($this->once())->method('getItems')->willReturn([$categoryFirst, $categorySecond]);
 
         $this->collectionProcessorMock->expects($this->once())
             ->method('process')
@@ -103,14 +103,6 @@ class CategoryListTest extends \PHPUnit\Framework\TestCase
         $searchResult->expects($this->once())->method('setSearchCriteria')->with($searchCriteria);
         $searchResult->expects($this->once())->method('setItems')->with([$categoryFirst, $categorySecond]);
         $searchResult->expects($this->once())->method('setTotalCount')->with($totalCount);
-
-        $this->categoryRepository->expects($this->exactly(2))
-            ->method('get')
-            ->willReturnMap([
-                [$categoryIdFirst, $categoryFirst],
-                [$categoryIdSecond, $categorySecond],
-            ])
-            ->willReturn($categoryFirst);
 
         $this->categorySearchResultsFactory->expects($this->once())->method('create')->willReturn($searchResult);
         $this->categoryCollectionFactory->expects($this->once())->method('create')->willReturn($collection);


### PR DESCRIPTION
…Model\CategoryList::getList Fixed issue with not working sorting for categories

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Issue was introduced in MAGETWO-58841. Fix I've implemented, was previously reverted because of issue with Tax Rules. This issue(with tax) is no longer reproduced
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. [magento/magento2#[<23342>:](https://github.com/magento/magento2/issues/23342) ]Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
