### PR TITLE
Use Default Store View Constant instead of '0'

### DIFF
--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle;
 
 use Magento\Framework\Data\Form\Element\AbstractElement;

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
@@ -7,6 +7,9 @@ namespace Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle;
 
 use Magento\Framework\Data\Form\Element\AbstractElement;
 
+/**
+ * Class \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle\Option
+ */
 class Option extends \Magento\Backend\Block\Widget
 {
     /**
@@ -79,6 +82,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Return Field Id
+     *
      * @return string
      */
     public function getFieldId()
@@ -87,6 +92,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Return Field Name
+     *
      * @return string
      */
     public function getFieldName()
@@ -108,6 +115,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Render
+     *
      * @param AbstractElement $element
      * @return string
      */
@@ -118,6 +127,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Set Element
+     *
      * @param AbstractElement $element
      * @return $this
      */
@@ -128,6 +139,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Get Element
+     *
      * @return AbstractElement|null
      */
     public function getElement()
@@ -136,6 +149,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Return Is Multi Websites
+     *
      * @return bool
      */
     public function isMultiWebsites()
@@ -144,6 +159,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Prepare Layout
+     *
      * @return $this
      */
     protected function _prepareLayout()
@@ -184,6 +201,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Get Add Button Html
+     *
      * @return string
      */
     public function getAddButtonHtml()
@@ -192,6 +211,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Get Close Search Button Html
+     *
      * @return string
      */
     public function getCloseSearchButtonHtml()
@@ -200,6 +221,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Get Add Selection Button Html
+     *
      * @return string
      */
     public function getAddSelectionButtonHtml()
@@ -239,6 +262,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Get Add Button Id
+     *
      * @return mixed
      */
     public function getAddButtonId()
@@ -248,6 +273,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Get Options Delete Button Html
+     *
      * @return string
      */
     public function getOptionDeleteButtonHtml()
@@ -256,6 +283,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Get Selection Html
+     *
      * @return string
      */
     public function getSelectionHtml()
@@ -264,6 +293,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Get Type Select Html
+     *
      * @return mixed
      */
     public function getTypeSelectHtml()
@@ -286,6 +317,8 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Get Require Select Html
+     *
      * @return mixed
      */
     public function getRequireSelectHtml()
@@ -304,10 +337,12 @@ class Option extends \Magento\Backend\Block\Widget
     }
 
     /**
+     * Return Is Default Store
+     *
      * @return bool
      */
     public function isDefaultStore()
     {
-        return $this->getProduct()->getStoreId() == '0';
+        return $this->getProduct()->getStoreId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID;
     }
 }

--- a/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
+++ b/app/code/Magento/Bundle/Block/Adminhtml/Catalog/Product/Edit/Tab/Bundle/Option.php
@@ -6,8 +6,11 @@
 namespace Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle;
 
 use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Store\Model\Store;
 
 /**
+ * Block for rendering option of bundle product
+ *
  * Class \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle\Option
  */
 class Option extends \Magento\Backend\Block\Widget
@@ -343,6 +346,6 @@ class Option extends \Magento\Backend\Block\Widget
      */
     public function isDefaultStore()
     {
-        return $this->getProduct()->getStoreId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID;
+        return $this->getProduct()->getStoreId() == Store::DEFAULT_STORE_ID;
     }
 }

--- a/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/BundlePanel.php
+++ b/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/BundlePanel.php
@@ -16,6 +16,7 @@ use Magento\Ui\Component\Container;
 use Magento\Ui\Component\Form;
 use Magento\Ui\Component\Form\Fieldset;
 use Magento\Ui\Component\Modal;
+use Magento\Store\Model\Store;
 
 /**
  * Create Ship Bundle Items and Affect Bundle Product Selections fields
@@ -814,6 +815,6 @@ class BundlePanel extends AbstractModifier
      */
     protected function isDefaultStore()
     {
-        return $this->locator->getProduct()->getStoreId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID;
+        return $this->locator->getProduct()->getStoreId() == Store::DEFAULT_STORE_ID;
     }
 }

