### PR TITLE
fixed issues #23886

### DIFF
--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/multi.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/multi.phtml
@@ -17,7 +17,7 @@
             <input type="hidden"
                    name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
                    value="<?= $block->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"
-                    class="bundle-option-<?= /* @escapeNotVerified */ $_option->getId() ?> bundle option"/>
+                    class="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?> bundle option"/>
         <?php else : ?>
             <select multiple="multiple"
                     size="5"

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/multi.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/multi.phtml
@@ -16,7 +16,8 @@
             <?= /* @noEscape */ $block->getSelectionQtyTitlePrice($_selections[0]) ?>
             <input type="hidden"
                    name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                   value="<?= $block->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"/>
+                   value="<?= $block->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"
+                    class="bundle-option-<?= /* @escapeNotVerified */ $_option->getId() ?> bundle option"/>
         <?php else : ?>
             <select multiple="multiple"
                     size="5"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23886: Bundle Product Show Incorrect Price if bundle options has only one multiple select option

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a bundle product
2. Now add some bundle items along with a bundle item of input type multiple select which has only one default option and make it as required.
3. For Example I have added one multiple select required item which has only one option ProductA of $23.00 and made it as default. then added a new item of select type of ProductB of $5 and made it as default.
4. It's not adding multiple select option price it's showing $5 below the add to cart button.
![Screenshot](https://user-images.githubusercontent.com/44425160/61878565-e18c9300-af0e-11e9-8bd0-cf654ecdc2cf.png)

