### PR TITLE
remove html tag  from option html from order page

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/items/column/name.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/items/column/name.phtml
@@ -28,9 +28,9 @@
                     <?php else : ?>
                         <?php $_option = $block->getFormattedOption($_option['value']); ?>
                         <?php $dots = 'dots' . uniqid(); ?>
-                        <?= $block->escapeHtml($_option['value']) ?><?php if (isset($_option['remainder']) && $_option['remainder']) : ?> <span id="<?= /* @noEscape */ $dots; ?>"> ...</span>
+                        <?= $block->escapeHtml($_option['value'], ['a']) ?><?php if (isset($_option['remainder']) && $_option['remainder']) : ?> <span id="<?= /* @noEscape */ $dots; ?>"> ...</span>
                             <?php $id = 'id' . uniqid(); ?>
-                            <span id="<?= /* @noEscape */ $id; ?>"><?= $block->escapeHtml($_option['remainder']) ?></span>
+                            <span id="<?= /* @noEscape */ $id; ?>"><?= $block->escapeHtml($_option['remainder'], ['a']) ?></span>
                             <script>
                                 require(['prototype'], function() {
                                     $('<?= /* @noEscape */ $id; ?>').hide();


### PR DESCRIPTION
Preconditions (*)
Magento CE 2.2.9

Fixed Issues (if relevant)
#23510 

Steps to reproduce (*)
Create a product with a customizable option field of type Area
When placing an order for that product fill that Area type field with multiple lines of text
Look at the new order in Admin Dashboard
Expected result (*)
The text of the field value of Area type is rendered with respect of each line (each line of next is on new line)

Actual result (*)
The value of product customizable option field of type Area is rendered with HTML <br> tag inside