### PR TITLE
Allow TinyMCE to save content with inline style tags

### DIFF
--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentovariable/editor_plugin.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentovariable/editor_plugin.js
@@ -171,7 +171,8 @@ define([
              * @returns {String}
              */
             decodeVariables: function (content) {
-                var doc = (new DOMParser()).parseFromString(content.replace(/&quot;/g, '&amp;quot;'), 'text/html');
+                var doc = (new DOMParser()).parseFromString(content.replace(/&quot;/g, '&amp;quot;'), 'text/html'),
+                    returnval = '';
 
                 [].forEach.call(doc.querySelectorAll('span.magento-variable'), function (el) {
                     var $el = jQuery(el);
@@ -195,7 +196,12 @@ define([
                     }
                 });
 
-                return doc.body ? doc.body.innerHTML.replace(/&amp;quot;/g, '&quot;') : content;
+                returnval += doc.head.innerHTML ?
+                    doc.head.innerHTML.replace(/&amp;quot;/g, '&quot;') : '';
+                returnval += doc.body.innerHTML ?
+                    doc.body.innerHTML.replace(/&amp;quot;/g, '&quot;') : '';
+
+                return returnval ? returnval : content;
             },
 
             /**

--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
@@ -189,7 +189,7 @@ define([
              * @return {String}
              */
             removeDuplicateAncestorWidgetSpanElement: function (content) {
-                var parser, doc;
+                var parser, doc, returnval = '';
 
                 if (!window.DOMParser) {
                     return content;
@@ -212,7 +212,12 @@ define([
                     widgetEl.parentNode.removeChild(widgetEl);
                 });
 
-                return doc.body ? doc.body.innerHTML.replace(/&amp;quot;/g, '&quot;') : content;
+                returnval += doc.head.innerHTML ?
+                    doc.head.innerHTML.replace(/&amp;quot;/g, '&quot;') : '';
+                returnval += doc.body.innerHTML ?
+                    doc.body.innerHTML.replace(/&amp;quot;/g, '&quot;') : '';
+
+                return returnval ? returnval : content;
             },
 
             /**

--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js
@@ -198,6 +198,7 @@ define([
                 'convert_urls': false,
                 'content_css': this.config.tinymce4['content_css'],
                 'relative_urls': true,
+                'valid_children': '+body[style]',
                 menubar: false,
                 plugins: this.config.tinymce4.plugins,
                 toolbar: this.config.tinymce4.toolbar,


### PR DESCRIPTION
### Description (*)

Firstly, we need to decide whether we allow `<style>` tags in TinyMCE editors. HTML5.1 and older forbid inline style tags (`<style>` is only valid in `<head>`), although most browsers allow it. HTML5.2 and newer now allow it, so lets get that out of the way and decided first.

Then......

There are two issues that needed to be resolved to allow `<style>` tags within the TinyMCE 4 editor.

### Issue 1
In the `decodeVariables` function of the magentovariable TinyMCE plugin and in the `removeDuplicateAncestorWidgetSpanElement `function of the magentowidget TinyMCE plugin, the content of the TinyMCE editor is passed through a `DOMParser `to convert certain tags. Usually the content parsed through the `DOMParser `is available in the `doc.body.innerHTML` field, and is returned by the plugins once alterations had been made. There is an issue however if the content of the TinyMCE editor starts with a `<style>` tag. The `DOMParser` splits the style elements off and makes them available in `doc.head.innerHTML` and the remainder of the TinyMCE contents are parsed into `doc.body.innerHTML`.

Thus you can see how, in the original function that only processed `doc.body.innerHTML`, that any `<style>` tags were getting stripped out. Note that this only happens if the `<style>` tag is the first item in the editor. `<p>test</p><style>test</style>` would get passed in its entirety to `doc.body.innerHTML` and the bug would not happen, but `<style>test</style><p>test</p>` would get split between `doc.head.innerHTML` and `doc.body.innerHTML` and the <style> tags would be lost.

This PR corrects this by concatenating both `doc.head.innerHTML` and `doc.body.innerHTML` on return from the respective plugin functions.

### Issue 2
The TinyMCE editor enforces strict HTML5 adherence in terms of what tags can go where. Up to HTML5.1 the `<style>` tag is not allowed in the `<body>` section of code. It can only be used in the `<head>` section. This can be confirmed in the source code to TinyMCE 4.9.5 which shows that in the preparation of the HTML5 schema, that `<style>` is not included as a valid tag within a `<body>` tag.

HTML5.2 however DOES now allow the `<style>` section to appear within `<body>`. This can be confirmed [here](https://www.w3.org/TR/html52/document-metadata.html#the-style-element). There are currently no versions of TinyMCE 4 that have been updated to allow it.

This PR adds `<style>` tag as valid to occur inside `<body>` in the TinyMCE config, and thus allows it to be a top level tag within a TinyMCE editor.

### Fixed Issues (if relevant)

1. magento/magento2#22867: Magento script and style filtering issue in CMS Blocks and Pages

### Manual testing scenarios (*)
1. `<p>test</p><style>test</style>`
2. `<style>test</style><p>test</p>`
3. `<p>test</p>`
4. `<style>test</style>`

### Questions or comments
As suggested in the original description, there might be some contention as to whether to allow inline `<style>` tags in the first place.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
