### PR TITLE
Add Cron Jobs names to New Relic transactions

### DIFF
--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -74,7 +74,7 @@ class ProcessCronQueueObserver implements ObserverInterface
     /**
      * Cron Job name pattern for Profiling
      */
-    const CRON_TIMERID = 'job %s';
+    private const CRON_TIMERID = 'job %s';
 
     /**
      * @var \Magento\Cron\Model\ResourceModel\Schedule\Collection
@@ -369,7 +369,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param string $jobName
      * @return void
      */
-    private function startProfiling(string $jobName = '')
+    private function startProfiling(string $jobName)
     {
         $this->statProfiler->clear();
         $this->statProfiler->start(
@@ -386,7 +386,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param string $jobName
      * @return void
      */
-    private function stopProfiling(string $jobName = '')
+    private function stopProfiling(string $jobName)
     {
         $this->statProfiler->stop(
             sprintf(self::CRON_TIMERID, $jobName),

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -3,9 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 /**
  * Handling cron jobs
  */
+
 namespace Magento\Cron\Observer;
 
 use Magento\Cron\Model\Schedule;
@@ -68,6 +70,11 @@ class ProcessCronQueueObserver implements ObserverInterface
      * Static lock prefix for cron group locking
      */
     const LOCK_PREFIX = 'CRON_GROUP_';
+
+    /**
+     * Cron Job name pattern for Profiling
+     */
+    const CRON_TIMERID = 'job %s';
 
     /**
      * @var \Magento\Cron\Model\ResourceModel\Schedule\Collection
@@ -311,7 +318,7 @@ class ProcessCronQueueObserver implements ObserverInterface
 
         $schedule->setExecutedAt(strftime('%Y-%m-%d %H:%M:%S', $this->dateTime->gmtTimestamp()))->save();
 
-        $this->startProfiling();
+        $this->startProfiling($jobCode);
         try {
             $this->logger->info(sprintf('Cron Job %s is run', $jobCode));
             //phpcs:ignore Magento2.Functions.DiscouragedFunction
@@ -323,7 +330,7 @@ class ProcessCronQueueObserver implements ObserverInterface
                     'Cron Job %s has an error: %s. Statistics: %s',
                     $jobCode,
                     $e->getMessage(),
-                    $this->getProfilingStat()
+                    $this->getProfilingStat($jobCode)
                 )
             );
             if (!$e instanceof \Exception) {
@@ -335,7 +342,7 @@ class ProcessCronQueueObserver implements ObserverInterface
             }
             throw $e;
         } finally {
-            $this->stopProfiling();
+            $this->stopProfiling($jobCode);
         }
 
         $schedule->setStatus(
@@ -351,7 +358,7 @@ class ProcessCronQueueObserver implements ObserverInterface
             sprintf(
                 'Cron Job %s is successfully finished. Statistics: %s',
                 $jobCode,
-                $this->getProfilingStat()
+                $this->getProfilingStat($jobCode)
             )
         );
     }
@@ -359,32 +366,47 @@ class ProcessCronQueueObserver implements ObserverInterface
     /**
      * Starts profiling
      *
+     * @param string $jobName
      * @return void
      */
-    private function startProfiling()
+    private function startProfiling(string $jobName = '')
     {
         $this->statProfiler->clear();
-        $this->statProfiler->start('job', microtime(true), memory_get_usage(true), memory_get_usage());
+        $this->statProfiler->start(
+            sprintf(self::CRON_TIMERID, $jobName),
+            microtime(true),
+            memory_get_usage(true),
+            memory_get_usage()
+        );
     }
 
     /**
      * Stops profiling
      *
+     * @param string $jobName
      * @return void
      */
-    private function stopProfiling()
+    private function stopProfiling(string $jobName = '')
     {
-        $this->statProfiler->stop('job', microtime(true), memory_get_usage(true), memory_get_usage());
+        $this->statProfiler->stop(
+            sprintf(self::CRON_TIMERID, $jobName),
+            microtime(true),
+            memory_get_usage(true),
+            memory_get_usage()
+        );
     }
 
     /**
      * Retrieves statistics in the JSON format
      *
+     * @param string $jobName
      * @return string
      */
-    private function getProfilingStat()
+    private function getProfilingStat(string $jobName): string
     {
-        $stat = $this->statProfiler->get('job');
+        $stat = $this->statProfiler->get(
+            sprintf(self::CRON_TIMERID, $jobName)
+        );
         unset($stat[Stat::START]);
         return json_encode($stat);
     }
@@ -418,7 +440,9 @@ class ProcessCronQueueObserver implements ObserverInterface
             'status',
             [
                 'in' => [
-                    Schedule::STATUS_PENDING, Schedule::STATUS_RUNNING, Schedule::STATUS_SUCCESS
+                    Schedule::STATUS_PENDING,
+                    Schedule::STATUS_RUNNING,
+                    Schedule::STATUS_SUCCESS
                 ]
             ]
         );
@@ -478,9 +502,9 @@ class ProcessCronQueueObserver implements ObserverInterface
     /**
      * Generate jobs for config information
      *
-     * @param   array $jobs
-     * @param   array $exists
-     * @param   string $groupId
+     * @param array $jobs
+     * @param array $exists
+     * @param string $groupId
      * @return  void
      */
     protected function _generateJobs($jobs, $exists, $groupId)

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -505,7 +505,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param array $jobs
      * @param array $exists
      * @param string $groupId
-     * @return  void
+     * @return void
      */
     protected function _generateJobs($jobs, $exists, $groupId)
     {

--- a/app/code/Magento/NewRelicReporting/Model/NewRelicWrapper.php
+++ b/app/code/Magento/NewRelicReporting/Model/NewRelicWrapper.php
@@ -83,6 +83,7 @@ class NewRelicWrapper
     /**
      * Wrapper for 'newrelic_end_transaction'
      * Cannot be public in 2.3-dev due to Backward Compatibility
+     *
      * @see https://devdocs.magento.com/guides/v2.3/contributor-guide/backward-compatible-development/
      * @TODO Make it public in 2.4-dev branch.
      *

--- a/app/code/Magento/NewRelicReporting/Model/NewRelicWrapper.php
+++ b/app/code/Magento/NewRelicReporting/Model/NewRelicWrapper.php
@@ -13,6 +13,12 @@ namespace Magento\NewRelicReporting\Model;
 class NewRelicWrapper
 {
     /**
+     * @TODO Remove this in 2.4-dev branch
+     * @var bool
+     */
+    private $transactionOpen = false;
+
+    /**
      * Wrapper for 'newrelic_add_custom_parameter' function
      *
      * @param string $param
@@ -49,8 +55,15 @@ class NewRelicWrapper
      */
     public function setAppName(string $appName)
     {
+        if ($this->transactionOpen === true) {
+            $this->endTransaction();
+        }
+
         if ($this->isExtensionInstalled()) {
             newrelic_set_appname($appName);
+
+            // Remove following line in 2.4-dev branch
+            $this->transactionOpen = true;
         }
     }
 
@@ -69,14 +82,20 @@ class NewRelicWrapper
 
     /**
      * Wrapper for 'newrelic_end_transaction'
+     * Cannot be public in 2.3-dev due to Backward Compatibility
+     * @see https://devdocs.magento.com/guides/v2.3/contributor-guide/backward-compatible-development/
+     * @TODO Make it public in 2.4-dev branch.
      *
      * @param bool $ignore
      * @return void
      */
-    public function endTransaction($ignore = false)
+    private function endTransaction($ignore = false)
     {
         if ($this->isExtensionInstalled()) {
             newrelic_end_transaction($ignore);
+
+            // @TODO Remove following line in 2.4-dev branch
+            $this->transactionOpen = false;
         }
     }
 

--- a/app/code/Magento/NewRelicReporting/Model/NewRelicWrapper.php
+++ b/app/code/Magento/NewRelicReporting/Model/NewRelicWrapper.php
@@ -68,6 +68,19 @@ class NewRelicWrapper
     }
 
     /**
+     * Wrapper for 'newrelic_end_transaction'
+     *
+     * @param bool $ignore
+     * @return void
+     */
+    public function endTransaction($ignore = false)
+    {
+        if ($this->isExtensionInstalled()) {
+            newrelic_end_transaction($ignore);
+        }
+    }
+
+    /**
      * Checks whether newrelic-php5 agent is installed
      *
      * @return bool

--- a/app/code/Magento/NewRelicReporting/Observer/NewrelicEndTransactionObserver.php
+++ b/app/code/Magento/NewRelicReporting/Observer/NewrelicEndTransactionObserver.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\NewRelicReporting\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+/**
+ * @TODO Remove with all the uses in 2.4-dev branch
+ * @package Magento\NewRelicReporting\Observer
+ */
+class NewrelicEndTransactionObserver implements ObserverInterface
+{
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        $this->endTransaction(true);
+    }
+
+    /**
+     * @param bool $ignore
+     * @return void
+     */
+    private function endTransaction($ignore = false)
+    {
+        if ($this->isExtensionInstalled()) {
+            newrelic_end_transaction($ignore);
+        }
+    }
+
+    /**
+     * Checks whether newrelic-php5 agent is installed
+     *
+     * @return bool
+     */
+    public function isExtensionInstalled()
+    {
+        if (extension_loaded('newrelic')) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/app/code/Magento/NewRelicReporting/Plugin/CommandPlugin.php
+++ b/app/code/Magento/NewRelicReporting/Plugin/CommandPlugin.php
@@ -26,15 +26,23 @@ class CommandPlugin
     private $newRelicWrapper;
 
     /**
+     * @var string[]
+     */
+    private $skipCommands;
+
+    /**
      * @param Config $config
      * @param NewRelicWrapper $newRelicWrapper
+     * @param array $skipCommands
      */
     public function __construct(
         Config $config,
-        NewRelicWrapper $newRelicWrapper
+        NewRelicWrapper $newRelicWrapper,
+        array $skipCommands = []
     ) {
         $this->config = $config;
         $this->newRelicWrapper = $newRelicWrapper;
+        $this->skipCommands = $skipCommands;
     }
 
     /**
@@ -46,9 +54,11 @@ class CommandPlugin
      */
     public function beforeRun(Command $command, ...$args)
     {
-        $this->newRelicWrapper->setTransactionName(
-            sprintf('CLI %s', $command->getName())
-        );
+        if (!in_array($command->getName(), $this->skipCommands)) {
+            $this->newRelicWrapper->setTransactionName(
+                sprintf('CLI %s', $command->getName())
+            );
+        }
 
         return $args;
     }

--- a/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
+++ b/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
@@ -49,19 +49,22 @@ class StatPlugin
     }
 
     /**
+     * Before running original profiler, register NewRelic transaction
+     *
      * @param Stat $schedule
-     * @param array $args
+     * @param array ...$args
      * @return array
      * @see \Magento\Cron\Observer\ProcessCronQueueObserver::startProfiling
      */
-    public function beforeStart(Stat $schedule, ...$args)
+    public function beforeStart(Stat $schedule, ...$args): array
     {
         $timerName = current($args);
 
-        if (0 === strpos($timerName, static::TIMER_NAME_CRON_PREFIX))
-        $this->newRelicWrapper->setTransactionName(
-            sprintf('Cron %s', $timerName)
-        );
+        if (0 === strpos($timerName, static::TIMER_NAME_CRON_PREFIX)) {
+            $this->newRelicWrapper->setTransactionName(
+                sprintf('Cron %s', $timerName)
+            );
+        }
 
         return $args;
     }
@@ -71,7 +74,7 @@ class StatPlugin
      * @param array ...$args
      * @return array
      */
-    public function beforeStop(Stat $schedule, ...$args)
+    public function beforeStop(Stat $schedule, ...$args): array
     {
         $this->newRelicWrapper->endTransaction();
 

--- a/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
+++ b/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
@@ -17,7 +17,8 @@ use Psr\Log\LoggerInterface;
  */
 class StatPlugin
 {
-    const TIMER_NAME_CRON_PREFIX = 'job';
+    private const TIMER_NAME_CRON_PREFIX = 'job';
+
     /**
      * @var Config
      */

--- a/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
+++ b/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
@@ -52,7 +52,7 @@ class StatPlugin
      * Before running original profiler, register NewRelic transaction
      *
      * @param Stat $schedule
-     * @param array ...$args
+     * @param array $args,...
      * @return array
      * @see \Magento\Cron\Observer\ProcessCronQueueObserver::startProfiling
      *
@@ -72,8 +72,10 @@ class StatPlugin
     }
 
     /**
+     * Before stopping original profiler, close NewRelic transaction
+     *
      * @param Stat $schedule
-     * @param array ...$args
+     * @param array $args,...
      * @return array
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)

--- a/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
+++ b/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
@@ -52,7 +52,7 @@ class StatPlugin
      * Before running original profiler, register NewRelic transaction
      *
      * @param Stat $schedule
-     * @param array $args,...
+     * @param array $args
      * @return array
      * @see \Magento\Cron\Observer\ProcessCronQueueObserver::startProfiling
      *
@@ -75,7 +75,7 @@ class StatPlugin
      * Before stopping original profiler, close NewRelic transaction
      *
      * @param Stat $schedule
-     * @param array $args,...
+     * @param array $args
      * @return array
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)

--- a/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
+++ b/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\NewRelicReporting\Plugin;
+
+use Magento\Framework\Profiler\Driver\Standard\Stat;
+use Magento\NewRelicReporting\Model\Config;
+use Magento\NewRelicReporting\Model\NewRelicWrapper;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class StatPlugin handles single Cron Jobs transaction names
+ */
+class StatPlugin
+{
+    const TIMER_NAME_CRON_PREFIX = 'job';
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @var NewRelicWrapper
+     */
+    private $newRelicWrapper;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param Config $config
+     * @param NewRelicWrapper $newRelicWrapper
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        Config $config,
+        NewRelicWrapper $newRelicWrapper,
+        LoggerInterface $logger
+    ) {
+        $this->config = $config;
+        $this->newRelicWrapper = $newRelicWrapper;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param Stat $schedule
+     * @param array $args
+     * @return array
+     * @see \Magento\Cron\Observer\ProcessCronQueueObserver::startProfiling
+     */
+    public function beforeStart(Stat $schedule, ...$args)
+    {
+        $timerName = current($args);
+
+        if (0 === strpos($timerName, static::TIMER_NAME_CRON_PREFIX))
+        $this->newRelicWrapper->setTransactionName(
+            sprintf('Cron %s', $timerName)
+        );
+
+        return $args;
+    }
+
+    /**
+     * @param Stat $schedule
+     * @param array ...$args
+     * @return array
+     */
+    public function beforeStop(Stat $schedule, ...$args)
+    {
+        $this->newRelicWrapper->endTransaction();
+
+        return $args;
+    }
+}

--- a/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
+++ b/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\NewRelicReporting\Plugin;
 
+use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Profiler\Driver\Standard\Stat;
 use Magento\NewRelicReporting\Model\Config;
 use Magento\NewRelicReporting\Model\NewRelicWrapper;
@@ -35,18 +36,26 @@ class StatPlugin
     private $logger;
 
     /**
+     * @var ManagerInterface
+     */
+    private $eventManager;
+
+    /**
      * @param Config $config
      * @param NewRelicWrapper $newRelicWrapper
      * @param LoggerInterface $logger
+     * @param ManagerInterface $eventManager
      */
     public function __construct(
         Config $config,
         NewRelicWrapper $newRelicWrapper,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        ManagerInterface $eventManager
     ) {
         $this->config = $config;
         $this->newRelicWrapper = $newRelicWrapper;
         $this->logger = $logger;
+        $this->eventManager = $eventManager;
     }
 
     /**
@@ -75,6 +84,8 @@ class StatPlugin
     /**
      * Before stopping original profiler, close NewRelic transaction
      *
+     * @TODO Replace with direct call to newRelicWrapper->endTransaction() in 2.4-dev branch
+     *
      * @param Stat $schedule
      * @param array $args
      * @return array
@@ -83,7 +94,7 @@ class StatPlugin
      */
     public function beforeStop(Stat $schedule, ...$args): array
     {
-        $this->newRelicWrapper->endTransaction();
+        $this->eventManager->dispatch('newrelic_end_transaction');
 
         return $args;
     }

--- a/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
+++ b/app/code/Magento/NewRelicReporting/Plugin/StatPlugin.php
@@ -55,6 +55,8 @@ class StatPlugin
      * @param array ...$args
      * @return array
      * @see \Magento\Cron\Observer\ProcessCronQueueObserver::startProfiling
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function beforeStart(Stat $schedule, ...$args): array
     {
@@ -73,6 +75,8 @@ class StatPlugin
      * @param Stat $schedule
      * @param array ...$args
      * @return array
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function beforeStop(Stat $schedule, ...$args): array
     {

--- a/app/code/Magento/NewRelicReporting/etc/di.xml
+++ b/app/code/Magento/NewRelicReporting/etc/di.xml
@@ -41,6 +41,16 @@
         </arguments>
     </type>
     <type name="Symfony\Component\Console\Command\Command">
-        <plugin name="newrelic-describe-commands"  type="Magento\NewRelicReporting\Plugin\CommandPlugin"/>
+        <plugin name="newrelic-describe-commands" type="Magento\NewRelicReporting\Plugin\CommandPlugin"/>
+    </type>
+    <type name="Magento\Framework\Profiler\Driver\Standard\Stat">
+        <plugin name="newrelic-describe-cronjobs" type="Magento\NewRelicReporting\Plugin\StatPlugin"/>
+    </type>
+    <type name="Magento\NewRelicReporting\Plugin\CommandPlugin">
+        <arguments>
+            <argument name="skipCommands" xsi:type="array">
+                <item xsi:type="string" name="cron_run">cron:run</item>
+            </argument>
+        </arguments>
     </type>
 </config>

--- a/app/code/Magento/NewRelicReporting/etc/events.xml
+++ b/app/code/Magento/NewRelicReporting/etc/events.xml
@@ -10,4 +10,7 @@
         <observer name="newrelicreporting_observer_report_sales_order_place" instance="Magento\NewRelicReporting\Model\Observer\ReportOrderPlaced" />
         <observer name="newrelicreporting_newrelic_report_sales_order_place" instance="Magento\NewRelicReporting\Model\Observer\ReportOrderPlacedToNewRelic" />
     </event>
+    <event name="newrelic_end_transaction">
+        <observer name="newrelicreporting_observer_newrelic_end_transaction" instance="Magento\NewRelicReporting\Observer\NewrelicEndTransactionObserver" />
+    </event>
 </config>


### PR DESCRIPTION
### Description (*)
Feature: Add missing transaction names for Cron Jobs in New Relic reports
![image](https://user-images.githubusercontent.com/1639941/61526219-509f4e80-aa1a-11e9-8eda-46a574a386c4.png)

I've modified private methods, as this is not backward incompatible.

### Fixed Issues (if relevant)
- #22047
- #22061

### Manual testing scenarios (*)
1. Run `bin/magento cron:run`
2. Enjoy the transaction labels for single cron jobs in NewRelic

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
