### PR TITLE
[Catalog] Improving the blocks' sorting logic.

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Details.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Details.php
@@ -45,8 +45,9 @@ class Details extends \Magento\Framework\View\Element\Template
         }
 
         ksort($childNamesSortOrder, SORT_NUMERIC);
+        $childNamesSortOrder += $notSortedChildNames;
 
-        foreach ($childNamesSortOrder + $notSortedChildNames as $childNames) {
+        foreach ($childNamesSortOrder as $childNames) {
             foreach ($childNames as $childName) {
                 array_push($sortedChildNames, $childName);
             }

--- a/app/code/Magento/Catalog/Block/Product/View/Details.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Details.php
@@ -30,18 +30,28 @@ class Details extends \Magento\Framework\View\Element\Template
     {
         $groupChildNames = $this->getGroupChildNames($groupName, $callback);
         $layout = $this->getLayout();
-
         $childNamesSortOrder = [];
+        $sortedChildNames = [];
+        $notSortedChildNames = [];
 
         foreach ($groupChildNames as $childName) {
             $alias = $layout->getElementAlias($childName);
-            $sortOrder = (int)$this->getChildData($alias, 'sort_order') ?? 0;
 
-            $childNamesSortOrder[$sortOrder] = $childName;
+            if ($sortOrder = (int) $this->getChildData($alias, 'sort_order')) {
+                $childNamesSortOrder[$sortOrder][] = $childName;
+            } else {
+                $notSortedChildNames[0][] = $childName;
+            }
         }
 
         ksort($childNamesSortOrder, SORT_NUMERIC);
 
-        return $childNamesSortOrder;
+        foreach ($childNamesSortOrder + $notSortedChildNames as $childNames) {
+            foreach ($childNames as $childName) {
+                array_push($sortedChildNames, $childName);
+            }
+        }
+
+        return $sortedChildNames;
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes and improves the block's `product.info.details` children sorting. The following solution allows the following cases:
- the blocks that don't have specified `sort_order` argument, will be placed at the end
- the blocks that have specified `sort_order`, will be placed in ascending order
- the blocks that have the same `sort_order`, will be placed alongside

### Fixed Issues (if relevant)
1. magento/magento2#24474: Method getGroupSortedChildNames when sort_order is not specified on block definition take the last only

### Manual testing scenarios (*)
1. Add several new tabs to product details, referencing to `product.info.details`
2. Use the `detailed_info` for grouping

### Questions or comments
For testing purposes, the following layout update can be used for `catalog_product_view.xml`:

```xml
<referenceBlock name="product.info.details">
    <block class="Magento\Catalog\Block\Product\View" name="deliveryinfo.tab" as="deliveryinfo"
           template="Magento_Catalog::product/view/tab-1.phtml" group="detailed_info" >
        <arguments>
            <argument translate="true" name="title" xsi:type="string">Tab 1 SortOrder 4</argument>
            <argument name="sort_order" xsi:type="string">4</argument>
        </arguments>
    </block>
    <block class="Magento\Catalog\Block\Product\View\Attributes" name="product.info.description.new"
           as="product.info.description.new"
           template="Magento_Catalog::product/view/tab-1.phtml" group="detailed_info" >
        <arguments>
            <argument translate="true" name="title" xsi:type="string">Tab 2 SortOrder none</argument>
        </arguments>
    </block>
    <block class="Magento\Catalog\Block\Product\View\Attributes"
           name="product.info.custom.attribute" as="product.info.custom.attribute"
           template="Magento_Catalog::product/view/tab-1.phtml" group="detailed_info">
        <arguments>
            <argument translate="true" name="title" xsi:type="string">Tab 3 SortOrder 31</argument>
            <argument name="sort_order" xsi:type="string">31</argument>
        </arguments>
    </block>
    <block class="Magento\Catalog\Block\Product\View\Attributes"
           name="product.info.custom.attribute.2" as="product.info.custom.attribute_2"
           template="Magento_Catalog::product/view/tab-1.phtml" group="detailed_info">
        <arguments>
            <argument translate="true" name="title" xsi:type="string">Tab 4 SortOrder 3</argument>
            <argument name="sort_order" xsi:type="string">3</argument>
        </arguments>
    </block>
</referenceBlock>
```

Create a new template file `Magento_Catalog::product/view/tab-1.phtml` with some test content.

### Result 

![image](https://user-images.githubusercontent.com/15868188/64479347-7943f900-d1be-11e9-915b-a51241f1d230.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
