### PR TITLE
Added check for array

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/Layer/Filter/Attribute.php
+++ b/app/code/Magento/CatalogSearch/Model/Layer/Filter/Attribute.php
@@ -154,7 +154,7 @@ class Attribute extends AbstractFilter
      */
     private function getOptionCount($value, $optionsFacetedData)
     {
-        return isset($optionsFacetedData[$value]['count'])
+        return !is_array($value) && isset($optionsFacetedData[$value]['count'])
             ? (int)$optionsFacetedData[$value]['count']
             : 0;
     }


### PR DESCRIPTION
#24344 # Description (*)
There is an error caused when navigating the listing pages if any of the filterable attributes are returning assoc arrays from their source model so that the items are grouped in a Select element.

### Fixed Issues (if relevant)
Checks if the value is an array and if so, returns 0 as the count.

### Manual testing scenarios (*)

- Create a product attribute with a custom source
- Return a multi dimensional array from the source so that the items are grouped in a Select element
- Assign one of the select options to the product
- Browse the listing page that contain the product
- The filter will not display our attribute and no error will be caused.
