### PR TITLE
[2.2][Backport] Transfer Encoding of emails changed to QUOTED-PRINTABLE

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Customer/Controller/AccountTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Controller/AccountTest.php
@@ -685,7 +685,7 @@ class AccountTest extends \Magento\TestFramework\TestCase\AbstractController
 
         $this->assertContains('To: ' . $email, $rawMessage);
 
-        $content = $message->getBody()->getPartContent(0);
+        $content = $message->getBody()->getParts()[0]->getRawContent();
         $confirmationUrl = $this->getConfirmationUrlFromMessageContent($content);
         $this->setRequestInfo($confirmationUrl, 'confirm');
         $this->clearCookieMessagesList();

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Model/SubscriberTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Model/SubscriberTest.php
@@ -6,6 +6,9 @@
 
 namespace Magento\Newsletter\Model;
 
+/**
+ * \Magento\Newsletter\Model\Subscriber tests
+ */
 class SubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -39,7 +42,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
         $this->assertContains(
             '/newsletter/subscriber/confirm/id/' . $this->_model->getSubscriberId()
             . '/code/ysayquyajua23iq29gxwu2eax2qb6gvy',
-            $transportBuilder->getSentMessage()->getRawMessage()
+            $transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent()
         );
         $this->assertEquals(Subscriber::STATUS_NOT_ACTIVE, $this->_model->getSubscriberStatus());
     }

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Create/SaveTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Create/SaveTest.php
@@ -141,7 +141,7 @@ class SaveTest extends AbstractBackendController
         );
 
         $this->assertEquals($message->getSubject(), $subject);
-        $this->assertThat($message->getRawMessage(), $assert);
+        $this->assertThat($message->getBody()->getParts()[0]->getRawContent(), $assert);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/AddCommentTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/AddCommentTest.php
@@ -54,7 +54,7 @@ class AddCommentTest extends AbstractCreditmemoControllerTest
         );
 
         $this->assertEquals($message->getSubject(), $subject);
-        $this->assertThat($message->getRawMessage(), $messageConstraint);
+        $this->assertThat($message->getBody()->getParts()[0]->getRawContent(), $messageConstraint);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/SaveTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/SaveTest.php
@@ -51,7 +51,7 @@ class SaveTest extends AbstractCreditmemoControllerTest
         );
 
         $this->assertEquals($message->getSubject(), $subject);
-        $this->assertThat($message->getRawMessage(), $messageConstraint);
+        $this->assertThat($message->getBody()->getParts()[0]->getRawContent(), $messageConstraint);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/EmailTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/EmailTest.php
@@ -82,7 +82,7 @@ class EmailTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
         );
 
         $this->assertEquals($message->getSubject(), $subject);
-        $this->assertThat($message->getRawMessage(), $assert);
+        $this->assertThat($message->getBody()->getParts()[0]->getRawContent(), $assert);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Invoice/AddCommentTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Invoice/AddCommentTest.php
@@ -55,7 +55,7 @@ class AddCommentTest extends AbstractInvoiceControllerTest
         );
 
         $this->assertEquals($message->getSubject(), $subject);
-        $this->assertThat($message->getRawMessage(), $messageConstraint);
+        $this->assertThat($message->getBody()->getParts()[0]->getRawContent(), $messageConstraint);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Invoice/EmailTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Invoice/EmailTest.php
@@ -59,7 +59,7 @@ class EmailTest extends AbstractInvoiceControllerTest
         );
 
         $this->assertEquals($message->getSubject(), $subject);
-        $this->assertThat($message->getRawMessage(), $messageConstraint);
+        $this->assertThat($message->getBody()->getParts()[0]->getRawContent(), $messageConstraint);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Invoice/SaveTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Invoice/SaveTest.php
@@ -51,7 +51,7 @@ class SaveTest extends AbstractInvoiceControllerTest
         );
 
         $this->assertEquals($message->getSubject(), $subject);
-        $this->assertThat($message->getRawMessage(), $messageConstraint);
+        $this->assertThat($message->getBody()->getParts()[0]->getRawContent(), $messageConstraint);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/CreateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/CreateTest.php
@@ -95,6 +95,6 @@ class CreateTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->assertEquals($message->getSubject(), $subject);
-        $this->assertThat($message->getRawMessage(), $assert);
+        $this->assertThat($message->getBody()->getParts()[0]->getRawContent(), $assert);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Shipping/Controller/Adminhtml/Order/Shipment/AddCommentTest.php
+++ b/dev/tests/integration/testsuite/Magento/Shipping/Controller/Adminhtml/Order/Shipment/AddCommentTest.php
@@ -54,7 +54,7 @@ class AddCommentTest extends AbstractShipmentControllerTest
         );
 
         $this->assertEquals($message->getSubject(), $subject);
