### PR TITLE
Resolve Warning during search in catalog by multiple custom option values. Warning should not be generated in log

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/Layer/Filter/Attribute.php
+++ b/app/code/Magento/CatalogSearch/Model/Layer/Filter/Attribute.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\CatalogSearch\Model\Layer\Filter;
 
 use Magento\Catalog\Model\Layer\Filter\AbstractFilter;

--- a/app/code/Magento/CatalogSearch/Model/Layer/Filter/Attribute.php
+++ b/app/code/Magento/CatalogSearch/Model/Layer/Filter/Attribute.php
@@ -62,6 +62,9 @@ class Attribute extends AbstractFilter
             ->getProductCollection();
         $productCollection->addFieldToFilter($attribute->getAttributeCode(), $attributeValue);
         $label = $this->getOptionText($attributeValue);
+        if (is_array($label)) {
+            $label = implode(',', $label);
+        }
         $this->getLayer()
             ->getState()
             ->addFilter($this->_createItem($label, $attributeValue));


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

magento/magento2#23557: Resolve Warning during search in catalog by multiple custom option values. Warning should not be generated in log

The reason because the "$label" should be always "string" to call the _createItem($label, $value) function. 

Solution: Convert array to string by using "implode'

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23557: Warning during search in catalog by multiple custom option values. Warning should not be generated in log

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Create the Category and go to it at the frontend like http://[magento domain]/shirt.html
2. Change URL parameter to filter, add "color=123,11111" (color is the attribute can filter at the navigation and has the options) . Url will be : http://[magento domain]/shirt.html?color=123,11111
3. Press Enter to query filter the color by the value "123,11111" 

Result: No error in Log 
 Warning: strip_tags() expects parameter 1 to be string, array given in /.../magento2/vendor/magento/framework/Filter/StripTags.php on line 48

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
