### PR TITLE
Resolve _save_after_commit not firing on Guest Checkout

### DIFF
--- a/app/code/Magento/Checkout/Model/ResourceModel/GenericCheckoutResource.php
+++ b/app/code/Magento/Checkout/Model/ResourceModel/GenericCheckoutResource.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Checkout\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+/**
+ * Intended solely to manually trigger transactions
+ */
+class GenericCheckoutResource extends AbstractDb
+{
+    /**
+     * Resource initialization
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->connectionName = 'checkout';
+    }
+}

--- a/app/code/Magento/Checkout/Model/ResourceModel/GenericSalesResource.php
+++ b/app/code/Magento/Checkout/Model/ResourceModel/GenericSalesResource.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Checkout\Model\ResourceModel;
+
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+/**
+ * Intended solely to manually trigger transactions
+ */
+class GenericSalesResource extends AbstractDb
+{
+    /**
+     * Resource initialization
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->connectionName = 'sales';
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
All sorts of commit_after events do not fire on Guest Checkout due to the creation of a transaction level outside of the Abstract Resource models - thereby preventing them from ever reaching a low enough transaction level to call the commit after event hooks

This removes that change and instead creates two very generic resource models solely existing to do the exact same thing while still triggering commit callbacks.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23340: sales_order_item_save_commit_after & sales_order_save_commit_after events do not fire for guest checkout

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
