### PR TITLE
Inefficient Usage of Factories

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Edit.php
@@ -6,45 +6,64 @@
  */
 namespace Magento\Catalog\Controller\Adminhtml\Product\Set;
 
-use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+use Magento\Framework\Registry;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\ObjectManager;
+use Magento\Backend\Model\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+use Magento\Framework\Controller\ResultInterface;
+use Magento\Eav\Api\AttributeSetRepositoryInterface;
+use Magento\Catalog\Controller\Adminhtml\Product\Set;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 
-class Edit extends \Magento\Catalog\Controller\Adminhtml\Product\Set implements HttpGetActionInterface
+class Edit extends Set implements HttpGetActionInterface
 {
     /**
-     * @var \Magento\Framework\View\Result\PageFactory
+     * @var PageFactory
      */
     protected $resultPageFactory;
 
     /**
-     * @param \Magento\Backend\App\Action\Context $context
-     * @param \Magento\Framework\Registry $coreRegistry
-     * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory
+     * @var AttributeSetRepositoryInterface
+     */
+    protected $attributeSetRepository;
+
+    /**
+     *
+     * @param Context $context
+     * @param Registry $coreRegistry
+     * @param PageFactory $resultPageFactory
+     * @param AttributeSetRepositoryInterface $attributeSetRepository
      */
     public function __construct(
-        \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\Registry $coreRegistry,
-        \Magento\Framework\View\Result\PageFactory $resultPageFactory
+        Context $context,
+        Registry $coreRegistry,
+        PageFactory $resultPageFactory,
+        AttributeSetRepositoryInterface $attributeSetRepository = null
     ) {
         parent::__construct($context, $coreRegistry);
         $this->resultPageFactory = $resultPageFactory;
+        $this->attributeSetRepository = $attributeSetRepository ?:
+            ObjectManager::getInstance()->get(AttributeSetRepositoryInterface::class);
     }
 
     /**
-     * @return \Magento\Backend\Model\View\Result\Page
+     *
+     * @return ResultInterface
+     *
+     * @throws NoSuchEntityException
      */
     public function execute()
     {
         $this->_setTypeId();
-        $attributeSet = $this->_objectManager->create(\Magento\Eav\Model\Entity\Attribute\Set::class)
-            ->load($this->getRequest()->getParam('id'));
-
+        $attributeSet = $this->attributeSetRepository->get($this->getRequest()->getParam('id'));
         if (!$attributeSet->getId()) {
             return $this->resultRedirectFactory->create()->setPath('catalog/*/index');
         }
-
         $this->_coreRegistry->register('current_attribute_set', $attributeSet);
 
-        /** @var \Magento\Backend\Model\View\Result\Page $resultPage */
+        /** @var Page $resultPage */
         $resultPage = $this->resultPageFactory->create();
         $resultPage->setActiveMenu('Magento_Catalog::catalog_attributes_sets');
         $resultPage->getConfig()->getTitle()->prepend(__('Attribute Sets'));

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Edit.php
@@ -30,7 +30,7 @@ class Edit extends Set implements HttpGetActionInterface
     /**
      * @var AttributeSetRepositoryInterface
      */
-    protected $attributeSetRepository;
+    private $attributeSetRepository;
 
     /**
      * @param Context $context

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Edit.php
@@ -17,6 +17,9 @@ use Magento\Catalog\Controller\Adminhtml\Product\Set;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\App\Action\HttpGetActionInterface;
 
+/**
+ * Edit attribute set controller.
+ */
 class Edit extends Set implements HttpGetActionInterface
 {
     /**
@@ -30,7 +33,6 @@ class Edit extends Set implements HttpGetActionInterface
     protected $attributeSetRepository;
 
     /**
-     *
      * @param Context $context
      * @param Registry $coreRegistry
      * @param PageFactory $resultPageFactory
@@ -49,10 +51,7 @@ class Edit extends Set implements HttpGetActionInterface
     }
 
     /**
-     *
-     * @return ResultInterface
-     *
-     * @throws NoSuchEntityException
+     * @inheritdoc
      */
     public function execute()
     {


### PR DESCRIPTION
### Description
#### Multiple code fixes in `Magento\Catalog\Controller\Adminhtml\Product\Set\Edit` as follows:
- Inefficient usage of Result Factories, where independent factories are used for `Redirect` and `Page`. Instead, systematically inherited `Magento\Framework\Controller\ResultFactory` can be used for a common Result object creation. 
- `Redirect` return type annotation in PHPDoc Block was missing. Common `Magento\Framework\Controller\ResultInterface` can be returned which is implemented by all controller Result types. (`Page` and `Redirect`, in this class)
- `ObjectManager` is used to create `Magento\Eav\Model\Entity\Attribute\Set`. Can be fixed using `Magento\Eav\Model\Entity\Attribute\SetFactory` instead, which is the entire purpose of said Factory.
- Refactored according to Magento Coding Standards, where necessary

### Fixed Issues
No specific issue, as this is a very common issue occurring in almost every other class in Magento Core code.

### Manual testing scenarios (*)
1. Code changes in affected class: `Magento\Catalog\Controller\Adminhtml\Product\Set\Edit`.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
