### PR TITLE
HTTP reason phrase is optional in RFC 7230

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/Client/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Curl.php
@@ -439,7 +439,7 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
     {
         if ($this->_headerCount == 0) {
             $line = explode(" ", trim($data), 3);
-            if (count($line) < 2) {
+            if (count($line) < 1) {
                 $this->doError("Invalid response line returned from server: " . $data);
             }
             $this->_responseStatus = (int)$line[1];


### PR DESCRIPTION
### Description (*)

When we use a HTTP server that uses a version of Tomcat 8.5+ with the HTTP client of Magento, we have this error: **Invalid response line returned from server** in Magento logs.

It's because since Tomcat 8.5, they have removed the reason phrase, as you can read in the [Tomcat changelog](http://tomcat.apache.org/tomcat-8.5-doc/changelog.html): **RFC 7230 states that clients should ignore reason phrases in HTTP/1.1 response messages. Since the reason phrase is optional, Tomcat no longer sends it.**

In [RFC 7230](https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html), you can read this: 
`Reason-Phrase  = *<TEXT, excluding CR, LF>`
The * means zero or more.

Concretely, instead to have this HTTP response from Tomcat:

`HTTP/1.1 404 Not Found`

You have:
`HTTP/1.1 404 `

Another bug report from Spring boot project where you can find more explanations: https://github.com/spring-projects/spring-boot/issues/6548

In the Magento source code, I don't see an usage of `$line[2]`.
To my actual understanding, it might be enough to not check if the third element in the array is present.

### Manual testing scenarios (*)
1. Setup a Spring Boot hello world project or any Java framework that uses Tomcat.
2. Use Magento HTTP client to connect

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
