### PR TITLE
Added default value in Discount amount field in Catalog Price Rule Ad…

### DIFF
--- a/app/code/Magento/CatalogRule/view/adminhtml/ui_component/catalog_rule_form.xml
+++ b/app/code/Magento/CatalogRule/view/adminhtml/ui_component/catalog_rule_form.xml
@@ -302,6 +302,7 @@
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">catalog_rule</item>
+                    <item name="default" xsi:type="number">0</item>
                 </item>
             </argument>
             <settings>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Discount Amount field shows validation error by default when open new form for Catalog Price Rule

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Admin
2. Marketing > catalog Price Rule > New Catalog Price Rule
3. It shows validation message on discount amount field

### Actual Result (*)
1. http://prntscr.com/o8876b

### Expected Result (*)
1. It must not dsiplay validation message on page load


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
