### PR TITLE
group_id overridden if set

### DIFF
--- a/app/code/Magento/Customer/Model/CustomerExtractor.php
+++ b/app/code/Magento/Customer/Model/CustomerExtractor.php
@@ -88,15 +88,18 @@ class CustomerExtractor
             $customerData,
             \Magento\Customer\Api\Data\CustomerInterface::class
         );
+        
         $store = $this->storeManager->getStore();
+        $storeId = $store->getId();
+        
         if ($isGroupIdEmpty) {
             $customerDataObject->setGroupId(
-                $this->customerGroupManagement->getDefaultGroup($store->getId())->getId()
+                $this->customerGroupManagement->getDefaultGroup($storeId)->getId()
             );
         }
 
         $customerDataObject->setWebsiteId($store->getWebsiteId());
-        $customerDataObject->setStoreId($store->getId());
+        $customerDataObject->setStoreId($storeId);
 
         return $customerDataObject;
     }

--- a/app/code/Magento/Customer/Model/CustomerExtractor.php
+++ b/app/code/Magento/Customer/Model/CustomerExtractor.php
@@ -1,9 +1,9 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Customer\Model;
 
 use Magento\Customer\Api\CustomerMetadataInterface;
@@ -11,6 +11,9 @@ use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Api\GroupManagementInterface;
 use Magento\Framework\App\RequestInterface;
 
+/**
+ * Customer Extractor model.
+ */
 class CustomerExtractor
 {
     /**

--- a/app/code/Magento/Customer/Model/CustomerExtractor.php
+++ b/app/code/Magento/Customer/Model/CustomerExtractor.php
@@ -63,6 +63,8 @@ class CustomerExtractor
     }
 
     /**
+     * Creates a Customer object populated with the given form code and request data.
+     * 
      * @param string $formCode
      * @param RequestInterface $request
      * @param array $attributeValues

--- a/app/code/Magento/Customer/Model/CustomerExtractor.php
+++ b/app/code/Magento/Customer/Model/CustomerExtractor.php
@@ -64,7 +64,7 @@ class CustomerExtractor
 
     /**
      * Creates a Customer object populated with the given form code and request data.
-     * 
+     *
      * @param string $formCode
      * @param RequestInterface $request
      * @param array $attributeValues

--- a/app/code/Magento/Customer/Model/CustomerExtractor.php
+++ b/app/code/Magento/Customer/Model/CustomerExtractor.php
@@ -80,7 +80,7 @@ class CustomerExtractor
         $customerData = $customerForm->compactData($customerData);
 
         $allowedAttributes = $customerForm->getAllowedAttributes();
-        $isGroupIdEmpty = isset($allowedAttributes['group_id']);
+        $isGroupIdEmpty = !isset($allowedAttributes['group_id']);
 
         $customerDataObject = $this->customerFactory->create();
         $this->dataObjectHelper->populateWithArray(

--- a/app/code/Magento/Customer/Test/Unit/Model/CustomerExtractorTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/CustomerExtractorTest.php
@@ -144,16 +144,6 @@ class CustomerExtractorTest extends \PHPUnit\Framework\TestCase
         $this->store->expects($this->once())
             ->method('getId')
             ->willReturn(1);
-//        $this->customerGroupManagement->expects($this->once())
-//            ->method('getDefaultGroup')
-//            ->with(1)
-//            ->willReturn($this->customerGroup);
-//        $this->customerGroup->expects($this->once())
-//            ->method('getId')
-//            ->willReturn(1);
-//        $this->customerData->expects($this->once())
-//            ->method('setGroupId')
-//            ->with(1);
         $this->store->expects($this->once())
             ->method('getWebsiteId')
             ->willReturn(1);

--- a/app/code/Magento/Customer/Test/Unit/Model/CustomerExtractorTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/CustomerExtractorTest.php
@@ -3,10 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Customer\Test\Unit\Model;
 
 use Magento\Customer\Model\CustomerExtractor;
 
+/**
+ * Unit test CustomerExtractorTest
+ */
 class CustomerExtractorTest extends \PHPUnit\Framework\TestCase
 {
     /** @var CustomerExtractor */
@@ -137,19 +141,19 @@ class CustomerExtractorTest extends \PHPUnit\Framework\TestCase
         $this->storeManager->expects($this->once())
             ->method('getStore')
             ->willReturn($this->store);
-        $this->store->expects($this->exactly(2))
+        $this->store->expects($this->once())
             ->method('getId')
             ->willReturn(1);
-        $this->customerGroupManagement->expects($this->once())
-            ->method('getDefaultGroup')
-            ->with(1)
-            ->willReturn($this->customerGroup);
-        $this->customerGroup->expects($this->once())
-            ->method('getId')
-            ->willReturn(1);
-        $this->customerData->expects($this->once())
-            ->method('setGroupId')
-            ->with(1);
+//        $this->customerGroupManagement->expects($this->once())
+//            ->method('getDefaultGroup')
+//            ->with(1)
+//            ->willReturn($this->customerGroup);
+//        $this->customerGroup->expects($this->once())
+//            ->method('getId')
+//            ->willReturn(1);
+//        $this->customerData->expects($this->once())
+//            ->method('setGroupId')
+//            ->with(1);
         $this->store->expects($this->once())
             ->method('getWebsiteId')
             ->willReturn(1);


### PR DESCRIPTION
### Description (*)
Setting the group_id will be overridden to use the default group id if set.

### Manual testing scenarios (*)
Include the group_id attribute id in the table customer_form_attribute.
 - form_code 'customer_account_create'
 - attribute_id 10

Set group_id in the CreatePost customer controller.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
