### PR TITLE
magento-issue-7852: Moved the review functionality from Magento_Custo…

### DIFF
--- a/app/code/Magento/Customer/composer.json
+++ b/app/code/Magento/Customer/composer.json
@@ -19,7 +19,6 @@
         "magento/module-newsletter": "*",
         "magento/module-page-cache": "*",
         "magento/module-quote": "*",
-        "magento/module-review": "*",
         "magento/module-sales": "*",
         "magento/module-store": "*",
         "magento/module-tax": "*",

--- a/app/code/Magento/Review/Block/Adminhtml/Edit/Tab/Reviews.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Edit/Tab/Reviews.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\Customer\Block\Adminhtml\Edit\Tab;
+namespace Magento\Review\Block\Adminhtml\Edit\Tab;
 
 /**
  * @api
@@ -28,6 +28,6 @@ class Reviews extends \Magento\Review\Block\Adminhtml\Grid
      */
     public function getGridUrl()
     {
-        return $this->getUrl('customer/*/productReviews', ['_current' => true]);
+        return $this->getUrl('review/customer/productReviews', ['_current' => true]);
     }
 }

--- a/app/code/Magento/Review/Block/Adminhtml/ReviewTab.php
+++ b/app/code/Magento/Review/Block/Adminhtml/ReviewTab.php
@@ -67,6 +67,6 @@ class ReviewTab extends TabWrapper
      */
     public function getTabUrl()
     {
-        return $this->getUrl('customer/*/productReviews', ['_current' => true]);
+        return $this->getUrl('review/customer/productReviews', ['_current' => true]);
     }
 }

--- a/app/code/Magento/Review/Controller/Adminhtml/Customer/ProductReviews.php
+++ b/app/code/Magento/Review/Controller/Adminhtml/Customer/ProductReviews.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\Customer\Controller\Adminhtml\Index;
+namespace Magento\Review\Controller\Adminhtml\Customer;
 
 class ProductReviews extends \Magento\Customer\Controller\Adminhtml\Index
 {

--- a/app/code/Magento/Review/view/adminhtml/layout/review_customer_productreviews.xml
+++ b/app/code/Magento/Review/view/adminhtml/layout/review_customer_productreviews.xml
@@ -7,6 +7,6 @@
 -->
 <layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <container name="root" label="Root">
-        <block class="Magento\Customer\Block\Adminhtml\Edit\Tab\Reviews" name="admin.customer.reviews"/>
+        <block class="Magento\Review\Block\Adminhtml\Edit\Tab\Reviews" name="admin.customer.reviews"/>
     </container>
 </layout>


### PR DESCRIPTION
…mer module to Magento_Review module for removing dependency of Customer module on Review module.

https://github.com/magento/magento2/issues/7852

### Description (*)
The block of the customer module which extended a block from review module was moved to the review module, also I moved the controller which call that block to the review module. All of these were did for removing the dependency of Customer module on the Review module.


### Questions or comments
I've removed the dependency of Customer module on Review module as it was required in the issue but that doesn't let to disable Magento_Review module by due to 2 others module have a dependency to Magento_Review module, it's Magento_Rerport and Magento_ReviewAnalytics. I think that we can disable Magento_Review with module together Magento_ReviewAnalytics module but the dependency of Magento_Rerport is another problem.
