### PR TITLE
Fix error in configurables

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/VariationMatrix.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/VariationMatrix.php
@@ -3,9 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\ConfigurableProduct\Model\Product\Type;
 
 /**
+ * Variation matrix.
+ *
  * @api
  * @since 100.0.2
  */
@@ -40,9 +43,9 @@ class VariationMatrix
             for ($attributeIndex = $attributesCount; $attributeIndex--;) {
                 $currentAttribute = $variationalAttributes[$attributeIndex];
                 $currentVariationValue = $currentVariation[$attributeIndex];
-                    if(!empty($currentAttribute['id'])) {
-                        $filledVariation[$currentAttribute['id']] = $currentAttribute['values'][$currentVariationValue]; 
-                    }
+                if (!empty($currentAttribute['id'])) {
+                    $filledVariation[$currentAttribute['id']] = $currentAttribute['values'][$currentVariationValue];
+                }
             }
 
             $variations[] = $filledVariation;

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/VariationMatrix.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/VariationMatrix.php
@@ -40,7 +40,9 @@ class VariationMatrix
             for ($attributeIndex = $attributesCount; $attributeIndex--;) {
                 $currentAttribute = $variationalAttributes[$attributeIndex];
                 $currentVariationValue = $currentVariation[$attributeIndex];
-                $filledVariation[$currentAttribute['id']] = $currentAttribute['values'][$currentVariationValue];
+                    if(isset($currentAttribute['id']) && $currentAttribute['id']) {
+                        $filledVariation[$currentAttribute['id']] = $currentAttribute['values'][$currentVariationValue]; 
+                    }
             }
 
             $variations[] = $filledVariation;

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/VariationMatrix.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/VariationMatrix.php
@@ -40,7 +40,7 @@ class VariationMatrix
             for ($attributeIndex = $attributesCount; $attributeIndex--;) {
                 $currentAttribute = $variationalAttributes[$attributeIndex];
                 $currentVariationValue = $currentVariation[$attributeIndex];
-                    if(isset($currentAttribute['id']) && $currentAttribute['id']) {
+                    if(!empty($currentAttribute['id'])) {
                         $filledVariation[$currentAttribute['id']] = $currentAttribute['values'][$currentVariationValue]; 
                     }
             }

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Type/VariationMatrixTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Type/VariationMatrixTest.php
@@ -25,46 +25,117 @@ class VariationMatrixTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetVariations()
+    /**
+     * Variations matrix test.
+     *
+     * @param array $expectedResult
+     * @dataProvider variationProvider
+     */
+    public function testGetVariations($expectedResult)
     {
-        $result = [
-            [
-                130 => [
-                    'value' => '3',
-                    'label' => 'red',
-                    'price' => ['value_index' => '3', 'pricing_value' => '', 'is_percent' => '0', 'include' => '1',],
-                ],
-            ],
-            [
-                130 => [
-                    'value' => '4',
-                    'label' => 'blue',
-                    'price' => ['value_index' => '4', 'pricing_value' => '', 'is_percent' => '0', 'include' => '1',],
-                ],
-            ],
-        ];
 
-        $input = [
-            130 => [
-                'values' => [
-                    [
-                        'value_index' => '3',
-                        'pricing_value' => '',
-                        'is_percent' => '0',
-                        'include' => '1'
-                    ],
-                    [
-                        'value_index' => '4',
-                        'pricing_value' => '',
-                        'is_percent' => '0',
-                        'include' => '1'
-                    ],
-                ],
-                'attribute_id' => '130',
-                'options' => [['value' => '3', 'label' => 'red',], ['value' => '4', 'label' => 'blue',],],
-            ],
-        ];
+        $this->assertEquals($expectedResult['result'], $this->model->getVariations($expectedResult['input']));
+    }
 
-        $this->assertEquals($result, $this->model->getVariations($input));
+    /**
+     * Test data provider.
+     */
+    public function variationProvider()
+    {
+        return [
+            [
+                'with_attribute_id' => [
+                    'result' => [
+                        [
+                            130 => [
+                                'value' => '3',
+                                'label' => 'red',
+                                'price' => [
+                                    'value_index' => '3',
+                                    'pricing_value' => '',
+                                    'is_percent' => '0',
+                                    'include' => '1'
+                                ],
+                            ],
+                        ],
+                        [
+                            130 => [
+                                'value' => '4',
+                                'label' => 'blue',
+                                'price' => [
+                                    'value_index' => '4',
+                                    'pricing_value' => '',
+                                    'is_percent' => '0',
+                                    'include' => '1'
+                                ],
+                            ],
+                        ],
+                    ],
+                    'input' => [
+                        130 => [
+                            'values' => [
+                                [
+                                    'value_index' => '3',
+                                    'pricing_value' => '',
+                                    'is_percent' => '0',
+                                    'include' => '1'
+                                ],
+                                [
+                                    'value_index' => '4',
+                                    'pricing_value' => '',
+                                    'is_percent' => '0',
+                                    'include' => '1'
+                                ],
+                            ],
+                            'attribute_id' => '130',
+                            'options' => [
+                                [
+                                    'value' => '3',
+                                    'label' => 'red'
+                                ],
+                                ['value' => '4',
+                                    'label' => 'blue'
+                                ]
+                            ],
+                        ],
+                    ]
+                ],
+                'without_attribute_id' => [
+                    'result' => [
+                        [
+                            130 => [
+                                'value' => '4',
+                                'label' => 'blue',
+                                'price' => [
+                                    'value_index' => '4',
+                                    'pricing_value' => '',
+                                    'is_percent' => '0',
+                                    'include' => '1'
+                                ],
+                            ],
+                        ],
+                    ],
+                    'input' => [
+                        130 => [
+                            'values' => [
+                                [
+                                    'value_index' => '3',
+                                    'pricing_value' => '',
+                                    'is_percent' => '0',
+                                    'include' => '1'
+                                ]
+                            ],
+                            'attribute_id' => '',
+                            'options' => [
+                                [
+                                    'value' => '3',
+                                    'label' => 'red'
+                                ]
+                            ],
+                        ],
+                    ]
+                ]
+            ]
+        ];
     }
 }


### PR DESCRIPTION
Problem with configurables when the simple products that were associated did not have a value for the configurable attribute.
Fix this issue https://github.com/magento/magento2/issues/14240

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14240: /vendor/magento/module-configurable-product/Model/Product/Type/VariationMatrix.php on line 43 #14240


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ x] Pull request has a meaningful description of its purpose
 - [x ] All commits are accompanied by meaningful commit messages
 - [ x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x] All automated tests passed successfully (all builds are green)
