### PR TITLE
Allow use factories and OM for creating objects with variadic arguments in constructor

### DIFF
--- a/lib/internal/Magento/Framework/Code/Reader/ClassReader.php
+++ b/lib/internal/Magento/Framework/Code/Reader/ClassReader.php
@@ -28,7 +28,8 @@ class ClassReader implements ClassReaderInterface
                         $parameter->getName(),
                         $parameter->getClass() !== null ? $parameter->getClass()->getName() : null,
                         !$parameter->isOptional() && !$parameter->isDefaultValueAvailable(),
-                        $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null,
+                        $this->getReflectionParameterDefaultValue($parameter),
+                        $parameter->isVariadic(),
                     ];
                 } catch (\ReflectionException $e) {
                     $message = $e->getMessage();
@@ -38,6 +39,19 @@ class ClassReader implements ClassReaderInterface
         }
 
         return $result;
+    }
+
+    /**
+     * @param \ReflectionParameter $parameter
+     * @return array|mixed|null
+     */
+    private function getReflectionParameterDefaultValue(\ReflectionParameter $parameter)
+    {
+        if ($parameter->isVariadic()) {
+            return [];
+        }
+
+        return $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Code/Reader/ClassReader.php
+++ b/lib/internal/Magento/Framework/Code/Reader/ClassReader.php
@@ -5,12 +5,15 @@
  */
 namespace Magento\Framework\Code\Reader;
 
+/**
+ * Class ClassReader
+ */
 class ClassReader implements ClassReaderInterface
 {
     /**
      * Read class constructor signature
      *
-     * @param string $className
+     * @param  string $className
      * @return array|null
      * @throws \ReflectionException
      */
@@ -42,7 +45,9 @@ class ClassReader implements ClassReaderInterface
     }
 
     /**
-     * @param \ReflectionParameter $parameter
+     * Get reflection parameter default value
+     *
+     * @param  \ReflectionParameter $parameter
      * @return array|mixed|null
      */
     private function getReflectionParameterDefaultValue(\ReflectionParameter $parameter)
@@ -63,7 +68,7 @@ class ClassReader implements ClassReaderInterface
      *     ...
      * )
      *
-     * @param string $className
+     * @param  string $className
      * @return string[]
      */
     public function getParents($className)

--- a/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
@@ -11,6 +11,9 @@ use Magento\Framework\Phrase;
 use Psr\Log\LoggerInterface;
 use Magento\Framework\App\ObjectManager;
 
