### PR TITLE
Removed ObjectManager::get() usage

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category.php
@@ -7,10 +7,13 @@ declare(strict_types=1);
 
 namespace Magento\Catalog\Controller\Adminhtml;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Store\Model\Store;
+use Magento\Framework\Controller\ResultFactory;
 
 /**
  * Catalog category controller
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 abstract class Category extends \Magento\Backend\App\Action
 {
@@ -27,19 +30,60 @@ abstract class Category extends \Magento\Backend\App\Action
     protected $dateFilter;
 
     /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var \Magento\Framework\Registry
+     */
+    private $registry;
+
+    /**
+     * @var \Magento\Cms\Model\Wysiwyg\Config
+     */
+    private $wysiwigConfig;
+
+    /**
+     * @var \Magento\Backend\Model\Auth\Session
+     */
+    private $authSession;
+
+    /**
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Framework\Stdlib\DateTime\Filter\Date|null $dateFilter
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Framework\Registry $registry
+     * @param \Magento\Cms\Model\Wysiwyg\Config $wysiwigConfig
+     * @param \Magento\Backend\Model\Auth\Session $authSession
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter = null
+        \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter = null,
+        \Magento\Store\Model\StoreManagerInterface $storeManager = null,
+        \Magento\Framework\Registry $registry = null,
+        \Magento\Cms\Model\Wysiwyg\Config $wysiwigConfig = null,
+        \Magento\Backend\Model\Auth\Session $authSession = null
     ) {
         $this->dateFilter = $dateFilter;
+        $this->storeManager = $storeManager ?: ObjectManager::getInstance()->get(
+            \Magento\Store\Model\StoreManagerInterface::class
+        );
+        $this->registry = $registry ?: ObjectManager::getInstance()->get(
+            \Magento\Framework\Registry::class
+        );
+        $this->wysiwigConfig = $wysiwigConfig ?: ObjectManager::getInstance()->get(
+            \Magento\Cms\Model\Wysiwyg\Config::class
+        );
+        $this->authSession = $authSession ?: ObjectManager::getInstance()->get(
+            \Magento\Backend\Model\Auth\Session::class
+        );
         parent::__construct($context);
     }
 
     /**
-     * Initialize requested category and put it into registry.
+     * Initialize requested category and put it into registry
+     *
      * Root category can be returned, if inappropriate store/category is specified
      *
      * @param bool $getRootInstead
@@ -55,11 +99,7 @@ abstract class Category extends \Magento\Backend\App\Action
         if ($categoryId) {
             $category->load($categoryId);
             if ($storeId) {
-                $rootId = $this->_objectManager->get(
-                    \Magento\Store\Model\StoreManagerInterface::class
-                )->getStore(
-                    $storeId
-                )->getRootCategoryId();
+                $rootId = $this->storeManager->getStore($storeId)->getRootCategoryId();
                 if (!in_array($rootId, $category->getPathIds())) {
                     // load root category instead wrong one
                     if ($getRootInstead) {
@@ -71,10 +111,9 @@ abstract class Category extends \Magento\Backend\App\Action
             }
         }
 
-        $this->_objectManager->get(\Magento\Framework\Registry::class)->register('category', $category);
-        $this->_objectManager->get(\Magento\Framework\Registry::class)->register('current_category', $category);
-        $this->_objectManager->get(\Magento\Cms\Model\Wysiwyg\Config::class)
-            ->setStoreId($storeId);
+        $this->registry->register('category', $category);
+        $this->registry->register('current_category', $category);
+        $this->wysiwigConfig->setStoreId($storeId);
         return $category;
     }
 
@@ -91,9 +130,8 @@ abstract class Category extends \Magento\Backend\App\Action
     }
 
     /**
-     * Resolve store id
+     * Resolve store Id, tries to take store id from store HTTP parameter
      *
-     * Tries to take store id from store HTTP parameter
      * @see Store
      *
      * @return int
@@ -121,11 +159,7 @@ abstract class Category extends \Magento\Backend\App\Action
         $breadcrumbsPath = $category->getPath();
         if (empty($breadcrumbsPath)) {
             // but if no category, and it is deleted - prepare breadcrumbs from path, saved in session
-            $breadcrumbsPath = $this->_objectManager->get(
-                \Magento\Backend\Model\Auth\Session::class
-            )->getDeletedPath(
-                true
-            );
+            $breadcrumbsPath = $this->authSession->getDeletedPath(true);
             if (!empty($breadcrumbsPath)) {
                 $breadcrumbsPath = explode('/', $breadcrumbsPath);
                 // no need to get parent breadcrumbs if deleting category level 1
@@ -138,19 +172,21 @@ abstract class Category extends \Magento\Backend\App\Action
             }
         }
 
-        $eventResponse = new \Magento\Framework\DataObject([
-            'content' => $resultPage->getLayout()->getUiComponent('category_form')->getFormHtml()
-                . $resultPage->getLayout()->getBlock('category.tree')
-                    ->getBreadcrumbsJavascript($breadcrumbsPath, 'editingCategoryBreadcrumbs'),
-            'messages' => $resultPage->getLayout()->getMessagesBlock()->getGroupedHtml(),
-            'toolbar' => $resultPage->getLayout()->getBlock('page.actions.toolbar')->toHtml()
-        ]);
+        $eventResponse = new \Magento\Framework\DataObject(
+            [
+                'content' => $resultPage->getLayout()->getUiComponent('category_form')->getFormHtml()
+                    . $resultPage->getLayout()->getBlock('category.tree')
+                        ->getBreadcrumbsJavascript($breadcrumbsPath, 'editingCategoryBreadcrumbs'),
+                'messages' => $resultPage->getLayout()->getMessagesBlock()->getGroupedHtml(),
+                'toolbar' => $resultPage->getLayout()->getBlock('page.actions.toolbar')->toHtml()
+            ]
+        );
         $this->_eventManager->dispatch(
             'category_prepare_ajax_response',
             ['response' => $eventResponse, 'controller' => $this]
         );
         /** @var \Magento\Framework\Controller\Result\Json $resultJson */
-        $resultJson = $this->_objectManager->get(\Magento\Framework\Controller\Result\Json::class);
+        $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         $resultJson->setHeader('Content-type', 'application/json', true);
         $resultJson->setData($eventResponse->getData());
         return $resultJson;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category/CategoriesJson.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category/CategoriesJson.php
@@ -1,13 +1,16 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Catalog\Controller\Adminhtml\Category;
 
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
+use Magento\Framework\App\ObjectManager;
 
