### PR TITLE
Add custom added url key to decoded directive string in WYSIWYG editor

### DIFF
--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js
@@ -645,9 +645,9 @@ define([
 
                 // process tag attributes string
                 attributesString = attributesString.gsub(/([a-z0-9\-\_]+)="(.*?)(\{\{.+?\}\})(.*?)"/i, function (m) {
-                    decodedDirectiveString = encodeURIComponent(Base64.mageEncode(m[3].replace(/&quot;/g, '"')));
+                    decodedDirectiveString = encodeURIComponent(Base64.mageEncode(m[3].replace(/&quot;/g, '"') + m[4]));
 
-                    return m[1] + '="' + m[2] + this.makeDirectiveUrl(decodedDirectiveString) + m[4] + '"';
+                    return m[1] + '="' + m[2] + this.makeDirectiveUrl(decodedDirectiveString) + '"';
                 }.bind(this));
 
                 return '<' + match[1] + attributesString + '>';


### PR DESCRIPTION
### Description (*)
Adding an url using a variable will remove a custom added url key when switching between show and hide editor.

### Fixed Issues (if relevant)
None I could find.

### Manual testing scenarios (*)
1. Open a CMS page and hide the editor so raw html can be inserted.
2. Insert `<p><a href="{{config path="web/secure/base_url"}}custom-key">custom</a></p>`
3. Click show/hide editor twice and you're back in the raw input mode.
4. Your added `custom-key` is now removed.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
