### PR TITLE
[2.2][Backport] Provide fallback GalleryOptions class when argument missing from layout xml file

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
@@ -9,6 +9,17 @@
  *
  * @var $block \Magento\Catalog\Block\Product\View\Gallery
  */
+
+// If block argument "gallery_options" is not set in xml layout file, then fallback
+// to an instance of \Magento\Catalog\Block\Product\View\GalleryOptions class manually
+if ($block->getGalleryOptions() === null) {
+    $block->setData(
+            'gallery_options',
+            \Magento\Framework\App\ObjectManager::getInstance()
+                ->get(\Magento\Catalog\Block\Product\View\GalleryOptions::class)
+    );
+}
+
 ?>
 <div class="gallery-placeholder _block-content-loading" data-gallery-role="gallery-placeholder">
     <div data-role="loader" class="loading-mask">


### PR DESCRIPTION
### Original PR (*)
1. magento/magento2#23733: [2.3] Provide fallback GalleryOptions class when argument missing from layout xml file

### Description (*)
The main product gallery layout file "catalog_product_view.xml" in "Magento_Catalog" now requires the argument "gallery_options" to be injected to the instance of the 
"\Magento\Catalog\Block\Product\View\Gallery" class for the "product.info.media.image" block in order for the product page to be rendered correctly (This is a recent change). If this option is not present then the product page will just render the product image, and nothing else as the getGalleryOptions() call will just return null.

This is not a problem in vanilla Magento, as the argument is present in the layout file, however third party module providers, or anyone instantiating an instance of the "\Magento\Catalog\Block\Product\View\Gallery" class, or inheriting from it now needs to inject this argument for the template to render correctly. This has broken backwards compatability with old third party modules code, who now need to update to inject this argument.

This PR introduces code into the phtml template, that detects if the option is not injected, and falls back to hard coded "\Magento\Catalog\Block\Product\View\GalleryOptions" class.

### Fixed Issues (if relevant)
1. magento/magento2#23432: When viewing product only the image shows

### Manual testing scenarios (*)
1. Remove argument "gallery_options" from "catalog_product_view.xml" in Magento_Catalog module.
2. Clear cache
3. View product page (product that has an image)
4. Ensure product page renders correctly.

### Questions or comments
See notes and discussion in Original PR where it is being discussed whether to implement this series of PR's or not. This backport should follow whatever the decision is for the 2.3 release line's PR.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)