### PR TITLE
Fixes less compilation problems in the Magento/blank theme

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/components/_modals_extend.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/components/_modals_extend.less
@@ -33,6 +33,10 @@
 
 //
 
+.modals-overlay {
+    &:extend(.abs-modal-overlay all);
+}
+
 .modal-popup,
 .modal-slide {
     .action-close {

--- a/app/design/frontend/Magento/blank/Magento_AdvancedCheckout/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_AdvancedCheckout/web/css/source/_module.less
@@ -53,12 +53,6 @@
             }
 
             .block-content {
-                &:extend(.abs-add-clearfix-desktop all);
-
-                .box {
-                    &:extend(.abs-blocks-2columns all);
-                }
-
                 .actions-toolbar {
                     clear: both;
                     .lib-actions-toolbar(
@@ -165,6 +159,18 @@
 
         .block-content {
             &:extend(.abs-add-clearfix-desktop all);
+        }
+    }
+
+    .column {
+        .block-addbysku {
+            .block-content {
+                &:extend(.abs-add-clearfix-desktop all);
+
+                .box {
+                    &:extend(.abs-blocks-2columns all);
+                }
+            }
         }
     }
 }

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_estimated-total.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_estimated-total.less
@@ -15,7 +15,6 @@
 
     .opc-estimated-wrapper {
         &:extend(.abs-add-clearfix all);
-        &:extend(.abs-no-display-desktop all);
         .lib-css(border-bottom, @border-width__base solid @color-gray80);
         margin: 0 0 15px;
         padding: 18px 15px;
@@ -37,7 +36,7 @@
                     &:before {
                         .lib-css(color, @button__color);
                     }
-                    
+
                     &:hover:before {
                         .lib-css(color, @button__hover__color);
                     }
@@ -53,6 +52,6 @@
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .opc-estimated-wrapper {
-        display: none;
+        &:extend(.abs-no-display-desktop all);
     }
 }

--- a/app/design/frontend/Magento/blank/Magento_GiftMessage/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_GiftMessage/web/css/source/_module.less
@@ -18,7 +18,6 @@
 & when (@media-common = true) {
     .gift-message {
         .field {
-            &:extend(.abs-clearfix all);
             margin-bottom: @indent__base;
 
             .label {

--- a/app/design/frontend/Magento/blank/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_extends.less
@@ -850,6 +850,24 @@
 }
 
 //
+//  Account pages: title
+//  ---------------------------------------------
+
+& when (@media-common = true) {
+    .abs-account-title {
+        > strong,
+        > span {
+            .lib-font-size(22);
+            .lib-css(font-weight, @font-weight__light);
+        }
+
+        .lib-css(border-bottom, 1px solid @border-color__base);
+        .lib-css(margin-bottom, @indent__m);
+        .lib-css(padding-bottom, @indent__s);
+    }
+}
+
+//
 //  Ratings: vertical alignment
 //  ---------------------------------------------
 

--- a/app/design/frontend/Magento/blank/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_extends.less
@@ -179,7 +179,7 @@
 & when (@media-common = true) {
     .abs-block-title {
         margin-bottom: 15px;
-        
+
         > strong {
             .lib-heading(h3);
         }
@@ -194,7 +194,7 @@
     .abs-account-blocks {
         .block-title {
             &:extend(.abs-block-title all);
-            
+
             > .action {
                 margin-left: 15px;
             }
@@ -844,6 +844,33 @@
 
             .product-item-name {
                 margin: 0;
+            }
+        }
+    }
+}
+
+//
+//  Ratings: vertical alignment
+//  ---------------------------------------------
+
+& when (@media-common = true) {
+    .abs-rating-summary {
+        .rating {
+            &-summary {
+                display: table-row;
+            }
+
+            &-label {
+                display: table-cell;
+                padding-bottom: @indent__xs;
+                padding-right: @indent__m;
+                padding-top: 1px;
+                vertical-align: top;
+            }
+
+            &-result {
+                display: table-cell;
+                vertical-align: top;
             }
         }
     }

--- a/app/design/frontend/Magento/luma/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_extends.less
@@ -1212,7 +1212,7 @@
 }
 
 //
-//  Forms: margin-bottom for small forms
+//  Ratings: vertical alignment
 //  ---------------------------------------------
 
 & when (@media-common = true) {

--- a/lib/web/css/source/components/_modals.less
+++ b/lib/web/css/source/components/_modals.less
@@ -150,7 +150,6 @@
 
     //  Modals overlay
     .modals-overlay {
-        &:extend(.abs-modal-overlay all);
         .lib-css(z-index, @overlay__z-index);
     }
 


### PR DESCRIPTION
### Description (*)

Hi

This PR is fixing less compilation problems in Magento's Blank theme as being reported in https://github.com/magento/magento2/issues/23619
A PR for fixing similar problems in the Luma theme exists [over here](https://github.com/magento/magento2/pull/24003).

These less compilation problems can be found when using the [original less.js compiler](http://lesscss.org/). Using version 2 or 3 of this compiler will output these problems.
These problems aren't being shown when using the [php port of this compiler](https://github.com/wikimedia/less.php/) which Magento uses by default.

But the fact that these compilation errors are being reported means that certain less code in Magento isn't quite right.
And by digging in further, I was able to fix some problems which even improve the rendering on the frontend for features which were supposed to work, but didn't work due to these (hidden) errors.

This PR consists of 5 commits.

#### Commit 1
The first commit is not directly related to the Blank theme, but caused a compilation problem with the Blank theme nonetheless:
1) The selector `.abs-modal-overlay` is being defined in the backend theme, but used in the `lib` code, so that's incorrect. Moved the usage to the backend theme. The resulting css files don't change by doing this.

#### Commit 2
The second commit is simply cleanup of code causing most of the compilation problems:

1) The selector `.abs-no-display-desktop` was being used in a different media query then where it was defined, resulting in the compiler not being able to find it. By moving it in the correct media query, we fix the compilation problem.
2) The selector `.abs-clearfix` is being defined in the backend theme, but was being used in a frontend theme, so this never worked, removed its usage on the frontend in this case.

After this second commit, the resulting CSS is almost unchanged, except for a single change which cuts down the filesize of the resulting css file a tiny bit while do keeping the css code the same in behavior.
This is the diff of the css files after the second commit:

```diff
$ diff -ur before/static/frontend/ after/pub/static/frontend/
diff -ur before/static/frontend/Magento/blank/en_US/css/styles-l.css after/pub/static/frontend/Magento/blank/en_US/css/styles-l.css
--- before/static/frontend/Magento/blank/en_US/css/styles-l.css 2019-08-01 20:53:24.000000000 +0200
+++ after/pub/static/frontend/Magento/blank/en_US/css/styles-l.css  2019-08-01 21:03:10.000000000 +0200
@@ -248,6 +248,7 @@
     margin-bottom: 0;
   }
   .abs-no-display-desktop,
+  .opc-estimated-wrapper,
   .sidebar .block.widget .pager .item:not(.pages-item-next):not(.pages-item-previous) {
     display: none;
   }
@@ -1313,9 +1314,6 @@
     float: right;
     margin: 22px 0 0;
   }
-  .opc-estimated-wrapper {
-    display: none;
-  }
   .opc-progress-bar-item {
     width: 185px;
   }
```

#### Commit 3
The third commit should in theory improve the rendering of a certain component in Magento Commerce.
Unfortunately I don't have a copy over here at the moment of Magento Commerce to test this out.
So if somebody could test this out in the Magento_AdvancedCheckout module on the frontend to see how and what this fixes exactly, that would be great!
  1) it should probably apply the mixin [`.lib-clearfix`](https://github.com/magento/magento2/blob/2.3.2/lib/web/css/source/lib/_utilities.less#L54-L64) to that `.block-addbysku .block-content` selector in this module
  2) it should probably apply the mixin [`@abs-blocks-2columns`](https://github.com/magento/magento2/blob/2.3.2/app/design/frontend/Magento/luma/web/css/source/_extends.less#L169-L184) to that `.block-addbysku .block-content .box` selector in this module
After this fix it should actually apply these mixins, before this fix these probably weren't being applied.

The diff in the generated css file after the third commit is a little bit more involved:

```diff
$ diff -ur before/pub/static/frontend/ after/pub/static/frontend/
diff -ur before/pub/static/frontend/Magento/blank/en_US/css/styles-l.css after/pub/static/frontend/Magento/blank/en_US/css/styles-l.css
--- before/pub/static/frontend/Magento/blank/en_US/css/styles-l.css 2019-08-01 20:53:24.000000000 +0200
+++ after/pub/static/frontend/Magento/blank/en_US/css/styles-l.css  2019-08-01 21:14:41.000000000 +0200
@@ -56,6 +56,7 @@
     width: auto;
   }
   .abs-blocks-2columns,
+  .column .block-addbysku .block-content .box,
   .login-container .block,
   .account .column.main .block:not(.widget) .block-content .box,
   .magento-rma-guest-returns .column.main .block:not(.widget) .block-content .box,
@@ -63,6 +64,7 @@
   .sales-guest-view .column.main .block:not(.widget) .block-content .box {
     width: 48.8%;
   }
+  .column .block-addbysku .block-content .box:nth-child(odd),
   .login-container .block:nth-child(odd),
   .account .column.main .block:not(.widget) .block-content .box:nth-child(odd),
   .magento-rma-guest-returns .column.main .block:not(.widget) .block-content .box:nth-child(odd),
@@ -71,6 +73,7 @@
     clear: left;
     float: left;
   }
+  .column .block-addbysku .block-content .box:nth-child(even),
   .login-container .block:nth-child(even),
   .account .column.main .block:not(.widget) .block-content .box:nth-child(even),
   .magento-rma-guest-returns .column.main .block:not(.widget) .block-content .box:nth-child(even),
@@ -134,6 +137,8 @@
   .abs-pager-toolbar:after,
   .block-cart-failed .block-content:before,
   .block-cart-failed .block-content:after,
+  .column .block-addbysku .block-content:before,
+  .column .block-addbysku .block-content:after,
   .cart-container:before,
   .cart-container:after,
   .login-container:before,
@@ -174,6 +179,7 @@
   .abs-add-clearfix-desktop:after,
   .abs-pager-toolbar:after,
   .block-cart-failed .block-content:after,
+  .column .block-addbysku .block-content:after,
   .cart-container:after,
   .login-container:after,
   .account .column.main .block:not(.widget) .block-content:after,
```

#### Commit 4
The definition `.abs-rating-summary` only existed in the Luma theme, but was being used in the Blank theme, so that didn't work. This definition is now copied over to the Blank theme so it can work again. This results in the stars of accepted product ratings to be vertically aligned.
Also changed the comment above the definition in the Luma theme, as it was incorrectly copy/pasted from the block above.

The diff in the generated css after the fourth commit is:
```diff
$ diff -ur before/pub/static/ after/pub/static/
diff -ur before/pub/static/frontend/Magento/blank/en_US/css/styles-m.css after/pub/static/frontend/Magento/blank/en_US/css/styles-m.css
--- before/pub/static/frontend/Magento/blank/en_US/css/styles-m.css   2019-08-11 13:07:07.000000000 +0200
+++ after/pub/static/frontend/Magento/blank/en_US/css/styles-m.css    2019-08-11 13:12:10.000000000 +0200
@@ -2043,6 +2043,20 @@
 .price-excluding-tax .cart-tax-total-expanded:after {
   content: '\e621';
 }
+.review-ratings .rating-summary {
+  display: table-row;
+}
+.review-ratings .rating-label {
+  display: table-cell;
+  padding-bottom: 5px;
+  padding-right: 25px;
+  padding-top: 1px;
+  vertical-align: top;
+}
+.review-ratings .rating-result {
+  display: table-cell;
+  vertical-align: top;
+}
 .block-minicart .subtotal .label:after,
 .minicart-items .details-qty .label:after,
 .minicart-items .price-minicart .label:after,
```

#### Commit 5
The definition `.abs-account-title` only existed in the Luma theme, but was being used in the Blank theme, so that didn't work. This definition is now copied over to the Blank theme so it can work again. This results in the titles on certain pages to be styled slightly differently (bigger font-size, more margin-bottom), modules affected: `Magento_GiftRegistry`, `Magento_MultipleWishlist` & `Magento_Multishipping`
After copying, I've changed the variable in the definition for the border color from `@account-title-border-color` to `@border-color__base` as the former doesn't exist in the Blank theme.

The diff in the generated css after the fifth commit is:
```diff
$ diff -ur before/pub/static/ after/pub/static/
diff -ur before/pub/static/frontend/Magento/blank/en_US/css/styles-m.css after/pub/static/frontend/Magento/blank/en_US/css/styles-m.css
--- before/pub/static/frontend/Magento/blank/en_US/css/styles-m.css   2019-08-11 13:07:07.000000000 +0200
+++ after/pub/static/frontend/Magento/blank/en_US/css/styles-m.css    2019-08-11 13:20:38.000000000 +0200
@@ -2043,6 +2043,39 @@
 .price-excluding-tax .cart-tax-total-expanded:after {
   content: '\e621';
 }
+.form-giftregistry-search .legend,
+.block-wishlist-search-form .block-title,
+.multicheckout .block-title,
+.multicheckout .block-content .title {
+  border-bottom: 1px solid #d1d1d1;
+  margin-bottom: 25px;
+  padding-bottom: 10px;
+}
+.form-giftregistry-search .legend > strong,
+.form-giftregistry-search .legend > span,
+.block-wishlist-search-form .block-title > strong,
+.block-wishlist-search-form .block-title > span,
+.multicheckout .block-title > strong,
+.multicheckout .block-title > span,
+.multicheckout .block-content .title > strong,
+.multicheckout .block-content .title > span {
+  font-size: 2.2rem;
+  font-weight: 300;
+}
.review-ratings .rating-summary {
  display: table-row;
}
```

### Fixed Issues (if relevant)

1. https://github.com/magento/magento2/issues/23619: Less compilation extend 'mixin' has no matches

### Manual testing scenarios (*)

1. Have nodejs installed (I'm using v8.16.0)
2. Install the latest version of the less.js compiler in the project (3.9.0 at the time of writing): `npm install less@3.9.0`
3. Remove temporarily created frontend files (if any): `rm -R var/view_preprocessed/* pub/static/*`
4. Generate intermediate files before less compilation can happen: `bin/magento dev:source-theme:deploy --theme=Magento/blank --locale=en_US`
5. Now lint the `styles-m.less` file using the less.js compiler: `node_modules/.bin/lessc -l var/view_preprocessed/pub/static/frontend/Magento/blank/en_US/css/styles-m.less`
6. Expected is to not get any errors, before this fix it would output the errors:
```
extend ' .abs-modal-overlay' has no matches
extend ' .abs-add-clearfix-desktop' has no matches
extend ' .abs-blocks-2columns' has no matches
extend ' .abs-no-display-desktop' has no matches
extend ' .abs-clearfix' has no matches
extend ' .abs-account-title' has no matches
extend ' .abs-rating-summary' has no matches
```
7. Also do a full `rm -R var/view_preprocessed/* pub/static/*; bin/magento setup:static-content:deploy -f --theme=Magento/blank --theme=Magento/luma --theme=Magento/backend en_US` and compare the changes between the resulting css files without and with these fixes, only changed css files should be in the Blank theme, no other theme's css files should have changed
8. Then look if these changes didn't cause regressions on the frontend when the Blank theme is being used

    - You can check in the frontend if the selector `.opc-estimated-wrapper` is still being hidden when the screens width >= 768px after this change on the checkout page:
      <img width="1785" alt="Screenshot 2019-08-03 at 10 54 26" src="https://user-images.githubusercontent.com/85479/62410052-b70e9a00-b5e0-11e9-847e-d5b727682c6f.png">

    - Somebody with access to Magento Commerce, should look at what happens to the following selectors and see if these are now being rendered properly (before the fix there should be something wrong with the layout I'm assuming):
        - `.column .block-addbysku .block-content .box`
        - `.column .block-addbysku .block-content .box:nth-child(odd)`
        - `.column .block-addbysku .block-content .box:nth-child(even)`
        - `.column .block-addbysku .block-content:before`
        - `.column .block-addbysku .block-content:after` 

    - Have some accepted product review with ratings and see if the stars are vertically aligned:
      <img width="503" alt="Screenshot 2019-08-11 at 13 23 49" src="https://user-images.githubusercontent.com/85479/62833259-0c2f5900-bc3c-11e9-9db0-0422711f4970.png">

    - Certain titles in the modules `Magento_GiftRegistry`, `Magento_MultipleWishlist` & `Magento_Multishipping` should be styled a bit differently, the font-size should be `2.2rem` instead of `1.8rem` and the margin-bottom increases from `15px` to `25px`.
       I could only test this with the `Magento_Multishipping` module, the other two are part of Magento Commerce of which I don't have an installation running here. So those should be checked as well I assume?

       Before:
       <img width="1025" alt="Screenshot 2019-08-11 at 13 05 28" src="https://user-images.githubusercontent.com/85479/62833234-b3f85700-bc3b-11e9-8c44-69a9e61f42a6.png">

       After:
       <img width="1025" alt="Screenshot 2019-08-11 at 13 05 44" src="https://user-images.githubusercontent.com/85479/62833238-bf4b8280-bc3b-11e9-86ff-c8e15f6739c8.png">


### Questions or comments
It would be nice if Magento could get some automated test which uses the less.js compiler linting mode to detect these problems.
Since one of these compilation problems was [recently introduced](https://github.com/magento/magento2/commit/ffbf8e6da2f5#diff-3df2988da960a31971a90e02c78804b8R132) in the Luma theme code, it probably can't hurt to do some automated testing to prevent this from happening again in the future.
See Manual testing scenario above for the commands needed to detect this.

### Contribution checklist (*)

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