+/**
+ * Class AbstractFactory
+ */
 abstract class AbstractFactory implements \Magento\Framework\ObjectManager\FactoryInterface
 {
     /**
@@ -49,10 +52,10 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
     protected $creationStack = [];
 
     /**
-     * @param \Magento\Framework\ObjectManager\ConfigInterface $config
-     * @param ObjectManagerInterface $objectManager
+     * @param \Magento\Framework\ObjectManager\ConfigInterface     $config
+     * @param ObjectManagerInterface                               $objectManager
      * @param \Magento\Framework\ObjectManager\DefinitionInterface $definitions
-     * @param array $globalArguments
+     * @param array                                                $globalArguments
      */
     public function __construct(
         \Magento\Framework\ObjectManager\ConfigInterface $config,
@@ -91,6 +94,8 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
     }
 
     /**
+     * Get definitions
+     *
      * @return \Magento\Framework\ObjectManager\DefinitionInterface
      */
     public function getDefinitions()
@@ -105,7 +110,7 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
      * Create object
      *
      * @param string $type
-     * @param array $args
+     * @param array  $args
      *
      * @return object
      * @throws RuntimeException
@@ -130,9 +135,9 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
     /**
      * Resolve an argument
      *
-     * @param array &$argument
+     * @param array  &$argument
      * @param string $paramType
-     * @param mixed $paramDefault
+     * @param mixed  $paramDefault
      * @param string $paramName
      * @param string $requestedType
      *
@@ -214,8 +219,8 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
      * Resolve constructor arguments
      *
      * @param string $requestedType
-     * @param array $parameters
-     * @param array $arguments
+     * @param array  $parameters
+     * @param array  $arguments
      *
      * @return array
      *

--- a/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
@@ -226,7 +226,7 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
     {
         $resolvedArguments = [];
         foreach ($parameters as $parameter) {
-            list($paramName, $paramType, $paramRequired, $paramDefault) = $parameter;
+            list($paramName, $paramType, $paramRequired, $paramDefault, $isVariadic) = $parameter;
             $argument = null;
             if (!empty($arguments) && (isset($arguments[$paramName]) || array_key_exists($paramName, $arguments))) {
                 $argument = $arguments[$paramName];
@@ -243,9 +243,13 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
                 $argument = $paramDefault;
             }
 
-            $this->resolveArgument($argument, $paramType, $paramDefault, $paramName, $requestedType);
+            if ($isVariadic && is_array($argument)) {
+                $resolvedArguments = array_merge($resolvedArguments, $argument);
+            } else {
+                $this->resolveArgument($argument, $paramType, $paramDefault, $paramName, $requestedType);
+                $resolvedArguments[] = $argument;
+            }
 
-            $resolvedArguments[] = $argument;
         }
         return $resolvedArguments;
     }

--- a/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
@@ -251,13 +251,14 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
             }
 
             if ($isVariadic && is_array($argument)) {
-                $resolvedArguments = array_merge($resolvedArguments, $argument);
+                $resolvedArguments[] = $argument;
             } else {
                 $this->resolveArgument($argument, $paramType, $paramDefault, $paramName, $requestedType);
-                $resolvedArguments[] = $argument;
+                $resolvedArguments[] = [$argument];
             }
 
         }
-        return $resolvedArguments;
+
+        return empty($resolvedArguments) ? [] : array_merge(...$resolvedArguments);
     }
 }

--- a/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
@@ -242,9 +242,9 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
     /**
      * Get resolved argument from parameter
      *
-     * @param string $requestedType
-     * @param array  $parameter
-     * @param array  $arguments
+     * @param  string $requestedType
+     * @param  array  $parameter
+     * @param  array  $arguments
      * @return array
      */
     private function getResolvedArgument(string $requestedType, array $parameter, array $arguments): array

--- a/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
@@ -137,7 +137,7 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
     /**
      * Resolve an argument
      *
-     * @param array  &$argument
+     * @param array  $argument
      * @param string $paramType
      * @param mixed  $paramDefault
      * @param string $paramName

--- a/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
@@ -120,7 +120,9 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
         try {
             return new $type(...array_values($args));
         } catch (\TypeError $exception) {
-            /** @var LoggerInterface $logger */
+            /**
+             * @var LoggerInterface $logger
+             */
             $logger = ObjectManager::getInstance()->get(LoggerInterface::class);
             $logger->critical(
                 sprintf('Type Error occurred when creating object: %s, %s', $type, $exception->getMessage())
@@ -249,7 +251,7 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
             }
 
             if ($isVariadic && is_array($argument)) {
-                $resolvedArguments = array_merge($resolvedArguments, $argument);
+                $resolvedArguments += $argument;
             } else {
                 $this->resolveArgument($argument, $paramType, $paramDefault, $paramName, $requestedType);
                 $resolvedArguments[] = $argument;

--- a/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
@@ -251,7 +251,7 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
             }
 
             if ($isVariadic && is_array($argument)) {
-                $resolvedArguments += $argument;
+                $resolvedArguments = array_merge($resolvedArguments, $argument);
             } else {
                 $this->resolveArgument($argument, $paramType, $paramDefault, $paramName, $requestedType);
                 $resolvedArguments[] = $argument;

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/CompiledTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/CompiledTest.php
@@ -38,6 +38,9 @@ class CompiledTest extends \PHPUnit\Framework\TestCase
     /** @var ObjectManager */
     private $objectManager;
 
+    /**
+     * Setup tests
+     */
     protected function setUp()
     {
         $this->objectManager = new ObjectManager($this);
@@ -57,6 +60,9 @@ class CompiledTest extends \PHPUnit\Framework\TestCase
         $this->objectManager->setBackwardCompatibleProperty($this->factory, 'definitions', $this->definitionsMock);
     }
 
+    /**
+     * Test create simple
+     */
     public function testCreateSimple()
     {
         $expectedConfig = $this->getSimpleConfig();
@@ -106,6 +112,9 @@ class CompiledTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($result->getNullValue());
     }
 
+    /**
+     * Test create simple configured arguments
+     */
     public function testCreateSimpleConfiguredArguments()
     {
         $expectedConfig = $this->getSimpleNestedConfig();
@@ -170,6 +179,9 @@ class CompiledTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($result->getNullValue());
     }
 
+    /**
+     * Test create get arguments in runtime
+     */
     public function testCreateGetArgumentsInRuntime()
     {
         // Stub OM to create test assets
@@ -308,18 +320,21 @@ class CompiledTest extends \PHPUnit\Framework\TestCase
                     1 => DependencyTesting::class,
                     2 => true,
                     3 => null,
+                    4 => false,
                 ],
             1 => [
                     0 => 'sharedDependency',
                     1 => DependencySharedTesting::class,
                     2 => true,
                     3 => null,
+                    4 => false,
                 ],
             2 => [
                     0 => 'value',
                     1 => null,
                     2 => false,
                     3 => 'value',
+                    4 => false,
                 ],
             3 => [
                     0 => 'valueArray',
@@ -329,18 +344,21 @@ class CompiledTest extends \PHPUnit\Framework\TestCase
                             0 => 'default_value1',
                             1 => 'default_value2',
                         ],
+                    4 => false,
                 ],
             4 => [
                     0 => 'globalValue',
                     1 => null,
                     2 => false,
                     3 => '',
+                    4 => false,
                 ],
             5 => [
                     0 => 'nullValue',
                     1 => null,
                     2 => false,
                     3 => null,
+                    4 => false,
                 ],
         ];
     }

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/FactoryTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/FactoryTest.php
@@ -272,7 +272,14 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
                 null,
                 null,
             ],
