### PR TITLE
Fix: Update customer email in quote

### DIFF
--- a/app/code/Magento/Customer/Observer/UpgradeQuoteCustomerEmailObserver.php
+++ b/app/code/Magento/Customer/Observer/UpgradeQuoteCustomerEmailObserver.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Customer\Observer;
 
@@ -36,25 +37,31 @@ class UpgradeQuoteCustomerEmailObserver implements ObserverInterface
      * @param Observer $observer
      * @return void
      */
-    public function execute(Observer $observer)
+    public function execute(Observer $observer): void
     {
+        /** @var \Magento\Customer\Model\Data\Customer $customerOrig */
+        $customerOrig = $observer->getEvent()->getOrigCustomerDataObject();
+        if (!$customerOrig) {
+            return;
+        }
+
+        $emailOrig = $customerOrig->getEmail();
+
         /** @var \Magento\Customer\Model\Data\Customer $customer */
         $customer = $observer->getEvent()->getCustomerDataObject();
         $email = $customer->getEmail();
 
-        /** @var \Magento\Customer\Model\Data\Customer $customerOrig */
-        $customerOrig = $observer->getEvent()->getOrigCustomerDataObject();
-        if ($customerOrig) {
-            $emailOrig = $customerOrig->getEmail();
-
-            if ($email != $emailOrig) {
-                try {
-                    $quote = $this->quoteRepository->getForCustomer($customer->getId());
-                    $quote->setCustomerEmail($email);
-                    $this->quoteRepository->save($quote);
-                } catch (NoSuchEntityException $e) {
-                }
-            }
+        if ($email == $emailOrig) {
+            return;
         }
+
+        try {
+            $quote = $this->quoteRepository->getForCustomer($customer->getId());
+            $quote->setCustomerEmail($email);
+            $this->quoteRepository->save($quote);
+        } catch (NoSuchEntityException $e) {
+            return;
+        }
+
     }
 }

--- a/app/code/Magento/Customer/Observer/UpgradeQuoteCustomerEmailObserver.php
+++ b/app/code/Magento/Customer/Observer/UpgradeQuoteCustomerEmailObserver.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 
 namespace Magento\Customer\Observer;
 
@@ -41,10 +45,11 @@ class UpgradeQuoteCustomerEmailObserver implements ObserverInterface
         $customerOrig = $observer->getEvent()->getOrigCustomerDataObject();
         $emailOrig = $customerOrig->getEmail();
 
-        if($email != $emailOrig){
-            $quote = $this->quoteRepository->getForCustomer($customer->getId());
-            $quote->setCustomerEmail($email);
-            $this->quoteRepository->save($quote);
+        if ($email != $emailOrig) {
+                $quote = $this->quoteRepository->getForCustomer($customer->getId());
+                $quote->setCustomerEmail($email);
+                $this->quoteRepository->save($quote);
+
         }
     }
 }

--- a/app/code/Magento/Customer/Observer/UpgradeQuoteCustomerEmailObserver.php
+++ b/app/code/Magento/Customer/Observer/UpgradeQuoteCustomerEmailObserver.php
@@ -14,40 +14,37 @@ class UpgradeQuoteCustomerEmailObserver implements ObserverInterface
     /**
      * @var CartRepositoryInterface
      */
-    private $cartRepository;
+    private $quoteRepository;
 
     /**
-     * @param CartRepositoryInterface $cartRepository
+     * @param CartRepositoryInterface $quoteRepository
      */
     public function __construct(
-        CartRepositoryInterface $cartRepository
+        CartRepositoryInterface $quoteRepository
     ) {
-        $this->cartRepository = $cartRepository;
+        $this->quoteRepository = $quoteRepository;
     }
 
     /**
      * Upgrade quote customer email when customer has changed email
+     *
      * @param Observer $observer
      * @return void
      */
     public function execute(Observer $observer)
     {
-        /**
-         * @var \Magento\Customer\Model\Data\Customer $customer
-         */
-        $customer = $observer->getEvent()->getData('customer_data_object');
+        /** @var \Magento\Customer\Model\Data\Customer $customer */
+        $customer = $observer->getEvent()->getCustomerDataObject();
         $email = $customer->getEmail();
 
-        /**
-         * @var \Magento\Customer\Model\Data\Customer $customer
-         */
-        $customerOrig = $observer->getEvent()->getData('orig_customer_data_object');
+        /** @var \Magento\Customer\Model\Data\Customer $customerOrig */
+        $customerOrig = $observer->getEvent()->getOrigCustomerDataObject();
         $emailOrig = $customerOrig->getEmail();
 
         if($email != $emailOrig){
-            $quote = $this->cartRepository->getForCustomer($customer->getId());
+            $quote = $this->quoteRepository->getForCustomer($customer->getId());
             $quote->setCustomerEmail($email);
-            $this->cartRepository->save($quote);
+            $this->quoteRepository->save($quote);
         }
     }
 }

--- a/app/code/Magento/Customer/Observer/UpgradeQuoteCustomerEmailObserver.php
+++ b/app/code/Magento/Customer/Observer/UpgradeQuoteCustomerEmailObserver.php
@@ -62,6 +62,5 @@ class UpgradeQuoteCustomerEmailObserver implements ObserverInterface
         } catch (NoSuchEntityException $e) {
             return;
         }
