### PR TITLE
24025 add caching for magento product version

### DIFF
--- a/lib/internal/Magento/Framework/App/ProductMetadata.php
+++ b/lib/internal/Magento/Framework/App/ProductMetadata.php
@@ -14,6 +14,7 @@ use Magento\Framework\Composer\ComposerInformation;
 
 /**
  * Class ProductMetadata
+ *
  * @package Magento\Framework\App
  */
 class ProductMetadata implements ProductMetadataInterface

--- a/lib/internal/Magento/Framework/App/ProductMetadata.php
+++ b/lib/internal/Magento/Framework/App/ProductMetadata.php
@@ -51,6 +51,7 @@ class ProductMetadata implements ProductMetadataInterface
      * @var \Magento\Framework\Composer\ComposerInformation
      */
     private $composerInformation;
+
     /**
      * @var CacheInterface
      */

--- a/lib/internal/Magento/Framework/App/ProductMetadata.php
+++ b/lib/internal/Magento/Framework/App/ProductMetadata.php
@@ -32,7 +32,7 @@ class ProductMetadata implements ProductMetadataInterface
     /**
      * Magento Product Version Cache Key
      */
-    const MAGENTO_PRODUCT_VERSION_CACHE_KEY = 'magento-product-version';
+    private const MAGENTO_PRODUCT_VERSION_CACHE_KEY = 'magento-product-version';
 
     /**
      * Product version


### PR DESCRIPTION
fixes https://github.com/magento/magento2/issues/24025

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
add caching for product version, to not utilize composer runtime on every request to the magento product version.

While this method is called rarely in the core, many 3rd party extensions rely on it to determine the magento version. This leads to many "real" projects having >100ms added to non cached requests

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/magento2/issues/24025

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. have a module installed that relies on the product version to determine e.g. feature compatibility
2. profile uncached requests

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
