### PR TITLE
Fix getCurrentUrl() not respecting store base path

### DIFF
--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -102,6 +102,7 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
      * @param Auth\Session $authSession
      * @param \Magento\Framework\Encryption\EncryptorInterface $encryptor
      * @param \Magento\Store\Model\StoreFactory $storeFactory
+     * @param \Magento\Store\Model\StoreManager $storeManager
      * @param \Magento\Framework\Data\Form\FormKey $formKey
      * @param array $data
      * @param HostChecker|null $hostChecker
@@ -126,6 +127,7 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
         \Magento\Backend\Model\Auth\Session $authSession,
         \Magento\Framework\Encryption\EncryptorInterface $encryptor,
         \Magento\Store\Model\StoreFactory $storeFactory,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Framework\Data\Form\FormKey $formKey,
         array $data = [],
         HostChecker $hostChecker = null,
@@ -144,6 +146,7 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
             $queryParamsResolver,
             $scopeConfig,
             $routeParamsPreprocessor,
+            $storeManager,
             $scopeType,
             $data,
             $hostChecker,


### PR DESCRIPTION
This is correcting an issue for magento where magentos
\Magento\Framework\Url::getCurrentUrl()
function is not respecting the stores base url.

### Background
$this->_request->getOriginalPathInfo();
In setups, where the stores are
switched with the setting of
  SetEnv MAGE_RUN_TYPE store
  SetEnv MAGE_RUN_CODE de_de
the path that is available in the php request object is in our setup
not including the complete path but only the path after the
storeBaseUrl.

 url in browser: https://example.com/de/shop/hosen/
 host in php: example.com
 path in php: /hosen/
 base url in Magento: https://example.com/de/shop/

Now we running into an issue with the add to compare list links. This
links are generated and the redirect url is set already in the link
itself with the 'uenc' parameter. And this parameter contains a wrong
url: https://example.com/hosen/

After tracing down where this wrong url is comming from, it looks like
in the getCurrentUrl function of magento the base url of the shop is not
respected. Therefor I decided to change this function in a way that is
respecting the store base url if it is set and falls back to server/php
url otherwise.

### additional changes
Additionaly this also refector the url generation in a way, that is not
relying on manualy determine the parts of the url, but using the
zend/php framework for this.

### Feedback
This Fix is not tested with a Multistore setup that is based on Symlinks. I am not 100% sure if the 
`$this->_request->getOriginalPathInfo()` is delivering the correct path in this setups.

Not sure on how to run the automated tests.

I have also checked the usages of this function and would not expect any mayor side effects.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