-
     }
 }

--- a/app/code/Magento/Customer/Observer/UpgradeQuoteCustomerEmailObserver.php
+++ b/app/code/Magento/Customer/Observer/UpgradeQuoteCustomerEmailObserver.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Magento\Customer\Observer;
+
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Quote\Api\CartRepositoryInterface;
+
+/**
+ * Class observer UpgradeQuoteCustomerEmailObserver
+ */
+class UpgradeQuoteCustomerEmailObserver implements ObserverInterface
+{
+    /**
+     * @var CartRepositoryInterface
+     */
+    private $cartRepository;
+
+    /**
+     * @param CartRepositoryInterface $cartRepository
+     */
+    public function __construct(
+        CartRepositoryInterface $cartRepository
+    ) {
+        $this->cartRepository = $cartRepository;
+    }
+
+    /**
+     * Upgrade quote customer email when customer has changed email
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        /**
+         * @var \Magento\Customer\Model\Data\Customer $customer
+         */
+        $customer = $observer->getEvent()->getData('customer_data_object');
+        $email = $customer->getEmail();
+
+        /**
+         * @var \Magento\Customer\Model\Data\Customer $customer
+         */
+        $customerOrig = $observer->getEvent()->getData('orig_customer_data_object');
+        $emailOrig = $customerOrig->getEmail();
+
+        if($email != $emailOrig){
+            $quote = $this->cartRepository->getForCustomer($customer->getId());
+            $quote->setCustomerEmail($email);
+            $this->cartRepository->save($quote);
+        }
+    }
+}

--- a/app/code/Magento/Customer/Observer/UpgradeQuoteCustomerEmailObserver.php
+++ b/app/code/Magento/Customer/Observer/UpgradeQuoteCustomerEmailObserver.php
@@ -8,6 +8,7 @@ namespace Magento\Customer\Observer;
 
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Api\CartRepositoryInterface;
 
 /**
@@ -43,13 +44,17 @@ class UpgradeQuoteCustomerEmailObserver implements ObserverInterface
 
         /** @var \Magento\Customer\Model\Data\Customer $customerOrig */
         $customerOrig = $observer->getEvent()->getOrigCustomerDataObject();