+/**
+ * Class CategoriesJson
+ */
 class CategoriesJson extends \Magento\Catalog\Controller\Adminhtml\Category implements HttpPostActionInterface
 {
     /**
@@ -21,18 +24,27 @@ class CategoriesJson extends \Magento\Catalog\Controller\Adminhtml\Category impl
     protected $layoutFactory;
 
     /**
+     * @var \Magento\Backend\Model\Auth\Session
+     */
+    private $authSession;
+
+    /**
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory
      * @param \Magento\Framework\View\LayoutFactory $layoutFactory
+     * @param \Magento\Backend\Model\Auth\Session $authSession
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
         \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory,
-        \Magento\Framework\View\LayoutFactory $layoutFactory
+        \Magento\Framework\View\LayoutFactory $layoutFactory,
+        \Magento\Backend\Model\Auth\Session $authSession = null
     ) {
         parent::__construct($context);
         $this->resultJsonFactory = $resultJsonFactory;
         $this->layoutFactory = $layoutFactory;
+        $this->authSession = $authSession ?: ObjectManager::getInstance()
+            ->get(\Magento\Backend\Model\Auth\Session::class);
     }
 
     /**
@@ -43,9 +55,9 @@ class CategoriesJson extends \Magento\Catalog\Controller\Adminhtml\Category impl
     public function execute()
     {
         if ($this->getRequest()->getParam('expand_all')) {
-            $this->_objectManager->get(\Magento\Backend\Model\Auth\Session::class)->setIsTreeWasExpanded(true);
+            $this->authSession->setIsTreeWasExpanded(true);
         } else {
-            $this->_objectManager->get(\Magento\Backend\Model\Auth\Session::class)->setIsTreeWasExpanded(false);
+            $this->authSession->setIsTreeWasExpanded(false);
         }
         $categoryId = (int)$this->getRequest()->getPost('id');
         if ($categoryId) {

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category/Edit.php
@@ -1,13 +1,16 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Catalog\Controller\Adminhtml\Category;
 
 use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+use Magento\Framework\App\ObjectManager;
 
+/**
+ * Class Edit
+ */
 class Edit extends \Magento\Catalog\Controller\Adminhtml\Category implements HttpGetActionInterface
 {
     /**
@@ -27,18 +30,23 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Category implements Htt
 
     /**
      * Edit constructor.
+     *
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory
      * @param \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
         \Magento\Framework\View\Result\PageFactory $resultPageFactory,
-        \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory
+        \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory,
+        \Magento\Store\Model\StoreManagerInterface $storeManager = null
     ) {
         parent::__construct($context);
         $this->resultPageFactory = $resultPageFactory;
         $this->resultJsonFactory = $resultJsonFactory;
+        $this->storeManager = $storeManager ?: ObjectManager::getInstance()
+            ->get(\Magento\Store\Model\StoreManagerInterface::class);
     }
 
     /**
@@ -51,20 +59,20 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Category implements Htt
     public function execute()
     {
         $storeId = (int)$this->getRequest()->getParam('store');
-        $store = $this->getStoreManager()->getStore($storeId);
-        $this->getStoreManager()->setCurrentStore($store->getCode());
+        $store = $this->storeManager->getStore($storeId);
+        $this->storeManager->setCurrentStore($store->getCode());
 
         $categoryId = (int)$this->getRequest()->getParam('id');
 
         if (!$categoryId) {
             if ($storeId) {
-                $categoryId = (int)$this->getStoreManager()->getStore($storeId)->getRootCategoryId();
+                $categoryId = (int)$this->storeManager->getStore($storeId)->getRootCategoryId();
             } else {
-                $defaultStoreView = $this->getStoreManager()->getDefaultStoreView();
+                $defaultStoreView = $this->storeManager->getDefaultStoreView();
                 if ($defaultStoreView) {
                     $categoryId = (int)$defaultStoreView->getRootCategoryId();
                 } else {
-                    $stores = $this->getStoreManager()->getStores();
+                    $stores = $this->storeManager->getStores();
                     if (count($stores)) {
                         $store = reset($stores);
                         $categoryId = (int)$store->getRootCategoryId();
@@ -108,17 +116,5 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Category implements Htt
         $resultPage->addBreadcrumb(__('Manage Catalog Categories'), __('Manage Categories'));
 
         return $resultPage;
-    }
-
-    /**
-     * @return \Magento\Store\Model\StoreManagerInterface
-     */
-    private function getStoreManager()
-    {
-        if (null === $this->storeManager) {
-            $this->storeManager = \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(\Magento\Store\Model\StoreManagerInterface::class);
-        }
-        return $this->storeManager;
     }
 }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category/Save.php
@@ -8,6 +8,7 @@ namespace Magento\Catalog\Controller\Adminhtml\Category;
 
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
 use Magento\Catalog\Api\Data\CategoryAttributeInterface;
+use Magento\Framework\App\ObjectManager;
 use Magento\Store\Model\StoreManagerInterface;
 
 /**
@@ -57,6 +58,11 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Category implements Htt
     private $eavConfig;
 
     /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
      * Constructor
      *
      * @param \Magento\Backend\App\Action\Context $context
@@ -66,6 +72,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Category implements Htt
      * @param \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter
      * @param StoreManagerInterface $storeManager
      * @param \Magento\Eav\Model\Config $eavConfig
+     * @param \Psr\Log\LoggerInterface $logger
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
@@ -74,15 +81,18 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Category implements Htt
         \Magento\Framework\View\LayoutFactory $layoutFactory,
         \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter,
         StoreManagerInterface $storeManager,
-        \Magento\Eav\Model\Config $eavConfig = null
+        \Magento\Eav\Model\Config $eavConfig = null,
+        \Psr\Log\LoggerInterface $logger = null
     ) {
         parent::__construct($context, $dateFilter);
         $this->resultRawFactory = $resultRawFactory;
         $this->resultJsonFactory = $resultJsonFactory;
         $this->layoutFactory = $layoutFactory;
         $this->storeManager = $storeManager;
-        $this->eavConfig = $eavConfig
-            ?: \Magento\Framework\App\ObjectManager::getInstance()->get(\Magento\Eav\Model\Config::class);
+        $this->eavConfig = $eavConfig ?: ObjectManager::getInstance()
+            ->get(\Magento\Eav\Model\Config::class);
+        $this->logger = $logger ?: ObjectManager::getInstance()
+            ->get(\Psr\Log\LoggerInterface::class);
     }
 
     /**
@@ -210,7 +220,9 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Category implements Htt
                                 __('The "%1" attribute is required. Enter and try again.', $attribute)
                             );
                         } else {
-                            throw new \Exception($error);
+                            $this->messageManager->addErrorMessage(__('Something went wrong while saving the category.'));
+                            $this->logger->critical('Something went wrong while saving the category.');
+                            $this->_getSession()->setCategoryData($categoryPostData);
                         }
                     }
                 }
@@ -221,11 +233,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Category implements Htt
                 $this->messageManager->addSuccessMessage(__('You saved the category.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
                 $this->messageManager->addExceptionMessage($e);
-                $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
-                $this->_getSession()->setCategoryData($categoryPostData);
-            } catch (\Exception $e) {
-                $this->messageManager->addErrorMessage(__('Something went wrong while saving the category.'));
-                $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
+                $this->logger->critical($e);
                 $this->_getSession()->setCategoryData($categoryPostData);
             }
         }
@@ -332,11 +340,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Category implements Htt
     {
         if (!$parentId) {
             if ($storeId) {
-                $parentId = $this->_objectManager->get(
-                    \Magento\Store\Model\StoreManagerInterface::class
-                )->getStore(
-                    $storeId
-                )->getRootCategoryId();
+                $parentId = $this->storeManager->getStore($storeId)->getRootCategoryId();
             } else {
                 $parentId = \Magento\Catalog\Model\Category::TREE_ROOT_ID;
             }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Save.php
@@ -7,8 +7,10 @@
 namespace Magento\Catalog\Controller\Adminhtml\Product\Action\Attribute;
 
 use Magento\AsynchronousOperations\Api\Data\OperationInterface;
+use Magento\Eav\Model\Config;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Backend\App\Action;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 
 /**
@@ -48,6 +50,16 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
     private $bulkSize;
 
     /**
+     * @var TimezoneInterface
+     */
+    private $timezone;
+
+    /**
+     * @var Config
+     */
+    private $eavConfig;
+
+    /**
      * @param Action\Context $context
      * @param \Magento\Catalog\Helper\Product\Edit\Action\Attribute $attributeHelper
      * @param \Magento\Framework\Bulk\BulkManagementInterface $bulkManagement
@@ -56,6 +68,9 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
      * @param \Magento\Framework\Serialize\SerializerInterface $serializer
      * @param \Magento\Authorization\Model\UserContextInterface $userContext
      * @param int $bulkSize
+     * @param TimezoneInterface $timezone
+     * @param Config $eavConfig
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
         Action\Context $context,
@@ -65,7 +80,9 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
         \Magento\Framework\DataObject\IdentityGeneratorInterface $identityService,
         \Magento\Framework\Serialize\SerializerInterface $serializer,
         \Magento\Authorization\Model\UserContextInterface $userContext,
-        int $bulkSize = 100
+        int $bulkSize = 100,
+        TimezoneInterface $timezone = null,
+        Config $eavConfig = null
     ) {
         parent::__construct($context, $attributeHelper);
         $this->bulkManagement = $bulkManagement;
@@ -74,6 +91,10 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
         $this->serializer = $serializer;
         $this->userContext = $userContext;
         $this->bulkSize = $bulkSize;
+        $this->timezone = $timezone ?: ObjectManager::getInstance()
+            ->get(TimezoneInterface::class);
+        $this->eavConfig = $eavConfig ?: ObjectManager::getInstance()
+            ->get(Config::class);
     }
 
     /**
@@ -122,11 +143,10 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product\Action\Attribut
      */
     private function sanitizeProductAttributes($attributesData)
     {
-        $dateFormat = $this->_objectManager->get(TimezoneInterface::class)->getDateFormat(\IntlDateFormatter::SHORT);
-        $config = $this->_objectManager->get(\Magento\Eav\Model\Config::class);
+        $dateFormat = $this->timezone->getDateFormat(\IntlDateFormatter::SHORT);
 
         foreach ($attributesData as $attributeCode => $value) {
-            $attribute = $config->getAttribute(\Magento\Catalog\Model\Product::ENTITY, $attributeCode);
+            $attribute = $this->eavConfig->getAttribute(\Magento\Catalog\Model\Product::ENTITY, $attributeCode);
             if (!$attribute->getAttributeId()) {
                 unset($attributesData[$attributeCode]);
                 continue;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Action/Attribute/Validate.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -9,7 +8,11 @@ namespace Magento\Catalog\Controller\Adminhtml\Product\Action\Attribute;
 use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
 use Magento\Catalog\Controller\Adminhtml\Product\Action\Attribute as AttributeAction;
+use Magento\Framework\App\ObjectManager;
 
+/**
+ * Class Validate
+ */
 class Validate extends AttributeAction implements HttpGetActionInterface, HttpPostActionInterface
 {
     /**
@@ -23,20 +26,29 @@ class Validate extends AttributeAction implements HttpGetActionInterface, HttpPo
     protected $layoutFactory;
 
     /**
+     * @var \Magento\Eav\Model\Config
+     */
+    private $eavConfig;
+
+    /**
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Catalog\Helper\Product\Edit\Action\Attribute $attributeHelper
      * @param \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory
      * @param \Magento\Framework\View\LayoutFactory $layoutFactory
+     * @param \Magento\Eav\Model\Config $eavConfig
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
         \Magento\Catalog\Helper\Product\Edit\Action\Attribute $attributeHelper,
         \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory,
-        \Magento\Framework\View\LayoutFactory $layoutFactory
+        \Magento\Framework\View\LayoutFactory $layoutFactory,
+        \Magento\Eav\Model\Config $eavConfig = null
     ) {
         parent::__construct($context, $attributeHelper);
         $this->resultJsonFactory = $resultJsonFactory;
         $this->layoutFactory = $layoutFactory;
+        $this->eavConfig = $eavConfig ?: ObjectManager::getInstance()
+            ->get(\Magento\Eav\Model\Config::class);
     }
 
     /**
@@ -54,8 +66,7 @@ class Validate extends AttributeAction implements HttpGetActionInterface, HttpPo
         try {
             if ($attributesData) {
                 foreach ($attributesData as $attributeCode => $value) {
-                    $attribute = $this->_objectManager->get(\Magento\Eav\Model\Config::class)
-                        ->getAttribute('catalog_product', $attributeCode);
+                    $attribute = $this->eavConfig->getAttribute('catalog_product', $attributeCode);
                     if (!$attribute->getAttributeId()) {
                         unset($attributesData[$attributeCode]);
                         continue;

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/AddAttributeToTemplate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/AddAttributeToTemplate.php
@@ -17,16 +17,16 @@ use Magento\Eav\Api\Data\AttributeGroupInterface;
 use Magento\Eav\Api\Data\AttributeGroupInterfaceFactory;
 use Magento\Eav\Api\Data\AttributeInterface;
 use Magento\Eav\Api\Data\AttributeSetInterface;
+use Magento\Framework\Api\ExtensionAttributesFactory;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\DataObject;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\App\ObjectManager;
-use Psr\Log\LoggerInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Framework\Api\ExtensionAttributesFactory;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class AddAttributeToTemplate
@@ -86,20 +86,49 @@ class AddAttributeToTemplate extends Product implements HttpPostActionInterface
      * @param Context $context
      * @param Builder $productBuilder
      * @param JsonFactory $resultJsonFactory
-     * @param AttributeGroupInterfaceFactory|null $attributeGroupFactory
+     * @param AttributeGroupInterfaceFactory $attributeGroupFactory
+     * @param AttributeRepositoryInterface $attributeRepository
+     * @param AttributeSetRepositoryInterface $attributeSetRepository
+     * @param AttributeGroupRepositoryInterface $attributeGroupRepository
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     * @param AttributeManagementInterface $attributeManagement
+     * @param LoggerInterface $logger
+     * @param ExtensionAttributesFactory $extensionAttributesFactory
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      * @SuppressWarnings(PHPMD.LongVariable)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
      */
     public function __construct(
         Context $context,
         Builder $productBuilder,
         JsonFactory $resultJsonFactory,
-        AttributeGroupInterfaceFactory $attributeGroupFactory = null
+        AttributeGroupInterfaceFactory $attributeGroupFactory = null,
+        AttributeRepositoryInterface $attributeRepository = null,
+        AttributeSetRepositoryInterface $attributeSetRepository = null,
+        AttributeGroupRepositoryInterface $attributeGroupRepository = null,
+        SearchCriteriaBuilder $searchCriteriaBuilder = null,
+        AttributeManagementInterface $attributeManagement = null,
+        LoggerInterface $logger = null,
+        ExtensionAttributesFactory $extensionAttributesFactory = null
     ) {
         parent::__construct($context, $productBuilder);
         $this->resultJsonFactory = $resultJsonFactory;
         $this->attributeGroupFactory = $attributeGroupFactory ?: ObjectManager::getInstance()
             ->get(AttributeGroupInterfaceFactory::class);
+        $this->attributeRepository = $attributeRepository ?: ObjectManager::getInstance()
+            ->get(AttributeRepositoryInterface::class);
+        $this->attributeSetRepository = $attributeSetRepository ?: ObjectManager::getInstance()
+            ->get(AttributeSetRepositoryInterface::class);
+        $this->attributeGroupRepository = $attributeGroupRepository ?: ObjectManager::getInstance()
+            ->get(AttributeGroupRepositoryInterface::class);
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder ?: ObjectManager::getInstance()
+            ->get(SearchCriteriaBuilder::class);
+        $this->attributeManagement = $attributeManagement ?: ObjectManager::getInstance()
+            ->get(AttributeManagementInterface::class);
+        $this->logger = $logger ?: ObjectManager::getInstance()
+            ->get(LoggerInterface::class);
+        $this->extensionAttributesFactory = $extensionAttributesFactory ?: ObjectManager::getInstance()
+            ->get(ExtensionAttributesFactory::class);
     }
 
     /**
@@ -115,13 +144,13 @@ class AddAttributeToTemplate extends Product implements HttpPostActionInterface
 
         try {
             /** @var AttributeSetInterface $attributeSet */
-            $attributeSet = $this->getAttributeSetRepository()->get($request->getParam('templateId'));
+            $attributeSet = $this->attributeSetRepository->get($request->getParam('templateId'));
             $groupCode = $request->getParam('groupCode');
             $groupName = $request->getParam('groupName');
             $groupSortOrder = $request->getParam('groupSortOrder');
 
             $attributeSearchCriteria = $this->getBasicAttributeSearchCriteriaBuilder()->create();
-            $attributeGroupSearchCriteria = $this->getSearchCriteriaBuilder()
+            $attributeGroupSearchCriteria = $this->searchCriteriaBuilder
                 ->addFilter('attribute_set_id', $attributeSet->getAttributeSetId())
                 ->addFilter('attribute_group_code', $groupCode)
                 ->setPageSize(1)
@@ -129,22 +158,24 @@ class AddAttributeToTemplate extends Product implements HttpPostActionInterface
 
             try {
                 /** @var AttributeGroupInterface[] $attributeGroupItems */
-                $attributeGroupItems = $this->getAttributeGroupRepository()->getList($attributeGroupSearchCriteria)
+                $attributeGroupItems = $this->attributeGroupRepository
+                    ->getList($attributeGroupSearchCriteria)
                     ->getItems();
 
-                if (!$attributeGroupItems) {
-                    throw new NoSuchEntityException;
+                if ($attributeGroupItems) {
+                    /** @var AttributeGroupInterface $attributeGroup */
+                    $attributeGroup = reset($attributeGroupItems);
+                } else {
+                    /** @var AttributeGroupInterface $attributeGroup */
+                    $attributeGroup = $this->attributeGroupFactory->create();
                 }
-
-                /** @var AttributeGroupInterface $attributeGroup */
-                $attributeGroup = reset($attributeGroupItems);
             } catch (NoSuchEntityException $e) {
                 /** @var AttributeGroupInterface $attributeGroup */
                 $attributeGroup = $this->attributeGroupFactory->create();
             }
 
             $extensionAttributes = $attributeGroup->getExtensionAttributes()
-                ?: $this->getExtensionAttributesFactory()->create(AttributeGroupInterface::class);
+                ?: $this->extensionAttributesFactory->create(AttributeGroupInterface::class);
 
             $extensionAttributes->setAttributeGroupCode($groupCode);
             $extensionAttributes->setSortOrder($groupSortOrder);
@@ -152,28 +183,31 @@ class AddAttributeToTemplate extends Product implements HttpPostActionInterface
             $attributeGroup->setAttributeSetId($attributeSet->getAttributeSetId());
             $attributeGroup->setExtensionAttributes($extensionAttributes);
 
-            $this->getAttributeGroupRepository()->save($attributeGroup);
+            $this->attributeGroupRepository->save($attributeGroup);
 
             /** @var AttributeInterface[] $attributesItems */
-            $attributesItems = $this->getAttributeRepository()->getList(
+            $attributesItems = $this->attributeRepository->getList(
                 ProductAttributeInterface::ENTITY_TYPE_CODE,
                 $attributeSearchCriteria
             )->getItems();
 
-            array_walk($attributesItems, function (AttributeInterface $attribute) use ($attributeSet, $attributeGroup) {
-                $this->getAttributeManagement()->assign(
-                    ProductAttributeInterface::ENTITY_TYPE_CODE,
-                    $attributeSet->getAttributeSetId(),
-                    $attributeGroup->getAttributeGroupId(),
-                    $attribute->getAttributeCode(),
-                    '0'
-                );
-            });
+            array_walk(
+                $attributesItems,
+                function (AttributeInterface $attribute) use ($attributeSet, $attributeGroup) {
+                    $this->attributeManagement->assign(
+                        ProductAttributeInterface::ENTITY_TYPE_CODE,
+                        $attributeSet->getAttributeSetId(),
+                        $attributeGroup->getAttributeGroupId(),
+                        $attribute->getAttributeCode(),
+                        '0'
+                    );
+                }
+            );
         } catch (LocalizedException $e) {
             $response->setError(true);
             $response->setMessage($e->getMessage());
         } catch (\Exception $e) {
-            $this->getLogger()->critical($e);
+            $this->logger->critical($e);
             $response->setError(true);
             $response->setMessage(__('Unable to add attribute'));
         }
@@ -195,105 +229,10 @@ class AddAttributeToTemplate extends Product implements HttpPostActionInterface
             throw new LocalizedException(__('Attributes were missing and must be specified.'));
         }
 
-        return $this->getSearchCriteriaBuilder()
-            ->addFilter('attribute_id', [$attributeIds['selected']], 'in');
-    }
-
-    /**
-     * Get AttributeRepositoryInterface
-     *
-     * @return AttributeRepositoryInterface
-     */
-    private function getAttributeRepository()
-    {
-        if (null === $this->attributeRepository) {
-            $this->attributeRepository = ObjectManager::getInstance()
-                ->get(AttributeRepositoryInterface::class);
-        }
-        return $this->attributeRepository;
-    }
-
-    /**
-     * Get AttributeSetRepositoryInterface
-     *
-     * @return AttributeSetRepositoryInterface
-     */
-    private function getAttributeSetRepository()
-    {
-        if (null === $this->attributeSetRepository) {
-            $this->attributeSetRepository = ObjectManager::getInstance()
-                ->get(AttributeSetRepositoryInterface::class);
-        }
-        return $this->attributeSetRepository;
-    }
-
-    /**
-     * Get AttributeGroupInterface
-     *
-     * @return AttributeGroupRepositoryInterface
-     */
-    private function getAttributeGroupRepository()
-    {
-        if (null === $this->attributeGroupRepository) {
-            $this->attributeGroupRepository = ObjectManager::getInstance()
-                ->get(AttributeGroupRepositoryInterface::class);
-        }
-        return $this->attributeGroupRepository;
-    }
-
-    /**
-     * Get SearchCriteriaBuilder
-     *
-     * @return SearchCriteriaBuilder
-     */
-    private function getSearchCriteriaBuilder()
-    {
-        if (null === $this->searchCriteriaBuilder) {
-            $this->searchCriteriaBuilder = ObjectManager::getInstance()
-                ->get(SearchCriteriaBuilder::class);
-        }
-        return $this->searchCriteriaBuilder;
-    }
-
-    /**
-     * Get AttributeManagementInterface
-     *
-     * @return AttributeManagementInterface
-     */
-    private function getAttributeManagement()
-    {
-        if (null === $this->attributeManagement) {
-            $this->attributeManagement = ObjectManager::getInstance()
-                ->get(AttributeManagementInterface::class);
-        }
-        return $this->attributeManagement;
-    }
-
-    /**
-     * Get LoggerInterface
-     *
-     * @return LoggerInterface
-     */
-    private function getLogger()
-    {
-        if (null === $this->logger) {
-            $this->logger = ObjectManager::getInstance()
-                ->get(LoggerInterface::class);
-        }
-        return $this->logger;
-    }
-
-    /**
-     * Get ExtensionAttributesFactory.
-     *
-     * @return ExtensionAttributesFactory
-     */
-    private function getExtensionAttributesFactory()
-    {
-        if (null === $this->extensionAttributesFactory) {
-            $this->extensionAttributesFactory = ObjectManager::getInstance()
-                ->get(ExtensionAttributesFactory::class);
-        }
-        return $this->extensionAttributesFactory;
+        return $this->searchCriteriaBuilder->addFilter(
+            'attribute_id',
+            [$attributeIds['selected']],
+            'in'
+        );
     }
 }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Duplicate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Duplicate.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -8,8 +7,13 @@ namespace Magento\Catalog\Controller\Adminhtml\Product;
 
 use Magento\Backend\App\Action;
 use Magento\Catalog\Controller\Adminhtml\Product;
+use Magento\Framework\App\ObjectManager;
 
-class Duplicate extends \Magento\Catalog\Controller\Adminhtml\Product
+/**
+ * Class Duplicate
+ */
+class Duplicate extends \Magento\Catalog\Controller\Adminhtml\Product implements
+    \Magento\Framework\App\Action\HttpGetActionInterface
 {
     /**
      * @var \Magento\Catalog\Model\Product\Copier
@@ -17,16 +21,25 @@ class Duplicate extends \Magento\Catalog\Controller\Adminhtml\Product
     protected $productCopier;
 
     /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param Action\Context $context
      * @param Builder $productBuilder
      * @param \Magento\Catalog\Model\Product\Copier $productCopier
+     * @param \Psr\Log\LoggerInterface $logger
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
         Product\Builder $productBuilder,
-        \Magento\Catalog\Model\Product\Copier $productCopier
+        \Magento\Catalog\Model\Product\Copier $productCopier,
+        \Psr\Log\LoggerInterface $logger = null
     ) {
         $this->productCopier = $productCopier;
+        $this->logger = $logger ?: ObjectManager::getInstance()
+            ->get(\Psr\Log\LoggerInterface::class);
         parent::__construct($context, $productBuilder);
     }
 
@@ -46,7 +59,7 @@ class Duplicate extends \Magento\Catalog\Controller\Adminhtml\Product
             $this->messageManager->addSuccessMessage(__('You duplicated the product.'));
             $resultRedirect->setPath('catalog/*/edit', ['_current' => true, 'id' => $newProduct->getId()]);
         } catch (\Exception $e) {
-            $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
+            $this->logger->critical($e);
             $this->messageManager->addErrorMessage($e->getMessage());
             $resultRedirect->setPath('catalog/*/edit', ['_current' => true]);
         }

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Edit.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -8,6 +7,7 @@
 namespace Magento\Catalog\Controller\Adminhtml\Product;
 
 use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+use Magento\Framework\App\ObjectManager;
 
 /**
  *  Edit product
@@ -27,17 +27,26 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
     protected $resultPageFactory;
 
     /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Catalog\Controller\Adminhtml\Product\Builder $productBuilder
      * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
         \Magento\Catalog\Controller\Adminhtml\Product\Builder $productBuilder,
-        \Magento\Framework\View\Result\PageFactory $resultPageFactory
+        \Magento\Framework\View\Result\PageFactory $resultPageFactory,
+        \Magento\Store\Model\StoreManagerInterface $storeManager = null
     ) {
         parent::__construct($context, $productBuilder);
         $this->resultPageFactory = $resultPageFactory;
+        $this->storeManager = $storeManager ?: ObjectManager::getInstance()
+            ->get(\Magento\Store\Model\StoreManagerInterface::class);
     }
 
     /**
@@ -47,11 +56,9 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
      */
     public function execute()
     {
-        /** @var \Magento\Store\Model\StoreManagerInterface $storeManager */
-        $storeManager = $this->_objectManager->get(\Magento\Store\Model\StoreManagerInterface::class);
         $storeId = (int) $this->getRequest()->getParam('store', 0);
-        $store = $storeManager->getStore($storeId);
-        $storeManager->setCurrentStore($store->getCode());
+        $store = $this->storeManager->getStore($storeId);
+        $this->storeManager->setCurrentStore($store->getCode());
         $productId = (int) $this->getRequest()->getParam('id');
         $product = $this->productBuilder->build($this->getRequest());
 
@@ -76,9 +83,8 @@ class Edit extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
         $resultPage->getConfig()->getTitle()->prepend(__('Products'));
         $resultPage->getConfig()->getTitle()->prepend($product->getName());
 
-        if (!$this->_objectManager->get(\Magento\Store\Model\StoreManagerInterface::class)->isSingleStoreMode()
-            &&
-            ($switchBlock = $resultPage->getLayout()->getBlock('store_switcher'))
+        if (!$this->storeManager->isSingleStoreMode()
+            && ($switchBlock = $resultPage->getLayout()->getBlock('store_switcher'))
         ) {
             $switchBlock->setDefaultStoreName(__('Default Values'))
                 ->setWebsiteIds($product->getWebsiteIds())

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Gallery/Upload.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Gallery/Upload.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -8,7 +7,11 @@ namespace Magento\Catalog\Controller\Adminhtml\Product\Gallery;
 
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ObjectManager;
 
+/**
+ * Class Upload
+ */
 class Upload extends \Magento\Backend\App\Action implements HttpPostActionInterface
 {
     /**
@@ -24,18 +27,47 @@ class Upload extends \Magento\Backend\App\Action implements HttpPostActionInterf
     protected $resultRawFactory;
 
     /**
+     * @var \Magento\Framework\Image\AdapterFactory
+     */
+    private $adapterFactory;
+
+    /**
+     * @var \Magento\Framework\Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var \Magento\Catalog\Model\Product\Media\Config
+     */
+    private $productMediaConfig;
+
+    /**
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Framework\Controller\Result\RawFactory $resultRawFactory
+     * @param \Magento\Framework\Image\AdapterFactory $adapterFactory
+     * @param \Magento\Framework\Filesystem $filesystem
+     * @param \Magento\Catalog\Model\Product\Media\Config $productMediaConfig
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
-        \Magento\Framework\Controller\Result\RawFactory $resultRawFactory
+        \Magento\Framework\Controller\Result\RawFactory $resultRawFactory,
+        \Magento\Framework\Image\AdapterFactory $adapterFactory = null,
+        \Magento\Framework\Filesystem $filesystem = null,
+        \Magento\Catalog\Model\Product\Media\Config $productMediaConfig = null
     ) {
         parent::__construct($context);
         $this->resultRawFactory = $resultRawFactory;
+        $this->adapterFactory = $adapterFactory ?: ObjectManager::getInstance()
+            ->get(\Magento\Framework\Image\AdapterFactory::class);
+        $this->filesystem = $filesystem ?: ObjectManager::getInstance()
+            ->get(\Magento\Framework\Filesystem::class);
+        $this->productMediaConfig = $productMediaConfig ?: ObjectManager::getInstance()
+            ->get(\Magento\Catalog\Model\Product\Media\Config::class);
     }
 
     /**
+     * Image upload in product gallery
+     *
      * @return \Magento\Framework\Controller\Result\Raw
      */
     public function execute()
@@ -46,16 +78,14 @@ class Upload extends \Magento\Backend\App\Action implements HttpPostActionInterf
                 ['fileId' => 'image']
             );
             $uploader->setAllowedExtensions(['jpg', 'jpeg', 'gif', 'png']);
-            /** @var \Magento\Framework\Image\Adapter\AdapterInterface $imageAdapter */
-            $imageAdapter = $this->_objectManager->get(\Magento\Framework\Image\AdapterFactory::class)->create();
+            $imageAdapter = $this->adapterFactory->create();
             $uploader->addValidateCallback('catalog_product_image', $imageAdapter, 'validateUploadFile');
             $uploader->setAllowRenameFiles(true);
             $uploader->setFilesDispersion(true);
-            /** @var \Magento\Framework\Filesystem\Directory\Read $mediaDirectory */
-            $mediaDirectory = $this->_objectManager->get(\Magento\Framework\Filesystem::class)
-                ->getDirectoryRead(DirectoryList::MEDIA);
-            $config = $this->_objectManager->get(\Magento\Catalog\Model\Product\Media\Config::class);
-            $result = $uploader->save($mediaDirectory->getAbsolutePath($config->getBaseTmpMediaPath()));
+            $mediaDirectory = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA);
+            $result = $uploader->save(
+                $mediaDirectory->getAbsolutePath($this->productMediaConfig->getBaseTmpMediaPath())
+            );
 
             $this->_eventManager->dispatch(
                 'catalog_product_gallery_upload_image_after',
@@ -65,8 +95,7 @@ class Upload extends \Magento\Backend\App\Action implements HttpPostActionInterf
             unset($result['tmp_name']);
             unset($result['path']);
 
-            $result['url'] = $this->_objectManager->get(\Magento\Catalog\Model\Product\Media\Config::class)
-                ->getTmpMediaUrl($result['file']);
+            $result['url'] = $this->productMediaConfig->getTmpMediaUrl($result['file']);
             $result['file'] = $result['file'] . '.tmp';
         } catch (\Exception $e) {
             $result = ['error' => $e->getMessage(), 'errorcode' => $e->getCode()];

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassStatus.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/MassStatus.php
@@ -7,8 +7,8 @@
 namespace Magento\Catalog\Controller\Adminhtml\Product;
 
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
-use Magento\Backend\App\Action;
 use Magento\Catalog\Controller\Adminhtml\Product;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Ui\Component\MassAction\Filter;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
@@ -37,22 +37,31 @@ class MassStatus extends \Magento\Catalog\Controller\Adminhtml\Product implement
     protected $collectionFactory;
 
     /**
-     * @param Action\Context $context
+     * @var \Magento\Catalog\Model\Product\Action
+     */
+    private $productAction;
+
+    /**
+     * @param \Magento\Backend\App\Action\Context $context
      * @param Builder $productBuilder
      * @param \Magento\Catalog\Model\Indexer\Product\Price\Processor $productPriceIndexerProcessor
      * @param Filter $filter
      * @param CollectionFactory $collectionFactory
+     * @param \Magento\Catalog\Model\Product\Action $productAction
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
         Product\Builder $productBuilder,
         \Magento\Catalog\Model\Indexer\Product\Price\Processor $productPriceIndexerProcessor,
         Filter $filter,
-        CollectionFactory $collectionFactory
+        CollectionFactory $collectionFactory,
+        \Magento\Catalog\Model\Product\Action $productAction = null
     ) {
         $this->filter = $filter;
         $this->collectionFactory = $collectionFactory;
         $this->_productPriceIndexerProcessor = $productPriceIndexerProcessor;
+        $this->productAction = $productAction ?: ObjectManager::getInstance()
+            ->get(\Magento\Catalog\Model\Product\Action::class);
         parent::__construct($context, $productBuilder);
     }
 
@@ -94,8 +103,7 @@ class MassStatus extends \Magento\Catalog\Controller\Adminhtml\Product implement
 
         try {
             $this->_validateMassStatus($productIds, $status);
-            $this->_objectManager->get(\Magento\Catalog\Model\Product\Action::class)
-                ->updateAttributes($productIds, ['status' => $status], (int) $storeId);
+            $this->productAction->updateAttributes($productIds, ['status' => $status], (int) $storeId);
             $this->messageManager->addSuccessMessage(
                 __('A total of %1 record(s) have been updated.', count($productIds))
             );

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -11,6 +10,7 @@ use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterf
 use Magento\Backend\App\Action;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Controller\Adminhtml\Product;
+use Magento\Framework\App\ObjectManager;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\App\Request\DataPersistorInterface;
 
@@ -56,12 +56,12 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
     private $storeManager;
 
     /**
-     * @var \Magento\Framework\Escaper|null
+     * @var \Magento\Framework\Escaper
      */
     private $escaper;
 
     /**
-     * @var null|\Psr\Log\LoggerInterface
+     * @var \Psr\Log\LoggerInterface
      */
     private $logger;
 
@@ -74,8 +74,11 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
      * @param \Magento\Catalog\Model\Product\Copier $productCopier
      * @param \Magento\Catalog\Model\Product\TypeTransitionManager $productTypeManager
      * @param \Magento\Catalog\Api\ProductRepositoryInterface $productRepository
-     * @param \Magento\Framework\Escaper|null $escaper
-     * @param \Psr\Log\LoggerInterface|null $logger
+     * @param \Magento\Framework\Escaper $escaper
+     * @param \Psr\Log\LoggerInterface $logger
+     * @param \Magento\Catalog\Api\CategoryLinkManagementInterface $categoryLinkManagement
+     * @param StoreManagerInterface $storeManager
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
@@ -85,15 +88,23 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
         \Magento\Catalog\Model\Product\TypeTransitionManager $productTypeManager,
         \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
         \Magento\Framework\Escaper $escaper = null,
-        \Psr\Log\LoggerInterface $logger = null
+        \Psr\Log\LoggerInterface $logger = null,
+        \Magento\Catalog\Api\CategoryLinkManagementInterface $categoryLinkManagement = null,
+        \Magento\Store\Model\StoreManagerInterface $storeManager = null
     ) {
+        parent::__construct($context, $productBuilder);
         $this->initializationHelper = $initializationHelper;
         $this->productCopier = $productCopier;
         $this->productTypeManager = $productTypeManager;
         $this->productRepository = $productRepository;
-        parent::__construct($context, $productBuilder);
-        $this->escaper = $escaper ?? $this->_objectManager->get(\Magento\Framework\Escaper::class);
-        $this->logger = $logger ?? $this->_objectManager->get(\Psr\Log\LoggerInterface::class);
+        $this->escaper = $escaper ?: ObjectManager::getInstance()
+            ->get(\Magento\Framework\Escaper::class);
+        $this->logger = $logger ?: ObjectManager::getInstance()
+            ->get(\Psr\Log\LoggerInterface::class);
+        $this->categoryLinkManagement = $categoryLinkManagement ?: ObjectManager::getInstance()
+            ->get(\Magento\Catalog\Api\CategoryLinkManagementInterface::class);
+        $this->storeManager = $storeManager ?: ObjectManager::getInstance()
+            ->get(\Magento\Store\Model\StoreManagerInterface::class);
     }
 
     /**
@@ -106,8 +117,8 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
     public function execute()
     {
         $storeId = $this->getRequest()->getParam('store', 0);
-        $store = $this->getStoreManager()->getStore($storeId);
-        $this->getStoreManager()->setCurrentStore($store->getCode());
+        $store = $this->storeManager->getStore($storeId);
+        $this->storeManager->setCurrentStore($store->getCode());
         $redirectBack = $this->getRequest()->getParam('back', false);
         $productId = $this->getRequest()->getParam('id');
         $resultRedirect = $this->resultRedirectFactory->create();
@@ -130,7 +141,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
                 $canSaveCustomOptions = $product->getCanSaveCustomOptions();
                 $product->save();
                 $this->handleImageRemoveError($data, $product->getId());
-                $this->getCategoryLinkManagement()->assignProductToCategories(
+                $this->categoryLinkManagement->assignProductToCategories(
                     $product->getSku(),
                     $product->getCategoryIds()
                 );
@@ -236,11 +247,9 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
     /**
      * Do copying data to stores
      *
-     * If the 'copy_from' field is not specified in the input data,
-     * the store fallback mechanism will automatically take the admin store's default value.
-     *
      * @param array $data
      * @param int $productId
+     *
      * @return void
      */
     protected function copyToStores($data, $productId)
@@ -250,19 +259,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
                 if (isset($data['product']['website_ids'][$websiteId])
                     && (bool)$data['product']['website_ids'][$websiteId]) {
                     foreach ($group as $store) {
-                        if (isset($store['copy_from'])) {
-                            $copyFrom = $store['copy_from'];
-                            $copyTo = (isset($store['copy_to'])) ? $store['copy_to'] : 0;
-                            if ($copyTo) {
-                                $this->_objectManager->create(\Magento\Catalog\Model\Product::class)
-                                    ->setStoreId($copyFrom)
-                                    ->load($productId)
-                                    ->setStoreId($copyTo)
-                                    ->setCanSaveCustomOptions($data['can_save_custom_options'])
-                                    ->setCopyFromView(true)
-                                    ->save();
-                            }
-                        }
+                        $this->copyToStore($data, $productId, $store);
                     }
                 }
             }
@@ -270,32 +267,30 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
     }
 
     /**
-     * Get categoryLinkManagement in a backward compatible way.
+     * Do copying data to stores
      *
-     * @return \Magento\Catalog\Api\CategoryLinkManagementInterface
-     */
-    private function getCategoryLinkManagement()
-    {
-        if (null === $this->categoryLinkManagement) {
-            $this->categoryLinkManagement = \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(\Magento\Catalog\Api\CategoryLinkManagementInterface::class);
-        }
-        return $this->categoryLinkManagement;
-    }
-
-    /**
-     * Get storeManager in a backward compatible way.
+     * If the 'copy_from' field is not specified in the input data,
+     * the store fallback mechanism will automatically take the admin store's default value.
      *
-     * @return StoreManagerInterface
-     * @deprecated 101.0.0
+     * @param array $data
+     * @param int $productId
+     * @param array $store
      */
-    private function getStoreManager()
+    private function copyToStore($data, $productId, $store)
     {
-        if (null === $this->storeManager) {
-            $this->storeManager = \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(\Magento\Store\Model\StoreManagerInterface::class);
+        if (isset($store['copy_from'])) {
+            $copyFrom = $store['copy_from'];
+            $copyTo = (isset($store['copy_to'])) ? $store['copy_to'] : 0;
+            if ($copyTo) {
+                $this->_objectManager->create(\Magento\Catalog\Model\Product::class)
+                    ->setStoreId($copyFrom)
+                    ->load($productId)
+                    ->setStoreId($copyTo)
+                    ->setCanSaveCustomOptions($data['can_save_custom_options'])
+                    ->setCopyFromView(true)
+                    ->save();
+            }
         }
-        return $this->storeManager;
     }
 
     /**

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Wysiwyg.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Wysiwyg.php
@@ -1,12 +1,17 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Catalog\Controller\Adminhtml\Product;
 
-class Wysiwyg extends \Magento\Catalog\Controller\Adminhtml\Product
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\ObjectManager;
+
+/**
+ * Class Wysiwyg
+ */
+class Wysiwyg extends \Magento\Catalog\Controller\Adminhtml\Product implements HttpPostActionInterface
 {
     /**
      * @var \Magento\Framework\Controller\Result\RawFactory
@@ -19,20 +24,29 @@ class Wysiwyg extends \Magento\Catalog\Controller\Adminhtml\Product
     protected $layoutFactory;
 
     /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * @param \Magento\Backend\App\Action\Context $context
      * @param \Magento\Catalog\Controller\Adminhtml\Product\Builder $productBuilder
      * @param \Magento\Framework\Controller\Result\RawFactory $resultRawFactory
      * @param \Magento\Framework\View\LayoutFactory $layoutFactory
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      */
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
         \Magento\Catalog\Controller\Adminhtml\Product\Builder $productBuilder,
         \Magento\Framework\Controller\Result\RawFactory $resultRawFactory,
-        \Magento\Framework\View\LayoutFactory $layoutFactory
+        \Magento\Framework\View\LayoutFactory $layoutFactory,
+        \Magento\Store\Model\StoreManagerInterface $storeManager = null
     ) {
         parent::__construct($context, $productBuilder);
         $this->resultRawFactory = $resultRawFactory;
         $this->layoutFactory = $layoutFactory;
+        $this->storeManager = $storeManager ?: ObjectManager::getInstance()
+            ->get(\Magento\Store\Model\StoreManagerInterface::class);
     }
 
     /**
@@ -42,10 +56,11 @@ class Wysiwyg extends \Magento\Catalog\Controller\Adminhtml\Product
      */
     public function execute()
     {
+        // @codingStandardsIgnoreStart
         $elementId = $this->getRequest()->getParam('element_id', md5(microtime()));
+        // @codingStandardsIgnoreEnd
         $storeId = $this->getRequest()->getParam('store_id', 0);
-        $storeMediaUrl = $this->_objectManager->get(\Magento\Store\Model\StoreManagerInterface::class)
-            ->getStore($storeId)
+        $storeMediaUrl = $this->storeManager->getStore($storeId)
             ->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA);
 
         $content = $this->layoutFactory->create()

--- a/app/code/Magento/Catalog/Controller/Product/View.php
+++ b/app/code/Magento/Catalog/Controller/Product/View.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -9,11 +8,14 @@ namespace Magento\Catalog\Controller\Product;
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
 use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
 use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\View\Result\PageFactory;
 use Magento\Catalog\Controller\Product as ProductAction;
 
 /**
- * View a product on storefront. Needs to be accessible by POST because of the store switching.
+ * View a product on storefront. Needs to be accessible by POST because of the store switching
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class View extends ProductAction implements HttpGetActionInterface, HttpPostActionInterface
 {
@@ -33,23 +35,41 @@ class View extends ProductAction implements HttpGetActionInterface, HttpPostActi
     protected $resultPageFactory;
 
     /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var \Magento\Framework\Json\Helper\Data
+     */
+    private $jsonHelper;
+
+    /**
      * Constructor
      *
      * @param Context $context
      * @param \Magento\Catalog\Helper\Product\View $viewHelper
      * @param \Magento\Framework\Controller\Result\ForwardFactory $resultForwardFactory
      * @param PageFactory $resultPageFactory
+     * @param \Psr\Log\LoggerInterface $logger
+     * @param \Magento\Framework\Json\Helper\Data $jsonHelper
      */
     public function __construct(
         Context $context,
         \Magento\Catalog\Helper\Product\View $viewHelper,
         \Magento\Framework\Controller\Result\ForwardFactory $resultForwardFactory,
-        PageFactory $resultPageFactory
+        PageFactory $resultPageFactory,
+        \Psr\Log\LoggerInterface $logger = null,
+        \Magento\Framework\Json\Helper\Data $jsonHelper = null
     ) {
+        parent::__construct($context);
         $this->viewHelper = $viewHelper;
         $this->resultForwardFactory = $resultForwardFactory;
         $this->resultPageFactory = $resultPageFactory;
-        parent::__construct($context);
+        $this->logger = $logger ?: ObjectManager::getInstance()
+            ->get(\Psr\Log\LoggerInterface::class);
+        $this->jsonHelper = $jsonHelper ?: ObjectManager::getInstance()
+            ->get(\Magento\Framework\Json\Helper\Data::class);
     }
 
     /**
@@ -84,21 +104,23 @@ class View extends ProductAction implements HttpGetActionInterface, HttpPostActi
 
         if ($this->getRequest()->isPost() && $this->getRequest()->getParam(self::PARAM_NAME_URL_ENCODED)) {
             $product = $this->_initProduct();
-            
+
             if (!$product) {
                 return $this->noProductRedirect();
             }
-            
+
             if ($specifyOptions) {
                 $notice = $product->getTypeInstance()->getSpecifyOptionMessage();
                 $this->messageManager->addNoticeMessage($notice);
             }
-            
+
             if ($this->getRequest()->isAjax()) {
                 $this->getResponse()->representJson(
-                    $this->_objectManager->get(\Magento\Framework\Json\Helper\Data::class)->jsonEncode([
-                        'backUrl' => $this->_redirect->getRedirectUrl()
-                    ])
+                    $this->jsonHelper->jsonEncode(
+                        [
+                            'backUrl' => $this->_redirect->getRedirectUrl()
+                        ]
+                    )
                 );
                 return;
             }
@@ -120,7 +142,7 @@ class View extends ProductAction implements HttpGetActionInterface, HttpPostActi
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
             return $this->noProductRedirect();
         } catch (\Exception $e) {
-            $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
+            $this->logger->critical($e);
             $resultForward = $this->resultForwardFactory->create();
             $resultForward->forward('noroute');
             return $resultForward;

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Category/EditTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Category/EditTest.php
@@ -96,7 +96,9 @@ class EditTest extends \PHPUnit\Framework\TestCase
     {
         $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
 
-        $this->categoryMock = $this->createPartialMock(\Magento\Catalog\Model\Category::class, [
+        $this->categoryMock = $this->createPartialMock(
+            \Magento\Catalog\Model\Category::class,
+            [
                 'getPath',
                 'addData',
                 'getId',
@@ -104,9 +106,12 @@ class EditTest extends \PHPUnit\Framework\TestCase
                 'getResource',
                 'setStoreId',
                 'toArray'
-            ]);
+            ]
+        );
 
-        $this->contextMock = $this->createPartialMock(\Magento\Backend\App\Action\Context::class, [
+        $this->contextMock = $this->createPartialMock(
+            \Magento\Backend\App\Action\Context::class,
+            [
                 'getTitle',
                 'getRequest',
                 'getObjectManager',
@@ -115,7 +120,9 @@ class EditTest extends \PHPUnit\Framework\TestCase
                 'getMessageManager',
                 'getResultRedirectFactory',
                 'getSession'
-            ]);
+            ]
+        );
+
         $this->resultRedirectFactoryMock = $this->createPartialMock(
             \Magento\Backend\Model\View\Result\RedirectFactory::class,
             ['create']
@@ -285,44 +292,8 @@ class EditTest extends \PHPUnit\Framework\TestCase
      */
     private function mockInitCategoryCall()
     {
-        /**
-         * @var \Magento\Framework\Registry
-         * |\PHPUnit_Framework_MockObject_MockObject $registryMock
-         */
-        $registryMock = $this->createPartialMock(\Magento\Framework\Registry::class, ['register']);
-        /**
-         * @var \Magento\Cms\Model\Wysiwyg\Config
-         * |\PHPUnit_Framework_MockObject_MockObject $wysiwygConfigMock
-         */
-        $wysiwygConfigMock = $this->createPartialMock(\Magento\Cms\Model\Wysiwyg\Config::class, ['setStoreId']);
-        /**
-         * @var \Magento\Store\Model\StoreManagerInterface
-         * |\PHPUnit_Framework_MockObject_MockObject $storeManagerMock
-         */
-        $storeManagerMock = $this->getMockForAbstractClass(
-            \Magento\Store\Model\StoreManagerInterface::class,
-            [],
-            '',
-            false,
-            true,
-            true,
-            ['getStore', 'getRootCategoryId']
-        );
-
         $this->objectManagerMock->expects($this->atLeastOnce())
             ->method('create')
             ->will($this->returnValue($this->categoryMock));
-
-        $this->objectManagerMock->expects($this->atLeastOnce())
-            ->method('get')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        [\Magento\Framework\Registry::class, $registryMock],
-                        [\Magento\Cms\Model\Wysiwyg\Config::class, $wysiwygConfigMock],
-                        [\Magento\Store\Model\StoreManagerInterface::class, $storeManagerMock],
-                    ]
-                )
-            );
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/MassStatusTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/MassStatusTest.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -110,14 +109,15 @@ class MassStatusTest extends \Magento\Catalog\Test\Unit\Controller\Adminhtml\Pro
             'resultFactory' => $resultFactory
         ];
         /** @var \Magento\Backend\App\Action\Context $context */
-        $context = $this->initContext($additionalParams, [[Action::class, $this->actionMock]]);
+        $context = $this->initContext($additionalParams);
 
         $this->action = new \Magento\Catalog\Controller\Adminhtml\Product\MassStatus(
             $context,
             $this->productBuilderMock,
             $this->priceProcessorMock,
             $this->filterMock,
-            $collectionFactoryMock
+            $collectionFactoryMock,
+            $this->actionMock
         );
     }
 
