### PR TITLE
Deprecate result factories in favor of one generic

### DIFF
--- a/app/code/Magento/Backend/Model/View/Result/RedirectFactory.php
+++ b/app/code/Magento/Backend/Model/View/Result/RedirectFactory.php
@@ -34,7 +34,7 @@ class RedirectFactory extends \Magento\Framework\Controller\Result\RedirectFacto
      */
     public function __construct(
         ObjectManagerInterface $objectManager,
-        $instanceName = \Magento\Backend\Model\View\Result\Redirect::class
+        $instanceName = Redirect::class
     ) {
         $this->objectManager = $objectManager;
         $this->instanceName = $instanceName;
@@ -44,7 +44,7 @@ class RedirectFactory extends \Magento\Framework\Controller\Result\RedirectFacto
      * Create class instance with specified parameters
      *
      * @param array $data
-     * @return \Magento\Backend\Model\View\Result\Redirect
+     * @return Redirect
      */
     public function create(array $data = [])
     {

--- a/lib/internal/Magento/Framework/Controller/Result/JsonFactory.php
+++ b/lib/internal/Magento/Framework/Controller/Result/JsonFactory.php
@@ -6,34 +6,39 @@
 
 namespace Magento\Framework\Controller\Result;
 
+use Magento\Framework\ObjectManagerInterface;
+
 /**
  * Factory class for @see \Magento\Framework\Controller\Result\Json
+ *
+ * @deprecated replaced with more generic ResultFactory
+ * @see \Magento\Framework\Controller\ResultFactory::create
  */
 class JsonFactory
 {
     /**
      * Object Manager instance
      *
-     * @var \Magento\Framework\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
-    protected $objectManager = null;
+    protected $objectManager;
 
     /**
      * Instance name to create
      *
      * @var string
      */
-    protected $instanceName = null;
+    protected $instanceName;
 
     /**
      * Factory constructor
      *
-     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param ObjectManagerInterface $objectManager
      * @param string $instanceName
      */
     public function __construct(
-        \Magento\Framework\ObjectManagerInterface $objectManager,
-        $instanceName = \Magento\Framework\Controller\Result\Json::class
+        ObjectManagerInterface $objectManager,
+        $instanceName = Json::class
     ) {
         $this->objectManager = $objectManager;
         $this->instanceName = $instanceName;
@@ -43,7 +48,7 @@ class JsonFactory
      * Create class instance with specified parameters
      *
      * @param array $data
-     * @return \Magento\Framework\Controller\Result\Json
+     * @return Json
      */
     public function create(array $data = [])
     {

--- a/lib/internal/Magento/Framework/Controller/Result/RedirectFactory.php
+++ b/lib/internal/Magento/Framework/Controller/Result/RedirectFactory.php
@@ -9,6 +9,9 @@ use Magento\Framework\ObjectManagerInterface;
 
 /**
  * @api
+ *
+ * @deprecated replaced with more generic ResultFactory
+ * @see \Magento\Framework\Controller\ResultFactory::create
  */
 class RedirectFactory
 {
@@ -32,7 +35,7 @@ class RedirectFactory
      */
     public function __construct(
         ObjectManagerInterface $objectManager,
-        $instanceName = \Magento\Framework\Controller\Result\Redirect::class
+        $instanceName = Redirect::class
     ) {
         $this->objectManager = $objectManager;
         $this->instanceName = $instanceName;
@@ -42,7 +45,7 @@ class RedirectFactory
      * Create class instance with specified parameters
      *
      * @param array $data
-     * @return \Magento\Framework\Controller\Result\Redirect
+     * @return Redirect
      */
     public function create(array $data = [])
     {

--- a/lib/internal/Magento/Framework/Controller/ResultFactory.php
+++ b/lib/internal/Magento/Framework/Controller/ResultFactory.php
@@ -7,6 +7,8 @@
 namespace Magento\Framework\Controller;
 
 use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\View\Result\Layout;
+use Magento\Framework\View\Result\Page;
 
 /**
  * Result Factory
@@ -15,7 +17,7 @@ use Magento\Framework\ObjectManagerInterface;
  */
 class ResultFactory
 {
-    /**#@+
+    /**
      * Allowed result types
      */
     const TYPE_JSON     = 'json';
@@ -24,16 +26,14 @@ class ResultFactory
     const TYPE_FORWARD  = 'forward';
     const TYPE_LAYOUT   = 'layout';
     const TYPE_PAGE     = 'page';
-    /**#@-*/
 
-    /**#@-*/
     protected $typeMap = [
         self::TYPE_JSON     => Result\Json::class,
         self::TYPE_RAW      => Result\Raw::class,
         self::TYPE_REDIRECT => Result\Redirect::class,
         self::TYPE_FORWARD  => Result\Forward::class,
-        self::TYPE_LAYOUT   => \Magento\Framework\View\Result\Layout::class,
-        self::TYPE_PAGE     => \Magento\Framework\View\Result\Page::class,
+        self::TYPE_LAYOUT   => Layout::class,
+        self::TYPE_PAGE     => Page::class,
     ];
 
     /**
@@ -95,7 +95,7 @@ class ResultFactory
          * Used for knowledge how result page was created, page was created through result factory or it's default page
          * in App\View created in constructor
          */
-        if ($resultInstance instanceof \Magento\Framework\View\Result\Layout) {
+        if ($resultInstance instanceof Layout) {
             // Initialization has to be in constructor of ResultPage
             $resultInstance->addDefaultHandle();
         }

--- a/lib/internal/Magento/Framework/View/Result/LayoutFactory.php
+++ b/lib/internal/Magento/Framework/View/Result/LayoutFactory.php
@@ -10,6 +10,9 @@ use Magento\Framework\ObjectManagerInterface;
 
 /**
  * @api
+ *
+ * @deprecated replaced with more generic ResultFactory
+ * @see \Magento\Framework\Controller\ResultFactory::create
  */
 class LayoutFactory
 {
@@ -29,18 +32,18 @@ class LayoutFactory
      */
     public function __construct(
         ObjectManagerInterface $objectManager,
-        $instanceName = \Magento\Framework\View\Result\Layout::class
+        $instanceName = Layout::class
     ) {
         $this->objectManager = $objectManager;
         $this->instanceName = $instanceName;
     }
 
     /**
-     * @return \Magento\Framework\View\Result\Layout
+     * @return Layout
      */
     public function create()
     {
-        /** @var \Magento\Framework\View\Result\Layout $resultLayout */
+        /** @var Layout $resultLayout */
         $resultLayout = $this->objectManager->create($this->instanceName);
         $resultLayout->addDefaultHandle();
         return $resultLayout;

--- a/lib/internal/Magento/Framework/View/Result/PageFactory.php
+++ b/lib/internal/Magento/Framework/View/Result/PageFactory.php
@@ -14,6 +14,9 @@ use Magento\Framework\ObjectManagerInterface;
  * which is by convention is determined from the controller action class
  *
  * @api
+ *
+ * @deprecated replaced with more generic ResultFactory
+ * @see \Magento\Framework\Controller\ResultFactory::create
  */
 class PageFactory
 {
@@ -33,7 +36,7 @@ class PageFactory
      */
     public function __construct(
         ObjectManagerInterface $objectManager,
-        $instanceName = \Magento\Framework\View\Result\Page::class
+        $instanceName = Page::class
     ) {
         $this->objectManager = $objectManager;
         $this->instanceName = $instanceName;
@@ -47,11 +50,11 @@ class PageFactory
      *
      * @param bool $isView
      * @param array $arguments
-     * @return \Magento\Framework\View\Result\Page
+     * @return Page
      */
     public function create($isView = false, array $arguments = [])
     {
-        /** @var \Magento\Framework\View\Result\Page $page */
+        /** @var Page $page */
         $page = $this->objectManager->create($this->instanceName, $arguments);
         // TODO Temporary solution for compatibility with View object. Will be deleted in MAGETWO-28359
         if (!$isView) {


### PR DESCRIPTION
### Description (*)

#### Issue
In magento we have a mess with result objects in adminhtml controllers. When you want to add new result type, for instance add json result - you have three options

1. _Inject new type with as constructor argument_ 
https://github.com/magento/magento2/blob/20069c4846043d90755d978c799b1e358ef2fe4f/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/Upload.php#L39
https://github.com/magento/magento2/blob/20069c4846043d90755d978c799b1e358ef2fe4f/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/Upload.php#L65


2. _Inject it via ObjectManger_ (really-really bad, but we could do that):
https://github.com/magento/magento2/blob/20069c4846043d90755d978c799b1e358ef2fe4f/app/code/Magento/Catalog/Controller/Adminhtml/Category/Add.php#L62
https://github.com/magento/magento2/blob/20069c4846043d90755d978c799b1e358ef2fe4f/app/code/Magento/Catalog/Controller/Adminhtml/Category/Add.php#L64

3. _Use **already existing** `resultFactory` object_:
https://github.com/magento/magento2/blob/20069c4846043d90755d978c799b1e358ef2fe4f/lib/internal/Magento/Framework/App/Action/AbstractAction.php#L44
https://github.com/magento/magento2/blob/20069c4846043d90755d978c799b1e358ef2fe4f/app/code/Magento/AdminNotification/Controller/Adminhtml/System/Message/ListAction.php#L72


#### Examples
In many places we're using 1st option that for different types causes not needed code duplicates, examples: 
https://github.com/magento/magento2/blob/20069c4846043d90755d978c799b1e358ef2fe4f/app/code/Magento/Sales/Controller/Adminhtml/Order.php#L111-L114

https://github.com/magento/magento2/blob/20069c4846043d90755d978c799b1e358ef2fe4f/app/code/Magento/Checkout/Controller/Onepage.php#L114-L117

https://github.com/magento/magento2/blob/20069c4846043d90755d978c799b1e358ef2fe4f/app/code/Magento/Customer/Controller/Adminhtml/Index.php#L222-L225

#### Solution 
My PR marks all specific result factories as `@deprecated` in favor of one generic factory that will have the same result, so we'll have only one option how to create result objects. It should decrease amount of mess in controllers.

#### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
I checked - option 3 works correctly in admin because it replaces result object types:
https://github.com/magento/magento2/blob/20069c4846043d90755d978c799b1e358ef2fe4f/app/code/Magento/Backend/etc/adminhtml/di.xml#L97-L114

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
