### PR TITLE
Allow null values for integer columns in declarative schema

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Factories/Integer.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Factories/Integer.php
@@ -50,7 +50,7 @@ class Integer implements FactoryInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function create(array $data)
     {

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Factories/Integer.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Factories/Integer.php
@@ -63,7 +63,7 @@ class Integer implements FactoryInterface
         }
 
         if (isset($data['default'])) {
-            $data['default'] = (int) $data['default'];
+            $data['default'] = $data['default'] !== 'null' ? (int) $data['default'] : null;
         }
 
         return $this->objectManager->create($this->className, $data);

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/types/integers/integer.xsd
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/types/integers/integer.xsd
@@ -17,7 +17,13 @@
                         Size is 4 bytes.
                     </xs:documentation>
                 </xs:annotation>
-                <xs:attribute name="default" type="xs:integer" />
+                <xs:attribute name="default">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:pattern value="\d+|null" />
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
                 <xs:attribute name="padding">
                     <xs:annotation>
                         <xs:documentation>


### PR DESCRIPTION
### Description (*)
This PR makes it possible to use `null` as a default value for integer columns.

### Fixed Issues (if relevant)
None I could find.

### Manual testing scenarios (*)
1. Create db_schema + whitelist in custom module.
```
<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
    <table name="cms_page" resource="default">
        <column xsi:type="smallint" name="is_active" nullable="true" default="null"/>
    </table>
</schema>

{
    "cms_page": {
        "column": {
            "is_active": true
        }
    }
}

```
2. Run `bin/magento setup:upgrade`
3. `is_active` column should have a default value `null`.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
