### PR TITLE
23583: Added website checker for product in \Magento\Catalog\Model\ProductRepository

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -304,6 +304,11 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                 $product->setData('_edit_mode', true);
             }
             $product->load($productId);
+            if (!$product->getId()) {
+                throw new NoSuchEntityException(
+                    __("The product that was requested doesn't exist. Verify the product and try again.")
+                );
+            }
             $productWebsites = $product->getExtensionAttributes()->getWebsiteIds();
             if ($storeId !== null) {
                 if (in_array($storeId, $productWebsites) || $storeId == $defaultAdminStoreId) {
@@ -316,11 +321,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                         )
                     );
                 }
-            }
-            if (!$product->getId()) {
-                throw new NoSuchEntityException(
-                    __("The product that was requested doesn't exist. Verify the product and try again.")
-                );
             }
             $this->cacheProduct($cacheKey, $product);
         }

--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -309,9 +309,9 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                     __("The product that was requested doesn't exist. Verify the product and try again.")
                 );
             }
-            $productWebsites = $product->getExtensionAttributes()->getWebsiteIds();
+            $productStoreIds = $this->getProductStoreIds($product);
             if ($storeId !== null) {
-                if (in_array($storeId, $productWebsites) || $storeId == $defaultAdminStoreId) {
+                if (in_array($storeId, $productStoreIds) || $storeId == $defaultAdminStoreId) {
                     $product->setData('store_id', $storeId);
                 } else {
                     throw new NoSuchEntityException(
@@ -865,5 +865,25 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
                 $e
             );
         }
+    }
+
+    /**
+     * Getting store ids of a product
+     *
+     * @param Product $product
+     *
+     * @return array
+     * @throws LocalizedException
+     */
+    private function getProductStoreIds($product): array
+    {
+        $productStoreIds = [];
+
+        $productWebsites = $product->getExtensionAttributes()->getWebsiteIds();
+        foreach ($productWebsites as $key => $value) {
+            $websiteStoreIds = $this->storeManager->getWebsite($value)->getStoreIds();
+            $productStoreIds += $websiteStoreIds;
+        }
+        return $productStoreIds;
     }
 }


### PR DESCRIPTION

Added condition for checking product website using extension attributes, some formatting

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added checked for requested product's website. In case product isn't assigned to requested website - and exception is thrown

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23583: \Magento\Catalog\Model\ProductRepository does not respect store scope

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Not needed

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
