### PR TITLE
Static Content Deploy - Optimize files scanning performance

### DIFF
--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -1050,10 +1050,10 @@ class Files
     {
         foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $modulePath) {
             if (preg_match(
-                    '/^' . preg_quote("{$modulePath}/", '/') . 'view\/([a-z]+)\/web\/(.+)$/i',
-                    $file,
-                    $matches
-                ) === 1
+                '/^' . preg_quote("{$modulePath}/", '/') . 'view\/([a-z]+)\/web\/(.+)$/i',
+                $file,
+                $matches
+            ) === 1
             ) {
                 list(, $area, $filePath) = $matches;
                 return [$area, '', '', $moduleName, $filePath, $file];

--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -909,7 +909,7 @@ class Files
             $moduleLocalePath[] = $moduleDir . "/view/{$area}/web/i18n/{$locale}";
         }
 
-        $this->_accumulateStaticFiles($area, $filePattern, $result);
+        $this->accumulateStaticFiles($area, $filePattern, $result);
         $this->_accumulateFilesByPatterns($moduleLocalePath, $filePattern, $result, '_parseModuleLocaleStatic');
         $this->accumulateThemeStaticFiles($area, $locale, $filePattern, $result);
         self::$_cache[$key] = $result;
@@ -1020,7 +1020,7 @@ class Files
     /**
      * Parse meta-info of a static file in module
      *
-     * @deprecated Replaced with method _accumulateStaticFiles()
+     * @deprecated Replaced with method accumulateStaticFiles()
      *
      * @param string $file
      * @return array
@@ -1049,7 +1049,7 @@ class Files
      * @param array $result
      * @return void
      */
-    private function _accumulateStaticFiles($area, $filePattern, array &$result)
+    private function accumulateStaticFiles($area, $filePattern, array &$result)
     {
         foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $moduleDir) {
             $moduleWebPath = $moduleDir . "/view/{$area}/web";

--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -1039,6 +1039,30 @@ class Files
     }
 
     /**
+     * Parse meta-info of a static file in module
+     *
+     * @deprecated Replaced with method _accumulateStaticFiles()
+     *
+     * @param string $file
+     * @return array
+     */
+    protected function _parseModuleStatic($file)
+    {
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $modulePath) {
+            if (preg_match(
+                    '/^' . preg_quote("{$modulePath}/", '/') . 'view\/([a-z]+)\/web\/(.+)$/i',
+                    $file,
+                    $matches
+                ) === 1
+            ) {
+                list(, $area, $filePath) = $matches;
+                return [$area, '', '', $moduleName, $filePath, $file];
+            }
+        }
+        return [];
+    }
+
+    /**
      * Search static files from all modules by the specified pattern and accumulate meta-info
      *
      * @param string $area
@@ -1046,7 +1070,7 @@ class Files
      * @param array $result
      * @return void
      */
-    protected function _accumulateStaticFiles($area, $filePattern, array &$result)
+    private function _accumulateStaticFiles($area, $filePattern, array &$result)
     {
         foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $moduleDir) {
             $moduleWebPath = $moduleDir . "/view/{$area}/web";

--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -371,12 +371,11 @@ class Files
             }
             $globPaths = [BP . '/app/etc/config.xml', BP . '/app/etc/*/config.xml'];
             $configXmlPaths = array_merge($globPaths, $configXmlPaths);
-            $files = [];
+            $files = [[]];
             foreach ($configXmlPaths as $xmlPath) {
-                // phpcs:ignore Magento2.Performance.ForeachArrayMerge
-                $files = array_merge($files, glob($xmlPath, GLOB_NOSORT));
+                $files[] = glob($xmlPath, GLOB_NOSORT);
             }
-            self::$_cache[$cacheKey] = $files;
+            self::$_cache[$cacheKey] = array_merge(...$files);
         }
         if ($asDataSet) {
             return self::composeDataSets(self::$_cache[$cacheKey]);

--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -24,44 +24,20 @@ use Magento\Framework\View\Design\Theme\ThemePackageList;
  */
 class Files
 {
-    /**
-     * Include app code
-     */
     const INCLUDE_APP_CODE = 1;
 
-    /**
-     * Include tests
-     */
     const INCLUDE_TESTS = 2;
 
-    /**
-     * Include dev tools
-     */
     const INCLUDE_DEV_TOOLS = 4;
 
-    /**
-     * Include templates
-     */
     const INCLUDE_TEMPLATES = 8;
 
-    /**
-     * Include lib files
-     */
     const INCLUDE_LIBS = 16;
 
-    /**
-     * Include pub code
-     */
     const INCLUDE_PUB_CODE = 32;
 
-    /**
-     * Include non classes
-     */
     const INCLUDE_NON_CLASSES = 64;
 
-    /**
-     * Include setup
-     */
     const INCLUDE_SETUP = 128;
 
     /**
@@ -397,6 +373,7 @@ class Files
             $configXmlPaths = array_merge($globPaths, $configXmlPaths);
             $files = [];
             foreach ($configXmlPaths as $xmlPath) {
+                // phpcs:ignore Magento2.Performance.ForeachArrayMerge
                 $files = array_merge($files, glob($xmlPath, GLOB_NOSORT));
             }
             self::$_cache[$cacheKey] = $files;
@@ -679,6 +656,7 @@ class Files
                         }
                     }
                 } else {
+                    // phpcs:ignore Magento2.Performance.ForeachArrayMerge
                     $files = array_merge($files, $moduleFiles);
                 }
             }
@@ -713,8 +691,10 @@ class Files
                 );
 
                 if ($params['with_metainfo']) {
+                    // phpcs:ignore Magento2.Performance.ForeachArrayMerge
                     $files = array_merge($this->parseThemeFiles($themeFiles, $currentThemePath, $theme));
                 } else {
+                    // phpcs:ignore Magento2.Performance.ForeachArrayMerge
                     $files = array_merge($files, $themeFiles);
                 }
             }


### PR DESCRIPTION
### Description (*)
According to XDebug profiling Magento2 calls preg_match() and preg_quote() unreasonable amount of times during static content deploy.

I've debugged it and found root cause. This is current algorithm:
1. Get list of all modules
2. Get array of all files in all modules
3. Now try to guess which file belongs to which module by using dynamic regex: preg_quote(), preg_match()

I've refactored it to avoid mixing all files in one array and then splitting again. Quite simple fix.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
Static content deploy:
1. Run static content deploy on base version and then on this branch
2. Compare all files

I did it this test on real projects - no changes were found.

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
