### PR TITLE
Fix: Check customerId for null validateResetPasswordToken

### DIFF
--- a/app/code/Magento/Customer/Api/AccountManagementInterface.php
+++ b/app/code/Magento/Customer/Api/AccountManagementInterface.php
@@ -160,8 +160,7 @@ interface AccountManagementInterface
     /**
      * Check if password reset token is valid.
      *
-     * @param int $customerId If 0 is given then a customer
-     * will be matched by the RP token.
+     * @param int $customerId
      * @param string $resetPasswordLinkToken
      *
      * @return bool True if the token is valid
@@ -172,6 +171,19 @@ interface AccountManagementInterface
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function validateResetPasswordLinkToken($customerId, $resetPasswordLinkToken);
+
+    /**
+     * Check if password reset token is valid.
+     *
+     * @param string $resetPasswordLinkToken
+     *
+     * @return bool True if the token is valid
+     * @throws \Magento\Framework\Exception\State\InputMismatchException If token is mismatched
+     * @throws \Magento\Framework\Exception\State\ExpiredException If token is expired
+     * @throws \Magento\Framework\Exception\NoSuchEntityException If customer doesn't exist
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function validateResetPasswordLinkTokenWithoutCustomerId($resetPasswordLinkToken);
 
     /**
      * Gets the account confirmation status.

--- a/app/code/Magento/Customer/Api/AccountManagementInterface.php
+++ b/app/code/Magento/Customer/Api/AccountManagementInterface.php
@@ -160,7 +160,7 @@ interface AccountManagementInterface
     /**
      * Check if password reset token is valid.
      *
-     * @param int $customerId If null is given then a customer
+     * @param int $customerId If 0 is given then a customer
      * will be matched by the RP token.
      * @param string $resetPasswordLinkToken
      *

--- a/app/code/Magento/Customer/Model/AccountManagement.php
+++ b/app/code/Magento/Customer/Model/AccountManagement.php
@@ -1136,7 +1136,7 @@ class AccountManagement implements AccountManagementInterface
      */
     private function validateResetPasswordToken($customerId, $resetPasswordLinkToken)
     {
-        if ($customerId !== null && $customerId <= 0) {
+        if ($customerId !== null && $customerId < 0) {
             throw new InputException(
                 __(
                     'Invalid value of "%value" provided for the %fieldName field.',
@@ -1145,7 +1145,7 @@ class AccountManagement implements AccountManagementInterface
             );
         }
 
-        if ($customerId === null) {
+        if ($customerId === 0) {
             //Looking for the customer.
             $customerId = $this->getByToken
                 ->execute($resetPasswordLinkToken)

--- a/app/code/Magento/Customer/etc/webapi.xml
+++ b/app/code/Magento/Customer/etc/webapi.xml
@@ -188,6 +188,12 @@
             <resource ref="anonymous"/>
         </resources>
     </route>
+    <route url="/V1/customers/password/resetLinkToken/:resetPasswordLinkToken" method="GET">
+        <service class="Magento\Customer\Api\AccountManagementInterface" method="validateResetPasswordLinkTokenWithoutCustomerId"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
     <route url="/V1/customers/password" method="PUT">
         <service class="Magento\Customer\Api\AccountManagementInterface" method="initiatePasswordReset"/>
         <resources>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Impossible to provide `null customerId` for `resetLinkToken` request
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24245: Unable to Verify Password Reset Token Without Customer ID - REST API

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Issue a password reset email for an existing customer.
2. Attempt to validate the password reset token via the REST API without customer ID since it is unavailable
(request to /V1/customers/{customerId}/password/resetLinkToken/{resetPasswordLinkToken}).

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
