### PR TITLE
Fix: cms breadcrumbs localization

### DIFF
--- a/app/code/Magento/Cms/Block/Page.php
+++ b/app/code/Magento/Cms/Block/Page.php
@@ -155,7 +155,7 @@ class Page extends \Magento\Framework\View\Element\AbstractBlock implements
                     'link' => $this->_storeManager->getStore()->getBaseUrl()
                 ]
             );
-            $breadcrumbsBlock->addCrumb('cms_page', ['label' => $page->getTitle(), 'title' => $page->getTitle()]);
+            $breadcrumbsBlock->addCrumb('cms_page', ['label' => __($page->getTitle()), 'title' => __($page->getTitle())]);
         }
     }
 


### PR DESCRIPTION
## Fix: CMS breadcrumbs localization

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
### The current a custom CMS page breadcrumbs status: is not localized.

### E.g: for ```ru_RU``` locale (Not localized):

```Главная >  About Us```
### Screenshot -> not localized breadcrumbs:
![Screenshot-20190714120436-305x68](https://user-images.githubusercontent.com/9606476/61183991-c0d35c00-a637-11e9-9ccf-b8a7e0a82a24.png)

### But expected (Localized):

```Главная >  О нас```
### Screenshot -> localized breadcrumbs:
![Screenshot-20190714130345-351x74](https://user-images.githubusercontent.com/9606476/61184001-d5175900-a637-11e9-97d3-3aaa5aca9429.png)

### Affected pages:
### Magento Community edition (Fixed):
```vendor/magento/module-cms/Block/Page.php:159```
### Magento Commerce edition (Should be fixed:)
```vendor/magento/module-versions-cms/Block/Cms/Page.php:113```
### before fix:
```            $breadcrumbsBlock->addCrumb('cms_page', ['label' => $page->getTitle(), 'title' => $page->getTitle())];```
### after fix:
```            $breadcrumbsBlock->addCrumb('cms_page', ['label' => __($page->getTitle()), 'title' => __($page->getTitle())]);```

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Opening any custom created CMS page
2. Checking breadcrumbs

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
