### PR TITLE
[Backport] Removed editor from phone and zipcode

### DIFF
--- a/app/code/Magento/Customer/view/adminhtml/ui_component/customer_listing.xml
+++ b/app/code/Magento/Customer/view/adminhtml/ui_component/customer_listing.xml
@@ -157,18 +157,12 @@
         <column name="billing_telephone" sortOrder="60">
             <settings>
                 <filter>text</filter>
-                <editor>
-                    <editorType>text</editorType>
-                </editor>
                 <label translate="true">Phone</label>
             </settings>
         </column>
         <column name="billing_postcode" sortOrder="70">
             <settings>
                 <filter>text</filter>
-                <editor>
-                    <editorType>text</editorType>
-                </editor>
                 <label translate="true">ZIP</label>
             </settings>
         </column>

--- a/app/code/Magento/Customer/view/adminhtml/ui_component/customer_listing.xml
+++ b/app/code/Magento/Customer/view/adminhtml/ui_component/customer_listing.xml
@@ -263,9 +263,6 @@
         <column name="billing_city" sortOrder="210">
             <settings>
                 <filter>text</filter>
-                <editor>
-                    <editorType>text</editorType>
-                </editor>
                 <label translate="true">City</label>
                 <visible>false</visible>
             </settings>
@@ -273,9 +270,6 @@
         <column name="billing_fax" sortOrder="220">
             <settings>
                 <filter>text</filter>
-                <editor>
-                    <editorType>text</editorType>
-                </editor>
                 <label translate="true">Fax</label>
                 <visible>false</visible>
             </settings>
@@ -283,9 +277,6 @@
         <column name="billing_vat_id" sortOrder="230">
             <settings>
                 <filter>text</filter>
-                <editor>
-                    <editorType>text</editorType>
-                </editor>
                 <label translate="true">VAT Number</label>
                 <visible>false</visible>
             </settings>
@@ -293,9 +284,6 @@
         <column name="billing_company" sortOrder="240">
             <settings>
                 <filter>text</filter>
-                <editor>
-                    <editorType>text</editorType>
-                </editor>
                 <label translate="true">Company</label>
                 <visible>false</visible>
             </settings>
@@ -303,9 +291,6 @@
         <column name="billing_firstname" sortOrder="250">
             <settings>
                 <filter>text</filter>
-                <editor>
-                    <editorType>text</editorType>
-                </editor>
                 <label translate="true">Billing Firstname</label>
                 <visible>false</visible>
             </settings>
@@ -313,9 +298,6 @@
         <column name="billing_lastname" sortOrder="260">
             <settings>
                 <filter>text</filter>
-                <editor>
-                    <editorType>text</editorType>
-                </editor>
                 <label translate="true">Billing Lastname</label>
                 <visible>false</visible>
             </settings>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/23494
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
- Removed editor field of Phone and ZIP from customer grid as it is dependable only on customer billing address. 

### Fixed Issues (if relevant)
1. #23467 : Removed Phone and ZIP field editor from customer grid.
