### PR TITLE
[EncryptionKey] Fixing the encryption key switching field

### DIFF
--- a/app/code/Magento/EncryptionKey/Block/Adminhtml/Crypt/Key/Form.php
+++ b/app/code/Magento/EncryptionKey/Block/Adminhtml/Crypt/Key/Form.php
@@ -45,7 +45,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'name' => 'generate_random',
                 'label' => __('Auto-generate a Key'),
                 'options' => [0 => __('No'), 1 => __('Yes')],
-                'onclick' => "var cryptKey = jQuery('#crypt_key'); var cryptKeyBlock = cryptKey.parent().parent(); ".
+                'onchange' => "var cryptKey = jQuery('#crypt_key'); var cryptKeyBlock = cryptKey.parent().parent(); ".
                     "cryptKey.prop('disabled', this.value === '1'); " .
                     "if (cryptKey.prop('disabled')) { cryptKeyBlock.hide() } " .
                     "else { cryptKeyBlock.show() }",


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes the event for switching the visibility for the `New Key` after choosing the `Auto-generate a Key` -> `Yes` option

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24436: Autogenerating encryption key requires manually entering the key

### Manual testing scenarios (*)
1. Navigate to `System / Manage Encryption Key`
2. Select `Yes` for `Auto-generate a Key`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
