### PR TITLE
Resolve undefined $product variable in updateItem(...)

### DIFF
--- a/app/code/Magento/Checkout/Model/Cart.php
+++ b/app/code/Magento/Checkout/Model/Cart.php
@@ -4,6 +4,8 @@
  * See COPYING.txt for license details.
  */
 
+declare(strict_types=1);
+
 namespace Magento\Checkout\Model;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
@@ -291,8 +293,8 @@ class Cart extends DataObject implements CartInterface
     /**
      * Get product object based on requested product information
      *
-     * @param   Product|int|string $productInfo
-     * @return  Product
+     * @param Product|int|string $productInfo
+     * @return Product
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     protected function _getProduct($productInfo)
@@ -332,8 +334,8 @@ class Cart extends DataObject implements CartInterface
     /**
      * Get request for product add to cart procedure
      *
-     * @param   \Magento\Framework\DataObject|int|array $requestInfo
-     * @return  \Magento\Framework\DataObject
+     * @param \Magento\Framework\DataObject|int|array $requestInfo
+     * @return \Magento\Framework\DataObject
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     protected function _getProductRequest($requestInfo)
@@ -376,6 +378,7 @@ class Cart extends DataObject implements CartInterface
                     ['info' => $requestInfo, 'product' => $product]
                 );
                 $result = $this->getQuote()->addProduct($product, $request);
+                // phpcs:ignore Magento2.Exceptions.ThrowCatch
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
                 $this->_checkoutSession->setUseNotice(false);
                 $result = $e->getMessage();
@@ -723,6 +726,7 @@ class Cart extends DataObject implements CartInterface
                 ['quote_item' => $result, 'product' => $product]
             );
             $this->_checkoutSession->setLastAddedProductId($productId);
+            // phpcs:ignore Magento2.Exceptions.ThrowCatch
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->_checkoutSession->setUseNotice(false);
             $result = $e->getMessage();

--- a/app/code/Magento/Checkout/Model/Cart.php
+++ b/app/code/Magento/Checkout/Model/Cart.php
@@ -717,6 +717,12 @@ class Cart extends DataObject implements CartInterface
             }
 
             $result = $this->getQuote()->updateItem($itemId, $request, $updatingParams);
+
+            $this->_eventManager->dispatch(
+                'checkout_cart_product_update_after',
+                ['quote_item' => $result, 'product' => $product]
+            );
+            $this->_checkoutSession->setLastAddedProductId($productId);
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->_checkoutSession->setUseNotice(false);
             $result = $e->getMessage();
@@ -732,11 +738,6 @@ class Cart extends DataObject implements CartInterface
             throw new \Magento\Framework\Exception\LocalizedException(__($result));
         }
 
-        $this->_eventManager->dispatch(
-            'checkout_cart_product_update_after',
-            ['quote_item' => $result, 'product' => $product]
-        );
-        $this->_checkoutSession->setLastAddedProductId($productId);
         return $result;
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Let check :

![image](https://user-images.githubusercontent.com/8234209/63648254-2fd3c280-c757-11e9-8ccd-287ae6502942.png)

in : `app/code/Magento/Checkout/Model/Cart.php`

I believe this function absolutely go wrong when the logic runs:
```
 catch (\Magento\Framework\Exception\LocalizedException $e) {
            $this->_checkoutSession->setUseNotice(false);
            $result = $e->getMessage();
        }
```

Solution:

```
        $this->_eventManager->dispatch(
            'checkout_cart_product_update_after',
            ['quote_item' => $result, 'product' => $product]
        );
        $this->_checkoutSession->setLastAddedProductId($productId);
```

**must move to`"try"` block**

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Test the updateItem function when the catch block runs: (can simulate by throw exception in             `$result = $this->getQuote()->updateItem($itemId, $request, $updatingParams);`
2. Expected Result: No undefined errors.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
