### PR TITLE
#2228; Encode xml entities in tag attributes

### DIFF
--- a/lib/internal/Magento/Framework/Simplexml/Element.php
+++ b/lib/internal/Magento/Framework/Simplexml/Element.php
@@ -245,7 +245,7 @@ class Element extends \SimpleXMLElement
         $attributes = $this->attributes();
         if ($attributes) {
             foreach ($attributes as $key => $value) {
-                $out .= ' ' . $key . '="' . str_replace('"', '\"', (string)$value) . '"';
+                $out .= ' ' . $key . '="' . str_replace('"', '\"', $this->xmlentities($value)) . '"';
             }
         }
 

--- a/lib/internal/Magento/Framework/Simplexml/Element.php
+++ b/lib/internal/Magento/Framework/Simplexml/Element.php
@@ -25,6 +25,19 @@ class Element extends \SimpleXMLElement
     protected $_parent = null;
 
     /**
+     * For future use
+     *
+     * @param \Magento\Framework\Simplexml\Element $element
+     * @return void
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * phpcs:disable Magento2.CodeAnalysis.EmptyBlock
+     */
+    public function setParent($element)
+    {
+    }
+    // phpcs:enable
+
+    /**
      * Returns parent node for the element
      *
      * Currently using xpath

--- a/lib/internal/Magento/Framework/Simplexml/Element.php
+++ b/lib/internal/Magento/Framework/Simplexml/Element.php
@@ -25,18 +25,6 @@ class Element extends \SimpleXMLElement
     protected $_parent = null;
 
     /**
-     * For future use
-     *
-     * @param \Magento\Framework\Simplexml\Element $element
-     * @return void
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
-    public function setParent($element)
-    {
-        //$this->_parent = $element;
-    }
-
-    /**
      * Returns parent node for the element
      *
      * Currently using xpath
@@ -179,7 +167,8 @@ class Element extends \SimpleXMLElement
     }
 
     /**
-     * asArray() analog, but without attributes
+     * The asArray() analog, but without attributes
+     *
      * @return array|string
      */
     public function asCanonicalArray()
@@ -469,8 +458,8 @@ class Element extends \SimpleXMLElement
 
     /**
      * Unset self from the XML-node tree
-     *
      * Note: trying to refer this object as a variable after "unsetting" like this will result in E_WARNING
+     *
      * @return void
      */
     public function unsetSelf()

--- a/lib/internal/Magento/Framework/Simplexml/Element.php
+++ b/lib/internal/Magento/Framework/Simplexml/Element.php
@@ -458,6 +458,7 @@ class Element extends \SimpleXMLElement
 
     /**
      * Unset self from the XML-node tree
+     *
      * Note: trying to refer this object as a variable after "unsetting" like this will result in E_WARNING
      *
      * @return void


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Xml attributes needed to be encoded to allow special symbols such as `&amp;`.

### Fixed Issues (if relevant)
1. magento/magento2#2228 Problem with adding google fonts with ampersand into default_head_blocks.xml

### Manual testing scenarios (*)
1. Per #2228, add the following to add a link to a page using the following code. The exception shouldn't be thrown.
```
<link src="//fonts.googleapis.com/css?family=Open+Sans|Roboto+Condensed|Open+Sans+Condensed:400,300,300italic,400italic,600,600italic,700italic,700&amp;subset=latin,cyrillic" src_type="url" />
```

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
