### PR TITLE
Fix quote fixture.

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Sales/_files/quote.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/quote.php
@@ -56,7 +56,7 @@ $quote->setIsMultiShipping('1');
 $quote->collectTotals();
 
 $quoteRepository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
-    ->create(\Magento\Quote\Api\CartRepositoryInterface::class);
+    ->get(\Magento\Quote\Api\CartRepositoryInterface::class);
 $quoteRepository->save($quote);
 
 /** @var \Magento\Quote\Model\QuoteIdMask $quoteIdMask */


### PR DESCRIPTION
### Description (*)
Create new instance of the quote repository can lead to unexpected behavior of functional tests.
See test scenario for more details

### Manual testing scenarios (*)

#### Steps to reproduce.
1. Create plugin with 'afterAfterSave' for Quote Address Model.
2. Try to load Quote from Quote Repository in the Plugin.
3. Run integration tests where fixture 'Magento/Sales/_files/quote.php' is used (e.g. \Magento\Quote\Model\ShippingMethodManagementTest::testTableRateFreeShipping)

#### Expected result
1. Test is successful. We have not changed anything in Quote.

#### Actual result
1. Test failed. Quote is invalid.

#### Description
The problem is related that if we during the Quote save load Quote with Quote Repository in 'afterAfterSave' plugin of Quote address, the Quote will be cached in Quote Repository. In this moment Quote is not fully saved and may be in invalid state.
Expected that Quote will be flushed from Quote Repository after save, but if we use different instances of Quote Repository it will lead to unexpected behavior.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
