### PR TITLE
Resolved edit configurable product from cart doesn't show selected swatch options #24306

### DIFF
--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -750,7 +750,7 @@ define([
 
             $(document).trigger('updateMsrpPriceBlock',
                 [
-                    parseInt($this.attr('index'), 10) + 1,
+                    _.findKey($widget.options.jsonConfig.index, $widget.options.jsonConfig.defaultValues),
                     $widget.options.jsonConfig.optionPrices
                 ]);
 


### PR DESCRIPTION
Resolved edit configurable product from cart doesn't show selected swatch options #24306

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24306: Edit configurable product from cart doesn't show selected swatch options

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. create a configurable product with more than one swatch attribute
2. add product to cart
3. then edit the same from cart

![issue](https://user-images.githubusercontent.com/44425160/63743930-75110500-c8bb-11e9-903b-cc4881f7efb8.png)

