### PR TITLE
Resolve "New Block" form still show "Store View" field in "Single Store Mode" issue24387

### DIFF
--- a/app/code/Magento/Cms/Ui/Component/Form/Field/StoreView.php
+++ b/app/code/Magento/Cms/Ui/Component/Form/Field/StoreView.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Cms\Ui\Component\Form\Field;
+
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use Magento\Framework\View\Element\UiComponentInterface;
+use Magento\Store\Model\StoreManagerInterface as StoreManager;
+use Magento\Ui\Component\Form\Field;
+
+/**
+ * Check to disable store view field
+ *
+ * Class \Magento\Cms\Ui\Component\Form\Field\StoreView
+ */
+class StoreView extends Field
+{
+    /**
+     * Store manager
+     *
+     * @var StoreManager
+     */
+    private $storeManager;
+
+    /**
+     * StoreView constructor.
+     *
+     * @param ContextInterface $context
+     * @param UiComponentFactory $uiComponentFactory
+     * @param StoreManager $storeManager
+     * @param array $components
+     * @param array $data
+     */
+    public function __construct(
+        ContextInterface $context,
+        UiComponentFactory $uiComponentFactory,
+        StoreManager $storeManager,
+        array $components = [],
+        array $data = []
+    ) {
+        parent::__construct($context, $uiComponentFactory, $components, $data);
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * Prepare component configuration
+     *
+     * @return void
+     */
+    public function prepare()
+    {
+        parent::prepare();
+        if ($this->storeManager->isSingleStoreMode()) {
+            $this->_data['config']['componentDisabled'] = true;
+        }
+    }
+}

--- a/app/code/Magento/Cms/view/adminhtml/ui_component/cms_block_form.xml
+++ b/app/code/Magento/Cms/view/adminhtml/ui_component/cms_block_form.xml
@@ -111,7 +111,7 @@
                 <dataScope>identifier</dataScope>
             </settings>
         </field>
-        <field name="storeviews" formElement="multiselect" class="Magento\Cms\Ui\Component\Form\Field\StoreView">
+        <field name="storeviews" formElement="multiselect" class="Magento\Store\Ui\Component\Form\Field\StoreView">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">block</item>

--- a/app/code/Magento/Cms/view/adminhtml/ui_component/cms_block_form.xml
+++ b/app/code/Magento/Cms/view/adminhtml/ui_component/cms_block_form.xml
@@ -111,7 +111,7 @@
                 <dataScope>identifier</dataScope>
             </settings>
         </field>
-        <field name="storeviews" formElement="multiselect">
+        <field name="storeviews" formElement="multiselect" class="Magento\Cms\Ui\Component\Form\Field\StoreView">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">block</item>

--- a/app/code/Magento/Store/Ui/Component/Form/Field/StoreView.php
+++ b/app/code/Magento/Store/Ui/Component/Form/Field/StoreView.php
@@ -5,18 +5,17 @@
  */
 declare(strict_types=1);
 
-namespace Magento\Cms\Ui\Component\Form\Field;
+namespace Magento\Store\Ui\Component\Form\Field;
 
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponentFactory;
-use Magento\Framework\View\Element\UiComponentInterface;
 use Magento\Store\Model\StoreManagerInterface as StoreManager;
 use Magento\Ui\Component\Form\Field;
 
 /**
  * Check to disable store view field
  *
- * Class \Magento\Cms\Ui\Component\Form\Field\StoreView
+ * Class \Magento\Store\Ui\Component\Form\Field\StoreView
  */
 class StoreView extends Field
 {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. Resolve magento/magento2#24387: "New Block" form still show "Store View" field in "Single Store Mode" 

Solution: Add the class to handle the case `$this->storeManager->isSingleStoreMode()
`
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24387: "New Block" form still show "Store View" field in "Single Store Mode" 
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Magento 2.3-develop
2. Enable "Single Store Mode"
![image](https://user-images.githubusercontent.com/8234209/64060881-2fc33f00-cbfd-11e9-81ac-1c622f65ff1c.png)
3. Go to backend
4. Content->Blocks
5. Add New Block
=> no Store View field in the form

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
