### PR TITLE
Correct image params - allow to disable image frame, fix image params hash

### DIFF
--- a/app/code/Magento/Catalog/Helper/Image.php
+++ b/app/code/Magento/Catalog/Helper/Image.php
@@ -213,31 +213,29 @@ class Image extends AbstractHelper implements ArgumentInterface
 
         // Set 'keep frame' flag
         $frame = $this->getFrame();
-        if (!empty($frame)) {
-            $this->_getModel()->setKeepFrame($frame);
-        }
+        $this->_getModel()->setKeepFrame($frame);
 
         // Set 'constrain only' flag
         $constrain = $this->getAttribute('constrain');
-        if (!empty($constrain)) {
+        if (null !== $constrain) {
             $this->_getModel()->setConstrainOnly($constrain);
         }
 
         // Set 'keep aspect ratio' flag
         $aspectRatio = $this->getAttribute('aspect_ratio');
-        if (!empty($aspectRatio)) {
+        if (null !== $aspectRatio) {
             $this->_getModel()->setKeepAspectRatio($aspectRatio);
         }
 
         // Set 'transparency' flag
         $transparency = $this->getAttribute('transparency');
-        if (!empty($transparency)) {
+        if (null !== $transparency) {
             $this->_getModel()->setKeepTransparency($transparency);
         }
 
         // Set background color
         $background = $this->getAttribute('background');
-        if (!empty($background)) {
+        if (null !== $background) {
             $this->_getModel()->setBackgroundColor($background);
         }
 

--- a/app/code/Magento/Catalog/Model/View/Asset/Image.php
+++ b/app/code/Magento/Catalog/Model/View/Asset/Image.php
@@ -200,11 +200,11 @@ class Image implements LocalInterface
         $miscParams['image_width'] = 'w:' . ($miscParams['image_width'] ?? 'empty');
         $miscParams['quality'] = 'q:' . ($miscParams['quality'] ?? 'empty');
         $miscParams['angle'] = 'r:' . ($miscParams['angle'] ?? 'empty');
-        $miscParams['keep_aspect_ratio'] = (isset($miscParams['keep_aspect_ratio']) ? '' : 'non') . 'proportional';
-        $miscParams['keep_frame'] = (isset($miscParams['keep_frame']) ? '' : 'no') . 'frame';
-        $miscParams['keep_transparency'] = (isset($miscParams['keep_transparency']) ? '' : 'no') . 'transparency';
-        $miscParams['constrain_only'] = (isset($miscParams['constrain_only']) ? 'do' : 'not') . 'constrainonly';
-        $miscParams['background'] = isset($miscParams['background'])
+        $miscParams['keep_aspect_ratio'] = (!empty($miscParams['keep_aspect_ratio']) ? '' : 'non') . 'proportional';
+        $miscParams['keep_frame'] = (!empty($miscParams['keep_frame']) ? '' : 'no') . 'frame';
+        $miscParams['keep_transparency'] = (!empty($miscParams['keep_transparency']) ? '' : 'no') . 'transparency';
+        $miscParams['constrain_only'] = (!empty($miscParams['constrain_only']) ? 'do' : 'not') . 'constrainonly';
+        $miscParams['background'] = !empty($miscParams['background'])
             ? 'rgb' . implode(',', $miscParams['background'])
             : 'nobackground';
         return $miscParams;

--- a/app/code/Magento/Catalog/Model/View/Asset/Image.php
+++ b/app/code/Magento/Catalog/Model/View/Asset/Image.php
@@ -88,7 +88,7 @@ class Image implements LocalInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getUrl()
     {
@@ -96,7 +96,7 @@ class Image implements LocalInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getContentType()
     {
@@ -104,7 +104,7 @@ class Image implements LocalInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getPath()
     {
@@ -112,7 +112,7 @@ class Image implements LocalInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getSourceFile()
     {
@@ -131,7 +131,7 @@ class Image implements LocalInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getContent()
     {
@@ -139,7 +139,7 @@ class Image implements LocalInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getFilePath()
     {
@@ -147,7 +147,8 @@ class Image implements LocalInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
+     *
      * @return ContextInterface
      */
     public function getContext()
@@ -156,7 +157,7 @@ class Image implements LocalInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getModule()
     {
@@ -191,10 +192,11 @@ class Image implements LocalInterface
 
     /**
      * Converting bool into a string representation
-     * @param $miscParams
+     *
+     * @param array $miscParams
      * @return array
      */
-    private function convertToReadableFormat($miscParams)
+    private function convertToReadableFormat(array $miscParams)
     {
         $miscParams['image_height'] = 'h:' . ($miscParams['image_height'] ?? 'empty');
         $miscParams['image_width'] = 'w:' . ($miscParams['image_width'] ?? 'empty');

--- a/app/code/Magento/Catalog/Test/Unit/Helper/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Helper/ImageTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Catalog\Test\Unit\Helper;
 
 use Magento\Catalog\Helper\Image;
@@ -295,32 +296,34 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     {
         $this->scopeConfig->expects($this->any())
             ->method('getValue')
-            ->willReturnMap([
+            ->willReturnMap(
                 [
-                    'design/watermark/' . $data['type'] . '_image',
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                    null,
-                    $data['watermark']
-                ],
-                [
-                    'design/watermark/' . $data['type'] . '_imageOpacity',
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                    null,
-                    $data['watermark_opacity']
-                ],
-                [
-                    'design/watermark/' . $data['type'] . '_position',
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                    null,
-                    $data['watermark_position']
-                ],
-                [
-                    'design/watermark/' . $data['type'] . '_size',
-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-                    null,
-                    $data['watermark_size']
-                ],
-            ]);
+                    [
+                        'design/watermark/' . $data['type'] . '_image',
+                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                        null,
+                        $data['watermark']
+                    ],
+                    [
+                        'design/watermark/' . $data['type'] . '_imageOpacity',
+                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                        null,
+                        $data['watermark_opacity']
+                    ],
+                    [
+                        'design/watermark/' . $data['type'] . '_position',
+                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                        null,
+                        $data['watermark_position']
+                    ],
+                    [
+                        'design/watermark/' . $data['type'] . '_size',
+                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                        null,
+                        $data['watermark_size']
+                    ],
+                ]
+            );
 
         $this->image->expects($this->any())
             ->method('setWatermarkFile')

--- a/app/code/Magento/Catalog/Test/Unit/Helper/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Helper/ImageTest.php
@@ -30,6 +30,11 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     protected $assetRepository;
 
     /**
+     * @var \Magento\Framework\Config\View|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $configView;
+
+    /**
      * @var \Magento\Framework\View\ConfigInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $viewConfig;
@@ -55,6 +60,10 @@ class ImageTest extends \PHPUnit\Framework\TestCase
         $this->mockImage();
 
         $this->assetRepository = $this->getMockBuilder(\Magento\Framework\View\Asset\Repository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->configView = $this->getMockBuilder(\Magento\Framework\Config\View::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -152,22 +161,88 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @param array $data - optional 'frame' key
+     * @param bool $whiteBorders view config
+     * @param bool $expectedKeepFrame
+     * @dataProvider initKeepFrameDataProvider
+     */
+    public function testInitKeepFrame($data, $whiteBorders, $expectedKeepFrame)
+    {
+        $imageId = 'test_image_id';
+        $attributes = [];
+
+        $productMock = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->prepareAttributes($data, $imageId);
+
+        $this->configView->expects(isset($data['frame']) ? $this->never() : $this->once())
+            ->method('getVarValue')
+            ->with('Magento_Catalog', 'product_image_white_borders')
+            ->willReturn($whiteBorders);
+
+        $this->viewConfig->expects($this->once())
+            ->method('getViewConfig')
+            ->willReturn($this->configView);
+
+        $this->image->expects($this->once())
+            ->method('setKeepFrame')
+            ->with($expectedKeepFrame)
+            ->willReturnSelf();
+
+        $this->helper->init($productMock, $imageId, $attributes);
+    }
+
+    /**
+     * @return array
+     */
+    public function initKeepFrameDataProvider()
+    {
+        return [
+            // when frame defined explicitly, it wins
+            [
+                'mediaImage' => [
+                    'frame' => 1,
+                ],
+                'whiteBorders' => true,
+                'expected' => true,
+            ],
+            [
+                'mediaImage' => [
+                    'frame' => 0,
+                ],
+                'whiteBorders' => true,
+                'expected' => false,
+            ],
+            // when frame is not defined, var is used
+            [
+                'mediaImage' => [],
+                'whiteBorders' => true,
+                'expected' => true,
+            ],
+            [
+                'mediaImage' => [],
+                'whiteBorders' => false,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    /**
      * @param $data
      * @param $imageId
      */
     protected function prepareAttributes($data, $imageId)
     {
-        $configViewMock = $this->getMockBuilder(\Magento\Framework\Config\View::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $configViewMock->expects($this->once())
+        $this->configView->expects($this->once())
             ->method('getMediaAttributes')
             ->with('Magento_Catalog', Image::MEDIA_TYPE_CONFIG_NODE, $imageId)
             ->willReturn($data);
 
         $this->viewConfig->expects($this->once())
             ->method('getViewConfig')
-            ->willReturn($configViewMock);
+            ->willReturn($this->configView);
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
1. Images, generated with "legacy" image generation (generated in backend when image URL is requested), do not respect `product_image_white_borders` [view config](https://github.com/magento/magento2/blob/2.3.2/app/design/frontend/Magento/luma/etc/view.xml#L259) and always have white borders. This is because `false` value does not pass `!empty()` check is [never passed](https://github.com/magento/magento2/blob/2.3.2/app/code/Magento/Catalog/Helper/Image.php#L216).

    While in Magento 2.3.0 images are generated only when requested, there're extensions that use old classes, for example [Algolia](https://github.com/algolia/algoliasearch-magento-2/blob/1.12.0/Helper/Entity/ProductHelper.php#L706). When new image thumbnail is first time created with "old" generation, image white borders are always set. If the same image thumbnail is first accessed from frontend category page, "new" generation is kicked off and white borders config is respected.

2. Different images - one with frame, and one without frame - result in same hash and the first generated wins:

    - `keep_frame` - before converting https://prnt.sc/peyz9s
    - `keep_frame` - after incorrect converting https://prnt.sc/peyzpr

    This happens because `isset($miscParams['keep_frame']` treats `false` values as "set".

<!---
### Fixed Issues (if relevant)
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
1. magento/magento2#<issue_number>: Issue title
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Edit theme view.xml app/design/frontend/Magento/luma/etc/view.xml:259:
    `<var name="product_image_white_borders">0</var>`
    This is normally overwritten in custom themes.

2. Use a module that uses "legacy" image generation. This can be Algolia, or I prepared a demo module as a showcase - https://github.com/unicoder88/demo-image

3. Upload new product image (JPG) and save, immediately generate image thumbnail. Image is generated with white borders, while should have transparent edges (problem 1 in this PR).

    With demo module, open this URL passing product ID: https://magento2.local/demo_image/thumbnail/make/id/1
  
    https://prnt.sc/pf07ix - image with white borders

4. Open product on frontend. On 2.3.0+ frontend, product thumbnail URL is generated with different classes and correctly respects `product_image_white_borders`, which in theory should make different image thumbnail than in step 3. However, generated image **hash** and thumbnail URL are **same** as in step 3. Normally images with different params should have different hashes. We see white borders on frontend, because thumbnail has already been made  (problem 2 in this PR).

    https://prnt.sc/pf08nt - product in category page, with grayed `<body>` background to highlight thumbnail borders.

<!---
### Questions or comments
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
