### PR TITLE
[Forwardport] fixed Quote Item Prices are NULL in cart related events. #18685

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Item.php
+++ b/app/code/Magento/Quote/Model/Quote/Item.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Quote\Model\Quote;
 
 use Magento\Framework\Api\AttributeValueFactory;

--- a/app/code/Magento/Quote/Model/Quote/Item/Processor.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/Processor.php
@@ -95,8 +95,9 @@ class Processor
             $item->setData(CartItemInterface::KEY_QTY, 0);
         }
         $item->addQty($candidate->getCartQty());
-        $item->setPrice($item->getProduct()->getFinalPrice());
+
         $customPrice = $request->getCustomPrice();
+        $item->setPrice($candidate->getFinalPrice());
         if (!empty($customPrice)) {
             $item->setCustomPrice($customPrice);
             $item->setOriginalCustomPrice($customPrice);

--- a/app/code/Magento/Quote/Model/Quote/Item/Processor.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/Processor.php
@@ -95,7 +95,7 @@ class Processor
             $item->setData(CartItemInterface::KEY_QTY, 0);
         }
         $item->addQty($candidate->getCartQty());
-
+        $item->setPrice($item->getProduct()->getFinalPrice());
         $customPrice = $request->getCustomPrice();
         if (!empty($customPrice)) {
             $item->setCustomPrice($customPrice);

--- a/app/code/Magento/Quote/Model/Quote/Item/Processor.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/Processor.php
@@ -53,8 +53,8 @@ class Processor
     /**
      * Initialize quote item object
      *
-     * @param DataObject $request
      * @param Product $product
+     * @param DataObject $request
      *
      * @return Item
      */

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ProcessorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ProcessorTest.php
@@ -99,7 +99,13 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
 
         $this->productMock = $this->createPartialMock(
             \Magento\Catalog\Model\Product::class,
-            ['getCustomOptions', '__wakeup', 'getParentProductId', 'getCartQty', 'getStickWithinParent', 'getFinalPrice']
+            [
+                'getCustomOptions', 
+                '__wakeup', 
+                'getParentProductId', 
+                'getCartQty', 
+                'getStickWithinParent', 
+                'getFinalPrice']
         );
         $this->objectMock = $this->createPartialMock(
             \Magento\Framework\DataObject::class,

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ProcessorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ProcessorTest.php
@@ -68,7 +68,8 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
             ['create']
         );
 
-        $this->itemMock = $this->createPartialMock(\Magento\Quote\Model\Quote\Item::class,
+        $this->itemMock = $this->createPartialMock(
+            \Magento\Quote\Model\Quote\Item::class,
             [
                 'getId',
                 'setOptions',

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ProcessorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ProcessorTest.php
@@ -68,7 +68,8 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
             ['create']
         );
 
-        $this->itemMock = $this->createPartialMock(\Magento\Quote\Model\Quote\Item::class, [
+        $this->itemMock = $this->createPartialMock(\Magento\Quote\Model\Quote\Item::class,
+            [
                 'getId',
                 'setOptions',
                 '__wakeup',
@@ -78,7 +79,8 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
                 'setOriginalCustomPrice',
                 'setData',
                 'setprice'
-            ]);
+            ]
+        );
         $this->quoteItemFactoryMock->expects($this->any())
             ->method('create')
             ->will($this->returnValue($this->itemMock));

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ProcessorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ProcessorTest.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Quote\Test\Unit\Model\Quote\Item;
 
 use Magento\Catalog\Model\Product;

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ProcessorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ProcessorTest.php
@@ -100,11 +100,11 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
         $this->productMock = $this->createPartialMock(
             \Magento\Catalog\Model\Product::class,
             [
-                'getCustomOptions', 
-                '__wakeup', 
-                'getParentProductId', 
-                'getCartQty', 
-                'getStickWithinParent', 
+                'getCustomOptions',
+                '__wakeup',
+                'getParentProductId',
+                'getCartQty',
+                'getStickWithinParent',
                 'getFinalPrice']
         );
         $this->objectMock = $this->createPartialMock(

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ProcessorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ProcessorTest.php
@@ -76,7 +76,8 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
                 'addQty',
                 'setCustomPrice',
                 'setOriginalCustomPrice',
-                'setData'
+                'setData',
+                'setprice'
             ]);
         $this->quoteItemFactoryMock->expects($this->any())
             ->method('create')
@@ -98,7 +99,7 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
 
         $this->productMock = $this->createPartialMock(
             \Magento\Catalog\Model\Product::class,
-            ['getCustomOptions', '__wakeup', 'getParentProductId', 'getCartQty', 'getStickWithinParent']
+            ['getCustomOptions', '__wakeup', 'getParentProductId', 'getCartQty', 'getStickWithinParent', 'getFinalPrice']
         );
         $this->objectMock = $this->createPartialMock(
             \Magento\Framework\DataObject::class,
@@ -239,6 +240,7 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
         $customPrice = 400000000;
         $itemId = 1;
         $requestItemId = 1;
+        $finalPrice = 1000000000;
 
         $this->productMock->expects($this->any())
             ->method('getCartQty')
@@ -246,6 +248,9 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
         $this->productMock->expects($this->any())
             ->method('getStickWithinParent')
             ->will($this->returnValue(false));
+        $this->productMock->expects($this->once())
+            ->method('getFinalPrice')
+            ->will($this->returnValue($finalPrice));
 
         $this->itemMock->expects($this->once())
             ->method('addQty')
@@ -255,6 +260,9 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue($itemId));
         $this->itemMock->expects($this->never())
             ->method('setData');
+        $this->itemMock->expects($this->once())
+            ->method('setPrice')
+            ->will($this->returnValue($this->itemMock));
 
         $this->objectMock->expects($this->any())
             ->method('getCustomPrice')
@@ -282,6 +290,7 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
         $customPrice = 400000000;
         $itemId = 1;
         $requestItemId = 1;
+        $finalPrice = 1000000000;
 
         $this->productMock->expects($this->any())
             ->method('getCartQty')
@@ -289,6 +298,9 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
         $this->productMock->expects($this->any())
             ->method('getStickWithinParent')
             ->will($this->returnValue(true));
+        $this->productMock->expects($this->once())
+            ->method('getFinalPrice')
+            ->will($this->returnValue($finalPrice));
 
         $this->itemMock->expects($this->once())
             ->method('addQty')
@@ -298,6 +310,9 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue($itemId));
         $this->itemMock->expects($this->never())
             ->method('setData');
+        $this->itemMock->expects($this->once())
+            ->method('setPrice')
+            ->will($this->returnValue($this->itemMock));
 
         $this->objectMock->expects($this->any())
             ->method('getCustomPrice')
@@ -325,6 +340,7 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
         $customPrice = 400000000;
         $itemId = 1;
         $requestItemId = 2;
+        $finalPrice = 1000000000;
 
         $this->productMock->expects($this->any())
             ->method('getCartQty')
@@ -332,6 +348,9 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
         $this->productMock->expects($this->any())
             ->method('getStickWithinParent')
             ->will($this->returnValue(false));
+        $this->productMock->expects($this->once())
+            ->method('getFinalPrice')
+            ->will($this->returnValue($finalPrice));
 
         $this->itemMock->expects($this->once())
             ->method('addQty')
@@ -341,6 +360,9 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue($itemId));
         $this->itemMock->expects($this->never())
             ->method('setData');
