### PR TITLE
refactor deployment config reader, change inconsistent load method to…

### DIFF
--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Reader.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Reader.php
@@ -16,7 +16,6 @@ use Magento\Framework\Phrase;
 /**
  * Deployment configuration reader.
  * Loads the merged configuration from config files.
- *
  * @see FileReader The reader for specific configuration file
  */
 class Reader
@@ -107,11 +106,9 @@ class Reader
                 }
             }
         } else {
-            $configFiles = $this->configFilePool->getPaths();
-            $allFilesData = [];
-            $result = [];
-            foreach (array_keys($configFiles) as $fileKey) {
-                $configFile = $path . '/' . $this->configFilePool->getPath($fileKey);
+            $configFiles = $this->getFiles();
+            foreach ($configFiles as $file) {
+                $configFile = $path . DIRECTORY_SEPARATOR . $file;
                 if ($fileDriver->isExists($configFile)) {
                     $fileData = include $configFile;
                     if (!is_array($fileData)) {
@@ -120,7 +117,6 @@ class Reader
                 } else {
                     continue;
                 }
-                $allFilesData[$configFile] = $fileData;
                 if ($fileData) {
                     $result = array_replace_recursive($result, $fileData);
                 }
@@ -136,6 +132,8 @@ class Reader
      * @param string $pathConfig The path config
      * @param bool $ignoreInitialConfigFiles Whether ignore custom pools
      * @return array
+     * @throws FileSystemException
+     * @throws RuntimeException
      * @deprecated 100.2.0 Magento does not support custom config file pools since 2.2.0 version
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */

--- a/lib/internal/Magento/Framework/App/DeploymentConfig/Reader.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig/Reader.php
@@ -108,7 +108,7 @@ class Reader
         } else {
             $configFiles = $this->getFiles();
             foreach ($configFiles as $file) {
-                $configFile = $path . DIRECTORY_SEPARATOR . $file;
+                $configFile = $path . '/' . $file;
                 if ($fileDriver->isExists($configFile)) {
                     $fileData = include $configFile;
                     if (!is_array($fileData)) {

--- a/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/ReaderTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfig/ReaderTest.php
@@ -43,17 +43,18 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
             ->willReturn(__DIR__ . '/_files');
         $this->fileDriver = $this->createMock(File::class);
         $this->fileDriver
-            ->expects($this->any())
             ->method('isExists')
-            ->will($this->returnValueMap([
-                [__DIR__ . '/_files/config.php', true],
-                [__DIR__ . '/_files/custom.php', true],
-                [__DIR__ . '/_files/duplicateConfig.php', true],
-                [__DIR__ . '/_files/env.php', true],
-                [__DIR__ . '/_files/mergeOne.php', true],
-                [__DIR__ . '/_files/mergeTwo.php', true],
-                [__DIR__ . '/_files/nonexistent.php', false]
-            ]));
+            ->willReturnMap(
+                [
+                    [__DIR__.'/_files/config.php', true],
+                    [__DIR__.'/_files/custom.php', true],
+                    [__DIR__.'/_files/duplicateConfig.php', true],
+                    [__DIR__.'/_files/env.php', true],
+                    [__DIR__.'/_files/mergeOne.php', true],
+                    [__DIR__.'/_files/mergeTwo.php', true],
+                    [__DIR__.'/_files/nonexistent.php', false]
+                ]
+            );
         $this->driverPool = $this->createMock(DriverPool::class);
         $this->driverPool
             ->expects($this->any())
@@ -152,8 +153,9 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
      * @expectedException \Magento\Framework\Exception\RuntimeException
      * @expectedExceptionMessageRegExp /Invalid configuration file: \'.*\/\_files\/emptyConfig\.php\'/
      * @return void
+     * @throws \Magento\Framework\Exception\FileSystemException
      */
-    public function testLoadInvalidConfigurationFile()
+    public function testLoadInvalidConfigurationFile(): void
     {
         $fileDriver = $this->getMockBuilder(File::class)
             ->disableOriginalConstructor()
@@ -173,22 +175,13 @@ class ReaderTest extends \PHPUnit\Framework\TestCase
         $configFilePool = $this->getMockBuilder(ConfigFilePool::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $configFilePool->expects($this->exactly(2))
+        $configFilePool->expects($this->once())
             ->method('getPaths')
             ->willReturn(
                 [
                     'configKeyOne' => 'config.php',
                     'testConfig' => 'emptyConfig.php'
                 ]
-            );
-        $configFilePool->expects($this->exactly(2))
-            ->method('getPath')
-            ->withConsecutive(
-                [$this->identicalTo('configKeyOne')],
-                [$this->identicalTo('testConfig')]
-            )->willReturnOnConsecutiveCalls(
-                'config.php',
-                'emptyConfig.php'
             );
         $object = new Reader($this->dirList, $driverPool, $configFilePool);
         $object->load();


### PR DESCRIPTION
### Description (*)
Method \Magento\Framework\App\DeploymentConfig\Reader::load is not consistent with constructor. 
The constructor is initializing the files member, but it is not used when loading configuration.

### Manual testing scenarios (*)
The configuration should work the same after deploying this changes.
