### PR TITLE
Add missing getClass() to image.phtml so it is more like image_with_borders.phtml

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/image.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image.phtml
@@ -6,7 +6,7 @@
 ?>
 <?php /** @var $block \Magento\Catalog\Block\Product\Image */ ?>
 
-<img class="photo image"
+<img class="photo image <?= $block->escapeHtmlAttr($block->getClass()) ?>"
     <?= $block->escapeHtml($block->getCustomAttributes()) ?>
     src="<?= $block->escapeUrl($block->getImageUrl()) ?>"
     width="<?= $block->escapeHtmlAttr($block->getWidth()) ?>"


### PR DESCRIPTION


### Description (*)
Just a small template improvement:
- Add missing getClass() to image.phtml so it is more like image_with_borders.phtml
- Because we now use getClass() in the template, it becomes easier to add CSS classes with a plugin.

### Manual testing scenarios (*)
Just a template change. Images should still work.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (not applicable)
 - [ ] All automated tests passed successfully (all builds are green)
