### PR TITLE
Fixed critical error 'Undefined constant formName'

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/helper/gallery.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/helper/gallery.phtml
@@ -61,7 +61,7 @@ $formName = $block->getFormName();
                    value="<%- data.label %>"/>
             <input type="hidden"
                    name="<?= $block->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][disabled]"
-                   data-form-part="<?= $block->escapeHtmlAttr(formName) ?>"
+                   data-form-part="<?= $block->escapeHtmlAttr($formName) ?>"
                    value="<%- data.disabled %>"/>
             <input type="hidden"
                    name="<?= $block->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][media_type]"

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/helper/gallery.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/helper/gallery.phtml
@@ -37,7 +37,7 @@ $formName = $block->getFormName();
                type="hidden"
                value="<?= $block->escapeHtmlAttr($typeData['value']) ?>"/>
         <?php
-} ?>
+    } ?>
 
     <script id="<?= $block->getHtmlId() ?>-template" type="text/x-magento-template">
         <div class="image item<% if (data.disabled == 1) { %> hidden-for-front<% } %>"


### PR DESCRIPTION
### Description (*)
Getting an 'undefined constant formName' error in the Admin panel when trying to edit products so just fixed the place in the template where this was happening - simple fix.
Stack: Alpine/Apache 2.4/PHP7.2.1 (+FPM)

Single file change: app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/helper/gallery.phtml

### Manual testing scenarios (*)
1. Admin > Catalog > Product then click on product to edit - previously error was being thrown and crashing the page now the product is editable.  

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose - yes 
 - [x] All commits are accompanied by meaningful commit messages - yes
 - [ ] All new or changed code is covered with unit/integration tests - n/a
 - [x] All automated tests passed successfully - ok, see output below

*./vendor/bin/phpunit -d memory_limit=1200M -c dev/tests/unit/phpunit.xml.dist app/code/Magento/Catalog/Test
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.
Time: 41.95 seconds, Memory: 170.25MB
OK, but incomplete, skipped, or risky tests!
Tests: 1573, Assertions: 4884, Skipped: 26, Incomplete: 2.*
