### PR TITLE
Fix #13278 - Wrong return type in Salesrule Module RuleInterface.php

### DIFF
--- a/app/code/Magento/SalesRule/Api/Data/RuleInterface.php
+++ b/app/code/Magento/SalesRule/Api/Data/RuleInterface.php
@@ -61,14 +61,14 @@ interface RuleInterface extends ExtensibleDataInterface
     /**
      * Get display label
      *
-     * @return RuleLabelInterface[]|null
+     * @return \Magento\SalesRule\Api\Data\RuleLabelInterface[]|null
      */
     public function getStoreLabels();
 
     /**
      * Set display label
      *
-     * @param RuleLabelInterface[]|null $storeLabels
+     * @param \Magento\SalesRule\Api\Data\RuleLabelInterface[]|null $storeLabels
      * @return $this
      */
     public function setStoreLabels(array $storeLabels = null);
@@ -182,14 +182,14 @@ interface RuleInterface extends ExtensibleDataInterface
     /**
      * Get condition for the rule
      *
-     * @return ConditionInterface|null
+     * @return \Magento\SalesRule\Api\Data\ConditionInterface|null
      */
     public function getCondition();
 
     /**
      * Set condition for the rule
      *
-     * @param ConditionInterface|null $condition
+     * @param \Magento\SalesRule\Api\Data\ConditionInterface|null $condition
      * @return $this
      */
     public function setCondition(ConditionInterface $condition = null);
@@ -197,14 +197,14 @@ interface RuleInterface extends ExtensibleDataInterface
     /**
      * Get action condition
      *
-     * @return ConditionInterface|null
+     * @return \Magento\SalesRule\Api\Data\ConditionInterface|null
      */
     public function getActionCondition();
 
     /**
      * Set action condition
      *
-     * @param ConditionInterface|null $actionCondition
+     * @param \Magento\SalesRule\Api\Data\ConditionInterface|null $actionCondition
      * @return $this
      */
     public function setActionCondition(ConditionInterface $actionCondition = null);
@@ -438,14 +438,14 @@ interface RuleInterface extends ExtensibleDataInterface
     /**
      * Retrieve existing extension attributes object or create a new one.
      *
-     * @return RuleExtensionInterface|null
+     * @return \Magento\SalesRule\Api\Data\RuleExtensionInterface|null
      */
     public function getExtensionAttributes();
 
     /**
      * Set an extension attributes object.
      *
-     * @param RuleExtensionInterface $extensionAttributes
+     * @param \Magento\SalesRule\Api\Data\RuleExtensionInterface $extensionAttributes
      * @return $this
      */
     public function setExtensionAttributes(RuleExtensionInterface $extensionAttributes);

--- a/app/code/Magento/SalesRule/Api/Data/RuleInterface.php
+++ b/app/code/Magento/SalesRule/Api/Data/RuleInterface.php
@@ -5,13 +5,15 @@
  */
 namespace Magento\SalesRule\Api\Data;
 
+use Magento\Framework\Api\ExtensibleDataInterface;
+
 /**
  * Interface RuleInterface
  *
  * @api
  * @since 100.0.2
  */
