### PR TITLE
Standardize the array structure for the getAttributes result

### DIFF
--- a/app/code/Magento/Eav/Model/AttributeProvider.php
+++ b/app/code/Magento/Eav/Model/AttributeProvider.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Eav\Model;
 
@@ -52,7 +53,7 @@ class AttributeProvider implements AttributeProviderInterface
      * Returns array of fields
      *
      * @param string $entityType
-     * @return array
+     * @return string[]
      * @throws \Exception
      */
     public function getAttributes($entityType)
@@ -66,6 +67,7 @@ class AttributeProvider implements AttributeProviderInterface
         foreach ($searchResult->getItems() as $attribute) {
             $attributes[] = $attribute->getAttributeCode();
         }
+
         return $attributes;
     }
 }

--- a/lib/internal/Magento/Framework/Model/EntitySnapshot.php
+++ b/lib/internal/Magento/Framework/Model/EntitySnapshot.php
@@ -45,6 +45,8 @@ class EntitySnapshot
     }
 
     /**
+     * Register snapshot of entity data.
+     *
      * @param string $entityType
      * @param object $entity
      * @return void

--- a/lib/internal/Magento/Framework/Model/EntitySnapshot.php
+++ b/lib/internal/Magento/Framework/Model/EntitySnapshot.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Framework\Model;
 
@@ -55,7 +56,7 @@ class EntitySnapshot
         $entityData = $hydrator->extract($entity);
         $attributes = $this->attributeProvider->getAttributes($entityType);
         $this->snapshotData[$entityType][$entityData[$metadata->getIdentifierField()]]
-            = array_intersect_key($entityData, $attributes);
+            = array_intersect(\array_keys($entityData), $attributes);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Model/EntitySnapshot/AttributeProviderInterface.php
+++ b/lib/internal/Magento/Framework/Model/EntitySnapshot/AttributeProviderInterface.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Framework\Model\EntitySnapshot;
 
@@ -12,8 +13,10 @@ namespace Magento\Framework\Model\EntitySnapshot;
 interface AttributeProviderInterface
 {
     /**
+     * Returns array of fields
+     *
      * @param string $entityType
-     * @return array
+     * @return string[]
      */
     public function getAttributes($entityType);
 }


### PR DESCRIPTION
The scope of this pull request is to fix two issues in the `\Magento\Framework\Model\EntitySnapshot` package. It makes more convenient the results of  `getAttributes`.

### Description (*)
The `getAttributes` method of the `\Magento\Framework\Model\EntitySnapshot\AttributeProviderInterface` has no standardized structure in its available implementations.  
`\Magento\Framework\Model\EntitySnapshot\AttributeProvider` deal with a dictionary where `\Magento\Eav\Model\AttributeProvider` returns a simple list of attribute code.
I have assumed that the results should be a list of field (as described in the methods description).

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
