### PR TITLE
Resolved Issue #24740

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -122,7 +122,7 @@
         > .admin__field-control {
             #mix-grid .column(@field-control-grid__column, @field-grid__columns);
             input[type="checkbox"] {
-                margin-top: @indent__s;
+                margin-top: 0;
             }
         }
 
@@ -156,7 +156,7 @@
                 .admin__field {
                     margin-top: 8px;
                 }
-            } 
+            }
         }
     }
     &.composite-bundle {
@@ -307,7 +307,7 @@
     .admin__fieldset > & {
         margin-bottom: 3rem;
         position: relative;
-        
+
         &.field-import_file {
             .input-file {
                 margin-top: 6px;
@@ -664,7 +664,7 @@
                 display: inline-block;
             }
         }
-        
+
 
         + .admin__field:last-child {
             width: auto;
@@ -700,7 +700,7 @@
                 width: 100%;
             }
         }
-        & > .admin__field-label { 
+        & > .admin__field-label {
             text-align: left;
         }
 


### PR DESCRIPTION
### Description
Fixed [Issue 24740](https://github.com/magento/magento2/issues/24740)

Extra margin for select fields caused the UI issue

### Fixed Issues (if relevant)
1. magento/magento2#24740: Change text and check box not in same aligned

### Manual testing scenarios (*)
1. Admin -> Catalog -> Products
2. Select any product and from Action drop-down choose Update Attributes
3. Review the Update Attributes page
4. Checkboxes and its label will now be aligned as per fix

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
