### PR TITLE
Resolve Account sidebar current tab is not marked as Active (issue 24068)

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
@@ -87,7 +87,9 @@ class Current extends Template
      */
     public function isCurrent()
     {
-        return $this->getCurrent() || $this->getUrl($this->getPath()) == $this->getUrl($this->getMca());
+        $pathUrl = preg_replace('/(\/index|(\/))+($|\/$)/', '', $this->getUrl($this->getPath()));
+        $mcaUrl = preg_replace('/(\/index|(\/))+($|\/$)/', '', $this->getUrl($this->getMca()));
+        return $this->getCurrent() || $pathUrl == $mcaUrl;
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
@@ -87,9 +87,9 @@ class Current extends Template
      */
     public function isCurrent()
     {
-        $pathUrl = preg_replace('/(\/index|(\/))+($|\/$)/', '', $this->getUrl($this->getPath()));
-        $mcaUrl = preg_replace('/(\/index|(\/))+($|\/$)/', '', $this->getUrl($this->getMca()));
-        return $this->getCurrent() || $pathUrl == $mcaUrl;
+        return $this->getCurrent() ||
+            preg_replace('/(\/index|(\/))+($|\/$)/', '', $this->getUrl($this->getPath()))
+            == preg_replace('/(\/index|(\/))+($|\/$)/', '', $this->getUrl($this->getMca()));
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
@@ -24,6 +24,11 @@ use Magento\Framework\View\Element\Template\Context;
 class Current extends Template
 {
     /**
+     * Search redundant /index and / in url
+     */
+    private const REGEX_INDEX_URL_PATTERN = '/(\/index|(\/))+($|\/$)/';
+
+    /**
      * Default path
      *
      * @var DefaultPathInterface
@@ -88,8 +93,8 @@ class Current extends Template
     public function isCurrent()
     {
         return $this->getCurrent() ||
-            preg_replace('/(\/index|(\/))+($|\/$)/', '', $this->getUrl($this->getPath()))
-            == preg_replace('/(\/index|(\/))+($|\/$)/', '', $this->getUrl($this->getMca()));
+            preg_replace(self::REGEX_INDEX_URL_PATTERN, '', $this->getUrl($this->getPath()))
+            == preg_replace(self::REGEX_INDEX_URL_PATTERN, '', $this->getUrl($this->getMca()));
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. Resolve magento/magento2#24068: Account sidebar current tab is not marked as Active

- Solution: Should remove all "/index" and "/" redundant before compare the Url. Use `preg_replace`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24068: Account sidebar current tab is not marked as Active

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login as customer. You can see below screen.
![AwesomeScreenshot-nlipoenfbbikpbjkfpfillcgkoblgpmj-upload html-2019-08-08_6_36](https://user-images.githubusercontent.com/44745569/62705669-790fdc80-ba0b-11e9-99ce-5013b47351b8.png)

2. Please note URL here.
a) <!-- Magento 2 base url --> /customer/account/
b) As above screenshot, My Account tab selected as current tab.

3. Please add index/ after /customer/account/
So URL become like <!-- Magento 2 base url --> /customer/account/index/
![AwesomeScreenshot-nlipoenfbbikpbjkfpfillcgkoblgpmj-upload html-2019-08-08_6_40](https://user-images.githubusercontent.com/44745569/62705897-fb000580-ba0b-11e9-8f0d-e800f30efc46.png)

You can see My Account tab is not marked as activate tab for /customer/account/index/. This issue available with whole sidebar tab in customer account section.


#### Expected result
<!--- Tell us what do you expect to happen. -->
1. My Account tab marked as activate tab for below both URLs.
a) <!-- Magento 2 base url --> /customer/account/
b) <!-- Magento 2 base url --> /customer/account/index/
2. Same thing with all other sidebar links.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
