### PR TITLE
Fix config backend model PDF file name extension

### DIFF
--- a/app/code/Magento/Config/Model/Config/Backend/File/Pdf.php
+++ b/app/code/Magento/Config/Model/Config/Backend/File/Pdf.php
@@ -8,8 +8,6 @@ namespace Magento\Config\Model\Config\Backend\File;
 
 /**
  * System config PDF field backend model.
- *
- * @api
  */
 class Pdf extends \Magento\Config\Model\Config\Backend\File
 {

--- a/app/code/Magento/Config/Model/Config/Backend/File/Pdf.php
+++ b/app/code/Magento/Config/Model/Config/Backend/File/Pdf.php
@@ -4,15 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-namespace Magento\Config\Model\Config\Backend\Image;
+namespace Magento\Config\Model\Config\Backend\File;
 
 /**
+ * System config PDF field backend model.
+ *
  * @api
  */
 class Pdf extends \Magento\Config\Model\Config\Backend\File
 {
     /**
-     * @return string[]
+     * @inheritdoc
      */
     protected function _getAllowedExtensions()
     {

--- a/app/code/Magento/Config/Model/Config/Backend/File/Pdf.php
+++ b/app/code/Magento/Config/Model/Config/Backend/File/Pdf.php
@@ -8,16 +8,14 @@ namespace Magento\Config\Model\Config\Backend\Image;
 
 /**
  * @api
- * @deprecated The wrong file type extensions are returned.
- * @see \Magento\Config\Model\Config\Backend\File\Pdf
  */
-class Pdf extends \Magento\Config\Model\Config\Backend\Image
+class Pdf extends \Magento\Config\Model\Config\Backend\File
 {
     /**
      * @return string[]
      */
     protected function _getAllowedExtensions()
     {
-        return ['tif', 'tiff', 'png', 'jpg', 'jpe', 'jpeg', 'pdf'];
+        return ['pdf'];
     }
 }

--- a/app/code/Magento/Config/Model/Config/Backend/Image/Pdf.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Image/Pdf.php
@@ -10,7 +10,7 @@ namespace Magento\Config\Model\Config\Backend\Image;
  * System config PDF field backend model.
  *
  * @api
- * @deprecated The wrong file type extensions are returned.
+ * @since 100.0.2
  * @see \Magento\Config\Model\Config\Backend\File\Pdf
  */
 class Pdf extends \Magento\Config\Model\Config\Backend\Image

--- a/app/code/Magento/Config/Model/Config/Backend/Image/Pdf.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Image/Pdf.php
@@ -7,6 +7,8 @@
 namespace Magento\Config\Model\Config\Backend\Image;
 
 /**
+ * System config PDF field backend model.
+ *
  * @api
  * @deprecated The wrong file type extensions are returned.
  * @see \Magento\Config\Model\Config\Backend\File\Pdf
@@ -14,7 +16,7 @@ namespace Magento\Config\Model\Config\Backend\Image;
 class Pdf extends \Magento\Config\Model\Config\Backend\Image
 {
     /**
-     * @return string[]
+     * @inheritdoc
      */
     protected function _getAllowedExtensions()
     {


### PR DESCRIPTION
# Description (*)

The PDF system config file backend model does not include the file name ending `pdf` in the list of allowed extensions.
Instead, it allows the extensions `['tif', 'tiff', 'png', 'jpg', 'jpe', 'jpeg']`, which are not relevant for PDF files.

This PR adds `pdf` to the list of allowed extensions without removing the existing wrong extensions. This way it's a backward compatible change, and it makes the backend model usable for PDFs.

It also adds a new backend model `\Magento\Config\Model\Config\Backend\Image\Pdf` as a replacement that only returns the allowed file name extension `pdf`.

I added a `@deprecated` annotation to the existing backend model with an explanation and a `@see` annotation to point to the new PDF backend model.

### Manual testing scenarios (*)
Referencing the backend model in a `system.xml` file, e.g

```xml
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
    <system>
        <section id="foo" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="200">
            <label>Foo</label>
            <tab>general</tab>
            <resource>Magento_Customer::config_customer</resource>
            <group id="bar" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="10">
                <label>Example</label>
                <field id="baz" type="file" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="10">
                    <label>PDF Upload</label>
                    <backend_model>Magento\Config\Model\Config\Backend\Image\Pdf</backend_model>
                    <upload_dir scope_info="1">foo/bar</upload_dir>
                    <base_url type="media" scope_info="1">foo/bar</base_url>
                </field>
            </group>
        </section>
    </system>
</config>
```

Then upload a file with a `.pdf` extension. It will be rejected by the server side validation in `\Magento\Config\Model\Config\Backend\File::beforeSave`

### Questions or comments

I'm not sure what the best way is to get this PR merged as quickly as possible.
If the deprecation of the `@api` class and addition of a new `@api` class prevent it from being merged, I would suggest to remove those annotations and just merge the file changes, and then add the annotations in a new PR that can be merged in the next major release.
Open to other suggestions if there is a better approach.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
