### PR TITLE
Resolve "Discount Amount" field is validated after the page load without any action from user in Create New Catalog Rule form issue23777

### DIFF
--- a/app/code/Magento/CatalogRule/view/adminhtml/ui_component/catalog_rule_form.xml
+++ b/app/code/Magento/CatalogRule/view/adminhtml/ui_component/catalog_rule_form.xml
@@ -307,6 +307,7 @@
             <settings>
                 <validation>
                     <rule name="required-entry" xsi:type="boolean">true</rule>
+                    <rule name="validate-number-range" xsi:type="string">0.00-100.00</rule>
                 </validation>
                 <dataType>text</dataType>
                 <label translate="true">Discount Amount</label>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. magento/magento2#23777: Resolve "Discount Amount" field is validated after the page load without any action from user in Create New Catalog Rule form

When the page loading, I see the function in vendor/magento/module-ui/view/base/web/js/form/element/abstract.js

            changed = utils.compare(rules, this.validation).equal;

            if (changed) {
                this.required(!!rules['required-entry']);
                this.validate();
            }

try to log it:

![image](https://user-images.githubusercontent.com/8234209/61572248-b6481500-aac4-11e9-9157-6b517cbea9f0.png)


Because the "discount_amount" in the xml field has the default validate (required-entry) doesn't match with the default  "Apply" field "Apply as percentage of original" (required-entry, validate-number-range 0-100) so that field was validated after the page load. So we should add the  "validate-number-range 0-100" to "discount_amount" default validate. It will match and no-validation anymore :)
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23777: "Discount Amount" field is validated after the page load without any action from user in Create New Catalog Rule form

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. In back end, go to Marketing -> Catalog Price Rule -> Add New Rule
2. Scroll to the Action fieldset
3. See the " Discount Amount" Field

Result:
1. Normal field, no error when page loads.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
