### PR TITLE
fix for the #24618 Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/paypal.js accessing undefined variables

### DIFF
--- a/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/paypal.js
+++ b/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/paypal.js
@@ -334,7 +334,7 @@ define([
             }
 
             return {
-                line1: address.street[0],
+                line1: _.isUndefined(address.street) || _.isUndefined(address.street[0]) ? '' : address.street[0],
                 city: address.city,
                 state: address.regionCode,
                 postalCode: address.postcode,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
fix for the #24618 Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/paypal.js accessing undefined variables . Adding  variable _.isUndefined check 

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Fixes issue where Magento_Braintree payment method is loaded when shipping address object is not filled with all address data jet . Adds additional variable check to the mix to validate if address.street is defined with _.isUndefined

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24618: Magento_Braintree/js/view/payment/method-renderer/paypal.js accessing undefined variables

