### PR TITLE
Refactor isSubscribed method to return the output of the expression

### DIFF
--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -353,11 +353,7 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
      */
     public function isSubscribed()
     {
-        if ($this->getId() && $this->getStatus() == self::STATUS_SUBSCRIBED) {
-            return true;
-        }
-
-        return false;
+        return $this->getId() && $this->getStatus() == self::STATUS_SUBSCRIBED;
     }
 
     /**

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -353,7 +353,7 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
      */
     public function isSubscribed()
     {
-        return $this->getId() && $this->getStatus() == self::STATUS_SUBSCRIBED;
+        return $this->getId() && $this->getStatus() === self::STATUS_SUBSCRIBED;
     }
 
     /**

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -353,7 +353,7 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
      */
     public function isSubscribed()
     {
-        return $this->getId() && $this->getStatus() === self::STATUS_SUBSCRIBED;
+        return $this->getId() && (int)$this->getStatus() === self::STATUS_SUBSCRIBED;
     }
 
     /**


### PR DESCRIPTION
Hey, I was reading this block while developing an extension and noticed this simplification. I hope this is useful.

### Description
The result of evaluating the boolean expression in the if statement is the same as the manually specified return values. We can simplify the code by directly returning the result of the boolean expression.

### Manual testing scenarios
This is a pure refactor and should not change any behavior.

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
