### PR TITLE
adding new validation for future dates to admin in customer DOB - issue #22692

### DIFF
--- a/app/code/Magento/Customer/Block/Widget/Dob.php
+++ b/app/code/Magento/Customer/Block/Widget/Dob.php
@@ -267,6 +267,8 @@ class Dob extends AbstractWidget
         $validators['validate-date'] = [
             'dateFormat' => $this->getDateFormat()
         ];
+        $validators['validate-dob'] = true;
+
         return 'data-validate="' . $this->_escaper->escapeHtml(json_encode($validators)) . '"';
     }
 

--- a/app/code/Magento/Customer/Test/Unit/Block/Widget/DobTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Widget/DobTest.php
@@ -547,7 +547,7 @@ class DobTest extends TestCase
             ->with('{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}')
             ->will(
                 $this->returnValue(
-                '{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}'
+                    '{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}'
                 )
             );
 

--- a/app/code/Magento/Customer/Test/Unit/Block/Widget/DobTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Widget/DobTest.php
@@ -9,13 +9,13 @@ namespace Magento\Customer\Test\Unit\Block\Widget;
 use Magento\Customer\Api\CustomerMetadataInterface;
 use Magento\Customer\Api\Data\AttributeMetadataInterface;
 use Magento\Customer\Api\Data\ValidationRuleInterface;
+use Magento\Customer\Block\Widget\Dob;
 use Magento\Customer\Helper\Address;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Cache\FrontendInterface;
 use Magento\Framework\Data\Form\FilterFactory;
 use Magento\Framework\Escaper;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Customer\Block\Widget\Dob;
 use Magento\Framework\Locale\Resolver;
 use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\Stdlib\DateTime\Timezone;
@@ -545,9 +545,11 @@ class DobTest extends TestCase
         $this->escaper->expects($this->any())
             ->method('escapeHtml')
             ->with('{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}')
-            ->will($this->returnValue(
+            ->will(
+                $this->returnValue(
                 '{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}'
-            ));
+                )
+            );
 
         $this->context->expects($this->any())->method('getEscaper')->will($this->returnValue($this->escaper));
 

--- a/app/code/Magento/Customer/Test/Unit/Block/Widget/DobTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Widget/DobTest.php
@@ -521,8 +521,8 @@ class DobTest extends TestCase
     {
         $this->escaper->expects($this->any())
             ->method('escapeHtml')
-            ->with('{"validate-date":{"dateFormat":"M\/d\/Y"}}')
-            ->will($this->returnValue('{"validate-date":{"dateFormat":"M\/d\/Y"}}'));
+            ->with('{"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}')
+            ->will($this->returnValue('{"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}'));
 
         $this->attribute->expects($this->once())
             ->method("isRequired")
@@ -530,7 +530,7 @@ class DobTest extends TestCase
 
         $this->assertEquals(
             $this->_block->getHtmlExtraParams(),
-            'data-validate="{"validate-date":{"dateFormat":"M\/d\/Y"}}"'
+            'data-validate="{"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}"'
         );
     }
 
@@ -544,13 +544,13 @@ class DobTest extends TestCase
             ->willReturn(true);
         $this->escaper->expects($this->any())
             ->method('escapeHtml')
-            ->with('{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"}}')
-            ->will($this->returnValue('{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"}}'));
+            ->with('{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}')
+            ->will($this->returnValue('{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}'));
 
         $this->context->expects($this->any())->method('getEscaper')->will($this->returnValue($this->escaper));
 
         $this->assertEquals(
-            'data-validate="{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"}}"',
+            'data-validate="{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}"',
             $this->_block->getHtmlExtraParams()
         );
     }

--- a/app/code/Magento/Customer/Test/Unit/Block/Widget/DobTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Widget/DobTest.php
@@ -545,7 +545,9 @@ class DobTest extends TestCase
         $this->escaper->expects($this->any())
             ->method('escapeHtml')
             ->with('{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}')
-            ->will($this->returnValue('{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}'));
+            ->will($this->returnValue(
+                '{"required":true,"validate-date":{"dateFormat":"M\/d\/Y"},"validate-dob":true}'
+            ));
 
         $this->context->expects($this->any())->method('getEscaper')->will($this->returnValue($this->escaper));
 

--- a/app/code/Magento/Customer/i18n/en_US.csv
+++ b/app/code/Magento/Customer/i18n/en_US.csv
@@ -539,3 +539,4 @@ Addresses,Addresses
 "Prefix","Prefix"
 "Middle Name/Initial","Middle Name/Initial"
 "Suffix","Suffix"
+"The Date of Birth should not be greater than today.","The Date of Birth should not be greater than today."

--- a/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
+++ b/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
@@ -264,6 +264,7 @@
             </argument>
             <settings>
                 <validation>
+                    <rule name="validate-date" xsi:type="boolean">true</rule>
                     <rule name="validate-dob" xsi:type="boolean">true</rule>
                 </validation>
                 <dataType>text</dataType>

--- a/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
+++ b/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
@@ -260,6 +260,9 @@
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">customer</item>
+                    <item name="options" xsi:type="array">
+                        <item name="maxDate" xsi:type="string">-1d</item>
+                    </item>
                 </item>
             </argument>
             <settings>

--- a/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
+++ b/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
@@ -264,7 +264,7 @@
             </argument>
             <settings>
                 <validation>
