### PR TITLE
Show view action only for active CMS pages

### DIFF
--- a/app/code/Magento/Cms/Ui/Component/Listing/Column/PageActions.php
+++ b/app/code/Magento/Cms/Ui/Component/Listing/Column/PageActions.php
@@ -83,6 +83,8 @@ class PageActions extends Column
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
                 $name = $this->getData('name');
+                $isActive = $item['is_active'] ?? false;
+
                 if (isset($item['page_id'])) {
                     $item[$name]['edit'] = [
                         'href' => $this->urlBuilder->getUrl($this->editUrl, ['page_id' => $item['page_id']]),
@@ -100,7 +102,7 @@ class PageActions extends Column
                         'post' => true,
                     ];
                 }
-                if (isset($item['identifier'])) {
+                if (isset($item['identifier'])/* && $isActive*/) {
                     $item[$name]['preview'] = [
                         'href' => $this->scopeUrlBuilder->getUrl(
                             $item['identifier'],

--- a/app/code/Magento/Cms/Ui/Component/Listing/Column/PageActions.php
+++ b/app/code/Magento/Cms/Ui/Component/Listing/Column/PageActions.php
@@ -102,7 +102,7 @@ class PageActions extends Column
                         'post' => true,
                     ];
                 }
-                if (isset($item['identifier'])/* && $isActive*/) {
+                if (isset($item['identifier']) && $isActive) {
                     $item[$name]['preview'] = [
                         'href' => $this->scopeUrlBuilder->getUrl(
                             $item['identifier'],


### PR DESCRIPTION
### Description 
This PR fixes the issue when an admin is able to see and use the CMS Pages grid View action for disabled CMS pages. 

### Fixed Issues (if relevant)

1. magento/magento2#24208: CMS Page Grid View action should be allowed only for enabled pages

### Manual testing scenarios

1. Log in as an admin
2. Go to *Content > Elements > Pages*
3. Disable a CMS page
4. Try to use **View** action for the disabled page

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
