### PR TITLE
remove reset data on deployment config object

### DIFF
--- a/lib/internal/Magento/Framework/App/DeploymentConfig.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig.php
@@ -7,6 +7,9 @@
 namespace Magento\Framework\App;
 
 use Magento\Framework\Config\ConfigOptionsListConstants;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Exception\RuntimeException;
+use Magento\Framework\Phrase;
 
 /**
  * Application deployment configuration
@@ -63,6 +66,8 @@ class DeploymentConfig
      * @param string $key
      * @param mixed $defaultValue
      * @return mixed|null
+     * @throws FileSystemException
+     * @throws RuntimeException
      */
     public function get($key = null, $defaultValue = null)
     {
@@ -82,10 +87,11 @@ class DeploymentConfig
      * Checks if data available
      *
      * @return bool
+     * @throws FileSystemException
+     * @throws RuntimeException
      */
     public function isAvailable()
     {
-        $this->data = null;
         $this->load();
         return isset($this->flatData[ConfigOptionsListConstants::CONFIG_PATH_INSTALL_DATE]);
     }
@@ -95,6 +101,8 @@ class DeploymentConfig
      *
      * @param string $key
      * @return null|mixed
+     * @throws FileSystemException
+     * @throws RuntimeException
      */
     public function getConfigData($key = null)
     {
@@ -104,11 +112,7 @@ class DeploymentConfig
             return null;
         }
 
-        if (isset($this->data[$key])) {
-            return $this->data[$key];
-        }
-
-        return $this->data;
+        return $this->data[$key] ?? $this->data;
     }
 
     /**
@@ -125,6 +129,8 @@ class DeploymentConfig
      * Check if data from deploy files is available
      *
      * @return bool
+     * @throws FileSystemException
+     * @throws RuntimeException
      * @since 100.1.3
      */
     public function isDbAvailable()
@@ -137,6 +143,8 @@ class DeploymentConfig
      * Loads the configuration data
      *
      * @return void
