### PR TITLE
Fix customer data and sections configuration race condition

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/js/customer-data.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/js/customer-data.phtml
@@ -6,16 +6,15 @@
 
 /** @var \Magento\Customer\Block\CustomerData $block */
 ?>
-<script type="text/x-magento-init">
-    {
-        "*": {
-            "Magento_Customer/js/customer-data": {
-                "sectionLoadUrl": "<?= $block->escapeJs($block->escapeUrl($block->getCustomerDataUrl('customer/section/load'))) ?>",
-                "expirableSectionLifetime": <?= (int)$block->getExpirableSectionLifetime() ?>,
-                "expirableSectionNames": <?= /* @noEscape */ $this->helper(\Magento\Framework\Json\Helper\Data::class)->jsonEncode($block->getExpirableSectionNames()) ?>,
-                "cookieLifeTime": "<?= $block->escapeJs($block->getCookieLifeTime()) ?>",
-                "updateSessionUrl": "<?= $block->escapeJs($block->escapeUrl($block->getCustomerDataUrl('customer/account/updateSession'))) ?>"
-            }
-        }
-    }
+<script>
+    requirejs.config({
+        config: <?= /* @noEscape */ $this->helper(\Magento\Framework\Json\Helper\Data::class)->jsonEncode(['Magento_Customer/js/customer-data' => [
+                    'sectionLoadUrl' => $block->getCustomerDataUrl('customer/section/load'),
+                    'expirableSectionLifetime' => $block->getExpirableSectionLifetime(),
+                    'expirableSectionNames' => $block->getExpirableSectionNames(),
+                    'cookieLifeTime' => $block->getCookieLifeTime(),
+                    'updateSessionUrl' => $block->getCustomerDataUrl('customer/account/updateSession'),
+                ]]); ?>
+
+    });
 </script>

--- a/app/code/Magento/Customer/view/frontend/templates/js/section-config.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/js/section-config.phtml
@@ -6,19 +6,17 @@
 
 /** @var \Magento\Customer\Block\SectionConfig $block */
 ?>
-<script type="text/x-magento-init">
-    {
-        "*": {
-            "Magento_Customer/js/section-config": {
-                "sections": <?= /* @noEscape */ $this->helper(\Magento\Framework\Json\Helper\Data::class)->jsonEncode($block->getSections()) ?>,
-                "clientSideSections": <?= /* @noEscape */ $this->helper(\Magento\Framework\Json\Helper\Data::class)->jsonEncode($block->getClientSideSections()) ?>,
-                "baseUrls": <?= /* @noEscape */ $this->helper(\Magento\Framework\Json\Helper\Data::class)->jsonEncode(array_unique([
-                    $block->getUrl(null, ['_secure' => true]),
-                    $block->getUrl(null, ['_secure' => false]),
-                ])) ?>,
-                "sectionNames": <?= /* @noEscape */ $this->helper(\Magento\Framework\Json\Helper\Data::class)
-                    ->jsonEncode($block->getData('sectionNamesProvider')->getSectionNames()) ?>
-            }
-        }
-    }
+<script>
+    requirejs.config({
+        config: <?= /* @noEscape */ $this->helper(\Magento\Framework\Json\Helper\Data::class)->jsonEncode([
+                    'Magento_Customer/js/section-config' => [
+                        'sections' => $block->getSections(),
+                        'clientSideSections' => $block->getClientSideSections(),
+                        'baseUrls' => array_unique([
+                            $block->getUrl(null, ['_secure' => true]),
+                            $block->getUrl(null, ['_secure' => false]),
+                        ]),
+                    ]
+                ]); ?>
+    });
 </script>

--- a/app/code/Magento/Customer/view/frontend/templates/js/section-config.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/js/section-config.phtml
@@ -16,6 +16,7 @@
                             $block->getUrl(null, ['_secure' => true]),
                             $block->getUrl(null, ['_secure' => false]),
                         ]),
+                        'sectionNames' => $block->getData('sectionNamesProvider')->getSectionNames()
                     ]
                 ]); ?>
     });

