### PR TITLE
Fix the false directory path comparison failure, which causes incorrect error message for no writable permission.

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Directory/PathValidator.php
+++ b/lib/internal/Magento/Framework/Filesystem/Directory/PathValidator.php
@@ -58,7 +58,7 @@ class PathValidator implements PathValidatorInterface
         }
 
         if (mb_strpos($actualPath, $realDirectoryPath) !== 0
-            && $path .DIRECTORY_SEPARATOR !== $realDirectoryPath
+            && rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR !== $realDirectoryPath
         ) {
             throw new ValidatorException(
                 new Phrase(

--- a/lib/internal/Magento/Framework/Filesystem/Test/Unit/Directory/PathValidatorTest.php
+++ b/lib/internal/Magento/Framework/Filesystem/Test/Unit/Directory/PathValidatorTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Unit Test for \Magento\Framework\Filesystem\Directory\PathValidator
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Filesystem\Test\Unit\Directory;
+
+use Magento\Framework\Filesystem\Directory\WriteInterface;
+use Magento\Framework\Filesystem\DriverInterface;
+
+class PathValidatorTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * \Magento\Framework\Filesystem\Driver
+     *
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $driver;
+
+    /**
+     * @var \Magento\Framework\Filesystem\Directory\PathValidator
+     */
+    protected $pathValidator;
+
+    /**
+     * Set up
+     */
+    protected function setUp()
+    {
+        $this->driver = $this->createMock(\Magento\Framework\Filesystem\Driver\File::class);
+        $this->pathValidator = new \Magento\Framework\Filesystem\Directory\PathValidator(
+            $this->driver
+        );
+    }
+
+    /**
+     * Tear down
+     */
+    protected function tearDown()
+    {
+        $this->pathValidator = null;
+    }
+
+    /**
+     * @param string $directoryPath
+     * @param string $path
+     * @param string $scheme
+     * @param bool $absolutePath
+     * @param string $prefix
+     * @dataProvider validateDataProvider
+     */
+    public function testValidate($directoryPath, $path, $scheme, $absolutePath, $prefix)
+    {
+        $this->driver->expects($this->exactly(2))
+            ->method('getRealPathSafety')
+            ->willReturnMap(
+                [
+                    [$directoryPath, $directoryPath],
+                    [null, $prefix . $directoryPath . ltrim($path, '/')],
+                ]
+            );
+
+        $this->assertNull(
+            $this->pathValidator->validate($directoryPath, $path, $scheme, $absolutePath)
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function validateDataProvider()
+    {
+        return [
+            ['/directory/path/', '/directory/path/', '/', false, '/://'],
+            ['/directory/path/', '/var/.regenerate', null, false, ''],
+        ];
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
It appends a DIRECTORY_SEPARATOR directly to the path without checking whether there is already one or not. This would cause the false comparison failure in some conditions. Please refer to the example in the manual testing scenarios.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
None

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Install Magento 2.3.2 on Linux or Unix machine.
2. Change the owner of Magento root directory to someone else, so that the web application user does not have writable permission.
3. Go to Magento backend, and navigate to Marketing -> Site Map
4. Add a sitemap with Path = '/' and Filename = 'sitemap.xml'
5. Click "Generate" to generate the sitemap.

Would get the following error message:
```    
Path "/var/www/magento_root_path/" cannot be used with directory "/var/www/magento_root_path/"
```
This error message is not meaningful at all, and it's actually caused by the defect in the path comparison. After applying the PR, we would get the following error message:
```
The path "/:///var/www/magento_root_path/" is not writable.
```

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
We might also be interested in why the scheme string in the path is `"/://"` which seems uncommon. It could be a separate issue we could track after this fix.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)