### PR TITLE
Fixed #23290 ./bin/magento config:show returns "Configuration for path: '...' doesn't exist" if config value equals to 0 or empty string

### DIFF
--- a/app/code/Magento/Config/App/Config/Source/RuntimeConfigSource.php
+++ b/app/code/Magento/Config/App/Config/Source/RuntimeConfigSource.php
@@ -60,7 +60,7 @@ class RuntimeConfigSource implements ConfigSourceInterface
     public function get($path = '')
     {
         $data = new DataObject($this->loadConfig());
-        return $data->getData($path) ?: [];
+        return $data->getData($path);
     }
 
     /**

--- a/app/code/Magento/Config/App/Config/Source/RuntimeConfigSource.php
+++ b/app/code/Magento/Config/App/Config/Source/RuntimeConfigSource.php
@@ -54,7 +54,7 @@ class RuntimeConfigSource implements ConfigSourceInterface
      * Get initial data.
      *
      * @param string $path Format is scope type and scope code separated by slash: e.g. "type/code"
-     * @return array
+     * @return mixed
      * @since 100.1.2
      */
     public function get($path = '')

--- a/app/code/Magento/Config/App/Config/Source/RuntimeConfigSource.php
+++ b/app/code/Magento/Config/App/Config/Source/RuntimeConfigSource.php
@@ -60,7 +60,7 @@ class RuntimeConfigSource implements ConfigSourceInterface
     public function get($path = '')
     {
         $data = new DataObject($this->loadConfig());
-        return $data->getData($path);
+        return $data->hasData($path) ? $data->getData($path) : [];
     }
 
     /**

--- a/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
+++ b/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
@@ -136,7 +136,7 @@ class ConfigShowCommand extends Command
      * Shows error message if configuration for given path doesn't exist
      * or scope/scope-code doesn't pass validation.
      *
-     * {@inheritdoc}
+     * @inheritdoc
      * @since 100.2.0
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -151,10 +151,12 @@ class ConfigShowCommand extends Command
             $configValue = $this->configSource->get($configPath);
 
             if ($configValue == null && empty($configValue)) {
-                $output->writeln(sprintf(
-                    '<error>%s</error>',
-                    __('Configuration for path: "%1" doesn\'t exist', $this->inputPath)->render()
-                ));
+                $output->writeln(
+                    sprintf(
+                        '<error>%s</error>',
+                        __('Configuration for path: "%1" doesn\'t exist', $this->inputPath)->render()
+                    )
+                );
                 return Cli::RETURN_FAILURE;
             }
 

--- a/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
+++ b/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
@@ -150,7 +150,7 @@ class ConfigShowCommand extends Command
             $configPath = $this->pathResolver->resolve($this->inputPath, $this->scope, $this->scopeCode);
             $configValue = $this->configSource->get($configPath);
 
-            if ($configValue == null && empty($configValue)) {
+            if (is_array($configValue) && empty($configValue)) {
                 $output->writeln(
                     sprintf(
                         '<error>%s</error>',

--- a/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
+++ b/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
@@ -150,7 +150,7 @@ class ConfigShowCommand extends Command
             $configPath = $this->pathResolver->resolve($this->inputPath, $this->scope, $this->scopeCode);
             $configValue = $this->configSource->get($configPath);
 
-            if (empty($configValue)) {
+            if ($configValue == null && empty($configValue)) {
                 $output->writeln(sprintf(
                     '<error>%s</error>',
                     __('Configuration for path: "%1" doesn\'t exist', $this->inputPath)->render()


### PR DESCRIPTION
Fixed #23290 ./bin/magento config:show returns "Configuration for path: '...' doesn't exist" if config value equals to 0 or empty string 

### Preconditions (*)
1. Magento 2.3.1
2. Create module `Vendor_Module`
3. Create `etc/config.xml` in created module `Vendor_Module` with new config path `default/vendor_module/general/value` with value `0` or `''` (empty string)

### Steps to reproduce (*)
1. Open magento cli and run command `./bin/magento config:show vendor_module/general/value`

### Expected result (*)
1. Should return `0` or `''` (empty string)

### Actual result (*)
1. Command returns `Configuration for path: "vendor_module/general/value" doesn't exist`

I think it happens because there `<magento_root>/vendor/magento/module-config/Console/Command/ConfigShowCommand.php:153` magento checks if value is empty and if it actualy is the error message is shown. But empty value does not mean that path does not exist. So we should check if path exist in different method.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
