### PR TITLE
Fix the error message of folder not writable.

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Directory/Write.php
+++ b/lib/internal/Magento/Framework/Filesystem/Directory/Write.php
@@ -53,9 +53,7 @@ class Write extends Read implements WriteInterface
     protected function assertWritable($path)
     {
         if ($this->isWritable($path) === false) {
-            $path = (!$this->driver->isFile($path))
-                ? $this->getAbsolutePath($this->path, $path)
-                : $this->getAbsolutePath($path);
+            $path = $this->getAbsolutePath($path);
             throw new FileSystemException(new \Magento\Framework\Phrase('The path "%1" is not writable.', [$path]));
         }
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The path you specified when creating the Sitemap is transferred to the beginning of the url in the error message

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24623: Subfolder string is used as scheme in generating sitemap error message.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create folder in root directory ( "test" for ex.);
2. Go to backend, and navigate to Marketing -> Site Map;
3. Add a sitemap with Path = '/test/' and Filename = 'sitemap.xml';
4. Change permissions for "test" directory (read only);
5. Click "Generate" button to generate the sitemap;

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
It looks like a bug in the original file system code. There was a commit b49fb919 fixed it when path is a file, while actual directory has the same problem. So the fix is just to remove the check of file or directory simply.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
