### PR TITLE
Moved Zero Subtotal Checkout Payment Settings

### DIFF
--- a/app/code/Magento/OfflinePayments/etc/adminhtml/system.xml
+++ b/app/code/Magento/OfflinePayments/etc/adminhtml/system.xml
@@ -152,41 +152,6 @@
                     <label>Sort Order</label>
                 </field>
             </group>
-            <group id="free" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
-                <label>Zero Subtotal Checkout</label>
-                <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                    <label>Enabled</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                </field>
-                <field id="order_status" translate="label" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                    <label>New Order Status</label>
-                    <source_model>Magento\Sales\Model\Config\Source\Order\Status\Newprocessing</source_model>
-                </field>
-                <field id="payment_action" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                    <label>Automatically Invoice All Items</label>
-                    <source_model>Magento\Payment\Model\Source\Invoice</source_model>
-                    <depends>
-                        <field id="order_status" separator=",">processing</field>
-                    </depends>
-                </field>
-                <field id="sort_order" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                    <label>Sort Order</label>
-                    <frontend_class>validate-number</frontend_class>
-                </field>
-                <field id="title" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Title</label>
-                </field>
-                <field id="allowspecific" translate="label" type="allowspecific" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                    <label>Payment from Applicable Countries</label>
-                    <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
-                </field>
-                <field id="specificcountry" translate="label" type="multiselect" sortOrder="51" showInDefault="1" showInWebsite="1" showInStore="0">
-                    <label>Payment from Specific Countries</label>
-                    <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
-                    <can_be_empty>1</can_be_empty>
-                </field>
-                <field id="model"></field>
-            </group>
         </section>
     </system>
 </config>

--- a/app/code/Magento/OfflinePayments/i18n/en_US.csv
+++ b/app/code/Magento/OfflinePayments/i18n/en_US.csv
@@ -21,5 +21,4 @@ Title,Title
 "Bank Transfer Payment","Bank Transfer Payment"
 Instructions,Instructions
 "Cash On Delivery Payment","Cash On Delivery Payment"
-"Zero Subtotal Checkout","Zero Subtotal Checkout"
 "Automatically Invoice All Items","Automatically Invoice All Items"

--- a/app/code/Magento/Payment/etc/adminhtml/system.xml
+++ b/app/code/Magento/Payment/etc/adminhtml/system.xml
@@ -11,6 +11,41 @@
             <label>Payment Methods</label>
             <tab>sales</tab>
             <resource>Magento_Payment::payment</resource>
+            <group id="free" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Zero Subtotal Checkout</label>
+                <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Enabled</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="order_status" translate="label" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>New Order Status</label>
+                    <source_model>Magento\Sales\Model\Config\Source\Order\Status\Newprocessing</source_model>
+                </field>
+                <field id="payment_action" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Automatically Invoice All Items</label>
+                    <source_model>Magento\Payment\Model\Source\Invoice</source_model>
+                    <depends>
+                        <field id="order_status" separator=",">processing</field>
+                    </depends>
+                </field>
+                <field id="sort_order" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Sort Order</label>
+                    <frontend_class>validate-number</frontend_class>
+                </field>
+                <field id="title" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Title</label>
+                </field>
+                <field id="allowspecific" translate="label" type="allowspecific" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Payment from Applicable Countries</label>
+                    <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+                </field>
+                <field id="specificcountry" translate="label" type="multiselect" sortOrder="51" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Payment from Specific Countries</label>
+                    <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                    <can_be_empty>1</can_be_empty>
+                </field>
+                <field id="model"></field>
+            </group>
         </section>
     </system>
 </config>

--- a/app/code/Magento/Payment/i18n/en_US.csv
+++ b/app/code/Magento/Payment/i18n/en_US.csv
@@ -58,3 +58,4 @@ No,No
 "Payment Methods Section","Payment Methods Section"
 "Payment Services","Payment Services"
 "Payment Methods","Payment Methods"
+"Zero Subtotal Checkout","Zero Subtotal Checkout"


### PR DESCRIPTION
### Description (*)
"Zero Subtotal Checkout" payment method settings disappear if "Offline Payments" module is disabled.

### Fixed Issues (if relevant)
1. magento/magento2#23678: Can't see "Zero Subtotal Checkout" payment method settings if "Offline Payments" module is disabled

### Manual testing scenarios (*)
1. php bin/magento module:disable Magento_OfflinePayments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
