### PR TITLE
Correction in the shipping method if it is empty it no longer shows t…

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/shipping-information.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/shipping-information.js
@@ -35,7 +35,9 @@ define([
                 shippingMethodTitle = ' - ' + shippingMethod['method_title'];
             }
 
-            return shippingMethod ? shippingMethod['carrier_title'] + shippingMethodTitle : shippingMethod['carrier_title'];
+            return shippingMethod ?
+                shippingMethod['carrier_title'] + shippingMethodTitle :
+                shippingMethod['carrier_title'];
         },
 
         /**

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/shipping-information.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/shipping-information.js
@@ -36,8 +36,6 @@ define([
             }
 
             return shippingMethod ? shippingMethod['carrier_title'] + shippingMethodTitle : shippingMethod['carrier_title'];
-
-            //return shippingMethod ? shippingMethod['carrier_title'] + ' - ' + shippingMethod['method_title'] : '';
         },
 
         /**

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/shipping-information.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/shipping-information.js
@@ -29,8 +29,15 @@ define([
          */
         getShippingMethodTitle: function () {
             var shippingMethod = quote.shippingMethod();
+            var shippingMethodTitle = '';
 
-            return shippingMethod ? shippingMethod['carrier_title'] + ' - ' + shippingMethod['method_title'] : '';
+            if (typeof shippingMethod['method_title'] !== 'undefined') {
+                shippingMethodTitle = ' - ' + shippingMethod['method_title'];
+            }
+
+            return shippingMethod ? shippingMethod['carrier_title'] + shippingMethodTitle : shippingMethod['carrier_title'];
+
+            //return shippingMethod ? shippingMethod['carrier_title'] + ' - ' + shippingMethod['method_title'] : '';
         },
 
         /**

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/shipping-information.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/shipping-information.js
@@ -28,8 +28,8 @@ define([
          * @return {String}
          */
         getShippingMethodTitle: function () {
-            var shippingMethod = quote.shippingMethod();
-            var shippingMethodTitle = '';
+            var shippingMethod = quote.shippingMethod(),
+                shippingMethodTitle = '';
 
             if (typeof shippingMethod['method_title'] !== 'undefined') {
                 shippingMethodTitle = ' - ' + shippingMethod['method_title'];


### PR DESCRIPTION

### Description (*)
I propose to correct this problem is to validate if the title of the method was undefined, show the carrier title in the opposite case concatenate the method title with the carrier title

I solved it with the validation was done in the file Magento/Checkout/view/frontend/web/js/view/shipping-information.js in the getShippingMethodTitle method, I create a variable to concatenate the names.

### Fixed Issues (if relevant)

1. magento/magento2#19853: Shipping method undefined issue


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
