### PR TITLE
Resolved configurable product image not showing as per selected options #24383

### DIFF
--- a/lib/web/mage/gallery/gallery.js
+++ b/lib/web/mage/gallery/gallery.js
@@ -478,12 +478,10 @@ define([
                             settings.fotoramaApi.load(data);
                             mainImageIndex = getMainImageIndex(data);
 
-                            if (mainImageIndex) {
-                                settings.fotoramaApi.show({
-                                    index: mainImageIndex,
-                                    time: 0
-                                });
-                            }
+                            settings.fotoramaApi.show({
+                                index: mainImageIndex,
+                                time: 0
+                            });
 
                             $.extend(false, settings, {
                                 data: data,


### PR DESCRIPTION
Resolved configurable product image not showing as per selected options #24383

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24383: configurable product image not showing as per selected options
2. magento/magento2#16409: Product page gallery doesn't update product images

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a configurable product with swatches
2. Set image for each associated products
3. Navigate to product page at frontend
4. Select second or third image of main product
5 . Then select any option it's not showing the actual image, it's showing previous image.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->


