### PR TITLE
Replace annoying multi-line warning with short message + context

### DIFF
--- a/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
@@ -22,6 +22,8 @@ use Psr\Log\LoggerInterface;
 
 /**
  * EAV read handler
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ReadHandler implements AttributeInterface
 {

--- a/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Eav\Model\ResourceModel;
 
+use Exception;
 use Magento\Eav\Model\Config;
+use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
 use Magento\Framework\DataObject;
 use Magento\Framework\DB\Select;
 use Magento\Framework\DB\Sql\UnionExpression;
 use Magento\Framework\EntityManager\MetadataPool;
 use Magento\Framework\EntityManager\Operation\AttributeInterface;
+use Magento\Framework\Exception\ConfigurationMismatchException;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Model\Entity\ScopeInterface;
 use Magento\Framework\Model\Entity\ScopeResolver;
 use Psr\Log\LoggerInterface;
@@ -63,7 +68,7 @@ class ReadHandler implements AttributeInterface
      *
      * @param string $entityType
      * @return \Magento\Eav\Api\Data\AttributeInterface[]
-     * @throws \Exception if for unknown entity type
+     * @throws Exception if for unknown entity type
      * @deprecated Not used anymore
      * @see ReadHandler::getEntityAttributes
      */
@@ -80,7 +85,7 @@ class ReadHandler implements AttributeInterface
      * @param string $entityType
      * @param DataObject $entity
      * @return \Magento\Eav\Api\Data\AttributeInterface[]
-     * @throws \Exception if for unknown entity type
+     * @throws Exception if for unknown entity type
      */
     private function getEntityAttributes(string $entityType, DataObject $entity): array
     {
@@ -111,9 +116,9 @@ class ReadHandler implements AttributeInterface
      * @param array $entityData
      * @param array $arguments
      * @return array
-     * @throws \Exception
-     * @throws \Magento\Framework\Exception\ConfigurationMismatchException
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws Exception
+     * @throws ConfigurationMismatchException
+     * @throws LocalizedException
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function execute($entityType, $entityData, $arguments = [])
@@ -129,7 +134,7 @@ class ReadHandler implements AttributeInterface
         $attributesMap = [];
         $selects = [];
 
-        /** @var \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute */
+        /** @var AbstractAttribute $attribute */
         foreach ($this->getEntityAttributes($entityType, new DataObject($entityData)) as $attribute) {
             if (!$attribute->isStatic()) {
                 $attributeTables[$attribute->getBackend()->getTable()][] = $attribute->getAttributeId();
@@ -170,8 +175,11 @@ class ReadHandler implements AttributeInterface
                     $entityData[$attributesMap[$attributeValue['attribute_id']]] = $attributeValue['value'];
                 } else {
                     $this->logger->warning(
-                        "Attempt to load value of nonexistent EAV attribute '{$attributeValue['attribute_id']}'
-                        for entity type '$entityType'."
+                        "Attempt to load value of nonexistent EAV attribute",
+                        [
+                            'attribute_id' => $attributeValue['attribute_id'],
+                            'entity_type' => $entityType
+                        ]
                     );
                 }
             }
@@ -184,8 +192,9 @@ class ReadHandler implements AttributeInterface
      *
      * @param Select[] $selects
      * @param array $identifiers
+     * @return void
      */
-    private function applyIdentifierForSelects(array $selects, array $identifiers)
+    private function applyIdentifierForSelects(array $selects, array $identifiers): void
     {
         foreach ($selects as $select) {
             foreach ($identifiers as $identifier) {


### PR DESCRIPTION
### Description (*)
When the warning occurs during reindex, the log entry is rather nasty:
```
[2019-07-25 21:03:35] x.WARNING: Attempt to load value of nonexistent EAV attribute '522'                          for entity type 'Magento\Catalog\Api\Data\ProductInterface'. [] []
[2019-07-25 21:03:35] x.WARNING: Attempt to load value of nonexistent EAV attribute '523'                          for entity type 'Magento\Catalog\Api\Data\ProductInterface'. [] []
[2019-07-25 21:03:35] x.WARNING: Attempt to load value of nonexistent EAV attribute '532'                          for entity type 'Magento\Catalog\Api\Data\ProductInterface'. [] []
```
with whitespaces. After changes, it's more valuable, because all the context is passed to context argument, so you can aggregate the warnings by message and attributes separately:
```
[2019-07-25 21:28:35] x.WARNING: Attempt to load value of nonexistent EAV attribute {"attribute_id":"532","entity_type":"Magento\\Catalog\\Api\\Data\\ProductInterface"} []
[2019-07-25 21:29:09] x.WARNING: Attempt to load value of nonexistent EAV attribute {"attribute_id":"532","entity_type":"Magento\\Catalog\\Api\\Data\\ProductInterface"} []
[2019-07-25 21:29:09] x.WARNING: Attempt to load value of nonexistent EAV attribute {"attribute_id":"532","entity_type":"Magento\\Catalog\\Api\\Data\\ProductInterface"} []
```

### Fixed Issues (if relevant)
Not applicable

### Manual testing scenarios (*)
1. Trigger situation where attribute_id is not defined for attributes map
2. Check logs for results

### Questions or comments
General improvement for readability and usability for log handlers like Graylog / ELK.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
