### PR TITLE
magento/magento2#24337: Creating a product through API doesn't accept…

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -546,6 +546,13 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $productDataArray['store_id'] = (int)$this->storeManager->getStore()->getId();
         $product = $this->initializeProductData($productDataArray, empty($existingProduct));
 
+        $validationResult = $this->resourceModel->validate($product);
+        if (true !== $validationResult) {
+            throw new CouldNotSaveException(
+                __('Invalid product data: %1', implode(',', $validationResult))
+            );
+        }
+
         $this->processLinks($product, $productLinks);
         if (isset($productDataArray['media_gallery'])) {
             $this->processMediaGallery($product, $productDataArray['media_gallery']['images']);
@@ -553,13 +560,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
 
         if (!$product->getOptionsReadonly()) {
             $product->setCanSaveCustomOptions(true);
-        }
-
-        $validationResult = $this->resourceModel->validate($product);
-        if (true !== $validationResult) {
-            throw new \Magento\Framework\Exception\CouldNotSaveException(
-                __('Invalid product data: %1', implode(',', $validationResult))
-            );
         }
 
         if ($tierPrices !== null) {

--- a/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
@@ -86,17 +86,9 @@ class MediaGalleryProcessor
                     $newEntries[] = $entry;
                 }
             }
-            foreach ($existingMediaGallery as $key => &$existingEntry) {
-                if (isset($entriesById[$existingEntry['value_id']])) {
-                    $updatedEntry = $entriesById[$existingEntry['value_id']];
-                    if ($updatedEntry['file'] === null) {
-                        unset($updatedEntry['file']);
-                    }
-                    $existingMediaGallery[$key] = array_merge($existingEntry, $updatedEntry);
-                } else {
-                    //set the removed flag
-                    $existingEntry['removed'] = true;
-                }
+            foreach ($existingMediaGallery as $key => $existingEntry) {
+                $updatedEntry = $entriesById[$existingEntry['value_id']] ?? null;
+                $existingMediaGallery[$key] = $this->updateMediaGalleryEntry($existingEntry, $updatedEntry);
             }
             $product->setData('media_gallery', ["images" => $existingMediaGallery]);
         } else {
@@ -110,6 +102,26 @@ class MediaGalleryProcessor
 
         $this->processMediaAttributes($product, $images);
         $this->processEntries($product, $newEntries, $entriesById);
+    }
+
+    /**
+     * @param array $existingEntry
+     * @param array|null $updatedEntry
+     * @return array
+     */
+    public function updateMediaGalleryEntry(
+        array $existingEntry,
+        ?array $updatedEntry
+    ) :array {
+        if ($updatedEntry !== null) {
+            if ($updatedEntry['file'] === null) {
+                unset($updatedEntry['file']);
+            }
+            $existingEntry = array_merge($existingEntry, $updatedEntry);
+        } else {
+            $existingEntry['removed'] = true;
+        }
+        return $existingEntry;
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
@@ -61,11 +61,6 @@ class MediaGalleryProcessor
     /**
      * Process Media gallery data before save product.
      *
-     * Compare Media Gallery Entries Data with existing Media Gallery
-     * * If Media entry has not value_id set it as new
-     * * If Existing entry 'value_id' absent in Media Gallery set 'removed' flag
-     * * Merge Existing and new media gallery
-     *
      * @param ProductInterface $product contains only existing media gallery items
      * @param array $mediaGalleryEntries array which contains all media gallery items
      * @return void
@@ -105,6 +100,13 @@ class MediaGalleryProcessor
     }
 
     /**
+     * Process existing gallery media entry.
+     *
+     * Compare Media Gallery Entries Data with existing Media Gallery
+     * * If Media entry has not value_id set it as new
+     * * If Existing entry 'value_id' absent in Media Gallery set 'removed' flag
+     * * Merge Existing and new media gallery
+     *
      * @param array $existingEntry
      * @param array|null $updatedEntry
      * @return array

--- a/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository/MediaGalleryProcessor.php
@@ -138,7 +138,7 @@ class MediaGalleryProcessor
 
         if (!$product->hasGalleryAttribute()) {
             throw new StateException(
-                __("The product that was requested doesn't exist. Verify the product and try again.")
+                __("The product that was requested doesn't have gallery attribute. Verify the product and try again.")
             );
         }
 


### PR DESCRIPTION
… gallery entries at the same time

### Description (*)
- fixed issue by moving products validation over processing media gallery and change error message for processing media gallery for product without media gallery attribute
- error that was reported in the issue was caused with wrong attribute_set which was provided in the request. If we want to create product with media gallery and provided attribute_set_id that doesn't exist or do not contains gallery attribute we receive error "The product that was requested doesn't exist. Verify the product and try again.".

### Fixed Issues (if relevant)

1. magento/magento2 #24337: Creating a product through API doesn't accept gallery entries at the same time

### Manual testing scenarios (*)
1. Get admin token using REST method (POST) /rest/V1/integration/admin/token
2. Use received token in method (POST) /rest/V1/products and in body use data provided in issue
3. If You use attribute_set_id that doesn't exist you should get error "Invalid product data: Invalid attribute set entity type". 
4. If you use attribute_set_id that exists  but doesn't contain attribute gallery you should receive error "The product that was requested doesn't have gallery attribute. Verify the product and try again.". 
5. If you use  attribute_set_id that exists  and contains attribute gallery, product should create successfully with provided media gallery data". 

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
