### PR TITLE
Fix for issue when query INSERT INTO “search_tmp…” never ends after m…

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/Adapter/Mysql/BaseSelectStrategy/BaseSelectAttributesSearchStrategy.php
+++ b/app/code/Magento/CatalogSearch/Model/Adapter/Mysql/BaseSelectStrategy/BaseSelectAttributesSearchStrategy.php
@@ -13,7 +13,6 @@ use Magento\Framework\Indexer\ScopeResolver\IndexScopeResolver;
 use Magento\CatalogSearch\Model\Search\SelectContainer\SelectContainer;
 
 /**
- * Class BaseSelectAttributesSearchStrategy
  * This class represents strategy for building base select query for search request
  *
  * The main idea of this strategy is using eav index table as main table for query

--- a/app/code/Magento/CatalogSearch/Model/Adapter/Mysql/BaseSelectStrategy/BaseSelectAttributesSearchStrategy.php
+++ b/app/code/Magento/CatalogSearch/Model/Adapter/Mysql/BaseSelectStrategy/BaseSelectAttributesSearchStrategy.php
@@ -68,13 +68,8 @@ class BaseSelectAttributesSearchStrategy implements BaseSelectStrategyInterface
 
         $select->distinct()
             ->from(
-                [$mainTableAlias => $this->resource->getTableName('catalog_product_index_eav')],
+                [$mainTableAlias => $this->resource->getTableName('catalog_product_entity')],
                 ['entity_id' => 'entity_id']
-            )->where(
-                $this->resource->getConnection()->quoteInto(
-                    sprintf('%s.store_id = ?', $mainTableAlias),
-                    $this->storeManager->getStore()->getId()
-                )
             );
 
         if ($selectContainer->isFullTextSearchRequired()) {

--- a/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/CustomAttributeFilter.php
+++ b/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/CustomAttributeFilter.php
@@ -113,15 +113,16 @@ class CustomAttributeFilter
             // is required to boost performance in case when we have just one filter by custom attribute
             $attribute = reset($attributes);
             $filter = reset($filters);
+            $filterJoinAlias = $this->aliasResolver->getAlias($filter);
             $select->where(
                 $this->conditionManager->generateCondition(
-                    sprintf('%s.attribute_id', $mainTableAlias),
+                    sprintf('%s.attribute_id', $filterJoinAlias),
                     '=',
                     $attribute
                 )
             )->where(
                 $this->conditionManager->generateCondition(
-                    sprintf('%s.value', $mainTableAlias),
+                    sprintf('%s.value', $filterJoinAlias),
                     is_array($filter->getValue()) ? 'in' : '=',
                     $filter->getValue()
                 )

--- a/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/FilterMapper.php
+++ b/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/FilterMapper.php
@@ -11,7 +11,6 @@ use Magento\CatalogSearch\Model\Adapter\Mysql\Filter\AliasResolver;
 use Magento\CatalogInventory\Model\Stock;
 
 /**
- * Class FilterMapper
  * This class applies filters to Select based on SelectContainer configuration
  *
  * @deprecated
@@ -66,8 +65,7 @@ class FilterMapper
     }
 
     /**
-     * Applies filters to Select query in SelectContainer
-     * based on SelectContainer configuration
+     * Applies filters to Select query in SelectContainer based on SelectContainer configuration
      *
      * @param SelectContainer $selectContainer
      * @return SelectContainer
@@ -98,8 +96,11 @@ class FilterMapper
         $appliedFilters = [];
 
         if ($selectContainer->hasVisibilityFilter()) {
-            $select = $this->visibilityFilter->apply($select, $selectContainer->getVisibilityFilter(),
-                VisibilityFilter::FILTER_BY_JOIN);
+            $select = $this->visibilityFilter->apply(
+                $select,
+                $selectContainer->getVisibilityFilter(),
+            VisibilityFilter::FILTER_BY_JOIN
+            );
             $appliedFilters[$this->aliasResolver->getAlias($selectContainer->getVisibilityFilter())] = true;
         }
 

--- a/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/FilterMapper.php
+++ b/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/FilterMapper.php
@@ -98,12 +98,8 @@ class FilterMapper
         $appliedFilters = [];
 
         if ($selectContainer->hasVisibilityFilter()) {
-            $filterType = VisibilityFilter::FILTER_BY_WHERE;
-            if ($selectContainer->hasCustomAttributesFilters()) {
-                $filterType = VisibilityFilter::FILTER_BY_JOIN;
-            }
-
-            $select = $this->visibilityFilter->apply($select, $selectContainer->getVisibilityFilter(), $filterType);
+            $select = $this->visibilityFilter->apply($select, $selectContainer->getVisibilityFilter(),
+                VisibilityFilter::FILTER_BY_JOIN);
             $appliedFilters[$this->aliasResolver->getAlias($selectContainer->getVisibilityFilter())] = true;
         }
 

--- a/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/FilterMapper.php
+++ b/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/FilterMapper.php
@@ -99,7 +99,7 @@ class FilterMapper
             $select = $this->visibilityFilter->apply(
                 $select,
                 $selectContainer->getVisibilityFilter(),
-            VisibilityFilter::FILTER_BY_JOIN
+                VisibilityFilter::FILTER_BY_JOIN
             );
             $appliedFilters[$this->aliasResolver->getAlias($selectContainer->getVisibilityFilter())] = true;
         }

--- a/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/StockStatusFilter.php
+++ b/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/StockStatusFilter.php
@@ -13,7 +13,6 @@ use Magento\CatalogInventory\Api\StockConfigurationInterface;
 use Magento\CatalogInventory\Api\StockRegistryInterface;
 
 /**
- * Class StockStatusFilter
  * Adds filter by stock status to base select
  *
  * @deprecated
@@ -97,7 +96,7 @@ class StockStatusFilter
         $this->addMainStockStatusJoin($select, $stockValues, $mainTableAlias, $showOutOfStockFlag);
 
         if ($type === self::FILTER_ENTITY_AND_SUB_PRODUCTS) {
-            $this->addSubProductsStockStatusJoin($select, $stockValues, $mainTableAlias, $showOutOfStockFlag);
+            $this->addSubProductsStockStatusJoin($select, $stockValues, $showOutOfStockFlag);
         }
 
         return $select;
@@ -105,6 +104,7 @@ class StockStatusFilter
 
     /**
      * Adds filter join for products by stock status
+     *
      * In case when $showOutOfStockFlag is true - joins are still required to filter only enabled products
      *
      * @param Select $select
@@ -147,15 +147,15 @@ class StockStatusFilter
 
     /**
      * Adds filter join for sub products by stock status
+     *
      * In case when $showOutOfStockFlag is true - joins are still required to filter only enabled products
      *
      * @param Select $select
      * @param array|int $stockValues
-     * @param string $mainTableAlias
      * @param bool $showOutOfStockFlag
      * @return void
      */
