### PR TITLE
Fix issue with Elasticsearch when products limit is not set on category page

### DIFF
--- a/lib/internal/Magento/Framework/Search/Request/Binder.php
+++ b/lib/internal/Magento/Framework/Search/Request/Binder.php
@@ -45,6 +45,10 @@ class Binder
         $limitList = ['from', 'size'];
         foreach ($limitList as $limit) {
             if (isset($bindData[$limit])) {
+                if ($limit === 'size' && $bindData[$limit] === 0 && isset($data[$limit])) {
+                    continue;
+                }
+
                 $data[$limit] = $bindData[$limit];
             }
         }


### PR DESCRIPTION
### Description (*)
These changes fixes #24190.
It happens because Elasticcache requires to set from/size in each query (see https://www.elastic.co/guide/en/elasticsearch/reference/6.0/search-request-from-size.html). In case which was described in #24190 Magento sends those parameters with both 0 and as result - 0 hits is returned.


### Fixed Issues (if relevant)

1. magento/magento2#24190

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Setup Magento 2.3.2 with Elasticsearch
2. Go to category page
3. Set "All" products to show

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
