### PR TITLE
Changed logic in lib/mage/collapsible.js so that _scrollToTopIfVisible is called only if element…

### DIFF
--- a/lib/web/mage/collapsible.js
+++ b/lib/web/mage/collapsible.js
@@ -582,7 +582,6 @@ define([
          */
         _isElementOutOfViewport: function (elem) {
             var rect = elem.getBoundingClientRect();
-
             return rect.bottom > window.innerHeight || rect.right < 0 || rect.left > window.innerWidth || rect.top < 0;
         }
     });

--- a/lib/web/mage/collapsible.js
+++ b/lib/web/mage/collapsible.js
@@ -570,7 +570,7 @@ define([
          * @private
          */
         _scrollToTopIfVisible: function (elem) {
-            if (this._isElementOutOfViewport(elem)) {
+            if (!this._isElementOutOfViewport(elem)) {
                 elem.scrollIntoView();
             }
         },
@@ -583,7 +583,7 @@ define([
         _isElementOutOfViewport: function (elem) {
             var rect = elem.getBoundingClientRect();
 
-            return rect.bottom < 0 || rect.right < 0 || rect.left > window.innerWidth || rect.top > window.innerHeight;
+            return rect.bottom > window.innerHeight || rect.right < 0 || rect.left > window.innerWidth || rect.top < 0;
         }
     });
 


### PR DESCRIPTION
… is in viewport. Previously it was called only when the element was outside it. Also changed the logic of _isElementOutOfViewport to work correctly.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Noticed that _scrollToTopIfVisible was called only if changing element was outside of viewport and thus wasn't working as intended. Also the checks in _isElementOutOfViewport for rect.bottom and rect.top were the wrong way around. 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. On product page scroll so that .product.data.items is partially visible.
2. Change tab. The whole .product.data.items should scroll into view.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
