### PR TITLE
[WIP] Fixes a bunch of less compilation problems and resolves some sm…

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/components/_modals_extend.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/components/_modals_extend.less
@@ -33,6 +33,10 @@
 
 //
 
+.modals-overlay {
+    &:extend(.abs-modal-overlay all);
+}
+
 .modal-popup,
 .modal-slide {
     .action-close {

--- a/app/design/frontend/Magento/blank/Magento_AdvancedCheckout/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_AdvancedCheckout/web/css/source/_module.less
@@ -53,12 +53,6 @@
             }
 
             .block-content {
-                &:extend(.abs-add-clearfix-desktop all);
-
-                .box {
-                    &:extend(.abs-blocks-2columns all);
-                }
-
                 .actions-toolbar {
                     clear: both;
                     .lib-actions-toolbar(
@@ -165,6 +159,18 @@
 
         .block-content {
             &:extend(.abs-add-clearfix-desktop all);
+        }
+    }
+
+    .column {
+        .block-addbysku {
+            .block-content {
+                &:extend(.abs-add-clearfix-desktop all);
+
+                .box {
+                    &:extend(.abs-blocks-2columns all);
+                }
+            }
         }
     }
 }

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_estimated-total.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_estimated-total.less
@@ -15,7 +15,6 @@
 
     .opc-estimated-wrapper {
         &:extend(.abs-add-clearfix all);
-        &:extend(.abs-no-display-desktop all);
         .lib-css(border-bottom, @border-width__base solid @color-gray80);
         margin: 0 0 15px;
         padding: 18px 15px;
@@ -37,7 +36,7 @@
                     &:before {
                         .lib-css(color, @button__color);
                     }
-                    
+
                     &:hover:before {
                         .lib-css(color, @button__hover__color);
                     }
@@ -53,6 +52,6 @@
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .opc-estimated-wrapper {
-        display: none;
+        &:extend(.abs-no-display-desktop all);
     }
 }

--- a/app/design/frontend/Magento/blank/Magento_GiftMessage/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_GiftMessage/web/css/source/_module.less
@@ -18,7 +18,6 @@
 & when (@media-common = true) {
     .gift-message {
         .field {
-            &:extend(.abs-clearfix all);
             margin-bottom: @indent__base;
 
             .label {

--- a/app/design/frontend/Magento/blank/Magento_GiftRegistry/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_GiftRegistry/web/css/source/_module.less
@@ -72,10 +72,6 @@
     .form-giftregistry-search {
         margin-bottom: @indent__l*2;
 
-        .legend {
-            &:extend(.abs-account-title all);
-        }
-
         .fields-specific-options {
             .field {
                 &:nth-last-of-type(1) {

--- a/app/design/frontend/Magento/blank/Magento_MultipleWishlist/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_MultipleWishlist/web/css/source/_module.less
@@ -180,10 +180,6 @@
     }
 
     .block-wishlist-search-form {
-        .block-title {
-            &:extend(.abs-account-title all);
-        }
-
         .form-wishlist-search {
             margin-bottom: @indent__l * 2;
             max-width: 500px;
@@ -218,7 +214,7 @@
         .block-title {
             .lib-font-size(22);
             margin-bottom: @indent__base;
-            
+
             > strong {
                 font-weight: @font-weight__light;
             }

--- a/app/design/frontend/Magento/blank/Magento_Multishipping/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Multishipping/web/css/source/_module.less
@@ -189,7 +189,6 @@
 
         .block-title,
         .block-content .title {
-            &:extend(.abs-account-title all);
             border-bottom: @border-width__base solid @border-color__base;
             padding-bottom: @indent__s;
 

--- a/app/design/frontend/Magento/blank/Magento_Review/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Review/web/css/source/_module.less
@@ -17,7 +17,7 @@
 & when (@media-common = true) {
     .rating-summary {
         .lib-rating-summary();
-        
+
         .rating-result {
             margin-left: -5px;
         }
@@ -299,7 +299,6 @@
             display: table;
             margin-bottom: @indent__s;
             max-width: 100%;
-            &:extend(.abs-rating-summary all);
         }
 
         &-author {

--- a/app/design/frontend/Magento/luma/Magento_AdvancedCheckout/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_AdvancedCheckout/web/css/source/_module.less
@@ -48,12 +48,6 @@
             }
 
             .block-content {
-                &:extend(.abs-add-clearfix-desktop all);
-
-                .box {
-                    &:extend(.abs-blocks-2columns all);
-                }
-
                 .actions-toolbar {
                     clear: both;
                     .lib-actions-toolbar(
@@ -186,6 +180,18 @@
 
         .block-content {
             &:extend(.abs-add-clearfix-desktop all);
+        }
+    }
+
+    .column {
+        .block-addbysku {
+            .block-content {
+                &:extend(.abs-add-clearfix-desktop all);
+
+                .box {
+                    &:extend(.abs-blocks-2columns all);
+                }
+            }
         }
     }
 }

--- a/app/design/frontend/Magento/luma/Magento_CatalogSearch/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_CatalogSearch/web/css/source/_module.less
@@ -18,7 +18,7 @@
 //  _____________________________________________
 
 & when (@media-common = true) {
-    
+
     .search {
         .fieldset {
             .control {
@@ -31,7 +31,7 @@
             }
         }
     }
-    
+
     .block-search {
         margin-bottom: 0;
 
@@ -136,8 +136,6 @@
     }
 
     .form.search.advanced {
-        &:extend(.abs-forms-general-desktop all);
-
         .fields.range {
             .field {
                 &:first-child {
@@ -274,5 +272,9 @@
 
     .search-autocomplete {
         margin-top: 0;
+    }
+
+    .form.search.advanced {
+        &:extend(.abs-forms-general-desktop all);
     }
 }

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_estimated-total.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_estimated-total.less
@@ -14,7 +14,6 @@
     //  ---------------------------------------------
 
     .opc-estimated-wrapper {
-        &:extend(.abs-no-display-desktop all);
         &:extend(.abs-add-clearfix all);
         .lib-css(background, @checkout-step-content-mobile__background);
         .lib-css(border-bottom, @checkout-step-title__border);
@@ -54,6 +53,6 @@
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .opc-estimated-wrapper {
-        display: none;
+        &:extend(.abs-no-display-desktop all);
     }
 }

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/fields/_file-uploader.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/fields/_file-uploader.less
@@ -129,7 +129,6 @@
 
 .file-uploader-preview {
     .action-remove {
-        &:extend(.abs-action-reset all);
         .lib-icon-font (
                 @icon-delete__content,
             @_icon-font: @icons__font-name,

--- a/app/design/frontend/Magento/luma/Magento_Downloadable/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Downloadable/web/css/source/_module.less
@@ -92,7 +92,6 @@
         }
 
         .field.choice {
-            &:extend(.clearer all);
             border-bottom: 1px solid @color-gray92;
             box-sizing: border-box;
             margin-bottom: @indent__s;
@@ -178,10 +177,6 @@
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .page-product-downloadable {
-        .product-add-form {
-            &:extend(.clearer all);
-        }
-
         .product-options-wrapper {
             float: left;
             width: 55%;

--- a/app/design/frontend/Magento/luma/Magento_GiftMessage/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_GiftMessage/web/css/source/_module.less
@@ -27,7 +27,6 @@
 & when (@media-common = true) {
     .gift-message {
         .field {
-            &:extend(.abs-clearfix all);
             margin-bottom: @indent__base;
 
             .label {

--- a/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
@@ -307,7 +307,6 @@
             margin-right: 30px;
 
             &.print {
-                &:extend(.abs-action-print all);
                 display: none;
                 margin: 0;
             }
@@ -585,6 +584,7 @@
 
     .order-actions-toolbar {
         .action.print {
+            &:extend(.abs-action-print all);
             display: block;
             float: right;
         }
@@ -705,7 +705,7 @@
     }
 }
 
-.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__l) { 
+.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__l) {
     .order-links {
         .item {
             margin: 0 @tab-control__margin-right 0 0;

--- a/lib/web/css/source/components/_modals.less
+++ b/lib/web/css/source/components/_modals.less
@@ -150,7 +150,6 @@
 
     //  Modals overlay
     .modals-overlay {
-        &:extend(.abs-modal-overlay all);
         .lib-css(z-index, @overlay__z-index);
     }
 


### PR DESCRIPTION
…all intended layout changes which didn't work due to mistakes being made and not being properly tested I guess.

### Description (*)
_Description updated 31 July 2019_

This is work in progress, all compilation issues are fixed in the Luma theme and blank theme now.
And I discovered some more compilation errors in Magento's Backend theme (while compiling `styles-old.less`, not sure if that's even actually used, but it's being compiled), errors:
```
extend ' .data-table tbody tr:nth-child(odd) td' has no matches
extend ' .grid-actions .export .label' has no matches
extend ' .grid-actions .export .action-' has no matches
extend ' .col-570' has no matches
```

I think I'm going to split up this PR into different PR's per theme, otherwise it's going to be a lot to review.
Also writing a full description is going to take me some time, so a little bit more patience :)


Here are some notes I kept while working on these fixes:
```
# luma theme

- app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/fields/_file-uploader.less

  => .abs-action-reset mixin is defined in backend module, so shouldn't be used in the frontend
  => has something to do with a custom attribute in the customer address for file uploads (according to commit message in https://github.com/magento/magento2/commit/ffbf8e6da2f5 where this issue was introduced)

- app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less

  => is being used in wrong media query
  => will add print icon to print link

- app/design/frontend/Magento/luma/Magento_CatalogSearch/web/css/source/_module.less

  => is being used in wrong media query
  => will hide legend in advanced search form

- app/design/frontend/Magento/luma/Magento_AdvancedCheckout/web/css/source/_module.less

  => is being used in wrong media query
  => can't test, this is probably a module from Magento Commerce, if somebody with access to that can figure out what this does and if the fix is ok, that would be great!
  1) it should probably apply the mixin ['.lib-clearfix'](https://github.com/magento/magento2/blob/2.3.2/lib/web/css/source/lib/_utilities.less#L54-L64) to that '.block-addbysku .block-content' selector in this module, after this fix it should actually do that, before this fix it probably won't be applied
  2) it should probably apply the mixin ['@abs-blocks-2columns'](https://github.com/magento/magento2/blob/2.3.2/app/design/frontend/Magento/luma/web/css/source/_extends.less#L169-L184) to that '.block-addbysku .block-content .box' selector in this module, after this fix it should actually do that, before this fix it probably won't be applied

- app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_estimated-total.less

  => is being used in wrong media query
  => won't change anything in generated css, except for fixing this compile problem

- app/design/frontend/Magento/luma/Magento_GiftMessage/web/css/source/_module.less

  => .abs-clearfix mixin is defined in backend module, so shouldn't be used in the frontend

- app/design/frontend/Magento/luma/Magento_Downloadable/web/css/source/_module.less

  => mixin '.clearer' was [first changed to '.mixin-clearer'](https://github.com/magento/magento2/commit/7249291d4bf#diff-b592349d70d86676439978ee25756c40L63), and [then later to '.lib-clearer'](https://github.com/magento/magento2/commit/993697797e3#diff-b592349d70d86676439978ee25756c40L65)
  => removing all together, it looks like these are no longer necessary

- lib/web/css/source/components/_modals.less

  => .abs-modal-overlay is defined in backend module but was used in lib code to be used in .modals-overlay which is used both on frontend and backend
  => moved the inclusion of .abs-modal-overlay to backend theme only, on frontend it will no longer be included (no problem: it didn't work before anyways)




# blank theme

- app/design/frontend/Magento/blank/Magento_Review/web/css/source/_module.less

  => .abs-rating-summary is defined in luma theme but used in blank theme, this makes no sense
  => so either we should remove its usage from blank theme, or add its definition to blank theme (its function is to align the stars of already submitted ratings nicely, not sure what to do here?)

- app/design/frontend/Magento/blank/Magento_Multishipping/web/css/source/_module.less
- app/design/frontend/Magento/blank/Magento_MultipleWishlist/web/css/source/_module.less
- app/design/frontend/Magento/blank/Magento_GiftRegistry/web/css/source/_module.less

  => .abs-account-title is defined in luma theme but used in blank theme, this makes no sense
  => so either we should remove its usage from blank theme, or add its definition to blank theme (not sure what to do here?)
  => I can't test the Magento_MultipleWishlist or Magento_GiftRegistry modules because they are part of Magento Commerce
```

Will update the description of the PR with clearer explanation once fully finished.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/23619: Less compilation extend 'mixin' has no matches

### Manual testing scenarios (*)
1. ...

### Questions or comments
Somebody with deep knowledge about blank & luma theme should best review. I think most of these changes are ok, but maybe it can still be reviewed by one of the original authors of these themes to be sure everything now works as intended.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
