### PR TITLE
Backward compatibility provided by #19765

### DIFF
--- a/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
@@ -265,6 +265,11 @@ abstract class AbstractEntity
     private $serializer;
 
     /**
+     * @var string $uniqueField
+     */
+    private $uniqueField;
+
+    /**
      * @param \Magento\Framework\Json\Helper\Data $jsonHelper
      * @param \Magento\ImportExport\Helper\Data $importExportData
      * @param \Magento\ImportExport\Model\ResourceModel\Import\Data $importData
@@ -273,6 +278,7 @@ abstract class AbstractEntity
      * @param \Magento\ImportExport\Model\ResourceModel\Helper $resourceHelper
      * @param \Magento\Framework\Stdlib\StringUtils $string
      * @param ProcessingErrorAggregatorInterface $errorAggregator
+     * @param string $uniqueField
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function __construct(
@@ -283,7 +289,8 @@ abstract class AbstractEntity
         ResourceConnection $resource,
         \Magento\ImportExport\Model\ResourceModel\Helper $resourceHelper,
         \Magento\Framework\Stdlib\StringUtils $string,
-        ProcessingErrorAggregatorInterface $errorAggregator
+        ProcessingErrorAggregatorInterface $errorAggregator,
+        $uniqueField = 'sku'
     ) {
         $this->jsonHelper = $jsonHelper;
         $this->_importExportData = $importExportData;
@@ -300,6 +307,7 @@ abstract class AbstractEntity
         $this->_entityTypeId = $entityType->getEntityTypeId();
         $this->_dataSourceModel = $importData;
         $this->_connection = $resource->getConnection();
+        $this->uniqueField = $uniqueField;
     }
 
     /**
@@ -391,7 +399,7 @@ abstract class AbstractEntity
         $nextRowBackup = [];
         $maxDataSize = $this->_resourceHelper->getMaxDataSize();
         $bunchSize = $this->_importExportData->getBunchSize();
-        $skuSet = [];
+        $uniqueFieldSet = [];
 
         $source->rewind();
         $this->_dataSourceModel->cleanBunches();
@@ -408,8 +416,8 @@ abstract class AbstractEntity
             if ($source->valid()) {
                 try {
                     $rowData = $source->current();
-                    if (array_key_exists('sku', $rowData)) {
-                        $skuSet[$rowData['sku']] = true;
+                    if ($this->uniqueField !== null) {
+                        $uniqueFieldSet[$rowData[$this->uniqueField]] = true;
                     }
                 } catch (\InvalidArgumentException $e) {
                     $this->addRowError($e->getMessage(), $this->_processedRowsCount);
@@ -438,8 +446,9 @@ abstract class AbstractEntity
                 $source->next();
             }
         }
-        $this->_processedEntitiesCount = (count($skuSet)) ? : $this->_processedRowsCount;
-
+        if ($this->uniqueField !== null) {
+            $this->_processedEntitiesCount = count($uniqueFieldSet);
+        }
         return $this;
     }
 


### PR DESCRIPTION
### Description (*)
Current fixes still don't provide complete backward compatibility with code designed for Magento 2.0.X, 2.1.X, 2.2.X.
IMO it is not good at all to have any variables related to SKU in abstract entity code. In the best case new class must be implemented and extended from abstract entity.
In case it is impossible to achieve that, then it would be probably better to introduce one more variable to the constructor.

### Fixed Issues (if relevant)

1. magento/magento2#22761: Backward compatibility 

### Manual testing scenarios (*)

1. Create a custom import adapter extending Magento\ImportExport\Model\Import\Entity\AbstractEntity
(override 'uniqueField' to your unique field)
2. Add valid columns in getValidColumnNames() function.
3. e.g. ['column1', 'column2', 'column3']
4. Create CSV file with columns stated above and add data.
5. Go to System > Import
6. Select your adapter from "Entity Type" dropdown
7. Select your CSV file in "Select File to Import" field.
8. Click on "Check Data" button
9. CSV file should get validated if column and data are available

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
