### PR TITLE
magento/magento2#24564: Captcha not shown on contact form

### DIFF
--- a/app/code/Magento/Captcha/view/frontend/layout/contact_index_index.xml
+++ b/app/code/Magento/Captcha/view/frontend/layout/contact_index_index.xml
@@ -7,7 +7,7 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="form.additional.info">
+        <referenceBlock name="contactForm">
             <block class="Magento\Captcha\Block\Captcha" name="captcha" after="-" cacheable="false">
                 <action method="setFormId">
                     <argument name="formId" xsi:type="string">contact_us</argument>
@@ -19,7 +19,7 @@
                     <argument name="width" xsi:type="string">50</argument>
                 </action>
             </block>
-        </referenceContainer>
+        </referenceBlock>
         <referenceBlock name="head.components">
             <block class="Magento\Framework\View\Element\Js\Components" name="captcha_page_head_components" template="Magento_Captcha::js/components.phtml"/>
         </referenceBlock>

--- a/app/code/Magento/Captcha/view/frontend/layout/customer_account_create.xml
+++ b/app/code/Magento/Captcha/view/frontend/layout/customer_account_create.xml
@@ -7,7 +7,7 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="form.additional.info">
+        <referenceBlock name="contactForm">
             <block class="Magento\Captcha\Block\Captcha" name="captcha" after="-" cacheable="false">
                 <action method="setFormId">
                     <argument name="formId" xsi:type="string">user_create</argument>
@@ -19,7 +19,7 @@
                     <argument name="width" xsi:type="string">50</argument>
                 </action>
             </block>
-        </referenceContainer>
+        </referenceBlock>
         <referenceBlock name="head.components">
             <block class="Magento\Framework\View\Element\Js\Components" name="captcha_page_head_components" template="Magento_Captcha::js/components.phtml"/>
         </referenceBlock>

--- a/app/code/Magento/Captcha/view/frontend/layout/customer_account_edit.xml
+++ b/app/code/Magento/Captcha/view/frontend/layout/customer_account_edit.xml
@@ -7,7 +7,7 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="form.additional.info">
+        <referenceBlock name="contactForm">
             <block class="Magento\Captcha\Block\Captcha" name="captcha" after="-" cacheable="false">
                 <action method="setFormId">
                     <argument name="formId" xsi:type="string">user_edit</argument>
@@ -19,7 +19,7 @@
                     <argument name="width" xsi:type="string">50</argument>
                 </action>
             </block>
-        </referenceContainer>
+        </referenceBlock>
         <referenceBlock name="head.components">
             <block class="Magento\Framework\View\Element\Js\Components" name="captcha_page_head_components" template="Magento_Captcha::js/components.phtml"/>
         </referenceBlock>

--- a/app/code/Magento/Captcha/view/frontend/layout/customer_account_forgotpassword.xml
+++ b/app/code/Magento/Captcha/view/frontend/layout/customer_account_forgotpassword.xml
@@ -7,7 +7,7 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="form.additional.info">
+        <referenceBlock name="contactForm">
             <block class="Magento\Captcha\Block\Captcha" name="captcha" after="-" cacheable="false">
                 <action method="setFormId">
                     <argument name="formId" xsi:type="string">user_forgotpassword</argument>
@@ -19,7 +19,7 @@
                     <argument name="width" xsi:type="string">50</argument>
                 </action>
             </block>
-        </referenceContainer>
+        </referenceBlock>
         <referenceBlock name="head.components">
             <block class="Magento\Framework\View\Element\Js\Components" name="captcha_page_head_components" template="Magento_Captcha::js/components.phtml"/>
         </referenceBlock>

--- a/app/code/Magento/Captcha/view/frontend/layout/customer_account_login.xml
+++ b/app/code/Magento/Captcha/view/frontend/layout/customer_account_login.xml
@@ -7,7 +7,7 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="form.additional.info">
+        <referenceBlock name="contactForm">
             <block class="Magento\Captcha\Block\Captcha" name="captcha" after="-" cacheable="false">
                 <action method="setFormId">
                     <argument name="formId" xsi:type="string">user_login</argument>
@@ -19,7 +19,7 @@
                     <argument name="width" xsi:type="string">50</argument>
                 </action>
             </block>
-        </referenceContainer>
+        </referenceBlock>
         <referenceBlock name="head.components">
             <block class="Magento\Framework\View\Element\Js\Components" name="captcha_page_head_components" template="Magento_Captcha::js/components.phtml"/>
         </referenceBlock>

--- a/app/code/Magento/Captcha/view/frontend/layout/default.xml
+++ b/app/code/Magento/Captcha/view/frontend/layout/default.xml
@@ -7,6 +7,19 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
+        <referenceBlock name="contactForm">
+            <block class="Magento\Captcha\Block\Captcha" name="captcha" after="-" cacheable="false">
+                <action method="setFormId">
+                    <argument name="formId" xsi:type="string">contact_us</argument>
+                </action>
+                <action method="setImgWidth">
+                    <argument name="width" xsi:type="string">230</argument>
+                </action>
+                <action method="setImgHeight">
+                    <argument name="width" xsi:type="string">50</argument>
+                </action>
+            </block>
+        </referenceBlock>
         <referenceBlock name="authentication-popup">
             <arguments>
                 <argument name="jsLayout" xsi:type="array">

--- a/app/code/Magento/Contact/view/frontend/layout/contact_index_index.xml
+++ b/app/code/Magento/Contact/view/frontend/layout/contact_index_index.xml
@@ -11,9 +11,7 @@
     </head>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Contact\Block\ContactForm" name="contactForm" template="Magento_Contact::form.phtml">
-                <container name="form.additional.info" label="Form Additional Info"/>
-            </block>
+            <block class="Magento\Contact\Block\ContactForm" name="contactForm" template="Magento_Contact::form.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/app/code/Magento/Contact/view/frontend/templates/form.phtml
+++ b/app/code/Magento/Contact/view/frontend/templates/form.phtml
@@ -39,7 +39,7 @@
                 <textarea name="comment" id="comment" title="<?= $block->escapeHtmlAttr(__('What’s on your mind?')) ?>" class="input-text" cols="5" rows="3" data-validate="{required:true}"><?= $block->escapeHtml($this->helper(\Magento\Contact\Helper\Data::class)->getPostValue('comment')) ?></textarea>
             </div>
         </div>
-        <?= $block->getChildHtml('form.additional.info') ?>
+        <?= $block->getChildHtml() ?>
     </fieldset>
     <div class="actions-toolbar">
         <div class="primary">


### PR DESCRIPTION
- Fixed issue. Remove the <container> tag xml because in content textarea does not have how to render, and the module need this to apply the CAPTCHA.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. Removed the <container> tag in xml
2. Replaces $block->getChildHtml("form.additional.info") in to $block->getChildHtml()
3. Add in all pages the CAPTCHA block
4. All contact forms without initialized with XML file will be type contact.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add a new contact form in admin, not in XML file.
2. Enter in the page and see if is rendered.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
