### PR TITLE
Remove hardcoded padding of 0 in navigation.less

### DIFF
--- a/lib/web/css/source/lib/_navigation.less
+++ b/lib/web/css/source/lib/_navigation.less
@@ -409,7 +409,6 @@
                 display: none;
                 left: 0;
                 margin: 0 !important;
-                padding: 0;
                 position: absolute;
                 z-index: 1;
 


### PR DESCRIPTION
### Description
Remove hardcoded padding of 0, because it overrides the padding, which is set by variable @_submenu-padding, see lib/web/css/source/lib/_navigation.less:411

```
.submenu {
...
    .lib-css(padding, @_submenu-padding);
    display: none;
    left: 0;
    margin: 0 !important;
    padding: 0;
...
```
### Contribution checklist
 - [+] Pull request has a meaningful description of its purpose
 - [+] All commits are accompanied by meaningful commit messages
 - [-] All new or changed code is covered with unit/integration tests (if applicable)
 - [-] All automated tests passed successfully (all builds are green)
