### PR TITLE
move breakpoint by -1px to make nav work correctly at viewport 768

### DIFF
--- a/lib/web/mage/menu.js
+++ b/lib/web/mage/menu.js
@@ -22,7 +22,7 @@ define([
             showDelay: 42,
             hideDelay: 300,
             delay: 0,
-            mediaBreakpoint: '(max-width: 768px)'
+            mediaBreakpoint: '(max-width: 767px)'
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The issue fixed in https://github.com/magento/magento2/issues/8298 made huge improvement however there is still a 1px gap where the nav functionality breaks. This is especially obvious on iPad where viewport is exactly 768px. This patch fixes the functionality by moving the breakpoint by 1px.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/magento2/issues/8298

### Manual testing scenarios (*)

1. Clean install with sample data
2. Open front page in a browser with specific width control (e.g firefox in responsive design mode)
3. Set viewport width to 767: see main nav is hidden and mobile/burger menu is visible (GOOD)
4. Set viewport width to 769: see main nav is visible and mobile/burger menu is hidden, dropdowns work on hover. (GOOD)
5. Set viewport width to 768: see main nav is visible and mobile/burger menu is hidden (GOOD, but:)
    1. without this patch: at 768 the dropdowns do not work on hover, and they contain the "All {category}" items that are only meant to be added on the burger/mobile nav.
    2. with this patch: at 768 the nav functions as expected, dropdown on hover and not including the "All {category}" items.

### Questions or comments
I do see 768 hard coded again in the menu.js file further down I tried changing this too but didn't see any affect. I don't know what that does or why its not using the `mediaBreakpoint` variable, so I left it alone.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All automated tests passed successfully (all builds are green)
