### PR TITLE
Resolve Export Csv, Export Excel in Report->Marketing->(Abandoned Cart, Products in Cart) has wrong ACL issue23924

### DIFF
--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart.php
@@ -55,15 +55,4 @@ abstract class Shopcart extends \Magento\Backend\App\Action
         $this->_addBreadcrumb(__('Shopping Cart'), __('Shopping Cart'));
         return $this;
     }
-
-    /**
-     * Determine if action is allowed for reports module
-     *
-     * @return bool
-     * phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod
-     */
-    protected function _isAllowed()
-    {
-        return parent::_isAllowed();
-    }
 }

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart.php
@@ -9,14 +9,23 @@
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
+declare(strict_types=1);
+
 namespace Magento\Reports\Controller\Adminhtml\Report;
 
 /**
+ * Class \Magento\Reports\Controller\Adminhtml\Report\Shopcart
+ *
+ * phpcs:disable Magento2.Classes.AbstractApi
  * @api
  * @since 100.0.2
  */
 abstract class Shopcart extends \Magento\Backend\App\Action
 {
+    /**
+     * Authorization of a shop cart report
+     */
+    const ADMIN_RESOURCE = 'Magento_Reports::shopcart';
     /**
      * @var \Magento\Framework\App\Response\Http\FileFactory
      */
@@ -51,22 +60,10 @@ abstract class Shopcart extends \Magento\Backend\App\Action
      * Determine if action is allowed for reports module
      *
      * @return bool
+     * phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod
      */
     protected function _isAllowed()
     {
-        switch ($this->getRequest()->getActionName()) {
-            case 'customer':
-                return $this->_authorization->isAllowed(null);
-                break;
-            case 'product':
-                return $this->_authorization->isAllowed('Magento_Reports::product');
-                break;
-            case 'abandoned':
-                return $this->_authorization->isAllowed('Magento_Reports::abandoned');
-                break;
-            default:
-                return $this->_authorization->isAllowed('Magento_Reports::shopcart');
-                break;
-        }
+        return parent::_isAllowed();
     }
 }

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/Abandoned.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/Abandoned.php
@@ -4,12 +4,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Reports\Controller\Adminhtml\Report\Shopcart;
 
 use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
 
