### PR TITLE
magento/magento2#21592: Newsletter subscription input box in footer:

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
@@ -704,6 +704,9 @@
 
             .block {
                 float: right;
+                &.newsletter{
+                    min-width: 310px;
+                }
             }
 
             ul {


### PR DESCRIPTION
- fix placeholder in newsletter for portrait mode ipad


### Description (*)

 Add a min-width in the footer block so that the placeholder is always visible.

### Fixed Issues (if relevant)

1. magento/magento2#21592: Newsletter subscription input box in footer: on iPad (9.7"), in portrait mode, placeholder text is not visible

### Manual testing scenarios (*)

tests in resolutions for mobiles

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