-        $emailOrig = $customerOrig->getEmail();
+        if ($customerOrig) {
+            $emailOrig = $customerOrig->getEmail();
 
-        if ($email != $emailOrig) {
-                $quote = $this->quoteRepository->getForCustomer($customer->getId());
-                $quote->setCustomerEmail($email);
-                $this->quoteRepository->save($quote);
-
+            if ($email != $emailOrig) {
+                try {
+                    $quote = $this->quoteRepository->getForCustomer($customer->getId());
+                    $quote->setCustomerEmail($email);
+                    $this->quoteRepository->save($quote);
+                } catch (NoSuchEntityException $e) {
+                }
+            }
         }
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Observer/UpgradeQuoteCustomerEmailObserverTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Observer/UpgradeQuoteCustomerEmailObserverTest.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 
 namespace Magento\Customer\Test\Unit\Observer;
 
@@ -19,8 +23,14 @@ class UpgradeQuoteCustomerEmailObserverTest extends \PHPUnit\Framework\TestCase
      */
     protected $quoteRepositoryMock;
 
+    /**
+     * @var \Magento\Framework\Event\Observer
+     */
     protected $observerMock;
 
+    /**
+     * @var \Magento\Framework\Event
+     */
     protected $eventMock;
 
     /**
@@ -46,7 +56,7 @@ class UpgradeQuoteCustomerEmailObserverTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     *
+     * Unit test for verifying quote customers email upgrade observer
      */
     public function testUpgradeQuoteCustomerEmail()
     {
@@ -75,6 +85,7 @@ class UpgradeQuoteCustomerEmailObserverTest extends \PHPUnit\Framework\TestCase
         $customer->expects($this->any())
             ->method('getEmail')
             ->willReturn($this->returnValue($email));
+
         $customerOrig->expects($this->any())
             ->method('getEmail')
             ->willReturn($this->returnValue($origEmail));

--- a/app/code/Magento/Customer/Test/Unit/Observer/UpgradeQuoteCustomerEmailObserverTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Observer/UpgradeQuoteCustomerEmailObserverTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Customer\Test\Unit\Observer;
 
@@ -82,13 +83,13 @@ class UpgradeQuoteCustomerEmailObserverTest extends \PHPUnit\Framework\TestCase
             ->method('getOrigCustomerDataObject')
             ->will($this->returnValue($customerOrig));
 
-        $customer->expects($this->any())
-            ->method('getEmail')
-            ->willReturn($this->returnValue($email));
-
         $customerOrig->expects($this->any())
             ->method('getEmail')
             ->willReturn($this->returnValue($origEmail));
+
+        $customer->expects($this->any())
+            ->method('getEmail')
+            ->willReturn($this->returnValue($email));
 
         $this->quoteRepositoryMock->expects($this->once())
             ->method('getForCustomer')

--- a/app/code/Magento/Customer/Test/Unit/Observer/UpgradeQuoteCustomerEmailObserverTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Observer/UpgradeQuoteCustomerEmailObserverTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Magento\Customer\Test\Unit\Observer;
+
+use Magento\Customer\Observer\UpgradeQuoteCustomerEmailObserver;
+
+/**
+ * Class UpgradeQuoteCustomerEmailObserverTest for testing upgrade quote customer email
+ */
+class UpgradeQuoteCustomerEmailObserverTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var UpgradeQuoteCustomerEmailObserver
+     */
+    protected $model;
+
+    /**
+     * @var \Magento\Quote\Api\CartRepositoryInterface
+     */
+    protected $quoteRepositoryMock;
+
+    protected $observerMock;
+
+    protected $eventMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->observerMock = $this->getMockBuilder(\Magento\Framework\Event\Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->eventMock = $this->getMockBuilder(\Magento\Framework\Event::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCustomerDataObject', 'getOrigCustomerDataObject'])
+            ->getMock();
+
+        $this->observerMock->expects($this->any())->method('getEvent')->will($this->returnValue($this->eventMock));
+
+        $this->quoteRepositoryMock = $this
+            ->getMockBuilder(\Magento\Quote\Api\CartRepositoryInterface::class)
+            ->getMockForAbstractClass();
+        $this->model = new UpgradeQuoteCustomerEmailObserver($this->quoteRepositoryMock);
+    }
+
+    /**
+     *
+     */
+    public function testUpgradeQuoteCustomerEmail()
+    {
+        $email = "test@test.com";
+        $origEmail = "origtest@test.com";
+
+        $customer = $this->getMockBuilder(\Magento\Customer\Api\Data\CustomerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $customerOrig = $this->getMockBuilder(\Magento\Customer\Api\Data\CustomerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $quoteMock = $this->getMockBuilder(\Magento\Quote\Model\Quote::class)
+            ->setMethods(['setCustomerEmail'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->eventMock->expects($this->any())
+            ->method('getCustomerDataObject')
+            ->will($this->returnValue($customer));
+        $this->eventMock->expects($this->any())
+            ->method('getOrigCustomerDataObject')
+            ->will($this->returnValue($customerOrig));
+
+        $customer->expects($this->any())
+            ->method('getEmail')
+            ->willReturn($this->returnValue($email));
+        $customerOrig->expects($this->any())
+            ->method('getEmail')
+            ->willReturn($this->returnValue($origEmail));
+
+        $this->quoteRepositoryMock->expects($this->once())
+            ->method('getForCustomer')
+            ->willReturn($quoteMock);
+
+        $quoteMock->expects($this->once())
+            ->method('setCustomerEmail');
+
+        $this->quoteRepositoryMock->expects($this->once())
+            ->method('save')
+            ->with($quoteMock);
+
+        $this->model->execute($this->observerMock);
+    }
+}

--- a/app/code/Magento/Customer/etc/events.xml
+++ b/app/code/Magento/Customer/etc/events.xml
@@ -15,4 +15,7 @@
     <event name="sales_quote_save_after">
         <observer name="customer_visitor" instance="Magento\Customer\Observer\Visitor\BindQuoteCreateObserver" />
     </event>
+    <event name="customer_save_after_data_object">
+        <observer name="upgrade_quote_customer_email" instance="Magento\Customer\Observer\UpgradeQuoteCustomerEmailObserver"/>
+    </event>
 </config>

--- a/app/code/Magento/Customer/etc/frontend/events.xml
+++ b/app/code/Magento/Customer/etc/frontend/events.xml
@@ -29,4 +29,7 @@
         <observer name="customer_password" instance="Magento\Customer\Observer\UpgradeCustomerPasswordObserver" />
         <observer name="customer_unlock" instance="Magento\Customer\Observer\CustomerLoginSuccessObserver" />
     </event>
+    <event name="customer_save_after_data_object">
+        <observer name="upgrade_quote_customer_email" instance="Magento\Customer\Observer\UpgradeQuoteCustomerEmailObserver"/>
+    </event>
 </config>

--- a/app/code/Magento/Customer/etc/frontend/events.xml
+++ b/app/code/Magento/Customer/etc/frontend/events.xml
@@ -29,7 +29,4 @@
         <observer name="customer_password" instance="Magento\Customer\Observer\UpgradeCustomerPasswordObserver" />
         <observer name="customer_unlock" instance="Magento\Customer\Observer\CustomerLoginSuccessObserver" />
     </event>
-    <event name="customer_save_after_data_object">
-        <observer name="upgrade_quote_customer_email" instance="Magento\Customer\Observer\UpgradeQuoteCustomerEmailObserver"/>
-    </event>
 </config>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
сustomer_email is not updated in `quote` and `sales_order` tables

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24012: Customer email Address is not updated in quote and sales_order tables

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to customer account
2. Add some products to the cart
3. Now move to My Account page.
4. Go to Edit Account Information page & check Change Email checkbox
5. Now change your email address & save your account information
6. Now move to checkout & place Order

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
