### PR TITLE
Removed Grunt Config Files From gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,11 +28,8 @@ atlassian*
 /lib/internal/flex/varien/.settings
 /node_modules
 /.grunt
-/Gruntfile.js
-/package.json
 /.php_cs
 /.php_cs.cache
-/grunt-config.json
 /pub/media/*.*
 !/pub/media/.htaccess
 /pub/media/attribute/*


### PR DESCRIPTION
### Description (*)
The following two DevDocs posts nicely show how to use Grunt in order to generate the CSS etc.:

* [Using Grunt for Magento tasks](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/tools/using_grunt.html)
* [Compile LESS using Grunt](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css_debug.html)

When working on a Magento 2 project, it makes sense that anyone working on the project uses the same Grunt configuration, so that the CSS is generated in the exact same way. Hence, it makes sense to include Grunt configuration files into git. The file `/dev/tools/grunt/configs/local-themes.js` has already been removed from `.gitignore` in other pull requests (#18960 / #19350). This pull requests removes the remaining Grunt configuration files from the default `.gitignore`.

### Manual testing scenarios (*)
1. Create Magento 2 project.
2. Install and configure Grunt as described in the [DevDocs](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/tools/using_grunt.html#grunt_config).
3. Expected behaviour: Grunt configuration files will be added to git.
4. Actual behaviour: Grunt configuration files are not added to git, because they are included in the default `.gitignore`.

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)