### PR TITLE
#12371 allows to add handlers via di

### DIFF
--- a/app/code/Magento/Catalog/Helper/Output.php
+++ b/app/code/Magento/Catalog/Helper/Output.php
@@ -20,6 +20,9 @@ use function method_exists;
 use function preg_match;
 use function strtolower;
 
+/**
+ * Html output
+ */
 class Output extends AbstractHelper
 {
     /**
@@ -86,6 +89,8 @@ class Output extends AbstractHelper
     }
 
     /**
+     * Return template processor
+     *
      * @return Template
      */
     protected function _getTemplateProcessor()

--- a/app/code/Magento/Catalog/Helper/Output.php
+++ b/app/code/Magento/Catalog/Helper/Output.php
@@ -9,9 +9,18 @@ namespace Magento\Catalog\Helper;
 
 use Magento\Catalog\Model\Category as ModelCategory;
 use Magento\Catalog\Model\Product as ModelProduct;
+use Magento\Eav\Model\Config;
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\Escaper;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filter\Template;
+use function is_object;
+use function method_exists;
+use function preg_match;
+use function strtolower;
 
-class Output extends \Magento\Framework\App\Helper\AbstractHelper
+class Output extends AbstractHelper
 {
     /**
      * Array of existing handlers
@@ -37,12 +46,12 @@ class Output extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Eav config
      *
-     * @var \Magento\Eav\Model\Config
+     * @var Config
      */
     protected $_eavConfig;
 
     /**
-     * @var \Magento\Framework\Escaper
+     * @var Escaper
      */
     protected $_escaper;
 
@@ -53,23 +62,26 @@ class Output extends \Magento\Framework\App\Helper\AbstractHelper
 
     /**
      * Output constructor.
-     * @param \Magento\Framework\App\Helper\Context $context
-     * @param \Magento\Eav\Model\Config $eavConfig
+     * @param Context $context
+     * @param Config $eavConfig
      * @param Data $catalogData
-     * @param \Magento\Framework\Escaper $escaper
+     * @param Escaper $escaper
      * @param array $directivePatterns
+     * @param array $handlers
      */
     public function __construct(
-        \Magento\Framework\App\Helper\Context $context,
-        \Magento\Eav\Model\Config $eavConfig,
+        Context $context,
+        Config $eavConfig,
         Data $catalogData,
-        \Magento\Framework\Escaper $escaper,
-        $directivePatterns = []
+        Escaper $escaper,
+        $directivePatterns = [],
+        array $handlers = []
     ) {
         $this->_eavConfig = $eavConfig;
         $this->_catalogData = $catalogData;
         $this->_escaper = $escaper;
         $this->directivePatterns = $directivePatterns;
+        $this->_handlers = $handlers;
         parent::__construct($context);
     }
 
@@ -115,8 +127,7 @@ class Output extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getHandlers($method)
     {
-        $method = strtolower($method);
-        return $this->_handlers[$method] ?? [];
+        return $this->_handlers[strtolower($method)] ?? [];
     }
 
     /**
@@ -145,21 +156,21 @@ class Output extends \Magento\Framework\App\Helper\AbstractHelper
      * @param string $attributeName
      * @return string
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function productAttribute($product, $attributeHtml, $attributeName)
     {
         $attribute = $this->_eavConfig->getAttribute(ModelProduct::ENTITY, $attributeName);
         if ($attribute &&
             $attribute->getId() &&
-            $attribute->getFrontendInput() != 'media_image' &&
+            $attribute->getFrontendInput() !== 'media_image' &&
             (!$attribute->getIsHtmlAllowedOnFront() &&
             !$attribute->getIsWysiwygEnabled())
         ) {
-            if ($attribute->getFrontendInput() != 'price') {
+            if ($attribute->getFrontendInput() !== 'price') {
                 $attributeHtml = $this->_escaper->escapeHtml($attributeHtml);
             }
-            if ($attribute->getFrontendInput() == 'textarea') {
+            if ($attribute->getFrontendInput() === 'textarea') {
                 $attributeHtml = nl2br($attributeHtml);
             }
         }
@@ -187,14 +198,14 @@ class Output extends \Magento\Framework\App\Helper\AbstractHelper
      * @param string $attributeHtml
      * @param string $attributeName
      * @return string
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function categoryAttribute($category, $attributeHtml, $attributeName)
     {
         $attribute = $this->_eavConfig->getAttribute(ModelCategory::ENTITY, $attributeName);
 
         if ($attribute &&
-            $attribute->getFrontendInput() != 'image' &&
+            $attribute->getFrontendInput() !== 'image' &&
             (!$attribute->getIsHtmlAllowedOnFront() &&
             !$attribute->getIsWysiwygEnabled())
         ) {


### PR DESCRIPTION
This PR allows to add handlers thanks to the di.xml configuration file.

### Description (*)
Today we can't add easily handlers to manage the output of a product attribute by using the output helper.
The solution is add a plugin on `getHandlers` methods, but you have to check in your side that you didn't already added the handler.
An other solution is to add the handlers once on the instantiation of the helper.

### Fixed Issues (if relevant)

1. magento/magento2#12371: Adding a handler to the Magento\Catalog\Helper\Output Class


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
