### PR TITLE
[Backport] [Ui] Calling the always action on opening and closing the modal.

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/modal/alert.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/alert.js
@@ -40,6 +40,14 @@ define([
         },
 
         /**
+         * Create widget.
+         */
+        _create: function () {
+            this.options.actions.always();
+            this._super();
+        },
+
+        /**
          * Close modal window.
          */
         closeModal: function () {

--- a/app/code/Magento/Ui/view/base/web/js/modal/alert.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/alert.js
@@ -43,7 +43,6 @@ define([
          * Close modal window.
          */
         closeModal: function () {
-            this.options.actions.always();
             this.element.bind('alertclosed', _.bind(this._remove, this));
 
             return this._super();

--- a/app/code/Magento/Ui/view/base/web/js/modal/alert.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/alert.js
@@ -43,6 +43,7 @@ define([
          * Close modal window.
          */
         closeModal: function () {
+            this.options.actions.always();
             this.element.bind('alertclosed', _.bind(this._remove, this));
 
             return this._super();

--- a/app/code/Magento/Ui/view/base/web/js/modal/alert.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/alert.js
@@ -51,7 +51,6 @@ define([
          * Close modal window.
          */
         closeModal: function () {
-            this.options.actions.always();
             this.element.bind('alertclosed', _.bind(this._remove, this));
 
             return this._super();

--- a/app/code/Magento/Ui/view/base/web/js/modal/confirm.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/confirm.js
@@ -80,6 +80,8 @@ define([
          * Open modal window.
          */
         openModal: function () {
+            this.options.actions.always();
+
             return this._super();
         },
 

--- a/app/code/Magento/Ui/view/base/web/js/modal/confirm.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/confirm.js
@@ -80,8 +80,6 @@ define([
          * Open modal window.
          */
         openModal: function () {
-            this.options.actions.always();
-
             return this._super();
         },
 


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/23234


<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes the calling of `always` action before opening the **alert** and **confirm** widgets.

### Fixed Issues (if relevant)
1. magento/magento2#23233: Alert widget doesn't trigger always method on showing the message

### Manual testing scenarios (*)
Keep the browser console open.

1. Create a new `alert` widget on frontend. The following simple code can be used:
```js
require([
        'jquery',
        'Magento_Ui/js/modal/alert'
    ], function ($, alert) {
        'use strict';

        alert({
            title: 'Alert Title',
            content: 'content',
            modalClass: 'alert',
            actions: {
                always: function() {
                    console.log('always triggering');
                }
            }
        });
    });
```

2. Click **OK** button


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
