### PR TITLE
Resolve Frontend Label For Custom Order Status not Editable in Magento Admin in Single Store Mode

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Status/NewStatus/Form.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Status/NewStatus/Form.php
@@ -56,9 +56,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             ['name' => 'label', 'label' => __('Status Label'), 'class' => 'required-entry', 'required' => true]
         );
 
-        if (!$this->_storeManager->isSingleStoreMode()) {
-            $this->_addStoresFieldset($model, $form);
-        }
+        $this->_addStoresFieldset($model, $form);
 
         if ($model) {
             $form->addValues($model->getData());
@@ -80,10 +78,31 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     protected function _addStoresFieldset($model, $form)
     {
         $labels = $model ? $model->getStoreLabels() : [];
-        $fieldset = $form->addFieldset(
-            'store_labels_fieldset',
-            ['legend' => __('Store View Specific Labels'), 'class' => 'store-scope']
-        );
+        if (!$this->_storeManager->isSingleStoreMode()) {
+            $fieldset = $form->addFieldset(
+                'store_labels_fieldset',
+                ['legend' => __('Store View Specific Labels'), 'class' => 'store-scope']
+            );
+        } else {
+            $fieldset = $form->addFieldset(
+                'store_labels_fieldset',
+                ['legend' => __('Frontend Label')]
+            );
+            $store = $this->_storeManager->getDefaultStoreView();
+            $fieldset->addField(
+                "store_label_{$store->getId()}",
+                'text',
+                [
+                    'name' => 'store_labels[' . $store->getId() . ']',
+                    'required' => false,
+                    'label' => $store->getName(),
+                    'value' => isset($labels[$store->getId()]) ? $labels[$store->getId()] : '',
+                    'fieldset_html_class' => 'store'
+                ]
+            );
+            return ;
+        }
+
         $renderer = $this->getLayout()->createBlock(
             \Magento\Backend\Block\Store\Switcher\Form\Renderer\Fieldset::class
         );


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

magento/magento2#23654: Frontend Label For Custom Order Status not Editable in Magento Admin in Single Store Mode

Reason: 

        if (!$this->_storeManager->isSingleStoreMode()) {
            $this->_addStoresFieldset($model, $form);
        }

Should be changed. Currently, it only processes the False value. We need to process it if $this->_storeManager->isSingleStoreMode() is True also.

Solution: Use the "if" condition to check if the settings is in "Single Store Mode", it will add only one field "Frontend Label" to change the label for the frontend instead of the Store View Specific Labels

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23654: Frontend Label For Custom Order Status not Editable in Magento Admin in Single Store Mode

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Enable "single store mode" in Configuration->General->Single-Store Mode
2. Go to Stores -> Order Status
3. Select any status
=> There should be a field where we can modify the string for a status for the frontend only

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
