### PR TITLE
Resolve "Clear Shopping Cart" button not working in Internet Explorer issue24491

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
@@ -56,7 +56,7 @@
                 <span><?= $block->escapeHtml(__('Continue Shopping')) ?></span>
             </a>
         <?php endif; ?>
-        <button type="submit"
+        <button type="button"
                 name="update_cart_action"
                 data-cart-empty=""
                 value="empty_cart"

--- a/app/code/Magento/Checkout/view/frontend/web/js/shopping-cart.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/shopping-cart.js
@@ -15,13 +15,12 @@ define([
             var items, i, reload;
 
             $(this.options.emptyCartButton).on('click', $.proxy(function (event) {
-                if (event.detail === 0) {
-                    return;
-                }
-
                 $(this.options.emptyCartButton).attr('name', 'update_cart_action_temp');
                 $(this.options.updateCartActionContainer)
                     .attr('name', 'update_cart_action').attr('value', 'empty_cart');
+                if ($(this.options.emptyCartButton).parents('form').length > 0) {
+                    $(this.options.emptyCartButton).parents('form').submit();
+                }
             }, this));
             items = $.find('[data-role="cart-item-qty"]');
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/shopping-cart.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/shopping-cart.js
@@ -14,10 +14,11 @@ define([
         _create: function () {
             var items, i, reload;
 
-            $(this.options.emptyCartButton).on('click', $.proxy(function (event) {
+            $(this.options.emptyCartButton).on('click', $.proxy(function () {
                 $(this.options.emptyCartButton).attr('name', 'update_cart_action_temp');
                 $(this.options.updateCartActionContainer)
                     .attr('name', 'update_cart_action').attr('value', 'empty_cart');
+
                 if ($(this.options.emptyCartButton).parents('form').length > 0) {
                     $(this.options.emptyCartButton).parents('form').submit();
                 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Resolve magento/magento2#24491: "Clear Shopping Cart" button not working in Internet Explorer 

The problem:

in this PR: https://github.com/magento/magento2/issues/21499 "Cart is emptied when enter is pressed after changing product quantity". This code is added to `app/code/Magento/Checkout/view/frontend/web/js/shopping-cart.js`

```
                if (event.detail === 0) {
                    return;
                }

```

However, IE 11 can not support `event.detail`. It always return 0

https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/16710370/

I believe when enter is pressed after changing product quantity we Shouldn't trigger click **"emptyCartButton"** and check the condition. I will be wrong. We should change the button empty cart to "button", not "submit". So button isn't clicked when press enter.

In my PR, I have changed it to normal button and process the empty cart only the user click to the "Clear shopping cart" button.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24491: "Clear Shopping Cart" button not working in Internet Explorer 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

Change Magento Theme to **BLANK**

1. Open Magento 2 site in Internet Explorer
2. Add item to the cart
3. Click `Clear Shopping Cart` button

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. All items are deleted from the shopping cart
2. The cart page is refreshed showing no items

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
