### PR TITLE
getStoreValuesForForm($empty = false, $all = false) has bad logic (undefine variable)

### DIFF
--- a/app/code/Magento/Store/Model/System/Store.php
+++ b/app/code/Magento/Store/Model/System/Store.php
@@ -121,6 +121,7 @@ class Store extends \Magento\Framework\DataObject implements OptionSourceInterfa
             $options[] = ['label' => __('All Store Views'), 'value' => 0];
         }
 
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction
         $nonEscapableNbspChar = html_entity_decode('&#160;', ENT_NOQUOTES, 'UTF-8');
 
         foreach ($this->_websiteCollection as $website) {
@@ -397,6 +398,7 @@ class Store extends \Magento\Framework\DataObject implements OptionSourceInterfa
 
     /**
      * Load/Reload collection(s) by type
+     *
      * Allowed types: website, group, store or null for all
      *
      * @param string $type

--- a/app/code/Magento/Store/Model/System/Store.php
+++ b/app/code/Magento/Store/Model/System/Store.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+declare(strict_types=1);
+
 namespace Magento\Store\Model\System;
 
 use Magento\Framework\Data\OptionSourceInterface;
@@ -126,7 +129,7 @@ class Store extends \Magento\Framework\DataObject implements OptionSourceInterfa
                 if ($website->getId() != $group->getWebsiteId()) {
                     continue;
                 }
-                $groupShow = false;
+                $values = [];
                 foreach ($this->_storeCollection as $store) {
                     if ($group->getId() != $store->getGroupId()) {
                         continue;
@@ -135,16 +138,12 @@ class Store extends \Magento\Framework\DataObject implements OptionSourceInterfa
                         $options[] = ['label' => $website->getName(), 'value' => []];
                         $websiteShow = true;
                     }
-                    if (!$groupShow) {
-                        $groupShow = true;
-                        $values = [];
-                    }
                     $values[] = [
                         'label' => str_repeat($nonEscapableNbspChar, 4) . $store->getName(),
                         'value' => $store->getId(),
                     ];
                 }
-                if ($groupShow) {
+                if (!empty($values)) {
                     $options[] = [
                         'label' => str_repeat($nonEscapableNbspChar, 4) . $group->getName(),
                         'value' => $values,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Please check:

`public function getStoreValuesForForm($empty = false, $all = false)`

in:

`app/code/Magento/Store/Model/System/Store.php`

![image](https://user-images.githubusercontent.com/8234209/63219172-7ee98880-c196-11e9-8c0d-1bb6f570eb14.png)

Bad logic here. **$groupShow is always TRUE** or **undefine error happen**

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. UNIT TEST COVERED

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
