### PR TITLE
Fixed #23465 double quote in order id field in order CSV export

### DIFF
--- a/app/code/Magento/Ui/Model/Export/MetadataProvider.php
+++ b/app/code/Magento/Ui/Model/Export/MetadataProvider.php
@@ -118,13 +118,6 @@ class MetadataProvider
         foreach ($this->getColumns($component) as $column) {
             $row[] = $column->getData('config/label');
         }
-
-        array_walk($row, function (&$header) {
-            if (mb_strpos($header, 'ID') === 0) {
-                $header = '"' . $header . '"';
-            }
-        });
-
         return $row;
     }
 

--- a/app/code/Magento/Ui/Test/Unit/Model/Export/MetadataProviderTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Model/Export/MetadataProviderTest.php
@@ -97,12 +97,12 @@ class MetadataProviderTest extends \PHPUnit\Framework\TestCase
     public function getColumnsDataProvider(): array
     {
         return [
-            [['ID'],['"ID"']],
+            [['ID'],['ID']],
             [['Name'],['Name']],
             [['Id'],['Id']],
             [['id'],['id']],
-            [['IDTEST'],['"IDTEST"']],
-            [['ID TEST'],['"ID TEST"']],
+            [['IDTEST'],['IDTEST']],
+            [['ID TEST'],['ID TEST']],
         ];
     }
 


### PR DESCRIPTION
Fixed #23465 Display double quote in order id field in order CSV export time

### Preconditions (*)
1. Magento 2.3.2

### Steps to reproduce (*)
1. Go to admin panel
2. Select sales ->Order
3. Export the order CSV

### Expected result (*)
1. Double quote's should not be display in CSV field title

### Actual result (*)
1. 
![image_2019_06_29T05_10_32_105Z](https://user-images.githubusercontent.com/19776194/60379964-9770d880-9a5a-11e9-97d4-e59a9f3619ee.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
