### PR TITLE
Allow multiple conditions for expired quotes collection

### DIFF
--- a/app/code/Magento/Sales/Model/ExpireQuotesFilterFieldsProvider.php
+++ b/app/code/Magento/Sales/Model/ExpireQuotesFilterFieldsProvider.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Model;
+
+/**
+ * Provides expire quotes filter fields.
+ */
+class ExpireQuotesFilterFieldsProvider
+{
+    /**
+     * @var array
+     */
+    private $expireQuotesFilterFields;
+
+    /**
+     * @param array $expireQuotesFilterFields
+     */
+    public function __construct(
+        array $expireQuotesFilterFields = []
+    ) {
+        $this->expireQuotesFilterFields = $expireQuotesFilterFields;
+    }
+
+    /**
+     * Get expire quotes filter fields.
+     *
+     * @return array
+     */
+    public function getFields(): array
+    {
+        return $this->expireQuotesFilterFields;
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Sales/Cron/CleanExpiredQuotesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Cron/CleanExpiredQuotesTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Cron;
+
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Quote\Model\QuoteRepository;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/**
+ * Test for Magento\Sales\Cron\CleanExpiredQuotes class.
+ *
+ * @magentoAppIsolation enabled
+ * @magentoDbIsolation enabled
+ */
+class CleanExpiredQuotesTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var CleanExpiredQuotes
+     */
+    private $cleanExpiredQuotes;
+
+    /**
+     * @var QuoteRepository
+     */
+    private $quoteRepository;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->cleanExpiredQuotes = $objectManager->get(CleanExpiredQuotes::class);
+        $this->quoteRepository = $objectManager->get(QuoteRepository::class);
+        $this->searchCriteriaBuilder = $objectManager->get(SearchCriteriaBuilder::class);
+    }
+
+    /**
+     * Check if outdated quotes are deleted.
+     *
+     * @magentoConfigFixture default_store checkout/cart/delete_quote_after -365
+     * @magentoDataFixture Magento/Sales/_files/quotes.php
+     */
+    public function testExecute()
+    {
+        $this->cleanExpiredQuotes->execute();
+        $searchCriteria = $this->searchCriteriaBuilder->create();
+        $totalCount = $this->quoteRepository->getList($searchCriteria)->getTotalCount();
+
+        $this->assertEquals(
+            1,
+            $totalCount
+        );
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/quotes.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/quotes.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Quote\Model\QuoteFactory;
+use Magento\Quote\Model\QuoteRepository;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\ObjectManager;
+
+require dirname(dirname(__DIR__)) . '/Store/_files/second_store.php';
+
+/** @var $objectManager ObjectManager */
+$objectManager = Bootstrap::getObjectManager();
+/** @var  QuoteFactory $quoteFactory */
+$quoteFactory = $objectManager->get(QuoteFactory::class);
+/** @var QuoteRepository $quoteRepository */
+$quoteRepository = $objectManager->get(QuoteRepository::class);
+
+$quotes = [
+    'quote for first store' => [
+        'store' => 1,
+    ],
+    'quote for second store' => [
+        'store' => 2,
+    ],
+];
+
+foreach ($quotes as $quoteData) {
+    $quote = $quoteFactory->create();
+    $quote->setStoreId($quoteData['store']);
+    $quoteRepository->save($quote);
+}

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/quotes_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/quotes_rollback.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Registry;
+use Magento\Quote\Model\QuoteRepository;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\ObjectManager;
+
+/** @var ObjectManager $objectManager */
+$objectManager = Bootstrap::getObjectManager();
+
+/** @var Registry $registry */
+$registry = $objectManager->get(Registry::class);
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+
+/** @var QuoteRepository $quoteRepository */
+$quoteRepository = $objectManager->get(QuoteRepository::class);
+/** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+$searchCriteriaBuilder = $objectManager->get(SearchCriteriaBuilder::class);
+$searchCriteria = $searchCriteriaBuilder->create();
+$items = $quoteRepository->getList($searchCriteria)
+    ->getItems();
+foreach ($items as $item) {
+    $quoteRepository->delete($item);
+}
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', false);
+
+require dirname(dirname(__DIR__)) . '/Store/_files/second_store_rollback.php';


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This is a refactoring of magento/magento2#20777

With Magento\Sales\Cron\CleanExpiredQuotes::setExpireQuotesAdditionalFilterFields() assigning values directly to the attribute and getExpireQuotesAdditionalFilterFields() being protected isn't callable outside the class, hence unable to add more to the existing condition, rather they end up being replaced with the new ones.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
-

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
-

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
EE code should also be adapted.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
