### PR TITLE
fix validation class for max-words

### DIFF
--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -226,7 +226,7 @@
     rules = {
         'max-words': [
             function (value, element, params) {
-                return this.optional(element) || $.mage.stripHtml(value).match(/\b\w+\b/g).length < params;
+                return this.optional(element) || $.mage.stripHtml(value).match(/\b\w+\b/g).length <= params;
             },
             $.mage.__('Please enter {0} words or less.')
         ],


### PR DESCRIPTION

Description (*)
wrong validation happen for max-words validation class

Fixed Issues (if relevant)
#23538 
Manual testing scenarios (*)
Create a form using static cms page or using the theme  and add validation class and add all word into with space .
e.g max-word: 5 then add 5 char with space and you will see that message, this message only see after 5 char.