### PR TITLE
#23180 attempt to fix final_price, price indexing for configurable product

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Indexer/Price/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Indexer/Price/Configurable.php
@@ -248,6 +248,8 @@ class Configurable implements DimensionalIndexerInterface
         // adds price of custom option, that was applied in DefaultPrice::_applyCustomOption
         $selectForCrossUpdate->columns(
             [
+                'price' => new \Zend_Db_Expr('i.max_price - i.price + io.max_price'),
+                'final_price' => new \Zend_Db_Expr('i.min_price - i.price + io.min_price'),
                 'min_price' => new \Zend_Db_Expr('i.min_price - i.price + io.min_price'),
                 'max_price' => new \Zend_Db_Expr('i.max_price - i.price + io.max_price'),
                 'tier_price' => 'io.tier_price',

--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Indexer/Price/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Indexer/Price/Configurable.php
@@ -117,18 +117,20 @@ class Configurable implements DimensionalIndexerInterface
     {
         $this->tableMaintainer->createMainTmpTable($dimensions);
 
-        $temporaryPriceTable = $this->indexTableStructureFactory->create([
-            'tableName' => $this->tableMaintainer->getMainTmpTable($dimensions),
-            'entityField' => 'entity_id',
-            'customerGroupField' => 'customer_group_id',
-            'websiteField' => 'website_id',
-            'taxClassField' => 'tax_class_id',
-            'originalPriceField' => 'price',
-            'finalPriceField' => 'final_price',
-            'minPriceField' => 'min_price',
-            'maxPriceField' => 'max_price',
-            'tierPriceField' => 'tier_price',
-        ]);
+        $temporaryPriceTable = $this->indexTableStructureFactory->create(
+            [
+                'tableName' => $this->tableMaintainer->getMainTmpTable($dimensions),
+                'entityField' => 'entity_id',
+                'customerGroupField' => 'customer_group_id',
+                'websiteField' => 'website_id',
+                'taxClassField' => 'tax_class_id',
+                'originalPriceField' => 'price',
+                'finalPriceField' => 'final_price',
+                'minPriceField' => 'min_price',
+                'maxPriceField' => 'max_price',
+                'tierPriceField' => 'tier_price',
+            ]
+        );
         $select = $this->baseFinalPrice->getQuery(
             $dimensions,
             \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE,
@@ -248,7 +250,7 @@ class Configurable implements DimensionalIndexerInterface
         // adds price of custom option, that was applied in DefaultPrice::_applyCustomOption
         $selectForCrossUpdate->columns(
             [
-                'price' => new \Zend_Db_Expr('i.max_price - i.price + io.max_price'),
+                'price' => new \Zend_Db_Expr('i.min_price - i.price + io.min_price'),
                 'final_price' => new \Zend_Db_Expr('i.min_price - i.price + io.min_price'),
                 'min_price' => new \Zend_Db_Expr('i.min_price - i.price + io.min_price'),
                 'max_price' => new \Zend_Db_Expr('i.max_price - i.price + io.max_price'),

--- a/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Indexer/Price/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ResourceModel/Product/Indexer/Price/Configurable.php
@@ -250,7 +250,6 @@ class Configurable implements DimensionalIndexerInterface
         // adds price of custom option, that was applied in DefaultPrice::_applyCustomOption
         $selectForCrossUpdate->columns(
             [
-                'price' => new \Zend_Db_Expr('i.min_price - i.price + io.min_price'),
                 'final_price' => new \Zend_Db_Expr('i.min_price - i.price + io.min_price'),
                 'min_price' => new \Zend_Db_Expr('i.min_price - i.price + io.min_price'),
                 'max_price' => new \Zend_Db_Expr('i.max_price - i.price + io.max_price'),


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When indexing a price for configurable product, wrong price (taken from saved EAV attribute) is saved to index table

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
It might partly help to fix wrong product order on some pages
1. magento/magento2#23180

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
