### PR TITLE
Avoid reindexing inactive catalog rules

### DIFF
--- a/app/code/Magento/CatalogRule/Model/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/Rule.php
@@ -588,7 +588,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
      */
     public function afterSave()
     {
-        if ($this->getIsActive()) {
+        if (!$this->getIsActive()) {
             return parent::afterSave();
         }
 

--- a/app/code/Magento/CatalogRule/Model/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/Rule.php
@@ -46,6 +46,7 @@ use Magento\CatalogRule\Model\ResourceModel\Product\ConditionsToCollectionApplie
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.ExcessivePublicCount)
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  */
 class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, IdentityInterface
 {
@@ -652,6 +653,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
 
     /**
      * Get array with data differences
+     *
      * @param array $array1
      * @param array $array2
      *
@@ -831,6 +833,8 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
+     * Get from date
+     *
      * @return string
      */
     public function getFromDate()
@@ -839,6 +843,8 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
+     * Get to date
+     *
      * @return string
      */
     public function getToDate()

--- a/app/code/Magento/CatalogRule/Model/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/Rule.php
@@ -588,6 +588,10 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
      */
     public function afterSave()
     {
+        if ($this->getIsActive()) {
+            return parent::afterSave();
+        }
+
         if ($this->isObjectNew() && !$this->_ruleProductProcessor->isIndexerScheduled()) {
             $productIds = $this->getMatchingProductIds();
             if (!empty($productIds) && is_array($productIds)) {

--- a/app/code/Magento/CatalogRule/Model/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/Rule.php
@@ -433,7 +433,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function validateData(DataObject $dataObject)
     {
@@ -582,7 +582,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      *
      * @return $this
      */
@@ -610,14 +610,19 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
      */
     public function reindex()
     {
-        $productIds = $this->_productIds ? array_keys(array_filter($this->_productIds, function (array $data) {
-            return array_filter($data);
-        })) : [];
+        $productIds = $this->_productIds ? array_keys(
+            array_filter(
+                $this->_productIds,
+                function (array $data) {
+                    return array_filter($data);
+                }
+            )
+        ) : [];
         $this->_ruleProductProcessor->reindexList($productIds);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      *
      * @return $this
      */
@@ -668,6 +673,8 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
+     * Getter for conditions field set ID
+     *
      * @param string $formName
      * @return string
      */
@@ -676,10 +683,8 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
         return $formName . 'rule_conditions_fieldset_' . $this->getId();
     }
 
-    //@codeCoverageIgnoreStart
-
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getRuleId()
     {
@@ -687,7 +692,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setRuleId($ruleId)
     {
@@ -695,7 +700,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getName()
     {
@@ -703,7 +708,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setName($name)
     {
@@ -711,7 +716,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getDescription()
     {
@@ -719,7 +724,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setDescription($description)
     {
@@ -727,7 +732,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getIsActive()
     {
@@ -735,7 +740,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setIsActive($isActive)
     {
@@ -743,7 +748,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getRuleCondition()
     {
@@ -751,7 +756,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setRuleCondition($condition)
     {
@@ -762,7 +767,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getStopRulesProcessing()
     {
@@ -770,7 +775,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setStopRulesProcessing($isStopProcessing)
     {
@@ -778,7 +783,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getSortOrder()
     {
@@ -786,7 +791,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setSortOrder($sortOrder)
     {
@@ -794,7 +799,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getSimpleAction()
     {
@@ -802,7 +807,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setSimpleAction($action)
     {
@@ -810,7 +815,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getDiscountAmount()
     {
@@ -818,7 +823,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setDiscountAmount($amount)
     {
@@ -842,7 +847,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      *
      * @return \Magento\CatalogRule\Api\Data\RuleExtensionInterface|null
      */
@@ -852,7 +857,7 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      *
      * @param \Magento\CatalogRule\Api\Data\RuleExtensionInterface $extensionAttributes
      * @return $this
@@ -863,6 +868,8 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
     }
 
     /**
+     * Getter for the rule condition converter
+     *
      * @return Data\Condition\Converter
      * @deprecated 100.1.0
      */
@@ -874,8 +881,6 @@ class Rule extends \Magento\Rule\Model\AbstractModel implements RuleInterface, I
         }
         return $this->ruleConditionConverter;
     }
-
-    //@codeCoverageIgnoreEnd
 
     /**
      * @inheritDoc

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/RuleTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/RuleTest.php
@@ -311,13 +311,27 @@ class RuleTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test after update action
+     * Test after update action for inactive rule
      *
      * @return void
      */
-    public function testAfterUpdate()
+    public function testAfterUpdateInactive()
     {
         $this->rule->isObjectNew(false);
+        $this->rule->setIsActive(0);
+        $this->_ruleProductProcessor->expects($this->never())->method('getIndexer');
+        $this->rule->afterSave();
+    }
+
+    /**
+     * Test after update action for active rule
+     *
+     * @return void
+     */
+    public function testAfterUpdateActive()
+    {
+        $this->rule->isObjectNew(false);
+        $this->rule->setIsActive(1);
         $indexer = $this->createMock(\Magento\Framework\Indexer\IndexerInterface::class);
         $indexer->expects($this->once())->method('invalidate');
         $this->_ruleProductProcessor->expects($this->once())->method('getIndexer')->will($this->returnValue($indexer));


### PR DESCRIPTION
### Description (*)
Hi @magento-team 
I suggest avoiding reindex catalog rules that have inactive status as it is causing redundant load on a server.

### Fixed Issues (if relevant)
None

### Manual testing scenarios (*)
1. Indexers are set to `Update on save` mode (To visualize the issue, otherwise check indexer process in the background required you have configured CRON)
2. Run `bin/magento setup:perf:generate-fixtures  setup/performance-toolkit/profiles/ce/medium.xml` - to install data.
3. Create and save a Catalog Rule with no conditions (applicable to all products), inactive status, assigned to all websites and user groups, and with any Discount Amount. 

Expected result:
The Catalog Rule is being saved fast and no any reindex is being executed

Actual result:
The Catalog Rule is being saved slow, it even can cause a timeout limit issue.

See beginning of the `\Magento\CatalogRule\Model\Rule::afterSave` method.

### Questions or comments
Why is Magento reindex inactive rules?

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
