### PR TITLE
[2.3] Database Media Storage : PDF Logo file now database aware

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
@@ -7,6 +7,7 @@
 namespace Magento\Sales\Model\Order\Pdf;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\MediaStorage\Helper\File\Storage\Database;
 
 /**
  * Sales Order PDF abstract model
@@ -15,6 +16,7 @@ use Magento\Framework\App\Filesystem\DirectoryList;
  * @api
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyFields)
  * @since 100.0.2
  */
 abstract class AbstractPdf extends \Magento\Framework\DataObject
@@ -123,6 +125,11 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
     private $pageSettings;
 
     /**
+     * @var Database
+     */
+    private $fileStorageDatabase;
+
+    /**
      * @param \Magento\Payment\Helper\Data $paymentData
      * @param \Magento\Framework\Stdlib\StringUtils $string
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
@@ -134,6 +141,7 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
      * @param \Magento\Framework\Translate\Inline\StateInterface $inlineTranslation
      * @param \Magento\Sales\Model\Order\Address\Renderer $addressRenderer
      * @param array $data
+     * @param Database $fileStorageDatabase
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -147,7 +155,8 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
         \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate,
         \Magento\Framework\Translate\Inline\StateInterface $inlineTranslation,
         \Magento\Sales\Model\Order\Address\Renderer $addressRenderer,
-        array $data = []
+        array $data = [],
+        Database $fileStorageDatabase = null
     ) {
         $this->addressRenderer = $addressRenderer;
         $this->_paymentData = $paymentData;
@@ -160,6 +169,8 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
         $this->_pdfTotalFactory = $pdfTotalFactory;
         $this->_pdfItemsFactory = $pdfItemsFactory;
         $this->inlineTranslation = $inlineTranslation;
+        $this->fileStorageDatabase = $fileStorageDatabase ?:
+            \Magento\Framework\App\ObjectManager::getInstance()->get(Database::class);
         parent::__construct($data);
     }
 
@@ -254,6 +265,11 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
         );
         if ($image) {
             $imagePath = '/sales/store/logo/' . $image;
+            if ($this->fileStorageDatabase->checkDbUsage() &&
+                !$this->_mediaDirectory->isFile($imagePath)
+            ) {
+                $this->fileStorageDatabase->saveFileToFilesystem($imagePath);
+            }
             if ($this->_mediaDirectory->isFile($imagePath)) {
                 $image = \Zend_Pdf_Image::imageWithPath($this->_mediaDirectory->getAbsolutePath($imagePath));
                 $top = 830;

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Pdf/InvoiceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Pdf/InvoiceTest.php
@@ -5,6 +5,18 @@
  */
 namespace Magento\Sales\Test\Unit\Model\Order\Pdf;
 
+use Magento\MediaStorage\Helper\File\Storage\Database;
+use Magento\Sales\Model\Order\Invoice;
+use Magento\Sales\Model\Order;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Sales\Model\Order\Address;
+use Magento\Sales\Model\Order\Address\Renderer;
+
+/**
+ * Class InvoiceTest
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class InvoiceTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -17,13 +29,38 @@ class InvoiceTest extends \PHPUnit\Framework\TestCase
      */
     protected $_pdfConfigMock;
 
