### PR TITLE
[2.3] magento catalog:images:resize now Database Media Storage mode aware

### DIFF
--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -22,6 +22,7 @@ use \Magento\Catalog\Model\ResourceModel\Product\Image as ProductImage;
 use Magento\Theme\Model\Config\Customization as ThemeCustomizationConfig;
 use Magento\Theme\Model\ResourceModel\Theme\Collection;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\MediaStorage\Helper\File\Storage\Database;
 
 /**
  * Image resize service.
@@ -86,6 +87,11 @@ class ImageResize
     private $filesystem;
 
     /**
+     * @var Database
+     */
+    private $fileStorageDatabase;
+
+    /**
      * @param State $appState
      * @param MediaConfig $imageConfig
      * @param ProductImage $productImage
@@ -96,6 +102,7 @@ class ImageResize
      * @param ThemeCustomizationConfig $themeCustomizationConfig
      * @param Collection $themeCollection
      * @param Filesystem $filesystem
+     * @param Database $fileStorageDatabase
      * @internal param ProductImage $gallery
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
@@ -109,7 +116,8 @@ class ImageResize
         AssertImageFactory $assertImageFactory,
         ThemeCustomizationConfig $themeCustomizationConfig,
         Collection $themeCollection,
-        Filesystem $filesystem
+        Filesystem $filesystem,
+        Database $fileStorageDatabase = null
     ) {
         $this->appState = $appState;
         $this->imageConfig = $imageConfig;
@@ -122,6 +130,8 @@ class ImageResize
         $this->themeCollection = $themeCollection;
         $this->mediaDirectory = $filesystem->getDirectoryWrite(DirectoryList::MEDIA);
         $this->filesystem = $filesystem;
+        $this->fileStorageDatabase = $fileStorageDatabase ?:
+            \Magento\Framework\App\ObjectManager::getInstance()->get(Database::class);
     }
 
     /**
@@ -132,9 +142,15 @@ class ImageResize
      */
     public function resizeFromImageName(string $originalImageName)
     {
-        $originalImagePath = $this->mediaDirectory->getAbsolutePath(
-            $this->imageConfig->getMediaPath($originalImageName)
-        );
+        $mediastoragefilename = $this->imageConfig->getMediaPath($originalImageName);
+        $originalImagePath = $this->mediaDirectory->getAbsolutePath($mediastoragefilename);
+
+        if ($this->fileStorageDatabase->checkDbUsage() &&
+            !$this->mediaDirectory->isFile($mediastoragefilename)
+        ) {
+            $this->fileStorageDatabase->saveFileToFilesystem($mediastoragefilename);
+        }
+
         if (!$this->mediaDirectory->isFile($originalImagePath)) {
             throw new NotFoundException(__('Cannot resize image "%1" - original image not found', $originalImagePath));
         }
@@ -162,10 +178,15 @@ class ImageResize
 
         foreach ($productImages as $image) {
             $originalImageName = $image['filepath'];
-            $originalImagePath = $this->mediaDirectory->getAbsolutePath(
-                $this->imageConfig->getMediaPath($originalImageName)
-            );
+            $mediastoragefilename = $this->imageConfig->getMediaPath($originalImageName);
+            $originalImagePath = $this->mediaDirectory->getAbsolutePath($mediastoragefilename);
+
             foreach ($viewImages as $viewImage) {
+                if ($this->fileStorageDatabase->checkDbUsage() &&
+                    !$this->mediaDirectory->isFile($mediastoragefilename)
+                ) {
+                    $this->fileStorageDatabase->saveFileToFilesystem($mediastoragefilename);
+                }
                 $this->resize($viewImage, $originalImagePath, $originalImageName);
             }
             yield $originalImageName => $count;
@@ -293,6 +314,11 @@ class ImageResize
             $image->resize($imageParams['image_width'], $imageParams['image_height']);
         }
         $image->save($imageAsset->getPath());
+
+        if ($this->fileStorageDatabase->checkDbUsage()) {
+            $mediastoragefilename = $this->mediaDirectory->getRelativePath($imageAsset->getPath());
+            $this->fileStorageDatabase->saveFile($mediastoragefilename);
+        }
     }
 
     /**

--- a/app/code/Magento/MediaStorage/Test/Unit/Service/ImageResizeTest.php
+++ b/app/code/Magento/MediaStorage/Test/Unit/Service/ImageResizeTest.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MediaStorage\Test\Unit\Service;
+
+use Magento\Catalog\Model\Product\Image\ParamsBuilder;
+use Magento\Catalog\Model\View\Asset\ImageFactory as AssetImageFactory;
+use Magento\Catalog\Model\View\Asset\Image as AssetImage;
+use Magento\Framework\DataObject;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Image\Factory as ImageFactory;
+use Magento\Framework\Image;
+use Magento\Catalog\Model\Product\Media\ConfigInterface as MediaConfig;
+use Magento\Framework\App\State;
+use Magento\Framework\View\ConfigInterface as ViewConfig;
+use Magento\Framework\Config\View;
+use Magento\Catalog\Model\ResourceModel\Product\Image as ProductImage;
+use Magento\Theme\Model\Config\Customization as ThemeCustomizationConfig;
+use Magento\Theme\Model\ResourceModel\Theme\Collection;
+use Magento\MediaStorage\Helper\File\Storage\Database;
+use Magento\Framework\App\Filesystem\DirectoryList;
+
+/**
+ * Class ImageResizeTest
+ *
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ImageResizeTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\MediaStorage\Service\ImageResize
+     */
+    protected $service;
+
+    /**
+     * @var State|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $appStateMock;
+
+    /**
+     * @var MediaConfig|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $imageConfigMock;
+
+    /**
+     * @var ProductImage|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $productImageMock;
+
+    /**
+     * @var ImageFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $imageFactoryMock;
+
+    /**
+     * @var Image|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $imageMock;
+
+    /**
+     * @var ParamsBuilder|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $paramsBuilderMock;
+
+    /**
+     * @var ViewConfig|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $viewConfigMock;
+
+    /**
+     * @var View|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $viewMock;
+
+    /**
+     * @var AssetImage|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $assetImageMock;
+
+    /**
+     * @var AssetImageFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $assetImageFactoryMock;
+
+    /**
+     * @var ThemeCustomizationConfig|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $themeCustomizationConfigMock;
+
+    /**
+     * @var Collection|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $themeCollectionMock;
+
+    /**
+     * @var Filesystem|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $filesystemMock;
+
+    /**
+     * @var Database|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $databaseMock;
+
+    /**
+     * @var Filesystem|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mediaDirectoryMock;
+
+    /**
+     * @var string
+     */
+    private $testfilename;
+
+    /**
+     * @var string
+     */
+    private $testfilepath;
+
+    protected function setUp()
+    {
+        $this->testfilename = "image.jpg";
+        $this->testfilepath = "/image.jpg";
+
+        $this->appStateMock = $this->createMock(State::class);
+        $this->imageConfigMock = $this->createMock(MediaConfig::class);
+        $this->productImageMock = $this->createMock(ProductImage::class);
+        $this->imageMock = $this->createMock(Image::class);
+        $this->imageFactoryMock = $this->createMock(ImageFactory::class);
+        $this->paramsBuilderMock = $this->createMock(ParamsBuilder::class);
+        $this->viewMock = $this->createMock(View::class);
+        $this->viewConfigMock = $this->createMock(ViewConfig::class);
+        $this->assetImageMock = $this->createMock(AssetImage::class);
+        $this->assetImageFactoryMock = $this->createMock(AssetImageFactory::class);
+        $this->themeCustomizationConfigMock = $this->createMock(ThemeCustomizationConfig::class);
+        $this->themeCollectionMock = $this->createMock(Collection::class);
+        $this->filesystemMock = $this->createMock(Filesystem::class);
+        $this->databaseMock = $this->createMock(Database::class);
+
+        $this->mediaDirectoryMock = $this->getMockBuilder(Filesystem::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getAbsolutePath','isFile','getRelativePath'])
+            ->getMock();
+
+        $this->filesystemMock->expects($this->any())
+            ->method('getDirectoryWrite')
+            ->with(DirectoryList::MEDIA)
+            ->willReturn($this->mediaDirectoryMock);
+
+        $this->imageFactoryMock->expects($this->any())
+            ->method('create')
+            ->willReturn($this->imageMock);
+        $this->assetImageMock->expects($this->any())
+            ->method('getPath')
+            ->will($this->returnValue($this->testfilepath));
+        $this->assetImageFactoryMock->expects($this->any())
+            ->method('create')
+            ->willReturn($this->assetImageMock);
+
+        $this->paramsBuilderMock->expects($this->any())
+            ->method('build')
+            ->willReturn(
+                [
+                    'keep_aspect_ratio' => null,
+                    'keep_frame' => null,
+                    'keep_transparency' => null,
+                    'constrain_only' => null,
+                    'background' => null,
+                    'quality' => null,
+                    'image_width' => null,
+                    'image_height' => null
+                ]
+            );
+
+        $this->imageConfigMock->expects($this->any())
+            ->method('getMediaPath')
+            ->with($this->testfilename)
+            ->willReturn($this->testfilepath);
+        $this->mediaDirectoryMock->expects($this->any())
+            ->method('getAbsolutePath')
+            ->with($this->testfilepath)
+            ->willReturn($this->testfilepath);
+        $this->mediaDirectoryMock->expects($this->any())
+            ->method('getRelativePath')
+            ->with($this->testfilepath)
+            ->willReturn($this->testfilepath);
+
+        $this->viewMock->expects($this->any())
+            ->method('getMediaEntities')
+            ->willReturn(
+                ['product_small_image' =>
+                    [
+                        'type' => 'small_image',
+                        'width' => 75,
+                        'height' => 75
+                    ]
+                ]
+            );
+        $this->viewConfigMock->expects($this->any())
+            ->method('getViewConfig')
+            ->willReturn($this->viewMock);
+
+        $this->service = new \Magento\MediaStorage\Service\ImageResize(
+            $this->appStateMock,
+            $this->imageConfigMock,
+            $this->productImageMock,
+            $this->imageFactoryMock,
+            $this->paramsBuilderMock,
+            $this->viewConfigMock,
+            $this->assetImageFactoryMock,
+            $this->themeCustomizationConfigMock,
+            $this->themeCollectionMock,
+            $this->filesystemMock,
+            $this->databaseMock
+        );
+    }
+
+    protected function tearDown()
+    {
+        unset($this->service);
+    }
+
+    public function testResizeFromThemesMediaStorageDatabase()
+    {
+        $this->databaseMock->expects($this->any())
+            ->method('checkDbUsage')
+            ->will($this->returnValue(true));
+
+        $this->productImageMock->expects($this->any())
+            ->method('getCountUsedProductImages')
+            ->willReturn(1);
+        $this->productImageMock->expects($this->any())
+            ->method('getUsedProductImages')
+            ->will(
+                $this->returnCallback(
+                    function () {
+                        $data = [[ 'filepath' => $this->testfilename ]];
+                        foreach ($data as $e) {
+                            yield $e;
+                        }
+                    }
+                )
+            );
+
+        $this->mediaDirectoryMock->expects($this->any())
+            ->method('isFile')
+            ->with($this->testfilepath)
+            ->will($this->returnValue(false));
+
+        $this->databaseMock->expects($this->once())
+            ->method('saveFileToFilesystem')
+            ->with($this->testfilepath);
+        $this->databaseMock->expects($this->once())
+            ->method('saveFile')
+            ->with($this->testfilepath);
+
+        $generator = $this->service->resizeFromThemes(['test-theme']);
+        while ($generator->valid()) {
+            $generator->next();
+        }
+    }
+
+    public function testResizeFromImageNameMediaStorageDatabase()
+    {
+        $this->databaseMock->expects($this->any())
+            ->method('checkDbUsage')
+            ->will($this->returnValue(true));
+
+        $this->mediaDirectoryMock->expects($this->any())
+            ->method('isFile')
+            ->with($this->testfilepath)
+            ->willReturnOnConsecutiveCalls(
+                $this->returnValue(false),
+                $this->returnValue(true)
+            );
+
+        $this->themeCollectionMock->expects($this->any())
+            ->method('loadRegisteredThemes')
+            ->willReturn(
+                [ new DataObject(['id' => '0']) ]
+            );
+        $this->themeCustomizationConfigMock->expects($this->any())
+            ->method('getStoresByThemes')
+            ->willReturn(
+                ['0' => []]
+            );
+
+        $this->databaseMock->expects($this->once())
+            ->method('saveFileToFilesystem')
+            ->with($this->testfilepath);
+        $this->databaseMock->expects($this->once())
+            ->method('saveFile')
+            ->with($this->testfilepath);
+
+        $this->service->resizeFromImageName($this->testfilename);
+    }
+}


