### PR TITLE
Fix issue with "Apply Discount Code" input hidden, when code is applied

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/coupon.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/coupon.phtml
@@ -7,10 +7,13 @@
 /**
  * @var \Magento\Framework\View\Element\AbstractBlock $block
  */
+
+// We should use strlen function because coupon code could be "0", converted to bool will lead to false
+$hasCouponCode = (bool) strlen($block->getCouponCode());
 ?>
 <div class="block discount"
      id="block-discount"
-     data-mage-init='{"collapsible":{"openedState": "active", "saveState": false}}'
+     data-mage-init='{"collapsible":{"active": <?= $hasCouponCode ? 'true' : 'false' ?>, "openedState": "active", "saveState": false}}'
 >
     <div class="title" data-role="title">
         <strong id="block-discount-heading" role="heading" aria-level="2"><?= $block->escapeHtml(__('Apply Discount Code')) ?></strong>
@@ -23,7 +26,7 @@
                                                "removeCouponSelector": "#remove-coupon",
                                                "applyButton": "button.action.apply",
                                                "cancelButton": "button.action.cancel"}}'>
-            <div class="fieldset coupon<?= strlen($block->getCouponCode()) ? ' applied' : '' ?>">
+            <div class="fieldset coupon<?= $hasCouponCode ? ' applied' : '' ?>">
                 <input type="hidden" name="remove" id="remove-coupon" value="0" />
                 <div class="field">
                     <label for="coupon_code" class="label"><span><?= $block->escapeHtml(__('Enter discount code')) ?></span></label>
@@ -34,14 +37,14 @@
                                name="coupon_code"
                                value="<?= $block->escapeHtmlAttr($block->getCouponCode()) ?>"
                                placeholder="<?= $block->escapeHtmlAttr(__('Enter discount code')) ?>"
-                                <?php if (strlen($block->getCouponCode())) :?>
+                                <?php if ($hasCouponCode) :?>
                                    disabled="disabled"
                                 <?php endif; ?>
                         />
                     </div>
                 </div>
                 <div class="actions-toolbar">
-                    <?php if (!strlen($block->getCouponCode())) :?>
+                    <?php if (!$hasCouponCode) :?>
                     <div class="primary">
                         <button class="action apply primary" type="button" value="<?= $block->escapeHtmlAttr(__('Apply Discount')) ?>">
                             <span><?= $block->escapeHtml(__('Apply Discount')) ?></span>
@@ -54,7 +57,7 @@
                     <?php endif; ?>
                 </div>
             </div>
-            <?php if (!strlen($block->getCouponCode())) : ?>
+            <?php if (!$hasCouponCode) : ?>
                 <?= /* @noEscape */ $block->getChildHtml('captcha') ?>
             <?php endif; ?>
         </form>


### PR DESCRIPTION
### Preconditions
Magento 2.3.2

### Description
"Apply Discount Code" input should be shown when customer applied coupon code

### Steps to reproduce:
1. Add product to the cart
2. Go to the cart page and ally coupon code
3. Reload the page

### Expected result
"Apply Discount Code" input is opened:
![Capture 2019-09-05 at 17 55 05](https://user-images.githubusercontent.com/34220204/64353396-5d95f280-d006-11e9-879c-1b7f3908ccde.png)

### Actual result
"Apply Discount Code" input is hidden:
![Capture 2019-09-05 at 17 54 40](https://user-images.githubusercontent.com/34220204/64353359-4e16a980-d006-11e9-9293-020abe9b8086.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
