### PR TITLE
Fix missing attribute_id condition from filter

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/ProductCollection.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/ProductCollection.php
@@ -84,8 +84,11 @@ class ProductCollection extends \Magento\Catalog\Model\ResourceModel\Product\Col
         $entity = $this->getEntity();
         $fKey = 'e.' . $this->getEntityPkName($entity);
         $pKey = $tableName . '.' . $this->getEntityPkName($entity);
+        $attributeId = $attributeModel->getAttributeId();
         $condition = "({$pKey} = {$fKey}) AND ("
             . $this->_getConditionSql("{$tableName}.value", $condition)
+            . ') AND ('
+            . $this->_getConditionSql("{$tableName}.attribute_id", $attributeId)
             . ')';
         $selectExistsInAllStores = $this->getConnection()->select()->from($tableName);
         $this->getSelect()->exists($selectExistsInAllStores, $condition);


### PR DESCRIPTION
### Description 
M2.3.2 changed the Magento\Catalog\Ui\DataProvider\Product\ProductCollection class and added logic for adding attribute filters beyond the base class. Unfortunately the SQL generated by the code omits the attribute_id condition which leads to any attribute of the same type (int, varchar, etc) matching the query if the values are same.

### Fixed Issues (if relevant)
1. magento/magento2#23435: Catalog Products Filter in 2.3.2

### Manual testing scenarios
1. Clean M2.3.2 installation with sampledata.
2. Disable one product.
3. Filter for disabled products.

Before this fix the status filter is not applied. (Or rather is, but any int attribute with value 2 will cause the product to be included in the filtered collection.)

After applying the fix the status filter works correctly. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