-interface RuleInterface extends \Magento\Framework\Api\ExtensibleDataInterface
+interface RuleInterface extends ExtensibleDataInterface
 {
     const FREE_SHIPPING_NONE = 'NONE';
     const FREE_SHIPPING_MATCHING_ITEMS_ONLY = 'MATCHING_ITEMS_ONLY';
@@ -59,14 +61,14 @@ interface RuleInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     /**
      * Get display label
      *
-     * @return \Magento\SalesRule\Api\Data\RuleLabelInterface[]|null
+     * @return RuleLabelInterface[]|null
      */
     public function getStoreLabels();
 
     /**
      * Set display label
      *
-     * @param \Magento\SalesRule\Api\Data\RuleLabelInterface[]|null $storeLabels
+     * @param RuleLabelInterface[]|null $storeLabels
      * @return $this
      */
     public function setStoreLabels(array $storeLabels = null);
@@ -173,21 +175,21 @@ interface RuleInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * Set whether the coupon is active
      *
      * @param bool $isActive
-     * @return bool
+     * @return $this
      */
     public function setIsActive($isActive);
 
     /**
      * Get condition for the rule
      *
-     * @return \Magento\SalesRule\Api\Data\ConditionInterface|null
+     * @return ConditionInterface|null
      */
     public function getCondition();
 
     /**
      * Set condition for the rule
      *
-     * @param \Magento\SalesRule\Api\Data\ConditionInterface|null $condition
+     * @param ConditionInterface|null $condition
      * @return $this
      */
     public function setCondition(ConditionInterface $condition = null);
@@ -195,14 +197,14 @@ interface RuleInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     /**
      * Get action condition
      *
-     * @return \Magento\SalesRule\Api\Data\ConditionInterface|null
+     * @return ConditionInterface|null
      */
     public function getActionCondition();
 
     /**
      * Set action condition
      *
-     * @param \Magento\SalesRule\Api\Data\ConditionInterface|null $actionCondition
+     * @param ConditionInterface|null $actionCondition
      * @return $this
      */
     public function setActionCondition(ConditionInterface $actionCondition = null);
@@ -436,15 +438,15 @@ interface RuleInterface extends \Magento\Framework\Api\ExtensibleDataInterface
     /**
      * Retrieve existing extension attributes object or create a new one.
      *
-     * @return \Magento\SalesRule\Api\Data\RuleExtensionInterface|null
+     * @return RuleExtensionInterface|null
      */
     public function getExtensionAttributes();
 
     /**
      * Set an extension attributes object.
      *
-     * @param \Magento\SalesRule\Api\Data\RuleExtensionInterface $extensionAttributes
+     * @param RuleExtensionInterface $extensionAttributes
      * @return $this
      */
-    public function setExtensionAttributes(\Magento\SalesRule\Api\Data\RuleExtensionInterface $extensionAttributes);
+    public function setExtensionAttributes(RuleExtensionInterface $extensionAttributes);
 }

--- a/app/code/Magento/SalesRule/Api/Data/RuleInterface.php
+++ b/app/code/Magento/SalesRule/Api/Data/RuleInterface.php
@@ -234,6 +234,8 @@ interface RuleInterface extends ExtensibleDataInterface
     public function getIsAdvanced();
 
     /**
+     * Set if rule is advanced
+     *
      * @param bool $isAdvanced
      * @return $this
      */
@@ -262,6 +264,8 @@ interface RuleInterface extends ExtensibleDataInterface
     public function getSortOrder();
 
     /**
+     * Set sort order
+     *
      * @param int $sortOrder
      * @return $this
      */

--- a/app/code/Magento/SalesRule/Model/Data/Rule.php
+++ b/app/code/Magento/SalesRule/Model/Data/Rule.php
@@ -5,10 +5,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\SalesRule\Model\Data;
 
+use Magento\Framework\Api\AbstractExtensibleObject;
 use Magento\SalesRule\Api\Data\ConditionInterface;
+use Magento\SalesRule\Api\Data\RuleExtensionInterface;
 use Magento\SalesRule\Api\Data\RuleInterface;
+use Magento\SalesRule\Api\Data\RuleLabelInterface;
 
 /**
  * Class Rule
@@ -16,7 +21,7 @@ use Magento\SalesRule\Api\Data\RuleInterface;
  * @SuppressWarnings(PHPMD.ExcessivePublicCount)
  * @codeCoverageIgnore
  */
