### PR TITLE
Adminhtml Create Order - Remove unrequired setQty(getQty) call

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Items/Grid.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Items/Grid.php
@@ -133,7 +133,6 @@ class Grid extends \Magento\Sales\Block\Adminhtml\Order\Create\AbstractCreate
         $oldSuperMode = $this->getQuote()->getIsSuperMode();
         $this->getQuote()->setIsSuperMode(false);
         foreach ($items as $item) {
-
             if (!$item->getMessage()) {
                 //Getting product ids for stock item last quantity validation before grid display
                 $stockItemToCheck = [];

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Items/Grid.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Items/Grid.php
@@ -133,8 +133,6 @@ class Grid extends \Magento\Sales\Block\Adminhtml\Order\Create\AbstractCreate
         $oldSuperMode = $this->getQuote()->getIsSuperMode();
         $this->getQuote()->setIsSuperMode(false);
         foreach ($items as $item) {
-            // To dispatch inventory event sales_quote_item_qty_set_after, set item qty
-            $item->setQty($item->getQty());
 
             if (!$item->getMessage()) {
                 //Getting product ids for stock item last quantity validation before grid display


### PR DESCRIPTION
### Description (*)
When adding products to an order in the Adminhtml backend, a call is made to setQty(getQty) on the cart items as they are added. There is a comment in the code that this is to force a dispatch of the 
sales_quote_item_qty_set_after event.

This call is not required as the sales_quote_item_qty_set_after event is fired shortly before this code is processed.

An unintended consequence of calling setQty(getQty) which the original author may not have been aware of (and may be a bug introduced since then) is that a call to setQty(getQty) actually triggers a stockitem validation call for double the quantity, as it treats it as a call to add x items to a stockitem that already has x items in it. I'll raise a separate issue to cover the bug in setQty, but for now, removing this setQty(getQty) call from the admin order seems to have no ill effect as the sales_quote_item_qty_set_after event has already been dispatched.

### Fixed Issues (if relevant)
1. magento/magento2#24191: Placing order in Admin for backordered items shows incorrect backorder message

### Manual testing scenarios (*)
1. Create stock item with 10 in stock, allow backorders with notify. 
2. Make order for 8 items. Verify no backorder message (without this fix, it warns backorder of 6)

1. Create stock item with 10 in stock, allow backorders with notify. 
2. Make order for 12 items. Verify backorder warning for 2 items is displayed. (without this fix, it actually displays 2 messages,  one with warning for 2 items, and one with warning for 12 items)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
