### PR TITLE
Fix Configurable product tier prices follow price display settings for tax #12225

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -296,6 +296,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
                 $tierPrices[] = [
                     'qty' => $this->localeFormat->getNumber($tierPrice['price_qty']),
                     'price' => $this->localeFormat->getNumber($tierPrice['price']->getValue()),
+                    'priceExTax' => $this->localeFormat->getNumber($tierPrice['price']->getValue('tax')),
                     'percentage' => $this->localeFormat->getNumber(
                         $tierPriceModel->getSavePercent($tierPrice['price'])
                     ),

--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -296,7 +296,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
                 $tierPrices[] = [
                     'qty' => $this->localeFormat->getNumber($tierPrice['price_qty']),
                     'price' => $this->localeFormat->getNumber($tierPrice['price']->getValue()),
-                    'priceExTax' => $this->localeFormat->getNumber($tierPrice['price']->getValue('tax')),
+                    'priceExclTax' => $this->localeFormat->getNumber($tierPrice['price']->getValue('tax')),
                     'percentage' => $this->localeFormat->getNumber(
                         $tierPriceModel->getSavePercent($tierPrice['price'])
                     ),

--- a/app/code/Magento/ConfigurableProduct/Pricing/Render/TierPriceBox.php
+++ b/app/code/Magento/ConfigurableProduct/Pricing/Render/TierPriceBox.php
@@ -57,13 +57,13 @@ class TierPriceBox extends FinalPriceBox
     {
         switch ($this->_scopeConfig->getValue('tax/display/type', \Magento\Store\Model\ScopeInterface::SCOPE_STORES)) {
             case \Magento\Tax\Model\Config::DISPLAY_TYPE_EXCLUDING_TAX:
-                return $this::DISPLAY_TIER_PRICE_EXCLUDING_TAX;
+                return self::DISPLAY_TIER_PRICE_EXCLUDING_TAX;
                 break;
             case \Magento\Tax\Model\Config::DISPLAY_TYPE_INCLUDING_TAX:
-                return $this::DISPLAY_TIER_PRICE_INCLUDING_TAX;
+                return self::DISPLAY_TIER_PRICE_INCLUDING_TAX;
                 break;
             case \Magento\Tax\Model\Config::DISPLAY_TYPE_BOTH:
-                return $this::DISPLAY_TIER_PRICE_BOTH;
+                return self::DISPLAY_TIER_PRICE_BOTH;
                 break;
         }
     }

--- a/app/code/Magento/ConfigurableProduct/Pricing/Render/TierPriceBox.php
+++ b/app/code/Magento/ConfigurableProduct/Pricing/Render/TierPriceBox.php
@@ -58,13 +58,10 @@ class TierPriceBox extends FinalPriceBox
         switch ($this->_scopeConfig->getValue('tax/display/type', \Magento\Store\Model\ScopeInterface::SCOPE_STORES)) {
             case \Magento\Tax\Model\Config::DISPLAY_TYPE_EXCLUDING_TAX:
                 return self::DISPLAY_TIER_PRICE_EXCLUDING_TAX;
-                break;
             case \Magento\Tax\Model\Config::DISPLAY_TYPE_INCLUDING_TAX:
                 return self::DISPLAY_TIER_PRICE_INCLUDING_TAX;
-                break;
             case \Magento\Tax\Model\Config::DISPLAY_TYPE_BOTH:
                 return self::DISPLAY_TIER_PRICE_BOTH;
-                break;
         }
     }
 }

--- a/app/code/Magento/ConfigurableProduct/Pricing/Render/TierPriceBox.php
+++ b/app/code/Magento/ConfigurableProduct/Pricing/Render/TierPriceBox.php
@@ -14,6 +14,11 @@ use Magento\Catalog\Pricing\Price\TierPrice;
  */
 class TierPriceBox extends FinalPriceBox
 {
+    // Price display settings
+    const DISPLAY_TIER_PRICE_EXCLUDING_TAX = 'priceExTax';
+    const DISPLAY_TIER_PRICE_INCLUDING_TAX = 'price';
+    const DISPLAY_TIER_PRICE_BOTH = 'both';
+
     /**
      * @inheritdoc
      */
@@ -41,5 +46,25 @@ class TierPriceBox extends FinalPriceBox
             }
         }
         return false;
