### PR TITLE
WIP:Add Magento2 error formatter to graphql executeQuery

### DIFF
--- a/lib/internal/Magento/Framework/GraphQl/Query/QueryProcessor.php
+++ b/lib/internal/Magento/Framework/GraphQl/Query/QueryProcessor.php
@@ -67,9 +67,11 @@ class QueryProcessor
             $contextValue,
             $variableValues,
             $operationName
-        )->setErrorFormatter(function(Error $error) {
-            return $this->exceptionFormatter->create($error);
-        })->toArray(
+        )->setErrorFormatter(
+            function (Error $error) {
+                return $this->exceptionFormatter->create($error, $error->getMessage());
+            }
+        )->toArray(
             $this->exceptionFormatter->shouldShowDetail() ?
                 \GraphQL\Error\Debug::INCLUDE_DEBUG_MESSAGE : false
         );

--- a/lib/internal/Magento/Framework/GraphQl/Query/QueryProcessor.php
+++ b/lib/internal/Magento/Framework/GraphQl/Query/QueryProcessor.php
@@ -67,7 +67,9 @@ class QueryProcessor
             $contextValue,
             $variableValues,
             $operationName
-        )->toArray(
+        )->setErrorFormatter(function(Error $error) {
+            return $this->exceptionFormatter->create($error);
+        })->toArray(
             $this->exceptionFormatter->shouldShowDetail() ?
                 \GraphQL\Error\Debug::INCLUDE_DEBUG_MESSAGE : false
         );


### PR DESCRIPTION
### Description
Fixed an issue where GraphQL query php errors weren't logged to exception log but instead transformed to "internal server error" by webonyx/graphql 

This pull requests aims to fix this by inserting the Magento 2 GraphQL errorFormatter which actually logs the errors to the exception.log file on production.

### Manual testing scenarios (*)
This is only reproduce-able when a custom or core GraphQL Resolver throws an error.
Below I will describe the steps to reproduce:

1. Create a new GraphQL Query and Resolver
2. In this GraphQL resolver do for example the following: `$this->productRepository->get({NON_EXISTING_SKU})`
3. GraphQL will throw the following error without exception logging: 
`{
  "errors": [
    {
      "message": "Internal server error",
      "category": "internal"
    }
  ]
}`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