--- a/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/BundlePanel.php
+++ b/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/BundlePanel.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Bundle\Ui\DataProvider\Product\Form\Modifier;
 
 use Magento\Bundle\Model\Product\Attribute\Source\Shipment\Type as ShipmentType;

--- a/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/BundlePanel.php
+++ b/app/code/Magento/Bundle/Ui/DataProvider/Product/Form/Modifier/BundlePanel.php
@@ -814,6 +814,6 @@ class BundlePanel extends AbstractModifier
      */
     protected function isDefaultStore()
     {
-        return $this->locator->getProduct()->getStoreId() == 0;
+        return $this->locator->getProduct()->getStoreId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID;
     }
 }

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
@@ -380,7 +380,7 @@ class Option extends Widget
      * @param int $scope
      * @return array
      */
-    public function getOptionValueOfGroupSelect($value, $option, $showPrice, $scope)
+    private function getOptionValueOfGroupSelect($value, $option, $showPrice, $scope)
     {
         $i = 0;
         $itemCount = 0;

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
@@ -14,6 +14,8 @@ use Magento\Catalog\Model\Product;
 use Magento\Catalog\Api\Data\ProductCustomOptionInterface;
 
 /**
+ * Class \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Option
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class Option extends Widget
@@ -105,6 +107,8 @@ class Option extends Widget
     }
 
     /**
+     * Get Item Count
+     *
      * @return int
      */
     public function getItemCount()
@@ -113,6 +117,8 @@ class Option extends Widget
     }
 
     /**
+     * Set Item Count
+     *
      * @param int $itemCount
      * @return $this
      */
@@ -142,6 +148,8 @@ class Option extends Widget
     }
 
     /**
+     * Set Product
+     *
      * @param Product $product
      * @return $this
      */
@@ -182,6 +190,8 @@ class Option extends Widget
     }
 
     /**
+     * Prepare Layout
+     *
      * @return $this
      */
     protected function _prepareLayout()
@@ -194,6 +204,8 @@ class Option extends Widget
     }
 
     /**
+     * Get Add Button Id
+     *
      * @return mixed
      */
     public function getAddButtonId()
@@ -203,6 +215,8 @@ class Option extends Widget
     }
 
     /**
+     * Get Type Select Html
+     *
      * @return mixed
      */
     public function getTypeSelectHtml()
@@ -224,6 +238,8 @@ class Option extends Widget
     }
 
     /**
+     * Get Require Select Html
+     *
      * @return mixed
      */
     public function getRequireSelectHtml()
