### PR TITLE
Fix Elasticsearch category page issues when 1 column layout is used

### DIFF
--- a/app/code/Magento/LayeredNavigation/Block/Navigation.php
+++ b/app/code/Magento/LayeredNavigation/Block/Navigation.php
@@ -148,6 +148,7 @@ class Navigation extends \Magento\Framework\View\Element\Template
             /** @var Collection $collection */
             $collection = $this->getLayer()->getProductCollection();
             $toolbarBlock->setCollection($collection);
+            $collection->setPageSize(false);
         }
     }
 }


### PR DESCRIPTION
### Description (*)
This changes fixes issue #24619 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24619: Elasticsearch category page issues when 1 column layout is used

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Choose category with products and set 1 column design to it (Catalog -> Categories -> Edit Category -> Design -> Layout -> "1 column"
2. Save category
3. Flush cache
4. Open this category on website and change sort order to "Price"
5. Go to page 2

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