+/**
+ * Class \Magento\Reports\Controller\Adminhtml\Report\Shopcart\Abandoned
+ */
 class Abandoned extends \Magento\Reports\Controller\Adminhtml\Report\Shopcart implements HttpGetActionInterface
 {
+    /**
+     * Authorization of a abandoned report
+     */
+    const ADMIN_RESOURCE = 'Magento_Reports::abandoned';
+
     /**
      * Abandoned carts action
      *

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/Abandoned.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/Abandoned.php
@@ -16,7 +16,7 @@ use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterfac
 class Abandoned extends \Magento\Reports\Controller\Adminhtml\Report\Shopcart implements HttpGetActionInterface
 {
     /**
-     * Authorization for an abandoned report
+     * Authorization of an abandoned report
      */
     const ADMIN_RESOURCE = 'Magento_Reports::abandoned';
 

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/Abandoned.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/Abandoned.php
@@ -16,7 +16,7 @@ use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterfac
 class Abandoned extends \Magento\Reports\Controller\Adminhtml\Report\Shopcart implements HttpGetActionInterface
 {
     /**
-     * Authorization of a abandoned report
+     * Authorization for an abandoned report
      */
     const ADMIN_RESOURCE = 'Magento_Reports::abandoned';
 

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/Customer.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/Customer.php
@@ -16,11 +16,6 @@ use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterfac
 class Customer extends \Magento\Reports\Controller\Adminhtml\Report\Shopcart implements HttpGetActionInterface
 {
     /**
-     * Authorization of a customer report
-     */
-    const ADMIN_RESOURCE = null;
-
-    /**
      * Customer shopping carts action
      *
      * @return void

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/Customer.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/Customer.php
@@ -4,10 +4,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Reports\Controller\Adminhtml\Report\Shopcart;
 
-class Customer extends \Magento\Reports\Controller\Adminhtml\Report\Shopcart
+use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+
+/**
+ * Class \Magento\Reports\Controller\Adminhtml\Report\Shopcart\Customer
+ */
+class Customer extends \Magento\Reports\Controller\Adminhtml\Report\Shopcart implements HttpGetActionInterface
 {
+    /**
+     * Authorization of a customer report
+     */
+    const ADMIN_RESOURCE = null;
+
     /**
      * Customer shopping carts action
      *

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportAbandonedCsv.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportAbandonedCsv.php
@@ -4,12 +4,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Reports\Controller\Adminhtml\Report\Shopcart;
 
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+use Magento\Reports\Controller\Adminhtml\Report\Shopcart\Abandoned as ShopCartAbandoned;
 
-class ExportAbandonedCsv extends \Magento\Reports\Controller\Adminhtml\Report\Shopcart
+/**
+ * Class \Magento\Reports\Controller\Adminhtml\Report\Shopcart\ExportAbandonedCsv
+ */
+class ExportAbandonedCsv extends ShopCartAbandoned implements HttpGetActionInterface
 {
     /**
      * Export abandoned carts report grid to CSV format

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportAbandonedExcel.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportAbandonedExcel.php
@@ -4,12 +4,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Reports\Controller\Adminhtml\Report\Shopcart;
 
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+use Magento\Reports\Controller\Adminhtml\Report\Shopcart\Abandoned as ShopCartAbandoned;
 
-class ExportAbandonedExcel extends \Magento\Reports\Controller\Adminhtml\Report\Shopcart
+/**
+ * Class \Magento\Reports\Controller\Adminhtml\Report\Shopcart\ExportAbandonedExcel
+ */
+class ExportAbandonedExcel extends ShopCartAbandoned implements HttpGetActionInterface
 {
     /**
      * Export abandoned carts report to Excel XML format

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportCustomerCsv.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportCustomerCsv.php
@@ -4,11 +4,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Reports\Controller\Adminhtml\Report\Shopcart;
 
 use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+use Magento\Reports\Controller\Adminhtml\Report\Shopcart\Customer as ShopCartCustomer;
 
-class ExportCustomerCsv extends \Magento\Reports\Controller\Adminhtml\Report\Shopcart
+/**
+ * Class \Magento\Reports\Controller\Adminhtml\Report\Shopcart\ExportCustomerCsv
+ */
+class ExportCustomerCsv extends ShopCartCustomer implements HttpGetActionInterface
 {
     /**
      * Export shopcart customer report to CSV format

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportCustomerExcel.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportCustomerExcel.php
@@ -4,11 +4,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Reports\Controller\Adminhtml\Report\Shopcart;
 
 use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+use Magento\Reports\Controller\Adminhtml\Report\Shopcart\Customer as ShopCartCustomer;
 
-class ExportCustomerExcel extends \Magento\Reports\Controller\Adminhtml\Report\Shopcart
+/**
+ * Class \Magento\Reports\Controller\Adminhtml\Report\Shopcart\ExportCustomerExcel
+ */
+class ExportCustomerExcel extends ShopCartCustomer implements HttpGetActionInterface
 {
     /**
      * Export shopcart customer report to Excel XML format

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportProductCsv.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportProductCsv.php
@@ -4,12 +4,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Reports\Controller\Adminhtml\Report\Shopcart;
 
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+use Magento\Reports\Controller\Adminhtml\Report\Shopcart\Product as ShopCartProduct;
 
-class ExportProductCsv extends \Magento\Reports\Controller\Adminhtml\Report\Shopcart
+/**
+ * Class \Magento\Reports\Controller\Adminhtml\Report\Shopcart\ExportProductCsv
+ */
+class ExportProductCsv extends ShopCartProduct implements HttpGetActionInterface
 {
     /**
      * Export products report grid to CSV format

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportProductExcel.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportProductExcel.php
@@ -4,12 +4,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Reports\Controller\Adminhtml\Report\Shopcart;
 
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+use Magento\Reports\Controller\Adminhtml\Report\Shopcart\Product as ShopCartProduct;
 
-class ExportProductExcel extends \Magento\Reports\Controller\Adminhtml\Report\Shopcart
+/**
+ * Class \Magento\Reports\Controller\Adminhtml\Report\Shopcart\ExportProductExcel
+ */
+class ExportProductExcel extends ShopCartProduct implements HttpGetActionInterface
 {
     /**
      * Export products report to Excel XML format

--- a/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/Product.php
+++ b/app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/Product.php
@@ -4,12 +4,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Reports\Controller\Adminhtml\Report\Shopcart;
 
 use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
 
+/**
+ * Class \Magento\Reports\Controller\Adminhtml\Report\Shopcart\Product
+ */
 class Product extends \Magento\Reports\Controller\Adminhtml\Report\Shopcart implements HttpGetActionInterface
 {
+    /**
+     * Authorization of a product report
+     */
+    const ADMIN_RESOURCE = 'Magento_Reports::product';
+
     /**
      * Products in carts action
      *


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Controller:

```
app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportAbandonedCsv.php
app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportAbandonedExcel.php
app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportProductCsv.php
app/code/Magento/Reports/Controller/Adminhtml/Report/Shopcart/ExportProductExcel.php
```

extends from `\Magento\Reports\Controller\Adminhtml\Report\Shopcart`

But in `_isAllowed()` function, because of the Action Name => It will run in "Default" case =>`Magento_Reports::shopcart` is the ACL
=> Has the wrong ACL.

=> admin with no permission "Abandoned Cart" still export Abandoned Cart Report CSV File
=> admin with no permission "Products in Cart" still export Products in Cart Report CSV File

Should be: `Magento_Reports::abandoned` and  `Magento_Reports::product`

SOLUTION: 
- Add exportproductcsv, exportproductexcel to the case 'product' 
- Add exportabandonedcsv, exportabandonedexcelto the case 'abandoned' 

in function `_isAllowed`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23924: Export Csv, Export Excel in Report->Marketing->(Abandoned Cart, Products in Cart) has wrong ACL

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Store->Configuration, Advanced->Admin, Set **"Add Secret Key to URLs" : "No"**

![image](https://user-images.githubusercontent.com/8234209/61936044-0e47b580-afb6-11e9-8421-0b4b105d4666.png)

2. Create New Role with followings Permission:
![image](https://user-images.githubusercontent.com/8234209/62000725-57a81a00-b108-11e9-9bd4-3cd8f4678b84.png)

3. Create New Admin User and Assign to this role.
4. Logout current admin user and login to New admin user.
5. Go to this url : http://[Magento 2 domain]/admin/reports/report_shopcart/exportProductCsv
 http://[Magento 2 domain]/admin/reports/report_shopcart/exportProductExcel
 http://[Magento 2 domain]/admin/reports/report_shopcart/exportAbandonedCsv
 http://[Magento 2 domain]/admin/reports/report_shopcart/exportAbandonedExcel

**Expected Result: Can not access because don't have permission**

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
