### PR TITLE
Bugfix/22964

### DIFF
--- a/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontRegionUpdatesAfterChangingCountryAndLeavingRegionSelectUnselectedTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontRegionUpdatesAfterChangingCountryAndLeavingRegionSelectUnselectedTest.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontRegionUpdatesAfterChangingCountryAndLeavingRegionSelectUnselectedTest">
+        <annotations>
+            <features value="Checkout"/>
+            <stories value="Region updates after changing country "/>
+            <title value="Region updates after changing country "/>
+            <description value="Region dupdates after changing country and leaving region select unselected"/>
+            <severity value="CRITICAL"/>
+            <testCaseId value="https://github.com/magento/magento2/issues/23460"/>
+            <group value="checkout"/>
+        </annotations>
+        <before>
+            <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
+        </before>
+        <after>
+            <deleteData createDataKey="createCustomer" stepKey="deleteCustomer"/>
+        </after>
+
+        <!-- Login to storefront from customer -->
+        <actionGroup ref="LoginToStorefrontActionGroup" stepKey="loginCustomer">
+            <argument name="Customer" value="$$createCustomer$$"/>
+        </actionGroup>
+
+        <actionGroup ref="StorefrontOpenMyAccountPageActionGroup" stepKey="goToMyAccountPage"/>
+
+        <actionGroup ref="StorefrontCustomerGoToSidebarMenu" stepKey="goToAddressBookPage">
+            <argument name="menu" value="Address Book"/>
+        </actionGroup>
+        <actionGroup ref="StoreFrontClickEditDefaultShippingAddressActionGroup" stepKey="clickEditAddress"/>
+        <selectOption selector="{{StorefrontCustomerAddressFormSection.country}}" userInput="{{updateCustomerFranceAddress.country}}" stepKey="selectCountry"/>
+        <actionGroup ref="AdminSaveCustomerAddressActionGroup" stepKey="saveAddress"/>
+
+        <see selector="{{StorefrontCustomerAddressesSection.defaultShippingAddress}}" userInput="{{updateCustomerFranceAddress.country}}" stepKey="seeAssertCustomerDefaultShippingAddressCountry"/>
+    </test>
+</tests>

--- a/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
@@ -164,7 +164,7 @@ define([
 
             // Populate state/province dropdown list if available or use input box
             if (this.options.regionJson[country]) {
-                $(regionList).find('option:selected').removeAttr("selected");
+                $(regionList).find('option:selected').removeAttr('selected');
                 this._removeSelectOptions(regionList);
                 $.each(this.options.regionJson[country], $.proxy(function (key, value) {
                     this._renderSelectOption(regionList, key, value);

--- a/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
@@ -224,8 +224,13 @@ define([
                     postcode.addClass('required-entry').closest('.field').addClass('required');
             }
 
-            // Add defaultvalue attribute to state/province select element
-            regionList.attr('defaultvalue', this.options.defaultRegion);
+            if (!this.options.defaultRegion) {
+                regionList.val('');
+                regionInput.val('');
+            } else {
+                // Add defaultvalue attribute to state/province select element
+                regionList.attr('defaultvalue', this.options.defaultRegion);
+            }
         },
 
         /**

--- a/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
@@ -162,9 +162,11 @@ define([
             this._clearError();
             this._checkRegionRequired(country);
 
+            $(regionList).find('option:selected').removeAttr('selected');
+            regionInput.val('');
+
             // Populate state/province dropdown list if available or use input box
             if (this.options.regionJson[country]) {
-                $(regionList).find('option:selected').removeAttr('selected');
                 this._removeSelectOptions(regionList);
                 $.each(this.options.regionJson[country], $.proxy(function (key, value) {
                     this._renderSelectOption(regionList, key, value);
@@ -199,7 +201,6 @@ define([
                 regionInput.hide();
                 label.attr('for', regionList.attr('id'));
             } else {
-                regionInput.val('');
                 this._removeSelectOptions(regionList);
 
                 if (this.options.isRegionRequired) {

--- a/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
@@ -227,6 +227,7 @@ define([
                     postcode.addClass('required-entry').closest('.field').addClass('required');
             }
 
+            // Add defaultvalue attribute to state/province select element
             regionList.attr('defaultvalue', this.options.defaultRegion);
         },
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
@@ -164,6 +164,7 @@ define([
 
             // Populate state/province dropdown list if available or use input box
             if (this.options.regionJson[country]) {
+                $(regionList).find('option:selected').removeAttr("selected");
                 this._removeSelectOptions(regionList);
                 $.each(this.options.regionJson[country], $.proxy(function (key, value) {
                     this._renderSelectOption(regionList, key, value);
@@ -198,6 +199,7 @@ define([
                 regionInput.hide();
                 label.attr('for', regionList.attr('id'));
             } else {
+                regionInput.val('');
                 this._removeSelectOptions(regionList);
 
                 if (this.options.isRegionRequired) {
@@ -224,13 +226,7 @@ define([
                     postcode.addClass('required-entry').closest('.field').addClass('required');
             }
 
-            if (!this.options.defaultRegion) {
-                regionList.val('');
-                regionInput.val('');
-            } else {
-                // Add defaultvalue attribute to state/province select element
-                regionList.attr('defaultvalue', this.options.defaultRegion);
-            }
+            regionList.attr('defaultvalue', this.options.defaultRegion);
         },
 
         /**

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/StoreFrontClickEditDefaultShippingAddressActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/StoreFrontClickEditDefaultShippingAddressActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+    <!--
+     /**
+      * Copyright © Magento, Inc. All rights reserved.
+      * See COPYING.txt for license details.
+      */
+    -->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+<actionGroup name="StoreFrontClickEditDefaultShippingAddressActionGroup">
+    <annotations>
+        <description>Click on the edit default shipping address link.</description>
+    </annotations>
+
+    <click stepKey="ClickEditDefaultShippingAddress" selector="{{StorefrontCustomerAddressesSection.editDefaultShippingAddress}}"/>
+    <waitForPageLoad stepKey="waitForStorefrontSignInPageLoad"/>
+</actionGroup>
+</actionGroups>


### PR DESCRIPTION
### Description
Removing the previously selected region after a country change

### Fixed Issues
1. magento/magento2#23460: Region doesn't updates after changing country and leaving region select unselected

### Manual testing scenarios

1. Create user
2. Create user address with country "United States" and region "Alabama"
3. Go to created customer page
4. Go to address customer address tab
5. Hit edit action for the created address at the addresses grid
6. Change the country to France
7. Don't choose any region
8. Save address
9. Now the region is updated

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All automated tests passed successfully
