### PR TITLE
Remove useless aliases for imports

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/UpdateConfigurableCartItemsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/UpdateConfigurableCartItemsTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Magento\GraphQl\ConfigurableProduct;
 
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
-use Magento\Framework\Exception\NoSuchEntityException as NoSuchEntityException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\GraphQl\Quote\GetMaskedQuoteIdByReservedOrderId;
 use Magento\Quote\Model\Quote\Item;
 use Magento\Quote\Model\QuoteFactory;

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/EditQuoteItemWithCustomOptionsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/EditQuoteItemWithCustomOptionsTest.php
@@ -9,7 +9,7 @@ namespace Magento\GraphQl\Quote;
 
 use Magento\Catalog\Api\ProductCustomOptionRepositoryInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\Framework\Exception\NoSuchEntityException as NoSuchEntityException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\Quote\Item;
 use Magento\Quote\Model\QuoteFactory;
 use Magento\Quote\Model\ResourceModel\Quote as QuoteResource;

--- a/dev/tests/integration/testsuite/Magento/Downloadable/_files/product_downloadable_with_custom_options.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/_files/product_downloadable_with_custom_options.php
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-use Magento\TestFramework\Helper\Bootstrap as Bootstrap;
+use Magento\TestFramework\Helper\Bootstrap;
 
 require __DIR__ . '/product_downloadable_with_purchased_separately_links.php';
 

--- a/dev/tests/integration/testsuite/Magento/Downloadable/_files/product_downloadable_with_purchased_separately_links.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/_files/product_downloadable_with_purchased_separately_links.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-use Magento\TestFramework\Helper\Bootstrap as Bootstrap;
+use Magento\TestFramework\Helper\Bootstrap;
 use Magento\Catalog\Model\Product\Attribute\Source\Status as ProductStatus;
 use Magento\Downloadable\Model\Product\Type as ProductType;
 use Magento\Catalog\Model\Product\Visibility as ProductVisibility;

--- a/dev/tests/integration/testsuite/Magento/Downloadable/_files/product_downloadable_without_purchased_separately_links.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/_files/product_downloadable_without_purchased_separately_links.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-use Magento\TestFramework\Helper\Bootstrap as Bootstrap;
+use Magento\TestFramework\Helper\Bootstrap;
 use Magento\Catalog\Model\Product\Attribute\Source\Status as ProductStatus;
 use Magento\Downloadable\Model\Product\Type as ProductType;
 use Magento\Catalog\Model\Product\Visibility as ProductVisibility;

--- a/dev/tests/static/framework/Magento/CodeMessDetector/Test/Unit/Rule/Design/AllPurposeActionTest.php
+++ b/dev/tests/static/framework/Magento/CodeMessDetector/Test/Unit/Rule/Design/AllPurposeActionTest.php
@@ -11,9 +11,9 @@ namespace Magento\CodeMessDetector\Test\Unit\Rule\Design;
 use Magento\CodeMessDetector\Rule\Design\AllPurposeAction;
 use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\ActionInterface;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use PHPUnit\Framework\MockObject\Builder\InvocationMocker as InvocationMocker;
+use PHPUnit\Framework\MockObject\Builder\InvocationMocker;
 use PHPMD\Report;
 use PHPMD\Node\ClassNode;
 

