### PR TITLE
#24452 Category Admin UI does not save tree changes unless OK button is clicked

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/tree.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/tree.phtml
@@ -507,8 +507,13 @@
                             })(jQuery);
                             this.closeModal();
                         }
-                    }]
-
+                    }],
+                    keyEventHandlers: {
+                        enterKey: function (event) {
+                            this.buttons[1].click();
+                            event.preventDefault();
+                        }
+                    }
                 }).trigger('openModal');
 
             }


### PR DESCRIPTION
### Description (*)
added enter button event handler and fixed js issue based on PR https://github.com/magento/magento2/pull/24498

### Fixed Issues (if relevant)
1. magento/magento2#24452: Category Admin UI does not save tree changes unless OK button is clicked

### Manual testing scenarios (*)
1. Navigate to Catalog -> Categories
2. Drag a category to a different location in the tree
3. When the warning dialog appears hit enter on the keyboard
4. Note that a no spinner appears and changes are not saved
5. refresh the page and see that your changes were not saved.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
