### PR TITLE
Fixed incorrect memory_limits according to DevDocs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -41,7 +41,7 @@
 ############################################
 ## adjust memory limit
 
-    php_value memory_limit 756M
+    php_value memory_limit 2G
     php_value max_execution_time 18000
 
 ############################################
@@ -64,7 +64,7 @@
 ############################################
 ## adjust memory limit
 
-    php_value memory_limit 756M
+    php_value memory_limit 2G
     php_value max_execution_time 18000
 
 ############################################

--- a/.htaccess.sample
+++ b/.htaccess.sample
@@ -40,7 +40,7 @@
 ############################################
 ## adjust memory limit
 
-    php_value memory_limit 756M
+    php_value memory_limit 2G
     php_value max_execution_time 18000
 
 ############################################

--- a/.user.ini
+++ b/.user.ini
@@ -1,4 +1,4 @@
-memory_limit = 756M
+memory_limit = 2G
 max_execution_time = 18000
 session.auto_start = off
 suhosin.session.cryptua = off

--- a/app/code/Magento/SampleData/Console/Command/SampleDataDeployCommand.php
+++ b/app/code/Magento/SampleData/Console/Command/SampleDataDeployCommand.php
@@ -154,8 +154,8 @@ class SampleDataDeployCommand extends Command
         if (function_exists('ini_set')) {
             @ini_set('display_errors', 1);
             $memoryLimit = trim(ini_get('memory_limit'));
-            if ($memoryLimit != -1 && $this->getMemoryInBytes($memoryLimit) < 756 * 1024 * 1024) {
-                @ini_set('memory_limit', '756M');
+            if ($memoryLimit != -1 && $this->getMemoryInBytes($memoryLimit) < 2048 * 1024 * 1024) {
+                @ini_set('memory_limit', '2G');
             }
         }
     }

--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -47,7 +47,7 @@ location ~* ^/setup($|/) {
         fastcgi_pass   fastcgi_backend;
 
         fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
-        fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=600";
+        fastcgi_param  PHP_VALUE "memory_limit=2G \n max_execution_time=600";
         fastcgi_read_timeout 600s;
         fastcgi_connect_timeout 600s;
 
@@ -179,7 +179,7 @@ location ~ ^/(index|get|static|errors/report|errors/404|errors/503|health_check)
     fastcgi_buffers 1024 4k;
 
     fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
-    fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";
+    fastcgi_param  PHP_VALUE "memory_limit=2G \n max_execution_time=18000";
     fastcgi_read_timeout 600s;
     fastcgi_connect_timeout 600s;
 

--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -37,7 +37,7 @@
 ############################################
 ## Adjust memory limit
 
-    php_value memory_limit 756M
+    php_value memory_limit 2G
     php_value max_execution_time 18000
 
 ############################################
@@ -55,7 +55,7 @@
 ############################################
 ## Adjust memory limit
 
-    php_value memory_limit 756M
+    php_value memory_limit 2G
     php_value max_execution_time 18000
 
 ############################################

--- a/pub/.user.ini
+++ b/pub/.user.ini
@@ -1,4 +1,4 @@
-memory_limit = 756M
+memory_limit = 2G
 max_execution_time = 18000
 session.auto_start = off
 suhosin.session.cryptua = off


### PR DESCRIPTION
This [DevDocs](https://devdocs.magento.com/guides/v2.3/install-gde/trouble/php/tshoot_php-set.html) recommends a PHP `memory_limit` setting of at least 2G. 

This [DevDocs](https://devdocs.magento.com/guides/v2.3/install-gde/prereq/php-settings.html) also say, that there should be at least 2G for running M2 properly. 

There has been an [issue (#11322)](https://github.com/magento/magento2/issues/11322) which was closed a while ago without solving the issue. 

Therefore, this pull request raises the limit of the default `memory_limit`.