### PR TITLE
Additional check for correct version of sodium

### DIFF
--- a/lib/internal/Magento/Framework/Encryption/Encryptor.php
+++ b/lib/internal/Magento/Framework/Encryption/Encryptor.php
@@ -162,7 +162,7 @@ class Encryptor implements EncryptorInterface
      */
     public function getLatestHashVersion(): int
     {
-        if (extension_loaded('sodium')) {
+        if (extension_loaded('sodium') && defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) {
             return self::HASH_VERSION_ARGON2ID13;
         }
 


### PR DESCRIPTION
The Encryptor class checks for the presence of the sodium library and if installed, adds the ARGON2ID13 as hashing mechanism for passwords. 
The problem is in official php Docker images, (even :7.2 and :7.3 tags - based on debian-stretch) have an older version of libsodium php extension (1.0.11) which doesn't have support for argon2id. Under this scenario, Magento will fail (e.g. running bin/magento will fail with an exception).
This PR adds an additional check for the presence of the SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13 constant (as we are not able to grab the sodium extension version correctly)

### Fixed Issues (if relevant)
1. magento/magento2#issue-23405: 2.3.2 installed and bin/magento setup:upgrade not working

### Manual testing scenarios (*)
1. Have a docker-compose.yml with a DB container with a 2.3.1 database and a FPM container based on php:7.2.4-fpm
2. On the FPM container , create a composer.json depending on Magento 2.3.2 (tested with magento/product-enterprise-edition but probably community has the same issue)
3. Ensure you have an env.php file with appropriate configuration for connectivity to the DB container
2. Run composer install
3. Run bin/magento setup:upgrade

Expected result: Magento DB should upgrade correctly
Actual result: bin/magento fails with 
```In ServiceManager.php line 1130:

  An abstract factory could not create an instance of magentosetupconsolecommandbackupcommand(alias: Magento\Setup\Console\Command\Back
  upCommand).


In ServiceManager.php line 941:

  An exception was raised while creating "Magento\Setup\Console\Command\BackupCommand"; no instance returned


In Di.php line 865:

  Missing instance/object for parameter maintenanceMode for Magento\Setup\Console\Command\BackupCommand::__construct


In ServiceManager.php line 1130:

  An abstract factory could not create an instance of magentoframeworkappmaintenancemode(alias: Magento\Framework\App\MaintenanceMode).


In ServiceManager.php line 941:

  An exception was raised while creating "Magento\Framework\App\MaintenanceMode"; no instance returned


In ErrorHandler.php line 61:

  Warning: Use of undefined constant SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13 - assumed 'SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13' (this will thr
  ow an Error in a future version of PHP) in /var/www/html/vendor/magento/framework/Encryption/Encryptor.php on line 153
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
