### PR TITLE
Resolve Bad style on Validate VAT number messages issue23738

### DIFF
--- a/app/code/Magento/Customer/view/adminhtml/templates/system/config/validatevat.phtml
+++ b/app/code/Magento/Customer/view/adminhtml/templates/system/config/validatevat.phtml
@@ -30,12 +30,13 @@ require(['prototype'], function(){
                         result = response.message;
                     }
                     if (response.valid == 1) {
-                        validationMessage.removeClassName('hidden').addClassName('success')
+                        validationMessage.removeClassName('hidden').removeClassName('admin__field-error').addClassName('note');
+                        validationMessage.setStyle({color:'green'});
                     } else {
-                        validationMessage.removeClassName('hidden').addClassName('error')
+                        validationMessage.removeClassName('hidden').addClassName('admin__field-error');
                     }
                 } catch (e) {
-                    validationMessage.removeClassName('hidden').addClassName('error')
+                    validationMessage.removeClassName('hidden').addClassName('admin__field-error');
                 }
                 validationMessage.update(result);
             }
@@ -48,8 +49,9 @@ require(['prototype'], function(){
 });
 </script>
 <div class="actions actions-validate-vat">
-    <div id="validation_result" class="message-validation hidden"></div>
     <button onclick="javascript:validateVat(); return false;" class="action-validate-vat" type="button" id="<?= $block->escapeHtmlAttr($block->getHtmlId()) ?>">
         <span><?= $block->escapeHtml($block->getButtonLabel()) ?></span>
     </button>
+    <p class="admin__field-error hidden" id="validation_result"></p>
 </div>
+

--- a/app/code/Magento/Customer/view/adminhtml/templates/system/config/validatevat.phtml
+++ b/app/code/Magento/Customer/view/adminhtml/templates/system/config/validatevat.phtml
@@ -49,9 +49,9 @@ require(['prototype'], function(){
 });
 </script>
 <div class="actions actions-validate-vat">
+    <p class="admin__field-error hidden" id="validation_result" style="margin-bottom:10px;"></p>
     <button onclick="javascript:validateVat(); return false;" class="action-validate-vat" type="button" id="<?= $block->escapeHtmlAttr($block->getHtmlId()) ?>">
         <span><?= $block->escapeHtml($block->getButtonLabel()) ?></span>
     </button>
-    <p class="admin__field-error hidden" id="validation_result"></p>
 </div>
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Resolve magento/magento2#23738: Bad style on Validate VAT number messages

Reason: No style for error and success class in CSS.

Solution: Use other class and add the color to the message

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23738: Bad style on Validate VAT number messages

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Go to Stores->Configuration->General
2. Scroll to Store Information
3. Click "Validate VAT number" with empty information. 
- Fill the correct VAT number with the country. Click "Validate VAT number"

Results
1. The error message should be red.
2. The success message should be green.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