-            'with_args' => [
+            'with_single_arg' => [
+                [
+                    'oneScalars' => $oneScalar1
+                ],
+                $oneScalar1,
+                null,
+            ],
+            'with_full_args' => [
                 [
                     'oneScalars' => [
                         $oneScalar1,
@@ -402,6 +409,14 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
                 ],
                 \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\SemiVariadic::DEFAULT_FOO_VALUE,
                 null,
+                null,
+            ],
+            'only_with_oneScalars_single_value' => [
+                [
+                    'oneScalars' => $oneScalar1
+                ],
+                \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\SemiVariadic::DEFAULT_FOO_VALUE,
+                $oneScalar1,
                 null,
             ],
             'only_with_oneScalars_full_value' => [

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/FactoryTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/FactoryTest.php
@@ -50,22 +50,34 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException \UnexpectedValueException
+     * @expectedException        \UnexpectedValueException
      * @expectedExceptionMessage Invalid parameter configuration provided for $firstParam argument
      */
     public function testResolveArgumentsException()
     {
         $configMock = $this->createMock(\Magento\Framework\ObjectManager\Config\Config::class);
-        $configMock->expects($this->once())->method('getArguments')
-            ->will($this->returnValue([
-                'firstParam' => 1,
-            ]));
+        $configMock->expects($this->once())->method('getArguments')->will(
+            $this->returnValue(
+                [
+                    'firstParam' => 1,
+                ]
+            )
+        );
 
         $definitionsMock = $this->createMock(\Magento\Framework\ObjectManager\DefinitionInterface::class);
-        $definitionsMock->expects($this->once())->method('getParameters')
-            ->will($this->returnValue([[
-                'firstParam', 'string', true, 'default_val', false
-            ]]));
+        $definitionsMock->expects($this->once())->method('getParameters')->will(
+            $this->returnValue(
+                [
+                    [
+                        'firstParam',
+                        'string',
+                        true,
+                        'default_val',
+                        false
+                    ]
+                ]
+            )
+        );
 
         $this->factory = new Developer(
             $configMock,
@@ -80,9 +92,14 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    /**
+     * Test create with one arg
+     */
     public function testCreateOneArg()
     {
-        /** @var \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\OneScalar $result */
+        /**
+         * @var \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\OneScalar $result
+         */
         $result = $this->factory->create(
             \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\OneScalar::class,
             ['foo' => 'bar']
@@ -91,6 +108,9 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('bar', $result->getFoo());
     }
 
+    /**
+     * Test create with injectable
+     */
     public function testCreateWithInjectable()
     {
         // let's imitate that One is injectable by providing DI configuration for it
@@ -101,7 +121,9 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
                 ],
             ]
         );
-        /** @var \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\Two $result */
+        /**
+         * @var \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\Two $result
+         */
         $result = $this->factory->create(\Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\Two::class);
         $this->assertInstanceOf(\Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\Two::class, $result);
         $this->assertInstanceOf(
@@ -113,8 +135,8 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param string $startingClass
-     * @param string $terminationClass
+     * @param        string $startingClass
+     * @param        string $terminationClass
      * @dataProvider circularDataProvider
      */
     public function testCircular($startingClass, $terminationClass)
@@ -139,23 +161,30 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    /**
+     * Test create using reflection
+     */
     public function testCreateUsingReflection()
     {
         $type = \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\Polymorphous::class;
         $definitions = $this->createMock(\Magento\Framework\ObjectManager\DefinitionInterface::class);
         // should be more than defined in "switch" of create() method
-        $definitions->expects($this->once())->method('getParameters')->with($type)->will($this->returnValue([
-            ['one', null, false, null, false],
-            ['two', null, false, null, false],
-            ['three', null, false, null, false],
-            ['four', null, false, null, false],
-            ['five', null, false, null, false],
-            ['six', null, false, null, false],
-            ['seven', null, false, null, false],
-            ['eight', null, false, null, false],
-            ['nine', null, false, null, false],
-            ['ten', null, false, null, false],
-        ]));
+        $definitions->expects($this->once())->method('getParameters')->with($type)->will(
+            $this->returnValue(
+                [
+                    ['one', null, false, null, false],
+                    ['two', null, false, null, false],
+                    ['three', null, false, null, false],
+                    ['four', null, false, null, false],
+                    ['five', null, false, null, false],
+                    ['six', null, false, null, false],
+                    ['seven', null, false, null, false],
+                    ['eight', null, false, null, false],
+                    ['nine', null, false, null, false],
+                    ['ten', null, false, null, false],
+                ]
+            )
+        );
         $factory = new Developer($this->config, null, $definitions);
         $result = $factory->create(
             $type,
@@ -178,9 +207,9 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * Test create objects with variadic argument in constructor
      *
-     * @param $createArgs
-     * @param $expectedArg0
-     * @param $expectedArg1
+     * @param        $createArgs
+     * @param        $expectedArg0
+     * @param        $expectedArg1
      * @dataProvider testCreateUsingVariadicDataProvider
      */
     public function testCreateUsingVariadic(
@@ -191,20 +220,24 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
         $type = \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\Variadic::class;
         $definitions = $this->createMock(\Magento\Framework\ObjectManager\DefinitionInterface::class);
 
-        $definitions->expects($this->once())->method('getParameters')->with($type)->will($this->returnValue([
-            [
+        $definitions->expects($this->once())->method('getParameters')->with($type)->will(
+            $this->returnValue(
+                [
+                    [
                 'oneScalars',
                 \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\OneScalar::class,
                 false,
                 [],
                 true
-            ],
-        ]));
+                    ],
+                ]
+            )
+        );
         $factory = new Developer($this->config, null, $definitions);
 
-
-
-        /** @var \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\Variadic $variadic */
+        /**
+         * @var \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\Variadic $variadic
+         */
         $variadic = is_null($createArgs)
             ? $factory->create($type)
             : $factory->create($type, $createArgs);
@@ -216,7 +249,8 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function testCreateUsingVariadicDataProvider() {
+    public function testCreateUsingVariadicDataProvider()
+    {
         $oneScalar1 = $this->createMock(\Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\OneScalar::class);
         $oneScalar2 = $this->createMock(\Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\OneScalar::class);
 
@@ -272,7 +306,9 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
                 ],
             ]
         );
-        /** @var \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\Variadic $variadic */
+        /**
+         * @var \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\Variadic $variadic
+         */
         $variadic = $this->factory->create(\Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\Variadic::class);
 
         $this->assertSame($oneScalar1, $variadic->getOneScalarByKey(0));

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/FactoryTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/FactoryTest.php
@@ -314,4 +314,131 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($oneScalar1, $variadic->getOneScalarByKey(0));
         $this->assertSame($oneScalar2, $variadic->getOneScalarByKey(1));
     }
+
+    /**
+     * Test create objects with non variadic and variadic argument in constructor
+     *
+     * @param        $createArgs
+     * @param        $expectedFooValue
+     * @param        $expectedArg0
+     * @param        $expectedArg1
+     * @dataProvider testCreateUsingSemiVariadicDataProvider
+     */
+    public function testCreateUsingSemiVariadic(
+        $createArgs,
+        $expectedFooValue,
+        $expectedArg0,
+        $expectedArg1
+    ) {
+        $type = \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\SemiVariadic::class;
+        $definitions = $this->createMock(\Magento\Framework\ObjectManager\DefinitionInterface::class);
+
+        $definitions->expects($this->once())->method('getParameters')->with($type)->will(
+            $this->returnValue(
+                [
+                    [
+                        'foo',
+                        null,
+                        false,
+                        \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\SemiVariadic::DEFAULT_FOO_VALUE,
+                        false
+                    ],
+                    [
+                        'oneScalars',
+                        \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\OneScalar::class,
+                        false,
+                        [],
+                        true
+                    ],
+                ]
+            )
+        );
+        $factory = new Developer($this->config, null, $definitions);
+
+        /**
+         * @var \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\SemiVariadic $semiVariadic
+         */
+        $semiVariadic = is_null($createArgs)
+            ? $factory->create($type)
+            : $factory->create($type, $createArgs);
+
+        $this->assertSame($expectedFooValue, $semiVariadic->getFoo());
+        $this->assertSame($expectedArg0, $semiVariadic->getOneScalarByKey(0));
+        $this->assertSame($expectedArg1, $semiVariadic->getOneScalarByKey(1));
+    }
+
+    /**
+     * @return array
+     */
+    public function testCreateUsingSemiVariadicDataProvider()
+    {
+        $oneScalar1 = $this->createMock(\Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\OneScalar::class);
+        $oneScalar2 = $this->createMock(\Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\OneScalar::class);
+
+        return [
+            'without_args'    => [
+                null,
+                \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\SemiVariadic::DEFAULT_FOO_VALUE,
+                null,
+                null,
+            ],
+            'with_empty_args' => [
+                [],
+                \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\SemiVariadic::DEFAULT_FOO_VALUE,
+                null,
+                null,
+            ],
+            'only_with_foo_value' => [
+                [
+                    'foo' => 'baz'
+                ],
+                'baz',
+                null,
+                null,
+            ],
+            'only_with_oneScalars_empty_value' => [
+                [
+                    'oneScalars' => []
+                ],
+                \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\SemiVariadic::DEFAULT_FOO_VALUE,
+                null,
+                null,
+            ],
+            'only_with_oneScalars_full_value' => [
+                [
+                    'oneScalars' => [
+                        $oneScalar1,
+                        $oneScalar2,
+                    ]
+                ],
+                \Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture\SemiVariadic::DEFAULT_FOO_VALUE,
+                $oneScalar1,
+                $oneScalar2,
+            ],
+            'with_all_values_defined_in_right_order' => [
+                [
+                    'foo' => 'baz',
+                    'oneScalars' => [
+                        $oneScalar1,
+                        $oneScalar2,
+                    ]
+                ],
+                'baz',
+                $oneScalar1,
+                $oneScalar2,
+            ],
+            'with_all_values_defined_in_reverse_order' => [
+                [
+                    'oneScalars' => [
+                        $oneScalar1,
+                        $oneScalar2,
+                    ],
+                    'foo' => 'baz',
+                ],
+                'baz',
+                $oneScalar1,
+                $oneScalar2,
+            ],
+        ];
+    }
 }

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/Fixture/SemiVariadic.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/Fixture/SemiVariadic.php
@@ -11,6 +11,7 @@ namespace Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture;
 class SemiVariadic
 {
     const DEFAULT_FOO_VALUE = 'bar';
+
     /**
      * @var OneScalar[]
      */
@@ -23,7 +24,8 @@ class SemiVariadic
 
     /**
      * SemiVariadic constructor.
-     * @param string $foo
+     *
+     * @param string      $foo
      * @param OneScalar[] ...$oneScalars
      */
     public function __construct(
@@ -35,7 +37,7 @@ class SemiVariadic
     }
 
     /**
-     * @param string $key
+     * @param  mixed $key
      * @return mixed
      */
     public function getOneScalarByKey($key)

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/Fixture/SemiVariadic.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/Fixture/SemiVariadic.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture;
+
+/**
+ * Constructor with non variadic and variadic argument in constructor
+ */
+class SemiVariadic
+{
+    const DEFAULT_FOO_VALUE = 'bar';
+    /**
+     * @var OneScalar[]
+     */
+    private $oneScalars;
+
+    /**
+     * @var string
+     */
+    private $foo;
+
+    /**
+     * SemiVariadic constructor.
+     * @param string $foo
+     * @param OneScalar[] ...$oneScalars
+     */
+    public function __construct(
+        string $foo = self::DEFAULT_FOO_VALUE,
+        OneScalar ...$oneScalars
+    ) {
+        $this->foo = $foo;
+        $this->oneScalars = $oneScalars;
+    }
+
+    /**
+     * @param string $key
+     * @return mixed
+     */
+    public function getOneScalarByKey($key)
+    {
+        return $this->oneScalars[$key] ?? null;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+}

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/Fixture/Variadic.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/Fixture/Variadic.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\ObjectManager\Test\Unit\Factory\Fixture;
+
+/**
+ * Constructor with variadic argument in constructor
+ */
+class Variadic
+{
+    /**
+     * @var OneScalar[]
+     */
+    private $oneScalars;
+
+    /**
+     * Variadic constructor.
+     * @param OneScalar[] ...$oneScalars
+     */
+    public function __construct(OneScalar ...$oneScalars)
+    {
+        $this->oneScalars = $oneScalars;
+    }
+
+    /**
+     * @param string $key
+     * @return mixed
+     */
+    public function getOneScalarByKey($key)
+    {
+        return $this->oneScalars[$key] ?? null;
+    }
+}


### PR DESCRIPTION
### Description (*)

Currently, if you have a class using a variadic argument in constructor, it is not possible to use generated factories or OM to instantiate it. Having this as example, there is no way to instantiate it using CustomObjectPoolFactory generated class:

```
/**
 * Demo class CustomObjectPool, accepting variable number of arguments, all of them of CustomObject type
 */
class CustomObjectPool
{
    /**
     * @var CustomObject[]
     */
    private $customObjects;

    /**
     * CustomObjectPool constructor.
     * @param CustomObject[] ...$customObjects
     */
    public function __construct(CustomObject ...$customObjects)
    {
        $this->customObjects = $customObjects;
    }
}
```

This is a test snippet, that fails with a type error exception:

```
<?php

use Magento\Framework\App\Area;

require __DIR__ . '/app/bootstrap.php';

/**
 * Demo class CustomObject
 */
class CustomObject
{
}

/**
 * Demo class CustomObjectPool, accepting variable number of arguments, all of them of CustomObject type
 */
class CustomObjectPool
{
    /**
     * @var CustomObject[]
     */
    private $customObjects;

    /**
     * CustomObjectPool constructor.
     * @param CustomObject[] ...$customObjects
     */
    public function __construct(CustomObject ...$customObjects)
    {
        $this->customObjects = $customObjects;
    }
}

/**
 * Class TestApp
 */
class TestApp extends \Magento\Framework\App\Http implements \Magento\Framework\AppInterface
{
    public function launch()
    {
        $this->_state->setAreaCode(Area::AREA_GLOBAL);
        $this->_objectManager->configure($this->_configLoader->load(Area::AREA_GLOBAL));

        // Used this way instead of constructor for convenience, not needed for ilustrative example
        $customObjectPoolFactory = $this->_objectManager->get(CustomObjectPoolFactory::class);
        // Line below throws type error exception
        $customObjectPool = $customObjectPoolFactory->create();
        // This line below also throws type error exception
        $customObjectPool = $customObjectPoolFactory->create(
            [
                'customObjects' => [
                    new CustomObject(),
                    new CustomObject(),
                ]
            ]
        );

        return $this->_response;
    }

    public function catchException(\Magento\Framework\App\Bootstrap $bootstrap, \Exception $exception)
    {
        var_dump($exception->getMessage());
        var_dump($exception->getTraceAsString());
        exit();
    }
}

$bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);

/** @var \Magento\Framework\App\Http $app */
$app = $bootstrap->createApplication(TestApp::class);
$bootstrap->run($app);
```

With provided changes, variadic arguments are supported, including building without arguments:
```
$customObjectPool = $customObjectPoolFactory->create();
```
Or defining them as an array:
```
$customObjectPool = $customObjectPoolFactory->create(
            [
                'customObjects' => [
                    new CustomObject(),
                    new CustomObject(),
                ]
            ]
        );
```
Or defining a single one in a simple way:
```
$customObjectPool = $customObjectPoolFactory->create(
            [
                'customObjects' => new CustomObject()
            ]
        );
```
Or injecting them from di.xml config.

### Fixed Issues (if relevant)
None AFAIK, improvement

### Manual testing scenarios (*)
Use provided snippet.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
