### PR TITLE
Fixed #22407 Top menu cache issue - 2.3.1

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -13,6 +13,7 @@ use Magento\Framework\Data\TreeFactory;
 use Magento\Framework\DataObject;
 use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\View\Element\Template;
+use Magento\Framework\Registry;
 
 /**
  * Html page top menu block
@@ -56,11 +57,13 @@ class Topmenu extends Template implements IdentityInterface
         Template\Context $context,
         NodeFactory $nodeFactory,
         TreeFactory $treeFactory,
+        Registry $registry,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->nodeFactory = $nodeFactory;
         $this->treeFactory = $treeFactory;
+        $this->_registry = $registry;
     }
 
     /**
@@ -444,5 +447,17 @@ class Topmenu extends Template implements IdentityInterface
         } else {
             $child->setClass($currentClass . ' ' . $outermostClass);
         }
+    }
+    
+    /**
+     * Get cache key informative items
+     *
+     * @return array
+     */
+    public function getCacheKeyInfo()
+    {
+        $keyInfo = parent::getCacheKeyInfo();
+        $keyInfo[] = $this->_registry->registry('current_category')->getEntityId();
+        return $keyInfo;
     }
 }


### PR DESCRIPTION
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1.Magento 2.3.1 with all cache types enabled


### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Create 2-3 categories, set include in menu = Yes
2. On frontend click on any category page in top menu
3. Flush magento cache
4. Open the same category page
5. Open any other category page

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
Just opened category is marked as active in top menu


### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
Both categories in top menu are marked as active
![test](https://user-images.githubusercontent.com/8502721/56359465-5488be00-61ea-11e9-9794-3df7b3015aa3.png)

