### PR TITLE
Fix for PHP_CodeSniffer error after app:config:dump

### DIFF
--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
@@ -80,9 +80,9 @@ class PhpFormatter implements FormatterInterface
      */
     private function varExportShort($var, int $depth = 0)
     {
-        if(null === $var){
+        if (null === $var) {
             return 'null';
-        }elseif (!is_array($var)) {
+        } elseif (!is_array($var)) {
             return var_export($var, true);
         }
 

--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
@@ -18,10 +18,11 @@ class PhpFormatter implements FormatterInterface
 
     /**
      * Format deployment configuration.
+     *
      * If $comments is present, each item will be added
      * as comment to the corresponding section
      *
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function format($data, array $comments = [])
     {
@@ -71,6 +72,8 @@ class PhpFormatter implements FormatterInterface
     }
 
     /**
+     * Format generated config files using the short array syntax.
+     *
      * If variable to export is an array, format with the php >= 5.4 short array syntax. Otherwise use
      * default var_export functionality.
      *

--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Writer/PhpFormatter.php
@@ -80,7 +80,9 @@ class PhpFormatter implements FormatterInterface
      */
     private function varExportShort($var, int $depth = 0)
     {
-        if (!is_array($var)) {
+        if(null === $var){
+            return 'null';
+        }elseif (!is_array($var)) {
             return var_export($var, true);
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
After app:config:dump in our CI environment phpcs complains about uppercase constant for "null"
(Generic.PHP.LowerCaseConstant.Found) TRUE, FALSE and NULL must be lowercase; expected "null" but  found "NULL" (Generic.PHP.LowerCaseConstant.Found)

The source of this uppercase constant can be found in the [php source].(https://github.com/php/php-src/blob/master/ext/standard/var.c#L486)


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)

1. install magento2
2. excute app:config:dump

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x ] Pull request has a meaningful description of its purpose
 - [x ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)