### PR TITLE
Option to send email from the stores email address using sendFriend

### DIFF
--- a/app/code/Magento/SendFriend/Controller/Product/Sendmail.php
+++ b/app/code/Magento/SendFriend/Controller/Product/Sendmail.php
@@ -101,6 +101,23 @@ class Sendmail extends \Magento\SendFriend\Controller\Product implements HttpPos
         $this->sendFriend->setRecipients($this->getRequest()->getPost('recipients'));
         $this->sendFriend->setProduct($product);
 
+        if ($this->sendFriend->isSentFromStore()){
+
+            // get the sender array
+            $sender = $this->getRequest()->getPost('sender');
+            
+            // set the reply to address to that of the sender
+            $this->sendFriend->setReplyTo(
+                $sender
+            );
+
+            // change the senders email to the email address of the store
+            $sender['email'] = $this->sendFriend->getEmailFromStore();
+
+            // set the sender to the new sender details
+            $this->sendFriend->setSender($sender);
+        }
+
         try {
             $validate = $this->sendFriend->validate();
 

--- a/app/code/Magento/SendFriend/Controller/Product/Sendmail.php
+++ b/app/code/Magento/SendFriend/Controller/Product/Sendmail.php
@@ -101,7 +101,7 @@ class Sendmail extends \Magento\SendFriend\Controller\Product implements HttpPos
         $this->sendFriend->setRecipients($this->getRequest()->getPost('recipients'));
         $this->sendFriend->setProduct($product);
 
-        if ($this->sendFriend->isSentFromStore()){
+        if ($this->sendFriend->isSentFromStore()) {
 
             // get the sender array
             $sender = $this->getRequest()->getPost('sender');

--- a/app/code/Magento/SendFriend/Helper/Data.php
+++ b/app/code/Magento/SendFriend/Helper/Data.php
@@ -18,6 +18,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
     const XML_PATH_ENABLED = 'sendfriend/email/enabled';
 
+    const SENT_FROM_STORE = 'sendfriend/email/sent_store';
+
+    const STORE_EMAIL_ADDRESS = 'trans_email/ident_general/email';
+
     const XML_PATH_ALLOW_FOR_GUEST = 'sendfriend/email/allow_guest';
 
     const XML_PATH_MAX_RECIPIENTS = 'sendfriend/email/max_recipients';
@@ -44,6 +48,36 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         return $this->scopeConfig->isSetFlag(
             self::XML_PATH_ENABLED,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    /**
+     * Check if email should be sent from store
+     *
+     * @param int $store
+     * @return bool
+     */
+    public function isSentFromStore($store = null)
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::SENT_FROM_STORE,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+    
+    /**
+     * Get the email address of the store
+     *
+     * @param int $store
+     * @return string
+     */
+    public function getStoreEmail($store = null)
+    {
+        return $this->scopeConfig->getValue(
+            self::STORE_EMAIL_ADDRESS,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/app/code/Magento/SendFriend/Model/SendFriend.php
+++ b/app/code/Magento/SendFriend/Model/SendFriend.php
@@ -374,7 +374,7 @@ class SendFriend extends \Magento\Framework\Model\AbstractModel
 
     /**
      * Set the reply to email address
-     * 
+     *
      * @param array $sender
      * @return void
      */

--- a/app/code/Magento/SendFriend/Model/SendFriend.php
+++ b/app/code/Magento/SendFriend/Model/SendFriend.php
@@ -376,10 +376,10 @@ class SendFriend extends \Magento\Framework\Model\AbstractModel
      * Set the reply to email address
      * 
      * @param array $sender
-     * 
      * @return void
      */
-    public function setReplyTo($sender){
+    public function setReplyTo($sender)
+    {
         $this->_transportBuilder->setReplyTo(
             $sender['email'],
             $sender['name']

--- a/app/code/Magento/SendFriend/Model/SendFriend.php
+++ b/app/code/Magento/SendFriend/Model/SendFriend.php
@@ -373,6 +373,20 @@ class SendFriend extends \Magento\Framework\Model\AbstractModel
     }
 
     /**
+     * Set the reply to email address
+     * 
+     * @param array $sender
+     * 
+     * @return void
+     */
+    public function setReplyTo($sender){
+        $this->_transportBuilder->setReplyTo(
+            $sender['email'],
+            $sender['name']
+        );
+    }
+
+    /**
      * Retrieve Sender Information Object
      *
      * @throws \Magento\Framework\Exception\LocalizedException
@@ -427,6 +441,26 @@ class SendFriend extends \Magento\Framework\Model\AbstractModel
     public function isExceedLimit()
     {
         return $this->getSentCount() >= $this->getMaxSendsToFriend();
+    }
+
+    /**
+     * Check if email should be sent from the store
+     *
+     * @return boolean
+     */
+    public function isSentFromStore()
+    {
+        return $this->_sendfriendData->isSentFromStore();
+    }
+
+    /**
+     * Gets the store email address
+     *
+     * @return string
+     */
+    public function getEmailFromStore()
+    {
+        return $this->_sendfriendData->getStoreEmail();
     }
 
     /**

--- a/app/code/Magento/SendFriend/etc/adminhtml/system.xml
+++ b/app/code/Magento/SendFriend/etc/adminhtml/system.xml
@@ -38,6 +38,11 @@
                     <label>Limit Sending By</label>
                     <source_model>Magento\SendFriend\Model\Source\Checktype</source_model>
                 </field>
+                <field id="sent_store" translate="label" type="select" sortOrder="7" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Email is sent from store</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>If set to no then the email is sent from the customers email address</comment>
+                </field>
             </group>
         </section>
     </system>

--- a/app/code/Magento/SendFriend/etc/config.xml
+++ b/app/code/Magento/SendFriend/etc/config.xml
@@ -15,6 +15,7 @@
                 <max_recipients>5</max_recipients>
                 <max_per_hour>5</max_per_hour>
                 <check_by>0</check_by>
+                <sent_store>0</sent_store>
             </email>
         </sendfriend>
         <captcha translate="label">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. APlease don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The Magento\SendFriend module sends the email using the email address entered by the user, this can be an issue when using an SMTP server that requires the senders email address to be authenticated. This PR adds the option for the store owner to set the email to be sent from the General Emaill address of the store instead of the submitted email address, the ReplyTo email address is then set to the submitted email address of the user.

### Manual testing scenarios (*)

1. Go to Stores>Configuration>Catalog>Email to a Friend and set `Email is sent from store` to Yes
2. Visit any product page
3. Click Email and sign in/create account if nesscary
4. Fill out the form and click `Send Email`

The email received will have the stores email as the From address and users submitted email as the Reply To address.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
