### PR TITLE
Resolve Incorrect base currency in order grid for historical orders issue 23805

### DIFF
--- a/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/PriceTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Ui/Component/Listing/Column/PriceTest.php
@@ -3,9 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Sales\Test\Unit\Ui\Component\Listing\Column;
 
-use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Directory\Model\Currency;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Sales\Ui\Component\Listing\Column\Price;
 
@@ -20,9 +22,9 @@ class PriceTest extends \PHPUnit\Framework\TestCase
     protected $model;
 
     /**
-     * @var PriceCurrencyInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var Currency|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $priceFormatterMock;
+    protected $currencyMock;
 
     protected function setUp()
     {
@@ -33,12 +35,13 @@ class PriceTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $contextMock->expects($this->never())->method('getProcessor')->willReturn($processor);
-        $this->priceFormatterMock = $this->getMockForAbstractClass(
-            \Magento\Framework\Pricing\PriceCurrencyInterface::class
-        );
+        $this->currencyMock = $this->getMockBuilder(\Magento\Directory\Model\Currency::class)
+            ->setMethods(['load', 'format'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->model = $objectManager->getObject(
             \Magento\Sales\Ui\Component\Listing\Column\Price::class,
-            ['priceFormatter' => $this->priceFormatterMock, 'context' => $contextMock]
+            ['currency' => $this->currencyMock, 'context' => $contextMock]
         );
     }
 
@@ -50,14 +53,22 @@ class PriceTest extends \PHPUnit\Framework\TestCase
         $dataSource = [
             'data' => [
                 'items' => [
-                    [$itemName => $oldItemValue]
+                    [
+                        $itemName => $oldItemValue,
+                        'base_currency_code' => 'US'
+                    ]
                 ]
             ]
         ];
 
-        $this->priceFormatterMock->expects($this->once())
+        $this->currencyMock->expects($this->once())
+            ->method('load')
+            ->with($dataSource['data']['items'][0]['base_currency_code'])
+            ->willReturnSelf();
+
+        $this->currencyMock->expects($this->once())
             ->method('format')
-            ->with($oldItemValue, false)
+            ->with($oldItemValue, [], false)
             ->willReturn($newItemValue);
 
         $this->model->setData('name', $itemName);

--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/Price.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/Price.php
@@ -3,12 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Sales\Ui\Component\Listing\Column;
 
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\Ui\Component\Listing\Columns\Column;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Directory\Model\Currency;
 
 /**
  * Class Price
@@ -21,6 +24,11 @@ class Price extends Column
     protected $priceFormatter;
 
     /**
+     * @var Currency
+     */
+    private $currency;
+
+    /**
      * Constructor
      *
      * @param ContextInterface $context
@@ -28,15 +36,19 @@ class Price extends Column
      * @param PriceCurrencyInterface $priceFormatter
      * @param array $components
      * @param array $data
+     * @param Currency $currency
      */
     public function __construct(
         ContextInterface $context,
         UiComponentFactory $uiComponentFactory,
         PriceCurrencyInterface $priceFormatter,
         array $components = [],
-        array $data = []
+        array $data = [],
+        Currency $currency = null
     ) {
         $this->priceFormatter = $priceFormatter;
+        $this->currency = $currency ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->create(Currency::class);
         parent::__construct($context, $uiComponentFactory, $components, $data);
     }
 
@@ -51,13 +63,9 @@ class Price extends Column
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
                 $currencyCode = isset($item['base_currency_code']) ? $item['base_currency_code'] : null;
-                $item[$this->getData('name')] = $this->priceFormatter->format(
-                    $item[$this->getData('name')],
-                    false,
-                    null,
-                    null,
-                    $currencyCode
-                );
+                $basePurchaseCurrency = $this->currency->load($currencyCode);
+                $item[$this->getData('name')] = $basePurchaseCurrency
+                    ->format($item[$this->getData('name')], [], false);
             }
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Resolve magento/magento2#23805: Incorrect base currency in order grid for historical orders

Problem: The Order Grid display the **current currency** in the Order Grid Not **the currency which the order was placed.**

Function **$this->priceFormatter->format** check if the currency code **doesn't have rate**, it will automatically switch to the base currency. **The rate is not necessary because the order was created.** So we can not use this function. Because the **Order was placed**, we can not change the currency code of the **OLD OLDER**

Solution: Use the **format** function of class "**Magento\Directory\Model\Currency**" . It is also the same class which **Magento\Sales\Model\Order** used.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23805: Incorrect base currency in order grid for historical orders

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Create an order with the base currency (USD)
2. Change store base currency (to EUR)
3. Go to order grid screen. 
**Result: Old base currency should be shown** (USD) 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
