### PR TITLE
Removing the $e->getPrevious() Method.

### DIFF
--- a/lib/internal/Magento/Framework/Crontab/CrontabManager.php
+++ b/lib/internal/Magento/Framework/Crontab/CrontabManager.php
@@ -209,7 +209,7 @@ class CrontabManager implements CrontabManagerInterface
             $this->shell->execute('echo "' . $content . '" | crontab -');
         } catch (LocalizedException $e) {
             throw new LocalizedException(
-                new Phrase('Error during saving of crontab: %1', [$e->getPrevious()->getMessage()]),
+                new Phrase('Error during saving of crontab: %1', [$e->getMessage()]),
                 $e
             );
         }


### PR DESCRIPTION
The method `$e->getPrevious()` not always return a value and doesn't seem to make sense in this scenario because it tries to get the previous error.

### Description (*)
After getting the error below:

`Fatal error: Uncaught Error: Call to a member function getMessage() on null in vendor/magento/framework/Crontab/CrontabManager.php:212`

I noticed that the return of the method `$e->getPrevious()` is not being validated before trying to call the `getMessage()` method.

Also, probably it's not right to implement this here since this code is trying to get the message of a previous exception, not the current one.

### Fixed Issues (if relevant)
I didn't find an issue with this description.

### Manual testing scenarios (*)
It's based on an improvement not in an issue.

### Questions or comments
Does my idea make sense?

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
