### PR TITLE
Create missing directories in imageuploader tree if they don't alread…

### DIFF
--- a/app/code/Magento/Cms/Helper/Wysiwyg/Images.php
+++ b/app/code/Magento/Cms/Helper/Wysiwyg/Images.php
@@ -224,8 +224,7 @@ class Images extends \Magento\Framework\App\Helper\AbstractHelper
     }
 
     /**
-     * Return path of the current selected directory or root directory for startup
-     * Try to create target directory if it doesn't exist
+     * Return path of the root directory for startup. Also try to create target directory if it doesn't exist
      *
      * @return string
      * @throws \Magento\Framework\Exception\LocalizedException
@@ -241,18 +240,34 @@ class Images extends \Magento\Framework\App\Helper\AbstractHelper
                     $currentPath = $path;
                 }
             }
-            try {
-                $currentDir = $this->_directory->getRelativePath($currentPath);
-                if (!$this->_directory->isExist($currentDir)) {
-                    $this->_directory->create($currentDir);
-                }
-            } catch (\Magento\Framework\Exception\FileSystemException $e) {
-                $message = __('The directory %1 is not writable by server.', $currentPath);
-                throw new \Magento\Framework\Exception\LocalizedException($message);
+
+            $currentTreePath = $this->_getRequest()->getParam('current_tree_path');
+            if ($currentTreePath) {
+                $currentTreePath = $this->convertIdToPath($currentTreePath);
+                $this->createSubDirIfNotExist($currentTreePath);
             }
+
             $this->_currentPath = $currentPath;
         }
+
         return $this->_currentPath;
+    }
+
+    private function createSubDirIfNotExist(string $absPath)
+    {
+        $relPath = $this->_directory->getRelativePath($absPath);
+        if (!$this->_directory->isExist($relPath)) {
+            try {
+                $this->_directory->create($relPath);
+            } catch (\Magento\Framework\Exception\FileSystemException $e) {
+                $message = __(
+                    'Can\'t create %1 as subdirectory of %2, you might have some permission issue.',
+                    $relPath,
+                    $this->_directory->getAbsolutePath()
+                );
+                throw new \Magento\Framework\Exception\LocalizedException($message);
+            }
+        }
     }
 
     /**
@@ -294,6 +309,8 @@ class Images extends \Magento\Framework\App\Helper\AbstractHelper
     public function idDecode($string)
     {
         $string = strtr($string, ':_-', '+/=');
+
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction
         return base64_decode($string);
     }
 
@@ -315,7 +332,7 @@ class Images extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Set user-traversable image directory subpath relative to media directory and relative to nested storage root
      *
-     * @var string $subpath
+     * @param string $subpath
      * @return void
      */
     public function setImageDirectorySubpath($subpath)


### PR DESCRIPTION
…y exist.

### Description (*)
This is a replacement for https://github.com/magento/magento2/pull/22681
This is partially fixing https://github.com/magento/magento2/issues/22609

I believe we can no longer fully fix https://github.com/magento/magento2/issues/22609 as the bug has existed for too long (2.3.0, 2.3.1, 2.3.2 & 2.3.3 are affected). If people accidentally uploaded images directly in the `pub/media` directory and we fully fix https://github.com/magento/magento2/issues/22609 by changing the storage root, they would no longer be able to access those uploaded images in the wrong directory.

This is a fix which creates those missing directories `pub/media/wysiwyg` or `pub/media/catalog/category` if the image uploader modal is being opened and those directories don't already exists.

Those directories get declared in some xml files (in the `initialMediaGalleryOpenSubpath` node):
- https://github.com/magento/magento2/blob/2.3.2/app/code/Magento/Catalog/view/adminhtml/ui_component/category_form.xml#L183
- https://github.com/magento/magento2/blob/2.3.2/app/code/Magento/Ui/view/base/ui_component/etc/definition.xml#L149

And then javascript sends those paths in an ajax request using the parameter 'current_tree_path'  after which php then creates those directories if they don't already exist.
It would be great if somebody could take a look at this from a security perspective if this is safe enough, or if some extra security precautions should be taken here to make sure javascript can't willy-nilly create all kinds of unwanted directories? It is probably safe enough due to [that regex checking](https://github.com/magento/magento2/blob/2.3.2/app/code/Magento/Cms/Helper/Wysiwyg/Images.php#L169-L171), but I'm not 100% sure?

I believe the current code didn't behave like it was originally intended, because [these lines](https://github.com/magento/magento2/blob/2.3.2/app/code/Magento/Cms/Helper/Wysiwyg/Images.php#L246-L248) are never executed because the `$currentPath` variable only gets set when [that directory already exists](https://github.com/magento/magento2/blob/2.3.2/app/code/Magento/Cms/Helper/Wysiwyg/Images.php#L240-L242).

I think this problem was probably introduced by some combination of oversights in [MAGETWO-87583](https://github.com/magento/magento2/commit/a083717504f63fd22748fb42d74b63c2906226ef#diff-624b27794e761bd53831eba1ede517bc) and [MAGETWO-87986](https://github.com/magento/magento2/commit/620d37de43bce5d96f59c10628551dd27dad22d1#diff-624b27794e761bd53831eba1ede517bc).

/cc @danmooney2, @davemacaulay, @sidolov

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/22609: Since Magento 2.3 the wysiwyg image uploader incorrectly uses pub/media as storage root

### Manual testing scenarios (*)
1. Setup a vanilla Magento installation
2. Verify that the directories `pub/media/wysiwyg` and `pub/media/catalog/category` don't exist
3. Log into the backend of Magento, and edit a category
4. Open the Content tab, and click the 'Select from Media Gallery' button.
5. Also click the 'Insert Image' button in the content wysiwyg field
6. It is expected the image uploader selects the correct directories even if they previously didn't existed, with this fix this is now happening, and without this fix, it wasn't happening.

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