### PR DESCRIPTION
### Description (*)
Since the catalog:images:resize function was rewritten in 2.3, it is no longer database media storage mode aware. Resized images were neither extracted from the database if they didn't exist locally prior to resizing, nor were they stored back into the database once the resize was complete.

This PR fixes this.

### Fixed Issues (if relevant)
1. magento/magento2#23594 Database Media Storage : php bin/magento catalog:images:resize fails when image does not exist locally
2. magento/magento2#23595 Database Media Storage : php bin/magento catalog:images:resize fails to generate cached images in database
3. magento/magento2#23596 Database Media Storage : Add new product image, cached images not generated

### Manual testing scenarios (*)
1. deploy 2.3-develop
2. Change system storage mode to Database Media Storage mode, Synchronize and Save
3. Clear cache
4. Create test product, assign test product an image, and save product.
5. Check that product image appears in pub/media/catalog/product
6. Check that product cached images appear in pub/media/catalog/product/cache (Testing #23596)
7. Check that product image appears in database
8. Check that product cached images appear in database (Testing #23596)
9. Clear pub/media/catalog/product folder completely
10. Clear cached product images from database, leaving main product image intact
11. Run php bin/magento catalog:images:resize (Testing #23594)
12. Check that product image appears in pub/media/catalog/product
13. Check that product cached images appear in pub/media/catalog/product/cache
15. Check that product cached images appear in database (Testing #23595)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
