### PR TITLE
Fix url for back button on multishipping new shipping address

### DIFF
--- a/app/code/Magento/Multishipping/Controller/Checkout/Address/NewShipping.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Address/NewShipping.php
@@ -6,6 +6,8 @@
 namespace Magento\Multishipping\Controller\Checkout\Address;
 
 /**
+ * New Shipping
+ * 
  * Class NewShipping
  * @package Magento\Multishipping\Controller\Checkout\Address
  */

--- a/app/code/Magento/Multishipping/Controller/Checkout/Address/NewShipping.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Address/NewShipping.php
@@ -6,9 +6,8 @@
 namespace Magento\Multishipping\Controller\Checkout\Address;
 
 /**
- * New Shipping
- * 
  * Class NewShipping
+ *
  * @package Magento\Multishipping\Controller\Checkout\Address
  */
 class NewShipping extends \Magento\Multishipping\Controller\Checkout\Address

--- a/app/code/Magento/Multishipping/Controller/Checkout/Address/NewShipping.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Address/NewShipping.php
@@ -1,11 +1,14 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Multishipping\Controller\Checkout\Address;
 
+/**
+ * Class NewShipping
+ * @package Magento\Multishipping\Controller\Checkout\Address
+ */
 class NewShipping extends \Magento\Multishipping\Controller\Checkout\Address
 {
     /**

--- a/app/code/Magento/Multishipping/Controller/Checkout/Address/NewShipping.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Address/NewShipping.php
@@ -35,7 +35,7 @@ class NewShipping extends \Magento\Multishipping\Controller\Checkout\Address
             if ($this->_getCheckout()->getCustomerDefaultShippingAddress()) {
                 $addressForm->setBackUrl($this->_url->getUrl('*/checkout/addresses'));
             } else {
-                $addressForm->setBackUrl($this->_url->getUrl('*/cart/'));
+                $addressForm->setBackUrl($this->_url->getUrl('checkout/cart/'));
             }
         }
         $this->_view->renderLayout();

--- a/app/code/Magento/Multishipping/Controller/Checkout/Address/NewShipping.php
+++ b/app/code/Magento/Multishipping/Controller/Checkout/Address/NewShipping.php
@@ -5,12 +5,15 @@
  */
 namespace Magento\Multishipping\Controller\Checkout\Address;
 
+use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+use Magento\Multishipping\Controller\Checkout\Address;
+
 /**
  * Class NewShipping
  *
- * @package Magento\Multishipping\Controller\Checkout\Address
+ * @package Address
  */
-class NewShipping extends \Magento\Multishipping\Controller\Checkout\Address
+class NewShipping extends Address implements HttpGetActionInterface
 {
     /**
      * Create New Shipping address Form

--- a/app/code/Magento/Multishipping/Test/Unit/Controller/Checkout/Address/NewShippingTest.php
+++ b/app/code/Magento/Multishipping/Test/Unit/Controller/Checkout/Address/NewShippingTest.php
@@ -170,7 +170,7 @@ class NewShippingTest extends \PHPUnit\Framework\TestCase
     {
         return [
             'shipping_address_exists' => ['*/checkout/addresses', 'shipping_address', 'back/address'],
-            'shipping_address_not_exist' => ['*/cart/', null, 'back/cart']
+            'shipping_address_not_exist' => ['checkout/cart/', null, 'back/cart']
         ];
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Fix back button url on multishipping new shipping address
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #24701 : Magento/Multishipping: Setting wrong back url on creation New Customer Shipping Address Page

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create new customer (customer should not have addresses).
2. Add some product to cart.
3. Open cart.
4. Click "Check Out with Multiple Addresses".
5. Check back button url that is hidden.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
![image](https://user-images.githubusercontent.com/5350377/66050212-26cad380-e503-11e9-889c-04efd374df1b.png)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
