### PR TITLE
Resolve "Action" column is not the last column in "Design Configuration" (issue 24139)

### DIFF
--- a/app/code/Magento/Theme/view/adminhtml/ui_component/design_config_listing.xml
+++ b/app/code/Magento/Theme/view/adminhtml/ui_component/design_config_listing.xml
@@ -78,7 +78,7 @@
                 <label translate="true">Store View</label>
             </settings>
         </column>
-        <actionsColumn name="actions" class="Magento\Theme\Ui\Component\Listing\Column\EditAction">
+        <actionsColumn name="actions" class="Magento\Theme\Ui\Component\Listing\Column\EditAction" sortOrder="50">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="editUrlPath" xsi:type="string">theme/design_config/edit</item>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. Resolve magento/magento2#24139:"Action" column is not the last column in "Design Configuration"

Solution: Add sortOrder = 50 in action column (it has no-value before)

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24139:"Action" column is not the last column in "Design Configuration"

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to backend
2. Content->Configuration
3. Check the grid

#### Expected result
<!--- Tell us what do you expect to happen. -->
![image](https://user-images.githubusercontent.com/8234209/63081023-c12f8180-bf6c-11e9-8324-c69f707c8d11.png)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