+        $this->itemMock->expects($this->once())
+            ->method('setPrice')
+            ->will($this->returnValue($this->itemMock));
 
         $this->objectMock->expects($this->any())
             ->method('getCustomPrice')
@@ -368,6 +390,7 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
         $customPrice = 400000000;
         $itemId = 1;
         $requestItemId = 1;
+        $finalPrice = 1000000000;
 
         $this->objectMock->expects($this->any())
             ->method('getResetCount')
@@ -386,10 +409,16 @@ class ProcessorTest extends \PHPUnit\Framework\TestCase
         $this->productMock->expects($this->any())
             ->method('getStickWithinParent')
             ->will($this->returnValue(false));
+        $this->productMock->expects($this->once())
+            ->method('getFinalPrice')
+            ->will($this->returnValue($finalPrice));
 
         $this->itemMock->expects($this->once())
             ->method('addQty')
             ->with($qty);
+        $this->itemMock->expects($this->once())
+            ->method('setPrice')
+            ->will($this->returnValue($this->itemMock));
 
         $this->objectMock->expects($this->any())
             ->method('getCustomPrice')

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CartItemRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CartItemRepositoryTest.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Catalog\Api;
 
 use Magento\TestFramework\TestCase\WebapiAbstract;

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CartItemRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CartItemRepositoryTest.php
@@ -9,6 +9,9 @@ use Magento\TestFramework\TestCase\WebapiAbstract;
 use Magento\Catalog\Api\Data\ProductCustomOptionInterface;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 
+/**
+ * Class \Magento\Catalog\Api\CartItemRepositoryTest
+ */
 class CartItemRepositoryTest extends WebapiAbstract
 {
     const SERVICE_NAME = 'quoteCartItemRepositoryV1';

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CartItemRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CartItemRepositoryTest.php
@@ -62,7 +62,7 @@ class CartItemRepositoryTest extends WebapiAbstract
                 'sku' => $item->getSku(),
                 'qty' => $item->getQty(),
                 'name' => $item->getName(),
-                
+                'price' => $item->getPrice(),
                 'product_type' => $item->getProductType(),
                 'quote_id' => $item->getQuoteId(),
                 'product_option' => [


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/18808
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
before these two observers checkout_cart_product_add_after, checkout_cart_product_update_after cart item is not saved into the database the object is only created and in the object price was not set but custom price was set so there was no issue of custom price, we could have added the price in the item from two files:
app/code/Magento/Quote/Model/Quote/Item/Processor.php and
app/code/Magento/Quote/Model/Quote.php
I have added the price in this file app/code/Magento/Quote/Model/Quote/Item/Processor.php

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#18685: Quote Item Prices are NULL in cart related events

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. create a module which has observers for these two events checkout_cart_product_add_after, checkout_cart_product_update_after cart
2. now in the observer try to get the added item price by calling $observer->getEvent()->getQuoteItem()->getPrice()

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
