### PR TITLE
#24581 Added unique key on eav_attribute_label table

### DIFF
--- a/app/code/Magento/Eav/etc/db_schema.xml
+++ b/app/code/Magento/Eav/etc/db_schema.xml
@@ -481,11 +481,11 @@
                     referenceColumn="attribute_id" onDelete="CASCADE"/>
         <constraint xsi:type="foreign" referenceId="EAV_ATTRIBUTE_LABEL_STORE_ID_STORE_STORE_ID" table="eav_attribute_label"
                     column="store_id" referenceTable="store" referenceColumn="store_id" onDelete="CASCADE"/>
-        <index referenceId="EAV_ATTRIBUTE_LABEL_STORE_ID" indexType="btree">
+        <constraint xsi:type="unique" referenceId="EAV_ATTRIBUTE_LABEL_ATTRIBUTE_ID_STORE_ID_UNIQUE">
             <column name="store_id"/>
-        </index>
-        <index referenceId="EAV_ATTRIBUTE_LABEL_ATTRIBUTE_ID_STORE_ID" indexType="btree">
             <column name="attribute_id"/>
+        </constraint>
+        <index referenceId="EAV_ATTRIBUTE_LABEL_STORE_ID" indexType="btree">
             <column name="store_id"/>
         </index>
     </table>

--- a/app/code/Magento/Eav/etc/db_schema.xml
+++ b/app/code/Magento/Eav/etc/db_schema.xml
@@ -488,6 +488,10 @@
         <index referenceId="EAV_ATTRIBUTE_LABEL_STORE_ID" indexType="btree">
             <column name="store_id"/>
         </index>
+        <index referenceId="EAV_ATTRIBUTE_LABEL_ATTRIBUTE_ID_STORE_ID" indexType="btree">
+            <column name="attribute_id"/>
+            <column name="store_id"/>
+        </index>
     </table>
     <table name="eav_form_type" resource="default" engine="innodb" comment="Eav Form Type">
         <column xsi:type="smallint" name="type_id" padding="5" unsigned="true" nullable="false" identity="true"

--- a/app/code/Magento/Eav/etc/db_schema_whitelist.json
+++ b/app/code/Magento/Eav/etc/db_schema_whitelist.json
@@ -304,7 +304,8 @@
         "constraint": {
             "PRIMARY": true,
             "EAV_ATTRIBUTE_LABEL_ATTRIBUTE_ID_EAV_ATTRIBUTE_ATTRIBUTE_ID": true,
-            "EAV_ATTRIBUTE_LABEL_STORE_ID_STORE_STORE_ID": true
+            "EAV_ATTRIBUTE_LABEL_STORE_ID_STORE_STORE_ID": true,
+            "EAV_ATTRIBUTE_LABEL_STORE_ID_ATTRIBUTE_ID": true
         }
     },
     "eav_form_type": {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#24581: Missing unique key on eav_attribute_label table

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Installed fresh magento2.3-develop and the unique key was missing
2. After added the unique key to table reinstall Magento and its fixed.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
