### PR TITLE
Allow TinyMCE to save content with inline script tags

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/Section/StorefrontCategoryMainSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/StorefrontCategoryMainSection.xml
@@ -20,7 +20,7 @@
         <element name="addToCartProductBySku" type="button" selector="//form[@data-product-sku='{{productSku}}']//button[contains(@class, 'tocart')]" parameterized="true" />
         <element name="SuccessMsg" type="button" selector="div.message-success"/>
         <element name="productCount" type="text" selector="#toolbar-amount"/>
-        <element name="CatalogDescription" type="text" selector="//div[@class='category-description']//p"/>
+        <element name="CatalogDescription" type="text" selector="//div[@class='category-description']"/>
         <element name="mediaDescription" type="text" selector="img[alt='{{var1}}']" parameterized="true"/>
         <element name="imageSource" type="text" selector="//img[contains(@src,'{{var1}}')]" parameterized="true"/>
         <element name="productImage" type="text" selector="img.product-image-photo"/>

--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js
@@ -211,7 +211,7 @@ define([
                 'content_css': this.config.tinymce4['content_css'],
                 'relative_urls': true,
                 'valid_children': '+body[style]',
-                'extended_valid_elements' : '+script[src|async|defer|type|charset]',
+                'extended_valid_elements': '+script[src|async|defer|type|charset]',
                 'forced_root_block': false,
                 menubar: false,
                 plugins: this.config.tinymce4.plugins,

--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js
@@ -190,6 +190,18 @@ define([
             var settings,
                 eventBus = this.eventBus;
 
+            /**
+             * valid_children : '+body[style]'
+             *  Allow <style> tags at the top level in editor
+             *
+             * extended_valid_element : '+script[src|async|defer|type|charset]'
+             *  Allow <script> tags at the top level in editor
+             *
+             * forced_root_block: false,
+             *  Disable the automatic wrapping of non block elements in
+             *  block elements i.e prevents adding of <p> tags to <script> tags
+             *  to make <p><style></style></p>
+             */
             settings = {
                 selector: '#' + this.getId(),
                 theme: 'modern',
@@ -199,6 +211,8 @@ define([
                 'content_css': this.config.tinymce4['content_css'],
                 'relative_urls': true,
                 'valid_children': '+body[style]',
+                'extended_valid_elements' : '+script[src|async|defer|type|charset]',
+                'forced_root_block': false,
                 menubar: false,
                 plugins: this.config.tinymce4.plugins,
                 toolbar: this.config.tinymce4.toolbar,


### PR DESCRIPTION
### Description (*)

### Issue 1
Since TinyMCE Version 4.2.0 the ability to have `<script>` tags inside the editor was disabled because of security concerns. See [TinyMCE 4.2.0 Release Notes](https://www.tiny.cloud/docs-4x/changelog/#version420june252015)

It is possible to add it back using the config setting 

`extended_valid_elements : "script[src|async|defer|type|charset]"`

This PR adds this setting.

### Issue 2
TinyMCE enforces that non block elements (of which `<script>` is one) are wrapped within block elements. Given the application of the above fix, `<script>` tags are now allowed, but get automatically wrapped in `<p>` tags.

This behaviour can be disabled by disabling the forced_root_block config setting in TinyMCE. This seems like the desired setting for Magento TinyMCE editors as we are only ever editing code snippets, not complete webpages where root elements `<head><body><html>` etc are present.

Edit : After this PR we were failing an MFTF test which assumed that when entering a category description, it was automatically wrapped with `<p></p>` by TinyMCE on save. Since adding the forced_root_block setting, it was no longer wrapped in `<p>'s` and thus failed. I have updated the test to pass. No other tests seem to expect the presence of `<p>` tags wrapped around any fields.

### Fixed Issues (if relevant)
1. magento/magento2#22867: Magento script and style filtering issue in CMS Blocks and Pages

### Manual testing scenarios (*)
1. N/A

### Questions or comments
There may need to be an internal discussion at Magento on the resolution to Issue 2 above. Are there any unintended consequences that I am unaware of?

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
