### PR TITLE
Fixed inconsistent grammar

### DIFF
--- a/app/code/Magento/Newsletter/Test/Mftf/Data/AdminMenuData.xml
+++ b/app/code/Magento/Newsletter/Test/Mftf/Data/AdminMenuData.xml
@@ -19,8 +19,8 @@
         <data key="dataUiId">magento-newsletter-newsletter-subscriber</data>
     </entity>
     <entity name="AdminMenuMarketingCommunicationsNewsletterTemplate">
-        <data key="pageTitle">Newsletter Template</data>
-        <data key="title">Newsletter Template</data>
+        <data key="pageTitle">Newsletter Templates</data>
+        <data key="title">Newsletter Templates</data>
         <data key="dataUiId">magento-newsletter-newsletter-template</data>
     </entity>
     <entity name="AdminMenuReportsMarketingNewsletterProblemReports">

--- a/app/code/Magento/Newsletter/etc/adminhtml/menu.xml
+++ b/app/code/Magento/Newsletter/etc/adminhtml/menu.xml
@@ -7,7 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
     <menu>
-        <add id="Magento_Newsletter::newsletter_template" title="Newsletter Template" translate="title" module="Magento_Newsletter" parent="Magento_Backend::marketing_communications" sortOrder="30" action="newsletter/template/" resource="Magento_Newsletter::template"/>
+        <add id="Magento_Newsletter::newsletter_template" title="Newsletter Templates" translate="title" module="Magento_Newsletter" parent="Magento_Backend::marketing_communications" sortOrder="30" action="newsletter/template/" resource="Magento_Newsletter::template"/>
         <add id="Magento_Newsletter::newsletter_queue" title="Newsletter Queue" translate="title" module="Magento_Newsletter" sortOrder="40" parent="Magento_Backend::marketing_communications" action="newsletter/queue/" resource="Magento_Newsletter::queue"/>
         <add id="Magento_Newsletter::newsletter_subscriber" title="Newsletter Subscribers" translate="title" module="Magento_Newsletter" sortOrder="50" parent="Magento_Backend::marketing_communications" action="newsletter/subscriber/" resource="Magento_Newsletter::subscriber"/>
         <add id="Magento_Newsletter::newsletter_problem" title="Newsletter Problem Reports" translate="title" module="Magento_Newsletter" sortOrder="50" parent="Magento_Reports::report_marketing" action="newsletter/problem/" resource="Magento_Newsletter::problem"/>


### PR DESCRIPTION
### Description
Fixed inconsistent grammar of Newsletter Templates title in menu.
All menu titles are in plural whereas Newsletter Templates title is in singular form. The title of the page once the menu item is clicked, is also in plural. 

Changed `Newsletter Template` -> `Newsletter Templates` under Marketing -> Communications

### Manual testing scenarios
1. Open Admin panel in `2.3-develop` branch
2. Verify change mentioned above in menu title

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
