### PR TITLE
[2.3] Provide fallback GalleryOptions class when argument missing from layout xml file

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
@@ -12,6 +12,16 @@
 ?>
 
 <?php
+// If block argument "gallery_options" is not set in xml layout file, then fallback
+// to an instance of \Magento\Catalog\Block\Product\View\GalleryOptions class manually
+if ($block->getGalleryOptions() === null) {
+    $block->setData(
+        'gallery_options',
+        \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\Magento\Catalog\Block\Product\View\GalleryOptions::class)
+    );
+}
+
 $images = $block->getGalleryImages()->getItems();
 $mainImage = current(array_filter($images, function ($img) use ($block) {
     return $block->isMainImage($img);
@@ -45,7 +55,7 @@ $mainImageData = $mainImage ?
                 "data": <?= /* @noEscape */ $block->getGalleryImagesJson() ?>,
                 "options": <?= /* @noEscape */ $block->getGalleryOptions()->getOptionsJson() ?>,
                 "fullscreen": <?= /* @noEscape */ $block->getGalleryOptions()->getFSOptionsJson() ?>,
-                 "breakpoints": <?= /* @noEscape */ $block->getBreakpoints() ?>
+                "breakpoints": <?= /* @noEscape */ $block->getBreakpoints() ?>
             }
         }
     }


### PR DESCRIPTION
### Description (*)
The main product gallery layout file "catalog_product_view.xml" in "Magento_Catalog" now requires the argument "gallery_options" to be injected to the instance of the 
"\Magento\Catalog\Block\Product\View\Gallery" class for the "product.info.media.image" block in order for the product page to be rendered correctly (This is a recent change). If this option is not present then the product page will just render the product image, and nothing else as the getGalleryOptions() call will just return null.

This is not a problem in vanilla Magento, as the argument is present in the layout file, however third party module providers, or anyone instantiating an instance of the "\Magento\Catalog\Block\Product\View\Gallery" class, or inheriting from it now needs to inject this argument for the template to render correctly. This has broken backwards compatability with old third party modules code, who now need to update to inject this argument.

This PR introduces code into the phtml template, that detects if the option is not injected, and falls back to hard coded "\Magento\Catalog\Block\Product\View\GalleryOptions" class.

### Fixed Issues (if relevant)
1. magento/magento2#23432: When viewing product only the image shows

### Manual testing scenarios (*)
1. Remove argument "gallery_options" from "catalog_product_view.xml" in Magento_Catalog module.
2. Clear cache
3. View product page (product that has an image)
4. Ensure product page renders correctly.

### Questions or comments
Someone from Magento will need to determine whether this is required, or whether this is the right place for this check, given it is not needed in vanilla Magento, and is a fallback for when third party modules and users do not implement the argument correctly in layout.xml, or have not updated their module to include the argument. Given there is an issue raised on this, it is happening in the wild and this PR would help. If deemed not required, close accordingly.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
