### PR TITLE
Fix for CLI Backup doesn't work properly when directory is a symlink …

### DIFF
--- a/lib/internal/Magento/Framework/Backup/Archive/Tar.php
+++ b/lib/internal/Magento/Framework/Backup/Archive/Tar.php
@@ -15,6 +15,9 @@ use Magento\Framework\Backup\Filesystem\Iterator\Filter;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
+/**
+ * Class to work with tar archives
+ */
 class Tar extends \Magento\Framework\Archive\Tar
 {
     /**
@@ -25,8 +28,7 @@ class Tar extends \Magento\Framework\Archive\Tar
     protected $_skipFiles = [];
 
     /**
-     * Overridden \Magento\Framework\Archive\Tar::_createTar method that does the same actions as it's parent but
-     * filters files using \Magento\Framework\Backup\Filesystem\Iterator\Filter
+     *  Method same as it's parent but filters files using \Magento\Framework\Backup\Filesystem\Iterator\Filter
      *
      * @param bool $skipRoot
      * @param bool $finalize
@@ -50,7 +52,7 @@ class Tar extends \Magento\Framework\Archive\Tar
 
         foreach ($iterator as $item) {
             // exclude symlinks to do not get duplicates after follow symlinks in RecursiveDirectoryIterator
-            if($item->isLink()) {
+            if ($item->isLink()) {
                 continue;
             }
             $this->_setCurrentFile($item->getPathname());

--- a/lib/internal/Magento/Framework/Backup/Archive/Tar.php
+++ b/lib/internal/Magento/Framework/Backup/Archive/Tar.php
@@ -38,9 +38,8 @@ class Tar extends \Magento\Framework\Archive\Tar
     protected function _createTar($skipRoot = false, $finalize = false)
     {
         $path = $this->_getCurrentFile();
-
         $filesystemIterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($path),
+            new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::FOLLOW_SYMLINKS),
             RecursiveIteratorIterator::SELF_FIRST
         );
 
@@ -50,6 +49,10 @@ class Tar extends \Magento\Framework\Archive\Tar
         );
 
         foreach ($iterator as $item) {
+            // exclude symlinks to do not get duplicates after follow symlinks in RecursiveDirectoryIterator
+            if($item->isLink()) {
+                continue;
+            }
             $this->_setCurrentFile($item->getPathname());
             $this->_packAndWriteCurrentFile();
         }


### PR DESCRIPTION
…#13218

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fix for issue from CLI Backup doesn't work properly when directory is a symlink #13218

### Fixed Issues (if relevant)

1. magento/magento2#13218:CLI Backup doesn't work properly when directory is a symlink

### Manual testing scenarios (*)

1. Replace pub/media to another folder on server
2. Create symlink to get pub/media linked to replaced files
3. bin/magento setup:backup --media

### Questions or comments
Right now updated added to use follow symlinks always. Maybe would be good to have additional option for command to use follow symlinks option conditionally.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
