### PR TITLE
Add Api to MediaStorage to simplify the interaction with files

### DIFF
--- a/app/code/Magento/MediaStorage/Api/StorageInterface.php
+++ b/app/code/Magento/MediaStorage/Api/StorageInterface.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\MediaStorage\Api;
+
+use Magento\Framework\Model\AbstractModel;
+
+/**
+ * Class Storage
+ *
+ * @api
+ * @since 100.0.2
+ */
+interface StorageInterface
+{
+    /**
+     * Storage systems ids
+     */
+    const STORAGE_MEDIA_FILE_SYSTEM = 0;
+
+    const STORAGE_MEDIA_DATABASE = 1;
+
+    /**
+     * Config paths for storing storage configuration
+     */
+    const XML_PATH_STORAGE_MEDIA = 'system/media_storage_configuration/media_storage';
+
+    const XML_PATH_STORAGE_MEDIA_DATABASE = 'system/media_storage_configuration/media_database';
+
+    const XML_PATH_MEDIA_UPDATE_TIME = 'system/media_storage_configuration/configuration_update_time';
+
+    const XML_PATH_MEDIA_RESOURCE_WHITELIST = 'system/media_storage_configuration/allowed_resources';
+
+    /**
+     * Retrieve storage model
+     * If storage not defined - retrieve current storage
+     *
+     * params = array(
+     *  connection  => string,  - define connection for model if needed
+     *  init        => bool     - force initialization process for storage model
+     * )
+     *
+     * @param int|null $storage
+     * @param array    $params
+     * @return AbstractModel|bool
+     */
+    public function getStorageModel($storage = null, $params = []);
+
+    /**
+     * Return current media directory, allowed resources for get.php script, etc.
+     *
+     * @return array
+     */
+    public function getScriptConfig();
+}

--- a/app/code/Magento/MediaStorage/Model/File/Storage.php
+++ b/app/code/Magento/MediaStorage/Model/File/Storage.php
@@ -9,6 +9,7 @@ namespace Magento\MediaStorage\Model\File;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Model\AbstractModel;
+use Magento\MediaStorage\Api\StorageInterface;
 
 /**
  * Class Storage
@@ -17,26 +18,8 @@ use Magento\Framework\Model\AbstractModel;
  * @api
  * @since 100.0.2
  */
-class Storage extends AbstractModel
+class Storage extends AbstractModel implements StorageInterface
 {
-    /**
-     * Storage systems ids
-     */
-    const STORAGE_MEDIA_FILE_SYSTEM = 0;
-
-    const STORAGE_MEDIA_DATABASE = 1;
-
-    /**
-     * Config paths for storing storage configuration
-     */
-    const XML_PATH_STORAGE_MEDIA = 'system/media_storage_configuration/media_storage';
-
-    const XML_PATH_STORAGE_MEDIA_DATABASE = 'system/media_storage_configuration/media_database';
-
-    const XML_PATH_MEDIA_RESOURCE_WHITELIST = 'system/media_storage_configuration/allowed_resources';
-
-    const XML_PATH_MEDIA_UPDATE_TIME = 'system/media_storage_configuration/configuration_update_time';
-
     /**
      * Prefix of model events names
      *
@@ -148,6 +131,7 @@ class Storage extends AbstractModel
      * Return synchronize process status flag
      *
      * @return \Magento\MediaStorage\Model\File\Storage\Flag
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getSyncFlag()
     {
@@ -199,10 +183,11 @@ class Storage extends AbstractModel
      *  connection  => string
      * )
      *
-     * @param  array $storage
+     * @param array $storage
      * @return $this
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function synchronize($storage)
     {

--- a/app/code/Magento/MediaStorage/etc/di.xml
+++ b/app/code/Magento/MediaStorage/etc/di.xml
@@ -26,4 +26,5 @@
             </argument>
         </arguments>
     </type>
+    <preference for="Magento\MediaStorage\Api\StorageInterface" type="Magento\MediaStorage\Model\File\Storage"/>
 </config>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
While working on Adobe Stock Integration development, we noticed that there is not a clear entry point for use Media Storage.

The proposed change pretend to make clear this entry point and therefore make easier for other modules to use and interact with Media Storage module.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. No behaviour has changed, Media Storage should be working as before.
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