--- a/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
@@ -11,13 +11,13 @@ define([
     'underscore',
     'ko',
     'Magento_Customer/js/section-config',
-    'mage/url',
+    'module',
     'mage/storage',
     'jquery/jquery-storageapi'
-], function ($, _, ko, sectionConfig, url) {
+], function ($, _, ko, sectionConfig, module) {
     'use strict';
 
-    var options = {},
+    var options = module.config(),
         storage,
         storageInvalidation,
         invalidateCacheBySessionTimeOut,
@@ -25,9 +25,6 @@ define([
         dataProvider,
         buffer,
         customerData;
-
-    url.setBaseUrl(window.BASE_URL);
-    options.sectionLoadUrl = url.build('customer/section/load');
 
     //TODO: remove global change, in this case made for initNamespaceStorage
     $.cookieStorage.setConf({
@@ -337,16 +334,14 @@ define([
         },
 
         /**
-         * @param {Object} settings
          * @constructor
          */
-        'Magento_Customer/js/customer-data': function (settings) {
-            options = settings;
-            invalidateCacheBySessionTimeOut(settings);
-            invalidateCacheByCloseCookieSession();
-            customerData.init();
-        }
+        'Magento_Customer/js/customer-data': function () {}
     };
+
+    invalidateCacheBySessionTimeOut(options);
+    invalidateCacheByCloseCookieSession();
+    customerData.init();
 
     /**
      * Events listener

--- a/app/code/Magento/Customer/view/frontend/web/js/section-config.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/section-config.js
@@ -3,10 +3,15 @@
  * See COPYING.txt for license details.
  */
 
-define(['underscore'], function (_) {
+define(['underscore', 'module'], function (_, module) {
     'use strict';
 
-    var baseUrls, sections, clientSideSections, sectionNames, canonize;
+    var options = module.config(),
+        baseUrls = options.baseUrls,
+        sections = options.sections,
+        clientSideSections = options.clientSideSections,
+        sectionNames = options.sectionNames,
+        canonize;
 
     /**
      * @param {String} url
@@ -80,14 +85,8 @@ define(['underscore'], function (_) {
         },
 
         /**
-         * @param {Object} options
          * @constructor
          */
-        'Magento_Customer/js/section-config': function (options) {
-            baseUrls = options.baseUrls;
-            sections = options.sections;
-            clientSideSections = options.clientSideSections;
-            sectionNames = options.sectionNames;
-        }
+        'Magento_Customer/js/section-config': function () {}
     };
 });


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
This pull request aims to fix all issues connected with the fact that the configuration of customer data and its sections is currently being passed through `x-magento-init` script block.
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The majority of information is already provided within https://github.com/magento/magento2/issues/17125 and https://github.com/magento/magento2/pull/23099. Because of the fact that both `customer-data.js` and `section-config.js` modules rely on `x-magento-init` script to initialize them with configuration there are situations in which they can be required and evaluated by other modules before that actually happens which results in multiple errors e.g.:

- `TypeError: sections is undefined`
- `Uncaught TypeError: Cannot set property 'sectionLoadUrl' of undefined`
- `TypeError: Cannot read property '*' of undefined`

My initial idea was to pass mentioned configuration simply via a global variable but then I remembered that RequireJS actually has a build-in mechanism for that https://requirejs.org/docs/api.html#config-moduleconfig which I took advantage of. This pull request also makes changes within https://github.com/magento/magento2/pull/23099 obsolete.

### Fixed Issues (if relevant)
1. magento/magento2#17125: x-magento-init initialisation not bound to happen in the right order.
2. https://github.com/magento/magento2/issues/14412 Magento 2.2.3 TypeErrors Cannot read property 'quoteData' / 'storecode' / 'sectionLoadUrl' of undefined
3. https://github.com/magento/magento2/issues/13403 Magento 2.1.11 CE ADD TO CART is stuck on ADDING
4. https://github.com/magento/magento2/issues/8628 cannot read property 'section loadurl' of undefined in all pages - Custom Theme

### Manual testing scenarios (*)
1. Reload the shop.
2. Trigger customer data or sections data module at the very beginning for example by running the following code:
```javascript
require(['Magento_Customer/js/section-config'], function(sectionsConfig) {
    console.log(sectionsConfig.getAffectedSections('test'));
});
```
3. `TypeError: sections is undefined` is being thrown without this changes.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
