### PR TITLE
Resolved Issue #24785

### DIFF
--- a/app/code/Magento/Downloadable/Test/Mftf/Section/StorefrontDownloadableProductSection.xml
+++ b/app/code/Magento/Downloadable/Test/Mftf/Section/StorefrontDownloadableProductSection.xml
@@ -15,5 +15,6 @@
         <element name="downloadableLinkSampleByTitle" type="text" selector="//label[contains(., '{{title}}')]/a[contains(@class, 'sample link')]" parameterized="true"/>
         <element name="downloadableSampleLabel" type="text" selector="//a[contains(.,normalize-space('{{title}}'))]" parameterized="true" timeout="30"/>
         <element name="downloadableLinkSelectAllCheckbox" type="checkbox" selector="#links_all" />
+        <element name="downloadableLinkSelectAllLabel" type="text" selector="label[for='links_all']" />
     </section>
 </sections>

--- a/app/code/Magento/Downloadable/Test/Mftf/Test/ManualSelectAllDownloadableLinksDownloadableProductTest.xml
+++ b/app/code/Magento/Downloadable/Test/Mftf/Test/ManualSelectAllDownloadableLinksDownloadableProductTest.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="ManualSelectAllDownloadableLinksDownloadableProductTest">
+        <annotations>
+            <features value="Catalog"/>
+            <stories value="Create Downloadable Product"/>
+            <title value="Manual select all downloadable links downloadable product test"/>
+            <description value="Manually selecting all downloadable links must change 'Select/Unselect all' button label to 'Unselect all', and 'Select all' otherwise"/>
+            <severity value="MAJOR"/>
+            <group value="Downloadable"/>
+        </annotations>
+        <before>
+            <!-- Create category -->
+            <createData entity="SimpleSubCategory" stepKey="createCategory"/>
+
+            <!-- Login as admin -->
+            <actionGroup ref="LoginAsAdmin" stepKey="LoginAsAdmin"/>
+
+            <!-- Create downloadable product -->
+            <amOnPage url="{{AdminProductIndexPage.url}}" stepKey="amOnProductGridPage"/>
+            <waitForPageLoad stepKey="waitForProductGridPageLoad"/>
+            <actionGroup ref="GoToSpecifiedCreateProductPage" stepKey="createProduct">
+                <argument name="productType" value="downloadable"/>
+            </actionGroup>
+
+            <!-- Fill downloadable product values -->
+            <actionGroup ref="fillMainProductFormNoWeight" stepKey="fillDownloadableProductForm">
+                <argument name="product" value="DownloadableProduct"/>
+            </actionGroup>
+
+            <!-- Add downloadable product to category -->
+            <searchAndMultiSelectOption selector="{{AdminProductFormSection.categoriesDropdown}}"
+                                        parameterArray="[$$createCategory.name$$]" stepKey="fillCategory"/>
+
+            <!-- Fill downloadable link information before the creation link -->
+            <actionGroup ref="AdminAddDownloadableLinkInformationActionGroup" stepKey="addDownloadableLinkInformation"/>
+
+            <!-- Links can be purchased separately -->
+            <checkOption selector="{{AdminProductDownloadableSection.isLinksPurchasedSeparately}}"
+                         stepKey="checkOptionPurchaseSeparately"/>
+
+            <!-- Add first downloadable link -->
+            <actionGroup ref="addDownloadableProductLinkWithMaxDownloads" stepKey="addFirstDownloadableProductLink">
+                <argument name="link" value="downloadableLinkWithMaxDownloads"/>
+            </actionGroup>
+
+            <!-- Add second downloadable link -->
+            <actionGroup ref="addDownloadableProductLink" stepKey="addSecondDownloadableProductLink">
+                <argument name="link" value="downloadableLink"/>
+            </actionGroup>
+
+            <!-- Save product -->
+            <actionGroup ref="saveProductForm" stepKey="saveProduct"/>
+        </before>
+        <after>
+            <!-- Delete category -->
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+
+            <!-- Delete created downloadable product -->
+            <actionGroup ref="deleteProductUsingProductGrid" stepKey="deleteProduct">
+                <argument name="product" value="DownloadableProduct"/>
+            </actionGroup>
+
+            <!-- Log out -->
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+
+        <!-- Step 1: Navigate to store front Product page as guest -->
+        <amOnPage url="/{{DownloadableProduct.sku}}.html"
+                  stepKey="amOnStorefrontProductPage"/>
+
+        <!-- Step 2: Check first downloadable link checkbox -->
+        <click
+            selector="{{StorefrontDownloadableProductSection.downloadableLinkByTitle(downloadableLinkWithMaxDownloads.title)}}"
+            stepKey="selectFirstCheckbox"/>
+
+        <!-- Step 3: Check second downloadable link checkbox -->
+        <click
+            selector="{{StorefrontDownloadableProductSection.downloadableLinkByTitle(downloadableLink.title)}}"
+            stepKey="selectSecondCheckbox"/>
+
+        <!-- Step 4: Grab "Select/Unselect All" button label text -->
+        <grabTextFrom
+            selector="{{StorefrontDownloadableProductSection.downloadableLinkSelectAllLabel}}"
+            stepKey="grabUnselectAllButtonText"/>
+
+        <!-- Step 5: Assert that 'Select/Unselect all' button text is 'Unselect all' after manually checking all checkboxes -->
+        <assertEquals
+            message="Assert that 'Select/Unselect all' button text is 'Unselect all' after manually checking all checkboxes"
+            stepKey="assertButtonTextOne">
+                <expectedResult type="string">Unselect all</expectedResult>
+                <actualResult type="string">{$grabUnselectAllButtonText}</actualResult>
+        </assertEquals>
+
+        <!-- Step 6: Uncheck second downloadable link checkbox -->
+        <click
+            selector="{{StorefrontDownloadableProductSection.downloadableLinkByTitle(downloadableLink.title)}}"
+            stepKey="unselectSecondCheckbox"/>
+
+        <!-- Step 7: Grab "Select/Unselect All" button label text -->
+        <grabTextFrom
+            selector="{{StorefrontDownloadableProductSection.downloadableLinkSelectAllLabel}}"
+            stepKey="grabSelectAllButtonText"/>
+
+        <!-- Step 8: Assert that 'Select/Unselect all' button text is 'Select all' after manually unchecking one checkbox -->
+        <assertEquals
+            message="Assert that 'Select/Unselect all' button text is 'Select all' after manually unchecking one checkbox"
+            stepKey="assertButtonTextTwo">
+                <expectedResult type="string">Select all</expectedResult>
+                <actualResult type="string">{$grabSelectAllButtonText}</actualResult>
+        </assertEquals>
+
+    </test>
+</tests>

