### PR TITLE
#23429 wrap url rewrite regeneration into transaction to keep existing urls form deletion

### DIFF
--- a/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
+++ b/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
@@ -282,7 +282,9 @@ class DbStorage extends AbstractStorage
             $this->insertMultiple($data);
 
             $this->connection->commit();
+            // @codingStandardsIgnoreStart
         } catch (\Magento\Framework\Exception\AlreadyExistsException $e) {
+            // @codingStandardsIgnoreEnd
             $this->connection->rollBack();
 
             /** @var \Magento\UrlRewrite\Service\V1\Data\UrlRewrite[] $urlConflicted */

--- a/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
+++ b/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
@@ -139,21 +139,21 @@ class DbStorage extends AbstractStorage
         $prioritizedUrlRewrites = [];
         foreach ($urlRewrites as $urlRewrite) {
             switch (true) {
-            case $urlRewrite[UrlRewrite::REQUEST_PATH] === $requestPath:
-                $priority = 1;
-                break;
-            case $urlRewrite[UrlRewrite::REQUEST_PATH] === urldecode($requestPath):
-                $priority = 2;
-                break;
-            case rtrim($urlRewrite[UrlRewrite::REQUEST_PATH], '/') === rtrim($requestPath, '/'):
-                $priority = 3;
-                break;
-            case rtrim($urlRewrite[UrlRewrite::REQUEST_PATH], '/') === rtrim(urldecode($requestPath), '/'):
-                $priority = 4;
-                break;
-            default:
-                $priority = 5;
-                break;
+                case $urlRewrite[UrlRewrite::REQUEST_PATH] === $requestPath:
+                    $priority = 1;
+                    break;
+                case $urlRewrite[UrlRewrite::REQUEST_PATH] === urldecode($requestPath):
+                    $priority = 2;
+                    break;
+                case rtrim($urlRewrite[UrlRewrite::REQUEST_PATH], '/') === rtrim($requestPath, '/'):
+                    $priority = 3;
+                    break;
+                case rtrim($urlRewrite[UrlRewrite::REQUEST_PATH], '/') === rtrim(urldecode($requestPath), '/'):
+                    $priority = 4;
+                    break;
+                default:
+                    $priority = 5;
+                    break;
             }
             $prioritizedUrlRewrites[$priority] = $urlRewrite;
         }
@@ -271,13 +271,14 @@ class DbStorage extends AbstractStorage
     {
         $this->connection->beginTransaction();
 
-        $this->deleteOldUrls($urls);
-
-        $data = [];
-        foreach ($urls as $url) {
-            $data[] = $url->toArray();
-        }
         try {
+            $this->deleteOldUrls($urls);
+
+            $data = [];
+            foreach ($urls as $url) {
+                $data[] = $url->toArray();
+            }
+
             $this->insertMultiple($data);
 
             $this->connection->commit();
@@ -307,6 +308,9 @@ class DbStorage extends AbstractStorage
             } else {
                 throw $e->getPrevious() ?: $e;
             }
+        } catch (\Exception $e) {
+            $this->connection->rollBack();
+            throw $e;
         }
 
         return $urls;

--- a/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
+++ b/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
@@ -49,9 +49,9 @@ class DbStorage extends AbstractStorage
     private $logger;
 
     /**
-     * @param UrlRewriteFactory $urlRewriteFactory
-     * @param DataObjectHelper $dataObjectHelper
-     * @param ResourceConnection $resource
+     * @param UrlRewriteFactory    $urlRewriteFactory
+     * @param DataObjectHelper     $dataObjectHelper
+     * @param ResourceConnection   $resource
      * @param LoggerInterface|null $logger
      */
     public function __construct(
@@ -71,7 +71,7 @@ class DbStorage extends AbstractStorage
     /**
      * Prepare select statement for specific filter
      *
-     * @param array $data
+     * @param  array $data
      * @return Select
      */
     protected function prepareSelect(array $data)
@@ -106,12 +106,14 @@ class DbStorage extends AbstractStorage
 
             $requestPath = $data[UrlRewrite::REQUEST_PATH];
             $decodedRequestPath = urldecode($requestPath);
-            $data[UrlRewrite::REQUEST_PATH] = array_unique([
+            $data[UrlRewrite::REQUEST_PATH] = array_unique(
+                [
                 rtrim($requestPath, '/'),
                 rtrim($requestPath, '/') . '/',
                 rtrim($decodedRequestPath, '/'),
                 rtrim($decodedRequestPath, '/') . '/',
-            ]);
+                ]
+            );
 
             $resultsFromDb = $this->connection->fetchAll($this->prepareSelect($data));
             if ($resultsFromDb) {
@@ -128,8 +130,8 @@ class DbStorage extends AbstractStorage
     /**
      * Extract most relevant url rewrite from url rewrites list
      *
-     * @param string $requestPath
-     * @param array $urlRewrites
+     * @param  string $requestPath
+     * @param  array  $urlRewrites
      * @return array|null
      */
     private function extractMostRelevantUrlRewrite(string $requestPath, array $urlRewrites): ?array
@@ -137,21 +139,21 @@ class DbStorage extends AbstractStorage
         $prioritizedUrlRewrites = [];
         foreach ($urlRewrites as $urlRewrite) {
             switch (true) {
-                case $urlRewrite[UrlRewrite::REQUEST_PATH] === $requestPath:
-                    $priority = 1;
-                    break;
-                case $urlRewrite[UrlRewrite::REQUEST_PATH] === urldecode($requestPath):
-                    $priority = 2;
-                    break;
-                case rtrim($urlRewrite[UrlRewrite::REQUEST_PATH], '/') === rtrim($requestPath, '/'):
-                    $priority = 3;
-                    break;
-                case rtrim($urlRewrite[UrlRewrite::REQUEST_PATH], '/') === rtrim(urldecode($requestPath), '/'):
-                    $priority = 4;
-                    break;
-                default:
-                    $priority = 5;
-                    break;
+            case $urlRewrite[UrlRewrite::REQUEST_PATH] === $requestPath:
+                $priority = 1;
+                break;
+            case $urlRewrite[UrlRewrite::REQUEST_PATH] === urldecode($requestPath):
+                $priority = 2;
+                break;
+            case rtrim($urlRewrite[UrlRewrite::REQUEST_PATH], '/') === rtrim($requestPath, '/'):
+                $priority = 3;
+                break;
+            case rtrim($urlRewrite[UrlRewrite::REQUEST_PATH], '/') === rtrim(urldecode($requestPath), '/'):
+                $priority = 4;
+                break;
+            default:
+                $priority = 5;
+                break;
             }
             $prioritizedUrlRewrites[$priority] = $urlRewrite;
         }
@@ -166,8 +168,8 @@ class DbStorage extends AbstractStorage
      * If request path matches the DB value or it's redirect - we can return result from DB
      * Otherwise return 301 redirect to request path from DB results
      *
-     * @param string $requestPath
-     * @param array $urlRewrite
+     * @param  string $requestPath
+     * @param  array  $urlRewrite
      * @return array
      */
     private function prepareUrlRewrite(string $requestPath, array $urlRewrite): array
@@ -197,7 +199,7 @@ class DbStorage extends AbstractStorage
     /**
      * Delete old URLs from DB.
      *
-     * @param UrlRewrite[] $urls
+     * @param  UrlRewrite[] $urls
      * @return void
      */
     private function deleteOldUrls(array $urls): void
@@ -242,7 +244,7 @@ class DbStorage extends AbstractStorage
     /**
      * Prepare array with unique entities
      *
-     * @param UrlRewrite[] $urls
+     * @param  UrlRewrite[] $urls
      * @return array
      */
     private function prepareUniqueEntities(array $urls): array
@@ -258,13 +260,14 @@ class DbStorage extends AbstractStorage
             }
             $uniqueEntities[$url->getStoreId()][$url->getEntityType()] = $entityIds;
         }
+
         return $uniqueEntities;
     }
 
     /**
      * @inheritDoc
      */
