### PR TITLE
Fixes excluding js files from bundles when minifying is enabled

### DIFF
--- a/app/code/Magento/Deploy/Service/Bundle.php
+++ b/app/code/Magento/Deploy/Service/Bundle.php
@@ -216,7 +216,7 @@ class Bundle
         $excludedFiles = $this->bundleConfig->getExcludedFiles($area, $theme);
         foreach ($excludedFiles as $excludedFileId) {
             $excludedFilePath = $this->prepareExcludePath($excludedFileId);
-            if ($excludedFilePath === $filePath) {
+            if ($excludedFilePath === $filePath || $excludedFilePath === str_replace('.min.js', '.js', $filePath)) {
                 return true;
             }
         }

--- a/app/design/adminhtml/Magento/backend/etc/view.xml
+++ b/app/design/adminhtml/Magento/backend/etc/view.xml
@@ -24,7 +24,6 @@
     </media>
     <exclude>
         <item type="file">Lib::mage/captcha.js</item>
-        <item type="file">Lib::mage/captcha.min.js</item>
         <item type="file">Lib::mage/common.js</item>
         <item type="file">Lib::mage/cookies.js</item>
         <item type="file">Lib::mage/dataPost.js</item>
@@ -46,7 +45,6 @@
         <item type="file">Lib::mage/translate-inline-vde.js</item>
         <item type="file">Lib::mage/webapi.js</item>
         <item type="file">Lib::mage/zoom.js</item>
-        <item type="file">Lib::mage/validation/dob-rule.js</item>
         <item type="file">Lib::mage/validation/validation.js</item>
         <item type="file">Lib::mage/adminhtml/varienLoader.js</item>
         <item type="file">Lib::mage/adminhtml/tools.js</item>
@@ -57,11 +55,9 @@
         <item type="file">Lib::jquery/jquery.parsequery.js</item>
         <item type="file">Lib::jquery/jquery.mobile.custom.js</item>
         <item type="file">Lib::jquery/jquery-ui.js</item>
-        <item type="file">Lib::jquery/jquery-ui.min.js</item>
         <item type="file">Lib::matchMedia.js</item>
         <item type="file">Lib::requirejs/require.js</item>
         <item type="file">Lib::requirejs/text.js</item>
-        <item type="file">Lib::date-format-normalizer.js</item>
         <item type="file">Lib::varien/js.js</item>
         <item type="directory">Lib::css</item>
         <item type="directory">Lib::lib</item>
@@ -72,10 +68,5 @@
         <item type="directory">Lib::fotorama</item>
         <item type="directory">Lib::magnifier</item>
         <item type="directory">Lib::tiny_mce</item>
-        <item type="directory">Lib::tiny_mce/classes</item>
-        <item type="directory">Lib::tiny_mce/langs</item>
-        <item type="directory">Lib::tiny_mce/plugins</item>
-        <item type="directory">Lib::tiny_mce/themes</item>
-        <item type="directory">Lib::tiny_mce/utils</item>
     </exclude>
 </view>

--- a/app/design/frontend/Magento/blank/etc/view.xml
+++ b/app/design/frontend/Magento/blank/etc/view.xml
@@ -262,12 +262,10 @@
         <item type="file">Lib::jquery/jquery.min.js</item>
         <item type="file">Lib::jquery/jquery-ui-1.9.2.js</item>
         <item type="file">Lib::jquery/jquery.details.js</item>
-        <item type="file">Lib::jquery/jquery.details.min.js</item>
         <item type="file">Lib::jquery/jquery.hoverIntent.js</item>
         <item type="file">Lib::jquery/colorpicker/js/colorpicker.js</item>
         <item type="file">Lib::requirejs/require.js</item>
         <item type="file">Lib::requirejs/text.js</item>
-        <item type="file">Lib::date-format-normalizer.js</item>
         <item type="file">Lib::legacy-build.min.js</item>
         <item type="file">Lib::mage/captcha.js</item>
         <item type="file">Lib::mage/dropdown_old.js</item>

--- a/app/design/frontend/Magento/luma/etc/view.xml
+++ b/app/design/frontend/Magento/luma/etc/view.xml
@@ -273,12 +273,10 @@
         <item type="file">Lib::jquery/jquery.min.js</item>
         <item type="file">Lib::jquery/jquery-ui-1.9.2.js</item>
         <item type="file">Lib::jquery/jquery.details.js</item>
-        <item type="file">Lib::jquery/jquery.details.min.js</item>
         <item type="file">Lib::jquery/jquery.hoverIntent.js</item>
         <item type="file">Lib::jquery/colorpicker/js/colorpicker.js</item>
         <item type="file">Lib::requirejs/require.js</item>
         <item type="file">Lib::requirejs/text.js</item>
-        <item type="file">Lib::date-format-normalizer.js</item>
         <item type="file">Lib::legacy-build.min.js</item>
         <item type="file">Lib::mage/captcha.js</item>
         <item type="file">Lib::mage/dropdown_old.js</item>


### PR DESCRIPTION
### Description (*)
When enabling both JS minification and JS bundling, there was as bug with determining files to be excluded from the bundled files.
From what I understand, it works like this when executing static content deployment:
- files are put in `pub/static/` per theme and locale
- when JS minification is enabled, all non-already minified files are minified and get a `.min.js` filename
- when JS bundling is enabled it will first make a list of all the files in `pub/static/` and then match those filenames against the files of files in the `view.xml` to determine if they should be included or excluded from the bundle

The problem here, is the fact that the `view.xml` file contains the original filenames, but the JS minification renames the files from `.js` to `.min.js` so it was no longer finding the correct files to exclude.

(I'm almost convinced this used to work perfectly fine in Magento 2.1.x, because I remember me looking at this a couple of years ago and noticing no problems with both bundling and minification enabled, but I'm not 100% sure)

This problem is fixed in the first commit of this PR.
The fix is actually the one suggested by @SKovbel in https://github.com/magento/magento2/issues/4506#issuecomment-433192100


The second commit adds jquery to be excluded, since it exists in two variants in the codebase, which is super weird.
@DanielRuf also [discovered this](https://github.com/magento/magento2/pull/22418#issuecomment-490736917), but I don't think anything was already done around this, we should probably clean this up one day so only a single jquery file is in Magento's codebase?

- https://github.com/magento/magento2/blob/2.3.2/lib/web/jquery.js (the fact that this file is outside of the `jquery` subdir is really strange, introduced in [MAGETWO-32494](https://github.com/magento/magento2/commit/98214d73ce4ab6d873786759c804b9994be82f29#diff-ead14c449199a97035614a13e5a13fee))
- https://github.com/magento/magento2/blob/2.3.2/lib/web/jquery/jquery.min.js

Only the `jquery/jquery.min.js` file was marked to be excluded from the bundles, but the first one was still being included.

I also removed some other files from the `view.xml` files of all themes:
- The minified files in there shouldn't have been excluded as that should happen automatically (this is what this PR is doing)
- The tiny_mce subdirs were not necessary to be explicitly specified, because the main directory was already marked to be excluded
- Other files were removed a long time ago:
  - `lib/web/mage/validation/dob-rule.js` in [MAGETWO-32480](https://github.com/magento/magento2/commit/01cb488ef12#diff-59fb94a327b789eea10c5b1e4e4985d6)
  - `lib/web/date-format-normalizer.js` in [MAGETWO-31654](https://github.com/magento/magento2/commit/155f1b27178#diff-2e7242f037d123c1cf7fe361563d281f)

#### Results after this PR:

| Theme | Files no longer in bundle | Bundle size before PR | Bundle size after PR |
|---|---|---|---|
| Blank & Luma | `mage/list.min.js`, `mage/dropdown_old.min.js`, `mage/zoom.min.js`, `mage/translate-inline-vde.min.js`, `mage/captcha.min.js`, `mage/webapi.min.js`, `mage/loader_old.min.js`, `mage/requirejs/mixins.min.js`, `mage/requirejs/static.min.js`, `Magento_Catalog/js/zoom.min.js`, `jquery/jquery.hoverIntent.min.js`, `jquery/jquery-ui-1.9.2.min.js`, `jquery/colorpicker/js/colorpicker.min.js`, `requirejs/text.min.js`, `requirejs/require.min.js`, `Magento_Ui/js/form/element/file-uploader.min.js`, `Magento_Ui/js/form/element/ui-select.min.js`, `Magento_Ui/js/form/components/insert-listing.min.js`, `Magento_Ui/js/form/components/insert.min.js`, `Magento_Ui/js/lib/step-wizard.min.js`, `Magento_Customer/js/zxcvbn.min.js`  | 7.0MB | 6.5MB |
| Backend | `matchMedia.min.js`, `mage/list.min.js`, `mage/dropdowns.min.js`, `mage/loader.min.js`, `mage/dialog.min.js`, `mage/zoom.min.js`, `mage/translate-inline-vde.min.js`, `mage/dataPost.min.js`, `mage/terms.min.js`, `mage/decorate.min.js`, `mage/webapi.min.js`, `mage/menu.min.js`, `mage/common.min.js`, `mage/deletable-item.min.js`, `mage/sticky.min.js`, `mage/item-table.min.js`, `mage/dropdown.min.js`, `mage/redirect-url.min.js`, `mage/fieldset-controls.min.js`, `mage/cookies.min.js`, `mage/tooltip.min.js`, `mage/toggle.min.js`, `mage/gallery/gallery.min.js`, `mage/requirejs/mixins.min.js`, `mage/requirejs/static.min.js`, `mage/adminhtml/varienLoader.min.js`, `mage/adminhtml/tools.min.js`, `mage/validation/validation.min.js`, `jquery/jquery.parsequery.min.js`, `jquery/jquery.mobile.custom.min.js`, `requirejs/text.min.js`, `requirejs/require.min.js`, `varien/js.min.js`  | 7.2MB | 7.1MB |

Be aware, [this other open PR](https://github.com/magento/magento2/pull/24477) will shave of another 3.7 MB of the bundle size, so they will be a bit more reasonable.

### Fixed Issues (if relevant)
This doesn't really fixes these issues, but is still related to them:
- https://github.com/magento/magento2/issues/4506: Javascript Bundling produces huge 13MB js files
- https://github.com/magento/magento2/issues/14357: zxcvbn.js included in merged.js
- https://github.com/magento/magento2/issues/13558: In Magento 2.2.2, Javascript bundling file size is big while comparing with Magento 2.1.10
- probably others as well...

### Manual testing scenarios (*)
Please test all JS functionality in blank, luma and backend themes and everything should keep working as expected when JS bundling is enabled (should be tested once with JS minification disabled, and also with it being enabled)

Maybe some performance testing could happen as well, see if this improves frontend performance somewhat?

### Questions or comments
Also including @DrewML and @vzabaznov in this since they are also working hard on improving the frontend performance problems M2 has been suffering with.

Would it make sense for somebody to take a critical look to those excluded files from all themes, because maybe those lists can be optimised some more still?
The last time this happened seems to be around the time when 2.1.0 got released: [MAGETWO-51628](https://github.com/magento/magento2/commit/034fcd6205d)

*Update*: hmm, I'm wondering if we should keep jquery in the bundle by default? It looks like it gets loaded on every single page after some quick testing, so it probably was intended to be used in the bundle? I was confused due to the 2 different jquery files in the codebase where one of them was excluded, but that starts to makes sense now.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
