### PR TITLE
Sort the name of modules before saving them to config.php

### DIFF
--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -442,6 +442,7 @@ class Installer
             }
         }
         if (!$dryRun) {
+            ksort($result);
             $this->deploymentConfigWriter->saveConfig([ConfigFilePool::APP_CONFIG => ['modules' => $result]], true);
         }
         return $result;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
I've added a simple `ksort()` before all the modules are saved to the `app/etc/config.php` file. With this change, the modules in this file now get sorted alphabetically. 

This currently is a problem because everytime you run `setup:upgrade`, Magento will alter the order of this module list. Git will register this as a change, preventing from updating your store using a simple `git pull`. It's more an annoyance than a real problem.

### Fixed Issues (if relevant)
None.

### Manual testing scenarios (*)
1. Run `setup:upgrade` on a clean Magento installation. 
2. Open `app/etc/config.php` 
3. All the values of the `modules` key should have been sorted alphabetically.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
