### PR TITLE
Resolved File type custom option value not showing properly in minicart

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/minicart/item/default.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/minicart/item/default.html
@@ -44,7 +44,10 @@
                             <!-- ko if: Array.isArray(option.value) -->
                                 <span data-bind="html: option.value.join('<br>')"></span>
                             <!-- /ko -->
-                            <!-- ko ifnot: Array.isArray(option.value) -->
+                            <!-- ko if: (!Array.isArray(option.value) && option.option_type == 'file') -->
+                                <span data-bind="html: option.value"></span>
+                            <!-- /ko -->
+                            <!-- ko if: (!Array.isArray(option.value) && option.option_type != 'file') -->
                                 <span data-bind="text: option.value"></span>
                             <!-- /ko -->
                         </dd>


### PR DESCRIPTION
Resolved File type custom option value not showing properly in minicart #24236

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues 
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24236: File type custom option value not showing properly in minicart

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. create a simple product with file type custom option
2. add this product to cart along with file
3. then in minicart file option value is showing with anchor tag

![file1](https://user-images.githubusercontent.com/44425160/63516074-e2164a80-c509-11e9-94c6-78242db6e29f.png)


