### PR TITLE
Fix for empty category field values in REST calls

### DIFF
--- a/app/code/Magento/Catalog/Model/Category/Tree.php
+++ b/app/code/Magento/Catalog/Model/Category/Tree.php
@@ -70,11 +70,11 @@ class Tree
     public function getRootNode($category = null)
     {
         if ($category !== null && $category->getId()) {
-            return $this->getNode($category);
+            $rootId = $category->getId();
+        } else {
+            $store = $this->storeManager->getStore();
+            $rootId = $store->getRootCategoryId();
         }
-
-        $store = $this->storeManager->getStore();
-        $rootId = $store->getRootCategoryId();
 
         $tree = $this->categoryTree->load(null);
         $this->prepareCollection();


### PR DESCRIPTION
### Description
When using either rest/all/V1/categories or rest/all/V1/categories?rootCategoryId=2 the name and product_count fields are empty for all categories in the tree. This does not happen when using a store code like default without a rootCategoryId as GET param, like this: rest/default/V1/categories

### Manual testing scenarios (*)
Use Magento installatie with a category tree and place a REST API call to 'rest/all/V1/categories'.

This will result in empty field values for name and product_count.

When using a storecode like default instead of all in the endpoint call, the fields will be filled in the data that we get back from the API endpoint.

### Contribution checklist (*)
 - [V] Pull request has a meaningful description of its purpose
 - [V ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
