### PR TITLE
magento/magento2#23295: Reset Password Confirmation Link Email Not St…

### DIFF
--- a/app/code/Magento/Customer/Model/EmailNotification.php
+++ b/app/code/Magento/Customer/Model/EmailNotification.php
@@ -340,7 +340,7 @@ class EmailNotification implements EmailNotificationInterface
      */
     public function passwordResetConfirmation(CustomerInterface $customer)
     {
-        $storeId = $this->storeManager->getStore()->getId();
+        $storeId = $customer->getStoreId();
         if (!$storeId) {
             $storeId = $this->getWebsiteStoreId($customer);
         }

--- a/app/code/Magento/Customer/Test/Unit/Model/EmailNotificationTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/EmailNotificationTest.php
@@ -521,7 +521,7 @@ class EmailNotificationTest extends \PHPUnit\Framework\TestCase
 
         /** @var CustomerInterface|\PHPUnit_Framework_MockObject_MockObject $customer */
         $customer = $this->createMock(CustomerInterface::class);
-        $customer->expects($this->any())
+        $customer->expects($this->once())
             ->method('getStoreId')
             ->willReturn($customerStoreId);
         $customer->expects($this->any())
@@ -537,11 +537,6 @@ class EmailNotificationTest extends \PHPUnit\Framework\TestCase
 
         $this->storeManagerMock->expects($this->at(0))
             ->method('getStore')
-            ->willReturn($this->storeMock);
-
-        $this->storeManagerMock->expects($this->at(1))
-            ->method('getStore')
-            ->with($customerStoreId)
             ->willReturn($this->storeMock);
 
         $this->customerRegistryMock->expects($this->once())


### PR DESCRIPTION
…ore Scoped For Global Customers

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23295: Reset Password Confirmation Link Email Not Store Scoped For Global Customers

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
