### PR TITLE
Refactor Shipping Address loading for Checkout to improve Performance if multiple addresses are given

### DIFF
--- a/app/code/Magento/Customer/view/frontend/web/js/model/address-list.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/model/address-list.js
@@ -12,9 +12,10 @@ define([
 ], function (ko, defaultProvider) {
     'use strict';
 
-    let customerAddresses = ko.observableArray([]).extend({ deferred: true });
+    let customerAddresses = ko.observableArray([]).extend({
+            deferred: true
+        });
     let customerAddressesDataArray = customerAddresses();
-
     let addressItems = defaultProvider.getAddressItems();
 
     ko.utils.arrayPushAll(

--- a/app/code/Magento/Customer/view/frontend/web/js/model/address-list.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/model/address-list.js
@@ -16,11 +16,10 @@ define([
     let customerAddressesDataArray = customerAddresses();
 
     let addressItems = defaultProvider.getAddressItems();
-    let mappedAddresses = addressItems ? addressItems.map(address => address) : [];
 
     ko.utils.arrayPushAll(
         customerAddressesDataArray,
-        mappedAddresses
+        addressItems
     );
 
     customerAddresses.valueHasMutated();

--- a/app/code/Magento/Customer/view/frontend/web/js/model/address-list.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/model/address-list.js
@@ -12,5 +12,18 @@ define([
 ], function (ko, defaultProvider) {
     'use strict';
 
-    return ko.observableArray(defaultProvider.getAddressItems());
+    let customerAddresses = ko.observableArray([]).extend({ deferred: true });
+    let customerAddressesDataArray = customerAddresses();
+
+    let addressItems = defaultProvider.getAddressItems();
+    let mappedAddresses = addressItems ? addressItems.map(address => address) : [];
+
+    ko.utils.arrayPushAll(
+        customerAddressesDataArray,
+        mappedAddresses
+    );
+
+    customerAddresses.valueHasMutated();
+
+    return customerAddresses;
 });

--- a/app/code/Magento/Customer/view/frontend/web/js/model/customer-addresses.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/model/customer-addresses.js
@@ -22,8 +22,7 @@ define([
             let customerAddresses = window.customerData.addresses;
 
             /**
-             * @param address
-             * @return {Object}
+             * @param {Address} address
              */
             let toAddress = address => new Address(address);
 

--- a/app/code/Magento/Customer/view/frontend/web/js/model/customer-addresses.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/model/customer-addresses.js
@@ -21,8 +21,14 @@ define([
         getAddressItems: function () {
             let customerAddresses = window.customerData.addresses;
 
+            /**
+             * @param address
+             * @return {Object}
+             */
+            let toAddress = address => new Address(address);
+
             return isLoggedIn()
-                ? customerAddresses.map(address => new Address(address))
+                ? customerAddresses.map(toAddress)
                 : [];
         }
     };

--- a/app/code/Magento/Customer/view/frontend/web/js/model/customer-addresses.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/model/customer-addresses.js
@@ -7,31 +7,24 @@
  * @api
  */
 define([
-    'jquery',
     'ko',
     './customer/address'
-], function ($, ko, Address) {
+], function (ko, Address) {
     'use strict';
 
-    var isLoggedIn = ko.observable(window.isCustomerLoggedIn);
+    let isLoggedIn = ko.observable(window.isCustomerLoggedIn);
 
     return {
         /**
          * @return {Array}
          */
         getAddressItems: function () {
-            var items = [],
-                customerData = window.customerData;
+            let customerAddresses = window.customerData.addresses;
 
-            if (isLoggedIn()) {
-                if (Object.keys(customerData).length) {
-                    $.each(customerData.addresses, function (key, item) {
-                        items.push(new Address(item));
-                    });
-                }
-            }
-
-            return items;
+            return isLoggedIn()
+                ? customerAddresses.map(address => new Address(address))
+                : [];
         }
     };
+
 });

--- a/app/code/Magento/Customer/view/frontend/web/js/model/customer-addresses.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/model/customer-addresses.js
@@ -27,9 +27,7 @@ define([
              */
             let toAddress = address => new Address(address);
 
-            return isLoggedIn()
-                ? customerAddresses.map(toAddress)
-                : [];
+            return isLoggedIn() ? customerAddresses.map(toAddress) : [];
         }
     };
 


### PR DESCRIPTION
### Description (*)
Initializing ShippingAddresses in Magento_Checkout is coded in an old way. I just refactored the Code for customer-addresses.js and address-list.js and made use of more faster ways to iterate through the objects. Accessing the underlying Array of the knockout.observableArray and use ".arrayPushAll()" together with ".valueHasMutated()" is way faster than pushing data through "observableArray(newArray)" because we decrease the number of calls made inside knockout.
This way, we gain a significant improvement of loading speed and/or handling of a great amount of data (which we had as an issue for one of our customers)


### Manual testing scenarios (*)
1. We had to load 1.586 (no joke!) addresses for a customer, which resulted in a dying browser multiple times with the old code.
2. with new code the loading time of 1.586 Shipping Addresses takes about 5 seconds

### Questions or comments
Feel free to improve it more!

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
