### PR TITLE
Fixed Issue #24803

### DIFF
--- a/app/code/Magento/Email/Test/Mftf/ActionGroup/EmailTemplateActionGroup.xml
+++ b/app/code/Magento/Email/Test/Mftf/ActionGroup/EmailTemplateActionGroup.xml
@@ -21,7 +21,7 @@
         <amOnPage url="{{AdminEmailTemplateIndexPage.url}}" stepKey="navigateToEmailTemplatePage"/>
         <!--Click "Add New Template" button-->
         <click selector="{{AdminMainActionsSection.add}}" stepKey="clickAddNewTemplateButton"/>
-        <!--Select value for "Template" drop-down menu in "Load default template" tab-->
+        <!--Select value for "Template" drop-down menu in "Load Default Template" tab-->
         <selectOption selector="{{AdminEmailTemplateEditSection.templateDropDown}}" userInput="Registry Update" stepKey="selectValueFromTemplateDropDown"/>
         <!--Fill in required fields in "Template Information" tab and click "Save Template" button-->
         <click selector="{{AdminEmailTemplateEditSection.loadTemplateButton}}" stepKey="clickLoadTemplateButton"/>

--- a/app/code/Magento/Email/i18n/en_US.csv
+++ b/app/code/Magento/Email/i18n/en_US.csv
@@ -72,7 +72,7 @@ City,City
 "We're sorry, an error has occurred while generating this content.","We're sorry, an error has occurred while generating this content."
 "Invalid sender data","Invalid sender data"
 Title,Title
-"Load default template","Load default template"
+"Load Default Template","Load Default Template"
 Template,Template
 "Are you sure you want to strip tags?","Are you sure you want to strip tags?"
 "Are you sure you want to delete this template?","Are you sure you want to delete this template?"

--- a/app/code/Magento/Email/view/adminhtml/templates/template/edit.phtml
+++ b/app/code/Magento/Email/view/adminhtml/templates/template/edit.phtml
@@ -12,7 +12,7 @@ use Magento\Framework\App\TemplateTypesInterface;
 <form action="<?= $block->escapeUrl($block->getLoadUrl()) ?>" method="post" id="email_template_load_form">
     <?= $block->getBlockHtml('formkey') ?>
     <fieldset class="admin__fieldset form-inline">
-        <legend class="admin__legend"><span><?= $block->escapeHtml(__('Load default template')) ?></span></legend><br>
+        <legend class="admin__legend"><span><?= $block->escapeHtml(__('Load Default Template')) ?></span></legend><br>
         <div class="admin__field">
             <label class="admin__field-label" for="template_select"><?= $block->escapeHtml(__('Template')) ?></label>
             <div class="admin__field-control">


### PR DESCRIPTION
### Description
Fixed the inconsistent and improper capitalization of heading in Admin -> Marketing -> Communications -> Email Templates

### Fixed Issues (if relevant)
1. magento/magento2#24803: Inconsistent and Improper Capitalization of Heading

### Manual testing scenarios
1. Log in to Admin
2. Navigate to Marketing -> Communications -> Email Templates
3. Create New Template
4. Verify proper capitalization of heading "Load Default Template"

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
