### PR TITLE
magento/magento2#24266: DHL Mexico isn´t working 

### DIFF
--- a/app/code/Magento/Dhl/Model/Carrier.php
+++ b/app/code/Magento/Dhl/Model/Carrier.php
@@ -1154,13 +1154,16 @@ class Carrier extends \Magento\Dhl\Model\AbstractDhl implements \Magento\Shippin
 
         if ($this->isDutiable($rawRequest->getOrigCountryId(), $rawRequest->getDestCountryId())) {
             // IsDutiable flag and Dutiable node indicates that cargo is not a documentation
-            $nodeBkgDetails->addChild('IsDutiable', 'Y');
-            $nodeDutiable = $nodeGetQuote->addChild('Dutiable');
-            $baseCurrencyCode = $this->_storeManager
-                ->getWebsite($this->_request->getWebsiteId())
-                ->getBaseCurrencyCode();
-            $nodeDutiable->addChild('DeclaredCurrency', $baseCurrencyCode);
-            $nodeDutiable->addChild('DeclaredValue', sprintf("%.2F", $rawRequest->getValue()));
+            if ($rawRequest->getOrigCountryId() != "MX") {
+                // Dhl for Mexico isn´t needed this parameters.
+                $nodeBkgDetails->addChild('IsDutiable', 'Y');
+                $nodeDutiable = $nodeGetQuote->addChild('Dutiable');
+                $baseCurrencyCode = $this->_storeManager
+                    ->getWebsite($this->_request->getWebsiteId())
+                    ->getBaseCurrencyCode();
+                $nodeDutiable->addChild('DeclaredCurrency', $baseCurrencyCode);
+                $nodeDutiable->addChild('DeclaredValue', sprintf("%.2F", $rawRequest->getValue()));
+            }
         }
 
         return $xml;


### PR DESCRIPTION
### Description (*)

Removed unneeded DHL params for MX

### Fixed Issues (if relevant)
1. magento/magento2#24266: DHL Mexico isn´t working

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
