### PR TITLE
Remove rogue closing tag from store-switcher template

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/templates/store/switcher.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/store/switcher.phtml
@@ -36,7 +36,6 @@
             <?php if ($block->hasDefaultOption()) : ?>
                 <li class="store-switcher-all <?php if (!($block->getDefaultSelectionName() != $block->getCurrentSelectionName())) : ?>disabled<?php endif; ?> <?php if (!$block->hasScopeSelected()) : ?>current<?php endif; ?>">
                     <?php if ($block->getDefaultSelectionName() != $block->getCurrentSelectionName()) : ?>
-                        ?>
                         <a data-role="store-view-id" data-value="" href="#">
                             <?= $block->escapeHtml($block->getDefaultSelectionName()) ?>
                         </a>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
A PHP closing tag has been left behind in the HTML after [this commit](https://github.com/magento/magento2/commit/c844e34e0cc6eebcf598613682841fde04e5777d), and is visible when switching store. 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. 2.3 develop
2. Create multiple websites
3. Go to Stores > Configuration
4. Switch to a different website
5. You should not see this!

![Screenshot 2019-06-25 17 11 38](https://user-images.githubusercontent.com/77671/60114777-6a77a980-976c-11e9-9073-6b823c941bb4.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
