### PR TITLE
Fixed #23460 Changed empty to isset so that the region will be update…

### DIFF
--- a/app/code/Magento/Customer/Controller/Address/FormPost.php
+++ b/app/code/Magento/Customer/Controller/Address/FormPost.php
@@ -166,7 +166,7 @@ class FormPost extends \Magento\Customer\Controller\Address implements HttpPostA
      */
     protected function updateRegionData(&$attributeValues)
     {
-        if (!empty($attributeValues['region_id'])) {
+        if (isset($attributeValues['region_id'])) {
             $newRegion = $this->regionFactory->create()->load($attributeValues['region_id']);
             $attributeValues['region_code'] = $newRegion->getCode();
             $attributeValues['region'] = $newRegion->getDefaultName();


### PR DESCRIPTION
### Description
When a customer address is created with the first region and the address will be edited, a change of the country set the region id to zero. The region it self will not be changed.

### Fixed Issues
1. magento/magento2#23460: Region doesn't updates after changing country and leaving region select unselected

### Manual testing scenarios
1. Create a customer with an address in United States and the Region Alabama
2. Save the address
3. Edit the address again and change the country to France
4. Save the address again
5. **Result** The region will be emptied.