### PR TITLE
resolve CData section too big on Export grid issue 24311

### DIFF
--- a/app/code/Magento/ImportExport/Ui/DataProvider/ExportFileDataProvider.php
+++ b/app/code/Magento/ImportExport/Ui/DataProvider/ExportFileDataProvider.php
@@ -13,6 +13,7 @@ use Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Io\File;
 
 /**
  * Data provider for export grid.
@@ -30,7 +31,7 @@ class ExportFileDataProvider extends DataProvider
     private $fileSystem;
     
     /**
-     * @var File Input Output
+     * @var File
      */
     private $fileIO;
     
@@ -44,6 +45,7 @@ class ExportFileDataProvider extends DataProvider
      * @param \Magento\Framework\Api\FilterBuilder $filterBuilder
      * @param DriverInterface $file
      * @param Filesystem $filesystem
+     * @param File $fileIO
      * @param array $meta
      * @param array $data
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -58,13 +60,13 @@ class ExportFileDataProvider extends DataProvider
         \Magento\Framework\Api\FilterBuilder $filterBuilder,
         DriverInterface $file,
         Filesystem $filesystem,
-        \Magento\Framework\Filesystem\Io\File $fileIO,
+        File $fileIO,
         array $meta = [],
         array $data = []
     ) {
         $this->file = $file;
         $this->fileSystem = $filesystem;
-        $this->fileIO = $fileIO;
+        $this->fileio = $fileIO;
         $this->request = $request;
         parent::__construct(
             $name,
@@ -99,7 +101,7 @@ class ExportFileDataProvider extends DataProvider
         }
         $result = [];
         foreach ($files as $file) {
-            $result['items'][]['file_name'] = $this->fileIO->getPathInfo($file)['basename'];
+            $result['items'][]['file_name'] = $this->fileio->getPathInfo($file)['basename'];
         }
 
         $pagesize = (int)($this->request->getParam('paging')['pageSize']);

--- a/app/code/Magento/ImportExport/Ui/DataProvider/ExportFileDataProvider.php
+++ b/app/code/Magento/ImportExport/Ui/DataProvider/ExportFileDataProvider.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 declare(strict_types=1);
 
 namespace Magento\ImportExport\Ui\DataProvider;
@@ -56,6 +58,7 @@ class ExportFileDataProvider extends DataProvider
     ) {
         $this->file = $file;
         $this->fileSystem = $filesystem;
+        $this->request = $request;
         parent::__construct(
             $name,
             $primaryFieldName,
@@ -92,7 +95,12 @@ class ExportFileDataProvider extends DataProvider
             $result['items'][]['file_name'] = basename($file);
         }
 
+        $pagesize = intval($this->request->getParam('paging')['pageSize']);
+        $pageCurrent = intval($this->request->getParam('paging')['current']);
+        $pageoffset = ($pageCurrent - 1) * $pagesize;
+
         $result['totalRecords'] = count($result['items']);
+        $result['items'] = array_slice($result['items'], $pageoffset, $pageoffset + $pagesize);
 
         return $result;
     }

--- a/app/code/Magento/ImportExport/Ui/DataProvider/ExportFileDataProvider.php
+++ b/app/code/Magento/ImportExport/Ui/DataProvider/ExportFileDataProvider.php
@@ -28,7 +28,12 @@ class ExportFileDataProvider extends DataProvider
      * @var Filesystem
      */
     private $fileSystem;
-
+    
+    /**
+     * @var File Input Output
+     */
+    private $fileIO;
+    
     /**
      * @param string $name
      * @param string $primaryFieldName
@@ -53,11 +58,13 @@ class ExportFileDataProvider extends DataProvider
         \Magento\Framework\Api\FilterBuilder $filterBuilder,
         DriverInterface $file,
         Filesystem $filesystem,
+        \Magento\Framework\Filesystem\Io\File $fileIO,
         array $meta = [],
         array $data = []
     ) {
         $this->file = $file;
         $this->fileSystem = $filesystem;
+        $this->fileIO = $fileIO;
         $this->request = $request;
         parent::__construct(
             $name,
@@ -92,15 +99,15 @@ class ExportFileDataProvider extends DataProvider
         }
         $result = [];
         foreach ($files as $file) {
-            $result['items'][]['file_name'] = basename($file);
+            $result['items'][]['file_name'] = $this->fileIO->getPathInfo($file)['basename'];
         }
 
-        $pagesize = intval($this->request->getParam('paging')['pageSize']);
-        $pageCurrent = intval($this->request->getParam('paging')['current']);
+        $pagesize = (int)($this->request->getParam('paging')['pageSize']);
+        $pageCurrent = (int)($this->request->getParam('paging')['current']);
         $pageoffset = ($pageCurrent - 1) * $pagesize;
 
         $result['totalRecords'] = count($result['items']);
-        $result['items'] = array_slice($result['items'], $pageoffset, $pageoffset + $pagesize);
+        $result['items'] = array_slice($result['items'],$pageoffset , $pagesize);
 
         return $result;
     }

--- a/app/code/Magento/ImportExport/Ui/DataProvider/ExportFileDataProvider.php
+++ b/app/code/Magento/ImportExport/Ui/DataProvider/ExportFileDataProvider.php
@@ -33,7 +33,7 @@ class ExportFileDataProvider extends DataProvider
     /**
      * @var File
      */
