### PR TITLE
If customer has already quote address, show as selected

### DIFF
--- a/app/code/Magento/Checkout/Model/Type/Onepage.php
+++ b/app/code/Magento/Checkout/Model/Type/Onepage.php
@@ -335,7 +335,7 @@ class Onepage
          * instead of just loading from sales/quote_address
          */
         $customer = $customerSession->getCustomerDataObject();
-        if ($customer) {
+        if ($customer && empty($this->_checkoutSession->getQuote()->getShippingAddress()->getAddressId())) {
             $quote->assignCustomer($customer);
         }
         return $this;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When there is no quote address, checkout address page should show default shipping address as selected but when there is a quote address that selected before, checkout address page should show selected address as selected not default shipping address.

assignCustomer function sets quote address object's shipping and billing address with default addresses.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
One can produce this issue by selecting different address from default address on checkout address page and continue to review page and return to the checkout address page, then selected address will be default address not the one selected before.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
