### PR TITLE
[issues/23809] Fixed. Product flat indexer fails with attribute "range"

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
@@ -361,7 +361,7 @@ class FlatTableBuilder
                         []
                     )->columns(
                         [$columnName => $columnValue]
-                    )->where('`' . $columnValue . '` IS NOT NULL');
+                    )->where('`' . $columnName . '` IS NOT NULL');
                     if (!empty($changedIds)) {
                         $select->where($this->_connection->quoteInto('et.entity_id IN (?)', $changedIds));
                     }

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
@@ -361,7 +361,7 @@ class FlatTableBuilder
                         []
                     )->columns(
                         [$columnName => $columnValue]
-                    )->where($columnValue . ' IS NOT NULL');
+                    )->where('`' . $columnValue . '` IS NOT NULL');
                     if (!empty($changedIds)) {
                         $select->where($this->_connection->quoteInto('et.entity_id IN (?)', $changedIds));
                     }


### PR DESCRIPTION
### Description
Product flat indexer fails

### Fixed Issues (if relevant)
1. magento/magento2#23809: Product Flat indexer fails

### Manual testing scenarios (*)
1. Create a product attribute with code 'range'
2.Run catalog_product_flat reindex

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