+     * @throws FileSystemException
+     * @throws RuntimeException
      */
     private function load()
     {
@@ -158,12 +166,15 @@ class DeploymentConfig
      *
      * @param array $params
      * @param string $path
+     * @param array $partialResult
      * @return array
-     * @throws \Exception
+     * @throws RuntimeException
      */
-    private function flattenParams(array $params, $path = null)
+    private function flattenParams(array $params, $path = null, array &$partialResult = null): array
     {
-        $cache = [];
+        if (null === $partialResult) {
+            $partialResult = [];
+        }
 
         foreach ($params as $key => $param) {
             if ($path) {
@@ -171,15 +182,15 @@ class DeploymentConfig
             } else {
                 $newPath = $key;
             }
-            if (isset($cache[$newPath])) {
-                throw new \Exception("Key collision {$newPath} is already defined.");
+            if (isset($partialResult[$newPath])) {
+                throw new RuntimeException(new Phrase("Key collision in deployment configuration at '%1' is already defined.", [$newPath]));
             }
-            $cache[$newPath] = $param;
+            $partialResult[$newPath] = $param;
             if (is_array($param)) {
-                $cache = array_merge($cache, $this->flattenParams($param, $newPath));
+                $this->flattenParams($param, $newPath, $partialResult);
             }
         }
 
-        return $cache;
+        return $partialResult;
     }
 }

--- a/lib/internal/Magento/Framework/Module/ModuleList.php
+++ b/lib/internal/Magento/Framework/Module/ModuleList.php
@@ -59,7 +59,7 @@ class ModuleList implements ModuleListInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      *
      * Note that this triggers loading definitions of all existing modules in the system.
      * Use this method only when you actually need modules' declared meta-information.
@@ -84,8 +84,7 @@ class ModuleList implements ModuleListInterface
     }
 
     /**
-     * {@inheritdoc}
-     * @see has()
+     * @inheritdoc
      */
     public function getOne($name)
     {
@@ -94,7 +93,7 @@ class ModuleList implements ModuleListInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getNames()
     {
@@ -107,7 +106,7 @@ class ModuleList implements ModuleListInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function has($name)
     {
@@ -136,12 +135,16 @@ class ModuleList implements ModuleListInterface
      * Loads configuration data only
      *
      * @return void
+     * @throws \Magento\Framework\Exception\FileSystemException
+     * @throws \Magento\Framework\Exception\RuntimeException
      */
     private function loadConfigData()
     {
-        $this->config->resetData();
-        if (null === $this->configData && null !== $this->config->get(ConfigOptionsListConstants::KEY_MODULES)) {
-            $this->configData = $this->config->get(ConfigOptionsListConstants::KEY_MODULES);
+        if (null === $this->configData) {
+            $this->config->resetData();
+            if (null !== $this->config->get(ConfigOptionsListConstants::KEY_MODULES)) {
+                $this->configData = $this->config->get(ConfigOptionsListConstants::KEY_MODULES);
+            }
         }
     }
 }

--- a/lib/internal/Magento/Framework/Module/Test/Unit/ModuleListTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/ModuleListTest.php
@@ -47,7 +47,7 @@ class ModuleListTest extends \PHPUnit\Framework\TestCase
 
     public function testGetAll()
     {
-        $this->config->expects($this->exactly(2))->method('resetData');
+        $this->config->expects($this->once())->method('resetData');
         $this->setLoadAllExpectation();
         $this->setLoadConfigExpectation();
         $expected = ['foo' => self::$allFixture['foo']];
@@ -65,7 +65,7 @@ class ModuleListTest extends \PHPUnit\Framework\TestCase
 
     public function testGetOne()
     {
-        $this->config->expects($this->exactly(2))->method('resetData');
+        $this->config->expects($this->once())->method('resetData');
         $this->setLoadAllExpectation();
         $this->setLoadConfigExpectation();
         $this->assertSame(['key' => 'value'], $this->model->getOne('foo'));
@@ -74,7 +74,7 @@ class ModuleListTest extends \PHPUnit\Framework\TestCase
 
     public function testGetNames()
     {
-        $this->config->expects($this->exactly(2))->method('resetData');
+        $this->config->expects($this->once())->method('resetData');
         $this->setLoadAllExpectation(false);
         $this->setLoadConfigExpectation();
         $this->assertSame(['foo'], $this->model->getNames());
@@ -83,7 +83,7 @@ class ModuleListTest extends \PHPUnit\Framework\TestCase
 
     public function testHas()
     {
-        $this->config->expects($this->exactly(2))->method('resetData');
+        $this->config->expects($this->once())->method('resetData');
         $this->setLoadAllExpectation(false);
         $this->setLoadConfigExpectation();
         $this->assertTrue($this->model->has('foo'));

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/ModuleEnableDisableCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/ModuleEnableDisableCommandTest.php
@@ -53,23 +53,24 @@ class ModuleEnableDisableCommandTest extends \PHPUnit\Framework\TestCase
     {
         $this->objectManagerProviderMock = $this->createMock(\Magento\Setup\Model\ObjectManagerProvider::class);
         $objectManager = $this->getMockForAbstractClass(\Magento\Framework\ObjectManagerInterface::class);
-        $this->objectManagerProviderMock->expects($this->any())
+        $this->objectManagerProviderMock
             ->method('get')
-            ->will($this->returnValue($objectManager));
+            ->willReturn($objectManager);
         $this->statusMock = $this->createMock(\Magento\Framework\Module\Status::class);
         $this->cacheMock = $this->createMock(\Magento\Framework\App\Cache::class);
         $this->cleanupFilesMock = $this->createMock(\Magento\Framework\App\State\CleanupFiles::class);
         $this->fullModuleListMock = $this->createMock(\Magento\Framework\Module\FullModuleList::class);
         $this->deploymentConfigMock = $this->createMock(\Magento\Framework\App\DeploymentConfig::class);
         $this->generatedFiles = $this->createMock(\Magento\Framework\Code\GeneratedFiles::class);
-        $objectManager->expects($this->any())
-            ->method('get')
-            ->will($this->returnValueMap([
-                [\Magento\Framework\Module\Status::class, $this->statusMock],
-                [\Magento\Framework\App\Cache::class, $this->cacheMock],
-                [\Magento\Framework\App\State\CleanupFiles::class, $this->cleanupFilesMock],
-                [\Magento\Framework\Module\FullModuleList::class, $this->fullModuleListMock],
-            ]));
+        $objectManager->method('get')
+                    ->willReturnMap(
+                        [
+                            [\Magento\Framework\Module\Status::class, $this->statusMock],
+                            [\Magento\Framework\App\Cache::class, $this->cacheMock],
+                            [\Magento\Framework\App\State\CleanupFiles::class, $this->cleanupFilesMock],
+                            [\Magento\Framework\Module\FullModuleList::class, $this->fullModuleListMock],
+                        ]
+                    );
     }
 
     /**
@@ -189,7 +190,7 @@ class ModuleEnableDisableCommandTest extends \PHPUnit\Framework\TestCase
         if ($isEnable) {
             $this->deploymentConfigMock->expects($this->once())
                 ->method('isAvailable')
-                ->willReturn(['Magento_Module1']);
+                ->willReturn(true);
         } else {
             $this->deploymentConfigMock->expects($this->never())
                 ->method('isAvailable');


### PR DESCRIPTION
### Description (*)
DeploymentConfig object reads data from configurations files defined under ConfigFilePool initialized in \Magento\Framework\App\Bootstrap::createConfigFilePool. 

Since the ConfigFilePool can't be overwritten after bootstrap, it make no sense to reset configuration data in some cases. 

### Fixed Issues (if relevant)
Multiple loading of configuration files. 
For example in app/code/Magento/Framework/Module/ModuleList.php:99

### Manual testing scenarios (*)
After deploying this branch all configurations of shops are the same and is working the same.  

### Questions or comments
Is it necessary to still allow \Magento\Framework\App\DeploymentConfig::resetData on this object? 
