### PR TITLE
Fix elastic alias doubled index if exception was thrown

### DIFF
--- a/app/code/Magento/Elasticsearch/Model/Adapter/Elasticsearch.php
+++ b/app/code/Magento/Elasticsearch/Model/Adapter/Elasticsearch.php
@@ -206,7 +206,7 @@ class Elasticsearch
         // prepare new index name and increase version
         $indexPattern = $this->indexNameResolver->getIndexPattern($storeId, $mappedIndexerId);
         $version = (int)(str_replace($indexPattern, '', $indexName));
-        $newIndexName = $indexPattern . ++$version;
+        $newIndexName = $indexPattern . (++$version);
 
         // remove index if already exists
         if ($this->client->indexExists($newIndexName)) {
@@ -357,12 +357,14 @@ class Elasticsearch
     {
         $this->indexBuilder->setStoreId($storeId);
         $settings = $this->indexBuilder->build();
-        $allAttributeTypes = $this->fieldMapper->getAllAttributesTypes([
-            'entityType' => $mappedIndexerId,
-            // Use store id instead of website id from context for save existing fields mapping.
-            // In future websiteId will be eliminated due to index stored per store
-            'websiteId' => $storeId
-        ]);
+        $allAttributeTypes = $this->fieldMapper->getAllAttributesTypes(
+            [
+                'entityType' => $mappedIndexerId,
+                // Use store id instead of website id from context for save existing fields mapping.
+                // In future websiteId will be eliminated due to index stored per store
+                'websiteId' => $storeId
+            ]
+        );
         $settings['index']['mapping']['total_fields']['limit'] = $this->getMappingTotalFieldsLimit($allAttributeTypes);
         $this->client->createIndex($indexName, ['settings' => $settings]);
         $this->client->addFieldsMapping(

--- a/app/code/Magento/Elasticsearch/Model/Adapter/Elasticsearch.php
+++ b/app/code/Magento/Elasticsearch/Model/Adapter/Elasticsearch.php
@@ -193,6 +193,9 @@ class Elasticsearch
      */
     public function cleanIndex($storeId, $mappedIndexerId)
     {
+        // needed to fix bug with double indices in alias because of second reindex in same process
+        unset($this->preparedIndex[$storeId]);
+
         $this->checkIndex($storeId, $mappedIndexerId, true);
         $indexName = $this->indexNameResolver->getIndexName($storeId, $mappedIndexerId, $this->preparedIndex);
         if ($this->client->isEmptyIndex($indexName)) {


### PR DESCRIPTION
### Description 
Problem appears when Magento runs few cron-jobs in one process. When you have few actual "indexer_reindex_all_invalid" jobs with pending status in cron_schedule table.
And after failured cron-jobs you have few indices in ElasticSearch alias, magento get products from all of them that causes "Item ... with the same ID ... already exists." exception.

### Fixed Issues (if relevant)
1. magento/magento2#24550: ElasticSearch doubled indices in alias trouble if exception was thrown 

### Manual testing scenarios
Described in [issue](https://github.com/magento/magento2/issues/24550).
1. You need few pending cron-jobs for invalid reindex
2. You need invalid catalogsearch index
3. Start cron jobs. For debugging on local environment I used `bin/magento cron:run --group=index --bootstrap=standaloneProcessStarted=1`.
4. Magento [prepares](https://github.com/magento/magento2/blob/320aac0d8715d7de3201488afaf2cfcaa268e1a4/app/code/Magento/Elasticsearch/Model/Adapter/Elasticsearch.php#L207-L217) new incremented index
5. You need to get exception in [saveIndex](https://github.com/magento/magento2/blob/2e036c4097f8101320dabda56332e6f0fcdf21c1/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext.php#L137). So first reindex job will be end up with failure. But it already has created new incremented index and send some docs to it.
6. Then \Magento\Cron\Observer\ProcessCronQueueObserver::processPendingJobs starts next reindex cron job in the same process. 
7. Then adapter [uses](https://github.com/magento/magento2/blob/320aac0d8715d7de3201488afaf2cfcaa268e1a4/app/code/Magento/Elasticsearch/Model/Adapter/Elasticsearch.php#L301) prepared index (with some docs), that was created in previous reindex and it [write](https://github.com/magento/magento2/blob/320aac0d8715d7de3201488afaf2cfcaa268e1a4/app/code/Magento/Elasticsearch/Model/Adapter/Elasticsearch.php#L310) it to alias without deleting old index. So now we have two indices in alias.
8. And then we got an error on category page



### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
