### PR TITLE
Resolved issue #24779

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/button.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/button.phtml
@@ -7,7 +7,10 @@
 <?php /** @var $block \Magento\Checkout\Block\Onepage\Success */ ?>
 
 <?php if ($block->getCanViewOrder() && $block->getCanPrintOrder()) :?>
-    <a href="<?= $block->escapeUrl($block->getPrintUrl()) ?>" target="_blank" class="print">
+    <a href="<?= $block->escapeUrl($block->getPrintUrl()) ?>"
+       class="action print"
+       target="_blank"
+       rel="noopener">
         <?= $block->escapeHtml(__('Print receipt')) ?>
     </a>
     <?= $block->getChildHtml() ?>

--- a/app/code/Magento/Customer/Test/Mftf/Test/AdminPanelIsFrozenIfStorefrontIsOpenedViaCustomerViewTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/AdminPanelIsFrozenIfStorefrontIsOpenedViaCustomerViewTest.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminPanelIsFrozenIfStorefrontIsOpenedViaCustomerViewTest">
+        <annotations>
+            <features value="Customer"/>
+            <stories value="Customer Order"/>
+            <title value="Place an order and click print"/>
+            <description value="Admin panel is not frozen if Storefront is opened via Customer View"/>
+            <severity value="MAJOR"/>
+            <testCaseId value="https://github.com/magento/magento2/pull/24845"/>
+            <group value="customer"/>
+        </annotations>
+        <before>
+            <createData entity="Simple_US_Customer" stepKey="simpleCustomer"/>
+            <createData entity="SimpleSubCategory" stepKey="createSimpleCategory"/>
+            <createData entity="SimpleProduct" stepKey="createSimpleProduct">
+                <requiredEntity createDataKey="createSimpleCategory"/>
+            </createData>
+            <actionGroup ref="LoginAsAdmin" stepKey="login"/>
+        </before>
+        <after>
+            <deleteData createDataKey="createSimpleCategory" stepKey="deleteCategory"/>
+            <deleteData createDataKey="createSimpleProduct" stepKey="deleteSimpleProduct"/>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+        <actionGroup ref="navigateToNewOrderPageExistingCustomer" stepKey="navigateToNewOrderPage">
+            <argument name="customer" value="$simpleCustomer$"/>
+        </actionGroup>
+        <actionGroup ref="addSimpleProductToOrder" stepKey="addSecondProduct">
+            <argument name="product" value="$createSimpleProduct$"/>
+        </actionGroup>
+        <actionGroup ref="fillOrderCustomerInformation" stepKey="fillCustomerInfo">
+            <argument name="customer" value="$simpleCustomer$"/>
+            <argument name="address" value="US_Address_TX"/>
+        </actionGroup>
+        <actionGroup ref="orderSelectFlatRateShipping" stepKey="selectFlatRate"/>
+        <actionGroup ref="AdminSubmitOrderActionGroup" stepKey="submitOrder"/>
+        <grabTextFrom selector="|Order # (\d+)|" stepKey="getOrderId"/>
+
+        <actionGroup ref="StartCreateInvoiceFromOrderPage" stepKey="startCreateInvoice"/>
+        <actionGroup ref="SubmitInvoice" stepKey="submitInvoice"/>
+        <actionGroup ref="goToShipmentIntoOrder" stepKey="goToShipment"/>
+        <actionGroup ref="submitShipmentIntoOrder" stepKey="submitShipment"/>
+
+        <!--Create Credit Memo-->
+        <actionGroup ref="StartToCreateCreditMemoActionGroup" stepKey="startToCreateCreditMemo">
+            <argument name="orderId" value="{$getOrderId}"/>
+        </actionGroup>
+        <actionGroup ref="SubmitCreditMemoActionGroup" stepKey="submitCreditMemo"/>
+
+        <actionGroup ref="LoginToStorefrontActionGroup" stepKey="logInCustomer">
+            <argument name="Customer" value="$$simpleCustomer$$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontCustomerGoToSidebarMenu" stepKey="goToMyOrdersPage">
+            <argument name="menu" value="My Orders"/>
+        </actionGroup>
+        <click selector="{{StorefrontCustomerOrderSection.viewOrder}}" stepKey="clickViewOrder"/>
+        <click selector="{{StorefrontCustomerOrderViewSection.printOrderLink}}" stepKey="clickPrintOrderLink"/>
+        <waitForPageLoad stepKey="waitPageReload"/>
+        <switchToWindow stepKey="switchToWindow"/>
+        <switchToPreviousTab stepKey="switchToPreviousTab"/>
+
+        <actionGroup ref="StorefrontCustomerGoToSidebarMenu" stepKey="goToAddressBook">
+            <argument name="menu" value="Address Book"/>
+        </actionGroup>
+        <see selector="{{CheckoutOrderSummarySection.shippingAddress}}" userInput="{{US_Address_TX.street[0]}} {{US_Address_TX.city}}, {{US_Address_TX.state}}, {{US_Address_TX.postcode}}" stepKey="checkShippingAddress"/>
+    </test>
+</tests>