-    private function addSubProductsStockStatusJoin(Select $select, $stockValues, $mainTableAlias, $showOutOfStockFlag)
+    private function addSubProductsStockStatusJoin(Select $select, $stockValues, $showOutOfStockFlag)
     {
         $catalogInventoryTable = $this->resourceConnection->getTableName('cataloginventory_stock_status');
         $select->joinInner(

--- a/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/StockStatusFilter.php
+++ b/app/code/Magento/CatalogSearch/Model/Search/FilterMapper/StockStatusFilter.php
@@ -162,7 +162,6 @@ class StockStatusFilter
             ['sub_products_stock_index' => $catalogInventoryTable],
             $this->conditionManager->combineQueries(
                 [
-                    sprintf('sub_products_stock_index.product_id = %s.source_id', $mainTableAlias),
                     $this->conditionManager->generateCondition(
                         'sub_products_stock_index.website_id',
                         '=',


### PR DESCRIPTION
### Description (*)
Fixed issue when a lot of queries INSERT INTO “search_tmp…” started until the server reaches pm.max_children parameter value and PHP-fpm die, and they constantly resurrecting even after MySQL restart and process kill.

### Fixed Issues (if relevant)
1. magento/magento2#15545: query INSERT INTO “search_tmp…” never ends after mass attribute update 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
