### PR TITLE
Fixed 24250: setFromAddress added in MessageInterface

### DIFF
--- a/lib/internal/Magento/Framework/Mail/FromAddressInterface.php
+++ b/lib/internal/Magento/Framework/Mail/FromAddressInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Mail;
+
+/**
+ * From Address interface
+ */
+interface FromAddressInterface extends MessageInterface
+{
+    /**
+     * Set from message
+     *
+     * @param string $fromAddress
+     * @param string|null $fromName
+     * @return $this
+     */
+    public function setFromAddress($fromAddress, $fromName = null);
+}

--- a/lib/internal/Magento/Framework/Mail/MessageInterface.php
+++ b/lib/internal/Magento/Framework/Mail/MessageInterface.php
@@ -68,15 +68,6 @@ interface MessageInterface
     public function setFrom($fromAddress);
 
     /**
-     * Set from message
-     *
-     * @param string $fromAddress
-     * @param string|null $fromName
-     * @return $this
-     */
-    public function setFromAddress($fromAddress, $fromName = null);
-
-    /**
      * Add to address
      *
      * @param string|array $toAddress

--- a/lib/internal/Magento/Framework/Mail/MessageInterface.php
+++ b/lib/internal/Magento/Framework/Mail/MessageInterface.php
@@ -68,6 +68,15 @@ interface MessageInterface
     public function setFrom($fromAddress);
 
     /**
+     * Set from message
+     *
+     * @param string $fromAddress
+     * @param string|null $fromName
+     * @return $this
+     */
+    public function setFromAddress($fromAddress, $fromName = null);
+
+    /**
      * Add to address
      *
      * @param string|array $toAddress


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
setFromAddress was missing in `Magento\Framework\Mail\MessageInterface` added
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed issue #24250 , setFromAddress was missing in MessageInterface
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #24250

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. function added `public function setFromAddress($fromAddress, $fromName = null);`
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
