### PR TITLE
#19921 : ACL incorrect for Advance in system configuration

### DIFF
--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -23,7 +23,7 @@
         <section id="advanced" translate="label" type="text" sortOrder="910" showInDefault="0" showInWebsite="0" showInStore="0">
             <label>Advanced</label>
             <tab>advanced</tab>
-            <resource>Magento_Backend::advanced</resource>
+            <resource>Magento_Config::advanced</resource>
             <group id="modules_disable_output" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Disable Modules Output</label>
                 <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset\Modules\DisableOutput</frontend_model>

--- a/app/code/Magento/Config/etc/acl.xml
+++ b/app/code/Magento/Config/etc/acl.xml
@@ -13,8 +13,7 @@
                     <resource id="Magento_Backend::stores_settings">
                         <resource id="Magento_Config::config" title="Configuration" translate="title" sortOrder="20">
                             <!--
-                            @deprecated Magento does not support custom disabling/enabling modules output since 2.2.0 version.
-                            Section 'Advanced Section' was disabled. This section will be removed from code in one release.
+                            @deprecated Magento_Config::advanced section ('Advanced Section') is disabled and is not displayed in the admin panel
                             -->
                             <resource id="Magento_Config::advanced" title="Advanced Section" translate="title" sortOrder="90" disabled="true" />
                             <resource id="Magento_Config::config_admin" title="Advanced Admin Section" translate="title" sortOrder="100" />

--- a/app/code/Magento/Config/etc/acl.xml
+++ b/app/code/Magento/Config/etc/acl.xml
@@ -12,7 +12,11 @@
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
                         <resource id="Magento_Config::config" title="Configuration" translate="title" sortOrder="20">
-                            <resource id="Magento_Config::advanced" title="Advanced Section" translate="title" sortOrder="90" />
+                            <!--
+                            @deprecated Magento does not support custom disabling/enabling modules output since 2.2.0 version.
+                            Section 'Advanced Section' was disabled. This section will be removed from code in one release.
+                            -->
+                            <resource id="Magento_Config::advanced" title="Advanced Section" translate="title" sortOrder="90" disabled="true" />
                             <resource id="Magento_Config::config_admin" title="Advanced Admin Section" translate="title" sortOrder="100" />
                             <resource id="Magento_Config::config_design" title="Design Section" translate="title" sortOrder="40" />
                             <resource id="Magento_Config::config_general" title="General Section" translate="title" sortOrder="20" />

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/_files/app/code/Magento/SomeModule/etc/adminhtml/system.xml
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/_files/app/code/Magento/SomeModule/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
         <section id="advanced" translate="label" type="text" sortOrder="910" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Advanced</label>
             <tab>advanced</tab>
-            <resource>Magento_Backend::advanced</resource>
+            <resource>Magento_Config::advanced</resource>
             <group id="modules_disable_output" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Disable Modules Output</label>
                 <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset\Modules\DisableOutput\Proxy</frontend_model>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19921: ACL incorrect for Advance in system configuration

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login into backend 
2. Go To System -> Permissions -> User Roles
3. 'Advanced Section' role has been disabled
4. ''Advanced Section'' has been deprecated

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
I think the best is to remove the code from the system.xml and acl.xml so we don't get ran into this issue again. Let me know your thoughts.
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
