### PR TITLE
Resolve Field "Billing ZIP Code" shows and disappears immediately in "Orders and Returns" form

### DIFF
--- a/app/code/Magento/Sales/view/frontend/templates/guest/form.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/guest/form.phtml
@@ -48,7 +48,7 @@
                        data-validate="{required:true, 'validate-email':true}"/>
             </div>
         </div>
-        <div id="oar-zip" class="field zip required">
+        <div id="oar-zip" style="display: none;" class="field zip required">
             <label class="label" for="oar_zip"><span><?= $block->escapeHtml(__('Billing ZIP Code')) ?></span></label>
 
             <div class="control">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Resolve magento/magento2#23746: Field "Billing ZIP Code" shows and disappears immediately in "Orders and Returns" form

Solution: Field  "Billing ZIP Code" should be "display: none" when loading page

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23746: Field "Billing ZIP Code" shows and disappears immediately in "Orders and Returns" form

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Go to http://[Magento 2 Domain]/sales/guest/form/
2. See the field
Results: Field "Billing ZIP Code" is hidden (doesn't shows and disappears immediately)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
