### PR TITLE
remove reset data on deployment config object

### DIFF
--- a/lib/internal/Magento/Framework/App/DeploymentConfig.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig.php
@@ -140,7 +140,7 @@ class DeploymentConfig
      */
     private function load()
     {
-        if (null === $this->data) {
+        if (!is_array($this->data)) {
             $this->data = $this->reader->load();
             if ($this->overrideData) {
                 $this->data = array_replace($this->data, $this->overrideData);

--- a/lib/internal/Magento/Framework/Module/ModuleList.php
+++ b/lib/internal/Magento/Framework/Module/ModuleList.php
@@ -139,7 +139,6 @@ class ModuleList implements ModuleListInterface
      */
     private function loadConfigData()
     {
-        $this->config->resetData();
         if (null === $this->configData && null !== $this->config->get(ConfigOptionsListConstants::KEY_MODULES)) {
             $this->configData = $this->config->get(ConfigOptionsListConstants::KEY_MODULES);
         }

--- a/lib/internal/Magento/Framework/Module/Test/Unit/ModuleListTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/ModuleListTest.php
@@ -47,7 +47,6 @@ class ModuleListTest extends \PHPUnit\Framework\TestCase
 
     public function testGetAll()
     {
-        $this->config->expects($this->exactly(2))->method('resetData');
         $this->setLoadAllExpectation();
         $this->setLoadConfigExpectation();
         $expected = ['foo' => self::$allFixture['foo']];
@@ -65,7 +64,6 @@ class ModuleListTest extends \PHPUnit\Framework\TestCase
 
     public function testGetOne()
     {
-        $this->config->expects($this->exactly(2))->method('resetData');
         $this->setLoadAllExpectation();
         $this->setLoadConfigExpectation();
         $this->assertSame(['key' => 'value'], $this->model->getOne('foo'));
@@ -74,7 +72,6 @@ class ModuleListTest extends \PHPUnit\Framework\TestCase
 
     public function testGetNames()
     {
-        $this->config->expects($this->exactly(2))->method('resetData');
         $this->setLoadAllExpectation(false);
         $this->setLoadConfigExpectation();
         $this->assertSame(['foo'], $this->model->getNames());
@@ -83,7 +80,6 @@ class ModuleListTest extends \PHPUnit\Framework\TestCase
 
     public function testHas()
     {
-        $this->config->expects($this->exactly(2))->method('resetData');
         $this->setLoadAllExpectation(false);
         $this->setLoadConfigExpectation();
         $this->assertTrue($this->model->has('foo'));
@@ -92,7 +88,6 @@ class ModuleListTest extends \PHPUnit\Framework\TestCase
 
     public function testIsModuleInfoAvailable()
     {
-        $this->config->expects($this->once())->method('resetData');
         $this->setLoadConfigExpectation(true);
         $this->assertTrue($this->model->isModuleInfoAvailable());
     }


### PR DESCRIPTION
### Description (*)
DeploymentConfig object reads data from configurations files defined under ConfigFilePool initialized in \Magento\Framework\App\Bootstrap::createConfigFilePool. 

Since the ConfigFilePool can't be overwritten after bootstrap, it make no sense to reset configuration data in some cases. 

### Fixed Issues (if relevant)
Multiple loading of configuration files. 
For example in app/code/Magento/Framework/Module/ModuleList.php:99

### Manual testing scenarios (*)
After deploying this branch all configurations of shops are the same and is working the same.  

### Questions or comments
Is it necessary to still allow \Magento\Framework\App\DeploymentConfig::resetData on this object? 
