### PR TITLE
Remove sr-only from subscribe button newsletter form

### DIFF
--- a/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
+++ b/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
@@ -30,7 +30,7 @@
                 </div>
             </div>
             <div class="actions">
-                <button class="action subscribe primary sr-only"
+                <button class="action subscribe primary"
                         title="<?= $block->escapeHtmlAttr(__('Subscribe')) ?>"
                         type="submit"
                         aria-label="Subscribe">


### PR DESCRIPTION
### Description (*)
Removed the sr-only from the button, to make it visable again.  
When using font-awesome or other frontend framework which has sr-only `defined`

### Fixed Issues
1. magento/magento2#24027: Issue title

### Manual testing scenarios (*)
1. Vanilla Magento 2.3.2
2. add CSS Font-Awsome (https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css) 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
