### PR TITLE
Fixed Issue #24809 Invisible reCaptcha does not replace default captcha on forgotten password form

### DIFF
--- a/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
+++ b/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
@@ -11,8 +11,13 @@
  */
 namespace Magento\Captcha\Helper\Adminhtml;
 
+use Magento\Store\Model\ScopeInterface;
+
 class Data extends \Magento\Captcha\Helper\Data
 {
+    // Configuration path
+    const XML_PATH_ENABLED_BACKEND = 'msp_securitysuite_recaptcha/backend/enabled';
+    
     /**
      * @var \Magento\Backend\App\ConfigInterface
      */
@@ -64,9 +69,10 @@ class Data extends \Magento\Captcha\Helper\Data
      *
      * @return bool
      */
-    public function reCaptchaEnable(){
-        return (bool)$this->scopeConfig->getValue(
-            'msp_securitysuite_recaptcha/backend/enabled',
+    public function reCaptchaEnable()
+    {
+        return (bool) $this->scopeConfig->getValue(
+            XML_PATH_ENABLED_BACKEND,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
     }

--- a/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
+++ b/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
@@ -73,7 +73,7 @@ class Data extends \Magento\Captcha\Helper\Data
     {
         return (bool) $this->scopeConfig->getValue(
             XML_PATH_ENABLED_BACKEND,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            ScopeInterface::SCOPE_STORE
         );
     }
 }

--- a/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
+++ b/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
@@ -58,4 +58,16 @@ class Data extends \Magento\Captcha\Helper\Data
     {
         return 'admin';
     }
+    
+     /**
+     * Check if reCaptcha is enable for backend
+     *
+     * @return bool
+     */
+    public function reCaptchaEnable(){
+        return $this->scopeConfig->getValue(
+            'msp_securitysuite_recaptcha/backend/enabled',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+    }
 }

--- a/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
+++ b/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
@@ -14,6 +14,12 @@ namespace Magento\Captcha\Helper\Adminhtml;
 
 use Magento\Store\Model\ScopeInterface;
 
+/**
+ * Captcha image model
+ *
+ * @api
+ * @since 100.0.2
+ */
 class Data extends \Magento\Captcha\Helper\Data
 {
     /**

--- a/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
+++ b/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
@@ -7,7 +7,7 @@
 /**
  * Captcha helper for adminhtml area
  *
- * @author     Magento Core Team <core@magentocommerce.com>
+ * @author Magento Core Team <core@magentocommerce.com>
  */
 
 namespace Magento\Captcha\Helper\Adminhtml;
@@ -20,7 +20,7 @@ class Data extends \Magento\Captcha\Helper\Data
      * @var \Magento\Backend\App\ConfigInterface
      */
     protected $_backendConfig;
-    
+
     /**
      * Backend configuration path for reCaptcha
      */
@@ -28,10 +28,10 @@ class Data extends \Magento\Captcha\Helper\Data
 
     /**
      * @param \Magento\Framework\App\Helper\Context $context
-     * @param \Magento\Store\Model\StoreManager $storeManager
-     * @param \Magento\Framework\Filesystem $filesystem
+     * @param \Magento\Store\Model\StoreManager     $storeManager
+     * @param \Magento\Framework\Filesystem         $filesystem
      * @param \Magento\Captcha\Model\CaptchaFactory $factory
-     * @param \Magento\Backend\App\ConfigInterface $backendConfig
+     * @param \Magento\Backend\App\ConfigInterface  $backendConfig
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
@@ -39,8 +39,7 @@ class Data extends \Magento\Captcha\Helper\Data
         \Magento\Framework\Filesystem $filesystem,
         \Magento\Captcha\Model\CaptchaFactory $factory,
         \Magento\Backend\App\ConfigInterface $backendConfig
-    )
-    {
+    ) {
         $this->_backendConfig = $backendConfig;
         parent::__construct($context, $storeManager, $filesystem, $factory);
     }
@@ -48,8 +47,8 @@ class Data extends \Magento\Captcha\Helper\Data
     /**
      * Returns config value for admin captcha
      *
-     * @param string $key The last part of XML_PATH_$area_CAPTCHA_ constant (case insensitive)
-     * @param \Magento\Store\Model\Store $store
+     * @param  string                     $key   The last part of XML_PATH_$area_CAPTCHA_ constant (case insensitive)
+     * @param  \Magento\Store\Model\Store $store
      * @return \Magento\Framework\App\Config\Element
      */
     public function getConfig($key, $store = null)
@@ -73,7 +72,7 @@ class Data extends \Magento\Captcha\Helper\Data
     /**
      * Get website code
      *
-     * @param mixed $website
+     * @param  mixed $website
      * @return string
      */
     protected function _getWebsiteCode($website = null)

--- a/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
+++ b/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
@@ -63,7 +63,7 @@ class Data extends \Magento\Captcha\Helper\Data
     public function reCaptchaEnable()
     {
         return (bool)$this->scopeConfig->getValue(
-            XML_PATH_ENABLED_BACKEND,
+            self::XML_PATH_ENABLED_BACKEND,
             ScopeInterface::SCOPE_STORE
         );
     }

--- a/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
+++ b/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
@@ -9,6 +9,7 @@
  *
  * @author     Magento Core Team <core@magentocommerce.com>
  */
+
 namespace Magento\Captcha\Helper\Adminhtml;
 
 use Magento\Store\Model\ScopeInterface;
@@ -17,7 +18,7 @@ class Data extends \Magento\Captcha\Helper\Data
 {
     // Configuration path
     const XML_PATH_ENABLED_BACKEND = 'msp_securitysuite_recaptcha/backend/enabled';
-    
+
     /**
      * @var \Magento\Backend\App\ConfigInterface
      */
@@ -36,7 +37,8 @@ class Data extends \Magento\Captcha\Helper\Data
         \Magento\Framework\Filesystem $filesystem,
         \Magento\Captcha\Model\CaptchaFactory $factory,
         \Magento\Backend\App\ConfigInterface $backendConfig
-    ) {
+    )
+    {
         $this->_backendConfig = $backendConfig;
         parent::__construct($context, $storeManager, $filesystem, $factory);
     }
@@ -54,6 +56,19 @@ class Data extends \Magento\Captcha\Helper\Data
     }
 
     /**
+     * Check if reCaptcha is enable for backend
+     *
+     * @return bool
+     */
+    public function reCaptchaEnable()
+    {
+        return (bool)$this->scopeConfig->getValue(
+            XML_PATH_ENABLED_BACKEND,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    /**
      * Get website code
      *
      * @param mixed $website
@@ -62,18 +77,5 @@ class Data extends \Magento\Captcha\Helper\Data
     protected function _getWebsiteCode($website = null)
     {
         return 'admin';
-    }
-    
-     /**
-     * Check if reCaptcha is enable for backend
-     *
-     * @return bool
-     */
-    public function reCaptchaEnable()
-    {
-        return (bool) $this->scopeConfig->getValue(
-            XML_PATH_ENABLED_BACKEND,
-            ScopeInterface::SCOPE_STORE
-        );
     }
 }

--- a/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
+++ b/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
@@ -65,7 +65,7 @@ class Data extends \Magento\Captcha\Helper\Data
      * @return bool
      */
     public function reCaptchaEnable(){
-        return $this->scopeConfig->getValue(
+        return (bool)$this->scopeConfig->getValue(
             'msp_securitysuite_recaptcha/backend/enabled',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );

--- a/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
+++ b/app/code/Magento/Captcha/Helper/Adminhtml/Data.php
@@ -16,13 +16,15 @@ use Magento\Store\Model\ScopeInterface;
 
 class Data extends \Magento\Captcha\Helper\Data
 {
-    // Configuration path
-    const XML_PATH_ENABLED_BACKEND = 'msp_securitysuite_recaptcha/backend/enabled';
-
     /**
      * @var \Magento\Backend\App\ConfigInterface
      */
     protected $_backendConfig;
+    
+    /**
+     * Backend configuration path for reCaptcha
+     */
+    const XML_PATH_ENABLED_BACKEND = 'msp_securitysuite_recaptcha/backend/enabled';
 
     /**
      * @param \Magento\Framework\App\Helper\Context $context

--- a/app/code/Magento/Captcha/Helper/Data.php
+++ b/app/code/Magento/Captcha/Helper/Data.php
@@ -40,7 +40,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const XML_PATH_CAPTCHA_FONTS = 'captcha/fonts';
 
     /**
-     * Default captcha type
+     * Captcha type
      */
     const DEFAULT_CAPTCHA_TYPE = 'Zend';
 

--- a/app/code/Magento/Captcha/Helper/Data.php
+++ b/app/code/Magento/Captcha/Helper/Data.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Captcha\Helper;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
@@ -42,7 +43,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * Default captcha type
      */
     const DEFAULT_CAPTCHA_TYPE = 'Zend';
-    
+
     // Configuration path
     const XML_PATH_ENABLED_FRONTEND = 'msp_securitysuite_recaptcha/frontend/enabled';
 
@@ -78,7 +79,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         Filesystem $filesystem,
         \Magento\Captcha\Model\CaptchaFactory $factory
-    ) {
+    )
+    {
         $this->_storeManager = $storeManager;
         $this->_filesystem = $filesystem;
         $this->_factory = $factory;
@@ -161,17 +163,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     }
 
     /**
-     * Get website code
-     *
-     * @param mixed $website
-     * @return string
-     */
-    protected function _getWebsiteCode($website = null)
-    {
-        return $this->_storeManager->getWebsite($website)->getCode();
-    }
-
-    /**
      * Get captcha image base URL
      *
      * @param mixed $website
@@ -180,22 +171,33 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getImgUrl($website = null)
     {
         return $this->_storeManager->getStore()->getBaseUrl(
-            DirectoryList::MEDIA
-        ) . 'captcha' . '/' . $this->_getWebsiteCode(
-            $website
-        ) . '/';
+                DirectoryList::MEDIA
+            ) . 'captcha' . '/' . $this->_getWebsiteCode(
+                $website
+            ) . '/';
     }
-    
-     /**
+
+    /**
      * Check if reCaptcha is enable for frontend
      *
      * @return bool
      */
     public function reCaptchaEnable()
     {
-        return (bool) $this->scopeConfig->getValue(
-             XML_PATH_ENABLED_FRONTEND,
-             ScopeInterface::SCOPE_STORE
+        return (bool)$this->scopeConfig->getValue(
+            XML_PATH_ENABLED_FRONTEND,
+            ScopeInterface::SCOPE_STORE
         );
+    }
+
+    /**
+     * Get website code
+     *
+     * @param mixed $website
+     * @return string
+     */
+    protected function _getWebsiteCode($website = null)
+    {
+        return $this->_storeManager->getWebsite($website)->getCode();
     }
 }

--- a/app/code/Magento/Captcha/Helper/Data.php
+++ b/app/code/Magento/Captcha/Helper/Data.php
@@ -3,46 +3,111 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+namespace Magento\Captcha\Helper;
 
-/**
- * Captcha helper for adminhtml area
- *
- * @author     Magento Core Team <core@magentocommerce.com>
- */
-namespace Magento\Captcha\Helper\Adminhtml;
-
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Store\Model\ScopeInterface;
 
-class Data extends \Magento\Captcha\Helper\Data
+/**
+ * Captcha image model
+ *
+ * @api
+ * @since 100.0.2
+ */
+class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
-    // Configuration path
-    const XML_PATH_ENABLED_BACKEND = 'msp_securitysuite_recaptcha/backend/enabled';
-    
     /**
-     * @var \Magento\Backend\App\ConfigInterface
+     * Used for "name" attribute of captcha's input field
      */
-    protected $_backendConfig;
+    const INPUT_NAME_FIELD_VALUE = 'captcha';
+
+    /**
+     * Always show captcha
+     */
+    const MODE_ALWAYS = 'always';
+
+    /**
+     * Show captcha only after certain number of unsuccessful attempts
+     */
+    const MODE_AFTER_FAIL = 'after_fail';
+
+    /**
+     * Captcha fonts path
+     */
+    const XML_PATH_CAPTCHA_FONTS = 'captcha/fonts';
+
+    /**
+     * Default captcha type
+     */
+    const DEFAULT_CAPTCHA_TYPE = 'Zend';
+    
+    // Configuration path
+    const XML_PATH_ENABLED_FRONTEND = 'msp_securitysuite_recaptcha/frontend/enabled';
+
+    /**
+     * List uses Models of Captcha
+     * @var array
+     */
+    protected $_captcha = [];
+
+    /**
+     * @var Filesystem
+     */
+    protected $_filesystem;
+
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    protected $_storeManager;
+
+    /**
+     * @var \Magento\Captcha\Model\CaptchaFactory
+     */
+    protected $_factory;
 
     /**
      * @param \Magento\Framework\App\Helper\Context $context
-     * @param \Magento\Store\Model\StoreManager $storeManager
-     * @param \Magento\Framework\Filesystem $filesystem
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param Filesystem $filesystem
      * @param \Magento\Captcha\Model\CaptchaFactory $factory
-     * @param \Magento\Backend\App\ConfigInterface $backendConfig
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
-        \Magento\Store\Model\StoreManager $storeManager,
-        \Magento\Framework\Filesystem $filesystem,
-        \Magento\Captcha\Model\CaptchaFactory $factory,
-        \Magento\Backend\App\ConfigInterface $backendConfig
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        Filesystem $filesystem,
+        \Magento\Captcha\Model\CaptchaFactory $factory
     ) {
-        $this->_backendConfig = $backendConfig;
-        parent::__construct($context, $storeManager, $filesystem, $factory);
+        $this->_storeManager = $storeManager;
+        $this->_filesystem = $filesystem;
+        $this->_factory = $factory;
+        parent::__construct($context);
     }
 
     /**
-     * Returns config value for admin captcha
+     * Get Captcha
+     *
+     * @param string $formId
+     * @return \Magento\Captcha\Model\CaptchaInterface
+     */
+    public function getCaptcha($formId)
+    {
+        if (!array_key_exists($formId, $this->_captcha)) {
+            $captchaType = ucfirst($this->getConfig('type'));
+            if (!$captchaType) {
+                $captchaType = self::DEFAULT_CAPTCHA_TYPE;
+            } elseif ($captchaType == 'Default') {
+                $captchaType = $captchaType . 'Model';
+            }
+
+            $this->_captcha[$formId] = $this->_factory->create($captchaType, $formId);
+        }
+        return $this->_captcha[$formId];
+    }
+
+    /**
+     * Returns config value
      *
      * @param string $key The last part of XML_PATH_$area_CAPTCHA_ constant (case insensitive)
      * @param \Magento\Store\Model\Store $store
@@ -50,7 +115,49 @@ class Data extends \Magento\Captcha\Helper\Data
      */
     public function getConfig($key, $store = null)
     {
-        return $this->_backendConfig->getValue('admin/captcha/' . $key);
+        return $this->scopeConfig->getValue(
+            'customer/captcha/' . $key,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    /**
+     * Get list of available fonts.
+     *
+     * Return format:
+     * [['arial'] => ['label' => 'Arial', 'path' => '/www/magento/fonts/arial.ttf']]
+     *
+     * @return array
+     */
+    public function getFonts()
+    {
+        $fontsConfig = $this->scopeConfig->getValue(\Magento\Captcha\Helper\Data::XML_PATH_CAPTCHA_FONTS, 'default');
+        $fonts = [];
+        if ($fontsConfig) {
+            $libDir = $this->_filesystem->getDirectoryRead(DirectoryList::LIB_INTERNAL);
+            foreach ($fontsConfig as $fontName => $fontConfig) {
+                $fonts[$fontName] = [
+                    'label' => $fontConfig['label'],
+                    'path' => $libDir->getAbsolutePath($fontConfig['path']),
+                ];
+            }
+        }
+        return $fonts;
+    }
+
+    /**
+     * Get captcha image directory
+     *
+     * @param mixed $website
+     * @return string
+     */
+    public function getImgDir($website = null)
+    {
+        $mediaDir = $this->_filesystem->getDirectoryWrite(DirectoryList::MEDIA);
+        $captchaDir = '/captcha/' . $this->_getWebsiteCode($website);
+        $mediaDir->create($captchaDir);
+        return $mediaDir->getAbsolutePath($captchaDir) . '/';
     }
 
     /**
@@ -61,19 +168,34 @@ class Data extends \Magento\Captcha\Helper\Data
      */
     protected function _getWebsiteCode($website = null)
     {
-        return 'admin';
+        return $this->_storeManager->getWebsite($website)->getCode();
+    }
+
+    /**
+     * Get captcha image base URL
+     *
+     * @param mixed $website
+     * @return string
+     */
+    public function getImgUrl($website = null)
+    {
+        return $this->_storeManager->getStore()->getBaseUrl(
+            DirectoryList::MEDIA
+        ) . 'captcha' . '/' . $this->_getWebsiteCode(
+            $website
+        ) . '/';
     }
     
      /**
-     * Check if reCaptcha is enable for backend
+     * Check if reCaptcha is enable for frontend
      *
      * @return bool
      */
     public function reCaptchaEnable()
     {
         return (bool) $this->scopeConfig->getValue(
-            XML_PATH_ENABLED_BACKEND,
-            ScopeInterface::SCOPE_STORE
+             XML_PATH_ENABLED_FRONTEND,
+             ScopeInterface::SCOPE_STORE
         );
     }
 }

--- a/app/code/Magento/Captcha/Helper/Data.php
+++ b/app/code/Magento/Captcha/Helper/Data.php
@@ -181,4 +181,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             $website
         ) . '/';
     }
+    
+     /**
+     * Check if reCaptcha is enable for frontend
+     *
+     * @return bool
+     */
+    public function reCaptchaEnable(){
+        return $this->scopeConfig->getValue(
+            'msp_securitysuite_recaptcha/frontend/enabled',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+    }
 }

--- a/app/code/Magento/Captcha/Helper/Data.php
+++ b/app/code/Magento/Captcha/Helper/Data.php
@@ -188,7 +188,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @return bool
      */
     public function reCaptchaEnable(){
-        return $this->scopeConfig->getValue(
+        return (bool)$this->scopeConfig->getValue(
             'msp_securitysuite_recaptcha/frontend/enabled',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );

--- a/app/code/Magento/Captcha/Helper/Data.php
+++ b/app/code/Magento/Captcha/Helper/Data.php
@@ -3,107 +3,46 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\Captcha\Helper;
-
-use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Filesystem;
-use Magento\Framework\Filesystem\DriverInterface;
 
 /**
- * Captcha image model
+ * Captcha helper for adminhtml area
  *
- * @api
- * @since 100.0.2
+ * @author     Magento Core Team <core@magentocommerce.com>
  */
-class Data extends \Magento\Framework\App\Helper\AbstractHelper
+namespace Magento\Captcha\Helper\Adminhtml;
+
+use Magento\Store\Model\ScopeInterface;
+
+class Data extends \Magento\Captcha\Helper\Data
 {
+    // Configuration path
+    const XML_PATH_ENABLED_BACKEND = 'msp_securitysuite_recaptcha/backend/enabled';
+    
     /**
-     * Used for "name" attribute of captcha's input field
+     * @var \Magento\Backend\App\ConfigInterface
      */
-    const INPUT_NAME_FIELD_VALUE = 'captcha';
-
-    /**
-     * Always show captcha
-     */
-    const MODE_ALWAYS = 'always';
-
-    /**
-     * Show captcha only after certain number of unsuccessful attempts
-     */
-    const MODE_AFTER_FAIL = 'after_fail';
-
-    /**
-     * Captcha fonts path
-     */
-    const XML_PATH_CAPTCHA_FONTS = 'captcha/fonts';
-
-    /**
-     * Default captcha type
-     */
-    const DEFAULT_CAPTCHA_TYPE = 'Zend';
-
-    /**
-     * List uses Models of Captcha
-     * @var array
-     */
-    protected $_captcha = [];
-
-    /**
-     * @var Filesystem
-     */
-    protected $_filesystem;
-
-    /**
-     * @var \Magento\Store\Model\StoreManagerInterface
-     */
-    protected $_storeManager;
-
-    /**
-     * @var \Magento\Captcha\Model\CaptchaFactory
-     */
-    protected $_factory;
+    protected $_backendConfig;
 
     /**
      * @param \Magento\Framework\App\Helper\Context $context
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
-     * @param Filesystem $filesystem
+     * @param \Magento\Store\Model\StoreManager $storeManager
+     * @param \Magento\Framework\Filesystem $filesystem
      * @param \Magento\Captcha\Model\CaptchaFactory $factory
+     * @param \Magento\Backend\App\ConfigInterface $backendConfig
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
-        \Magento\Store\Model\StoreManagerInterface $storeManager,
-        Filesystem $filesystem,
-        \Magento\Captcha\Model\CaptchaFactory $factory
+        \Magento\Store\Model\StoreManager $storeManager,
+        \Magento\Framework\Filesystem $filesystem,
+        \Magento\Captcha\Model\CaptchaFactory $factory,
+        \Magento\Backend\App\ConfigInterface $backendConfig
     ) {
-        $this->_storeManager = $storeManager;
-        $this->_filesystem = $filesystem;
-        $this->_factory = $factory;
-        parent::__construct($context);
+        $this->_backendConfig = $backendConfig;
+        parent::__construct($context, $storeManager, $filesystem, $factory);
     }
 
     /**
-     * Get Captcha
-     *
-     * @param string $formId
-     * @return \Magento\Captcha\Model\CaptchaInterface
-     */
-    public function getCaptcha($formId)
-    {
-        if (!array_key_exists($formId, $this->_captcha)) {
-            $captchaType = ucfirst($this->getConfig('type'));
-            if (!$captchaType) {
-                $captchaType = self::DEFAULT_CAPTCHA_TYPE;
-            } elseif ($captchaType == 'Default') {
-                $captchaType = $captchaType . 'Model';
-            }
-
-            $this->_captcha[$formId] = $this->_factory->create($captchaType, $formId);
-        }
-        return $this->_captcha[$formId];
-    }
-
-    /**
-     * Returns config value
+     * Returns config value for admin captcha
      *
      * @param string $key The last part of XML_PATH_$area_CAPTCHA_ constant (case insensitive)
      * @param \Magento\Store\Model\Store $store
@@ -111,49 +50,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getConfig($key, $store = null)
     {
-        return $this->scopeConfig->getValue(
-            'customer/captcha/' . $key,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-            $store
-        );
-    }
-
-    /**
-     * Get list of available fonts.
-     *
-     * Return format:
-     * [['arial'] => ['label' => 'Arial', 'path' => '/www/magento/fonts/arial.ttf']]
-     *
-     * @return array
-     */
-    public function getFonts()
-    {
-        $fontsConfig = $this->scopeConfig->getValue(\Magento\Captcha\Helper\Data::XML_PATH_CAPTCHA_FONTS, 'default');
-        $fonts = [];
-        if ($fontsConfig) {
-            $libDir = $this->_filesystem->getDirectoryRead(DirectoryList::LIB_INTERNAL);
-            foreach ($fontsConfig as $fontName => $fontConfig) {
-                $fonts[$fontName] = [
-                    'label' => $fontConfig['label'],
-                    'path' => $libDir->getAbsolutePath($fontConfig['path']),
-                ];
-            }
-        }
-        return $fonts;
-    }
-
-    /**
-     * Get captcha image directory
-     *
-     * @param mixed $website
-     * @return string
-     */
-    public function getImgDir($website = null)
-    {
-        $mediaDir = $this->_filesystem->getDirectoryWrite(DirectoryList::MEDIA);
-        $captchaDir = '/captcha/' . $this->_getWebsiteCode($website);
-        $mediaDir->create($captchaDir);
-        return $mediaDir->getAbsolutePath($captchaDir) . '/';
+        return $this->_backendConfig->getValue('admin/captcha/' . $key);
     }
 
     /**
@@ -164,33 +61,19 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     protected function _getWebsiteCode($website = null)
     {
-        return $this->_storeManager->getWebsite($website)->getCode();
-    }
-
-    /**
-     * Get captcha image base URL
-     *
-     * @param mixed $website
-     * @return string
-     */
-    public function getImgUrl($website = null)
-    {
-        return $this->_storeManager->getStore()->getBaseUrl(
-            DirectoryList::MEDIA
-        ) . 'captcha' . '/' . $this->_getWebsiteCode(
-            $website
-        ) . '/';
+        return 'admin';
     }
     
      /**
-     * Check if reCaptcha is enable for frontend
+     * Check if reCaptcha is enable for backend
      *
      * @return bool
      */
-    public function reCaptchaEnable(){
-        return (bool)$this->scopeConfig->getValue(
-            'msp_securitysuite_recaptcha/frontend/enabled',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+    public function reCaptchaEnable()
+    {
+        return (bool) $this->scopeConfig->getValue(
+            XML_PATH_ENABLED_BACKEND,
+            ScopeInterface::SCOPE_STORE
         );
     }
 }

--- a/app/code/Magento/Captcha/Helper/Data.php
+++ b/app/code/Magento/Captcha/Helper/Data.php
@@ -44,7 +44,9 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     const DEFAULT_CAPTCHA_TYPE = 'Zend';
 
-    // Configuration path
+    /**
+     * Frontend configuration path for reCaptcha
+     */
     const XML_PATH_ENABLED_FRONTEND = 'msp_securitysuite_recaptcha/frontend/enabled';
 
     /**
@@ -171,7 +173,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getImgUrl($website = null)
     {
         return $this->_storeManager->getStore()->getBaseUrl(
-                DirectoryList::MEDIA
+            DirectoryList::MEDIA
             ) . 'captcha' . '/' . $this->_getWebsiteCode(
                 $website
             ) . '/';
@@ -185,8 +187,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function reCaptchaEnable()
     {
         return (bool)$this->scopeConfig->getValue(
-            self::XML_PATH_ENABLED_FRONTEND,
-            ScopeInterface::SCOPE_STORE
+        self::XML_PATH_ENABLED_FRONTEND,
+        ScopeInterface::SCOPE_STORE
         );
     }
 

--- a/app/code/Magento/Captcha/Helper/Data.php
+++ b/app/code/Magento/Captcha/Helper/Data.php
@@ -51,6 +51,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     /**
      * List uses Models of Captcha
+     *
      * @var array
      */
     protected $_captcha = [];
@@ -71,18 +72,17 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     protected $_factory;
 
     /**
-     * @param \Magento\Framework\App\Helper\Context $context
+     * @param \Magento\Framework\App\Helper\Context      $context
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
-     * @param Filesystem $filesystem
-     * @param \Magento\Captcha\Model\CaptchaFactory $factory
+     * @param Filesystem                                 $filesystem
+     * @param \Magento\Captcha\Model\CaptchaFactory      $factory
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         Filesystem $filesystem,
         \Magento\Captcha\Model\CaptchaFactory $factory
-    )
-    {
+    ) {
         $this->_storeManager = $storeManager;
         $this->_filesystem = $filesystem;
         $this->_factory = $factory;
@@ -92,7 +92,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Get Captcha
      *
-     * @param string $formId
+     * @param  string $formId
      * @return \Magento\Captcha\Model\CaptchaInterface
      */
     public function getCaptcha($formId)
@@ -113,8 +113,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Returns config value
      *
-     * @param string $key The last part of XML_PATH_$area_CAPTCHA_ constant (case insensitive)
-     * @param \Magento\Store\Model\Store $store
+     * @param  string                     $key   The last part of XML_PATH_$area_CAPTCHA_ constant (case insensitive)
+     * @param  \Magento\Store\Model\Store $store
      * @return \Magento\Framework\App\Config\Element
      */
     public function getConfig($key, $store = null)
@@ -153,7 +153,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Get captcha image directory
      *
-     * @param mixed $website
+     * @param  mixed $website
      * @return string
      */
     public function getImgDir($website = null)
@@ -167,16 +167,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Get captcha image base URL
      *
-     * @param mixed $website
+     * @param  mixed $website
      * @return string
      */
     public function getImgUrl($website = null)
     {
         return $this->_storeManager->getStore()->getBaseUrl(
             DirectoryList::MEDIA
-            ) . 'captcha' . '/' . $this->_getWebsiteCode(
-                $website
-            ) . '/';
+        ) . 'captcha' . '/' . $this->_getWebsiteCode(
+            $website
+        ) . '/';
     }
 
     /**
@@ -187,15 +187,15 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function reCaptchaEnable()
     {
         return (bool)$this->scopeConfig->getValue(
-        self::XML_PATH_ENABLED_FRONTEND,
-        ScopeInterface::SCOPE_STORE
+            self::XML_PATH_ENABLED_FRONTEND,
+            ScopeInterface::SCOPE_STORE
         );
     }
 
     /**
      * Get website code
      *
-     * @param mixed $website
+     * @param  mixed $website
      * @return string
      */
     protected function _getWebsiteCode($website = null)

--- a/app/code/Magento/Captcha/Helper/Data.php
+++ b/app/code/Magento/Captcha/Helper/Data.php
@@ -185,7 +185,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function reCaptchaEnable()
     {
         return (bool)$this->scopeConfig->getValue(
-            XML_PATH_ENABLED_FRONTEND,
+            self::XML_PATH_ENABLED_FRONTEND,
             ScopeInterface::SCOPE_STORE
         );
     }

--- a/app/code/Magento/Captcha/Model/DefaultModel.php
+++ b/app/code/Magento/Captcha/Model/DefaultModel.php
@@ -145,6 +145,10 @@ class DefaultModel extends \Zend\Captcha\Image implements \Magento\Captcha\Model
      */
     public function isRequired($login = null)
     {
+        if($this->captchaData->reCaptchaEnable()){
+            return false;
+        }
+        
         if (($this->isUserAuth()
                 && !$this->isShownToLoggedInUser())
             || !$this->isEnabled()

--- a/app/code/Magento/Captcha/Model/DefaultModel.php
+++ b/app/code/Magento/Captcha/Model/DefaultModel.php
@@ -145,7 +145,7 @@ class DefaultModel extends \Zend\Captcha\Image implements \Magento\Captcha\Model
      */
     public function isRequired($login = null)
     {
-        if($this->captchaData->reCaptchaEnable()){
+        if ($this->captchaData->reCaptchaEnable()) {
             return false;
         }
         


### PR DESCRIPTION
Fixed Issue #24809
When enabling the invisible recaptcha on 2.3.2 the default magneto recaptcha is not replaced on the forgotten password form and both captchas are presented to the user.
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento 2.3.2
2. v3 reCaptcha enabled on frontend

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Add api keys for v3 invisible reCaptcha
2. Enable reCaptcha on all front-end pages.

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. Default captcha is replaced with the v3 reCaptcha on forgotten password form.

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Both captchas are displayed on form.
![Screenshot_2019-10-01 Forgot Your Password](https://user-images.githubusercontent.com/33320744/65962391-7b614680-e450-11e9-9a67-d50176cf5d42.png)
