### PR TITLE
Resolve "Currency Converter API" can not get Currency Rate

### DIFF
--- a/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
@@ -103,7 +103,7 @@ class CurrencyConverterApi extends AbstractImport
                         $data[$currencyFrom][$to] = null;
                     } else {
                         if (isset($response['error']) && $response['error']) {
-                            $this->_messages[] = __($response['error']);
+                            $this->_messages[] = $response['error'];
                             $data[$currencyFrom][$to] = null;
                         } else {
                             $data[$currencyFrom][$to] = $this->_numberFormat(

--- a/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
@@ -17,12 +17,7 @@ class CurrencyConverterApi extends AbstractImport
     /**
      * @var string
      */
-    const CURRENCY_CONVERTER_URL = 'http://free.currencyconverterapi.com/api/v3/convert?q={{CURRENCY_FROM}}_{{CURRENCY_TO}}&compact=ultra'; //@codingStandardsIgnoreLine
-
-    /**
-     * @var string
-     */
-    const API_KEY = 'apiKey';
+    const CURRENCY_CONVERTER_URL = 'http://free.currencyconverterapi.com/api/v3/convert?q={{CURRENCY_FROM}}_{{CURRENCY_TO}}&compact=ultra&apiKey={{API_KEY}}'; //@codingStandardsIgnoreLine
 
     /**
      * Http Client Factory
@@ -98,7 +93,7 @@ class CurrencyConverterApi extends AbstractImport
             try {
                 $url = str_replace('{{CURRENCY_FROM}}', $currencyFrom, self::CURRENCY_CONVERTER_URL);
                 $url = str_replace('{{CURRENCY_TO}}', $to, $url);
-                $url = $url . '&' . self::API_KEY . '=' . $apiKey;
+                $url = str_replace('{{API_KEY}}', $apiKey, $url);
                 $response = $this->getServiceResponse($url);
                 if ($currencyFrom == $to) {
                     $data[$currencyFrom][$to] = $this->_numberFormat(1);

--- a/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/CurrencyConverterApi.php
@@ -103,7 +103,9 @@ class CurrencyConverterApi extends AbstractImport
                         $data[$currencyFrom][$to] = null;
                     } else {
                         if (isset($response['error']) && $response['error']) {
-                            $this->_messages[] = $response['error'];
+                            if (!in_array($response['error'], $this->_messages)) {
+                                $this->_messages[] = $response['error'];
+                            }
                             $data[$currencyFrom][$to] = null;
                         } else {
                             $data[$currencyFrom][$to] = $this->_numberFormat(

--- a/app/code/Magento/Directory/etc/adminhtml/system.xml
+++ b/app/code/Magento/Directory/etc/adminhtml/system.xml
@@ -47,7 +47,12 @@
             </group>
             <group id="currencyconverterapi" translate="label" sortOrder="45" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Currency Converter API</label>
-                <field id="timeout" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="api_key" translate="label" type="obscure" sortOrder="0" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>API Key</label>
+                    <config_path>currency/currencyconverterapi/api_key</config_path>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                </field>
+                <field id="timeout" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Connection Timeout in Seconds</label>
                 </field>
             </group>

--- a/app/code/Magento/Directory/etc/config.xml
+++ b/app/code/Magento/Directory/etc/config.xml
@@ -24,6 +24,7 @@
             </fixerio>
             <currencyconverterapi>
                 <timeout>100</timeout>
+                <api_key backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
             </currencyconverterapi>
             <import>
                 <enabled>0</enabled>

--- a/app/code/Magento/Directory/i18n/en_US.csv
+++ b/app/code/Magento/Directory/i18n/en_US.csv
@@ -52,3 +52,4 @@ Service,Service
 "The """%1"" is not allowed as base currency for your subscription plan.","The """%1"" is not allowed as base currency for your subscription plan."
 "An invalid base currency has been entered.","An invalid base currency has been entered."
 "Currency rates can't be retrieved.","Currency rates can't be retrieved."
+"No API Key was specified.","No API Key was specified."


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Resolve "Currency Converter API" can not get Currency Rate.

As my inspection, https://free.currencyconverterapi.com/ now required the API key.

![image](https://user-images.githubusercontent.com/8234209/62417641-fb507780-b67e-11e9-8822-914427e28af4.png)

But now in Magento 2.3, it doesn't have the API Key config. => Missing information and can not get the rate.

Solution: Add the "API Key" config to the settings, pass the key to the API Url.
- also Process the "Error" response (to fix the issue magento/magento2#24007 -**Notice: Undefined index** ) 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24007: "Currency Converter API" notify "Notice: Undefined index" when import currency rate
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
**- When no fill API Key**

1. Go to Backend
2. Store -> Currency Rate
3. "Import Service" choose "Currency Converter API"
4. Click "Import"

#### Expected result 
1. Notify correct error message 

**- When fill correct API Key**
1. Get API from https://free.currencyconverterapi.com/ (by register)
2. Store->Configurations->Currency Setup
3. Currency Converter API -> API Key. Fill the **API Key** get from email which sent by https://free.currencyconverterapi.com/
4. Store -> Currency Rate
5.  "Import Service" choose "Currency Converter API"
6. Click "Import"

#### Expected result 
1. Get the rate successfully from currencyconverterapi

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
