### PR TITLE
FIX: set correct page number for customer grid indexer iterator

### DIFF
--- a/app/code/Magento/Customer/Model/Indexer/Source.php
+++ b/app/code/Magento/Customer/Model/Indexer/Source.php
@@ -96,7 +96,7 @@ class Source implements \IteratorAggregate, \Countable, SourceProviderInterface
     {
         $this->customerCollection->setPageSize($this->batchSize);
         $lastPage = $this->customerCollection->getLastPageNumber();
-        $pageNumber = 0;
+        $pageNumber = 1;
         do {
             $this->customerCollection->clear();
             $this->customerCollection->setCurPage($pageNumber);


### PR DESCRIPTION
### Description 
If the first page to filter out a collection is set to `0` it will return the same collection of items as if it would be equal to `1`. In that case, the system gets the same collection of items twice. I changed the start page number it to `1` to prevent unnecessarily call.  

### Fixed Issues
N/A/

### Manual testing scenarios
Steps to reproduce:

1. `php bin/magento indexer:reset customer_grid`
1. Put a breakpoint at `\Magento\Customer\Model\Indexer\Source::getIterator` to check what items will be filtered out with the page equals to 0 and 1.
1. `php bin/magento indexer:reindex customer_grid`

### Questions or comments
N/A
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
