### PR TITLE
PayPal - fix configuration path in config model for "Disable Funding Options"

### DIFF
--- a/app/code/Magento/Paypal/Model/AbstractConfig.php
+++ b/app/code/Magento/Paypal/Model/AbstractConfig.php
@@ -293,7 +293,7 @@ abstract class AbstractConfig implements ConfigInterface
             case Config::METHOD_WPS_BML:
             case Config::METHOD_WPP_BML:
                 $disabledFunding = $this->_scopeConfig->getValue(
-                    'payment/paypal_express/disable_funding_options',
+                    'paypal/style/disable_funding_options',
                     ScopeInterface::SCOPE_STORE,
                     $this->_storeId
                 );

--- a/app/code/Magento/Paypal/Test/Unit/Model/AbstractConfigTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/AbstractConfigTest.php
@@ -306,7 +306,7 @@ class AbstractConfigTest extends \PHPUnit\Framework\TestCase
     {
         $this->scopeConfigMock->method('getValue')
             ->with(
-                self::equalTo('payment/paypal_express/disable_funding_options'),
+                self::equalTo('paypal/style/disable_funding_options'),
                 self::equalTo('store')
             )
             ->willReturn($disableFundingOptions);

--- a/app/code/Magento/Paypal/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/ConfigTest.php
@@ -9,6 +9,9 @@ use Magento\Paypal\Model\Config;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 
+/**
+ * Class ConfigTest
+ */
 class ConfigTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -362,11 +365,15 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue($expectedFlag));
         $this->scopeConfig->expects($this->any())
             ->method('getValue')
-            ->will($this->returnValueMap([
-                ['payment/' . Config::METHOD_WPP_BML . '/' . $section . '_display', 'store', 1, $expectedValue],
-                ['payment/' . Config::METHOD_WPP_BML . '/active', 'store', 1, $expectedValue],
-                ['payment/' . Config::METHOD_WPP_PE_BML . '/active', 'store', 1, $expectedValue],
-            ]));
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['payment/' . Config::METHOD_WPP_BML . '/' . $section . '_display', 'store', 1, $expectedValue],
+                        ['payment/' . Config::METHOD_WPP_BML . '/active', 'store', 1, $expectedValue],
+                        ['payment/' . Config::METHOD_WPP_PE_BML . '/active', 'store', 1, $expectedValue],
+                    ]
+                )
+            );
         $this->assertEquals($expected, $this->model->getBmlDisplay($section));
     }
 
@@ -407,11 +414,13 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
 
         $this->scopeConfig->expects($this->any())
             ->method('getValue')
-            ->willReturnMap([
-                ['paypal/wpp/button_flavor', ScopeInterface::SCOPE_STORE, 123, $areButtonDynamic],
-                ['paypal/wpp/sandbox_flag', ScopeInterface::SCOPE_STORE, 123, $sandboxFlag],
-                ['paypal/wpp/button_type', ScopeInterface::SCOPE_STORE, 123, $buttonType],
-            ]);
+            ->willReturnMap(
+                [
+                    ['paypal/wpp/button_flavor', ScopeInterface::SCOPE_STORE, 123, $areButtonDynamic],
+                    ['paypal/wpp/sandbox_flag', ScopeInterface::SCOPE_STORE, 123, $sandboxFlag],
+                    ['paypal/wpp/button_type', ScopeInterface::SCOPE_STORE, 123, $buttonType],
+                ]
+            );
 
         $this->assertEquals(
             $result,
@@ -475,10 +484,12 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
 
         $this->scopeConfig->expects($this->any())
             ->method('getValue')
-            ->willReturnMap([
-                ['paypal/wpp/button_flavor', ScopeInterface::SCOPE_STORE, 123, $areButtonDynamic],
-                ['paypal/wpp/sandbox_flag', ScopeInterface::SCOPE_STORE, 123, $sandboxFlag],
-            ]);
+            ->willReturnMap(
+                [
+                    ['paypal/wpp/button_flavor', ScopeInterface::SCOPE_STORE, 123, $areButtonDynamic],
+                    ['paypal/wpp/sandbox_flag', ScopeInterface::SCOPE_STORE, 123, $sandboxFlag],
+                ]
+            );
 
         $this->assertEquals(
             $result,

--- a/app/code/Magento/Paypal/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/ConfigTest.php
@@ -122,7 +122,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             $valueMap = [
                 ['paypal/general/merchant_country', ScopeConfigInterface::SCOPE_TYPE_DEFAULT, null, 'US'],
                 ['paypal/general/merchant_country', ScopeInterface::SCOPE_STORE, null, 'US'],
-                ['payment/paypal_express/disable_funding_options', ScopeConfigInterface::SCOPE_TYPE_DEFAULT, null, []],
+                ['paypal/style/disable_funding_options', ScopeConfigInterface::SCOPE_TYPE_DEFAULT, null, []],
             ];
             $this->scopeConfig
                 ->method('getValue')


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This PR fixes inconsistency issue with PayPal Express Checkout payment method configuration related to displaying "PayPal Credit" button if feature "Display on Shopping Cart" is enabled.

The configuration is located under Stores -> Settings -> Configuration -> PayPal Express Checkout -> Advance Settings -> Frontend Experience Settings -> Features -> Disable Funding Options:
![paypal express checkout - disable funding options - config](https://user-images.githubusercontent.com/3918875/62936952-cb6a4800-bdd3-11e9-8b55-a6bcde485ca6.png)

Related configuration path (from `app/code/Magento/Paypal/etc/adminhtml/system/express_checkout.xml`) is `<config_path>paypal/style/disable_funding_options</config_path>`.

But the configuration model `app/code/Magento/Paypal/Model/AbstractConfig.php` has incorrect path `payment/paypal_express/disable_funding_options` for processing the configuration field value (from method `isMethodActive()`):
```php
...
            case Config::METHOD_WPP_BML:
                $disabledFunding = $this->_scopeConfig->getValue(
                    'payment/paypal_express/disable_funding_options',
                    ScopeInterface::SCOPE_STORE,
                    $this->_storeId
                );
                $isExpressCreditEnabled = $disabledFunding
                    ? strpos($disabledFunding, 'CREDIT') === false
                    : true;
                $isEnabled = $isExpressCreditEnabled
                || $this->_scopeConfig->isSetFlag(
                    'payment/' . Config::METHOD_WPP_BML .'/active',
                    ScopeInterface::SCOPE_STORE,
                    $this->_storeId
                );
                $method = Config::METHOD_WPP_BML;
                break;
...
```
As you can see `payment/paypal_express/disable_funding_options` != `paypal/style/disable_funding_options`. This causes unable to disable displaying button "PayPal Credit" on Shopping Cart page (and in minicart block as well).

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22525: Enable PayPal Credit option not avaible for USA.
2. magento/magento2#22528: PayPal and Magento2 2.3.1.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Just enable displaying of PayPal Express Checkout on Shopping Cart.
2. Add some product to the Shopping Cart.
3. Go to Shopping Cart (or look at minicart block).

## Expected Result
There is only "Checkout with PayPal" button.

## Actual Result
There is displayed button PayPal Credit additionally to "Checkout with PayPal" button.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

PayPal Credit documentation is not actual anymore with Magento v2.3.1:
https://docs.magento.com/m2/ce/user_guide/payment/paypal-credit.html

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
