### PR TITLE
Fix integer url key causing error in product import

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -2761,6 +2761,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
     {
         $resource = $this->getResource();
         foreach ($this->urlKeys as $storeId => $urlKeys) {
+            $urlKeysAsStrings = array_map('strval', array_keys($urlKeys));
             $urlKeyDuplicates = $this->_connection->fetchAssoc(
                 $this->_connection->select()->from(
                     ['url_rewrite' => $resource->getTable('url_rewrite')],
@@ -2768,7 +2769,7 @@ class Product extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                 )->joinLeft(
                     ['cpe' => $resource->getTable('catalog_product_entity')],
                     "cpe.entity_id = url_rewrite.entity_id"
-                )->where('request_path IN (?)', array_keys($urlKeys))
+                )->where('request_path IN (?)', $urlKeysAsStrings)
                     ->where('store_id IN (?)', $storeId)
                     ->where('cpe.sku not in (?)', array_values($urlKeys))
             );


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
During product import, when checking duplicate URL keys, integer URL keys can potentially match to non-equal rows from url_rewrite table.

`SELECT * FROM url_rewrite WHERE request_path IN (5)` matches to request_path '5-test-product', which causes undefined index exception.

Query should be `SELECT * FROM url_rewrite WHERE request_path IN ('5')`. The change fixes this by converting all url keys to strings before passing them to where() function.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create product with name '5 test product'
2. Import a product with url key '5', for example
[import_file.zip](https://github.com/magento/magento2/files/3550754/import_file.zip)
3. Error is shown: Notice: Undefined index: 5-test-product in /usr/src/app/vendor/magento/module-catalog-import-export/Model/Import/Product.php on line 2868
![Screenshot 2019-08-28 at 15 09 28](https://user-images.githubusercontent.com/50874886/63854642-47ed5100-c9a6-11e9-8d0f-cd3a13f9a590.png)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
