### PR TITLE
fix for duplicate condition and action on error display 

### DIFF
--- a/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Save.php
+++ b/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Save.php
@@ -95,6 +95,15 @@ class Save extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote implement
                     foreach ($validateResult as $errorMessage) {
                         $this->messageManager->addErrorMessage($errorMessage);
                     }
+
+                    if(isset($data['conditions_serialized'])){
+                        unset($data['conditions_serialized']);
+                    }
+
+                    if(isset($data['actions_serialized'])){
+                        unset($data['actions_serialized']);
+                    }
+
                     $session->setPageData($data);
                     $this->dataPersistor->set('sale_rule', $data);
                     $this->_redirect('sales_rule/*/edit', ['id' => $model->getId()]);

--- a/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Save.php
+++ b/app/code/Magento/SalesRule/Controller/Adminhtml/Promo/Quote/Save.php
@@ -96,11 +96,11 @@ class Save extends \Magento\SalesRule\Controller\Adminhtml\Promo\Quote implement
                         $this->messageManager->addErrorMessage($errorMessage);
                     }
 
-                    if(isset($data['conditions_serialized'])){
+                    if(isset($data['conditions_serialized'])) {
                         unset($data['conditions_serialized']);
                     }
 
-                    if(isset($data['actions_serialized'])){
+                    if(isset($data['actions_serialized'])) {
                         unset($data['actions_serialized']);
                     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
   When Magento\Rule\Model\AbstractModel::validateData return any error during validation and If we have any conditions or action in the rule then it duplicates the it's value
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<23137>: Sales rule condtions are duplicated when data validation error occurs #23137 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Created a cart rule with some condition and action.
2. Return some error message from Magento\Rule\Model\AbstractModel::validateData so it display the error message on without saving it's data
3. Once it display the error message verified that condition or action is not duplicating. 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [*] Pull request has a meaningful description of its purpose
 - [*] All commits are accompanied by meaningful commit messages
 - [*] All new or changed code is covered with unit/integration tests (if applicable)
 - [*] All automated tests passed successfully (all builds are green)
