### PR TITLE
Added missing Save on Bulk operation when being published

### DIFF
--- a/app/code/Magento/AsynchronousOperations/Model/BulkManagement.php
+++ b/app/code/Magento/AsynchronousOperations/Model/BulkManagement.php
@@ -198,6 +198,7 @@ class BulkManagement implements \Magento\Framework\Bulk\BulkManagementInterface
     {
         $operationsByTopics = [];
         foreach ($operations as $operation) {
+            $this->entityManager->save($operation);
             $operationsByTopics[$operation->getTopicName()][] = $operation;
         }
         foreach ($operationsByTopics as $topicName => $operations) {

--- a/app/code/Magento/AsynchronousOperations/Test/Unit/Model/BulkManagementTest.php
+++ b/app/code/Magento/AsynchronousOperations/Test/Unit/Model/BulkManagementTest.php
@@ -135,7 +135,9 @@ class BulkManagementTest extends \PHPUnit\Framework\TestCase
         $bulkSummary->expects($this->once())->method('setUserType')->with($userType)->willReturnSelf();
         $bulkSummary->expects($this->once())->method('getOperationCount')->willReturn(1);
         $bulkSummary->expects($this->once())->method('setOperationCount')->with(3)->willReturnSelf();
-        $this->entityManager->expects($this->once())->method('save')->with($bulkSummary)->willReturn($bulkSummary);
+        $this->entityManager->expects($this->exactly(3))->method('save')
+            ->withConsecutive([$bulkSummary], [$operation], [$operation])
+            ->will($this->onConsecutiveCalls($bulkSummary, $operation, $operation));
         $connection->expects($this->once())->method('commit')->willReturnSelf();
         $operation->expects($this->exactly(2))->method('getTopicName')
             ->willReturnOnConsecutiveCalls($topicNames[0], $topicNames[1]);
@@ -227,6 +229,7 @@ class BulkManagementTest extends \PHPUnit\Framework\TestCase
         $connection->expects($this->once())->method('commit')->willReturnSelf();
         $operation->expects($this->once())->method('getTopicName')->willReturn($topicName);
         $this->publisher->expects($this->once())->method('publish')->with($topicName, [$operation])->willReturn(null);
+        $this->entityManager->expects($this->once())->method('save')->with($operation)->willReturn($operation);
         $this->assertEquals(1, $this->bulkManagement->retryBulk($bulkUuid, $errorCodes));
     }
 


### PR DESCRIPTION
### Description
When we create a new Bulk with a list of operations, the bulk is saved but the operations are not. Which results in everlasting pending operations in the operations grid

![image](https://user-images.githubusercontent.com/9752966/62627318-7c329c00-b929-11e9-8bfe-b9eef9aa317b.png)


### Fixed Issues (if relevant)
1. magento/magento2#23958: New bulk schedule doesn't create operations automatically

### Manual testing scenarios
1. Create new bulk
2. Notice that the operations are added to the `magento_operations` table.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
