### PR TITLE
fix: escapeUrl("0") should return "0", not ""

### DIFF
--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -335,8 +335,16 @@ class Escaper
      */
     private function escapeScriptIdentifiers(string $data): string
     {
-        $filteredData = preg_replace('/[\x00-\x1F\x7F\xA0]/u', '', $data) ?: '';
-        $filteredData = preg_replace(self::$xssFiltrationPattern, ':', $filteredData) ?: '';
+        $filteredData = preg_replace('/[\x00-\x1F\x7F\xA0]/u', '', $data);
+        if ($filteredData === false || $filteredData === '') {
+            return '';
+        }
+
+        $filteredData = preg_replace(self::$xssFiltrationPattern, ':', $filteredData);
+        if ($filteredData === false) {
+            return '';
+        }
+
         if (preg_match(self::$xssFiltrationPattern, $filteredData)) {
             $filteredData = $this->escapeScriptIdentifiers($filteredData);
         }

--- a/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
@@ -344,6 +344,10 @@ class EscaperTest extends \PHPUnit\Framework\TestCase
     {
         return [
             [
+                '0',
+                '0',
+            ],
+            [
                 'javascript%3Aalert%28String.fromCharCode%280x78%29%2BString.'
                 . 'fromCharCode%280x73%29%2BString.fromCharCode%280x73%29%29',
                 ':alert%28String.fromCharCode%280x78%29%2BString.'


### PR DESCRIPTION
### Description (*)
Fixed: #23987

previously, we assumed that when removing XSS-like script URLs, the only
non-truthy result would be a failure in preg_replace, or an empty
string. A value of "0" would therefor pass through the script-tag
check, but then be converted into the empty string because it is
non-truthy.

instead, we now specifically test for those values which we want to
convert into an empty string, and do so immediately. This allows the
value of "0" to remain intact when passed through a escape methods such
as encodeUrlParam(...) or escapeUrl(...)

### Fixed Issues (if relevant)
1. magento/magento2#23987: Escaper#escapeXssInUrl (internally: Escaper#escapeScriptIdentifiers) incorrectly convert un-truthy values to empty string

### Manual testing scenarios (*)
1. use of $this->_escaper->escapeUrl("0") should return "0" in block context
2. use of $this->_escaper->encodeUrlParam("0") should return "0" in block context
3. (unit test data has been included)

### Questions or comments
Arguably, this is not the "real" solution. Theoretically, this happens
because of the expectation that escapeXssInUrl should only be called
on "full" URLs, and is intended to remove URLs such as
"javascript:alert('I am an XSS attack')". However, escapeXssInUrl is
used by escapeUrl, which is in-turn used by encodeUrlParam. I believe
this to potentially be a bug in encodeUrlParam, which (by its name)
seems to be intended to actually do something similar to PHP's builtin
urlencode(...) function.

I consider this to be a separate issue, however, and this change would
both fix the encodeUrlParam case for this specific issue, while not
negatively-impacting the pathological case of the string "0" being
passed to escapeUrl directly.

I'm not sure how to check that "all builds are green"

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [?] All automated tests passed successfully (all builds are green)
