### PR TITLE
#24441 : Minicart height calculated incorrectly when child items contain margins

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -347,7 +347,7 @@ define([
                 if ($(this).find('.options').length > 0) {
                     $(this).collapsible();
                 }
-                outerHeight = $(this).outerHeight();
+                outerHeight = $(this).outerHeight(true);
 
                 if (counter-- > 0) {
                     height += outerHeight;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixed the minicart height calculation issue when child items have the margin
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24441: Minicart height calculated incorrectly when child items contain margins

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Deploy 2.3-develop
2. Create Test product and add to cart
3. View minicart
4. Open browser development tools
5. Locate the line `<li class="item product product-item" data-role="product-item">`
6. In the style explorer locate the css item `.minicart-items .product-item`
7. Add the style `padding-bottom: 100px !important;`
8. Close and reopen minicart to force recalculate the height
9. Notice that the minicart height is correctly calculated and there is a padding of 100px in the minicart.
![image](https://user-images.githubusercontent.com/39480008/64274009-1ce39e00-cf60-11e9-85c5-6c31293925d9.png)
10. Remove the style `padding-bottom: 100px !important;`
11. Add the style `margin-bottom: 100px !important;`
12. Close and reopen minicart to force recalculate the height
![image](https://user-images.githubusercontent.com/39480008/64273893-e017a700-cf5f-11e9-8bdd-d4d657e257ac.png)
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
