### PR TITLE
Magento_ProductAlert module. Replace replace deprecated message functions

### DIFF
--- a/app/code/Magento/ProductAlert/Controller/Add/Price.php
+++ b/app/code/Magento/ProductAlert/Controller/Add/Price.php
@@ -6,16 +6,17 @@
 
 namespace Magento\ProductAlert\Controller\Add;
 
-use Magento\Framework\App\Action\HttpGetActionInterface;
-use Magento\ProductAlert\Controller\Add as AddController;
-use Magento\Framework\App\Action\Context;
-use Magento\Customer\Model\Session as CustomerSession;
-use Magento\Store\Model\StoreManagerInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\Framework\UrlInterface;
+use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Controller\Result\Redirect;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\UrlInterface;
+use Magento\ProductAlert\Controller\Add as AddController;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Controller for notifying about price.
@@ -28,15 +29,17 @@ class Price extends AddController implements HttpGetActionInterface
     protected $storeManager;
 
     /**
-     * @var  \Magento\Catalog\Api\ProductRepositoryInterface
+     * @var \Magento\Catalog\Api\ProductRepositoryInterface
      */
     protected $productRepository;
 
     /**
-     * @param \Magento\Framework\App\Action\Context $context
-     * @param \Magento\Customer\Model\Session $customerSession
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
-     * @param \Magento\Catalog\Api\ProductRepositoryInterface $productRepository
+     * Price constructor.
+     *
+     * @param Context $context
+     * @param CustomerSession $customerSession
+     * @param StoreManagerInterface $storeManager
+     * @param ProductRepositoryInterface $productRepository
      */
     public function __construct(
         Context $context,
@@ -54,6 +57,7 @@ class Price extends AddController implements HttpGetActionInterface
      *
      * @param string $url
      * @return bool
+     * @throws NoSuchEntityException
      */
     protected function isInternal($url)
     {
@@ -68,13 +72,14 @@ class Price extends AddController implements HttpGetActionInterface
     /**
      * Method for adding info about product alert price.
      *
-     * @return \Magento\Framework\Controller\Result\Redirect
+     * @return \Magento\Framework\Controller\ResultInterface
+     * @throws NoSuchEntityException
      */
     public function execute()
     {
         $backUrl = $this->getRequest()->getParam(Action::PARAM_NAME_URL_ENCODED);
         $productId = (int)$this->getRequest()->getParam('product_id');
-        /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */
+        /** @var Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         if (!$backUrl || !$productId) {
             $resultRedirect->setPath('/');
@@ -93,9 +98,9 @@ class Price extends AddController implements HttpGetActionInterface
                 ->setWebsiteId($store->getWebsiteId())
                 ->setStoreId($store->getId());
             $model->save();
-            $this->messageManager->addSuccess(__('You saved the alert subscription.'));
+            $this->messageManager->addSuccessMessage(__('You saved the alert subscription.'));
         } catch (NoSuchEntityException $noEntityException) {
-            $this->messageManager->addError(__('There are not enough parameters.'));
+            $this->messageManager->addErrorMessage(__('There are not enough parameters.'));
             if ($this->isInternal($backUrl)) {
                 $resultRedirect->setUrl($backUrl);
             } else {
@@ -103,7 +108,7 @@ class Price extends AddController implements HttpGetActionInterface
             }
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __("The alert subscription couldn't update at this time. Please try again later.")
             );

--- a/app/code/Magento/ProductAlert/Controller/Add/Stock.php
+++ b/app/code/Magento/ProductAlert/Controller/Add/Stock.php
@@ -76,13 +76,13 @@ class Stock extends AddController implements HttpGetActionInterface
                 ->setWebsiteId($store->getWebsiteId())
                 ->setStoreId($store->getId());
             $model->save();
-            $this->messageManager->addSuccess(__('Alert subscription has been saved.'));
+            $this->messageManager->addSuccessMessage(__('Alert subscription has been saved.'));
         } catch (NoSuchEntityException $noEntityException) {
-            $this->messageManager->addError(__('There are not enough parameters.'));
+            $this->messageManager->addErrorMessage(__('There are not enough parameters.'));
             $resultRedirect->setUrl($backUrl);
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __("The alert subscription couldn't update at this time. Please try again later.")
             );

--- a/app/code/Magento/ProductAlert/Controller/Unsubscribe/Price.php
+++ b/app/code/Magento/ProductAlert/Controller/Unsubscribe/Price.php
@@ -6,6 +6,7 @@
 
 namespace Magento\ProductAlert\Controller\Unsubscribe;
 
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\ProductAlert\Controller\Unsubscribe as UnsubscribeController;
 use Magento\Framework\App\Action\Context;
 use Magento\Customer\Model\Session as CustomerSession;
@@ -13,7 +14,10 @@ use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\NoSuchEntityException;
 
-class Price extends UnsubscribeController
+/**
+ * Class Price
+ */
+class Price extends UnsubscribeController implements HttpGetActionInterface
 {
     /**
      * @var \Magento\Catalog\Api\ProductRepositoryInterface
@@ -35,6 +39,8 @@ class Price extends UnsubscribeController
     }
 
     /**
+     * Unsubscribe action
+     *
      * @return \Magento\Framework\Controller\Result\Redirect
      */
     public function execute()
@@ -51,8 +57,13 @@ class Price extends UnsubscribeController
             /* @var $product \Magento\Catalog\Model\Product */
             $product = $this->productRepository->getById($productId);
             if (!$product->isVisibleInCatalog()) {
-                throw new NoSuchEntityException();
+                $this->messageManager->addErrorMessage(
+                    __("The product wasn't found. Verify the product and try again.")
+                );
+                $resultRedirect->setPath('customer/account/');
+                return $resultRedirect;
             }
+
             /** @var \Magento\ProductAlert\Model\Price $model */
             $model = $this->_objectManager->create(\Magento\ProductAlert\Model\Price::class)
                 ->setCustomerId($this->customerSession->getCustomerId())
@@ -67,13 +78,13 @@ class Price extends UnsubscribeController
                 $model->delete();
             }
 
-            $this->messageManager->addSuccess(__('You deleted the alert subscription.'));
+            $this->messageManager->addSuccessMessage(__('You deleted the alert subscription.'));
         } catch (NoSuchEntityException $noEntityException) {
-            $this->messageManager->addError(__("The product wasn't found. Verify the product and try again."));
+            $this->messageManager->addErrorMessage(__("The product wasn't found. Verify the product and try again."));
             $resultRedirect->setPath('customer/account/');
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __("The alert subscription couldn't update at this time. Please try again later.")
             );

--- a/app/code/Magento/ProductAlert/Controller/Unsubscribe/Stock.php
+++ b/app/code/Magento/ProductAlert/Controller/Unsubscribe/Stock.php
@@ -94,13 +94,13 @@ class Stock extends UnsubscribeController implements HttpPostActionInterface
             if ($model->getId()) {
                 $model->delete();
             }
-            $this->messageManager->addSuccess(__('You will no longer receive stock alerts for this product.'));
+            $this->messageManager->addSuccessMessage(__('You will no longer receive stock alerts for this product.'));
         } catch (NoSuchEntityException $noEntityException) {
-            $this->messageManager->addError(__('The product was not found.'));
+            $this->messageManager->addErrorMessage(__('The product was not found.'));
             $resultRedirect->setPath('customer/account/');
             return $resultRedirect;
         } catch (\Exception $e) {
-            $this->messageManager->addException(
+            $this->messageManager->addExceptionMessage(
                 $e,
                 __("The alert subscription couldn't update at this time. Please try again later.")
             );

--- a/app/code/Magento/ProductAlert/Test/Unit/Controller/Unsubscribe/PriceTest.php
+++ b/app/code/Magento/ProductAlert/Test/Unit/Controller/Unsubscribe/PriceTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductAlert\Test\Unit\Controller\Unsubscribe;
+
+use Magento\Backend\App\Action\Context;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Customer\Model\Session;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Message\Manager;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\ProductAlert\Controller\Unsubscribe\Price;
+
+/**
+ * Test class for \Magento\ProductAlert\Controller\Unsubscribe\Price
+ */
+class PriceTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var Price
+     */
+    private $priceController;
+
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var Http|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $requestMock;
+
+    /**
+     * @var Redirect|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $resultRedirectMock;
+
+    /**
+     * @var ResultFactory|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $resultFactoryMock;
+
+    /**
+     * @var Manager|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $messageManagerMock;
+
+    /**
+     * @var Product|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $productMock;
+
+    /**
+     * @var Session|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $customerSessionMock;
+
+    /**
+     * @var Context|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $contextMock;
+
+    /**
+     * @var ProductRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $productRepositoryMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->objectManager = new ObjectManager($this);
+        $this->requestMock = $this->createMock(Http::class);
+        $this->resultFactoryMock = $this->createMock(ResultFactory::class);
+        $this->resultRedirectMock = $this->createMock(Redirect::class);
+        $this->messageManagerMock = $this->createMock(Manager::class);
+        $this->productMock = $this->createMock(Product::class);
+        $this->contextMock = $this->createMock(Context::class);
+        $this->customerSessionMock = $this->createMock(Session::class);
+        $this->productRepositoryMock = $this->createMock(ProductRepositoryInterface::class);
+        $this->resultFactoryMock->expects($this->any())
+            ->method('create')
+            ->with(ResultFactory::TYPE_REDIRECT)
+            ->willReturn($this->resultRedirectMock);
+        $this->contextMock->expects($this->any())->method('getRequest')->willReturn($this->requestMock);
+        $this->contextMock->expects($this->any())->method('getResultFactory')->willReturn($this->resultFactoryMock);
+        $this->contextMock->expects($this->any())->method('getMessageManager')->willReturn($this->messageManagerMock);
+
+        $this->priceController = $this->objectManager->getObject(
+            Price::class,
+            [
+                'context' => $this->contextMock,
+                'customerSession' => $this->customerSessionMock,
+                'productRepository' => $this->productRepositoryMock,
+            ]
+        );
+    }
+
+    public function testProductIsNotVisibleInCatalog()
+    {
+        $productId = 123;
+        $this->requestMock->expects($this->any())->method('getParam')->with('product')->willReturn($productId);
+        $this->productRepositoryMock->expects($this->any())
+            ->method('getById')
+            ->with($productId)
+            ->willReturn($this->productMock);
+        $this->productMock->expects($this->any())->method('isVisibleInCatalog')->willReturn(false);
+        $this->messageManagerMock->expects($this->once())->method('addErrorMessage')->with(__("The product wasn't found. Verify the product and try again."));
+        $this->resultRedirectMock->expects($this->once())->method('setPath')->with('customer/account/');
+
+        $this->assertEquals(
+            $this->resultRedirectMock,
+            $this->priceController->execute()
+        );
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
PR replaces deprecated message functions in the `Magento_ProductAlert` module.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
