### PR TITLE
fix 404 url for sitemap content url

### DIFF
--- a/app/code/Magento/Sitemap/Model/Sitemap.php
+++ b/app/code/Magento/Sitemap/Model/Sitemap.php
@@ -362,7 +362,6 @@ class Sitemap extends \Magento\Framework\Model\AbstractModel implements \Magento
                 self::OPEN_TAG_KEY => '<?xml version="1.0" encoding="UTF-8"?>' .
                     PHP_EOL .
                     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"' .
-                    ' xmlns:content="http://www.google.com/schemas/sitemap-content/1.0"' .
                     ' xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">' .
                     PHP_EOL,
                 self::CLOSE_TAG_KEY => '</urlset>',

--- a/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-1-1.xml
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-1-1.xml
@@ -6,7 +6,6 @@
  */
 -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:content="http://www.google.com/schemas/sitemap-content/1.0"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
     <url>
         <loc>http://store.com/category.html</loc>

--- a/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-1-2.xml
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-1-2.xml
@@ -6,7 +6,6 @@
  */
 -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:content="http://www.google.com/schemas/sitemap-content/1.0"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
     <url>
         <loc>http://store.com/category/sub-category.html</loc>

--- a/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-1-3.xml
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-1-3.xml
@@ -6,7 +6,6 @@
  */
 -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:content="http://www.google.com/schemas/sitemap-content/1.0"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
     <url>
         <loc>http://store.com/product.html</loc>

--- a/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-1-4.xml
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-1-4.xml
@@ -6,7 +6,6 @@
  */
 -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:content="http://www.google.com/schemas/sitemap-content/1.0"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
     <url>
         <loc>http://store.com/product2.html</loc>

--- a/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-single.xml
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/_files/sitemap-single.xml
@@ -6,7 +6,6 @@
  */
 -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:content="http://www.google.com/schemas/sitemap-content/1.0"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
     <url>
         <loc>http://store.com/category.html</loc>


### PR DESCRIPTION
Fixed Issues (if relevant)
#23706

Solution:-  As per google sitemap doc only three types of additional media types images, news, and video so the need of content tag. (More info: - https://support.google.com/webmasters/answer/183668?hl=en)
4

Preconditions (*)
1.Magento2.2.2 install

Steps to reproduce (*)
Go to:
1.Dashboard->Marketing->SEO & Search->sitemap
2.Click add new fill in required fields
3. hit save & generate
4.Open newly created xml and check urlset tag attr xmlns:content is: "http://www.google.com/schemas/sitemap-content/1.0"

Expected result (*)
Should be one of returns 200 OK like: http://www.sitemaps.org/schemas/sitemap/0.9

Actual result (*)
http://www.google.com/schemas/sitemap-content/1.0
ref:
Screenshot 2019-07-15 at 14 13 36

More Info: File https://github.com/magento/magento2/blob/2.2/app/code/Magento/Sitemap/Model/Sitemap.php#L324

Thanks.