### PR TITLE
Default filter for reports set to past month

### DIFF
--- a/app/code/Magento/Reports/Block/Adminhtml/Grid.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Grid.php
@@ -135,8 +135,8 @@ class Grid extends \Magento\Backend\Block\Widget\Grid
             $data = $this->parameters->toArray();
 
             if (!isset($data['report_from'])) {
-                // getting all reports from 2001 year
-                $date = (new \DateTime())->setTimestamp(mktime(0, 0, 0, 1, 1, 2001));
+                // Get records for the past month
+                $date = new \DateTime('-1 month');
                 $data['report_from'] = $this->_localeDate->formatDateTime(
                     $date,
                     \IntlDateFormatter::SHORT,
@@ -145,7 +145,6 @@ class Grid extends \Magento\Backend\Block\Widget\Grid
             }
 
             if (!isset($data['report_to'])) {
-                // getting all reports from 2001 year
                 $date = new \DateTime();
                 $data['report_to'] = $this->_localeDate->formatDateTime(
                     $date,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR sets the default date range for report filters to the past month instead of the past 18 years. The reason and troubles are described in the original issue.

### Fixed Issues (if relevant)
1. #23606 : Default value for report filters might result in errors

### Manual testing scenarios (*)
1. Go to Admin ->Reports -> Products -> Ordered.
2. Click the "Refresh" button without setting values for "From->to" filter. 
3. You should see the records only for the past month instead of the past 18 years.
