### PR TITLE
Fix regular expression comment on function isNameValid() in ImageContentValidator.php

### DIFF
--- a/lib/internal/Magento/Framework/Api/ImageContentValidator.php
+++ b/lib/internal/Magento/Framework/Api/ImageContentValidator.php
@@ -86,7 +86,7 @@ class ImageContentValidator implements ImageContentValidatorInterface
      */
     protected function isNameValid($name)
     {
-        // Cannot contain \ / : * ? " < > |
+        // Cannot contain \ / ? * : " ; < > ( ) | { }
         if (!preg_match('/^[^\\/?*:";<>()|{}\\\\]+$/', $name)) {
             return false;
         }


### PR DESCRIPTION
### Description (*)
* This is a simple fix to a regular expression comment in the file ImageContentValidator.php
* The comment did not match the regular expression being used in the code.
* I've added the symbols that were missing.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
This is a change to a comment only, there are no changes to logic.

### Questions or comments
None.

### Contribution checklist (*)
 - [✓] Pull request has a meaningful description of its purpose
 - [✓] All commits are accompanied by meaningful commit messages
 - [N/A] All new or changed code is covered with unit/integration tests (if applicable)
 - [✓] All automated tests passed successfully (all builds are green)