+    }
+
+    /**
+     * Get price display settings
+     *
+     * @return string
+     */
+    public function getTaxDisplayType()
+    {
+        switch ($this->_scopeConfig->getValue('tax/display/type', \Magento\Store\Model\ScopeInterface::SCOPE_STORES)) {
+            case \Magento\Tax\Model\Config::DISPLAY_TYPE_EXCLUDING_TAX:
+                return self::DISPLAY_TIER_PRICE_EXCLUDING_TAX;
+                break;
+            case  \Magento\Tax\Model\Config::DISPLAY_TYPE_INCLUDING_TAX:
+                return self::DISPLAY_TIER_PRICE_INCLUDING_TAX;
+                break;
+            case \Magento\Tax\Model\Config::DISPLAY_TYPE_BOTH:
+                return self::DISPLAY_TIER_PRICE_BOTH;
+                break;
+        }
     }
 }

--- a/app/code/Magento/ConfigurableProduct/Pricing/Render/TierPriceBox.php
+++ b/app/code/Magento/ConfigurableProduct/Pricing/Render/TierPriceBox.php
@@ -15,7 +15,7 @@ use Magento\Catalog\Pricing\Price\TierPrice;
 class TierPriceBox extends FinalPriceBox
 {
     // Price display settings
-    const DISPLAY_TIER_PRICE_EXCLUDING_TAX = 'priceExTax';
+    const DISPLAY_TIER_PRICE_EXCLUDING_TAX = 'priceExclTax';
     const DISPLAY_TIER_PRICE_INCLUDING_TAX = 'price';
     const DISPLAY_TIER_PRICE_BOTH = 'both';
 
@@ -57,13 +57,13 @@ class TierPriceBox extends FinalPriceBox
     {
         switch ($this->_scopeConfig->getValue('tax/display/type', \Magento\Store\Model\ScopeInterface::SCOPE_STORES)) {
             case \Magento\Tax\Model\Config::DISPLAY_TYPE_EXCLUDING_TAX:
-                return self::DISPLAY_TIER_PRICE_EXCLUDING_TAX;
+                return $this::DISPLAY_TIER_PRICE_EXCLUDING_TAX;
                 break;
-            case  \Magento\Tax\Model\Config::DISPLAY_TYPE_INCLUDING_TAX:
-                return self::DISPLAY_TIER_PRICE_INCLUDING_TAX;
+            case \Magento\Tax\Model\Config::DISPLAY_TYPE_INCLUDING_TAX:
+                return $this::DISPLAY_TIER_PRICE_INCLUDING_TAX;
                 break;
             case \Magento\Tax\Model\Config::DISPLAY_TYPE_BOTH:
-                return self::DISPLAY_TIER_PRICE_BOTH;
+                return $this::DISPLAY_TIER_PRICE_BOTH;
                 break;
         }
     }

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
@@ -377,6 +377,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
                             'qty' => $priceQty,
                             'price' => $amount,
                             'percentage' => $percentage,
+                            'priceExclTax' => $amount,
                         ],
                     ],
                     'msrpPrice' => [

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
@@ -233,9 +233,11 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
     public function testGetCacheKeyInfo(array $expected, string $priceCurrency = null, string $customerGroupId = null)
     {
         $storeMock = $this->getMockBuilder(\Magento\Store\Api\Data\StoreInterface::class)
-            ->setMethods([
-                'getCurrentCurrency',
-            ])
+            ->setMethods(
+                [
+                    'getCurrentCurrency',
+                ]
+            )
             ->getMockForAbstractClass();
         $storeMock->expects($this->any())
             ->method('getCode')
@@ -270,9 +272,11 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
         $amountMock = $this->getAmountMock($amount);
 
         $priceMock = $this->getMockBuilder(\Magento\Framework\Pricing\Price\PriceInterface::class)
-            ->setMethods([
-                'getAmount',
-            ])
+            ->setMethods(
+                [
+                    'getAmount',
+                ]
+            )
             ->getMockForAbstractClass();
         $priceMock->expects($this->any())->method('getAmount')->willReturn($amountMock);
         $tierPriceMock = $this->getTierPriceMock($amountMock, $priceQty, $percentage);
@@ -287,11 +291,13 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $priceInfoMock->expects($this->any())
             ->method('getPrice')
-            ->willReturnMap([
-                ['regular_price', $priceMock],
-                ['final_price', $priceMock],
-                ['tier_price', $tierPriceMock],
-            ]);
+            ->willReturnMap(
+                [
+                    ['regular_price', $priceMock],
+                    ['final_price', $priceMock],
+                    ['tier_price', $tierPriceMock],
+                ]
+            );
 
         $productMock->expects($this->any())->method('getTypeInstance')->willReturn($productTypeMock);
         $productMock->expects($this->any())->method('getPriceInfo')->willReturn($priceInfoMock);
@@ -422,9 +428,11 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
             ->willReturn('%s');
 
         $storeMock = $this->getMockBuilder(\Magento\Store\Api\Data\StoreInterface::class)
-            ->setMethods([
-                'getCurrentCurrency',
-            ])
+            ->setMethods(
+                [
+                    'getCurrentCurrency',
+                ]
+            )
             ->getMockForAbstractClass();
         $storeMock->expects($this->any())
             ->method('getCurrentCurrency')
@@ -476,10 +484,12 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
     protected function getAmountMock($amount): \PHPUnit_Framework_MockObject_MockObject
     {
         $amountMock = $this->getMockBuilder(\Magento\Framework\Pricing\Amount\AmountInterface::class)
-            ->setMethods([
-                'getValue',
-                'getBaseAmount',
-            ])
+            ->setMethods(
+                [
+                    'getValue',
+                    'getBaseAmount',
+                ]
+            )
             ->getMockForAbstractClass();
         $amountMock->expects($this->any())
             ->method('getValue')
@@ -508,10 +518,12 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
         ];
 
         $tierPriceMock = $this->getMockBuilder(\Magento\Catalog\Pricing\Price\TierPriceInterface::class)
-            ->setMethods([
-                'getTierPriceList',
-                'getSavePercent',
-            ])
+            ->setMethods(
+                [
+                    'getTierPriceList',
+                    'getSavePercent',
+                ]
+            )
             ->getMockForAbstractClass();
         $tierPriceMock->expects($this->any())
             ->method('getTierPriceList')

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
@@ -503,6 +503,7 @@ class ConfigurableTest extends \PHPUnit\Framework\TestCase
         $tierPrice = [
             'price_qty' => $priceQty,
             'price' => $amountMock,
+            'priceExclTax' => $amountMock,
         ];
 
         $tierPriceMock = $this->getMockBuilder(\Magento\Catalog\Pricing\Price\TierPriceInterface::class)

--- a/app/code/Magento/ConfigurableProduct/composer.json
+++ b/app/code/Magento/ConfigurableProduct/composer.json
@@ -16,7 +16,8 @@
         "magento/module-media-storage": "*",
         "magento/module-quote": "*",
         "magento/module-store": "*",
-        "magento/module-ui": "*"
+        "magento/module-ui": "*",
+        "magento/module-tax": "*"
     },
     "suggest": {
         "magento/module-msrp": "*",
@@ -25,8 +26,7 @@
         "magento/module-sales-rule": "*",
         "magento/module-product-video": "*",
         "magento/module-configurable-sample-data": "*",
-        "magento/module-product-links-sample-data": "*",
-        "magento/module-tax": "*"
+        "magento/module-product-links-sample-data": "*"
     },
     "type": "magento2-module",
     "license": [

--- a/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
@@ -10,11 +10,11 @@
         <?php $taxDisplayType = $block->getTaxDisplayType(); ?>
         <?php if ($taxDisplayType == Magento\ConfigurableProduct\Pricing\Render\TierPriceBox::DISPLAY_TIER_PRICE_BOTH) : ?>
             <% _.each(tierPrices, function(item, key) { %>
-            <%  var priceStr = '<span class="price-container price-tier_price tax">'
+            <%  var priceStr = '<span class="price-container price-tier_price">'
                 + '<span data-price-amount="' + priceUtils.formatPrice(item.price, currencyFormat) + '"'
                 + ' data-price-type=""' + ' class="price-wrapper ">'
-                + '<span class="price-wrapper price-including-tax">' + priceUtils.formatPrice(item.price, currencyFormat) + '</span>'
-                + '<span class="price-wrapper price-excluding-tax" data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?>">' + priceUtils.formatPrice(item.priceExclTax, currencyFormat) + '</span>'
+                + '<span class="price tier-price-including-tax">' + priceUtils.formatPrice(item.price, currencyFormat) + '</span>'
+                + '<span class="price tier-price-excluding-tax" data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?> ">' + priceUtils.formatPrice(item.priceExclTax, currencyFormat) + '</span>'
                 + '</span>'
             + '</span>'; %>
         <?php else : ?>

--- a/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
@@ -3,16 +3,29 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 ?>
 <script type="text/x-magento-template" id="tier-prices-template">
     <ul class="prices-tier items">
-        <% _.each(tierPrices, function(item, key) { %>
-        <%  var priceStr = '<span class="price-container price-tier_price">'
+        <?php $taxDisplayType = $block->getTaxDisplayType(); ?>
+        <?php if ($taxDisplayType == Magento\ConfigurableProduct\Pricing\Render\TierPriceBox::DISPLAY_TIER_PRICE_BOTH): ?>
+            <% _.each(tierPrices, function(item, key) { %>
+            <%  var priceStr = '<span class="price-container price-tier_price tax">'
                 + '<span data-price-amount="' + priceUtils.formatPrice(item.price, currencyFormat) + '"'
                 + ' data-price-type=""' + ' class="price-wrapper ">'
-                + '<span class="price">' + priceUtils.formatPrice(item.price, currencyFormat) + '</span>'
+                + '<span class="price-wrapper price-including-tax">' + priceUtils.formatPrice(item.price, currencyFormat) + '</span>'
+                + '<span class="price-wrapper price-excluding-tax" data-label="<?=__('Excl. Tax') ?>">' + priceUtils.formatPrice(item.priceExTax, currencyFormat) + '</span>'
                 + '</span>'
             + '</span>'; %>
+        <?php else: ?>
+            <% _.each(tierPrices, function(item, key) { %>
+            <%  var priceStr = '<span class="price-container price-tier_price">'
+                + '<span data-price-amount="' + priceUtils.formatPrice(item.<?= $taxDisplayType ?>, currencyFormat) + '"'
+                + ' data-price-type=""' + ' class="price-wrapper ">'
+                + '<span class="price">' + priceUtils.formatPrice(item.<?= $taxDisplayType ?>, currencyFormat) + '</span>'
+                + '</span>'
+            + '</span>'; %>
+        <?php endif ?>
         <li class="item">
             <%= '<?= $block->escapeHtml(__('Buy %1 for %2 each and', '%1', '%2')) ?>'
             .replace('%1', item.qty)

--- a/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
@@ -8,21 +8,21 @@
 <script type="text/x-magento-template" id="tier-prices-template">
     <ul class="prices-tier items">
         <?php $taxDisplayType = $block->getTaxDisplayType(); ?>
-        <?php if ($taxDisplayType == Magento\ConfigurableProduct\Pricing\Render\TierPriceBox::DISPLAY_TIER_PRICE_BOTH): ?>
+        <?php if ($taxDisplayType == Magento\ConfigurableProduct\Pricing\Render\TierPriceBox::DISPLAY_TIER_PRICE_BOTH) : ?>
             <% _.each(tierPrices, function(item, key) { %>
             <%  var priceStr = '<span class="price-container price-tier_price tax">'
                 + '<span data-price-amount="' + priceUtils.formatPrice(item.price, currencyFormat) + '"'
                 + ' data-price-type=""' + ' class="price-wrapper ">'
                 + '<span class="price-wrapper price-including-tax">' + priceUtils.formatPrice(item.price, currencyFormat) + '</span>'
-                + '<span class="price-wrapper price-excluding-tax" data-label="<?=__('Excl. Tax') ?>">' + priceUtils.formatPrice(item.priceExTax, currencyFormat) + '</span>'
+                + '<span class="price-wrapper price-excluding-tax" data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?>">' + priceUtils.formatPrice(item.priceExclTax, currencyFormat) + '</span>'
                 + '</span>'
             + '</span>'; %>
-        <?php else: ?>
+        <?php else : ?>
             <% _.each(tierPrices, function(item, key) { %>
             <%  var priceStr = '<span class="price-container price-tier_price">'
-                + '<span data-price-amount="' + priceUtils.formatPrice(item.<?= $taxDisplayType ?>, currencyFormat) + '"'
+                + '<span data-price-amount="' + priceUtils.formatPrice(item.<?= $block->escapeHtml($taxDisplayType) ?>, currencyFormat) + '"'
                 + ' data-price-type=""' + ' class="price-wrapper ">'
-                + '<span class="price">' + priceUtils.formatPrice(item.<?= $taxDisplayType ?>, currencyFormat) + '</span>'
+                + '<span class="price">' + priceUtils.formatPrice(item.<?= $block->escapeHtml($taxDisplayType) ?>, currencyFormat) + '</span>'
                 + '</span>'
             + '</span>'; %>
         <?php endif ?>


### PR DESCRIPTION
### Description (*)
These changes fix issue #12225 

### Fixed Issues (if relevant)
1. #12225: Tier pricing tax shows only including tax

### Manual testing scenarios (*)
1. Create a configurable product
2. Add tier prices to the related simple products
3. Change price display settings (tax/display/type) to either the 'excluding tax' or 'both' option
4. Flush cache
5. View the product page and select a configuration option
6. Tier prices should now correctly display with or without tax

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
