### PR TITLE
Resolved + character issue in custom widget

### DIFF
--- a/lib/internal/Magento/Framework/Filter/Template/Tokenizer/AbstractTokenizer.php
+++ b/lib/internal/Magento/Framework/Filter/Template/Tokenizer/AbstractTokenizer.php
@@ -94,7 +94,7 @@ abstract class AbstractTokenizer
      */
     public function setString($value)
     {
-        $this->_string = $value;
+        $this->_string = rawurldecode($value);
         $this->reset();
     }
 

--- a/lib/internal/Magento/Framework/Filter/Template/Tokenizer/AbstractTokenizer.php
+++ b/lib/internal/Magento/Framework/Filter/Template/Tokenizer/AbstractTokenizer.php
@@ -94,7 +94,7 @@ abstract class AbstractTokenizer
      */
     public function setString($value)
     {
-        $this->_string = urldecode($value);
+        $this->_string = $value;
         $this->reset();
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Resolved + [plus] character issue for the custom widget.

### Issue Number
#16234

### Steps to reproduce
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Create a widget with a parameter of xsi:type="text" or xsi:type="block" with a textarea block
2. Add the widget to the content of a CMS page
3. Enter a string containing a + character into the text field of the widget

### Expected result
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. The + character appears on the rendered page

### Actual result:
1. The + character is missing from the rendered page. It is still present in the page content stored in the database, and appears when editing the widget.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
