### PR TITLE
Static Content Deploy - Sort JS Translations to have them in the same order on every build

### DIFF
--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -120,6 +120,8 @@ class DataProvider implements DataProviderInterface
             }
         }
 
+        ksort($dictionary);
+
         return $dictionary;
     }
 

--- a/app/code/Magento/Translation/Test/Unit/Model/Js/DataProviderTest.php
+++ b/app/code/Magento/Translation/Test/Unit/Model/Js/DataProviderTest.php
@@ -149,8 +149,11 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
 
         $actualResult = $this->model->getData($themePath);
         $this->assertEquals($expectedResult, $actualResult);
-        $this->assertEquals(json_encode($expectedResult), json_encode($actualResult),
-            "Translations should be sorted by key");
+        $this->assertEquals(
+            json_encode($expectedResult),
+            json_encode($actualResult),
+            "Translations should be sorted by key"
+        );
     }
 
     /**

--- a/app/code/Magento/Translation/Test/Unit/Model/Js/DataProviderTest.php
+++ b/app/code/Magento/Translation/Test/Unit/Model/Js/DataProviderTest.php
@@ -90,7 +90,7 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
         $themePath = 'blank';
         $areaCode = 'adminhtml';
 
-        $filePaths = [['path1'], ['path2'], ['path3'], ['path4']];
+        $filePaths = [['path1'], ['path2'], ['path4'], ['path3']];
 
         $jsFilesMap = [
             ['base', $themePath, '*', '*', [$filePaths[0]]],
@@ -111,8 +111,8 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
         $contentsMap = [
             'content1$.mage.__("hello1")content1',
             'content2$.mage.__("hello2")content2',
+            'content2$.mage.__("hello4")content4', // this value should be last after running data provider
             'content2$.mage.__("hello3")content3',
-            'content2$.mage.__("hello4")content4'
         ];
 
         $translateMap = [
@@ -147,7 +147,10 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
             ->method('render')
             ->willReturnMap($translateMap);
 
-        $this->assertEquals($expectedResult, $this->model->getData($themePath));
+        $actualResult = $this->model->getData($themePath);
+        $this->assertEquals($expectedResult, $actualResult);
+        $this->assertEquals(json_encode($expectedResult), json_encode($actualResult),
+            "Translations should be sorted by key");
     }
 
     /**


### PR DESCRIPTION
### Description (*)
We've faced an issue on BitBucket Pipelines: every build had own unique order of JS translations.
We couldn't see the real diff between builds because of it.
Simple alphabetical sorting of translations resolves this issue.

### Fixed Issues (if relevant)
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
N/A

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
