### PR TITLE
Use appropriate label for store switch

### DIFF
--- a/app/code/Magento/Backend/i18n/en_US.csv
+++ b/app/code/Magento/Backend/i18n/en_US.csv
@@ -258,7 +258,7 @@ Minute,Minute
 "To use this website you must first enable JavaScript in your browser.","To use this website you must first enable JavaScript in your browser."
 "This is only a demo store. You can browse and place orders, but nothing will be processed.","This is only a demo store. You can browse and place orders, but nothing will be processed."
 "Report an Issue","Report an Issue"
-"Store View:","Store View:"
+"Scope:","Scope:"
 "Stores Configuration","Stores Configuration"
 "Please confirm scope switching. All data that hasn't been saved will be lost.","Please confirm scope switching. All data that hasn't been saved will be lost."
 "Additional Cache Management","Additional Cache Management"

--- a/app/code/Magento/Backend/view/adminhtml/templates/store/switcher.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/store/switcher.phtml
@@ -9,7 +9,7 @@
 <?php if ($websites = $block->getWebsites()) : ?>
 
 <div class="store-switcher store-view">
-    <span class="store-switcher-label"><?= $block->escapeHtml(__('Store View:')) ?></span>
+    <span class="store-switcher-label"><?= $block->escapeHtml(__('Scope:')) ?></span>
     <div class="actions dropdown closable">
         <input type="hidden" name="store_switcher" id="store_switcher"
                data-role="store-view-id" data-param="<?= $block->escapeHtmlAttr($block->getStoreVarName()) ?>"


### PR DESCRIPTION
### Description
"Store view" is a particular scope level and therefore shouldn't be used as the label for a dropdown which may include multiple scope levels. The current wording leads to nonsensical instructions if written out or spoken aloud, like "select XYZ website as the store view." That encourages confusion about how scopes in Magento work.

This PR switches it back to say "scope," an appropriately general term (which it did prior to 9f3e59e).

### Fixed Issues (if relevant)
none

### Manual testing scenarios
The label for the scope selector in the configuration area (among others) now says: "Scope" rather than "Store View."

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
