### PR TITLE
Fixes issue 22112 (https://github.com/magento/magento2/issues/22112) …

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/billing-address-postcode-validator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/billing-address-postcode-validator.js
@@ -18,7 +18,6 @@ define([
 
     var postcodeElementName = 'postcode';
 
-
     return {
         validateZipCodeTimeout: 0,
         validateDelay: 2000,

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/billing-address-postcode-validator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/billing-address-postcode-validator.js
@@ -29,6 +29,7 @@ define([
          */
         initFields: function (formPath) {
             var self = this;
+
             uiRegistry.async(formPath + '.' + postcodeElementName)(self.bindHandler.bind(self));
         },
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/billing-address-postcode-validator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/billing-address-postcode-validator.js
@@ -23,7 +23,6 @@ define([
         validateZipCodeTimeout: 0,
         validateDelay: 2000,
 
-
         /**
          * Perform postponed binding for fieldset elements
          *

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/billing-address-postcode-validator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/billing-address-postcode-validator.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define([
+           'jquery',
+           'Magento_Checkout/js/model/postcode-validator',
+           'mage/translate',
+           'uiRegistry',
+       ], function (
+    $,
+    postcodeValidator,
+    $t,
+    uiRegistry,
+) {
+    'use strict';
+
+    var postcodeElementName = 'postcode';
+
+
+    return {
+        validateZipCodeTimeout: 0,
+        validateDelay: 2000,
+
+
+        /**
+         * Perform postponed binding for fieldset elements
+         *
+         * @param {String} formPath
+         */
+        initFields: function (formPath) {
+            var self = this;
+            uiRegistry.async(formPath + '.' + postcodeElementName)(self.bindHandler.bind(self));
+        },
+
+        /**
+         * @param {Object} element
+         * @param {Number} delay
+         */
+        bindHandler: function (element, delay) {
+            var self = this;
+
+            delay = typeof delay === 'undefined' ? self.validateDelay : delay;
+
+            element.on('value', function () {
+                clearTimeout(self.validateZipCodeTimeout);
+                self.validateZipCodeTimeout = setTimeout(function () {
+                    self.postcodeValidation(element);
+                }, delay);
+            });
+        },
+
+        /**
+         * @param {Object} postcodeElement
+         * @return {*}
+         */
+        postcodeValidation: function (postcodeElement) {
+            var countryId = $('select[name="country_id"]:visible').val(),
+                validationResult,
+                warnMessage;
+
+            if (postcodeElement == null || postcodeElement.value() == null) {
+                return true;
+            }
+
+            postcodeElement.warn(null);
+            validationResult = postcodeValidator.validate(postcodeElement.value(), countryId);
+
+            if (!validationResult) {
+                warnMessage = $t('Provided Zip/Postal Code seems to be invalid.');
+
+                if (postcodeValidator.validatedPostCodeExample.length) {
+                    warnMessage += $t(' Example: ') + postcodeValidator.validatedPostCodeExample.join('; ') + '. ';
+                }
+                warnMessage += $t('If you believe it is the right one you can ignore this notice.');
+                postcodeElement.warn(warnMessage);
+            }
+
+            return validationResult;
+        }
+    };
+});

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/billing-address-postcode-validator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/billing-address-postcode-validator.js
@@ -7,12 +7,12 @@ define([
            'jquery',
            'Magento_Checkout/js/model/postcode-validator',
            'mage/translate',
-           'uiRegistry',
+           'uiRegistry'
        ], function (
     $,
     postcodeValidator,
     $t,
-    uiRegistry,
+    uiRegistry
 ) {
     'use strict';
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/billing-address.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/billing-address.js
@@ -18,7 +18,7 @@ define([
     'Magento_Checkout/js/action/set-billing-address',
     'Magento_Ui/js/model/messageList',
     'mage/translate',
-    'Magento_Checkout/js/model/shipping-rates-validator'
+    'Magento_Checkout/js/model/billing-address-postcode-validator'
 ],
 function (
     ko,
@@ -35,7 +35,7 @@ function (
     setBillingAddressAction,
     globalMessageList,
     $t,
-    shippingRatesValidator
+    billingAddressPostcodeValidator
 ) {
     'use strict';
 
@@ -66,7 +66,7 @@ function (
             quote.paymentMethod.subscribe(function () {
                 checkoutDataResolver.resolveBillingAddress();
             }, this);
-            shippingRatesValidator.initFields(this.get('name') + '.form-fields');
+            billingAddressPostcodeValidator.initFields(this.get('name') + '.form-fields');
         },
 
         /**


### PR DESCRIPTION
…by removing shipping address validation from the new billing address form in checkout. It appears this was added initially simply to validate the postcode in the form, but running the billing address through the actual shipping rate functionality in shipping-rates-validator's validateFields function was causing the issues leading to the address disappearing from the Ship To section & being deselected in the Shipping step. Instead, this validation is replaced in the billing address form by a simpler validator which only checks the postcode.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
While in checkout & adding a new billing address, the address was being run through the shipping rates validator (Magento\Checkout\view\frontend\web\js\model\shipping-rates-validator.js). This, specifically the point at which the address was sent through the validateFields function, which was attempting to set the billing address as the shipping address, was causing the shipping address information to disappear from the "Ship To" section in the billing step, as well as causing the shipping address to be deselected in the shipping step. Instead, as it appears that the validation was initially added only to ensure the postcode was being validated (https://github.com/magento/magento2/commit/e97e0e08bff18bc84f01ce0e9ad6aee7ef70860a), I have created a simple validator based on the shipping rates validator which only validates the postcode of the address.

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22112: Shipping address information is lost in billing step

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Log in with the test account roni_cost@example.com
2. Add a product to the cart
3. Proceed to checkout
4. Select a shipping address & shipping method, then continue to the billing step
5. Deselect "my billing and shipping address are the same" and create a brand new billing address
6. Once the address is completed, you should still see the shipping address information in the Ship To section.
7. Postcode validation should still occur on this form - if you enter a 4-digit postcode for the US, you should still see the warning message.
8. If you go back to the shipping step, your previously-selected shipping address should still be selected.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
