### PR TITLE
Extract handles from layout updates before layout merge step.

### DIFF
--- a/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
+++ b/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
@@ -18,6 +18,7 @@ use Magento\Framework\View\Model\Layout\Update\Validator;
  * Layout merge model
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
 class Merge implements \Magento\Framework\View\Layout\ProcessorInterface
 {
@@ -462,20 +463,7 @@ class Merge implements \Magento\Framework\View\Layout\ProcessorInterface
             return $this;
         }
 
-        // Walk all updates and extract handles before the merge step.
-        foreach ($this->updates as $update) {
-            $updateXml = null;
-
-            try {
-                $updateXml = $this->_loadXmlString($update);
-            } catch (\Exception $exception) {
-                // ignore invalid
-            }
-
-            if ($updateXml && strtolower($updateXml->getName()) == 'update' && isset($updateXml['handle'])) {
-                $this->addHandle((string)$updateXml['handle']);
-            }
-        }
+        $this->extractHandlers();
 
         foreach ($this->getHandles() as $handle) {
             $this->_merge($handle);
@@ -965,5 +953,26 @@ class Merge implements \Magento\Framework\View\Layout\ProcessorInterface
         $layoutCacheKeys = $this->layoutCacheKey->getCacheKeys();
         // phpcs:ignore Magento2.Security.InsecureFunction
         return $this->generateCacheId(md5(implode('|', array_merge($this->getHandles(), $layoutCacheKeys))));
+    }
+
+    /**
+     * Walk all updates and extract handles before the merge step.
+     */
+    private function extractHandlers(): void
+    {
+        foreach ($this->updates as $update) {
+            $updateXml = null;
+
+            try {
+                $updateXml = $this->_loadXmlString($update);
+                // phpcs:ignore Magento2.CodeAnalysis.EmptyBlock
+            } catch (\Exception $exception) {
+                // ignore invalid
+            }
+
+            if ($updateXml && strtolower($updateXml->getName()) == 'update' && isset($updateXml['handle'])) {
+                $this->addHandle((string)$updateXml['handle']);
+            }
+        }
     }
 }

--- a/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
+++ b/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
@@ -462,6 +462,21 @@ class Merge implements \Magento\Framework\View\Layout\ProcessorInterface
             return $this;
         }
 
+        // Walk all updates and extract handles before the merge step.
+        foreach ($this->updates as $update) {
+            $updateXml = null;
+
+            try {
+                $updateXml = $this->_loadXmlString($update);
+            } catch (\Exception $exception) {
+                // ignore invalid
+            }
+
+            if ($updateXml && strtolower($updateXml->getName()) == 'update' && isset($updateXml['handle'])) {
+                $this->addHandle((string)$updateXml['handle']);
+            }
+        }
+
         foreach ($this->getHandles() as $handle) {
             $this->_merge($handle);
         }


### PR DESCRIPTION


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

The `\Magento\Framework\View\Model\Layout\Merge::$updates` can contain handle updates which aren't processed by merge step. This pull request extracts handles from layout updates before layout merge step.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#5901: "update" in category custom layout xml is ignored

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Per #5901 add a layout update to a category using a handle and see if it applies.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