@@ -137,11 +137,13 @@ class MassStatusTest extends \Magento\Catalog\Test\Unit\Controller\Adminhtml\Pro
             ->willReturn([3]);
         $this->request->expects($this->exactly(3))
             ->method('getParam')
-            ->willReturnMap([
-                ['store', null, $storeId],
-                ['status', null, $status],
-                ['filters', [], $filters]
-            ]);
+            ->willReturnMap(
+                [
+                    ['store', null, $storeId],
+                    ['status', null, $status],
+                    ['filters', [], $filters]
+                ]
+            );
         $this->actionMock->expects($this->once())
             ->method('updateAttributes')
             ->with([3], ['status' => $status], 2);

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Category/ViewTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Category/ViewTest.php
@@ -25,7 +25,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
     protected $response;
 
     /**
-     * @var \Magento\Framework\App\ResponseInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Catalog\Helper\Category|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $categoryHelper;
 
@@ -165,13 +165,17 @@ class ViewTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->will($this->returnValue($this->page));
 
-        $this->action = (new ObjectManager($this))->getObject(\Magento\Catalog\Controller\Category\View::class, [
-            'context' => $this->context,
-            'catalogDesign' => $this->catalogDesign,
-            'categoryRepository' => $this->categoryRepository,
-            'storeManager' => $this->storeManager,
-            'resultPageFactory' => $resultPageFactory
-        ]);
+        $this->action = (new ObjectManager($this))->getObject(
+            \Magento\Catalog\Controller\Category\View::class,
+            [
+                'context' => $this->context,
+                'catalogDesign' => $this->catalogDesign,
+                'categoryRepository' => $this->categoryRepository,
+                'storeManager' => $this->storeManager,
+                'resultPageFactory' => $resultPageFactory,
+                'categoryHelper' => $this->categoryHelper
+            ]
+        );
     }
 
     public function testApplyCustomLayoutUpdate()
@@ -179,19 +183,17 @@ class ViewTest extends \PHPUnit\Framework\TestCase
         $categoryId = 123;
         $pageLayout = 'page_layout';
 
-        $this->objectManager->expects($this->any())->method('get')->will($this->returnValueMap([
-            [\Magento\Catalog\Helper\Category::class, $this->categoryHelper],
-        ]));
-
-        $this->request->expects($this->any())->method('getParam')->will($this->returnValueMap([
-            [Action::PARAM_NAME_URL_ENCODED],
-            ['id', false, $categoryId],
-        ]));
+        $this->request->expects($this->any())->method('getParam')->willReturnMap(
+            [
+                [Action::PARAM_NAME_URL_ENCODED],
+                ['id', false, $categoryId]
+            ]
+        );
 
         $this->categoryRepository->expects($this->any())->method('get')->with($categoryId)
             ->will($this->returnValue($this->category));
 
-        $this->categoryHelper->expects($this->any())->method('canShow')->will($this->returnValue(true));
+        $this->categoryHelper->expects($this->once())->method('canShow')->with($this->category)->willReturn(true);
 
         $settings = $this->createPartialMock(
             \Magento\Framework\DataObject::class,


### PR DESCRIPTION
### Description
Cleaned `ObjectManager::get()` in Magento_Catalog/Controller, for methods/classes which aren't deprecated, and classes which have constructors to move the dependencies to. Moved qualifying dependencies to constructor, and fixed necessary PHPDoc annotations.
- Improper usage of `ObjectManager::get()` to get instance of a class inside a method instead of using Constructor Dependency Injection.
- Dependencies are scattered all over the class hindering with clarity of class dependencies.

### Fixed Issues (if relevant)
1. magento/magento2#24646: Replacing the usage of ObjectManager in Magento_Catalog Controllers

### Manual testing scenarios (*)
No practical functionality change.

### Questions or comments
Bug fix, as usage of ObjectManager directly in code is prohibited.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