--- a/app/code/Magento/Sales/view/frontend/templates/order/creditmemo/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/creditmemo/items.phtml
@@ -7,8 +7,9 @@
 <?php $_order = $block->getOrder() ?>
 <div class="actions-toolbar">
     <a href="<?= $block->escapeUrl($block->getPrintAllCreditmemosUrl($_order)) ?>"
-       onclick="this.target='_blank'"
-       class="action print">
+       class="action print"
+       target="_blank"
+       rel="noopener">
         <span><?= $block->escapeHtml(__('Print All Refunds')) ?></span>
     </a>
 </div>
@@ -16,8 +17,9 @@
     <div class="order-title">
         <strong><?= $block->escapeHtml(__('Refund #')) ?><?= $block->escapeHtml($_creditmemo->getIncrementId()) ?> </strong>
         <a href="<?= $block->escapeUrl($block->getPrintCreditmemoUrl($_creditmemo)) ?>"
-           onclick="this.target='_blank'"
-           class="action print">
+           class="action print"
+           target="_blank"
+           rel="noopener">
             <span><?= $block->escapeHtml(__('Print Refund')) ?></span>
         </a>
     </div>

--- a/app/code/Magento/Sales/view/frontend/templates/order/info/buttons.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/info/buttons.phtml
@@ -16,9 +16,10 @@
             <span><?= $block->escapeHtml(__('Reorder')) ?></span>
         </a>
     <?php endif ?>
-    <a class="action print"
-       href="<?= $block->escapeUrl($block->getPrintUrl($_order)) ?>"
-       onclick="this.target='_blank';">
+    <a href="<?= $block->escapeUrl($block->getPrintUrl($_order)) ?>"
+       class="action print"
+       target="_blank"
+       rel="noopener">
         <span><?= $block->escapeHtml(__('Print Order')) ?></span>
     </a>
     <?= $block->getChildHtml() ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/invoice/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/invoice/items.phtml
@@ -7,8 +7,9 @@
 <?php $_order = $block->getOrder() ?>
 <div class="actions-toolbar">
     <a href="<?= $block->escapeUrl($block->getPrintAllInvoicesUrl($_order)) ?>"
+       class="action print"
        target="_blank"
-       class="action print">
+       rel="noopener">
         <span><?= $block->escapeHtml(__('Print All Invoices')) ?></span>
     </a>
 </div>
@@ -16,8 +17,9 @@
     <div class="order-title">
         <strong><?= $block->escapeHtml(__('Invoice #')) ?><?= $block->escapeHtml($_invoice->getIncrementId()) ?></strong>
         <a href="<?= $block->escapeUrl($block->getPrintInvoiceUrl($_invoice)) ?>"
-           onclick="this.target='_blank'"
-           class="action print">
+           class="action print"
+           target="_blank"
+           rel="noopener">
             <span><?= $block->escapeHtml(__('Print Invoice')) ?></span>
         </a>
     </div>

--- a/app/code/Magento/Shipping/view/frontend/templates/items.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/items.phtml
@@ -15,8 +15,9 @@
         <?= $block->getChildHtml('track-all-link') ?>
     <?php endif; ?>
     <a href="<?= $block->escapeUrl($block->getPrintAllShipmentsUrl($_order)) ?>"
-       onclick="this.target='_blank'"
-       class="action print">
+       class="action print"
+       target="_blank"
+       rel="noopener">
         <span><?= $block->escapeHtml(__('Print All Shipments')) ?></span>
     </a>
 </div>
@@ -24,8 +25,9 @@
     <div class="order-title">
         <strong><?= $block->escapeHtml(__('Shipment #')) ?><?= $block->escapeHtml($_shipment->getIncrementId()) ?></strong>
         <a href="<?= $block->escapeUrl($block->getPrintShipmentUrl($_shipment)) ?>"
-           onclick="this.target='_blank'"
-           class="action print">
+           class="action print"
+           target="_blank"
+           rel="noopener">
             <span><?= $block->escapeHtml(__('Print Shipment')) ?></span>
         </a>
         <a href="#"


### PR DESCRIPTION
### Description
Resolved Issue #24779 
- Added a `rel="noopener"` attribute to the anchor tag prevents freezing of parent tabs

### Fixed Issues
- magento/magento2#24779: Admin panel is frozen if Storefront is opened via Customer View

### Manual testing scenarios
1. In Admin panel, navigate to Sales -> Orders
2. Open an order
3. Click Customer View in the profile menu on top right
4. Create a test customer in the tab that was opened automatically (do not close previous tab)
5. Place an order and click print.
6. You should see the print preview in new tab (do not close previous tab)

**All previously opened tabs are responsive and active now.**

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
