### PR TITLE
remove reset data on deployment config object

### DIFF
--- a/lib/internal/Magento/Framework/App/DeploymentConfig.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig.php
@@ -85,7 +85,6 @@ class DeploymentConfig
      */
     public function isAvailable()
     {
-        $this->data = null;
         $this->load();
         return isset($this->flatData[ConfigOptionsListConstants::CONFIG_PATH_INSTALL_DATE]);
     }
@@ -140,7 +139,7 @@ class DeploymentConfig
      */
     private function load()
     {
-        if (null === $this->data) {
+        if (!is_array($this->data)) {
             $this->data = $this->reader->load();
             if ($this->overrideData) {
                 $this->data = array_replace($this->data, $this->overrideData);

--- a/lib/internal/Magento/Framework/Module/ModuleList.php
+++ b/lib/internal/Magento/Framework/Module/ModuleList.php
@@ -139,7 +139,6 @@ class ModuleList implements ModuleListInterface
      */
     private function loadConfigData()
     {
-        $this->config->resetData();
         if (null === $this->configData && null !== $this->config->get(ConfigOptionsListConstants::KEY_MODULES)) {
             $this->configData = $this->config->get(ConfigOptionsListConstants::KEY_MODULES);
         }


### PR DESCRIPTION
### Description (*)
DeploymentConfig object reads data from configurations files defined under ConfigFilePool initialized in \Magento\Framework\App\Bootstrap::createConfigFilePool. 

Since the ConfigFilePool can't be overwritten after bootstrap, it make no sense to reset configuration data in some cases. 

### Fixed Issues (if relevant)
Multiple loading of configuration files. 
For example in app/code/Magento/Framework/Module/ModuleList.php:99

### Manual testing scenarios (*)
After deploying this branch all configurations of shops are the same and is working the same.  

### Questions or comments
Is it necessary to still allow \Magento\Framework\App\DeploymentConfig::resetData on this object? 