-                    <rule name="validate-date" xsi:type="boolean">true</rule>
+                    <rule name="validate-dob" xsi:type="boolean">true</rule>
                 </validation>
                 <dataType>text</dataType>
                 <visible>true</visible>

--- a/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
+++ b/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
@@ -260,9 +260,6 @@
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">customer</item>
-                    <item name="options" xsi:type="array">
-                        <item name="maxDate" xsi:type="string">-1d</item>
-                    </item>
                 </item>
             </argument>
             <settings>
@@ -273,6 +270,15 @@
                 <dataType>text</dataType>
                 <visible>true</visible>
             </settings>
+            <formElements>
+                <date>
+                    <settings>
+                        <options>
+                            <option name="maxDate" xsi:type="string">-1d</option>
+                        </options>
+                    </settings>
+                </date>
+            </formElements>
         </field>
         <field name="taxvat" formElement="input">
             <argument name="data" xsi:type="array">

--- a/app/code/Magento/Customer/view/frontend/templates/widget/dob.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/dob.phtml
@@ -35,3 +35,11 @@ $fieldCssClass .= $block->isRequired() ? ' required' : '';
         <?php endif; ?>
     </div>
 </div>
+
+<script type="text/x-magento-init">
+    {
+       "*": {
+           "Magento_Customer/js/validation": {}
+       }
+    }
+ </script>

--- a/app/code/Magento/Customer/view/frontend/web/js/validation.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/validation.js
@@ -1,0 +1,19 @@
+require([
+    'jquery',
+    'moment',
+    'jquery/ui',
+    'jquery/validate',
+    'mage/translate',
+], function($, moment) {
+    'use strict';
+    $.validator.addMethod(
+        "validate-dob",
+        function (value) {
+            if (value === '') {
+                return true;
+            }
+            return moment(value).isBefore(moment());
+        },
+        $.mage.__('The Date of Birth should not be greater than today.')
+    );
+});

--- a/app/code/Magento/Customer/view/frontend/web/js/validation.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/validation.js
@@ -3,7 +3,7 @@ require([
     'moment',
     'jquery/validate',
     'mage/translate',
-], function($, moment) {
+], function ($, moment) {
     'use strict';
 
     $.validator.addMethod(

--- a/app/code/Magento/Customer/view/frontend/web/js/validation.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/validation.js
@@ -2,7 +2,7 @@ require([
     'jquery',
     'moment',
     'jquery/validate',
-    'mage/translate',
+    'mage/translate'
 ], function ($, moment) {
     'use strict';
 

--- a/app/code/Magento/Customer/view/frontend/web/js/validation.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/validation.js
@@ -1,4 +1,4 @@
-require([
+define([
     'jquery',
     'moment',
     'jquery/validate',

--- a/app/code/Magento/Customer/view/frontend/web/js/validation.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/validation.js
@@ -6,7 +6,7 @@ require([
 ], function($, moment) {
     'use strict';
     $.validator.addMethod(
-        "validate-dob",
+        'validate-dob',
         function (value) {
             if (value === '') {
                 return true;

--- a/app/code/Magento/Customer/view/frontend/web/js/validation.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/validation.js
@@ -1,7 +1,6 @@
 require([
     'jquery',
     'moment',
-    'jquery/ui',
     'jquery/validate',
     'mage/translate',
 ], function($, moment) {
@@ -12,6 +11,7 @@ require([
             if (value === '') {
                 return true;
             }
+
             return moment(value).isBefore(moment());
         },
         $.mage.__('The Date of Birth should not be greater than today.')

--- a/app/code/Magento/Customer/view/frontend/web/js/validation.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/validation.js
@@ -5,6 +5,7 @@ require([
     'mage/translate',
 ], function($, moment) {
     'use strict';
+
     $.validator.addMethod(
         'validate-dob',
         function (value) {

--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -1076,7 +1076,7 @@ define([
 
                 return moment(value).isBefore(moment());
             },
-            $.mage.__('The Date of Birth should not be greater than today')
+            $.mage.__('The Date of Birth should not be greater than today.')
         ]
     }, function (data) {
         return {

--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -1067,6 +1067,16 @@ define([
                 return new RegExp(param).test(value);
             },
             $.mage.__('This link is not allowed.')
+        ],
+        'validate-dob': [
+            function (value, params, additionalParams) {
+                if(value === '') {
+                    return true;
+                }
+
+                return moment(value).isBefore(moment());
+            },
+            $.mage.__('The Date of Birth should not be greater than today')
         ]
     }, function (data) {
         return {

--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -1069,8 +1069,8 @@ define([
             $.mage.__('This link is not allowed.')
         ],
         'validate-dob': [
-            function (value, params, additionalParams) {
-                if(value === '') {
+            function (value) {
+                if (value === '') {
                     return true;
                 }
 


### PR DESCRIPTION
### Description (*)
We have tried to create new customer from Magento back end and added Future date as Date of Birth example - 09/09/2020 and we can save customer without any issue

### Fixed Issues
On Admin, when creating a new customer, there was no validation for future dates. It was possible to add dates greater than the current date. 
Added new validation to the field.

1. magento/magento2#22692: Add New Customer from admin panel - DOB field validation missing for future dates

### Manual testing scenarios (*)
1. Log in to Admin > Customer > All customers > Add new customer.
2. Change the DoB date for invalid dates or greater than current date.
3. Try to save new customer

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
