### PR TITLE
magento/magento2#22173: dd/mm mm/yy Sales order grid Date Filters not…

### DIFF
--- a/app/code/Magento/Ui/Component/Form/Element/DataType/Date.php
+++ b/app/code/Magento/Ui/Component/Form/Element/DataType/Date.php
@@ -112,10 +112,7 @@ class Date extends AbstractDataType
     {
         try {
             $dateObj = $this->localeDate->date(
-                new \DateTime(
-                    $date,
-                    new \DateTimeZone($this->localeDate->getConfigTimezone())
-                ),
+                $date,
                 $this->getLocale(),
                 true
             );


### PR DESCRIPTION
… working in en_GB locale

### Description (*)
- new DateTime object was unnecessarily created in convertDate method. Date method from localeDate can handel this when date is passed as string. It sets correct format and timezone.

### Fixed Issues (if relevant)

1. magento/magento2#22173: dd/mm mm/yy Sales order grid Date Filters not working in en_GB locale

### Manual testing scenarios (*)

1.Create test product and create test order
2. Change admin locale to en_GB
3.View Sales order grid
4.Set a date filter to include the order date in From and To

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
