### PR TITLE
[Tax] Confirmation popup improvement

### DIFF
--- a/app/code/Magento/Tax/view/adminhtml/templates/rule/edit.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/rule/edit.phtml
@@ -166,7 +166,7 @@ require([
                             rateValue = that.parent().find('input[type="checkbox"]').val();
 
                         confirm({
-                            content: '<?= /* @escapeNotVerified */ __('Do you really want to delete this tax rate?') ?>',
+                            content: '<?= $block->escapeJs(__('Do you really want to delete this tax rate?')) ?>',
                             actions: {
                                 /**
                                  * Confirm action.

--- a/app/code/Magento/Tax/view/adminhtml/templates/rule/edit.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/rule/edit.phtml
@@ -10,11 +10,12 @@
 require([
     'jquery',
     'Magento_Ui/js/modal/alert',
+    'Magento_Ui/js/modal/confirm',
     "jquery/ui",
     'mage/multiselect',
     "mage/mage",
     'Magento_Ui/js/modal/modal'
-], function($, alert){
+], function($, alert, confirm) {
 
     $.widget("adminhtml.dialogRates", $.mage.modal, {
         options: {
@@ -160,53 +161,58 @@ require([
             taxRateField.find('.mselect-list')
                     .on('click.mselect-edit', '.mselect-edit', this.edit)
                     .on("click.mselect-delete", ".mselect-delete", function () {
-                        if (!confirm('<?= $block->escapeJs(__('Do you really want to delete this tax rate?')) ?>')) {
-                            return;
-                        }
-
                         var that = $(this),
                             select = that.closest('.mselect-list').prev(),
                             rateValue = that.parent().find('input[type="checkbox"]').val();
 
-                        $('body').trigger('processStart');
-                        var ajaxOptions = {
-                            type: 'POST',
-                            data: {
-                                tax_calculation_rate_id: rateValue,
-                                form_key: $('input[name="form_key"]').val()
-                            },
-                            dataType: 'json',
-                            url: '<?= $block->escapeJs($block->escapeUrl($block->getTaxRateDeleteUrl())) ?>',
-                            success: function(result, status) {
-                                $('body').trigger('processStop');
-                                if (result.success) {
-                                    that.parent().remove();
-                                    select.find('option').each(function() {
-                                        if (this.value === rateValue) {
-                                            $(this).remove();
+                        confirm({
+                            content: '<?= /* @escapeNotVerified */ __('Do you really want to delete this tax rate?') ?>',
+                            actions: {
+                                /**
+                                 * Confirm action.
+                                 */
+                                confirm: function () {
+                                    $('body').trigger('processStart');
+                                    var ajaxOptions = {
+                                        type: 'POST',
+                                        data: {
+                                            tax_calculation_rate_id: rateValue,
+                                            form_key: $('input[name="form_key"]').val()
+                                        },
+                                        dataType: 'json',
+                                        url: '<?= $block->escapeJs($block->escapeUrl($block->getTaxRateDeleteUrl())) ?>',
+                                        success: function(result, status) {
+                                            $('body').trigger('processStop');
+                                            if (result.success) {
+                                                that.parent().remove();
+                                                select.find('option').each(function() {
+                                                    if (this.value === rateValue) {
+                                                        $(this).remove();
+                                                    }
+                                                });
+                                                select.trigger('change.hiddenSelect');
+                                            } else {
+                                                if (result.error_message)
+                                                    alert({
+                                                        content: result.error_message
+                                                    });
+                                                else
+                                                    alert({
+                                                        content: '<?= $block->escapeJs($block->escapeHtml(__('An error occurred'))) ?>'
+                                                    });
+                                            }
+                                        },
+                                        error: function () {
+                                            $('body').trigger('processStop');
+                                            alert({
+                                                content: '<?= $block->escapeJs($block->escapeHtml(__('An error occurred'))) ?>'
+                                            });
                                         }
-                                    });
-                                    select.trigger('change.hiddenSelect');
-                                } else {
-                                    if (result.error_message)
-                                        alert({
-                                            content: result.error_message
-                                        });
-                                    else
-                                        alert({
-                                            content: '<?= $block->escapeJs($block->escapeHtml(__('An error occurred'))) ?>'
-                                        });
+                                    };
+                                    $.ajax(ajaxOptions);
                                 }
-                            },
-                            error: function () {
-                                $('body').trigger('processStop');
-                                alert({
-                                    content: '<?= $block->escapeJs($block->escapeHtml(__('An error occurred'))) ?>'
-                                });
                             }
-                        };
-                        $.ajax(ajaxOptions);
-
+                        });
                     })
                     .on('click.mselectAdd', '.mselect-button-add', function () {
                         taxRateForm


### PR DESCRIPTION

### Description (*)
This PR replaces the default confirm popup with Magento one.

### Fixed Issues (if relevant)
1. magento/magento2#24537: Remove tax rule popup not same as per other default popup

### Manual testing scenarios (*)
1. Admin -> Store -> Taxes -> Tax Rules -> Add new Tax Rules
2. Tax Rate -> Click on Delete icon any tax rule
3. Review the popup


### Questions or comments
Result
![image](https://user-images.githubusercontent.com/15868188/64610636-5ee56780-d3d8-11e9-8b08-aaa0f1fa230e.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
