### PR TITLE
[2.3] Improve Database Media Storage Configuration settings usability

### DIFF
--- a/app/code/Magento/MediaStorage/etc/adminhtml/system.xml
+++ b/app/code/Magento/MediaStorage/etc/adminhtml/system.xml
@@ -10,11 +10,11 @@
         <section id="system" type="text" sortOrder="900" showInDefault="1" showInWebsite="1" showInStore="1">
             <group id="media_storage_configuration" translate="label" type="text" sortOrder="900" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Storage Configuration for Media</label>
-                <field id="media_storage" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="media_storage" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Media Storage</label>
                     <source_model>Magento\MediaStorage\Model\Config\Source\Storage\Media\Storage</source_model>
                 </field>
-                <field id="media_database" translate="label" type="select" sortOrder="200" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                <field id="media_database" translate="label" type="select" sortOrder="200" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Select Media Database</label>
                     <source_model>Magento\MediaStorage\Model\Config\Source\Storage\Media\Database</source_model>
                     <backend_model>Magento\MediaStorage\Model\Config\Backend\Storage\Media\Database</backend_model>
@@ -24,7 +24,7 @@
                 </field>
                 <field id="synchronize" translate="label comment" type="button" sortOrder="300" showInDefault="1" showInWebsite="0" showInStore="0">
                     <frontend_model>Magento\MediaStorage\Block\System\Config\System\Storage\Media\Synchronize</frontend_model>
-                    <comment>After selecting a new media storage location, press the Synchronize button to transfer all media to that location. Media will not be available in the new location until the synchronization process is complete.</comment>
+                    <comment>After selecting a new media storage location, press the Synchronize button to transfer all media to that location. Media will not be available in the new location until the synchronization process is complete. Remember to "Save Config" following change of mode and synchronization.</comment>
                 </field>
                 <field id="configuration_update_time" translate="label" type="text" sortOrder="400" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Environment Update Time</label>

--- a/app/code/Magento/MediaStorage/etc/adminhtml/system.xml
+++ b/app/code/Magento/MediaStorage/etc/adminhtml/system.xml
@@ -24,7 +24,7 @@
                 </field>
                 <field id="synchronize" translate="label comment" type="button" sortOrder="300" showInDefault="1" showInWebsite="0" showInStore="0">
                     <frontend_model>Magento\MediaStorage\Block\System\Config\System\Storage\Media\Synchronize</frontend_model>
-                    <comment>After selecting a new media storage location, press the Synchronize button to transfer all media to that location. Media will not be available in the new location until the synchronization process is complete. Remember to "Save Config" following change of mode and synchronization.</comment>
+                    <comment>After selecting a new media storage location, press the Synchronize button to transfer all media to that location and then "Save Config". Media will not be available in the new location until the synchronization process is complete.</comment>
                 </field>
                 <field id="configuration_update_time" translate="label" type="text" sortOrder="400" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Environment Update Time</label>


### PR DESCRIPTION
### Description (*)
The Media Storage Location setting has the option to "use default value", however this option causes issues with the page's javascript routines which need to independently control whether the media storage location dropdown box is enabled or not. This can result in situations where the use default value checkbox is checked, but the setting is enabled (and ignored). This PR removed the "Use default value" option for both the media storage mode and location.

### Fixed Issues (if relevant)
1. magento/magento2#23597: Database Media Storage : Difficulty changing mode to database media storage due to poor "Use Default Value" checkbox behaviour

### Manual testing scenarios (*)

1. Stores -> Configuration -> Advanced -> System -> Storage Configuration for Media
2. Ensure there is no "Use default value" checkbox next to "Media Storage" dropdown
3. Ensure "Media Storage" is enabled
4. Change mode to Database
5. Ensure there is no "Use default value" checkbox next to "Database" dropdown
6. Select "default setup" for database
7. Click Synchronize
8. Verify that both "Media Storage" and "Database" are both greyed out during the synchronization, but are re-enabled once complete.
9. Click "Save Config"
10. After screen refresh, Verify that both "Media Storage" and "Database" are both enabled and selectable.
11. Change mode to Filesystem
12. Click Synchronize
13. Verify that "Media Storage" is greyed out during the synchronization, but is re-enabled once complete.
14. Click "Save Config"

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
