### PR TITLE
[2.3] Plain Text Emails are now sent with correct MIME Encoding

### DIFF
--- a/lib/internal/Magento/Framework/Mail/Message.php
+++ b/lib/internal/Magento/Framework/Mail/Message.php
@@ -157,26 +157,6 @@ class Message implements MailMessageInterface
     }
 
     /**
-     * Create HTML mime message from the string.
-     *
-     * @param string $htmlBody
-     * @return \Zend\Mime\Message
-     *
-     * @deprecated All emails that Magento sends should be mime encoded. Therefore
-     * use generic function createMimeFromString
-     * @see createMimeFromString()
-     */
-    private function createHtmlMimeFromString($htmlBody)
-    {
-        $htmlPart = new Part($htmlBody);
-        $htmlPart->setCharset($this->zendMessage->getEncoding());
-        $htmlPart->setType(Mime::TYPE_HTML);
-        $mimeMessage = new \Zend\Mime\Message();
-        $mimeMessage->addPart($htmlPart);
-        return $mimeMessage;
-    }
-
-    /**
      * Create mime message from the string.
      *
      * @param string $body

--- a/lib/internal/Magento/Framework/Mail/Test/Unit/MessageTest.php
+++ b/lib/internal/Magento/Framework/Mail/Test/Unit/MessageTest.php
@@ -8,41 +8,34 @@ namespace Magento\Framework\Mail\Test\Unit;
 class MessageTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\Mail\Message
+     * @var \Magento\Framework\Mail\Message
      */
-    protected $_messageMock;
+    protected $message;
 
     protected function setUp()
     {
-        $this->_messageMock = $this->createPartialMock(
-            \Magento\Framework\Mail\Message::class,
-            ['setBody', 'setMessageType']
-        );
+        $this->message = new \Magento\Framework\Mail\Message();
     }
 
     public function testSetBodyHtml()
     {
-        $this->_messageMock->expects($this->once())
-            ->method('setMessageType')
-            ->with('text/html');
+        $this->message->setBodyHtml('body');
 
-        $this->_messageMock->expects($this->once())
-            ->method('setBody')
-            ->with('body');
-
-        $this->_messageMock->setBodyHtml('body');
+        $part = $this->message->getBody()->getParts()[0];
+        $this->assertEquals('text/html', $part->getType());
+        $this->assertEquals('8bit', $part->getEncoding());
+        $this->assertEquals('utf-8', $part->getCharset());
+        $this->assertEquals('body', $part->getContent());
     }
 
     public function testSetBodyText()
     {
-        $this->_messageMock->expects($this->once())
-            ->method('setMessageType')
-            ->with('text/plain');
+        $this->message->setBodyText('body');
 
-        $this->_messageMock->expects($this->once())
-            ->method('setBody')
-            ->with('body');
-
-        $this->_messageMock->setBodyText('body');
+        $part = $this->message->getBody()->getParts()[0];
+        $this->assertEquals('text/plain', $part->getType());
+        $this->assertEquals('8bit', $part->getEncoding());
+        $this->assertEquals('utf-8', $part->getCharset());
+        $this->assertEquals('body', $part->getContent());
     }
 }

--- a/lib/internal/Magento/Framework/Mail/Test/Unit/MessageTest.php
+++ b/lib/internal/Magento/Framework/Mail/Test/Unit/MessageTest.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\Framework\Mail\Test\Unit;
 
+/**
+ * test Magento\Framework\Mail\Message
+ */
 class MessageTest extends \PHPUnit\Framework\TestCase
 {
     /**


### PR DESCRIPTION
### Description (*)
Since Magento switched to Zend Framework 2 (2.2.8+ and 2.3.0+) Plain text emails are no longer sent as mime.

This PR ensures that all emails, regardless of type are sent as MIME. 

Unit tests now check correct message encoding for both html and plain text emails.

### Fixed Issues (if relevant)
1. magento/magento2#22103: Character Encoding in Plain Text Emails Fails since 2.2.8/2.3.0 due to emails no longer being sent as MIME
2. magento/magento2#23199: NO sender in email header for magento 2 sales order and password change emails to customer

### Manual testing scenarios (*)
```
Backend
=======
Marketing -> Email Templates -> Add New Template
    Template Name = Newsletter Success Plain
    Subject = Success Subject
    Template Content = ✅Success Body
    Convert to Plain Text
    Save Template
Marketing -> Email Templates -> Add New Template
    Template Name = Newsletter Success Html
    Subject = Success Subject
    Template Content = <html><body>✅Success Body</body></html>
    Save Template
Store -> Configuration -> General -> Store Email Addresses
    General Contact
        Sender Name = Owner Name
        Sender Email = owner@domain.com
Store -> Configuration -> Customers -> Newsletter -> Subscription Options
    Success Email Template = Newsletter Success Plain

Frontend
========
Subscribe to newsletter

Ensure email received contains the following headers

MIME-Version: 1.0
Content-Type: text/plain; charset="utf-8"
Content-Transfer-Encoding: 8bit

Ensure email client interprets ✅ correctly in message body

Backend
=======
Store -> Configuration -> Customers -> Newsletter -> Subscription Options
    Success Email Template = Newsletter Success Html

Frontend
========
Subscribe to newsletter

Ensure email received contains the following headers

MIME-Version: 1.0
Content-Type: text/html; charset="utf-8"
Content-Transfer-Encoding: 8bit

Ensure email client interprets ✅ correctly in message body
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