--- a/app/code/Magento/Downloadable/view/frontend/web/js/downloadable.js
+++ b/app/code/Magento/Downloadable/view/frontend/web/js/downloadable.js
@@ -65,6 +65,31 @@ define([
                     }
                 }
             });
+
+            this.reloadAllCheckText();
+        },
+
+        /**
+         * Reload all-elements-checkbox's label
+         * @private
+         */
+        reloadAllCheckText: function () {
+            let allChecked = true,
+                allElementsCheck = $(this.options.allElements),
+                allElementsLabel = $('label[for="' + allElementsCheck.attr('id') + '"] > span');
+            $(this.options.linkElement).each(function () {
+                if (!this.checked) {
+                    allChecked = false;
+                }
+            });
+
+            if (allChecked) {
+                allElementsLabel.text(allElementsCheck.attr('data-checked'));
+                allElementsCheck.prop('checked', true)
+            } else {
+                allElementsLabel.text(allElementsCheck.attr('data-notchecked'));
+                allElementsCheck.prop('checked', false)
+            }
         }
     });
 

--- a/app/code/Magento/Downloadable/view/frontend/web/js/downloadable.js
+++ b/app/code/Magento/Downloadable/view/frontend/web/js/downloadable.js
@@ -10,7 +10,8 @@ define([
     'jquery-ui-modules/widget',
     'Magento_Catalog/js/price-box'
 ], function ($) {
-
+    'use strict';
+    
     /**
      * Downloadable widget
      */
@@ -78,7 +79,7 @@ define([
          * @private
          */
         reloadAllCheckText: function () {
-            let allChecked = true,
+            var allChecked = true,
                 allElementsCheck = $(this.options.allElements),
                 allElementsLabel = $('label[for="' + allElementsCheck.attr('id') + '"] > span');
 

--- a/app/code/Magento/Downloadable/view/frontend/web/js/downloadable.js
+++ b/app/code/Magento/Downloadable/view/frontend/web/js/downloadable.js
@@ -11,7 +11,7 @@ define([
     'Magento_Catalog/js/price-box'
 ], function ($) {
     'use strict';
-    
+
     /**
      * Downloadable widget
      */

--- a/app/code/Magento/Downloadable/view/frontend/web/js/downloadable.js
+++ b/app/code/Magento/Downloadable/view/frontend/web/js/downloadable.js
@@ -10,12 +10,12 @@ define([
     'jquery-ui-modules/widget',
     'Magento_Catalog/js/price-box'
 ], function ($) {
-    'use strict';
 
     $.widget('mage.downloadable', {
         options: {
             priceHolderSelector: '.price-box'
         },
+
 
         /** @inheritdoc */
         _create: function () {
@@ -77,6 +77,7 @@ define([
             let allChecked = true,
                 allElementsCheck = $(this.options.allElements),
                 allElementsLabel = $('label[for="' + allElementsCheck.attr('id') + '"] > span');
+
             $(this.options.linkElement).each(function () {
                 if (!this.checked) {
                     allChecked = false;
@@ -85,10 +86,10 @@ define([
 
             if (allChecked) {
                 allElementsLabel.text(allElementsCheck.attr('data-checked'));
-                allElementsCheck.prop('checked', true)
+                allElementsCheck.prop('checked', true);
             } else {
                 allElementsLabel.text(allElementsCheck.attr('data-notchecked'));
-                allElementsCheck.prop('checked', false)
+                allElementsCheck.prop('checked', false);
             }
         }
     });

--- a/app/code/Magento/Downloadable/view/frontend/web/js/downloadable.js
+++ b/app/code/Magento/Downloadable/view/frontend/web/js/downloadable.js
@@ -11,13 +11,17 @@ define([
     'Magento_Catalog/js/price-box'
 ], function ($) {
 
+    /**
+     * Downloadable widget
+     */
     $.widget('mage.downloadable', {
         options: {
             priceHolderSelector: '.price-box'
         },
 
-
-        /** @inheritdoc */
+        /**
+         *  @inheritdoc
+         */
         _create: function () {
             var self = this;
 


### PR DESCRIPTION
### Description
Resolved issue #24785 

Added a JS method to handle the state of checked links in a downloadable product. The state is now managed and reflected in the label. **Also added MFTF test to test changing of label.**
- `Unselect all` is displayed _only_ when all links are checked
- `Select all` is displayed otherwise

### Fixed Issues
1. magento/magento2#24785: All selected values still display as Select all in downloadable product

### Manual testing scenarios
1. Create a downloadable product in admin _with_ downloadable links which can be purchased separately
2. Go to storefront, add the product to cart with both downloadable links checked
3. Open minicart and edit the product just added
4. Verify state of checked links with the conditions mentioned in the description

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
