### PR TITLE
#23705 : Css selector [role="button"] in related products javascript is not specific enough

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
@@ -170,7 +170,7 @@ switch ($type = $block->getType()) {
                 <?php if ($type == 'related' && $canItemsAddToCart) :?>
                     <div class="block-actions">
                         <?= $block->escapeHtml(__('Check items to add to the cart or')) ?>
-                        <button type="button" class="action select" role="button"><span><?= $block->escapeHtml(__('select all')) ?></span></button>
+                        <button type="button" class="action select" data-role="select-all"><span><?= $block->escapeHtml(__('select all')) ?></span></button>
                     </div>
                 <?php endif; ?>
                 <div class="products wrapper grid products-grid products-<?= $block->escapeHtmlAttr($type) ?>">

--- a/app/code/Magento/Catalog/view/frontend/web/js/related-products.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/related-products.js
@@ -17,7 +17,7 @@ define([
             relatedProductsField: '#related-products-field', // Hidden input field that stores related products.
             selectAllMessage: $.mage.__('select all'),
             unselectAllMessage: $.mage.__('unselect all'),
-            selectAllLink: '[role="button"]',
+            selectAllLink: '[data-role="select-all"]',
             elementsSelector: '.item.product'
         },
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23705: Css selector [role="button"] in related products javascript is not specific enough

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open product detail page with related products
2. Click on "Add to wishlist" or "Compare" icon of a related product
3. Added to the wishlist (If the customer is logged in)
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
