### PR TITLE
Fixed issue:24031 Layer navigation displaying whenever select Static …

### DIFF
--- a/app/code/Magento/LayeredNavigation/Block/Navigation.php
+++ b/app/code/Magento/LayeredNavigation/Block/Navigation.php
@@ -107,7 +107,8 @@ class Navigation extends \Magento\Framework\View\Element\Template
      */
     public function canShowBlock()
     {
-        return $this->visibilityFlag->isEnabled($this->getLayer(), $this->getFilters());
+        return $this->getLayer()->getCurrentCategory()->getDisplayMode() !== \Magento\Catalog\Model\Category::DM_PAGE
+            && $this->visibilityFlag->isEnabled($this->getLayer(), $this->getFilters());
     }
 
     /**

--- a/app/code/Magento/LayeredNavigation/Test/Unit/Block/NavigationTest.php
+++ b/app/code/Magento/LayeredNavigation/Test/Unit/Block/NavigationTest.php
@@ -6,6 +6,8 @@
 
 namespace Magento\LayeredNavigation\Test\Unit\Block;
 
+use Magento\Catalog\Model\Category;
+
 class NavigationTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -98,7 +100,59 @@ class NavigationTest extends \PHPUnit\Framework\TestCase
             ->method('isEnabled')
             ->with($this->catalogLayerMock, $filters)
             ->will($this->returnValue($enabled));
+        
+        $category = $this->createMock(Category::class);
+        $this->catalogLayerMock->expects($this->atLeastOnce())->method('getCurrentCategory')->willReturn($category);
+        $category->expects($this->once())->method('getDisplayMode')->willReturn(Category::DM_PRODUCT);
+
         $this->assertEquals($enabled, $this->model->canShowBlock());
+    }
+
+    /**
+     * Test canShowBlock() with different category display types.
+     *
+     * @param string $mode
+     * @param bool $result
+     *
+     * @dataProvider canShowBlockDataProvider
+     */
+    public function testCanShowBlockWithDifferentDisplayModes(string $mode, bool $result)
+    {
+        $filters = ['To' => 'be', 'or' => 'not', 'to' => 'be'];
+        
+        $this->filterListMock->expects($this->atLeastOnce())->method('getFilters')
+            ->with($this->catalogLayerMock)
+            ->will($this->returnValue($filters));
+        $this->assertEquals($filters, $this->model->getFilters());
+        
+        $this->visibilityFlagMock
+            ->expects($this->any())
+            ->method('isEnabled')
+            ->with($this->catalogLayerMock, $filters)
+            ->will($this->returnValue(true));
+
+        $category = $this->createMock(Category::class);
+        $this->catalogLayerMock->expects($this->atLeastOnce())->method('getCurrentCategory')->willReturn($category);
+        $category->expects($this->once())->method('getDisplayMode')->willReturn($mode);
+        $this->assertEquals($result, $this->model->canShowBlock());
+    }
+
+    public function canShowBlockDataProvider()
+    {
+        return [
+            [
+                Category::DM_PRODUCT,
+                true,
+            ],
+            [
+                Category::DM_PAGE,
+                false,
+            ],
+            [
+                Category::DM_MIXED,
+                true,
+            ],
+        ];
     }
 
     public function testGetClearUrl()


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Fiexed: Layer navigation displaying whenever select Static Block only.
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #24031 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. After fixings set category as display **static block only**, now only static block is displayed 
2. Check by setting category as display **static block and products**, Now block and layered navigation displayed.
3. Check by setting category as display **products only** , Now layered navigation is displayed

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
