### PR TITLE
Correct array type hints in Visibility model

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Visibility.php
+++ b/app/code/Magento/Catalog/Model/Product/Visibility.php
@@ -86,6 +86,7 @@ class Visibility extends \Magento\Framework\DataObject implements OptionSourceIn
      * Retrieve option array
      *
      * @return array
+     * phpcs:disable Magento2.Functions.StaticFunction
      */
     public static function getOptionArray()
     {
@@ -134,6 +135,7 @@ class Visibility extends \Magento\Framework\DataObject implements OptionSourceIn
         $options = self::getOptionArray();
         return isset($options[$optionId]) ? $options[$optionId] : null;
     }
+    //phpcs:enable Magento2.Functions.StaticFunction
 
     /**
      * Retrieve flat column definition
@@ -251,7 +253,7 @@ class Visibility extends \Magento\Framework\DataObject implements OptionSourceIn
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function toOptionArray()
     {

--- a/app/code/Magento/Catalog/Model/Product/Visibility.php
+++ b/app/code/Magento/Catalog/Model/Product/Visibility.php
@@ -55,7 +55,7 @@ class Visibility extends \Magento\Framework\DataObject implements OptionSourceIn
     /**
      * Retrieve visible in catalog ids array
      *
-     * @return string[]
+     * @return int[]
      */
     public function getVisibleInCatalogIds()
     {
@@ -65,7 +65,7 @@ class Visibility extends \Magento\Framework\DataObject implements OptionSourceIn
     /**
      * Retrieve visible in search ids array
      *
-     * @return string[]
+     * @return int[]
      */
     public function getVisibleInSearchIds()
     {
@@ -75,7 +75,7 @@ class Visibility extends \Magento\Framework\DataObject implements OptionSourceIn
     /**
      * Retrieve visible in site ids array
      *
-     * @return string[]
+     * @return int[]
      */
     public function getVisibleInSiteIds()
     {


### PR DESCRIPTION
### Description (*)
The visibility consts returned the the arrays are `int` not `string`

### Manual testing scenarios (*)
1. Reference function in IDE and note the hinted array types match what the functions actually return.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