-        $this->assertThat($message->getRawMessage(), $messageConstraint);
+        $this->assertThat($message->getBody()->getParts()[0]->getRawContent(), $messageConstraint);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Shipping/Controller/Adminhtml/Order/Shipment/SaveTest.php
+++ b/dev/tests/integration/testsuite/Magento/Shipping/Controller/Adminhtml/Order/Shipment/SaveTest.php
@@ -51,7 +51,7 @@ class SaveTest extends AbstractShipmentControllerTest
         );
 
         $this->assertEquals($message->getSubject(), $subject);
-        $this->assertThat($message->getRawMessage(), $messageConstraint);
+        $this->assertThat($message->getBody()->getParts()[0]->getRawContent(), $messageConstraint);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Mail/Message.php
+++ b/lib/internal/Magento/Framework/Mail/Message.php
@@ -182,6 +182,8 @@ class Message implements MailMessageInterface
     {
         $part = new Part($body);
         $part->setCharset($this->zendMessage->getEncoding());
+        $part->setEncoding(Mime::ENCODING_QUOTEDPRINTABLE);
+        $part->setDisposition(Mime::DISPOSITION_INLINE);
         $part->setType($messageType);
         $mimeMessage = new \Zend\Mime\Message();
         $mimeMessage->addPart($part);

--- a/lib/internal/Magento/Framework/Mail/Test/Unit/MessageTest.php
+++ b/lib/internal/Magento/Framework/Mail/Test/Unit/MessageTest.php
@@ -26,9 +26,10 @@ class MessageTest extends \PHPUnit\Framework\TestCase
 
         $part = $this->message->getBody()->getParts()[0];
         $this->assertEquals('text/html', $part->getType());
-        $this->assertEquals('8bit', $part->getEncoding());
+        $this->assertEquals('quoted-printable', $part->getEncoding());
         $this->assertEquals('utf-8', $part->getCharset());
         $this->assertEquals('body', $part->getContent());
+        $this->assertEquals('inline', $part->getDisposition());
     }
 
     public function testSetBodyText()
@@ -37,8 +38,9 @@ class MessageTest extends \PHPUnit\Framework\TestCase
 
         $part = $this->message->getBody()->getParts()[0];
         $this->assertEquals('text/plain', $part->getType());
-        $this->assertEquals('8bit', $part->getEncoding());
+        $this->assertEquals('quoted-printable', $part->getEncoding());
         $this->assertEquals('utf-8', $part->getCharset());
         $this->assertEquals('body', $part->getContent());
+        $this->assertEquals('inline', $part->getDisposition());
     }
 }


### PR DESCRIPTION
### Original PR (*)
1. magento/magento2#23649: [2.3] Transfer Encoding of emails changed to QUOTED-PRINTABLE

### Description (*)
When Magento used Zend Framework 1 for emails, MIME emails were sent with Transfer Encoding set to QUOTED-PRINTABLE. This means that emails with long lines (particularly emails with large inline css) are encoded properly. This can be confirmed by running tests under 2.2.7.

When Magento switched to Zend Framework 2, the default Transfer Encoding was set to 8-bit. This emails with long lines were being rejected by some mail servers as they were not encoded quoted-printable as expected.

Magento 2.2.8+ and 2.3.0+ are affected by this.

This PR changes the default encoding of all MIME emails to quoted-printable.

### Fixed Issues (if relevant)
1. magento/magento2#23643: Mime parts of email are no more encoded with quoted printable

### Manual testing scenarios (*)
```
Backend
=======
Marketing -> Email Templates -> Add New Template
    Template Name = Newsletter Success Plain
    Subject = Success Subject
    Template Content = Success Body
    Convert to Plain Text
    Save Template
Marketing -> Email Templates -> Add New Template
    Template Name = Newsletter Success Html
    Subject = Success Subject
    Template Content = <html><body>Success Body</body></html>
    Save Template
Store -> Configuration -> General -> Store Email Addresses
    General Contact
        Sender Name = Owner Name
        Sender Email = owner@domain.com
Store -> Configuration -> Customers -> Newsletter -> Subscription Options
    Success Email Template = Newsletter Success Plain

Frontend
========
Subscribe to newsletter

Ensure email received contains the following headers

MIME-Version: 1.0
Content-Type: text/plain; charset="utf-8"
Content-Transfer-Encoding: quoted-printable

Backend
=======
Store -> Configuration -> Customers -> Newsletter -> Subscription Options
    Success Email Template = Newsletter Success Html

Frontend
========
Subscribe to newsletter

Ensure email received contains the following headers

MIME-Version: 1.0
Content-Type: text/html; charset="utf-8"
Content-Transfer-Encoding: quoted-printable
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
