### PR TITLE
fixed issue #22662

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_creditmemo_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_creditmemo_grid.xml
@@ -201,7 +201,7 @@
                 <visible>false</visible>
             </settings>
         </column>
-        <column name="shipping_and_handling" class="Magento\Sales\Ui\Component\Listing\Column\Price">
+        <column name="shipping_and_handling" class="Magento\Sales\Ui\Component\Listing\Column\PurchasedPrice">
             <settings>
                 <filter>textRange</filter>
                 <label translate="true">Shipping &amp; Handling</label>

--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_view_creditmemo_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_view_creditmemo_grid.xml
@@ -207,14 +207,14 @@
                 <visible>false</visible>
             </settings>
         </column>
-        <column name="subtotal" class="Magento\Sales\Ui\Component\Listing\Column\Price">
+        <column name="subtotal" class="Magento\Sales\Ui\Component\Listing\Column\PurchasedPrice">
             <settings>
                 <filter>textRange</filter>
                 <label translate="true">Subtotal</label>
                 <visible>false</visible>
             </settings>
         </column>
-        <column name="shipping_and_handling" class="Magento\Sales\Ui\Component\Listing\Column\Price">
+        <column name="shipping_and_handling" class="Magento\Sales\Ui\Component\Listing\Column\PurchasedPrice">
             <settings>
                 <filter>textRange</filter>
                 <label translate="true">Shipping &amp; Handling</label>


### PR DESCRIPTION
Wrong currency symbol in creditmemo_grid & sales_order_view > creditmemo grid

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
For Column subtotal & Shipping and Handling fee in creditmemo_grid & sales_order_view > credit memo grid if the order is placed with the different currency.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2 #22662: Wrong currency symbol in creditmemo_grid & sales_order_view > credit memo grid for subtotal & Shipping and Handling fee

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set USD as Base Currency
2. Set INR currency for different store
3. Place an order from INR Currency store.
4. Go to Backend > SALES > Credit Memos, create Credit Memo
5. Check Subtotal & Shipping and Handling fee column on Credit Memo grid (sales_creditmemo_index) & sales_order_view > credit memo grid.

### Questions or comments
Finally, Subtotal & Shipping and Handling fee column value is showing correctly currency symbol.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
