### PR TITLE
magento/magento2#24186: CLI: cron:install. Break tasks to default and non-optional.

### DIFF
--- a/app/code/Magento/Cron/Console/Command/CronInstallCommand.php
+++ b/app/code/Magento/Cron/Console/Command/CronInstallCommand.php
@@ -21,8 +21,8 @@ use Symfony\Component\Console\Input\InputOption;
  */
 class CronInstallCommand extends Command
 {
-    const COMMAND_OPTION_FORCE = 'force';
-    const COMMAND_OPTION_NON_OPTIONAL = 'non-optional';
+    private const COMMAND_OPTION_FORCE = 'force';
+    private const COMMAND_OPTION_NON_OPTIONAL = 'non-optional';
 
     /**
      * @var CrontabManagerInterface

--- a/app/code/Magento/Cron/Console/Command/CronInstallCommand.php
+++ b/app/code/Magento/Cron/Console/Command/CronInstallCommand.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Cron\Console\Command;
 
 use Magento\Framework\Crontab\CrontabManagerInterface;
@@ -19,6 +21,9 @@ use Symfony\Component\Console\Input\InputOption;
  */
 class CronInstallCommand extends Command
 {
+    const COMMAND_OPTION_FORCE = 'force';
+    const COMMAND_OPTION_NON_OPTIONAL = 'non-optional';
+
     /**
      * @var CrontabManagerInterface
      */
@@ -44,19 +49,27 @@ class CronInstallCommand extends Command
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function configure()
     {
         $this->setName('cron:install')
             ->setDescription('Generates and installs crontab for current user')
-            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force install tasks');
+            ->addOption(self::COMMAND_OPTION_FORCE, 'f', InputOption::VALUE_NONE, 'Force install tasks')
+            // @codingStandardsIgnoreStart
+            ->addOption(self::COMMAND_OPTION_NON_OPTIONAL, 'd', InputOption::VALUE_NONE, 'Install only the non-optional (default) tasks');
+            // @codingStandardsIgnoreEnd
 
         parent::configure();
     }
 
     /**
-     * {@inheritdoc}
+     * Executes "cron:install" command.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null
+     * @throws LocalizedException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -65,8 +78,13 @@ class CronInstallCommand extends Command
             return Cli::RETURN_FAILURE;
         }
 
+        $tasks = $this->tasksProvider->getTasks();
+        if ($input->getOption(self::COMMAND_OPTION_NON_OPTIONAL)) {
+            $tasks = $this->extractNonOptionalTasks($tasks);
+        }
+
         try {
-            $this->crontabManager->saveTasks($this->tasksProvider->getTasks());
+            $this->crontabManager->saveTasks($tasks);
         } catch (LocalizedException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
             return Cli::RETURN_FAILURE;
@@ -75,5 +93,24 @@ class CronInstallCommand extends Command
         $output->writeln('<info>Crontab has been generated and saved</info>');
 
         return Cli::RETURN_SUCCESS;
+    }
+
+    /**
+     * Returns an array of non-optional tasks
+     *
+     * @param array $tasks
+     * @return array
+     */
+    private function extractNonOptionalTasks(array $tasks = []): array
+    {
+        $defaultTasks = [];
+
+        foreach ($tasks as $taskCode => $taskParams) {
+            if (!$taskParams['optional']) {
+                $defaultTasks[$taskCode] = $taskParams;
+            }
+        }
+
+        return $defaultTasks;
     }
 }

--- a/app/code/Magento/Cron/etc/di.xml
+++ b/app/code/Magento/Cron/etc/di.xml
@@ -66,12 +66,15 @@
             <argument name="tasks" xsi:type="array">
                 <item name="cronMagento" xsi:type="array">
                     <item name="command" xsi:type="string">{magentoRoot}bin/magento cron:run | grep -v "Ran jobs by schedule" >> {magentoLog}magento.cron.log</item>
+                    <item name="optional" xsi:type="boolean">false</item>
                 </item>
                 <item name="cronUpdate" xsi:type="array">
                     <item name="command" xsi:type="string">{magentoRoot}update/cron.php >> {magentoLog}update.cron.log</item>
+                    <item name="optional" xsi:type="boolean">true</item>
                 </item>
                 <item name="cronSetup" xsi:type="array">
                     <item name="command" xsi:type="string">{magentoRoot}bin/magento setup:cron:run >> {magentoLog}setup.cron.log</item>
+                    <item name="optional" xsi:type="boolean">true</item>
                 </item>
             </argument>
         </arguments>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

`bin/magento cron:install` command adds the extra cron job - `update/cron.php`:

```
#~ MAGENTO START c5f9e5ed71cceaabc4d4fd9b3e827a2b
#* * * * * /usr/bin/php7.1 /home/dev/sites/pgs/bin/magento cron:run 2>&1 | grep -v "Ran jobs by schedule" >> /home/dev/sites/pgs/var/log/magento.cron.log
#* * * * * /usr/bin/php7.1 /home/dev/sites/pgs/update/cron.php >> /home/dev/sites/pgs/var/log/update.cron.log
#* * * * * /usr/bin/php7.1 /home/dev/sites/pgs/bin/magento setup:cron:run >> /home/dev/sites/pgs/var/log/setup.cron.log
#~ MAGENTO END c5f9e5ed71cceaabc4d4fd9b3e827a2b
```


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24186: bin/magento cron:install adds extra cron job
2. https://github.com/magento/magento2/issues/10040
3. https://github.com/magento/devdocs/issues/1740
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
**Example #1**
1. Install Magento 2.3 via `bin/magento setup:install` command
2. Run `bin/magento cron:install`
3. Run `crontab -l`
4. Check `<magento root folder>/update` folder. 

**Actual result:**
1. `<magento root folder>/update` folder does not exist.
2. `<magento root folder>/update/cron.php` does not exist.

**Example #2**
1. Install Magento 2.3 via `Web Setup Wizard`
2. Run `bin/magento cron:install`
3. Run `crontab -l`
4. Check `<magento root folder>/update` folder. 

**Actual result:**
1. `<magento root folder>/update` folder does not exist.
2. `<magento root folder>/update/cron.php` does not exist.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)

CC: @hostep 