### PR TITLE
Resolve API create /V1/products/attribute-sets/groups ("sort_order" and "attribute_group_code") not changing.

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductAttributeGroupRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductAttributeGroupRepository.php
@@ -4,12 +4,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Catalog\Model;
 
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\StateException;
 
+/**
+ * Class \Magento\Catalog\Model\ProductAttributeGroupRepository
+ */
 class ProductAttributeGroupRepository implements \Magento\Catalog\Api\ProductAttributeGroupRepositoryInterface
 {
     /**
@@ -43,15 +47,21 @@ class ProductAttributeGroupRepository implements \Magento\Catalog\Api\ProductAtt
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function save(\Magento\Eav\Api\Data\AttributeGroupInterface $group)
     {
+        /** @var \Magento\Catalog\Model\Product\Attribute\Group $group */
+        $extensionAttributes = $group->getExtensionAttributes();
+        if ($extensionAttributes) {
+            $group->setSortOrder($extensionAttributes->getSortOrder());
+            $group->setAttributeGroupCode($extensionAttributes->getAttributeGroupCode());
+        }
         return $this->groupRepository->save($group);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria)
     {
@@ -59,7 +69,7 @@ class ProductAttributeGroupRepository implements \Magento\Catalog\Api\ProductAtt
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function get($groupId)
     {
@@ -75,7 +85,7 @@ class ProductAttributeGroupRepository implements \Magento\Catalog\Api\ProductAtt
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function deleteById($groupId)
     {
@@ -86,7 +96,7 @@ class ProductAttributeGroupRepository implements \Magento\Catalog\Api\ProductAtt
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function delete(\Magento\Eav\Api\Data\AttributeGroupInterface $group)
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

magento/magento2#23634: Resolve API create /V1/products/attribute-sets/groups two fields (sort_order and "attribute_group_code" field) not changing in the DataBase. **Remember check in the Database, because the API always return the "sort_order" and "attribute_group_code" which is sent in the body parameter of request.**

Solution: The reason is in the save() function, it doesn't get the value in the extension_attributes. To fix it, in the save() function of repository, we need to get the value in the extension_attributes and add them to the model.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23634: Eav Group Repository Order not changing.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

Call the API:
Method: POST
http://[magento2 domain]/rest/default/V1/integration/admin/token
`{"username":"admin","password":"123123q"}`

The result is the [TOKEN]

Method: POST
http://[magento 2 domain]/rest/default/V1/products/attribute-sets/groups
Authorization: Bearer [TOKEN]
```
{
  "group": {
    "attribute_group_name": "Product Details",
    "attribute_set_id": "3",
    "extension_attributes": {
      "attribute_group_code": "details-test",
      "sort_order": "50"
    }
  }
}
```

Check in the Database, the last record in the table "eav_attribute_group". The attribute_group_code : "details-test" and "sort_order": "50" are saved correctly.

 **Remember check in the Database, because the API always return the "sort_order" and "attribute_group_code" which is sent in the body parameter of request.**

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
