### PR TITLE
Add Show Address Fields configuration to Magento > Stores > Configura…

### DIFF
--- a/app/code/Magento/Customer/Block/Form/Register.php
+++ b/app/code/Magento/Customer/Block/Form/Register.php
@@ -230,6 +230,6 @@ class Register extends \Magento\Directory\Block\Data
      * @return bool
      */
     public function getShowAddressFields():bool {
-          return $this->_scopeConfig->getValue((bool)$this->getData('show_address_fields'));
+          return (bool)$this->_scopeConfig->getValue($this->getData('show_address_fields'));
     }
 }

--- a/app/code/Magento/Customer/Block/Form/Register.php
+++ b/app/code/Magento/Customer/Block/Form/Register.php
@@ -223,4 +223,13 @@ class Register extends \Magento\Directory\Block\Data
     {
         return $this->_scopeConfig->getValue(AccountManagement::XML_PATH_REQUIRED_CHARACTER_CLASSES_NUMBER);
     }
+
+    /**
+     * Get show address fields
+     *
+     * @return bool
+     */
+    public function getShowAddressFields():bool {
+          return $this->_scopeConfig->getValue((bool)$this->getData('show_address_fields'));
+    }
 }

--- a/app/code/Magento/Customer/Test/Unit/Block/Form/RegisterTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Form/RegisterTest.php
@@ -397,4 +397,20 @@ class RegisterTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertEquals(3, $this->_block->getRequiredCharacterClassesNumber());
     }
+
+    /**
+     * Test Get Show Address Fields when configuration value is Equal NULL
+     */
+    public function testShowAddressFieldsWhenNull(){
+        $this->_scopeConfig->expects($this->once())->method('getValue')->will($this->returnValue(null));
+        $this->assertEquals(0,$this->_block->getShowAddressFields());
+    }
+
+    /**
+     * Test Get Show Address Fields when configuration value is Equal True
+     */
+    public function testShowAddressFieldsWhenTrue(){
+        $this->_scopeConfig->expects($this->once())->method('getValue')->will($this->returnValue(1));
+        $this->assertEquals(1,$this->_block->getShowAddressFields());
+    }
 }

--- a/app/code/Magento/Customer/etc/adminhtml/system.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/system.xml
@@ -246,20 +246,33 @@
                     <source_model>Magento\Config\Model\Config\Source\Nooptreq</source_model>
                     <backend_model>Magento\Customer\Model\Config\Backend\Show\Customer</backend_model>
                 </field>
-                <field id="telephone_show" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="show_address_fields" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Show Address Fields</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="telephone_show" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Show Telephone</label>
                     <source_model>Magento\Config\Model\Config\Source\Nooptreq</source_model>
                     <backend_model>Magento\Customer\Model\Config\Backend\Show\AddressOnly</backend_model>
+                    <depends>
+                        <field id="show_address_fields">1</field>
+                    </depends>
                 </field>
-                <field id="company_show" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="company_show" translate="label" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Show Company</label>
                     <source_model>Magento\Config\Model\Config\Source\Nooptreq</source_model>
                     <backend_model>Magento\Customer\Model\Config\Backend\Show\AddressOnly</backend_model>
+                    <depends>
+                        <field id="show_address_fields">1</field>
+                    </depends>
                 </field>
-                <field id="fax_show" translate="label" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="fax_show" translate="label" type="select" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Show Fax</label>
                     <source_model>Magento\Config\Model\Config\Source\Nooptreq</source_model>
                     <backend_model>Magento\Customer\Model\Config\Backend\Show\AddressOnly</backend_model>
+                    <depends>
+                        <field id="show_address_fields">1</field>
+                    </depends>
                 </field>
             </group>
             <group id="startup" translate="label" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/app/code/Magento/Customer/etc/config.xml
+++ b/app/code/Magento/Customer/etc/config.xml
@@ -51,6 +51,7 @@
                 <suffix_options />
                 <dob_show />
                 <gender_show />
+                <show_address_fields>0</show_address_fields>
                 <telephone_show>req</telephone_show>
                 <company_show>opt</company_show>
                 <fax_show/>

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account_create.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account_create.xml
@@ -17,6 +17,7 @@
             <block class="Magento\Customer\Block\Form\Register" name="customer_form_register" template="Magento_Customer::form/register.phtml">
                 <arguments>
                     <argument name="attribute_data" xsi:type="object">Magento\Customer\Block\DataProviders\AddressAttributeData</argument>
+                    <argument name="show_address_fields" xsi:type="string">customer/address/show_address_fields</argument>
                 </arguments>
                 <container name="form.additional.info" as="form_additional_info"/>
                 <container name="customer.form.register.fields.before" as="form_fields_before" label="Form Fields Before" htmlTag="div" htmlClass="customer-form-before"/>


### PR DESCRIPTION
…tions > Customers > Customer configuration > Name and Address options. Now we are able to enable/disable address fields on customer registration page.


### Description (*)
According to ticket #22841 Administrator is not able to make visible address fields on customer registration page. This gap exists because of lack of configuration input(on/off) in admin panel in customer section(Customers > Customer configuration > Name and Address options). At the present time this section can be visible only by custom development(by passing argument in customer_account_create.xml -> block customer_form_register -> argument show_address_fields ==1). To avoid custom development I have created a configuration in admin panel where admin can enable Address Fields in registration form.

<img width="1130" alt="Zrzut ekranu 2019-09-15 o 16 17 44" src="https://user-images.githubusercontent.com/11194035/64922895-8ff8da00-d7d4-11e9-9007-934ea2635dfe.png">

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/22841

### Manual testing scenarios (*)
When Show Address Fields is enabled then Admin can see list of available fields which can be enabled
<img width="849" alt="Zrzut ekranu 2019-09-15 o 16 20 45" src="https://user-images.githubusercontent.com/11194035/64922916-d3534880-d7d4-11e9-8ab1-c67c58e211a0.png">
<img width="722" alt="Zrzut ekranu 2019-09-15 o 16 20 51" src="https://user-images.githubusercontent.com/11194035/64922918-d817fc80-d7d4-11e9-8c1c-0e14dea1fee6.png">

Then after cache clean fields are visible on frontend
<img width="908" alt="Zrzut ekranu 2019-09-15 o 16 36 41" src="https://user-images.githubusercontent.com/11194035/64923110-0e567b80-d7d7-11e9-8445-c45e856146c1.png">

