### PR TITLE
Removing unused mixin

### DIFF
--- a/lib/web/css/source/lib/_layout.less
+++ b/lib/web/css/source/lib/_layout.less
@@ -7,34 +7,6 @@
 //  Layout
 //  _____________________________________________
 
-//  Page Width mixin
-.lib-layout-width(
-    @_layout__min-width: @layout__min-width,
-    @_layout__max-width: @layout__max-width,
-    @_layout__indent: @layout-indent__width
-) when not (@responsive = true) {
-    ._lib-layout-width(@_layout__min-width, @_layout__max-width);
-    .lib-css(padding-left, @layout-indent__width);
-    .lib-css(padding-right, @layout-indent__width);
-    margin: 0 auto;
-}
-
-._lib-layout-width(
-        @_layout__min-width: @layout__min-width,
-        @_layout__max-width: @layout__max-width
-    ) when (@_layout__min-width = @_layout__max-width) {
-    .lib-css(width, @_layout__min-width);
-}
-
-._lib-layout-width(
-        @_layout__min-width: @layout__min-width,
-        @_layout__max-width: @layout__max-width
-    ) when not (@_layout__min-width = @_layout__max-width) {
-    .lib-css(max-width, @_layout__max-width);
-    .lib-css(min-width, @_layout__min-width);
-    width: auto;
-}
-
 #lib-layout-columns() {
     & when (@use-flex = true) {
         .lib-vendor-prefix-display(flex);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Removing unused mixin from layout lib less file.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#15060: .lib-layout-width mixin not available?

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
N/A

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
