### PR TITLE
Excludes Magento_Tinymce3 scripts from the bundling, saves about 3.7 …

### DIFF
--- a/app/design/adminhtml/Magento/backend/etc/view.xml
+++ b/app/design/adminhtml/Magento/backend/etc/view.xml
@@ -63,6 +63,7 @@
         <item type="file">Lib::requirejs/text.js</item>
         <item type="file">Lib::date-format-normalizer.js</item>
         <item type="file">Lib::varien/js.js</item>
+        <item type="directory">Magento_Tinymce3::tiny_mce</item>
         <item type="directory">Lib::css</item>
         <item type="directory">Lib::lib</item>
         <item type="directory">Lib::prototype</item>

--- a/app/design/frontend/Magento/blank/etc/view.xml
+++ b/app/design/frontend/Magento/blank/etc/view.xml
@@ -292,6 +292,7 @@
         <item type="directory">Magento_Ui::templates/grid</item>
         <item type="directory">Magento_Ui::templates/dynamic-rows</item>
         <item type="directory">Magento_Swagger::swagger-ui</item>
+        <item type="directory">Magento_Tinymce3::tiny_mce</item>
         <item type="directory">Lib::modernizr</item>
         <item type="directory">Lib::tiny_mce</item>
         <item type="directory">Lib::varien</item>

--- a/app/design/frontend/Magento/luma/etc/view.xml
+++ b/app/design/frontend/Magento/luma/etc/view.xml
@@ -303,6 +303,7 @@
         <item type="directory">Magento_Ui::templates/grid</item>
         <item type="directory">Magento_Ui::templates/dynamic-rows</item>
         <item type="directory">Magento_Swagger::swagger-ui</item>
+        <item type="directory">Magento_Tinymce3::tiny_mce</item>
         <item type="directory">Lib::modernizr</item>
         <item type="directory">Lib::tiny_mce</item>
         <item type="directory">Lib::varien</item>


### PR DESCRIPTION
…MB in the generated JS bundle size.

### Description (*)
This was discovered by accident (we normally disable the Magento_Tinymce3 module so we didn't notice this before).
Anyways, the Magento_Tinymce3 module was introduced in Magento 2.3.0, so this is probably already going on since then.
Apparently it was forgotten to exclude the javascripts of that module from the JS Bundling.

The JS bundle files took a total of about 6.9 MB and consisted of 8 files.
With this added exclusion, the bundled files are reduced to 3.2 MB and only consist of 4 files.

### Fixed Issues (if relevant)
None that I could find

### Manual testing scenarios (*)
1. Enable JS bundling
2. Enable JS minifying (probably not necessary, but I used this for testing)
3. Put shop in production mode
4. Run static content deploy
5. Watch the files in `pub/static/frontend/Magento/blank/en_US/js/bundle/` and `pub/static/frontend/Magento/luma/en_US/js/bundle/`

Somebody should probably also test if when you switch from TinyMCE4 to TinyMCE3 everything still works as expected, this is found in the configuration under General > Content Management > WYSIWYG Options > WYSIWYG Editor (I didn't go this far to test this).

### Questions or comments
Stuff like this should get caught automatically somehow, if in one release the bundle size suddenly increases significantly, this should raise some flags ...

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
