### PR TITLE
MC-19600 - Unable to Verify Password Reset Token Without Customer ID - REST API

### DIFF
--- a/app/code/Magento/Customer/Api/AccountManagementInterface.php
+++ b/app/code/Magento/Customer/Api/AccountManagementInterface.php
@@ -172,22 +172,9 @@ interface AccountManagementInterface
      * @throws \Magento\Framework\Exception\NoSuchEntityException If customer doesn't exist
      * @throws \Magento\Framework\Exception\LocalizedException
      * @deprecated
-     * @see \Magento\Customer\Api\AccountManagementInterface::validateResetPasswordLinkByToken()
+     * @see \Magento\Customer\Api\PasswordManagementInterface::validateResetPasswordLinkByToken()
      */
     public function validateResetPasswordLinkToken($customerId, $resetPasswordLinkToken);
-
-    /**
-     * Check if password reset token is valid.
-     *
-     * @param string $resetPasswordLinkToken
-     *
-     * @return bool True if the token is valid
-     * @throws \Magento\Framework\Exception\State\InputMismatchException If token is mismatched
-     * @throws \Magento\Framework\Exception\State\ExpiredException If token is expired
-     * @throws \Magento\Framework\Exception\InputException If token is invalid
-     * @throws \Magento\Framework\Exception\LocalizedException
-     */
-    public function validateResetPasswordLinkByToken($resetPasswordLinkToken);
 
     /**
      * Gets the account confirmation status.

--- a/app/code/Magento/Customer/Api/AccountManagementInterface.php
+++ b/app/code/Magento/Customer/Api/AccountManagementInterface.php
@@ -153,6 +153,7 @@ interface AccountManagementInterface
      *
      * @return bool true on success
      * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException If empty email and can't find customer by reset token
      * @throws InputException
      */
     public function resetPassword($email, $resetToken, $newPassword);
@@ -170,8 +171,23 @@ interface AccountManagementInterface
      * @throws \Magento\Framework\Exception\InputException If token or customer id is invalid
      * @throws \Magento\Framework\Exception\NoSuchEntityException If customer doesn't exist
      * @throws \Magento\Framework\Exception\LocalizedException
+     * @deprecated
+     * @see \Magento\Customer\Api\AccountManagementInterface::validateResetPasswordLinkByToken()
      */
     public function validateResetPasswordLinkToken($customerId, $resetPasswordLinkToken);
