### PR TITLE
Require missing "doctrine/instantiator" dependency

### DIFF
--- a/lib/internal/Magento/Framework/MessageQueue/MessageValidator.php
+++ b/lib/internal/Magento/Framework/MessageQueue/MessageValidator.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\MessageQueue;
 
-use Doctrine\Instantiator\Exception\InvalidArgumentException;
+use InvalidArgumentException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
 use Magento\Framework\Communication\ConfigInterface as CommunicationConfig;
@@ -58,6 +58,7 @@ class MessageValidator
      * @param bool $requestType
      * @return void
      * @throws InvalidArgumentException
+     * @throws LocalizedException
      */
     public function validate($topic, $message, $requestType = true)
     {

--- a/lib/internal/Magento/Framework/MessageQueue/composer.json
+++ b/lib/internal/Magento/Framework/MessageQueue/composer.json
@@ -11,8 +11,7 @@
     ],
     "require": {
         "magento/framework": "*",
-        "php": "~7.1.3||~7.2.0||~7.3.0",
-        "doctrine/instantiator": "^1.0"
+        "php": "~7.1.3||~7.2.0||~7.3.0"
     },
     "autoload": {
         "psr-4": {

--- a/lib/internal/Magento/Framework/MessageQueue/composer.json
+++ b/lib/internal/Magento/Framework/MessageQueue/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "magento/framework": "*",
-        "php": "~7.1.3||~7.2.0||~7.3.0"
+        "php": "~7.1.3||~7.2.0||~7.3.0",
+        "doctrine/instantiator": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Yea, well. If you are gonna use code from "doctrine/instantiator", you may declare that in composer.json.

If you won't add this to the composer.json, following will happen, if you use that MessageQueue Module:
```
Fatal error: Uncaught Error: Class 'Doctrine\Instantiator\Exception\InvalidArgumentException' not found in /var/www/html/vendor/magento/framework-message-queue/MessageValidator.php on line 123

Error: Class 'Doctrine\Instantiator\Exception\InvalidArgumentException' not found in /var/www/html/vendor/magento/framework-message-queue/MessageValidator.php on line 123

Call Stack:
    0.0001     388800   1. {main}() /var/www/html/bin/magerun:0
    0.0410    2203840   2. N98\Magento\Application->run() /var/www/html/bin/magerun:8
    1.9646   47865896   3. N98\Magento\Application->run() phar:///var/www/html/bin/magerun/src/N98/Magento/Application.php:327
    1.9647   47865896   4. N98\Magento\Application->doRun() phar:///var/www/html/bin/magerun/vendor/symfony/console/Application.php:117
    2.0298   49673432   5. N98\Magento\Application->doRun() phar:///var/www/html/bin/magerun/src/N98/Magento/Application.php:237
    2.0300   49673432   6. N98\Magento\Application->doRunCommand() phar:///var/www/html/bin/magerun/vendor/symfony/console/Application.php:185

{"messages":{"error":[{"code":500,"message":"Fatal Error: 'Uncaught Error: Class 'Doctrine\\Instantiator\\Exception\\InvalidArgumentException' not found in \/var\/www\/html\/vendor\/magento\/framework-message-queue\/MessageValidator.php:123\nStack trace:\n#0 \/var\/www\/html\/vendor\/magento\/framework-message-queue\/MessageValidator.php(102): Magento\\Framework\\MessageQueue\\MessageValidator->validatePrimitiveType(Array, 'string', 'neusta.cart-bul...')\n#1 \/var\/www\/html\/vendor\/magento\/framework-message-queue\/MessageValidator.php(67): Magento\\Framework\\MessageQueue\\MessageValidator->validateMessage(Array, 'string', 'neusta.cart-bul...')\n#2 \/var\/www\/html\/vendor\/magento\/framework-message-queue\/Publisher.php(79): Magento\\Framework\\MessageQueue\\MessageValidator->validate('neusta.cart-bul...', Array)\n#3 \/var\/www\/html\/vendor\/magento\/framework-message-queue\/PublisherPool.php(89): Magento\\Framework\\MessageQueue\\Publisher->publish('neusta.cart-bul...', Array)\n#4 \/var\/www\/html\/_modules\/neusta-bulk-add-to-cart\/src\/Model\/Publisher\/BulkAddToCart.php(26): Magento\\Framework\\MessageQueue\\PublisherPool->p' in '\/var\/www\/html\/vendor\/magento\/framework-message-queue\/MessageValidator.php' on line 123","trace":"Trace is not available."}]}}bin/magento some:test  0,52s user 0,10s system 17% cpu 3,560 total
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
