### PR TITLE
Fix for bug: If multiple children had the same sort order only one of…

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Details.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Details.php
@@ -40,9 +40,8 @@ class Details extends \Magento\Framework\View\Element\Template
             $childNamesSortOrder[$childName] = $sortOrder;
         }
 
-        asort($childNamesSortOrder);
-        $childNamesSortOrder = array_keys($childNamesSortOrder);
+        asort($childNamesSortOrder, SORT_NUMERIC);
 
-        return $childNamesSortOrder;
+        return array_keys($childNamesSortOrder);
     }
 }

--- a/app/code/Magento/Catalog/Block/Product/View/Details.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Details.php
@@ -37,10 +37,11 @@ class Details extends \Magento\Framework\View\Element\Template
             $alias = $layout->getElementAlias($childName);
             $sortOrder = (int)$this->getChildData($alias, 'sort_order') ?? 0;
 
-            $childNamesSortOrder[$sortOrder] = $childName;
+            $childNamesSortOrder[$childName] = $sortOrder;
         }
 
-        ksort($childNamesSortOrder, SORT_NUMERIC);
+        asort($childNamesSortOrder);
+        $childNamesSortOrder = array_keys($childNamesSortOrder);
 
         return $childNamesSortOrder;
     }


### PR DESCRIPTION
… them would be rendered

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Changed Magento\Catalog\Block\Product\View\Details to fix issue with multiple children having the same sort order causing only one of them to render.

### Fixed Issues (if relevant)
If you have multiple tabs on product page with the same sort order or without sort order only one of them will render.

### Manual testing scenarios (*)
Have multiple tabs on product page with the same sort order. 
Before fix: only one is rendered.
After: All of them are rendered.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
