### PR TITLE
Added quantity validation on Shipping Multiple Address Page

### DIFF
--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/addresses.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/addresses.phtml
@@ -62,8 +62,9 @@
                                            name="ship[<?= $block->escapeHtml($_index) ?>][<?= $block->escapeHtml($_item->getQuoteItemId()) ?>][qty]"
                                            value="<?= $block->escapeHtml($_item->getQty()) ?>"
                                            size="2"
+                                           min="0"
                                            class="input-text qty"
-                                           data-validate="{number: true}"/>
+                                           data-validate="{number: true,'validate-greater-than-zero':true}"/>
                                 </div>
                             </div>
                         </td>


### PR DESCRIPTION
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)
Cart empty after update qty with -1 and change address.

### Reference Issue
#23466

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento 2.3.x

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Front end >> Login into account
2. Add 1 product with 4 qty to the cart
3. Cart >> Go to checkout with multiple addresses
4. Change address for 1st product and update qty with -1
5. Click on Update qty & addresses
6. It will clear the shopping cart

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. -1 Qty should not allow while update qty.

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. https://www.screencast.com/t/dsyR2fC4
