### PR TITLE
* Fix issue with double calculation of stock item during

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Items/Grid.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Items/Grid.php
@@ -133,8 +133,6 @@ class Grid extends \Magento\Sales\Block\Adminhtml\Order\Create\AbstractCreate
         $oldSuperMode = $this->getQuote()->getIsSuperMode();
         $this->getQuote()->setIsSuperMode(false);
         foreach ($items as $item) {
-            // To dispatch inventory event sales_quote_item_qty_set_after, set item qty
-            $item->setQty($item->getQty());
 
             if (!$item->getMessage()) {
                 //Getting product ids for stock item last quantity validation before grid display


### PR DESCRIPTION
https://github.com/magento/magento2/issues/18245

Solution of double triggering of Magento\Sales\Model\Config\Source\Order\Status::checkQuoteItemQty() when add products from admin area