+    /**
+     * @var Database|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $databaseMock;
+
+    /**
+     * @var ScopeConfigInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $scopeConfigMock;
+
+    /**
+     * @var \Magento\Framework\Filesystem\Directory\Write|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $directoryMock;
+
+    /**
+     * @var Renderer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $addressRendererMock;
+
+    /**
+     * @var \Magento\Payment\Helper\Data|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $paymentDataMock;
+
     protected function setUp()
     {
         $this->_pdfConfigMock = $this->getMockBuilder(\Magento\Sales\Model\Order\Pdf\Config::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $directoryMock = $this->createMock(\Magento\Framework\Filesystem\Directory\Write::class);
-        $directoryMock->expects($this->any())->method('getAbsolutePath')->will(
+        $this->directoryMock = $this->createMock(\Magento\Framework\Filesystem\Directory\Write::class);
+        $this->directoryMock->expects($this->any())->method('getAbsolutePath')->will(
             $this->returnCallback(
                 function ($argument) {
                     return BP . '/' . $argument;
@@ -31,8 +68,17 @@ class InvoiceTest extends \PHPUnit\Framework\TestCase
             )
         );
         $filesystemMock = $this->createMock(\Magento\Framework\Filesystem::class);
-        $filesystemMock->expects($this->any())->method('getDirectoryRead')->will($this->returnValue($directoryMock));
-        $filesystemMock->expects($this->any())->method('getDirectoryWrite')->will($this->returnValue($directoryMock));
+        $filesystemMock->expects($this->any())
+            ->method('getDirectoryRead')
+            ->will($this->returnValue($this->directoryMock));
+        $filesystemMock->expects($this->any())
+            ->method('getDirectoryWrite')
+            ->will($this->returnValue($this->directoryMock));
+
+        $this->databaseMock = $this->createMock(Database::class);
+        $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
+        $this->addressRendererMock = $this->createMock(Renderer::class);
+        $this->paymentDataMock = $this->createMock(\Magento\Payment\Helper\Data::class);
 
         $helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->_model = $helper->getObject(
@@ -40,6 +86,11 @@ class InvoiceTest extends \PHPUnit\Framework\TestCase
             [
                 'filesystem' => $filesystemMock,
                 'pdfConfig' => $this->_pdfConfigMock,
+                'fileStorageDatabase' => $this->databaseMock,
+                'scopeConfig' => $this->scopeConfigMock,
+                'addressRenderer' => $this->addressRendererMock,
+                'string' => new \Magento\Framework\Stdlib\StringUtils(),
+                'paymentData' => $this->paymentDataMock
             ]
         );
     }
@@ -71,5 +122,84 @@ class InvoiceTest extends \PHPUnit\Framework\TestCase
             ],
             $renderers->getValue($this->_model)
         );
+    }
+
+    public function testInsertLogoDatabaseMediaStorage()
+    {
+        $filename = 'image.jpg';
+        $path = '/sales/store/logo/';
+
+        $this->_pdfConfigMock->expects($this->once())
+            ->method('getRenderersPerProduct')
+            ->with('invoice')
+            ->will($this->returnValue(['product_type_one' => 'Renderer_Type_One_Product_One']));
+        $this->_pdfConfigMock->expects($this->any())
+            ->method('getTotals')
+            ->will($this->returnValue([]));
+
+        $block = $this->getMockBuilder(\Magento\Framework\View\Element\Template::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setIsSecureMode','toPdf'])
+            ->getMock();
+        $block->expects($this->any())
+            ->method('setIsSecureMode')
+            ->willReturn($block);
+        $block->expects($this->any())
+            ->method('toPdf')
+            ->will($this->returnValue(''));
+        $this->paymentDataMock->expects($this->any())
+            ->method('getInfoBlock')
+            ->willReturn($block);
+
+        $this->addressRendererMock->expects($this->any())
+            ->method('format')
+            ->will($this->returnValue(''));
+
+        $this->databaseMock->expects($this->any())
+            ->method('checkDbUsage')
+            ->will($this->returnValue(true));
+
+        $invoiceMock = $this->createMock(Invoice::class);
+        $orderMock = $this->createMock(Order::class);
+        $addressMock = $this->createMock(Address::class);
+        $orderMock->expects($this->any())
+            ->method('getBillingAddress')
+            ->willReturn($addressMock);
+        $orderMock->expects($this->any())
+            ->method('getIsVirtual')
+            ->will($this->returnValue(true));
+        $infoMock = $this->createMock(\Magento\Payment\Model\InfoInterface::class);
+        $orderMock->expects($this->any())
+            ->method('getPayment')
+            ->willReturn($infoMock);
+        $invoiceMock->expects($this->any())
+            ->method('getOrder')
+            ->willReturn($orderMock);
+        $invoiceMock->expects($this->any())
+            ->method('getAllItems')
+            ->willReturn([]);
+
+        $this->scopeConfigMock->expects($this->at(0))
+            ->method('getValue')
+            ->with('sales/identity/logo', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null)
+            ->will($this->returnValue($filename));
+        $this->scopeConfigMock->expects($this->at(1))
+            ->method('getValue')
+            ->with('sales/identity/address', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null)
+            ->will($this->returnValue(''));
+
+        $this->directoryMock->expects($this->any())
+            ->method('isFile')
+            ->with($path . $filename)
+            ->willReturnOnConsecutiveCalls(
+                $this->returnValue(false),
+                $this->returnValue(false)
+            );
+
+        $this->databaseMock->expects($this->once())
+            ->method('saveFileToFilesystem')
+            ->with($path . $filename);
+
+        $this->_model->getPdf([$invoiceMock]);
     }
 }


### PR DESCRIPTION
### Description (*)
When generating PDF invoices etc, the pdf logo is assumed to be on the local storage. This may not be the case in Database Media Storage mode where it should be extracted from the database and saved locally prior to being used to generate the pdf.

### Fixed Issues (if relevant)
1. magento/magento2#23751: Database Media Storage : PDF Logo file not database aware

### Manual testing scenarios (*)
```
Backend
=======
Stores -> Configuration -> Advanced -> System
    Storage Configuration for Media
        Media Storage = Database
        Select Media Database = default_setup
        Synchronize
        Save Config
Stores -> Configuration
    Sales -> Sales
        Invoice and Packing Slip Design
            Logo for PDF Print-outs
                Choose Logo File
                Save Configuration
Catalog -> Products -> Add Product
    Name = Test
    Price = 111
    Quantity = 111
    New Category
        Name = TC
        Parent Category = Default Category
        Create Category
    Save & Close
    
Frontend
========
Purchase test product

Verify logo in database
=======================
www-data@dev:~/dev1$ mysql -e 'select filename,directory from dev1_magento.media_storage_file_storage;'
+----------------------------------+--------------------------+
| filename                         | directory                |
+----------------------------------+--------------------------+
| preview_image_5d2ee48863d5a.jpeg | theme/preview            |
| preview_image_5d2ee4889216e.jpeg | theme/preview            |
| image.jpg                        | sales/store/logo/default |
+----------------------------------+--------------------------+
www-data@dev:~/dev1$

Verify logo in filesystem
=========================
www-data@dev:~/dev1$ find ./pub/media -name *.jpg
./pub/media/sales/store/logo/default/image.jpg
www-data@dev:~/dev1$

Backend
=======
Sales -> Orders
    View Order 00000001
    Invoice
    Submit Invoice
Sales -> Orders
    Select Order 00000001
    Print Invoice
Verify Logo appears at top of pdf

Clear logo from Filesystem
==========================
www-data@dev:~/dev1$ rm -rf pub/media/sales/
www-data@dev:~/dev1$

Backend
=======
Sales -> Orders
    Select Order 00000001
    Print Invoice
Verify Logo appears at top of pdf <- This step would fail without this PR

Verify logo in filesystem
=========================
www-data@dev:~/dev1$ find ./pub/media -name *.jpg
./pub/media/sales/store/logo/default/image.jpg <- This step would fail without this PR
www-data@dev:~/dev1$

```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
