### PR TITLE
 Fixed an issue where an attribute named length would break the use default value checkbox from saving

### DIFF
--- a/lib/web/mage/utils/misc.js
+++ b/lib/web/mage/utils/misc.js
@@ -231,7 +231,7 @@ define([
             separator = separator || '-';
 
             _.each(data, function (value, key) {
-                if (_.isObject(value) && !value.length) {
+                if (_.isObject(value) && !Array.isArray(value)) {
                     this.filterFormData(value, suffix, separator);
                 } else if (_.isString(key) && ~key.indexOf(suffix)) {
                     data[key.split(separator)[0]] = value;

--- a/lib/web/mage/utils/objects.js
+++ b/lib/web/mage/utils/objects.js
@@ -148,7 +148,7 @@ define([
             separator = separator || '.';
             result = result || {};
 
-            if(!data) {
+            if (!data) {
                 return result;
             }
 

--- a/lib/web/mage/utils/objects.js
+++ b/lib/web/mage/utils/objects.js
@@ -148,7 +148,18 @@ define([
             separator = separator || '.';
             result = result || {};
 
-            _.each(data, function (node, name) {
+            if(!data) {
+                return result;
+            }
+
+            // UnderscoreJS each breaks when an object has a length property so we use Object.keys
+            _.each(Object.keys(data), function (name) {
+                var node = data[name];
+
+                if ({}.toString.call(node) === '[object Function]') {
+                    return;
+                }
+
                 if (parent) {
                     name = parent + separator + name;
                 }
@@ -436,3 +447,4 @@ define([
         }
     };
 });
+


### PR DESCRIPTION
### Description (*)
This pull request aims to solve an issue where the use default value checkbox won't save any data if there is an attribute with attribute code "length". Due to the value.length call resulting in the length attribute value. Also there's a bug in UnderscoreJS where an object with a length property breaks the _.each function.

### Manual testing scenarios (*)
1. Create a new product.
2. Create an attribute with code length and set scope to website and assign the attribute to your product.
3. Check use default value for any of your attributes
4. Use default value won't be saved. Since it is filtered out by the filterFormData function

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully (all builds are green)
