### PR TITLE
No validation "Sort Order" in "New Rating" form issue 23984

### DIFF
--- a/app/code/Magento/Review/Block/Adminhtml/Rating/Edit/Tab/Form.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Rating/Edit/Tab/Form.php
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types = 1);
+
 namespace Magento\Review\Block\Adminhtml\Rating\Edit\Tab;
 
+/**
+ * Class Magento\Review\Block\Adminhtml\Rating\Edit\Tab\Form
+ */
 class Form extends \Magento\Backend\Block\Widget\Form\Generic
 {
     /**
@@ -227,7 +232,15 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             ['label' => __('Is Active'), 'name' => 'is_active', 'value' => 1]
         );
         $this->getFieldset('visibility_form')
-            ->addField('position', 'text', ['label' => __('Sort Order'), 'name' => 'position']);
+            ->addField(
+                'position',
+                'text',
+                [
+                    'label' => __('Sort Order'),
+                    'name' => 'position',
+                    'class' => 'validate-not-negative-number'
+                ]
+            );
     }
 
     /**

--- a/app/code/Magento/Review/Block/Adminhtml/Rating/Edit/Tab/Form.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Rating/Edit/Tab/Form.php
@@ -255,8 +255,6 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         if (!isset($this->fieldset[$formId])) {
             if (!$this->getForm()->getElement($formId)) {
                 $this->fieldset[$formId] = $this->getForm()->addFieldset($formId, $config);
-            } elseif ($this->getForm()->getElement($formId)) {
-                //do nothing
             }
         }
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. Resolve magento/magento2#23984: No validation "Sort Order" in "New Rating" form

Solution : Add class "validate-not-negative-number" to sort order field

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23984: No validation "Sort Order" in "New Rating" form

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Stores-> Rating
2. Add New Rating
3. Fill All information, "Sort Order" fill "one"
4. Save Rating 
=> Can not save

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
