### PR TITLE
[Fixed] - Display double quote in order CSV/XML export on ID field.

### DIFF
--- a/app/code/Magento/Ui/Model/Export/ConvertToCsv.php
+++ b/app/code/Magento/Ui/Model/Export/ConvertToCsv.php
@@ -77,7 +77,8 @@ class ConvertToCsv
         $this->directory->create('export');
         $stream = $this->directory->openFile($file, 'w+');
         $stream->lock();
-        $stream->writeCsv($this->metadataProvider->getHeaders($component));
+        $headers = array_map(function ($value) { return str_replace('"', '', $value); }, $this->metadataProvider->getHeaders($component));
+        $stream->writeCsv($headers);
         $i = 1;
         $searchCriteria = $dataProvider->getSearchCriteria()
             ->setCurrentPage($i)

--- a/app/code/Magento/Ui/Model/Export/ConvertToXml.php
+++ b/app/code/Magento/Ui/Model/Export/ConvertToXml.php
@@ -158,7 +158,8 @@ class ConvertToXml
         $stream = $this->directory->openFile($file, 'w+');
         $stream->lock();
 
-        $excel->setDataHeader($this->metadataProvider->getHeaders($component));
+        $headers = array_map(function ($value) { return str_replace('"', '', $value); }, $this->metadataProvider->getHeaders($component));
+        $excel->setDataHeader($headers);
         $excel->write($stream, $component->getName() . '.xml');
 
         $stream->unlock();


### PR DESCRIPTION
### Preconditions (*)
1. Magento 2.3.2

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Display double quote in order id field in order CSV export time

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23465: Display double quote in order id field in order CSV export time

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to admin panel
2. Go to sales > order
3. Select Orders and click on export.

### Expected result (*)
1. Double quote's should not be display in CSV field title

### Actual result (*)
![image_2019_06_29T05_10_32_105Z](https://user-images.githubusercontent.com/19776194/60379964-9770d880-9a5a-11e9-97d4-e59a9f3619ee.png)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
