### PR TITLE
Allow construction of products with custom_attributes in $data

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ProductTest.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace Magento\Catalog\Model;
 
+use Magento\Eav\Model\Config as EavConfig;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\TestFramework\ObjectManager;
 
 /**
  * Tests product model:
@@ -49,8 +51,8 @@ class ProductTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\FileSystemException
      * @return void
+     * @throws \Magento\Framework\Exception\FileSystemException
      */
     public static function tearDownAfterClass()
     {
@@ -307,9 +309,9 @@ class ProductTest extends \PHPUnit\Framework\TestCase
         $this->_model = $this->productRepository->get('simple');
 
         // fixture
-        $this->assertTrue((bool)$this->_model->isSalable());
-        $this->assertTrue((bool)$this->_model->isSaleable());
-        $this->assertTrue((bool)$this->_model->isAvailable());
+        $this->assertTrue((bool) $this->_model->isSalable());
+        $this->assertTrue((bool) $this->_model->isSaleable());
+        $this->assertTrue((bool) $this->_model->isAvailable());
         $this->assertTrue($this->_model->isInStock());
     }
 
@@ -324,9 +326,9 @@ class ProductTest extends \PHPUnit\Framework\TestCase
         $this->_model = $this->productRepository->get('simple');
 
         $this->_model->setStatus(0);
-        $this->assertFalse((bool)$this->_model->isSalable());
-        $this->assertFalse((bool)$this->_model->isSaleable());
-        $this->assertFalse((bool)$this->_model->isAvailable());
+        $this->assertFalse((bool) $this->_model->isSalable());
+        $this->assertFalse((bool) $this->_model->isSaleable());
+        $this->assertFalse((bool) $this->_model->isAvailable());
         $this->assertFalse($this->_model->isInStock());
     }
 
@@ -585,7 +587,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
                 continue;
             }
             foreach ($option->getValues() as $value) {
-                $this->assertEquals($expectedValue[$value->getSku()], (float)$value->getPrice());
+                $this->assertEquals($expectedValue[$value->getSku()], (float) $value->getPrice());
             }
         }
     }
@@ -631,5 +633,41 @@ class ProductTest extends \PHPUnit\Framework\TestCase
             [-1, 1, true],
             [1, 1, true],
         ];
+    }
+
+    public function testConstructionWithCustomAttributesMapInData()
+    {
+        $data = [
+            'custom_attributes' => [
+                'tax_class_id' => '3',
+                'category_ids' => '1,2'
+            ],
+        ];
+
+        /** @var Product $product */
+        $product = ObjectManager::getInstance()->create(Product::class, ['data' => $data]);
+        $this->assertSame($product->getCustomAttribute('tax_class_id')->getValue(), '3');
+        $this->assertSame($product->getCustomAttribute('category_ids')->getValue(), '1,2');
+    }
+
+    public function testConstructionWithCustomAttributesArrayInData()
+    {
+        $data = [
+            'custom_attributes' => [
+                [
+                    'attribute_code' => 'tax_class_id',
+                    'value' => '3'
+                ],
+                [
+                    'attribute_code' => 'category_ids',
+                    'value' => '1,2'
+                ]
+            ],
+        ];
+
+        /** @var Product $product */
+        $product = ObjectManager::getInstance()->create(Product::class, ['data' => $data]);
+        $this->assertSame($product->getCustomAttribute('tax_class_id')->getValue(), '3');
+        $this->assertSame($product->getCustomAttribute('category_ids')->getValue(), '1,2');
     }
 }

