### PR TITLE
#5891 UI listing drop-down value issue

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/select.js
@@ -45,10 +45,8 @@ define([
             options.forEach(function (item) {
                 if (_.contains(values, item.value + '')) {
                     label.push(item.label);
-                } else {
-                    if (_.contains(multiSelectValues, item.value + '')) {
-                        label.push(item.label);
-                    }
+                } else if (_.contains(multiSelectValues, item.value + '')) {
+                    label.push(item.label);
                 }
             });
 

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/select.js
@@ -21,10 +21,15 @@ define([
         getLabel: function () {
             var options = this.options || [],
                 values = this._super(),
+                multiSelectValues = [],
                 label = [];
 
             if (_.isString(values)) {
-                values = values.split(',');
+                multiSelectValues = values.split(',');
+
+                multiSelectValues = multiSelectValues.map(function (value) {
+                    return value + '';
+                });
             }
 
             if (!_.isArray(values)) {
@@ -40,6 +45,10 @@ define([
             options.forEach(function (item) {
                 if (_.contains(values, item.value + '')) {
                     label.push(item.label);
+                } else {
+                    if (_.contains(multiSelectValues, item.value + '')) {
+                        label.push(item.label);
+                    }
                 }
             });
 


### PR DESCRIPTION
### Description (*)
added support comma separeted values for select ui component 

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/magento2/issues/5891: UI listing drop-down value issue

### Manual testing scenarios (*)
1. Add to options array value with comma, for example:
Magento\Cms\Model\Page\Source\PageLayout
`public function toOptionArray()
    {
        if ($this->options !== null) {
            return $this->options;
        }

        $configOptions = $this->pageLayoutBuilder->getPageLayoutsConfig()->getOptions();
        $options = [];
        foreach ($configOptions as $key => $value) {
            $options[] = [
                'label' => $value,
                'value' => $key,
            ];
        }

        ///Test
        $options[] = [
            'label' => 'test',
            'value' => 'test, test',
        ];
        ///
        $this->options = $options;
        return $this->options;
    }`
( this is just example you can add similar values to any drop down ui component )
2. For any CMS Page change "Page Layout" value to "test".
3. check the value in the CMS Page grid

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
