### PR TITLE
Added newline to the end of var/report reports output

### DIFF
--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -480,7 +480,7 @@ class Processor
      */
     public function saveReport($reportData)
     {
-        $this->reportData = $reportData;
+        $this->reportData = $reportData . PHP_EOL;
         $this->reportId   = abs((int)(microtime(true) * random_int(100, 1000)));
         $this->_reportFile = $this->_reportDir . '/' . $this->reportId;
         $this->_setReportData($reportData);

--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -480,7 +480,7 @@ class Processor
      */
     public function saveReport($reportData)
     {
-        $this->reportData = $reportData . PHP_EOL;
+        $this->reportData = $reportData;
         $this->reportId   = abs((int)(microtime(true) * random_int(100, 1000)));
         $this->_reportFile = $this->_reportDir . '/' . $this->reportId;
         $this->_setReportData($reportData);
@@ -489,7 +489,7 @@ class Processor
             @mkdir($this->_reportDir, 0777, true);
         }
 
-        @file_put_contents($this->_reportFile, $this->serializer->serialize($reportData));
+        @file_put_contents($this->_reportFile, $this->serializer->serialize($reportData). PHP_EOL);
 
         if (isset($reportData['skin']) && self::DEFAULT_SKIN != $reportData['skin']) {
             $this->_setSkin($reportData['skin']);


### PR DESCRIPTION
Description (*)
A simple PHP_EOL was added to report output, this will make it so reports have a newline at the end.

Fixed Issues (if relevant)
magento#24558: Newline Missing from Reports in var/reports
Manual testing scenarios (*)
Reports generated will now have a newline.
Questions or comments
Very small fix, seems cosmetic, but it affects automated parsing of these files.

Contribution checklist (*)
[*] Pull request has a meaningful description of its purpose
[*] All commits are accompanied by meaningful commit messages
[*] All new or changed code is covered with unit/integration tests (if applicable)
[*] All automated tests passed successfully (all builds are green)