-    private $fileIO;
+    private $fileio;
     
     /**
      * @param string $name
@@ -109,7 +109,7 @@ class ExportFileDataProvider extends DataProvider
         $pageoffset = ($pageCurrent - 1) * $pagesize;
 
         $result['totalRecords'] = count($result['items']);
-        $result['items'] = array_slice($result['items'],$pageoffset , $pagesize);
+        $result['items'] = array_slice($result['items'],$pageoffset,$pagesize);
 
         return $result;
     }

--- a/app/code/Magento/ImportExport/view/adminhtml/ui_component/export_grid.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/ui_component/export_grid.xml
@@ -41,15 +41,11 @@
             </item>
         </argument>
         <paging name="listing_paging">
-            <argument name="data" xsi:type="array">
-                <item name="config" xsi:type="array">
-                    <item name="selectProvider" xsi:type="string">export_grid.export_grid_data_source.export_grid_columns.file_name</item>
-                    <item name="storageConfig" xsi:type="array">
-                        <item name="provider" xsi:type="string">export_grid.export_grid_data_source.listing_top.bookmarks</item>
-                        <item name="namespace" xsi:type="string">current.paging</item>
-                    </item>
-                </item>
-            </argument>
+            <settings>
+                <sticky>false</sticky>
+            </settings>
+            <bookmark name="bookmarks"/>
+            <paging name="listing_paging"/>
         </paging>
     </listingToolbar>
     <columns name="export_grid_columns">

--- a/app/code/Magento/ImportExport/view/adminhtml/ui_component/export_grid.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/ui_component/export_grid.xml
@@ -33,7 +33,40 @@
                 <primaryFieldName>file_name</primaryFieldName>
             </settings>
         </dataProvider>
+        <argument name="dataProvider" xsi:type="configurableObject">
+            <argument name="class" xsi:type="string">Magento\ImportExport\Ui\DataProvider\ExportFileDataProvider</argument>
+            <argument name="name" xsi:type="string">export_grid_data_source</argument>
+            <argument name="primaryFieldName" xsi:type="string">file_name</argument>
+            <argument name="requestFieldName" xsi:type="string">file_name</argument>
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="component" xsi:type="string">Magento_Ui/js/grid/provider</item>
+                    <item name="update_url" xsi:type="url" path="mui/index/render"/>
+                    <item name="storageConfig" xsi:type="array">
+                        <item name="indexField" xsi:type="string">file_name</item>
+                    </item>
+                </item>
+            </argument>
+        </argument>
     </dataSource>
+    <listingToolbar name="listing_top">
+        <argument name="data" xsi:type="array">
+            <item name="config" xsi:type="array">
+                <item name="sticky" xsi:type="boolean">true</item>
+            </item>
+        </argument>
+        <paging name="listing_paging">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="selectProvider" xsi:type="string">export_grid.export_grid_data_source.export_grid_columns.file_name</item>
+                    <item name="storageConfig" xsi:type="array">
+                        <item name="provider" xsi:type="string">export_grid.export_grid_data_source.listing_top.bookmarks</item>
+                        <item name="namespace" xsi:type="string">current.paging</item>
+                    </item>
+                </item>
+            </argument>
+        </paging>
+    </listingToolbar>
     <columns name="export_grid_columns">
         <column name="file_name">
             <settings>

--- a/app/code/Magento/ImportExport/view/adminhtml/ui_component/export_grid.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/ui_component/export_grid.xml
@@ -41,10 +41,6 @@
             </item>
         </argument>
         <paging name="listing_paging">
-            <settings>
-                <sticky>false</sticky>
-            </settings>
-            <bookmark name="bookmarks"/>
             <paging name="listing_paging"/>
         </paging>
     </listingToolbar>

--- a/app/code/Magento/ImportExport/view/adminhtml/ui_component/export_grid.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/ui_component/export_grid.xml
@@ -33,21 +33,6 @@
                 <primaryFieldName>file_name</primaryFieldName>
             </settings>
         </dataProvider>
-        <argument name="dataProvider" xsi:type="configurableObject">
-            <argument name="class" xsi:type="string">Magento\ImportExport\Ui\DataProvider\ExportFileDataProvider</argument>
-            <argument name="name" xsi:type="string">export_grid_data_source</argument>
-            <argument name="primaryFieldName" xsi:type="string">file_name</argument>
-            <argument name="requestFieldName" xsi:type="string">file_name</argument>
-            <argument name="data" xsi:type="array">
-                <item name="config" xsi:type="array">
-                    <item name="component" xsi:type="string">Magento_Ui/js/grid/provider</item>
-                    <item name="update_url" xsi:type="url" path="mui/index/render"/>
-                    <item name="storageConfig" xsi:type="array">
-                        <item name="indexField" xsi:type="string">file_name</item>
-                    </item>
-                </item>
-            </argument>
-        </argument>
     </dataSource>
     <listingToolbar name="listing_top">
         <argument name="data" xsi:type="array">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues 
1. magento/magento2#24311: "CData section too big" error while accessing configurable product in backend 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. At export history grid number of files more (>  20000)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
