### PR TITLE
fix lost the table prefix in setup

### DIFF
--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -756,9 +756,10 @@ class Installer
         SchemaSetupInterface $setup,
         AdapterInterface $connection
     ) {
-        if (!$connection->isTableExists($setup->getTable('flag'))) {
+        $tableName = $setup->getTable('flag');
+        if (!$connection->isTableExists($tableName)) {
             $table = $connection->newTable(
-                $setup->getTable('flag')
+                $tableName
             )->addColumn(
                 'flag_id',
                 \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
@@ -797,7 +798,7 @@ class Installer
             );
             $connection->createTable($table);
         } else {
-            $this->updateColumnType($connection, 'flag', 'flag_data', 'mediumtext');
+            $this->updateColumnType($connection, $tableName, 'flag_data', 'mediumtext');
         }
     }
 


### PR DESCRIPTION
Fix lost the table prefix in setup

### Description (*)
to get the error after upgrade Magento
```
bin/magento setup:upgrade
Cache cleared successfully
File system cleanup:
/var/www/magento2ce/generated/code/ClawRock
/var/www/magento2ce/generated/code/Composer
/var/www/magento2ce/generated/code/Magento
/var/www/magento2ce/generated/code/Symfony
The directory '/var/www/magento2ce/generated/metadata/' doesn't exist - skipping cleanup
Updating modules:
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'magento.flag' doesn't exist, query was: DESCRIBE `flag`
```

### Manual testing scenarios (*)
1. install vanila magento2
2. composer require --dev clawrock/magento2-debug
3. bin/magento setup:upgrade

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
