### PR TITLE
"New Tax Rate" missing validation => data is automatically changed when saving issue 23967

### DIFF
--- a/app/code/Magento/Tax/Block/Adminhtml/Rate/Form.php
+++ b/app/code/Magento/Tax/Block/Adminhtml/Rate/Form.php
@@ -9,6 +9,8 @@
  *
  * @author      Magento Core Team <core@magentocommerce.com>
  */
+declare(strict_types=1);
+
 namespace Magento\Tax\Block\Adminhtml\Rate;
 
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -228,7 +230,8 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'note' => __(
                     "'*' - matches any; 'xyz*' - matches any that begins on 'xyz' and are not longer than %1.",
                     $this->_taxData->getPostCodeSubStringLength()
-                )
+                ),
+                'class' => 'validate-length maximum-length-' . $this->_taxData->getPostCodeSubStringLength()
             ]
         );
 

--- a/app/code/Magento/Tax/Test/Mftf/Data/TaxRateData.xml
+++ b/app/code/Magento/Tax/Test/Mftf/Data/TaxRateData.xml
@@ -117,4 +117,14 @@
         <data key="zip_is_range">0</data>
         <data key="rate">10</data>
     </entity>
+    <entity name="taxRateWithInvalidPostCodeLength" type="taxRate">
+        <data key="code" unique="suffix">Tax Rate </data>
+        <data key="tax_country_id">US</data>
+        <data key="tax_country">United States</data>
+        <data key="tax_region_id">12</data>
+        <data key="tax_region">California</data>
+        <data key="tax_postcode">12345678901</data>
+        <data key="zip_is_range">0</data>
+        <data key="rate">100.0000</data>
+    </entity>
 </entities>

--- a/app/code/Magento/Tax/Test/Mftf/Section/AdminTaxRateFormSection.xml
+++ b/app/code/Magento/Tax/Test/Mftf/Section/AdminTaxRateFormSection.xml
@@ -20,5 +20,6 @@
         <element name="rangeFrom" type="text" selector="#zip_from"/>
         <element name="rangeTo" type="text" selector="#zip_to"/>
         <element name="zipCode" type="input" selector="#tax_postcode"/>
+        <element name="fieldError" type="text" selector="//input[@name='{{fieldName}}']/following-sibling::label[@class='mage-error']" parameterized="true"/>
     </section>
 </sections>

--- a/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRateInvalidPostcodeTestLength.xml
+++ b/app/code/Magento/Tax/Test/Mftf/Test/AdminCreateTaxRateInvalidPostcodeTestLength.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminCreateTaxRateInvalidPostcodeTestLength">
+        <annotations>
+            <stories value="Create tax rate"/>
+            <title value="Create tax rate, invalid post code length"/>
+            <description value="Test log in to Create Tax Rate and Create Tax Rate with invalid post code length"/>
+            <testCaseId value="MC-18817"/>
+            <severity value="AVERAGE"/>
+            <group value="tax"/>
+            <group value="mtf_migrated"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+        </before>
+
+        <amOnPage url="{{AdminTaxRateGridPage.url}}" stepKey="goToTaxRateIndex1"/>
+        <waitForPageLoad stepKey="waitForTaxRateIndex1"/>
+        <!-- Create a tax rate for large postcodes -->
+        <click selector="{{AdminTaxRateGridSection.add}}" stepKey="clickAddNewTaxRateButton"/>
+        <fillField selector="{{AdminTaxRateFormSection.taxIdentifier}}" userInput="{{taxRateWithInvalidPostCodeLength.code}}" stepKey="fillRuleName"/>
+        <fillField selector="{{AdminTaxRateFormSection.zipCode}}" userInput="{{taxRateWithInvalidPostCodeLength.tax_postcode}}" stepKey="fillPostCode"/>
+        <selectOption selector="{{AdminTaxRateFormSection.country}}" userInput="{{taxRateWithInvalidPostCodeLength.tax_country}}" stepKey="selectCountry1"/>
+        <selectOption selector="{{AdminTaxRateFormSection.state}}" userInput="{{taxRateWithInvalidPostCodeLength.tax_region}}" stepKey="selectState" />
+        <fillField selector="{{AdminTaxRateFormSection.rate}}" userInput="{{taxRateWithInvalidPostCodeLength.rate}}" stepKey="fillRate"/>
+        <click selector="{{AdminTaxRateFormSection.save}}" stepKey="clickSave"/>
+        <see selector="{{AdminTaxRateFormSection.fieldError('tax_postcode')}}" userInput="Please enter less or equal than 10 symbols." stepKey="seeErrorMessage"/>
+    </test>
+</tests>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Resolve magento/magento2#23967: "New Tax Rate" missing validation => data is automatically changed when saving

Problem: Missing the "validate-length maximum-length" validate
Solution: Add to the class

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23967: "New Tax Rate" missing validation => data is automatically changed when saving

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Store -> Tax Zone and Rate
2. New Tax Rate
3. Fill: 12345678901 (over 10 character) in "Zip/Post Code"
4. Save
**=> Don't allow to save**

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
