### PR TITLE
use filesystem driver code in validatePath of DirectorResolver class

### DIFF
--- a/lib/internal/Magento/Framework/App/Filesystem/DirectoryResolver.php
+++ b/lib/internal/Magento/Framework/App/Filesystem/DirectoryResolver.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\Framework\App\Filesystem;
 
 use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\DriverPool;
 
 /**
  * Magento directories resolver.
@@ -44,12 +45,13 @@ class DirectoryResolver
      *
      * @param string $path
      * @param string $directoryConfig
+     * @param string $driverCode
      * @return bool
      * @throws \Magento\Framework\Exception\FileSystemException
      */
-    public function validatePath($path, $directoryConfig = DirectoryList::MEDIA)
+    public function validatePath($path, $directoryConfig = DirectoryList::MEDIA, $driverCode = DriverPool::FILE)
     {
-        $directory = $this->filesystem->getDirectoryWrite($directoryConfig);
+        $directory = $this->filesystem->getDirectoryWrite($directoryConfig, $driverCode);
         $realPath = $directory->getDriver()->getRealPathSafety($path);
         $root = $this->directoryList->getPath($directoryConfig);
 


### PR DESCRIPTION
### Description (*)
Extension developers are not able to implement other type of file systems.

### Manual testing scenarios (*)
Anything related to disk files should work the same as before applying the changes. 
Check static files deploy, product images or other type of files.