### PR TITLE
Database Media Storage : Fixed error in database deleteFolder function. Now correctly deletes folder

### DIFF
--- a/app/code/Magento/MediaStorage/Model/ResourceModel/File/Storage/Database.php
+++ b/app/code/Magento/MediaStorage/Model/ResourceModel/File/Storage/Database.php
@@ -341,10 +341,14 @@ class Database extends \Magento\MediaStorage\Model\ResourceModel\File\Storage\Ab
             return;
         }
 
-        $likeExpression = $this->_resourceHelper->addLikeEscape($folderName . '/', ['position' => 'start']);
         $this->getConnection()->delete(
             $this->getMainTable(),
-            new \Zend_Db_Expr('filename LIKE ' . $likeExpression)
+            new \Zend_Db_Expr(
+                'directory LIKE ' .
+                $this->_resourceHelper->addLikeEscape($folderName . '/', ['position' => 'start'])
+                . ' ' . \Magento\Framework\DB\Select::SQL_OR . ' ' .
+                $this->getConnection()->prepareSqlCondition('directory', ['seq' => $folderName])
+            )
         );
     }
 

--- a/dev/tests/integration/testsuite/Magento/MediaStorage/Helper/File/Storage/DatabaseTest.php
+++ b/dev/tests/integration/testsuite/Magento/MediaStorage/Helper/File/Storage/DatabaseTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\MediaStorage\Helper\File\Storage;
+
+use Magento\Framework\ObjectManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Framework\Filesystem\Directory\WriteInterface;
+use Magento\Framework\Filesystem;
+use Magento\Framework\App\Filesystem\DirectoryList;
+
+/**
+ * Integration tests for Magento\MediaStorage\Helper\File\Storage\Database
+ */
+class DatabaseTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var Database
+     */
+    private $databaseHelper;
+
+    /**
+     * @var WriteInterface
+     */
+    private $mediaDirectory;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->filesystem = $this->objectManager->get(Filesystem::class);
+        $this->mediaDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::MEDIA);
+    }
+
+    /**
+     * test for \Magento\MediaStorage\Model\File\Storage\Database::deleteFolder()
+     *
+     * @magentoDataFixture Magento/MediaStorage/_files/database_mode.php
+     */
+    public function testDeleteFolder()
+    {
+        $this->databaseHelper = $this->objectManager->get(
+            Database::class
+        );
+
+        $filenames = [
+            'test1/test2/test3/test4.dat',
+            'test1/test2/test3/test4a.dat',
+            'test5/test6/test7.dat',
+            'test5/test6a/test7a.dat',
+            'test8/test9.dat'
+        ];
+
+        foreach ($filenames as $filename) {
+            $this->mediaDirectory->writeFile($filename, '');
+            $this->databaseHelper->saveFile($filename);
+            $this->assertEquals(true, $this->databaseHelper->fileExists($filename));
+        }
+
+        $this->databaseHelper->deleteFolder('test1/test2/test3');
+        $this->databaseHelper->deleteFolder('test5');
+        $this->databaseHelper->deleteFolder('test8');
+
+        foreach ($filenames as $filename) {
+            $this->assertEquals(false, $this->databaseHelper->fileExists($filename));
+            $this->mediaDirectory->delete($filename);
+        }
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/MediaStorage/_files/database_mode.php
+++ b/dev/tests/integration/testsuite/Magento/MediaStorage/_files/database_mode.php
@@ -5,11 +5,11 @@
  */
 declare(strict_types=1);
 
-/** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+/** @var $objectManager \Magento\TestFramework\ObjectManager */
 $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+
 /** @var $database \Magento\MediaStorage\Helper\File\Storage\Database */
 $database = $objectManager->get(\Magento\MediaStorage\Helper\File\Storage\Database::class);
-
 $database->getStorageDatabaseModel()->init();
 
 $config = $objectManager->get(Magento\Framework\App\Config\ConfigResource\ConfigInterface::class);


### PR DESCRIPTION
### Description (*)
The Magento implementation of the deleteFolder function in MediaStorage's resource model for the database is broken.

Currently the delete command for $folder is

`
"delete from media_storage_file_storage WHERE filename LIKE $folder/%"
`

Unfortunately entries in the media_storage_file_storage table have entries with directory and filename as separate entries, hence the above will never work.

The query needs to be

`
"delete from media_storage_file_storage WHERE directory LIKE $folder/% OR directory=$folder"
`

Thus it will delete any entries where the file is in $folder, and also delete any files in any subdirectories of $folder.

This is the correct behaviour, and this is what this PR implements.

### Fixed Issues (if relevant)
1. magento/magento2#23936: Database Media Storage : clearing image cache does not clear cached image files from database

### Manual testing scenarios (*)
Deploy 2.3-develop
```
Stores -> Configuration
    Advanced -> System
        Storage Configuration for Media
            Media Storage = Database
            Select Media Database = default_setup
            Synchronize
            Save Config
Catalog -> Products
    Add Product
        Name = Test
        Price = 111
        Images and Videos
            Upload image "a.jpg"
        Save & Close
```
Verify cached images exist in filesystem
```
www-data@dev:~/dev1$ find pub/media/catalog/product/cache -name *.jpg
pub/media/catalog/product/cache/6e14adab429f71aeb7223303a247c563/a/_/a.jpg
pub/media/catalog/product/cache/f62d29ead3f33fe6484fbdb6d3785dc1/a/_/a.jpg
pub/media/catalog/product/cache/be852cb44d0b54faab62ffaae6be8535/a/_/a.jpg
pub/media/catalog/product/cache/cec7ecf00f20929af760713af4400fed/a/_/a.jpg
pub/media/catalog/product/cache/37bfafdfb226dffa175577a00672b1ba/a/_/a.jpg
pub/media/catalog/product/cache/8b2dc6afd39ee28ff58514eb10993c8f/a/_/a.jpg
pub/media/catalog/product/cache/d975e82a925000253a32e9c4541ea68c/a/_/a.jpg
pub/media/catalog/product/cache/09c5a17c8da4235f70a8c07e75bb5ef0/a/_/a.jpg
pub/media/catalog/product/cache/9fda6c6842c3f655bbb560bcbe7ed6d5/a/_/a.jpg
pub/media/catalog/product/cache/d5f386a768d7e7f87cc4fb8a6c1ef14f/a/_/a.jpg
pub/media/catalog/product/cache/52952a29dad7e0f0b516b44cc9fe0760/a/_/a.jpg
pub/media/catalog/product/cache/06dfa18d55e0337076e1f5ddd2129562/a/_/a.jpg
pub/media/catalog/product/cache/faa05d146573dd135d15c4c56517ffdb/a/_/a.jpg
pub/media/catalog/product/cache/3ced2c8980660288e4ea38fe4970b4e9/a/_/a.jpg
pub/media/catalog/product/cache/2bdb51d37a492679108b7c6c17f34e97/a/_/a.jpg
pub/media/catalog/product/cache/4ed1686d54d03efa60ce0fb8e68e54e9/a/_/a.jpg
pub/media/catalog/product/cache/ee5242f5f0a2a47237a7610f0274bc15/a/_/a.jpg
pub/media/catalog/product/cache/8f18f3a902701264b776ead80189598e/a/_/a.jpg
pub/media/catalog/product/cache/39fe0b11cb432d7c2d562e3c5b5d5f43/a/_/a.jpg
pub/media/catalog/product/cache/34c2321368257a27e78b60f1cf77ce60/a/_/a.jpg
www-data@dev:~/dev1$
```
Verify cached images exist in database
```
mysql> mysql> select filename,directory from media_storage_file_storage where directory LIKE 'catalog/product/cache%';
+----------+------------------------------------------------------------+
| filename | directory                                                  |
+----------+------------------------------------------------------------+
| a.jpg    | catalog/product/cache/9fda6c6842c3f655bbb560bcbe7ed6d5/a/_ |
| a.jpg    | catalog/product/cache/f62d29ead3f33fe6484fbdb6d3785dc1/a/_ |
| a.jpg    | catalog/product/cache/d5f386a768d7e7f87cc4fb8a6c1ef14f/a/_ |
| a.jpg    | catalog/product/cache/52952a29dad7e0f0b516b44cc9fe0760/a/_ |
| a.jpg    | catalog/product/cache/ee5242f5f0a2a47237a7610f0274bc15/a/_ |
| a.jpg    | catalog/product/cache/cec7ecf00f20929af760713af4400fed/a/_ |
| a.jpg    | catalog/product/cache/09c5a17c8da4235f70a8c07e75bb5ef0/a/_ |
| a.jpg    | catalog/product/cache/39fe0b11cb432d7c2d562e3c5b5d5f43/a/_ |
| a.jpg    | catalog/product/cache/3ced2c8980660288e4ea38fe4970b4e9/a/_ |
| a.jpg    | catalog/product/cache/8f18f3a902701264b776ead80189598e/a/_ |
| a.jpg    | catalog/product/cache/06dfa18d55e0337076e1f5ddd2129562/a/_ |
| a.jpg    | catalog/product/cache/34c2321368257a27e78b60f1cf77ce60/a/_ |
| a.jpg    | catalog/product/cache/37bfafdfb226dffa175577a00672b1ba/a/_ |
| a.jpg    | catalog/product/cache/be852cb44d0b54faab62ffaae6be8535/a/_ |
| a.jpg    | catalog/product/cache/4ed1686d54d03efa60ce0fb8e68e54e9/a/_ |
| a.jpg    | catalog/product/cache/2bdb51d37a492679108b7c6c17f34e97/a/_ |
| a.jpg    | catalog/product/cache/d975e82a925000253a32e9c4541ea68c/a/_ |
| a.jpg    | catalog/product/cache/6e14adab429f71aeb7223303a247c563/a/_ |
| a.jpg    | catalog/product/cache/faa05d146573dd135d15c4c56517ffdb/a/_ |
| a.jpg    | catalog/product/cache/8b2dc6afd39ee28ff58514eb10993c8f/a/_ |
+----------+------------------------------------------------------------+
20 rows in set (0.00 sec)

mysql>
```

```
System -> Cache Management
    Flush Catalog Images Cache
```
Verify cached images no longer exist in filesystem
```
www-data@dev:~/dev1$ find pub/media/catalog/product/cache -name *.jpg
find: ‘pub/media/catalog/product/cache’: No such file or directory
www-data@dev:~/dev1$
```
Verify cached images no longer exist in database
```
mysql> select filename,directory from media_storage_file_storage where directory LIKE 'catalog/product/cache%';
Empty set (0.00 sec)

mysql>
```
When the image cache is cleared, all cached images are removed from filesystem and database

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
