### PR TITLE
Set isMultiShipping to 0 in database so it can be used correctly by rest api requests on checkout page

### DIFF
--- a/app/code/Magento/Multishipping/Controller/Checkout/Plugin.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Plugin.php
@@ -34,8 +34,9 @@ class Plugin
      */
     public function beforeExecute(\Magento\Framework\App\Action\Action $subject)
     {
-        if ($this->cart->getQuote()->getIsMultiShipping()) {
-            $this->cart->getQuote()->setIsMultiShipping(0);
+        $quote = $this->cart->getQuote();
+        if ($quote->getIsMultiShipping()) {
+            $quote->setIsMultiShipping(0);
             $this->cart->saveQuote();
         }
     }

--- a/app/code/Magento/Multishipping/Controller/Checkout/Plugin.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Plugin.php
@@ -1,11 +1,15 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Multishipping\Controller\Checkout;
 
+/**
+ * Class Plugin
+ *
+ * @package Magento\Multishipping\Controller\Checkout
+ */
 class Plugin
 {
     /**

--- a/app/code/Magento/Multishipping/Controller/Checkout/Plugin.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Plugin.php
@@ -34,7 +34,9 @@ class Plugin
      */
     public function beforeExecute(\Magento\Framework\App\Action\Action $subject)
     {
-        $this->cart->getQuote()->setIsMultiShipping(0);
-        $this->cart->saveQuote();
+        if ($this->cart->getQuote()->getIsMultiShipping()) {
+            $this->cart->getQuote()->setIsMultiShipping(0);
+            $this->cart->saveQuote();
+        }
     }
 }

--- a/app/code/Magento/Multishipping/Controller/Checkout/Plugin.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Plugin.php
@@ -31,5 +31,6 @@ class Plugin
     public function beforeExecute(\Magento\Framework\App\Action\Action $subject)
     {
         $this->cart->getQuote()->setIsMultiShipping(0);
+        $this->cart->saveQuote();
     }
 }

--- a/app/code/Magento/Multishipping/Controller/Checkout/Plugin.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Plugin.php
@@ -3,12 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Multishipping\Controller\Checkout;
 
 /**
- * Class Plugin
- *
- * @package Magento\Multishipping\Controller\Checkout
+ * Turns Off Multishipping mode for Quote.
  */
 class Plugin
 {

--- a/app/code/Magento/Multishipping/Test/Unit/Controller/Checkout/PluginTest.php
+++ b/app/code/Magento/Multishipping/Test/Unit/Controller/Checkout/PluginTest.php
@@ -4,6 +4,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+declare(strict_types=1);
+
 namespace Magento\Multishipping\Test\Unit\Controller\Checkout;
 
 use Magento\Multishipping\Controller\Checkout\Plugin;
@@ -30,16 +33,27 @@ class PluginTest extends \PHPUnit\Framework\TestCase
         $this->cartMock = $this->createMock(\Magento\Checkout\Model\Cart::class);
         $this->quoteMock = $this->createPartialMock(
             \Magento\Quote\Model\Quote::class,
-            ['__wakeUp', 'setIsMultiShipping']
+            ['__wakeUp', 'setIsMultiShipping', 'getIsMultiShipping']
         );
         $this->cartMock->expects($this->once())->method('getQuote')->will($this->returnValue($this->quoteMock));
         $this->object = new \Magento\Multishipping\Controller\Checkout\Plugin($this->cartMock);
     }
 
-    public function testExecuteTurnsOffMultishippingModeOnQuote()
+    public function testExecuteTurnsOffMultishippingModeOnMultishippingQuote(): void
     {
         $subject = $this->createMock(\Magento\Checkout\Controller\Index\Index::class);
+        $this->quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(1);
         $this->quoteMock->expects($this->once())->method('setIsMultiShipping')->with(0);
+        $this->cartMock->expects($this->once())->method('saveQuote');
+        $this->object->beforeExecute($subject);
+    }
+
+    public function testExecuteTurnsOffMultishippingModeOnNotMultishippingQuote(): void
+    {
+        $subject = $this->createMock(\Magento\Checkout\Controller\Index\Index::class);
+        $this->quoteMock->expects($this->once())->method('getIsMultiShipping')->willReturn(0);
+        $this->quoteMock->expects($this->never())->method('setIsMultiShipping');
+        $this->cartMock->expects($this->never())->method('saveQuote');
         $this->object->beforeExecute($subject);
     }
 }


### PR DESCRIPTION
### Description (*)
After user visits multishipping checkout page magento sets is_multi_shipping flag to 1 in database. When user will return to the website and go to the regular checkout page, is_multi_shipping flag will be still contain value 1. It is makes it useless for checkout ajax requests. e.g. get shipping methods list.
Current PR will fix it.

### Manual testing scenarios (*)
1. Add products to the shopping cart
2. Go to the shopping cart page
3. Click "Check Out with Multiple Addresses". Go to Multishipping checkout page
4. Check that in the database table "quote" column "is_multi_shipping" = 1
5. Click "Back to Shopping Cart"
6. Click "Proceed to Checkout". Go to regular checkout page
7. Check that in the database table "quote" column "is_multi_shipping" = 0

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