+
+    /**
+     * Check if password reset token is valid.
+     *
+     * @param string $resetPasswordLinkToken
+     *
+     * @return bool True if the token is valid
+     * @throws \Magento\Framework\Exception\State\InputMismatchException If token is mismatched
+     * @throws \Magento\Framework\Exception\State\ExpiredException If token is expired
+     * @throws \Magento\Framework\Exception\InputException If token is invalid
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function validateResetPasswordLinkByToken($resetPasswordLinkToken);
 
     /**
      * Gets the account confirmation status.

--- a/app/code/Magento/Customer/Api/PasswordManagementInterface.php
+++ b/app/code/Magento/Customer/Api/PasswordManagementInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Customer\Api;
+
+/**
+ * Interface for managing customers password.
+ * @api
+ * @since 100.0.6
+ */
+interface PasswordManagementInterface
+{
+    /**
+     * Check if password reset token is valid.
+     *
+     * @param string $resetPasswordLinkToken
+     *
+     * @return bool True if the token is valid
+     * @throws \Magento\Framework\Exception\State\InputMismatchException If token is mismatched
+     * @throws \Magento\Framework\Exception\State\ExpiredException If token is expired
+     * @throws \Magento\Framework\Exception\InputException If token is invalid
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function validateResetPasswordLinkByToken($resetPasswordLinkToken);
+}

--- a/app/code/Magento/Customer/Model/AccountManagement.php
+++ b/app/code/Magento/Customer/Model/AccountManagement.php
@@ -13,6 +13,7 @@ use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Api\Data\AddressInterface;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Api\Data\ValidationResultsInterfaceFactory;
+use Magento\Customer\Api\PasswordManagementInterface;
 use Magento\Customer\Helper\View as CustomerViewHelper;
 use Magento\Customer\Model\Config\Share as ConfigShare;
 use Magento\Customer\Model\Customer as CustomerModel;
@@ -629,15 +630,6 @@ class AccountManagement implements AccountManagementInterface
     /**
      * @inheritdoc
      */
-    public function validateResetPasswordLinkByToken($resetPasswordLinkToken)
-    {
-        $this->validateResetPasswordByToken($resetPasswordLinkToken);
-        return true;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function initiatePasswordReset($email, $template, $websiteId = null)
     {
         if ($websiteId === null) {
@@ -1159,7 +1151,7 @@ class AccountManagement implements AccountManagementInterface
      * @throws NoSuchEntityException If customer doesn't exist
      * @SuppressWarnings(PHPMD.LongVariable)
      * @deprecated
-     * @see validateResetPasswordByToken()
+     * @see PasswordManagementInterface::validateResetPasswordByToken()
      */
     private function validateResetPasswordToken($customerId, $resetPasswordLinkToken)
     {
@@ -1178,38 +1170,6 @@ class AccountManagement implements AccountManagementInterface
                 ->execute($resetPasswordLinkToken)
                 ->getId();
         }
-        if (!is_string($resetPasswordLinkToken) || empty($resetPasswordLinkToken)) {
-            $params = ['fieldName' => 'resetPasswordLinkToken'];
-            throw new InputException(__('"%fieldName" is required. Enter and try again.', $params));
-        }
-        $customerSecureData = $this->customerRegistry->retrieveSecureData($customerId);
-        $rpToken = $customerSecureData->getRpToken();
-        $rpTokenCreatedAt = $customerSecureData->getRpTokenCreatedAt();
-        if (!Security::compareStrings($rpToken, $resetPasswordLinkToken)) {
-            throw new InputMismatchException(__('The password token is mismatched. Reset and try again.'));
-        } elseif ($this->isResetPasswordLinkTokenExpired($rpToken, $rpTokenCreatedAt)) {
-            throw new ExpiredException(__('The password token is expired. Reset and try again.'));
-        }
-        return true;
-    }
-
-    /**
-     * Validate the Reset Password Token for a customer.
-     *
-     * @param string $resetPasswordLinkToken
-     *
-     * @return bool
-     * @throws ExpiredException
-     * @throws InputException
-     * @throws InputMismatchException
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
-     */
-    private function validateResetPasswordByToken($resetPasswordLinkToken)
-    {
-        $customerId = $this->getByToken
-            ->execute($resetPasswordLinkToken)
-            ->getId();
         if (!is_string($resetPasswordLinkToken) || empty($resetPasswordLinkToken)) {
             $params = ['fieldName' => 'resetPasswordLinkToken'];
             throw new InputException(__('"%fieldName" is required. Enter and try again.', $params));

--- a/app/code/Magento/Customer/Model/ForgotPasswordToken/GetCustomerByToken.php
+++ b/app/code/Magento/Customer/Model/ForgotPasswordToken/GetCustomerByToken.php
@@ -73,7 +73,7 @@ class GetCustomerByToken
         }
         if ($found->getTotalCount() === 0) {
             //Customer with such token not found.
-            new NoSuchEntityException(
+            throw new NoSuchEntityException(
                 new Phrase(
                     'No such entity with rp_token = %value',
                     [

--- a/app/code/Magento/Customer/Model/PasswordManagement.php
+++ b/app/code/Magento/Customer/Model/PasswordManagement.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Customer\Model;
+
+use Magento\Customer\Api\AccountManagementInterface;
+use Magento\Customer\Api\PasswordManagementInterface;
+use Magento\Customer\Model\Customer as CustomerModel;
+use Magento\Customer\Model\ForgotPasswordToken\GetCustomerByToken;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Encryption\Helper\Security;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Exception\State\ExpiredException;
+use Magento\Framework\Exception\State\InputMismatchException;
+use Magento\Framework\Intl\DateTimeFactory;
+
+/**
+ * Handle customer password actions
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
+ */
+class PasswordManagement implements PasswordManagementInterface
+{
+    /**
+     * @var CustomerModel
+     */
+    protected $customerModel;
+
+    /**
+     * @var CustomerRegistry
+     */
+    private $customerRegistry;
+
+    /**
+     * @var DateTimeFactory
+     */
+    private $dateTimeFactory;
+
+    /**
+     * @var GetCustomerByToken
+     */
+    private $getByToken;
+
+    /**
+     * @param CustomerRegistry $customerRegistry
+     * @param AccountManagementInterface|null $accountManagement
+     * @param GetCustomerByToken|null $getByToken
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @SuppressWarnings(PHPMD.LongVariable)
+     */
+    public function __construct(
+        CustomerRegistry $customerRegistry,
+        CustomerModel $customerModel,
+        DateTimeFactory $dateTimeFactory = null,
+        GetCustomerByToken $getByToken = null
+    ) {
+        $this->customerRegistry = $customerRegistry;
+        $this->customerModel = $customerModel;
+        $objectManager = ObjectManager::getInstance();
+        $this->dateTimeFactory = $dateTimeFactory ?: $objectManager->get(DateTimeFactory::class);
+        $this->getByToken = $getByToken
+            ?: $objectManager->get(GetCustomerByToken::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function validateResetPasswordLinkByToken($resetPasswordLinkToken)
+    {
+        $this->validateResetPasswordByToken($resetPasswordLinkToken);
+        return true;
+    }
+
+    /**
+     * Validate the Reset Password Token for a customer.
+     *
+     * @param string $resetPasswordLinkToken
+     *
+     * @return bool
+     * @throws ExpiredException
+     * @throws InputException
+     * @throws InputMismatchException
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    private function validateResetPasswordByToken($resetPasswordLinkToken)
+    {
+        $customerId = $this->getByToken
+            ->execute($resetPasswordLinkToken)
+            ->getId();
+        if (!is_string($resetPasswordLinkToken) || empty($resetPasswordLinkToken)) {
+            $params = ['fieldName' => 'resetPasswordLinkToken'];
+            throw new InputException(__('"%fieldName" is required. Enter and try again.', $params));
+        }
+        $customerSecureData = $this->customerRegistry->retrieveSecureData($customerId);
+        $rpToken = $customerSecureData->getRpToken();
+        $rpTokenCreatedAt = $customerSecureData->getRpTokenCreatedAt();
+        if (!Security::compareStrings($rpToken, $resetPasswordLinkToken)) {
+            throw new InputMismatchException(__('The password token is mismatched. Reset and try again.'));
+        } elseif ($this->isResetPasswordLinkTokenExpired($rpToken, $rpTokenCreatedAt)) {
+            throw new ExpiredException(__('The password token is expired. Reset and try again.'));
+        }
+        return true;
+    }
+
+    /**
+     * Check if rpToken is expired
+     *
+     * @param string $rpToken
+     * @param string $rpTokenCreatedAt
+     * @return bool
+     */
+    private function isResetPasswordLinkTokenExpired($rpToken, $rpTokenCreatedAt)
+    {
+        if (empty($rpToken) || empty($rpTokenCreatedAt)) {
+            return true;
+        }
+
+        $expirationPeriod = $this->customerModel->getResetPasswordLinkExpirationPeriod();
+
+        $currentTimestamp = $this->dateTimeFactory->create()->getTimestamp();
+        $tokenTimestamp = $this->dateTimeFactory->create($rpTokenCreatedAt)->getTimestamp();
+        if ($tokenTimestamp > $currentTimestamp) {
+            return true;
+        }
+
+        $hourDifference = floor(($currentTimestamp - $tokenTimestamp) / (60 * 60));
+        if ($hourDifference >= $expirationPeriod) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/app/code/Magento/Customer/Model/PasswordManagement.php
+++ b/app/code/Magento/Customer/Model/PasswordManagement.php
@@ -6,7 +6,6 @@
 
 namespace Magento\Customer\Model;
 
-use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\PasswordManagementInterface;
 use Magento\Customer\Model\Customer as CustomerModel;
 use Magento\Customer\Model\ForgotPasswordToken\GetCustomerByToken;
@@ -32,7 +31,7 @@ class PasswordManagement implements PasswordManagementInterface
     /**
      * @var CustomerModel
      */
-    protected $customerModel;
+    private $customerModel;
 
     /**
      * @var CustomerRegistry
@@ -51,8 +50,9 @@ class PasswordManagement implements PasswordManagementInterface
 
     /**
      * @param CustomerRegistry $customerRegistry
-     * @param AccountManagementInterface|null $accountManagement
+     * @param CustomerModel $customerModel
      * @param GetCustomerByToken|null $getByToken
+     * @param DateTimeFactory|null $dateTimeFactory
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      * @SuppressWarnings(PHPMD.NPathComplexity)

--- a/app/code/Magento/Customer/Model/PasswordManagement.php
+++ b/app/code/Magento/Customer/Model/PasswordManagement.php
@@ -51,8 +51,8 @@ class PasswordManagement implements PasswordManagementInterface
     /**
      * @param CustomerRegistry $customerRegistry
      * @param CustomerModel $customerModel
-     * @param GetCustomerByToken|null $getByToken
      * @param DateTimeFactory|null $dateTimeFactory
+     * @param GetCustomerByToken|null $getByToken
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      * @SuppressWarnings(PHPMD.NPathComplexity)

--- a/app/code/Magento/Customer/Test/Unit/Model/AccountManagementTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/AccountManagementTest.php
@@ -1334,61 +1334,6 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Framework\Exception\InputException
-     * @expectedExceptionMessage "resetPasswordLinkToken" is required. Enter and try again.
-     */
-    public function testValidateResetPasswordByTokenEmptyResetPasswordLinkToken()
-    {
-        $this->accountManagement->validateResetPasswordLinkByToken('');
-    }
-
-    /**
-     * @expectedException \Magento\Framework\Exception\State\InputMismatchException
-     * @expectedExceptionMessage The password token is mismatched. Reset and try again.
-     */
-    public function testValidateResetPasswordByTokenTokenMismatch()
-    {
-        $this->customerRegistry->expects($this->atLeastOnce())
-            ->method('retrieveSecureData')
-            ->willReturn($this->customerSecure);
-
-        $this->accountManagement->validateResetPasswordLinkByToken('newStringToken');
-    }
-
-    /**
-     * @expectedException \Magento\Framework\Exception\State\ExpiredException
-     * @expectedExceptionMessage The password token is expired. Reset and try again.
-     */
-    public function testValidateResetPasswordByTokenTokenExpired()
-    {
-        $this->reInitModel();
-        $this->customerRegistry->expects($this->atLeastOnce())
-            ->method('retrieveSecureData')
-            ->willReturn($this->customerSecure);
-
-        $this->accountManagement->validateResetPasswordLinkByToken('newStringToken');
-    }
-
-    /**
-     * return bool
-     */
-    public function testValidateResetPasswordByToken()
-    {
-        $this->reInitModel();
-
-        $this->customer
-            ->expects($this->once())
-            ->method('getResetPasswordLinkExpirationPeriod')
-            ->willReturn(100000);
-
-        $this->customerRegistry->expects($this->atLeastOnce())
-            ->method('retrieveSecureData')
-            ->willReturn($this->customerSecure);
-
-        $this->assertTrue($this->accountManagement->validateResetPasswordLinkByToken('newStringToken'));
-    }
-
-    /**
-     * @expectedException \Magento\Framework\Exception\InputException
      * @expectedExceptionMessage Invalid value of "0" provided for the customerId field
      */
     public function testValidateResetPasswordTokenBadCustomerId()

--- a/app/code/Magento/Customer/Test/Unit/Model/AccountManagementTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/AccountManagementTest.php
@@ -1334,6 +1334,61 @@ class AccountManagementTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @expectedException \Magento\Framework\Exception\InputException
+     * @expectedExceptionMessage "resetPasswordLinkToken" is required. Enter and try again.
+     */
+    public function testValidateResetPasswordByTokenEmptyResetPasswordLinkToken()
+    {
+        $this->accountManagement->validateResetPasswordLinkByToken('');
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\State\InputMismatchException
+     * @expectedExceptionMessage The password token is mismatched. Reset and try again.
+     */
+    public function testValidateResetPasswordByTokenTokenMismatch()
+    {
+        $this->customerRegistry->expects($this->atLeastOnce())
+            ->method('retrieveSecureData')
+            ->willReturn($this->customerSecure);
+
+        $this->accountManagement->validateResetPasswordLinkByToken('newStringToken');
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\State\ExpiredException
+     * @expectedExceptionMessage The password token is expired. Reset and try again.
+     */
+    public function testValidateResetPasswordByTokenTokenExpired()
+    {
+        $this->reInitModel();
+        $this->customerRegistry->expects($this->atLeastOnce())
+            ->method('retrieveSecureData')
+            ->willReturn($this->customerSecure);
+
+        $this->accountManagement->validateResetPasswordLinkByToken('newStringToken');
+    }
+
+    /**
+     * return bool
+     */
+    public function testValidateResetPasswordByToken()
+    {
+        $this->reInitModel();
+
+        $this->customer
+            ->expects($this->once())
+            ->method('getResetPasswordLinkExpirationPeriod')
+            ->willReturn(100000);
+
+        $this->customerRegistry->expects($this->atLeastOnce())
+            ->method('retrieveSecureData')
+            ->willReturn($this->customerSecure);
+
+        $this->assertTrue($this->accountManagement->validateResetPasswordLinkByToken('newStringToken'));
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\InputException
      * @expectedExceptionMessage Invalid value of "0" provided for the customerId field
      */
     public function testValidateResetPasswordTokenBadCustomerId()

--- a/app/code/Magento/Customer/Test/Unit/Model/PasswordManagementTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/PasswordManagementTest.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Customer\Test\Unit\Model;
+
+use Magento\Customer\Model\PasswordManagement;
+use Magento\Framework\Intl\DateTimeFactory;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+
+/**
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class PasswordManagementTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var PasswordManagement */
+    private $passwordManagement;
+
+    /** @var ObjectManagerHelper */
+    private $objectManagerHelper;
+
+    /** @var \Magento\Customer\Model\Customer|\PHPUnit_Framework_MockObject_MockObject */
+    private $customer;
+
+    /** @var \Magento\Customer\Model\CustomerRegistry|\PHPUnit_Framework_MockObject_MockObject */
+    private $customerRegistry;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Customer\Model\Data\CustomerSecure
+     */
+    private $customerSecure;
+
+    /**
+     * @var DateTimeFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $dateTimeFactory;
+
+    /** @var \Magento\Framework\DataObjectFactory|\PHPUnit_Framework_MockObject_MockObject */
+    private $objectFactory;
+
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    protected function setUp()
+    {
+        $this->customer = $this->createMock(\Magento\Customer\Model\Customer::class);
+        $this->customerRegistry = $this->createMock(\Magento\Customer\Model\CustomerRegistry::class);
+        $this->customerSecure = $this->getMockBuilder(\Magento\Customer\Model\Data\CustomerSecure::class)
+            ->setMethods(['setRpToken', 'addData', 'setRpTokenCreatedAt', 'setData'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->dateTimeFactory = $this->createMock(DateTimeFactory::class);
+        $this->objectManagerHelper = new ObjectManagerHelper($this);
+        $this->passwordManagement = $this->objectManagerHelper->getObject(
+            \Magento\Customer\Model\PasswordManagement::class,
+            [
+                'customerRegistry' => $this->customerRegistry,
+                'customerModel' => $this->customer,
+                'dateTimeFactory' => $this->dateTimeFactory
+            ]
+        );
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\InputException
+     * @expectedExceptionMessage "resetPasswordLinkToken" is required. Enter and try again.
+     */
+    public function testValidateResetPasswordByTokenEmptyResetPasswordLinkToken()
+    {
+        $this->passwordManagement->validateResetPasswordLinkByToken('');
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\State\InputMismatchException
+     * @expectedExceptionMessage The password token is mismatched. Reset and try again.
+     */
+    public function testValidateResetPasswordByTokenTokenMismatch()
+    {
+        $this->customerRegistry->expects($this->atLeastOnce())
+            ->method('retrieveSecureData')
+            ->willReturn($this->customerSecure);
+
+        $this->passwordManagement->validateResetPasswordLinkByToken('newStringToken');
+    }
+
+    /**
+     * @expectedException \Magento\Framework\Exception\State\ExpiredException
+     * @expectedExceptionMessage The password token is expired. Reset and try again.
+     */
+    public function testValidateResetPasswordByTokenTokenExpired()
+    {
+        $this->reInitModel();
+        $this->customerRegistry->expects($this->atLeastOnce())
+            ->method('retrieveSecureData')
+            ->willReturn($this->customerSecure);
+
+        $this->passwordManagement->validateResetPasswordLinkByToken('newStringToken');
+    }
+
+    /**
+     * return bool
+     */
+    public function testValidateResetPasswordByToken()
+    {
+        $this->reInitModel();
+
+        $this->customer
+            ->expects($this->once())
+            ->method('getResetPasswordLinkExpirationPeriod')
+            ->willReturn(100000);
+
+        $this->customerRegistry->expects($this->atLeastOnce())
+            ->method('retrieveSecureData')
+            ->willReturn($this->customerSecure);
+
+        $this->assertTrue($this->passwordManagement->validateResetPasswordLinkByToken('newStringToken'));
+    }
+
+    /**
+     * reInit $this->passwordManagement object
+     */
+    private function reInitModel()
+    {
+        $this->customerSecure = $this->getMockBuilder(\Magento\Customer\Model\Data\CustomerSecure::class)
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'getRpToken',
+                    'getRpTokenCreatedAt',
+                ]
+            )
+            ->getMock();
+        $this->customerSecure->expects($this->any())
+            ->method('getRpToken')
+            ->willReturn('newStringToken');
+        $pastDateTime = '2016-10-25 00:00:00';
+        $this->customerSecure->expects($this->any())
+            ->method('getRpTokenCreatedAt')
+            ->willReturn($pastDateTime);
+
+        $this->prepareDateTimeFactory();
+
+        $dateTime = '2017-10-25 18:57:08';
+        $timestamp = '1508983028';
+        $dateTimeMock = $this->getMockBuilder(\DateTime::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['format', 'getTimestamp', 'setTimestamp'])
+            ->getMock();
+
+        $dateTimeMock->expects($this->any())
+            ->method('format')
+            ->with(\Magento\Framework\Stdlib\DateTime::DATETIME_PHP_FORMAT)
+            ->willReturn($dateTime);
+        $dateTimeMock->expects($this->any())
+            ->method('getTimestamp')
+            ->willReturn($timestamp);
+        $dateTimeMock->expects($this->any())
+            ->method('setTimestamp')
+            ->willReturnSelf();
+        $dateTimeFactory = $this->getMockBuilder(DateTimeFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $dateTimeFactory->expects($this->any())->method('create')->willReturn($dateTimeMock);
+
+        $this->objectManagerHelper = new ObjectManagerHelper($this);
+        $this->passwordManagement = $this->objectManagerHelper->getObject(
+            PasswordManagement::class,
+            [
+                'customerRegistry' => $this->customerRegistry,
+                'customerModel' => $this->customer,
+                'dateTimeFactory' => $dateTimeFactory
+            ]
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function prepareDateTimeFactory()
+    {
+        $dateTime = '2017-10-25 18:57:08';
+        $timestamp = '1508983028';
+        $dateTimeMock = $this->createMock(\DateTime::class);
+        $dateTimeMock->expects($this->any())
+            ->method('format')
+            ->with(\Magento\Framework\Stdlib\DateTime::DATETIME_PHP_FORMAT)
+            ->willReturn($dateTime);
+
+        $dateTimeMock
+            ->expects($this->any())
+            ->method('getTimestamp')
+            ->willReturn($timestamp);
+
+        $this->dateTimeFactory
+            ->expects($this->any())
+            ->method('create')
+            ->willReturn($dateTimeMock);
+
+        return $dateTime;
+    }
+}

--- a/app/code/Magento/Customer/Test/Unit/Model/PasswordManagementTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/PasswordManagementTest.php
@@ -38,9 +38,6 @@ class PasswordManagementTest extends \PHPUnit\Framework\TestCase
      */
     private $dateTimeFactory;
 
-    /** @var \Magento\Framework\DataObjectFactory|\PHPUnit_Framework_MockObject_MockObject */
-    private $objectFactory;
-
     /**
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */

--- a/app/code/Magento/Customer/etc/di.xml
+++ b/app/code/Magento/Customer/etc/di.xml
@@ -35,6 +35,8 @@
                 type="Magento\Framework\Api\SearchResults" />
     <preference for="Magento\Customer\Api\AccountManagementInterface"
                 type="Magento\Customer\Model\AccountManagement" />
+    <preference for="Magento\Customer\Api\PasswordManagementInterface"
+                type="Magento\Customer\Model\PasswordManagement" />
     <preference for="Magento\Customer\Api\CustomerMetadataInterface"
                 type="Magento\Customer\Model\Metadata\CustomerCachedMetadata" />
     <preference for="Magento\Customer\Api\AddressMetadataInterface"

--- a/app/code/Magento/Customer/etc/webapi.xml
+++ b/app/code/Magento/Customer/etc/webapi.xml
@@ -182,8 +182,15 @@
             <parameter name="customerId" force="true">%customer_id%</parameter>
         </data>
     </route>
+    <!-- @deprecated @see validateResetPasswordLinkByToken -->
     <route url="/V1/customers/:customerId/password/resetLinkToken/:resetPasswordLinkToken" method="GET">
         <service class="Magento\Customer\Api\AccountManagementInterface" method="validateResetPasswordLinkToken"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
+    <route url="/V1/customers/password/resetLinkToken/:resetPasswordLinkToken" method="GET">
+        <service class="Magento\Customer\Api\AccountManagementInterface" method="validateResetPasswordLinkByToken"/>
         <resources>
             <resource ref="anonymous"/>
         </resources>

--- a/app/code/Magento/Customer/etc/webapi.xml
+++ b/app/code/Magento/Customer/etc/webapi.xml
@@ -190,7 +190,7 @@
         </resources>
     </route>
     <route url="/V1/customers/password/resetLinkToken/:resetPasswordLinkToken" method="GET">
-        <service class="Magento\Customer\Api\AccountManagementInterface" method="validateResetPasswordLinkByToken"/>
+        <service class="Magento\Customer\Api\PasswordManagementInterface" method="validateResetPasswordLinkByToken"/>
         <resources>
             <resource ref="anonymous"/>
         </resources>


### PR DESCRIPTION
### Description

Can not use null in url parameter for customerId


Rest Api:
/V1/customers/{customerId}/password/resetLinkToken/{resetPasswordLinkToken}

customerId is a required field. Doc has a description:

```
customerId  *required

If null is given then a customer will be matched by the RP token.
```

https://devdocs.magento.com/redoc/2.3/customer-rest-api.html#operation/customerAccountManagementV1ResetPasswordPost


### Fixed Issues
1. magento/magento2#24245: Unable to Verify Password Reset Token Without Customer ID - REST API 

### Manual testing scenarios

    1. Request a customer password reset link for an existing customer.
    2. Attempt to validate the password reset token via the REST API without customer ID since it is unavailable
    (request to /V1/customers/{customerId}/password/resetLinkToken/{resetPasswordLinkToken}).


### Questions or comments


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
