### PR TITLE
Fix lib-button-as-link not using color argument

### DIFF
--- a/lib/web/css/source/lib/_buttons.less
+++ b/lib/web/css/source/lib/_buttons.less
@@ -200,14 +200,13 @@
     .lib-css(line-height, @_line-height);
     .lib-css(margin, @_margin);
     .lib-css(padding, @_padding);
-    .lib-link();
+    .lib-link(
+        @_link-color: @_link-color,
+        @_link-color-hover: @_link-color-hover
+    );
     background: none;
     border: 0;
     display: inline;
-
-    &:hover {
-        .lib-css(color, @_link-color-hover);
-    }
 
     &:hover,
     &:active,


### PR DESCRIPTION
### Description (*)
`.lib-button-as-link();` was only using its `@_link-color` for `[disabled]` variants. It was also inefficiently emitting both the default `.lib-link()` hover colors, and the mixin's own provided `@_link-color-hover` variant.

Let's bring both arguments into the actual .lib-link() call  instead.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Use `.lib-button-as-link(@_link-color: @color-white)`
2. Observe that outputted styles do not change link color to white

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