-    protected function doReplace(array $urls)
+    protected function doReplace(array $urls): array
     {
         $this->connection->beginTransaction();
 
@@ -312,12 +315,12 @@ class DbStorage extends AbstractStorage
     /**
      * Insert multiple
      *
-     * @param array $data
+     * @param  array $data
      * @return void
      * @throws \Magento\Framework\Exception\AlreadyExistsException|\Exception
      * @throws \Exception
      */
-    protected function insertMultiple($data)
+    protected function insertMultiple($data): void
     {
         try {
             $this->connection->insertMultiple($this->resource->getTableName(self::TABLE_NAME), $data);
@@ -337,11 +340,11 @@ class DbStorage extends AbstractStorage
     /**
      * Get filter for url rows deletion due to provided urls
      *
-     * @param UrlRewrite[] $urls
-     * @return array
+     * @param      UrlRewrite[] $urls
+     * @return     array
      * @deprecated Not used anymore.
      */
-    protected function createFilterDataBasedOnUrls($urls)
+    protected function createFilterDataBasedOnUrls($urls): array
     {
         $data = [];
         foreach ($urls as $url) {

--- a/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
+++ b/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
@@ -266,6 +266,8 @@ class DbStorage extends AbstractStorage
      */
     protected function doReplace(array $urls)
     {
+        $this->connection->beginTransaction();
+
         $this->deleteOldUrls($urls);
 
         $data = [];
@@ -274,7 +276,11 @@ class DbStorage extends AbstractStorage
         }
         try {
             $this->insertMultiple($data);
+
+            $this->connection->commit();
         } catch (\Magento\Framework\Exception\AlreadyExistsException $e) {
+            $this->connection->rollBack();
+
             /** @var \Magento\UrlRewrite\Service\V1\Data\UrlRewrite[] $urlConflicted */
             $urlConflicted = [];
             foreach ($urls as $url) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
If an error occurred, deadlock, exception during URL Rewrite regeneration then old urls are lost and new ones not generated that leads to 404 error page on affected products. 
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added transaction to rollback unsuccessful regeneration. 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23429: Url Rewrites are lost if an exception thrown or deadlock during regeneration

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Emulate deadlock on `url_rewrite` table 
2. Regenerate URL rewrites 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
