### PR TITLE
Resolve Rule coupon code generate form validation issue23778

### DIFF
--- a/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Coupons/Form.php
+++ b/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Coupons/Form.php
@@ -3,12 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\SalesRule\Block\Adminhtml\Promo\Quote\Edit\Tab\Coupons;
 
 /**
  * Coupons generation parameters form
- *
  * @author      Magento Core Team <core@magentocommerce.com>
+ *
+ * Class \Magento\SalesRule\Block\Adminhtml\Promo\Quote\Edit\Tab\Coupons\Form
  */
 class Form extends \Magento\Backend\Block\Widget\Form\Generic
 {

--- a/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Coupons/Form.php
+++ b/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Coupons/Form.php
@@ -9,6 +9,7 @@ namespace Magento\SalesRule\Block\Adminhtml\Promo\Quote\Edit\Tab\Coupons;
 
 /**
  * Coupons generation parameters form
+ *
  * @author      Magento Core Team <core@magentocommerce.com>
  *
  * Class \Magento\SalesRule\Block\Adminhtml\Promo\Quote\Edit\Tab\Coupons\Form

--- a/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Coupons/Form.php
+++ b/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Coupons/Form.php
@@ -77,7 +77,8 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'label' => __('Coupon Qty'),
                 'title' => __('Coupon Qty'),
                 'required' => true,
-                'class' => 'validate-digits validate-greater-than-zero'
+                'class' => 'validate-digits validate-greater-than-zero',
+                'onchange' => 'window.validateCouponGenerate(this)'
             ]
         );
 
@@ -91,7 +92,8 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'required' => true,
                 'note' => __('Excluding prefix, suffix and separators.'),
                 'value' => $couponHelper->getDefaultLength(),
-                'class' => 'validate-digits validate-greater-than-zero'
+                'class' => 'validate-digits validate-greater-than-zero',
+                'onchange' => 'window.validateCouponGenerate(this)'
             ]
         );
 
@@ -103,7 +105,8 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'name' => 'format',
                 'options' => $couponHelper->getFormatsList(),
                 'required' => true,
-                'value' => $couponHelper->getDefaultFormat()
+                'value' => $couponHelper->getDefaultFormat(),
+                'onchange' => 'window.validateCouponGenerate(this)'
             ]
         );
 
@@ -138,7 +141,8 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'title' => __('Dash Every X Characters'),
                 'note' => __('If empty no separation.'),
                 'value' => $couponHelper->getDefaultDashInterval(),
-                'class' => 'validate-digits'
+                'class' => 'validate-digits',
+                'onchange' => 'window.validateCouponGenerate(this)'
             ]
         );
 

--- a/app/code/Magento/SalesRule/view/adminhtml/templates/promo/salesrulejs.phtml
+++ b/app/code/Magento/SalesRule/view/adminhtml/templates/promo/salesrulejs.phtml
@@ -20,10 +20,19 @@ function refreshCouponCodesGrid(grid, gridMassAction, transport) {
 
 function generateCouponCodes(idPrefix, generateUrl, grid) {
     $(idPrefix + 'information_fieldset').removeClassName('ignore-validate');
+    var listInvalidElement = [];
     var validationResult = $(idPrefix + 'information_fieldset').select('input',
             'select', 'textarea').collect( function(elm) {
-        return jQuery.validator.validateElement(elm);
+        var validateOneElementResult = jQuery.validator.validateSingleElement(elm);
+        if (!validateOneElementResult) {
+            listInvalidElement.push(elm);
+        }
+        return validateOneElementResult;
     }).all();
+    if (listInvalidElement.length) {
+        listInvalidElement[0].focus();
+    }
+
     $(idPrefix + 'information_fieldset').addClassName('ignore-validate');
 
     if (!validationResult) {

--- a/app/code/Magento/SalesRule/view/adminhtml/templates/promo/salesrulejs.phtml
+++ b/app/code/Magento/SalesRule/view/adminhtml/templates/promo/salesrulejs.phtml
@@ -86,6 +86,11 @@ function generateCouponCodes(idPrefix, generateUrl, grid) {
     });
 }
 
+function validateCouponGenerate(elm) {
+    jQuery.validator.validateSingleElement(elm);
+}
+
+window.validateCouponGenerate = validateCouponGenerate;
 window.generateCouponCodes = generateCouponCodes;
 window.refreshCouponCodesGrid = refreshCouponCodesGrid;
 });


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. magento/magento2#23778: Resolve Rule coupon code generate form validation

Reason: **validateElement** function of jquery validation doesn't show the message.
Should use **validateSingleElement**

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23778: Rule coupon code generate form validation

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Case 1: 
1. Login to Admin
2. Create new sales rule with 'Use Auto Generation' enabled 
3. save rule
4. Open 'Manage Coupon Codes' section
5. Click 'Generate' button without filling required values

Expected result:
1. Validation error messages should be displayed 

Case 2: 
1. Login to Admin
2. Create new sales rule with 'Use Auto Generation' enabled 
3. save rule
4. Open 'Manage Coupon Codes' section
5. Add non integer value to 'Dash Every X Characters' box
5. Click 'Generate' button 

Expected result:
1. Proper  Validation error messages should be displayed so customer can input integer value there

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
