### PR TITLE
Fix product flat indexing for attributes with attribute codes named With MySQL keywords / reserved words

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
@@ -361,7 +361,7 @@ class FlatTableBuilder
                         []
                     )->columns(
                         [$columnName => $columnValue]
-                    )->where($columnValue . ' IS NOT NULL');
+                    )->where('`' . $columnValue . '` IS NOT NULL');
                     if (!empty($changedIds)) {
                         $select->where($this->_connection->quoteInto('et.entity_id IN (?)', $changedIds));
                     }


### PR DESCRIPTION
### Description (*)

The attribute codes in the flat product indexer should be escaped using backticks to prevent issues with MySQL keywords and reserved words. 

### Fixed Issues (if relevant)

1. magento/magento2#23003: SQL error on indexer:reindex 2.2.8

### Manual testing scenarios (*)

1. Enable flat product indexing
2. Create an attribute with the attribute code of 'condition', and 'Used in product listing': yes.
3. Reindex the catalog_product_flat indexer

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
