### PR TITLE
Resolved Issue 24708

### DIFF
--- a/app/code/Magento/Analytics/Model/ExportDataHandler.php
+++ b/app/code/Magento/Analytics/Model/ExportDataHandler.php
@@ -157,7 +157,9 @@ class ExportDataHandler implements ExportDataHandlerInterface
     private function prepareFileDirectory(WriteInterface $directory, $path)
     {
         $directory->delete($path);
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction
         if (dirname($path) !== '.') {
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
             $directory->create(dirname($path));
         }
 
@@ -176,6 +178,7 @@ class ExportDataHandler implements ExportDataHandlerInterface
         $this->archive->pack(
             $source,
             $destination,
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
             is_dir($source) ?: false
         );
 

--- a/app/code/Magento/Analytics/Model/ExportDataHandler.php
+++ b/app/code/Magento/Analytics/Model/ExportDataHandler.php
@@ -89,7 +89,7 @@ class ExportDataHandler implements ExportDataHandlerInterface
     public function prepareExportData()
     {
         try {
-            $tmpDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::SYS_TMP);
+            $tmpDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
 
             $this->prepareDirectory($tmpDirectory, $this->getTmpFilesDirRelativePath());
             $this->reportWriter->write($tmpDirectory, $this->getTmpFilesDirRelativePath());

--- a/app/code/Magento/Analytics/Test/Unit/Model/ExportDataHandlerTest.php
+++ b/app/code/Magento/Analytics/Test/Unit/Model/ExportDataHandlerTest.php
@@ -13,7 +13,7 @@ use Magento\Analytics\Model\ReportWriterInterface;
 use Magento\Framework\Archive;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\WriteInterface;
-use Magento\Framework\Filesystem\DirectoryList;
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 
 class ExportDataHandlerTest extends \PHPUnit\Framework\TestCase
@@ -137,7 +137,7 @@ class ExportDataHandlerTest extends \PHPUnit\Framework\TestCase
         $this->filesystemMock
             ->expects($this->once())
             ->method('getDirectoryWrite')
-            ->with(DirectoryList::SYS_TMP)
+            ->with(DirectoryList::VAR_DIR)
             ->willReturn($this->directoryMock);
         $this->directoryMock
             ->expects($this->exactly(4))
@@ -238,7 +238,7 @@ class ExportDataHandlerTest extends \PHPUnit\Framework\TestCase
         $this->filesystemMock
             ->expects($this->once())
             ->method('getDirectoryWrite')
-            ->with(DirectoryList::SYS_TMP)
+            ->with(DirectoryList::VAR_DIR)
             ->willReturn($this->directoryMock);
         $this->reportWriterMock
             ->expects($this->once())


### PR DESCRIPTION
### Description (*)
Resolved [Issue 24708](https://github.com/magento/magento2/issues/24708) 

### Fixed Issues (if relevant)
1. magento/magento2#24708: Module Analytics ExportDataHandler.php

### Manual testing scenarios (*)
1. Execute `analytics_collect_data` cron task of Advanced Reporting module
2. Data creation will be generated within Magento document root `var/` folder instead of `tmp/`

### Questions or comments
Please refer Issue linked for more information

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
