### PR TITLE
Bakend: AbstractBlock parent construct should be called at the end

### DIFF
--- a/app/code/Magento/Backend/Block/AbstractBlock.php
+++ b/app/code/Magento/Backend/Block/AbstractBlock.php
@@ -27,7 +27,7 @@ class AbstractBlock extends \Magento\Framework\View\Element\AbstractBlock
      */
     public function __construct(\Magento\Backend\Block\Context $context, array $data = [])
     {
-        parent::__construct($context, $data);
         $this->_authorization = $context->getAuthorization();
+        parent::__construct($context, $data);
     }
 }


### PR DESCRIPTION
Parent construct should be called in last, after the assignments.

### Description (*)
Class `\Magento\Backend\Block\AbstractBlock` extends `\Magento\Framework\View\Element\AbstractBlock` which have the protected method `_construct`. This method is called at the end of the original __construct, which allows to perform some action as initialization, after the dependencies are loaded.
However in `\Magento\Backend\Block\AbstractBlock`, the _authorization class member is assigned after the parent::__construct, so the _construct is called before that the _authorization class member is set.

### Manual testing scenarios (*)
1. Extends `\Magento\Backend\Block\AbstractBlock`
2. Override `_construct` and call $this->_authorization
3. Exception is raised, _authorization is null

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
