### PR TITLE
issue/24043: add better exception handling for cli commands

### DIFF
--- a/lib/internal/Magento/Framework/Console/Cli.php
+++ b/lib/internal/Magento/Framework/Console/Cli.php
@@ -102,6 +102,7 @@ class Cli extends Console\Application
      */
     public function doRun(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
     {
+        $exitCode = null;
         try {
             $exitCode = parent::doRun($input, $output);
         } catch (\Exception $e) {

--- a/lib/internal/Magento/Framework/Console/Cli.php
+++ b/lib/internal/Magento/Framework/Console/Cli.php
@@ -102,7 +102,11 @@ class Cli extends Console\Application
      */
     public function doRun(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
     {
-        $exitCode = parent::doRun($input, $output);
+        try {
+            $exitCode = parent::doRun($input, $output);
+        } catch (\Exception $e) {
+            $output->writeln($e->getTraceAsString());
+        }
 
         if ($this->initException) {
             throw $this->initException;

--- a/lib/internal/Magento/Framework/Console/Cli.php
+++ b/lib/internal/Magento/Framework/Console/Cli.php
@@ -214,6 +214,7 @@ class Cli extends Console\Application
         $commands = [];
         foreach (CommandLocator::getCommands() as $commandListClass) {
             if (class_exists($commandListClass)) {
+                // phpcs:ignore Magento2.Performance.ForeachArrayMerge
                 $commands = array_merge(
                     $commands,
                     $objectManager->create($commandListClass)->getCommands()


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24043: Better exception handling during cli commands

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Have a module with a wrong path in registration.php. For example set the path in vendor/magento/module-catalog/registration.php to __DIR__ . '/wrong_folder'
2. Run bin/magento setup:upgrade
3. See that it shows the actual exception (error with module registration)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