--- a/lib/internal/Magento/Framework/Model/AbstractExtensibleModel.php
+++ b/lib/internal/Magento/Framework/Model/AbstractExtensibleModel.php
@@ -75,6 +75,28 @@ abstract class AbstractExtensibleModel extends AbstractModel implements
     }
 
     /**
+     * Convert the custom attributes array format to map format
+     *
+     * The method \Magento\Framework\Reflection\DataObjectProcessor::buildOutputDataArray generates a custom_attributes
+     * array representation where each custom attribute is a sub-array with a `attribute_code and value key.
+     * This method maps such an array to the plain code => value map format exprected by filterCustomAttributes
+     *
+     * @param array[] $customAttributesData
+     * @return array
+     */
+    private function flattenCustomAttributesArrayToMap(array $customAttributesData): array
+    {
+        return array_reduce(
+            $customAttributesData,
+            function (array $acc, array $customAttribute): array {
+                $acc[$customAttribute['attribute_code']] = $customAttribute['value'];
+                return $acc;
+            },
+            []
+        );
+    }
+
+    /**
      * Verify custom attributes set on $data and unset if not a valid custom attribute
      *
      * @param array $data
@@ -85,9 +107,12 @@ abstract class AbstractExtensibleModel extends AbstractModel implements
         if (empty($data[self::CUSTOM_ATTRIBUTES])) {
             return $data;
         }
-        $customAttributesCodes = $this->getCustomAttributesCodes();
+        if (isset($data[self::CUSTOM_ATTRIBUTES][0])) {
+            $data[self::CUSTOM_ATTRIBUTES] = $this->flattenCustomAttributesArrayToMap($data[self::CUSTOM_ATTRIBUTES]);
+        }
+        $customAttributesCodes         = $this->getCustomAttributesCodes();
         $data[self::CUSTOM_ATTRIBUTES] = array_intersect_key(
-            (array)$data[self::CUSTOM_ATTRIBUTES],
+            (array) $data[self::CUSTOM_ATTRIBUTES],
             array_flip($customAttributesCodes)
         );
         foreach ($data[self::CUSTOM_ATTRIBUTES] as $code => $value) {


### PR DESCRIPTION
# Description

This patch does two things:

1. Currently it is not possible to pass an array with `custom_attributes`
   to the `\Magento\Catalog\Model\Product` constructor (it causes a fatal error).
   The reason is because the `filterCustomAttribute` and `eavConfig` arguments are
   assigned after the call to `parent::__construct`.
   However, the properties are used during the `parent::__construct` calls.
   The flow of execution is as follows:
   `Product::__construct` -> `Catalog\Model\AbstractModel::__construct`
   `Catalog\Model\AbstractModel::__construct` -> `AbstractExtensibleModel::__construct`
   `AbstractExtensibleModel::__construct` -> `AbstractExtensibleModel::filterCustomAttributes`
   `AbstractExtensibleModel::filterCustomAttributes` -> `AbstractExtensibleModel::getCustomAttributesCodes`
   ...which is overridden by `Product::getCustomAttributesCodes`
  ` getCustomAttributesCodes` expectes the `filterCustomAttribute` and `eavConfig` properties to be set if
       `custom_attributes` are present in `$data`, but they are still null because the `Product::__construct`
       method has not yet completed.
   The fix this PR applies is to assign the properties before the call to `parent::__construct`.
   The bug and fix are covered by the integration test:
   `\Magento\Catalog\Model\ProductTest::testConstructionWithCustomAttributesMapInData`

2. The method `AbstractExtensibleModel::filterCustomAttribute` expects the `custom_attributes` in `$data` to
   be a simple map from codes to values, e.g. `['category_ids => '1,2']`.
   However, the method `\Magento\Framework\Reflection\DataObjectProcessor::buildOutputDataArray` generates a
   numerically indexed custom attributes array, where each custom attribute is a sub-array with a `attribute_code`
   and `value` record.
   This PR allows passing such an `custom_attributes` array into the `Product` model constructor.
   Currently it would be ignored, but with this patch the code checks if `custom_attributes` is numerically indexed,
   and if so, flattens the sub-arrays into the expected map format.
  This improvement is covered by the integration test
  `\Magento\Catalog\Model\ProductTest::testConstructionWithCustomAttributesArrayInData`

   To illustrate the difference of the `custom_attributes` array formats:

```
   // Map:
   [
       'custom_attributes' => [
           'category_ids' => '1,2',
           'tax_class_id' => '3',
       ]
   ]
```
```
   // Numerically indexed array of sub-arrays:
   [
      'custom_attributes' => [
          [
              'attribute_code' => 'category_ids',
              'value'          => '1,2'
          ],
          [
              'attribute_code' => 'tax_class_id',
              'value'          => '3'
          ],

      ]
  ]
```

This PR contains no backward incompatible changes.

## Manual testing scenarios:

Create a product model instance passing in a `$data` array with `custom_attributes` (any format).  
An example of this can be seen in the tests in this PR.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
