### PR TITLE
Optimize performance by using isset() instead of in_array()

### DIFF
--- a/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
+++ b/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
@@ -78,6 +78,8 @@ class Loader
     public function load(array $exclude = [])
     {
         $result = [];
+        $excludeSet = array_flip($exclude);
+
         foreach ($this->getModuleConfigs() as list($file, $contents)) {
             try {
                 $this->parser->loadXML($contents);
@@ -93,7 +95,7 @@ class Loader
 
             $data = $this->converter->convert($this->parser->getDom());
             $name = key($data);
-            if (!in_array($name, $exclude)) {
+            if (!isset($excludeSet[$name])) {
                 $result[$name] = $data[$name];
             }
         }

--- a/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
+++ b/lib/internal/Magento/Framework/Module/ModuleList/Loader.php
@@ -140,7 +140,7 @@ class Loader
 
             $expanded[] = [
                 'name' => $moduleName,
-                'sequence' => $sequence,
+                'sequence_set' => array_flip($sequence),
             ];
         }
 
@@ -148,7 +148,7 @@ class Loader
         $total = count($expanded);
         for ($i = 0; $i < $total - 1; $i++) {
             for ($j = $i; $j < $total; $j++) {
-                if (in_array($expanded[$j]['name'], $expanded[$i]['sequence'], true)) {
+                if (isset($expanded[$i]['sequence_set'][$expanded[$j]['name']])) {
                     $temp = $expanded[$i];
                     $expanded[$i] = $expanded[$j];
                     $expanded[$j] = $temp;
@@ -196,18 +196,19 @@ class Loader
      */
     private function expandSequence($list, $name, $accumulated = [])
     {
-        $accumulated[] = $name;
+        $accumulated[$name] = true;
         $result = $list[$name]['sequence'];
+        $allResults = [];
         foreach ($result as $relatedName) {
-            if (in_array($relatedName, $accumulated)) {
-                throw new \Exception("Circular sequence reference from '{$name}' to '{$relatedName}'.");
+            if (isset($accumulated[$relatedName])) {
+                throw new \LogicException("Circular sequence reference from '{$name}' to '{$relatedName}'.");
             }
             if (!isset($list[$relatedName])) {
                 continue;
             }
-            $relatedResult = $this->expandSequence($list, $relatedName, $accumulated);
-            $result = array_unique(array_merge($result, $relatedResult));
+            $allResults[] = $this->expandSequence($list, $relatedName, $accumulated);
         }
-        return $result;
+        $allResults[] = $result;
+        return array_unique(array_merge(...$allResults));
     }
 }

--- a/lib/internal/Magento/Framework/Setup/Lists.php
+++ b/lib/internal/Magento/Framework/Setup/Lists.php
@@ -96,9 +96,10 @@ class Lists
         $languages = (new LanguageBundle())->get(Resolver::DEFAULT_LOCALE)['Languages'];
         $countries = (new RegionBundle())->get(Resolver::DEFAULT_LOCALE)['Countries'];
         $locales = \ResourceBundle::getLocales('') ?: [];
+        $allowedLocales = array_flip($this->allowedLocales);
         $list = [];
         foreach ($locales as $locale) {
-            if (!in_array($locale, $this->allowedLocales)) {
+            if (!isset($allowedLocales[$locale])) {
                 continue;
             }
             $language = \Locale::getPrimaryLanguage($locale);


### PR DESCRIPTION
### Description (*)
I've run XDebug profiler to see why static content deploy takes so much time. 
Many calls of in_array() grabbed my attention and I've fixed two such places:
1. lib/internal/Magento/Framework/Module/ModuleList/Loader.php 
2. lib/internal/Magento/Framework/Setup/Lists.php 

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
General regression testing.

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
