### PR TITLE
magento/magento2#24116: Webapi schema generation fail in case when Ge…

### DIFF
--- a/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
+++ b/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
@@ -705,7 +705,8 @@ class Generator extends AbstractSchemaGenerator
      */
     private function handleComplex($name, $type, $prefix, $isArray)
     {
-        $parameters = $this->typeProcessor->getTypeData($type)['parameters'];
+        $typeData = $this->typeProcessor->getTypeData($type);
+        $parameters = $typeData['parameters'] ?? [];
         $queryNames = [];
         foreach ($parameters as $subParameterName => $subParameterInfo) {
             $subParameterType = $subParameterInfo['type'];


### PR DESCRIPTION
### Description (*)
Fix swagger schema generator in case of using 'GET' endpoint with parameter which can have extension attributes.

### Fixed Issues (if relevant)
1. magento/magento2#24116: Webapi Swager schema generation fail in case when Get endpoint has param with Extension Attributes

### Manual testing scenarios (*)
Please see the issue.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
