### PR TITLE
Prevent removal existing images while importing products by API

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
@@ -92,7 +92,7 @@ class MediaGalleryProcessor
                     if ($updatedEntry['file'] === null) {
                         unset($updatedEntry['file']);
                     }
-                    $existingMediaGallery[$key] = array_merge($existingEntry, $updatedEntry);
+                    $existingMediaGallery[$key] += $updatedEntry;
                 } else {
                     //set the removed flag
                     $existingEntry['removed'] = true;

--- a/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
@@ -80,7 +80,7 @@ class MediaGalleryProcessor
         $entriesById = [];
         if (!empty($existingMediaGallery)) {
             foreach ($mediaGalleryEntries as $entry) {
-                if (isset($entry['value_id'])) {
+                if (isset($entry['value_id']) && $entry['value_id'] != '') {
                     $entriesById[$entry['value_id']] = $entry;
                 } else {
                     $newEntries[] = $entry;

--- a/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
@@ -86,16 +86,16 @@ class MediaGalleryProcessor
                     $newEntries[] = $entry;
                 }
             }
-            foreach ($existingMediaGallery as $key => &$existingEntry) {
+            foreach ($existingMediaGallery as $key => $existingEntry) {
                 if (isset($entriesById[$existingEntry['value_id']])) {
                     $updatedEntry = $entriesById[$existingEntry['value_id']];
                     if ($updatedEntry['file'] === null) {
                         unset($updatedEntry['file']);
                     }
-                    $existingMediaGallery[$key] += $updatedEntry;
+                    $existingMediaGallery[$key] = ($updatedEntry + $existingEntry);
                 } else {
                     //set the removed flag
-                    $existingEntry['removed'] = true;
+                    $existingMediaGallery[$key]['removed'] = true;
                 }
             }
             $product->setData('media_gallery', ["images" => $existingMediaGallery]);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Prevent removal existing images while importing products by API

### Fixed Issues (if relevant)
1. magento/magento2#10461: Updating a product through the API removes its images

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a new product by the API
2. Link some images in the magento interface
3. Update product by rest API
4. Validate product images still exists

### Questions or comments
not applicable

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable) _not applicable_
 - [x] All automated tests passed successfully (all builds are green)
