### PR TITLE
bug fix where massactions whould give table not found error #23451

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Massaction/AbstractMassaction.php
@@ -292,7 +292,7 @@ abstract class AbstractMassaction extends \Magento\Backend\Block\Widget
             $idsSelect->reset(\Magento\Framework\DB\Select::LIMIT_COUNT);
             $idsSelect->reset(\Magento\Framework\DB\Select::LIMIT_OFFSET);
             $idsSelect->reset(\Magento\Framework\DB\Select::COLUMNS);
-            $idsSelect->columns($this->getMassactionIdField(), 'main_table');
+            $idsSelect->columns($this->getMassactionIdField());
             $idList = $collection->getConnection()->fetchCol($idsSelect);
         } else {
             $idList = $collection->setPageSize(0)->getColumnValues($this->getMassactionIdField());


### PR DESCRIPTION
**Description:**
Removed 'main_table' in idsSelect->columns() in getGridIdsJson()  

**Fixed issues:**
#23451 Zend_Db_Select_Exception when accessing dynamic data such as blackbird/contentypes

**Manual testing scenario:**
See isuee #23451

- Implement new grid Magento\Backend\Block\Widget\Grid (I know it's deprecated)
- The gris MUST use an EAV collection type
- Add following massaction block: Magento\Backend\Block\Widget\Grid\Massaction

