### PR TITLE
Fix url rewrite generation in single store mode

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
@@ -407,9 +407,9 @@ class Helper
     private function filterWebsiteIds($websiteIds)
     {
         if (!$this->storeManager->isSingleStoreMode()) {
-            $websiteIds = array_filter((array)$websiteIds);
+            $websiteIds = array_keys(array_filter((array)$websiteIds));
         } else {
-            $websiteIds[$this->storeManager->getWebsite(true)->getId()] = 1;
+            $websiteIds = [$this->storeManager->getWebsite(true)->getId()];
         }
 
         return $websiteIds;

--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -818,9 +818,6 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
         if (!$this->hasStoreIds()) {
             $storeIds = [];
             if ($websiteIds = $this->getWebsiteIds()) {
-                if ($this->_storeManager->isSingleStoreMode()) {
-                    $websiteIds = array_keys($websiteIds);
-                }
                 foreach ($websiteIds as $websiteId) {
                     $websiteStores = $this->_storeManager->getWebsite($websiteId)->getStoreIds();
                     $storeIds = array_merge($storeIds, $websiteStores);

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Initialization/HelperTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Initialization/HelperTest.php
@@ -340,7 +340,7 @@ class HelperTest extends \PHPUnit\Framework\TestCase
             [
                 'single_store' => false,
                 'website_ids' => ['1' => 1, '2' => 1],
-                'expected_website_ids' => ['1' => 1, '2' => 1],
+                'expected_website_ids' => [1, 2],
                 'links' => [],
                 'linkTypes' => ['related', 'upsell', 'crosssell'],
                 'expected_links' => [],
@@ -349,7 +349,7 @@ class HelperTest extends \PHPUnit\Framework\TestCase
             [
                 'single_store' => false,
                 'website_ids' => ['1' => 1, '2' => 0],
-                'expected_website_ids' => ['1' => 1],
+                'expected_website_ids' => [1],
                 'links' => [],
                 'linkTypes' => ['related', 'upsell', 'crosssell'],
                 'expected_links' => [],
@@ -365,7 +365,7 @@ class HelperTest extends \PHPUnit\Framework\TestCase
             [
                 'single_store' => true,
                 'website_ids' => [],
-                'expected_website_ids' => ['1' => 1],
+                'expected_website_ids' => [1],
                 'links' => [],
                 'linkTypes' => ['related', 'upsell', 'crosssell'],
                 'expected_links' => [],
@@ -375,7 +375,7 @@ class HelperTest extends \PHPUnit\Framework\TestCase
             [
                 'single_store' => false,
                 'website_ids' => ['1' => 1, '2' => 1],
-                'expected_website_ids' => ['1' => 1, '2' => 1],
+                'expected_website_ids' => [1, 2],
                 'links' => [
                     'related' => [
                         0 => [
@@ -401,7 +401,7 @@ class HelperTest extends \PHPUnit\Framework\TestCase
             [
                 'single_store' => false,
                 'website_ids' => ['1' => 1, '2' => 1],
-                'expected_website_ids' => ['1' => 1, '2' => 1],
+                'expected_website_ids' => [1, 2],
                 'links' => [
                     'customlink' => [
                         0 => [
@@ -427,7 +427,7 @@ class HelperTest extends \PHPUnit\Framework\TestCase
             [
                 'single_store' => false,
                 'website_ids' => ['1' => 1, '2' => 1],
-                'expected_website_ids' => ['1' => 1, '2' => 1],
+                'expected_website_ids' => [1, 2],
                 'links' => [
                     'related' => [
                         0 => [
@@ -467,7 +467,7 @@ class HelperTest extends \PHPUnit\Framework\TestCase
             [
                 'single_store' => false,
                 'website_ids' => ['1' => 1, '2' => 1],
-                'expected_website_ids' => ['1' => 1, '2' => 1],
+                'expected_website_ids' => [1, 2],
                 'links' => [
                     'related' => [
                         0 => [


### PR DESCRIPTION
### Description (*)
I have fixed the product url rewrite auto generation bug, that occurred in single store mode.

### Fixed Issues (if relevant)
1. magento/magento2#5929: Saving Product does not update URL rewrite in Magento 2.1.0

### Manual testing scenarios (*)
1. Switch to single store mode
2. Create a new product
3. Check if url rewrite is generated