--- a/dev/tests/static/framework/Magento/CodeMessDetector/Test/Unit/Rule/Design/AllPurposeActionTest.php
+++ b/dev/tests/static/framework/Magento/CodeMessDetector/Test/Unit/Rule/Design/AllPurposeActionTest.php
@@ -40,7 +40,8 @@ class AllPurposeActionTest extends TestCase
     {
         return [
             [
-                new class implements ActionInterface, HttpGetActionInterface {
+                new class implements ActionInterface, HttpGetActionInterface
+                {
                     /**
                      * @inheritDoc
                      */
@@ -52,7 +53,8 @@ class AllPurposeActionTest extends TestCase
                 false
             ],
             [
-                new class implements ActionInterface {
+                new class implements ActionInterface
+                {
                     /**
                      * @inheritDoc
                      */
@@ -64,7 +66,8 @@ class AllPurposeActionTest extends TestCase
                 true
             ],
             [
-                new class implements HttpGetActionInterface {
+                new class implements HttpGetActionInterface
+                {
                     /**
                      * @inheritDoc
                      */
@@ -76,7 +79,8 @@ class AllPurposeActionTest extends TestCase
                 false
             ],
             [
-                new class {
+                new class
+                {
 
                 },
                 false
@@ -94,13 +98,15 @@ class AllPurposeActionTest extends TestCase
         $node = $this->getMockBuilder(ClassNode::class)
             ->disableOriginalConstructor()
             ->disableProxyingToOriginalMethods()
-            ->setMethods([
-                // disable name lookup from AST artifact
-                'getNamespaceName',
-                'getParentName',
-                'getName',
-                'getFullQualifiedName',
-            ])
+            ->setMethods(
+                [
+                    // disable name lookup from AST artifact
+                    'getNamespaceName',
+                    'getParentName',
+                    'getName',
+                    'getFullQualifiedName',
+                ]
+            )
             ->getMock();
         $node->expects($this->any())
             ->method('getFullQualifiedName')
@@ -114,10 +120,8 @@ class AllPurposeActionTest extends TestCase
      * @param bool $expects
      * @return InvocationMocker
      */
-    private function expectsRuleViolation(
-        AllPurposeAction $rule,
-        bool $expects
-    ): InvocationMocker {
+    private function expectsRuleViolation(AllPurposeAction $rule, bool $expects): InvocationMocker
+    {
         /** @var Report|MockObject $report */
         $report = $this->getMockBuilder(Report::class)->getMock();
         if ($expects) {

--- a/lib/internal/Magento/Framework/Acl/Loader/ResourceLoader.php
+++ b/lib/internal/Magento/Framework/Acl/Loader/ResourceLoader.php
@@ -8,7 +8,7 @@
 namespace Magento\Framework\Acl\Loader;
 
 use Magento\Framework\Acl;
-use Magento\Framework\Acl\AclResource as AclResource;
+use Magento\Framework\Acl\AclResource;
 use Magento\Framework\Acl\AclResource\ProviderInterface;
 use Magento\Framework\Acl\AclResourceFactory;
 

--- a/lib/internal/Magento/Framework/Api/ExtensionAttribute/JoinProcessor.php
+++ b/lib/internal/Magento/Framework/Api/ExtensionAttribute/JoinProcessor.php
@@ -61,7 +61,7 @@ class JoinProcessor implements \Magento\Framework\Api\ExtensionAttribute\JoinPro
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function process(DbCollection $collection, $extensibleEntityClass = null)
     {
@@ -95,7 +95,7 @@ class JoinProcessor implements \Magento\Framework\Api\ExtensionAttribute\JoinPro
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function extractExtensionAttributes($extensibleEntityClass, array $data)
     {
@@ -127,10 +127,9 @@ class JoinProcessor implements \Magento\Framework\Api\ExtensionAttribute\JoinPro
      *
      * @param string $attributeCode
      * @param array $directive
-     * @param array &$data
-     * @param array &$extensionData
+     * @param array $data
+     * @param array $extensionData
      * @param string $extensibleEntityClass
-     * @return void
      */
     private function populateAttributeCodeWithDirective(
         $attributeCode,

--- a/lib/internal/Magento/Framework/Api/ExtensionAttribute/JoinProcessor.php
+++ b/lib/internal/Magento/Framework/Api/ExtensionAttribute/JoinProcessor.php
@@ -7,7 +7,7 @@
 namespace Magento\Framework\Api\ExtensionAttribute;
 
 use Magento\Framework\Api\ExtensionAttribute\Config;
-use Magento\Framework\Api\ExtensionAttribute\Config\Converter as Converter;
+use Magento\Framework\Api\ExtensionAttribute\Config\Converter;
 use Magento\Framework\Data\Collection\AbstractDb as DbCollection;
 use Magento\Framework\Reflection\TypeProcessor;
 use Magento\Framework\Api\ExtensibleDataInterface;

--- a/lib/internal/Magento/Framework/Api/ExtensionAttribute/JoinProcessorHelper.php
+++ b/lib/internal/Magento/Framework/Api/ExtensionAttribute/JoinProcessorHelper.php
@@ -7,7 +7,7 @@
 namespace Magento\Framework\Api\ExtensionAttribute;
 
 use Magento\Framework\Api\ExtensionAttribute\Config;
-use Magento\Framework\Api\ExtensionAttribute\Config\Converter as Converter;
+use Magento\Framework\Api\ExtensionAttribute\Config\Converter;
 use Magento\Framework\Api\SimpleDataObjectConverter;
 
 /**

--- a/lib/internal/Magento/Framework/Controller/Test/Unit/Router/Route/FactoryTest.php
+++ b/lib/internal/Magento/Framework/Controller/Test/Unit/Router/Route/FactoryTest.php
@@ -9,7 +9,7 @@ namespace Magento\Framework\Controller\Test\Unit\Router\Route;
 use \Magento\Framework\Controller\Router\Route\Factory;
 
 use Magento\Framework\Controller\Router\Route\Factory as RouteFactory;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManager;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 class FactoryTest extends \PHPUnit\Framework\TestCase
 {

--- a/lib/internal/Magento/Framework/ObjectManager/Profiler/Log.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Profiler/Log.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Framework\ObjectManager\Profiler;
 
-use Magento\Framework\ObjectManager\Profiler\Tree\Item as Item;
+use Magento\Framework\ObjectManager\Profiler\Tree\Item;
 
 /**
  * Class Log

--- a/lib/internal/Magento/Framework/ObjectManager/Profiler/Log.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Profiler/Log.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Framework\ObjectManager\Profiler;
 
 use Magento\Framework\ObjectManager\Profiler\Tree\Item;
@@ -133,17 +134,19 @@ class Log
     {
         $this->stats['used'] = count($this->used);
         $this->stats['unused'] = $this->stats['total'] - $this->stats['used'];
+        //phpcs:disable
         echo '<table border="1" cellspacing="0" cellpadding="2">',
-            '<thead><tr><th>',
-            "Creation chain (Red items are never used) Total: {$this->stats['total']}\n",
-            "Used: {$this->stats['used']} Not used: {$this->stats['unused']}",
-            '</th></tr></thead>',
-            '<tbody>',
-            '<tr><th>Instance class</th></tr>';
+        '<thead><tr><th>',
+        "Creation chain (Red items are never used) Total: {$this->stats['total']}\n",
+        "Used: {$this->stats['used']} Not used: {$this->stats['unused']}",
+        '</th></tr></thead>',
+        '<tbody>',
+        '<tr><th>Instance class</th></tr>';
         foreach ($this->roots as $root) {
             $this->displayItem($root);
         }
         echo '</tbody></table>';
+        //phpcs:enable
     }
 
     /**
@@ -156,9 +159,10 @@ class Log
     protected function displayItem(Item $item, $level = 0)
     {
         $colorStyle = isset($this->used[$item->getHash()]) ? '' : ' style="color:red" ';
-
+        //phpcs:disable
         echo "<tr><td $colorStyle>" . str_repeat('·&nbsp;', $level) . $item->getClass()
             . ' - ' . $item->getHash() . '</td></tr>';
+        //phpcs:enable
 
         foreach ($item->getChildren() as $child) {
             $this->displayItem($child, $level + 1);

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/CompiledTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/CompiledTest.php
@@ -6,7 +6,7 @@
 namespace Magento\Framework\ObjectManager\Test\Unit\Config;
 
 use Magento\Framework\ObjectManager\Config\Compiled;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManager;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 
 class CompiledTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
### Description (*)
Remove useless aliases for imports.

### Fixed Issues (if relevant)
None

### Manual testing scenarios (*)
Not necessary

### Questions or comments
Unfortunately, we don't have such rule in https://github.com/FriendsOfPHP/PHP-CS-Fixer to add to our `.php_cs.dist` 😕 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