@@ -272,10 +288,13 @@ class Option extends Widget
     }
 
     /**
+     * Get Option Values
+     *
      * @return \Magento\Framework\DataObject[]
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * phpcs:disable Generic.Metrics.NestingLevel
      */
     public function getOptionValues()
     {
@@ -307,7 +326,7 @@ class Option extends Widget
                 $value['sort_order'] = $option->getSortOrder();
                 $value['can_edit_price'] = $this->getCanEditPrice();
 
-                if ($this->getProduct()->getStoreId() != '0') {
+                if ($this->getProduct()->getStoreId() != \Magento\Store\Model\Store::DEFAULT_STORE_ID) {
                     $value['checkboxScopeTitle'] = $this->getCheckboxScopeHtml(
                         $option->getOptionId(),
                         'title',
@@ -335,7 +354,7 @@ class Option extends Widget
                             'sort_order' => $_value->getSortOrder(),
                         ];
 
-                        if ($this->getProduct()->getStoreId() != '0') {
+                        if ($this->getProduct()->getStoreId() != \Magento\Store\Model\Store::DEFAULT_STORE_ID) {
                             $value['optionValues'][$i]['checkboxScopeTitle'] = $this->getCheckboxScopeHtml(
                                 $_value->getOptionId(),
                                 'title',
@@ -371,7 +390,7 @@ class Option extends Widget
                     $value['file_extension'] = $option->getFileExtension();
                     $value['image_size_x'] = $option->getImageSizeX();
                     $value['image_size_y'] = $option->getImageSizeY();
-                    if ($this->getProduct()->getStoreId() != '0'
+                    if ($this->getProduct()->getStoreId() != \Magento\Store\Model\Store::DEFAULT_STORE_ID
                         && $scope == \Magento\Store\Model\Store::PRICE_SCOPE_WEBSITE
                     ) {
                         $value['checkboxScopePrice'] = $this->getCheckboxScopeHtml(
@@ -431,6 +450,8 @@ class Option extends Widget
     }
 
     /**
+     * Get Price Value
+     *
      * @param float $value
      * @param string $type
      * @return string

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
@@ -7,6 +7,8 @@
 /**
  * Customers defined options
  */
+declare(strict_types=1);
+
 namespace Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options;
 
 use Magento\Backend\Block\Widget;

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
@@ -478,9 +478,9 @@ class Option extends Widget
     public function getPriceValue($value, $type)
     {
         if ($type == 'percent') {
-            return number_format($value, 2, null, '');
+            return number_format((float)$value, 2, null, '');
         } elseif ($type == 'fixed') {
-            return number_format($value, 2, null, '');
+            return number_format((float)$value, 2, null, '');
         }
     }
 

--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Tab/Options/Option.php
@@ -12,8 +12,11 @@ namespace Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options;
 use Magento\Backend\Block\Widget;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Api\Data\ProductCustomOptionInterface;
+use Magento\Store\Model\Store;
 
 /**
+ * Block for rendering option of product
+ *
  * Class \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Option
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -294,7 +297,6 @@ class Option extends Widget
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
-     * phpcs:disable Generic.Metrics.NestingLevel
      */
     public function getOptionValues()
     {
@@ -326,7 +328,7 @@ class Option extends Widget
                 $value['sort_order'] = $option->getSortOrder();
                 $value['can_edit_price'] = $this->getCanEditPrice();
 
-                if ($this->getProduct()->getStoreId() != \Magento\Store\Model\Store::DEFAULT_STORE_ID) {
+                if ($this->getProduct()->getStoreId() != Store::DEFAULT_STORE_ID) {
                     $value['checkboxScopeTitle'] = $this->getCheckboxScopeHtml(
                         $option->getOptionId(),
                         'title',
@@ -336,49 +338,7 @@ class Option extends Widget
                 }
 
                 if ($option->getGroupByType() == ProductCustomOptionInterface::OPTION_GROUP_SELECT) {
-                    $i = 0;
-                    $itemCount = 0;
-                    foreach ($option->getValues() as $_value) {
-                        /* @var $_value \Magento\Catalog\Model\Product\Option\Value */
-                        $value['optionValues'][$i] = [
-                            'item_count' => max($itemCount, $_value->getOptionTypeId()),
-                            'option_id' => $_value->getOptionId(),
-                            'option_type_id' => $_value->getOptionTypeId(),
-                            'title' => $_value->getTitle(),
-                            'price' => $showPrice ? $this->getPriceValue(
-                                $_value->getPrice(),
-                                $_value->getPriceType()
-                            ) : '',
-                            'price_type' => $showPrice ? $_value->getPriceType() : 0,
-                            'sku' => $_value->getSku(),
-                            'sort_order' => $_value->getSortOrder(),
-                        ];
-
-                        if ($this->getProduct()->getStoreId() != \Magento\Store\Model\Store::DEFAULT_STORE_ID) {
-                            $value['optionValues'][$i]['checkboxScopeTitle'] = $this->getCheckboxScopeHtml(
-                                $_value->getOptionId(),
-                                'title',
-                                $_value->getStoreTitle() === null,
-                                $_value->getOptionTypeId()
-                            );
-                            $value['optionValues'][$i]['scopeTitleDisabled'] = $_value->getStoreTitle() === null
-                                ? 'disabled'
-                                : null;
-                            if ($scope == \Magento\Store\Model\Store::PRICE_SCOPE_WEBSITE) {
-                                $value['optionValues'][$i]['checkboxScopePrice'] = $this->getCheckboxScopeHtml(
-                                    $_value->getOptionId(),
-                                    'price',
-                                    $_value->getstorePrice() === null,
-                                    $_value->getOptionTypeId(),
-                                    ['$(this).up(1).previous()']
-                                );
-                                $value['optionValues'][$i]['scopePriceDisabled'] = $_value->getStorePrice() === null
-                                    ? 'disabled'
-                                    : null;
-                            }
-                        }
-                        $i++;
-                    }
+                    $value = $this->getOptionValueOfGroupSelect($value, $option, $showPrice, $scope);
                 } else {
                     $value['price'] = $showPrice ? $this->getPriceValue(
                         $option->getPrice(),
@@ -390,7 +350,7 @@ class Option extends Widget
                     $value['file_extension'] = $option->getFileExtension();
                     $value['image_size_x'] = $option->getImageSizeX();
                     $value['image_size_y'] = $option->getImageSizeY();
-                    if ($this->getProduct()->getStoreId() != \Magento\Store\Model\Store::DEFAULT_STORE_ID
+                    if ($this->getProduct()->getStoreId() != Store::DEFAULT_STORE_ID
                         && $scope == \Magento\Store\Model\Store::PRICE_SCOPE_WEBSITE
                     ) {
                         $value['checkboxScopePrice'] = $this->getCheckboxScopeHtml(
@@ -407,6 +367,63 @@ class Option extends Widget
         }
 
         return $this->_values;
+    }
+
+    /**
+     * Get Option Value Of Group Select
+     *
+     * @param array $value
+     * @param \Magento\Catalog\Model\Product\Option $option
+     * @param boolean $showPrice
+     * @param int $scope
+     * @return array
+     */
+    public function getOptionValueOfGroupSelect($value, $option, $showPrice, $scope)
+    {
+        $i = 0;
+        $itemCount = 0;
+        foreach ($option->getValues() as $_value) {
+            /* @var $_value \Magento\Catalog\Model\Product\Option\Value */
+            $value['optionValues'][$i] = [
+                'item_count' => max($itemCount, $_value->getOptionTypeId()),
+                'option_id' => $_value->getOptionId(),
+                'option_type_id' => $_value->getOptionTypeId(),
+                'title' => $_value->getTitle(),
+                'price' => $showPrice ? $this->getPriceValue(
+                    $_value->getPrice(),
+                    $_value->getPriceType()
+                ) : '',
+                'price_type' => $showPrice ? $_value->getPriceType() : 0,
+                'sku' => $_value->getSku(),
+                'sort_order' => $_value->getSortOrder(),
+            ];
+
+            if ($this->getProduct()->getStoreId() != Store::DEFAULT_STORE_ID) {
+                $value['optionValues'][$i]['checkboxScopeTitle'] = $this->getCheckboxScopeHtml(
+                    $_value->getOptionId(),
+                    'title',
+                    $_value->getStoreTitle() === null,
+                    $_value->getOptionTypeId()
+                );
+                $value['optionValues'][$i]['scopeTitleDisabled'] = $_value->getStoreTitle() === null
+                    ? 'disabled'
+                    : null;
+                if ($scope == \Magento\Store\Model\Store::PRICE_SCOPE_WEBSITE) {
+                    $value['optionValues'][$i]['checkboxScopePrice'] = $this->getCheckboxScopeHtml(
+                        $_value->getOptionId(),
+                        'price',
+                        $_value->getstorePrice() === null,
+                        $_value->getOptionTypeId(),
+                        ['$(this).up(1).previous()']
+                    );
+                    $value['optionValues'][$i]['scopePriceDisabled'] = $_value->getStorePrice() === null
+                        ? 'disabled'
+                        : null;
+                }
+            }
+            $i++;
+        }
+        return $value;
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Should Use Default Store View Constant "\Magento\Store\Model\Store::DEFAULT_STORE_ID" instead of hard coded string '0'

### Fixed Issues (if relevant)

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Check the file changes of Source code
2. ->getProduct()->getStoreId() == '0' should replace by the constant : \Magento\Store\Model\Store::DEFAULT_STORE_ID

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