-class Rule extends \Magento\Framework\Api\AbstractExtensibleObject implements RuleInterface
+class Rule extends AbstractExtensibleObject implements RuleInterface
 {
     const KEY_RULE_ID = 'rule_id';
     const KEY_NAME = 'name';
@@ -187,7 +192,7 @@ class Rule extends \Magento\Framework\Api\AbstractExtensibleObject implements Ru
      * Set whether the coupon is active
      *
      * @param bool $isActive
-     * @return bool
+     * @return $this
      */
     public function setIsActive($isActive)
     {
@@ -197,7 +202,7 @@ class Rule extends \Magento\Framework\Api\AbstractExtensibleObject implements Ru
     /**
      * Get condition for the rule
      *
-     * @return \Magento\SalesRule\Api\Data\ConditionInterface|null
+     * @return ConditionInterface|null
      */
     public function getCondition()
     {
@@ -207,7 +212,7 @@ class Rule extends \Magento\Framework\Api\AbstractExtensibleObject implements Ru
     /**
      * Set condition for the rule
      *
-     * @param \Magento\SalesRule\Api\Data\ConditionInterface|null $condition
+     * @param ConditionInterface|null $condition
      * @return $this
      */
     public function setCondition(ConditionInterface $condition = null)
@@ -218,7 +223,7 @@ class Rule extends \Magento\Framework\Api\AbstractExtensibleObject implements Ru
     /**
      * Get action condition
      *
-     * @return \Magento\SalesRule\Api\Data\ConditionInterface|null
+     * @return ConditionInterface|null
      */
     public function getActionCondition()
     {
@@ -228,7 +233,7 @@ class Rule extends \Magento\Framework\Api\AbstractExtensibleObject implements Ru
     /**
      * Set action condition
      *
-     * @param \Magento\SalesRule\Api\Data\ConditionInterface|null $actionCondition
+     * @param ConditionInterface|null $actionCondition
      * @return $this
      */
     public function setActionCondition(ConditionInterface $actionCondition = null)
@@ -283,7 +288,7 @@ class Rule extends \Magento\Framework\Api\AbstractExtensibleObject implements Ru
     /**
      * Get display label
      *
-     * @return \Magento\SalesRule\Api\Data\RuleLabelInterface[]|null
+     * @return RuleLabelInterface[]|null
      */
     public function getStoreLabels()
     {
@@ -293,7 +298,7 @@ class Rule extends \Magento\Framework\Api\AbstractExtensibleObject implements Ru
     /**
      * Set display label
      *
-     * @param \Magento\SalesRule\Api\Data\RuleLabelInterface[]|null $storeLabels
+     * @param RuleLabelInterface[]|null $storeLabels
      * @return $this
      */
     public function setStoreLabels(array $storeLabels = null)
@@ -622,7 +627,7 @@ class Rule extends \Magento\Framework\Api\AbstractExtensibleObject implements Ru
     /**
      * @inheritdoc
      *
-     * @return \Magento\SalesRule\Api\Data\RuleExtensionInterface|null
+     * @return RuleExtensionInterface|null
      */
     public function getExtensionAttributes()
     {
@@ -632,11 +637,11 @@ class Rule extends \Magento\Framework\Api\AbstractExtensibleObject implements Ru
     /**
      * @inheritdoc
      *
-     * @param \Magento\SalesRule\Api\Data\RuleExtensionInterface $extensionAttributes
+     * @param RuleExtensionInterface $extensionAttributes
      * @return $this
      */
     public function setExtensionAttributes(
-        \Magento\SalesRule\Api\Data\RuleExtensionInterface $extensionAttributes
+        RuleExtensionInterface $extensionAttributes
     ) {
         return $this->_setExtensionAttributes($extensionAttributes);
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This is fix for #13278 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#13278: Wrong return type in Salesrule Module RuleInterface.php

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create salesrule object via RuleInterfaceFactory and use its setIsActive() method before another setter method with method chaining.
2. Return typehint of setIsActive() of Magento\SalesRule\Api\Data\RuleInterface should be RuleInterface type ($this).

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
