### PR TITLE
Use Null Coalesce Operator (??) when possible

### DIFF
--- a/dev/tests/api-functional/framework/Magento/TestFramework/Authentication/OauthHelper.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/Authentication/OauthHelper.php
@@ -109,7 +109,7 @@ class OauthHelper
     public static function getApiAccessCredentials($resources = null, Integration $integrationModel = null)
     {
         if (!self::$_apiCredentials) {
-            $integration = $integrationModel === null ? self::_createIntegration($resources) : $integrationModel;
+            $integration = $integrationModel ?? self::_createIntegration($resources);
             $objectManager = Bootstrap::getObjectManager();
             /** @var \Magento\Integration\Api\OauthServiceInterface $oauthService */
             $oauthService = $objectManager->get(\Magento\Integration\Api\OauthServiceInterface::class);

--- a/dev/tests/api-functional/framework/Magento/TestFramework/TestCase/GraphQlAbstract.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/TestCase/GraphQlAbstract.php
@@ -163,10 +163,8 @@ abstract class GraphQlAbstract extends WebapiAbstract
     protected function assertResponseFields($actualResponse, $assertionMap)
     {
         foreach ($assertionMap as $key => $assertionData) {
-            $expectedValue = isset($assertionData['expected_value'])
-                ? $assertionData['expected_value']
-                : $assertionData;
-            $responseField = isset($assertionData['response_field']) ? $assertionData['response_field'] : $key;
+            $expectedValue = $assertionData['expected_value'] ?? $assertionData;
+            $responseField = $assertionData['response_field'] ?? $key;
             self::assertNotNull(
                 $expectedValue,
                 "Value of '{$responseField}' field must not be NULL"

--- a/dev/tests/api-functional/framework/Magento/TestFramework/TestCase/Webapi/Adapter/Soap.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/TestCase/Webapi/Adapter/Soap.php
@@ -58,7 +58,7 @@ class Soap implements \Magento\TestFramework\TestCase\Webapi\AdapterInterface
             ? $this->toSnakeCase($this->_converter->convertStdObjectToArray($soapResponse, true))
             : $soapResponse;
         /** Remove result wrappers */
-        $result = isset($result[SoapHandler::RESULT_NODE_NAME]) ? $result[SoapHandler::RESULT_NODE_NAME] : $result;
+        $result = $result[SoapHandler::RESULT_NODE_NAME] ?? $result;
         return $result;
     }
 

--- a/dev/tests/api-functional/framework/Magento/TestFramework/TestCase/WebapiAbstract.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/TestCase/WebapiAbstract.php
@@ -565,7 +565,7 @@ abstract class WebapiAbstract extends \PHPUnit\Framework\TestCase
         $this->assertContains($expectedMessage, $soapFault->getMessage(), "Fault message is invalid.");
 
         $errorDetailsNode = 'GenericFault';
-        $errorDetails = isset($soapFault->detail->$errorDetailsNode) ? $soapFault->detail->$errorDetailsNode : null;
+        $errorDetails = $soapFault->detail->$errorDetailsNode ?? null;
         if (!empty($expectedErrorParams) || !empty($expectedWrappedErrors)) {
             /** Check SOAP fault details */
             $this->assertNotNull($errorDetails, "Details must be present.");

--- a/dev/tests/api-functional/framework/bootstrap.php
+++ b/dev/tests/api-functional/framework/bootstrap.php
@@ -126,7 +126,7 @@ function setCustomErrorHandler()
                     E_USER_DEPRECATED => 'User Deprecated',
                 ];
 
-                $errName = isset($errorNames[$errNo]) ? $errorNames[$errNo] : "";
+                $errName = $errorNames[$errNo] ?? "";
 
                 throw new \PHPUnit\Framework\Exception(
                     sprintf("%s: %s in %s:%s.", $errName, $errStr, $errFile, $errLine),

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CategoryRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/CategoryRepositoryTest.php
@@ -182,8 +182,7 @@ class CategoryRepositoryTest extends WebapiAbstract
     {
         return [
             'parent_id' => '2',
-            'name' => isset($categoryData['name'])
-                ? $categoryData['name'] : uniqid('Category-', true),
+            'name' => $categoryData['name'] ?? uniqid('Category-', true),
             'is_active' => '1',
             'include_in_menu' => '1',
             'available_sort_by' => ['position', 'name'],

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductRepositoryInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductRepositoryInterfaceTest.php
@@ -1127,10 +1127,8 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
     protected function getSimpleProductData($productData = [])
     {
         return [
-            ProductInterface::SKU => isset($productData[ProductInterface::SKU])
-                ? $productData[ProductInterface::SKU] : uniqid('sku-', true),
-            ProductInterface::NAME => isset($productData[ProductInterface::NAME])
-                ? $productData[ProductInterface::NAME] : uniqid('sku-', true),
+            ProductInterface::SKU => $productData[ProductInterface::SKU] ?? uniqid('sku-', true),
+            ProductInterface::NAME => $productData[ProductInterface::NAME] ?? uniqid('sku-', true),
             ProductInterface::VISIBILITY => 4,
             ProductInterface::TYPE_ID => 'simple',
             ProductInterface::PRICE => 3.62,

--- a/dev/tests/api-functional/testsuite/Magento/WebapiAsync/Model/AsyncBulkScheduleTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/WebapiAsync/Model/AsyncBulkScheduleTest.php
@@ -385,10 +385,8 @@ class AsyncBulkScheduleTest extends WebapiAbstract
     private function getSimpleProductData($productData = [])
     {
         return [
-            ProductInterface::SKU              => isset($productData[ProductInterface::SKU])
-                ? $productData[ProductInterface::SKU] : uniqid('sku-', true),
-            ProductInterface::NAME             => isset($productData[ProductInterface::NAME])
-                ? $productData[ProductInterface::NAME] : uniqid('sku-', true),
+            ProductInterface::SKU              => $productData[ProductInterface::SKU] ?? uniqid('sku-', true),
+            ProductInterface::NAME             => $productData[ProductInterface::NAME] ?? uniqid('sku-', true),
             ProductInterface::VISIBILITY       => 4,
             ProductInterface::TYPE_ID          => 'simple',
             ProductInterface::PRICE            => 3.62,
@@ -411,8 +409,7 @@ class AsyncBulkScheduleTest extends WebapiAbstract
     private function getWrongProductStructureData($productData = [])
     {
         return [
-            ProductInterface::SKU => isset($productData[ProductInterface::SKU])
-                ? $productData[ProductInterface::SKU] : uniqid('sku-', true),
+            ProductInterface::SKU => $productData[ProductInterface::SKU] ?? uniqid('sku-', true),
         ];
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/WebapiAsync/Model/AsyncScheduleCustomRouteTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/WebapiAsync/Model/AsyncScheduleCustomRouteTest.php
@@ -211,10 +211,8 @@ class AsyncScheduleCustomRouteTest extends WebapiAbstract
     private function getSimpleProductData($productData = [])
     {
         return [
-            ProductInterface::SKU              => isset($productData[ProductInterface::SKU])
-                ? $productData[ProductInterface::SKU] : uniqid('sku-', true),
-            ProductInterface::NAME             => isset($productData[ProductInterface::NAME])
-                ? $productData[ProductInterface::NAME] : uniqid('sku-', true),
+            ProductInterface::SKU              => $productData[ProductInterface::SKU] ?? uniqid('sku-', true),
+            ProductInterface::NAME             => $productData[ProductInterface::NAME] ?? uniqid('sku-', true),
             ProductInterface::VISIBILITY       => 4,
             ProductInterface::TYPE_ID          => 'simple',
             ProductInterface::PRICE            => 3.62,

--- a/dev/tests/api-functional/testsuite/Magento/WebapiAsync/Model/AsyncScheduleMultiStoreTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/WebapiAsync/Model/AsyncScheduleMultiStoreTest.php
@@ -303,10 +303,8 @@ class AsyncScheduleMultiStoreTest extends WebapiAbstract
     private function getSimpleProductData($productData = [])
     {
         return [
-            ProductInterface::SKU => isset($productData[ProductInterface::SKU])
-                ? $productData[ProductInterface::SKU] : uniqid('sku-', true),
-            ProductInterface::NAME => isset($productData[ProductInterface::NAME])
-                ? $productData[ProductInterface::NAME] : uniqid('sku-', true),
+            ProductInterface::SKU => $productData[ProductInterface::SKU] ?? uniqid('sku-', true),
+            ProductInterface::NAME => $productData[ProductInterface::NAME] ?? uniqid('sku-', true),
             ProductInterface::VISIBILITY => 4,
             ProductInterface::TYPE_ID => 'simple',
             ProductInterface::PRICE => 3.62,

--- a/dev/tests/api-functional/testsuite/Magento/WebapiAsync/Model/AsyncScheduleTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/WebapiAsync/Model/AsyncScheduleTest.php
@@ -250,10 +250,8 @@ class AsyncScheduleTest extends WebapiAbstract
     private function getSimpleProductData($productData = [])
     {
         return [
-            ProductInterface::SKU              => isset($productData[ProductInterface::SKU])
-                ? $productData[ProductInterface::SKU] : uniqid('sku-', true),
-            ProductInterface::NAME             => isset($productData[ProductInterface::NAME])
-                ? $productData[ProductInterface::NAME] : uniqid('sku-', true),
+            ProductInterface::SKU              => $productData[ProductInterface::SKU] ?? uniqid('sku-', true),
+            ProductInterface::NAME             => $productData[ProductInterface::NAME] ?? uniqid('sku-', true),
             ProductInterface::VISIBILITY       => 4,
             ProductInterface::TYPE_ID          => 'simple',
             ProductInterface::PRICE            => 3.62,

--- a/dev/tests/error_handler.php
+++ b/dev/tests/error_handler.php
@@ -30,7 +30,7 @@ function setCustomErrorHandler()
                     E_USER_DEPRECATED => 'User Deprecated',
                 ];
 
-                $errName = isset($errorNames[$errNo]) ? $errorNames[$errNo] : "";
+                $errName = $errorNames[$errNo] ?? "";
 
                 throw new \PHPUnit\Framework\Exception(
                     sprintf("%s: %s in %s:%s.", $errName, $errStr, $errFile, $errLine),

--- a/dev/tests/functional/bootstrap.php
+++ b/dev/tests/functional/bootstrap.php
@@ -51,7 +51,7 @@ function setCustomErrorHandler()
                     E_USER_DEPRECATED => 'User Deprecated',
                 ];
 
-                $errName = isset($errorNames[$errNo]) ? $errorNames[$errNo] : "";
+                $errName = $errorNames[$errNo] ?? "";
 
                 throw new \PHPUnit\Framework\Exception(
                     sprintf("%s: %s in %s:%s.", $errName, $errStr, $errFile, $errLine),

--- a/dev/tests/functional/lib/Magento/Mtf/Constraint/AbstractAssertForm.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Constraint/AbstractAssertForm.php
@@ -51,7 +51,7 @@ abstract class AbstractAssertForm extends AbstractConstraint
             if (in_array($key, $this->skippedFields)) {
                 continue;
             }
-            $formValue = isset($formData[$key]) ? $formData[$key] : null;
+            $formValue = $formData[$key] ?? null;
             if (is_numeric($formValue)) {
                 $formValue = (float)$formValue;
             }

--- a/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Factory/AbstractFactory.php
+++ b/dev/tests/functional/lib/Magento/Mtf/Util/Generate/Factory/AbstractFactory.php
@@ -150,8 +150,8 @@ abstract class AbstractFactory
         ];
 
         while ($fallback = array_pop($fallbacks)) {
-            $path = isset($fallback['path']) ? $fallback['path'] : '';
-            $ns = isset($fallback['namespace']) ? $fallback['namespace'] : '';
+            $path = $fallback['path'] ?? '';
+            $ns = $fallback['namespace'] ?? '';
             $location = $path . ($ns ? ('/' . str_replace('\\', '/', $ns)) : '');
 
             $pattern = $this->_getPattern($type, $location);

--- a/dev/tests/functional/tests/app/Magento/AdvancedPricingImportExport/Test/Constraint/AssertImportAdvancedPricing.php
+++ b/dev/tests/functional/tests/app/Magento/AdvancedPricingImportExport/Test/Constraint/AssertImportAdvancedPricing.php
@@ -108,7 +108,7 @@ class AssertImportAdvancedPricing extends AbstractConstraint
 
         $csvKeys = [];
         foreach (array_shift($csvData) as $csvKey) {
-            $csvKeys[] = isset($this->mappingData[$csvKey]) ? $this->mappingData[$csvKey] : $csvKey;
+            $csvKeys[] = $this->mappingData[$csvKey] ?? $csvKey;
         }
 
         $resultCsvData = [];

--- a/dev/tests/functional/tests/app/Magento/Backend/Test/Block/Menu.php
+++ b/dev/tests/functional/tests/app/Magento/Backend/Test/Block/Menu.php
@@ -76,7 +76,7 @@ class Menu extends Block
     {
         $menuChain = array_map('trim', explode('>', $menuItem));
         $mainMenu = $menuChain[0];
-        $subMenu = isset($menuChain[1]) ? $menuChain[1] : null;
+        $subMenu = $menuChain[1] ?? null;
 
         // Click on element in main menu
         $mainMenuElement = $this->_rootElement->find(sprintf($this->mainMenu, $mainMenu), Locator::SELECTOR_XPATH);
@@ -114,7 +114,7 @@ class Menu extends Block
     {
         $menuChain = array_map('trim', explode('>', $menuItem));
         $mainMenu = $menuChain[0];
-        $subMenu = isset($menuChain[1]) ? $menuChain[1] : null;
+        $subMenu = $menuChain[1] ?? null;
 
         $mainMenuElement = $this->_rootElement->find(sprintf($this->mainMenu, $mainMenu), Locator::SELECTOR_XPATH);
         if (!$mainMenuElement->isVisible()) {

--- a/dev/tests/functional/tests/app/Magento/Backend/Test/Block/Widget/Grid.php
+++ b/dev/tests/functional/tests/app/Magento/Backend/Test/Block/Widget/Grid.php
@@ -225,12 +225,8 @@ abstract class Grid extends Block
         foreach ($filters as $key => $value) {
             if (isset($this->filters[$key])) {
                 $selector = $this->filters[$key]['selector'];
-                $strategy = isset($this->filters[$key]['strategy'])
-                    ? $this->filters[$key]['strategy']
-                    : Locator::SELECTOR_CSS;
-                $typifiedElement = isset($this->filters[$key]['input'])
-                    ? $this->filters[$key]['input']
-                    : null;
+                $strategy = $this->filters[$key]['strategy'] ?? Locator::SELECTOR_CSS;
+                $typifiedElement = $this->filters[$key]['input'] ?? null;
                 $this->_rootElement->find($selector, $strategy, $typifiedElement)->setValue($value);
             } else {
                 throw new \Exception("Column $key is absent in the grid or not described yet.");

--- a/dev/tests/functional/tests/app/Magento/Backend/Test/Handler/Conditions.php
+++ b/dev/tests/functional/tests/app/Magento/Backend/Test/Handler/Conditions.php
@@ -205,7 +205,7 @@ abstract class Conditions extends Curl
      */
     private function getTypeParam($name)
     {
-        return isset($this->mapTypeParams[$name]) ? $this->mapTypeParams[$name] : [];
+        return $this->mapTypeParams[$name] ?? [];
     }
 
     /**

--- a/dev/tests/functional/tests/app/Magento/Bundle/Test/Block/Catalog/Product/View.php
+++ b/dev/tests/functional/tests/app/Magento/Bundle/Test/Block/Catalog/Product/View.php
@@ -125,9 +125,7 @@ class View extends \Magento\Catalog\Test\Block\Product\View
     {
         /** @var \Magento\Bundle\Test\Fixture\BundleProduct $product */
         $checkoutData = $product->getCheckoutData();
-        $bundleCheckoutData = isset($checkoutData['options']['bundle_options'])
-            ? $checkoutData['options']['bundle_options']
-            : [];
+        $bundleCheckoutData = $checkoutData['options']['bundle_options'] ?? [];
 
         if (!$this->getBundleBlock()->isVisible()) {
             $this->clickCustomize();

--- a/dev/tests/functional/tests/app/Magento/Bundle/Test/Block/Catalog/Product/View/Type/Bundle.php
+++ b/dev/tests/functional/tests/app/Magento/Bundle/Test/Block/Catalog/Product/View/Type/Bundle.php
@@ -123,7 +123,7 @@ class Bundle extends Block
         /** @var BundleProduct  $product */
         $this->product = $product;
         $bundleSelections = $product->getBundleSelections();
-        $bundleOptions = isset($bundleSelections['bundle_options']) ? $bundleSelections['bundle_options'] : [];
+        $bundleOptions = $bundleSelections['bundle_options'] ?? [];
 
         $listFormOptions = $this->getListOptions();
         $formOptions = [];

--- a/dev/tests/functional/tests/app/Magento/Bundle/Test/Constraint/AssertBundleItemsOnProductPage.php
+++ b/dev/tests/functional/tests/app/Magento/Bundle/Test/Constraint/AssertBundleItemsOnProductPage.php
@@ -55,7 +55,7 @@ class AssertBundleItemsOnProductPage extends AbstractAssertForm
     protected function prepareBundleOptions(BundleProduct $product)
     {
         $bundleSelections = $product->getBundleSelections();
-        $bundleOptions = isset($bundleSelections['bundle_options']) ? $bundleSelections['bundle_options'] : [];
+        $bundleOptions = $bundleSelections['bundle_options'] ?? [];
         $result = [];
 
         foreach ($bundleOptions as $optionKey => $bundleOption) {
@@ -68,9 +68,7 @@ class AssertBundleItemsOnProductPage extends AbstractAssertForm
             $key = 0;
             foreach ($bundleOption['assigned_products'] as $productKey => $assignedProduct) {
                 if ($this->isInStock($product, $key++)) {
-                    $price = isset($assignedProduct['data']['selection_price_value'])
-                        ? $assignedProduct['data']['selection_price_value']
-                        : $bundleSelections['products'][$optionKey][$productKey]->getPrice();
+                    $price = $assignedProduct['data']['selection_price_value'] ?? $bundleSelections['products'][$optionKey][$productKey]->getPrice();
 
                     $optionData['options'][$productKey] = [
                         'title' => $assignedProduct['search_data']['name'],

--- a/dev/tests/functional/tests/app/Magento/Bundle/Test/Fixture/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Magento/Bundle/Test/Fixture/Cart/Item.php
@@ -25,9 +25,7 @@ class Item extends \Magento\Catalog\Test\Fixture\Cart\Item
         parent::getData($key);
         $bundleSelection = $this->product->getBundleSelections();
         $checkoutData = $this->product->getCheckoutData();
-        $checkoutBundleOptions = isset($checkoutData['options']['bundle_options'])
-            ? $checkoutData['options']['bundle_options']
-            : [];
+        $checkoutBundleOptions = $checkoutData['options']['bundle_options'] ?? [];
 
         $productSku = [$this->product->getSku()];
         foreach ($checkoutBundleOptions as $checkoutOptionKey => $checkoutOption) {

--- a/dev/tests/functional/tests/app/Magento/Bundle/Test/Handler/BundleProduct/Webapi.php
+++ b/dev/tests/functional/tests/app/Magento/Bundle/Test/Handler/BundleProduct/Webapi.php
@@ -50,9 +50,7 @@ class Webapi extends SimpleProductWebapi implements BundleProductInterface
      */
     protected function prepareBundleItems()
     {
-        $bundleSelections = isset($this->fields['product']['bundle_selections'])
-            ? $this->fields['product']['bundle_selections']
-            : [];
+        $bundleSelections = $this->fields['product']['bundle_selections'] ?? [];
         $bundleProductOptions = [];
 
         if (!empty($bundleSelections)) {
@@ -92,15 +90,9 @@ class Webapi extends SimpleProductWebapi implements BundleProductInterface
                 'sku' => $product->getSku(),
                 'qty' => $productLink['data']['selection_qty'],
                 'is_default' => false,
-                'price' => isset($productLink['data']['selection_price_value'])
-                    ? $productLink['data']['selection_price_value']
-                    : null,
-                'price_type' => isset($productLink['data']['selection_price_type'])
-                    ? $productLink['data']['selection_price_type']
-                    : null,
-                'can_change_quantity' => isset($productLink['data']['user_defined'])
-                    ? $productLink['data']['user_defined']
-                    : 0,
+                'price' => $productLink['data']['selection_price_value'] ?? null,
+                'price_type' => $productLink['data']['selection_price_type'] ?? null,
+                'can_change_quantity' => $productLink['data']['user_defined'] ?? 0,
                 'position' => $linkKey,
             ];
         }

--- a/dev/tests/functional/tests/app/Magento/Bundle/Test/TestCase/UpdateBundleProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Magento/Bundle/Test/TestCase/UpdateBundleProductEntityTest.php
@@ -112,7 +112,7 @@ class UpdateBundleProductEntityTest extends Injectable
         return [
             'category' => $category,
             'stores' => isset($store) ? [$store] : [],
-            'optionTitles' => isset($optionTitle) ? $optionTitle : []
+            'optionTitles' => $optionTitle ?? []
         ];
     }
 

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/AbstractConfigureBlock.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/AbstractConfigureBlock.php
@@ -49,7 +49,7 @@ abstract class AbstractConfigureBlock extends Form
     public function fillOptions(FixtureInterface $product)
     {
         $dataConfig = $product->getDataConfig();
-        $typeId = isset($dataConfig['type_id']) ? $dataConfig['type_id'] : null;
+        $typeId = $dataConfig['type_id'] ?? null;
         $checkoutData = null;
 
         /** @var CatalogProductSimple $product */
@@ -59,9 +59,7 @@ abstract class AbstractConfigureBlock extends Form
 
         /** @var CatalogProductSimple $product */
         $checkoutData = $product->getCheckoutData();
-        $checkoutCustomOptions = isset($checkoutData['options']['custom_options'])
-            ? $checkoutData['options']['custom_options']
-            : [];
+        $checkoutCustomOptions = $checkoutData['options']['custom_options'] ?? [];
         $customOptions = $product->hasData('custom_options')
             ? $product->getDataFieldConfig('custom_options')['source']->getCustomOptions()
             : [];
@@ -96,12 +94,8 @@ abstract class AbstractConfigureBlock extends Form
             if (isset($options[$attribute])) {
                 $result[] = [
                     'type' => $options[$attribute]['type'],
-                    'title' => isset($options[$attribute]['title'])
-                            ? $options[$attribute]['title']
-                            : $attribute,
-                    'value' => isset($options[$attribute]['options'][$option]['title'])
-                            ? $options[$attribute]['options'][$option]['title']
-                            : $option,
+                    'title' => $options[$attribute]['title'] ?? $attribute,
+                    'value' => $options[$attribute]['options'][$option]['title'] ?? $option,
                 ];
             }
         }

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/AbstractPriceBlock.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/AbstractPriceBlock.php
@@ -46,7 +46,7 @@ abstract class AbstractPriceBlock extends Block
         $mapTypePrice = $this->mapTypePrices[$type];
         return $this->_rootElement->find(
             $mapTypePrice['selector'],
-            isset($mapTypePrice['strategy']) ? $mapTypePrice['strategy'] : Locator::SELECTOR_CSS
+            $mapTypePrice['strategy'] ?? Locator::SELECTOR_CSS
         );
     }
 

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/Attribute/CustomAttribute.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/Attribute/CustomAttribute.php
@@ -67,7 +67,7 @@ class CustomAttribute extends SimpleElement
     public function setValue($data)
     {
         $this->eventManager->dispatchEvent(['set_value'], [__METHOD__, $this->getAbsoluteSelector()]);
-        $code = isset($data['code']) ? $data['code'] : $this->getAttributeCode($this->getAbsoluteSelector());
+        $code = $data['code'] ?? $this->getAttributeCode($this->getAbsoluteSelector());
         $element = $this->getElementByClass($this->getElementClass($code));
         $value = is_array($data) ? $data['value'] : $data;
         if ($value !== null) {

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/Attribute/Edit/Options.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/Attribute/Edit/Options.php
@@ -69,7 +69,7 @@ class Options extends SimpleElement
     {
         return ObjectManager::getInstance()->create(
             \Magento\Catalog\Test\Block\Adminhtml\Product\Attribute\Edit\Tab\Options\Option::class,
-            ['element' => $element === null ? $this->find($this->option . ':last-child') : $element]
+            ['element' => $element ?? $this->find($this->option . ':last-child')]
         );
     }
 }

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/Edit/Section/Options/AbstractOptions.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/Edit/Section/Options/AbstractOptions.php
@@ -23,7 +23,7 @@ abstract class AbstractOptions extends Section
      */
     public function fillOptions(array $fields, SimpleElement $element = null)
     {
-        $element = $element === null ? $this->_rootElement : $element;
+        $element = $element ?? $this->_rootElement;
         $mapping = $this->dataMapping($fields);
         $this->_fill($mapping, $element);
 
@@ -39,7 +39,7 @@ abstract class AbstractOptions extends Section
      */
     public function getDataOptions(array $fields = null, SimpleElement $element = null)
     {
-        $element = $element === null ? $this->_rootElement : $element;
+        $element = $element ?? $this->_rootElement;
         $mapping = $this->dataMapping($fields);
 
         return $this->_getData($mapping, $element);
@@ -54,7 +54,7 @@ abstract class AbstractOptions extends Section
      */
     public function getTextForOptionValues(array $fields = null, SimpleElement $element = null)
     {
-        $element = $element === null ? $this->_rootElement : $element;
+        $element = $element ?? $this->_rootElement;
         $mapping = $this->dataMapping($fields);
         $data = [];
 

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/FormPageActions.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/FormPageActions.php
@@ -91,7 +91,7 @@ class FormPageActions extends ParentFormPageActions
 
         if ($product) {
             $dataConfig = $product->getDataConfig();
-            $typeId = isset($dataConfig['type_id']) ? $dataConfig['type_id'] : null;
+            $typeId = $dataConfig['type_id'] ?? null;
         }
 
         if ($this->hasRender($typeId)) {

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/ProductForm.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Adminhtml/Product/ProductForm.php
@@ -99,7 +99,7 @@ class ProductForm extends FormSections
     {
         $this->waitPageToLoad();
         $dataConfig = $product->getDataConfig();
-        $typeId = isset($dataConfig['type_id']) ? $dataConfig['type_id'] : null;
+        $typeId = $dataConfig['type_id'] ?? null;
 
         if ($this->hasRender($typeId)) {
             $renderArguments = [

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Product/View.php
@@ -260,7 +260,7 @@ class View extends AbstractConfigureBlock
 
         if ($product) {
             $dataConfig = $product->getDataConfig();
-            $typeId = isset($dataConfig['type_id']) ? $dataConfig['type_id'] : null;
+            $typeId = $dataConfig['type_id'] ?? null;
         }
 
         if ($this->hasRender($typeId)) {
@@ -456,7 +456,7 @@ class View extends AbstractConfigureBlock
     {
         /** @var CatalogProductSimple $product */
         $dataConfig = $product->getDataConfig();
-        $typeId = isset($dataConfig['type_id']) ? $dataConfig['type_id'] : null;
+        $typeId = $dataConfig['type_id'] ?? null;
 
         return $this->hasRender($typeId) ? $this->callRender(
             $typeId,

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Product/View/CustomOptions.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Product/View/CustomOptions.php
@@ -227,7 +227,7 @@ class CustomOptions extends Form
         $maxCharacters = null;
         if ($maxCharactersElement->isVisible()) {
             preg_match('/\s([0-9]+)\s/', $maxCharactersElement->getText(), $match);
-            $maxCharacters = isset($match[1]) ? $match[1] : $maxCharactersElement->getText();
+            $maxCharacters = $match[1] ?? $maxCharactersElement->getText();
         }
 
         return [

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductAttributeIsRequired.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductAttributeIsRequired.php
@@ -47,9 +47,7 @@ class AssertProductAttributeIsRequired extends AbstractConstraint
         $productForm->getAttributeElement($attribute)->setValue('');
         $catalogProductEdit->getFormPageActions()->save();
         $validationErrors = $productForm->getSection($sectionName)->getValidationErrors();
-        $actualMessage = isset($validationErrors[$attribute->getFrontendLabel()])
-            ? $validationErrors[$attribute->getFrontendLabel()]
-            : '';
+        $actualMessage = $validationErrors[$attribute->getFrontendLabel()] ?? '';
 
         \PHPUnit\Framework\Assert::assertEquals(
             self::REQUIRE_MESSAGE,

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductCustomOptionsOnProductPage.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductCustomOptionsOnProductPage.php
@@ -134,7 +134,7 @@ class AssertProductCustomOptionsOnProductPage extends AbstractAssertForm
             if (in_array($key, $this->skippedFields, true)) {
                 continue;
             }
-            $formValue = isset($formData[$key]) ? $formData[$key] : null;
+            $formValue = $formData[$key] ?? null;
             $errors = $this->verifyDataForErrors($formValue, $key, $errors, $value);
         }
         return $this->prepareErrorsForOutput($fixtureData, $formData, $isStrict, $isPrepareError, $errors);
@@ -228,9 +228,7 @@ class AssertProductCustomOptionsOnProductPage extends AbstractAssertForm
      */
     private function prepareEachCustomOption($actualPrice, $customOption, $result)
     {
-        $skippedField = isset($this->skippedFieldOptions[$customOption['type']])
-            ? $this->skippedFieldOptions[$customOption['type']]
-            : [];
+        $skippedField = $this->skippedFieldOptions[$customOption['type']] ?? [];
         foreach ($customOption['options'] as &$option) {
             // recalculate percent price
             if ('Percent' == $option['price_type']) {

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductInCart.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductInCart.php
@@ -125,7 +125,7 @@ class AssertProductInCart extends AbstractConstraint
     {
         /** @var CatalogProductSimple $product */
         $checkoutData = $product->getCheckoutData();
-        $checkoutCartItem = isset($checkoutData['cartItem']) ? $checkoutData['cartItem'] : [];
+        $checkoutCartItem = $checkoutData['cartItem'] ?? [];
         if (isset($checkoutCartItem['price'])) {
             $this->fixturePrice = $checkoutCartItem['price'];
         }
@@ -143,9 +143,7 @@ class AssertProductInCart extends AbstractConstraint
         /** @var CatalogProductSimple $product */
         $customOptions = $product->getCustomOptions();
         $checkoutData = $product->getCheckoutData();
-        $checkoutCustomOptions = isset($checkoutData['options']['custom_options'])
-            ? $checkoutData['options']['custom_options']
-            : [];
+        $checkoutCustomOptions = $checkoutData['options']['custom_options'] ?? [];
         foreach ($checkoutCustomOptions as $checkoutOption) {
             $attributeKey = str_replace('attribute_key_', '', $checkoutOption['title']);
             $optionKey = str_replace('option_key_', '', $checkoutOption['value']);

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductSearchableBySku.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductSearchableBySku.php
@@ -54,9 +54,7 @@ class AssertProductSearchableBySku extends AbstractConstraint
         $cmsIndex->getSearchBlock()->search($sku);
 
         $quantityAndStockStatus = $product->getQuantityAndStockStatus();
-        $stockStatus = isset($quantityAndStockStatus['is_in_stock'])
-            ? $quantityAndStockStatus['is_in_stock']
-            : null;
+        $stockStatus = $quantityAndStockStatus['is_in_stock'] ?? null;
 
         $isVisible = $catalogSearchResult->getListProductBlock()->getProductItem($product)->isVisible();
         while (!$isVisible && $catalogSearchResult->getBottomToolbar()->nextPage()) {

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductTierPriceOnProductPage.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductTierPriceOnProductPage.php
@@ -83,7 +83,7 @@ class AssertProductTierPriceOnProductPage extends AbstractConstraint implements 
             if (!$noError) {
                 break;
             }
-            $tierPriceValue = isset($tierPrice['price']) ? $tierPrice['price'] : $tierPrice['percentage_value'];
+            $tierPriceValue = $tierPrice['price'] ?? $tierPrice['percentage_value'];
             if ($match[1] !== $tierPrice['price_qty']
                 || $match[2] !== number_format($tierPriceValue, $this->priceFormat)
             ) {

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductVisibleInCategory.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Constraint/AssertProductVisibleInCategory.php
@@ -78,7 +78,7 @@ class AssertProductVisibleInCategory extends AbstractConstraint
     protected function getStockStatus(FixtureInterface $product)
     {
         $quantityAndStockStatus = $product->getQuantityAndStockStatus();
-        return isset($quantityAndStockStatus['is_in_stock']) ? $quantityAndStockStatus['is_in_stock'] : null;
+        return $quantityAndStockStatus['is_in_stock'] ?? null;
     }
 
     /**

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Fixture/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Fixture/Cart/Item.php
@@ -43,32 +43,24 @@ class Item extends DataSource
     public function getData($key = null)
     {
         $checkoutData = $this->product->getCheckoutData();
-        $cartItem = isset($checkoutData['cartItem']) ? $checkoutData['cartItem'] : [];
+        $cartItem = $checkoutData['cartItem'] ?? [];
         $customOptions = $this->product->hasData('custom_options') ? $this->product->getCustomOptions() : [];
-        $checkoutCustomOptions = isset($checkoutData['options']['custom_options'])
-            ? $checkoutData['options']['custom_options']
-            : [];
+        $checkoutCustomOptions = $checkoutData['options']['custom_options'] ?? [];
 
         foreach ($checkoutCustomOptions as $key => $checkoutCustomOption) {
             $attribute = str_replace('attribute_key_', '', $checkoutCustomOption['title']);
             $option = str_replace('option_key_', '', $checkoutCustomOption['value']);
 
             $checkoutCustomOptions[$key] = [
-                'title' => isset($customOptions[$attribute]['title'])
-                    ? $customOptions[$attribute]['title']
-                    : $attribute,
-                'value' => isset($customOptions[$attribute]['options'][$option]['title'])
-                    ? $customOptions[$attribute]['options'][$option]['title']
-                    : $option,
+                'title' => $customOptions[$attribute]['title'] ?? $attribute,
+                'value' => $customOptions[$attribute]['options'][$option]['title'] ?? $option,
             ];
         }
 
         $cartItem['options'] = isset($cartItem['options'])
             ? $cartItem['options'] + $checkoutCustomOptions
             : $checkoutCustomOptions;
-        $cartItem['qty'] = isset($checkoutData['qty'])
-            ? $checkoutData['qty']
-            : 1;
+        $cartItem['qty'] = $checkoutData['qty'] ?? 1;
         $cartItem['sku'] = $this->product->getSku();
         $cartItem['name'] = $this->product->getName();
         $this->data = $cartItem;

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Fixture/Product/WebsiteIds.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Fixture/Product/WebsiteIds.php
@@ -96,7 +96,7 @@ class WebsiteIds extends DataSource
         if ($dataset instanceof Store) {
             $store = $dataset;
         } elseif (is_array($dataset)) {
-            $store = isset($dataset['store']) ? $dataset['store'] :
+            $store = $dataset['store'] ??
                 (isset($dataset['dataset']) ? $this->fixtureFactory->createByCode('store', $dataset) : null);
         }
         if (isset($store)) {

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Handler/CatalogProductSimple/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Handler/CatalogProductSimple/Curl.php
@@ -256,7 +256,7 @@ class Curl extends AbstractCurl implements CatalogProductSimpleInterface
     protected function parseResponse($response)
     {
         preg_match('~Location: [^\s]*\/id\/(\d+)~', $response, $matches);
-        $id = isset($matches[1]) ? $matches[1] : null;
+        $id = $matches[1] ?? null;
         return ['id' => $id];
     }
 
@@ -268,7 +268,7 @@ class Curl extends AbstractCurl implements CatalogProductSimpleInterface
      */
     protected function getUrl(array $config)
     {
-        $requestParams = isset($config['create_url_params']) ? $config['create_url_params'] : [];
+        $requestParams = $config['create_url_params'] ?? [];
         $params = '';
         foreach ($requestParams as $key => $value) {
             $params .= $key . '/' . $value . '/';
@@ -327,9 +327,7 @@ class Curl extends AbstractCurl implements CatalogProductSimpleInterface
      */
     protected function prepareStatus()
     {
-        $this->fields['product']['status'] = isset($this->fields['product']['status'])
-            ? $this->fields['product']['status']
-            : 'Yes';
+        $this->fields['product']['status'] = $this->fields['product']['status'] ?? 'Yes';
     }
 
     /**
@@ -351,9 +349,7 @@ class Curl extends AbstractCurl implements CatalogProductSimpleInterface
      */
     protected function prepareIsVirtual()
     {
-        $this->fields['product']['is_virtual'] = isset($this->fields['product']['is_virtual'])
-            ? $this->fields['product']['is_virtual']
-            : 'No';
+        $this->fields['product']['is_virtual'] = $this->fields['product']['is_virtual'] ?? 'No';
     }
 
     /**
@@ -406,9 +402,7 @@ class Curl extends AbstractCurl implements CatalogProductSimpleInterface
      */
     protected function prepareQuantityAndStockStatus()
     {
-        $quantityAndStockStatus = isset($this->fields['product']['quantity_and_stock_status'])
-            ? $this->fields['product']['quantity_and_stock_status']
-            : ['is_in_stock' => 'In Stock'];
+        $quantityAndStockStatus = $this->fields['product']['quantity_and_stock_status'] ?? ['is_in_stock' => 'In Stock'];
 
         if (!isset($quantityAndStockStatus['is_in_stock'])) {
             $qty = isset($quantityAndStockStatus['qty']) ? (int)$quantityAndStockStatus['qty'] : null;
@@ -589,9 +583,7 @@ class Curl extends AbstractCurl implements CatalogProductSimpleInterface
      */
     protected function prepareAutosetting()
     {
-        $this->fields['product']['visibility'] = isset($this->fields['product']['visibility'])
-            ? $this->fields['product']['visibility']
-            : 'Catalog, Search';
+        $this->fields['product']['visibility'] = $this->fields['product']['visibility'] ?? 'Catalog, Search';
     }
 
     /**

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Handler/CatalogProductSimple/Webapi.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Handler/CatalogProductSimple/Webapi.php
@@ -242,9 +242,7 @@ class Webapi extends AbstractWebApi implements CatalogProductSimpleInterface
         $stockData = $this->fields['product']['stock_data'];
 
         if (!isset($stockData['is_in_stock'])) {
-            $stockData['is_in_stock'] = isset($this->fields['product']['quantity_and_stock_status']['is_in_stock'])
-                ? $this->fields['product']['quantity_and_stock_status']['is_in_stock']
-                : false;
+            $stockData['is_in_stock'] = $this->fields['product']['quantity_and_stock_status']['is_in_stock'] ?? false;
         }
         if (!isset($stockData['qty']) && isset($this->fields['product']['quantity_and_stock_status']['qty'])) {
             $stockData['qty'] = $this->fields['product']['quantity_and_stock_status']['qty'];

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Handler/Category/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Handler/Category/Curl.php
@@ -174,13 +174,9 @@ class Curl extends AbstractCurl implements CategoryInterface
      */
     protected function prepareGeneralInformation()
     {
-        $this->fields['general']['is_anchor'] = isset($this->fields['general']['is_anchor'])
-            ? $this->fields['general']['is_anchor']
-            : 'No';
+        $this->fields['general']['is_anchor'] = $this->fields['general']['is_anchor'] ?? 'No';
 
-        $this->fields['general']['include_in_menu'] = isset($this->fields['general']['include_in_menu'])
-            ? $this->fields['general']['include_in_menu']
-            : 'Yes';
+        $this->fields['general']['include_in_menu'] = $this->fields['general']['include_in_menu'] ?? 'Yes';
     }
 
     /**

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/TestCase/Product/UpdateSimpleProductEntityTest.php
@@ -127,7 +127,7 @@ class UpdateSimpleProductEntityTest extends Injectable
         return [
             'category' => $category,
             'stores' => isset($store) ? [$store] : [],
-            'productNames' => isset($productName) ? $productName : [],
+            'productNames' => $productName ?? [],
         ];
     }
 

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/TestStep/CreateProductsStep.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/TestStep/CreateProductsStep.php
@@ -69,8 +69,8 @@ class CreateProductsStep implements TestStepInterface
             } else {
                 $productDataSet = explode('::', $productDataSet);
                 $fixtureClass = $productDataSet[0];
-                $dataset = isset($productDataSet[1]) ? $productDataSet[1] : '';
-                $data = isset($this->data[$key]) ? $this->data[$key] : [];
+                $dataset = $productDataSet[1] ?? '';
+                $data = $this->data[$key] ?? [];
                 /** @var FixtureInterface[] $products */
                 $products[$key] = $this->fixtureFactory->createByCode(
                     trim($fixtureClass),

--- a/dev/tests/functional/tests/app/Magento/CatalogImportExport/Test/TestCase/ExportProductsTest.php
+++ b/dev/tests/functional/tests/app/Magento/CatalogImportExport/Test/TestCase/ExportProductsTest.php
@@ -119,7 +119,7 @@ class ExportProductsTest extends Injectable
     {
         $createdProducts = [];
         foreach ($products as $product) {
-            $data = isset($product['data']) ? $product['data'] : [];
+            $data = $product['data'] ?? [];
             if (isset($product['store'])) {
                 $store = $this->fixtureFactory->createByCode('store', ['dataset' => $product['store']]);
                 $store->persist();

--- a/dev/tests/functional/tests/app/Magento/CatalogRule/Test/Handler/CatalogRule/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/CatalogRule/Test/Handler/CatalogRule/Curl.php
@@ -121,16 +121,14 @@ class Curl extends Conditions implements CatalogRuleInterface
         if (isset($data['website_ids'])) {
             $websiteIds = [];
             foreach ($data['website_ids'] as $websiteId) {
-                $websiteIds[] = isset($this->websiteIds[$websiteId]) ? $this->websiteIds[$websiteId] : $websiteId;
+                $websiteIds[] = $this->websiteIds[$websiteId] ?? $websiteId;
             }
             $data['website_ids'] = $websiteIds;
         }
         if (isset($data['customer_group_ids'])) {
             $customerGroupIds = [];
             foreach ($data['customer_group_ids'] as $customerGroupId) {
-                $customerGroupIds[] = isset($this->customerGroupIds[$customerGroupId])
-                    ? $this->customerGroupIds[$customerGroupId]
-                    : $customerGroupId;
+                $customerGroupIds[] = $this->customerGroupIds[$customerGroupId] ?? $customerGroupId;
             }
             $data['customer_group_ids'] = $customerGroupIds;
         }

--- a/dev/tests/functional/tests/app/Magento/CatalogSearch/Test/Block/Advanced/SearchResultsTitle.php
+++ b/dev/tests/functional/tests/app/Magento/CatalogSearch/Test/Block/Advanced/SearchResultsTitle.php
@@ -31,7 +31,7 @@ class SearchResultsTitle extends Block
         $searchQueryResult = $this->_rootElement->find(sprintf($this->searchResultsFor), Locator::SELECTOR_CSS)
             ->getText();
         preg_match("~Search results for: \'(.*)\'~", $searchQueryResult, $matches);
-        $query = isset($matches[1]) ? $matches[1] : null;
+        $query = $matches[1] ?? null;
         return $query;
     }
 }

--- a/dev/tests/functional/tests/app/Magento/CatalogSearch/Test/Constraint/AssertAdvancedSearchProductsResult.php
+++ b/dev/tests/functional/tests/app/Magento/CatalogSearch/Test/Constraint/AssertAdvancedSearchProductsResult.php
@@ -136,7 +136,7 @@ class AssertAdvancedSearchProductsResult extends AbstractConstraint
                     $compareData[$key][] = $value['price_to'];
                 }
             } else {
-                $index = isset($this->placeholder[$key]) ? $this->placeholder[$key] : $key;
+                $index = $this->placeholder[$key] ?? $key;
                 $compareData[$index][] = $value;
             }
         }

--- a/dev/tests/functional/tests/app/Magento/CatalogSearch/Test/Constraint/AssertConfigurableWithDisabledOptionCatalogSearchNoResult.php
+++ b/dev/tests/functional/tests/app/Magento/CatalogSearch/Test/Constraint/AssertConfigurableWithDisabledOptionCatalogSearchNoResult.php
@@ -47,8 +47,7 @@ class AssertConfigurableWithDisabledOptionCatalogSearchNoResult extends Abstract
         /** @var ConfigurableProduct $product */
         $product = $catalogSearch->getDataFieldConfig('query_text')['source']->getFirstProduct();
 
-        $matrix = isset($product->getConfigurableAttributesData()['matrix']) ?
-            $product->getConfigurableAttributesData()['matrix'] :
+        $matrix = $product->getConfigurableAttributesData()['matrix'] ??
             [];
 
         foreach ($matrix as $option) {

--- a/dev/tests/functional/tests/app/Magento/CatalogSearch/Test/Fixture/CatalogSearchQuery/QueryText.php
+++ b/dev/tests/functional/tests/app/Magento/CatalogSearch/Test/Fixture/CatalogSearchQuery/QueryText.php
@@ -58,7 +58,7 @@ class QueryText extends DataSource
             if (!empty($productData) && count($productData) > 1) {
                 $product = $this->createProduct($fixtureFactory, $productData);
 
-                $searchValue = isset($productData[2]) ? $productData[2] : $productData[1];
+                $searchValue = $productData[2] ?? $productData[1];
                 if ($this->data === null) {
                     if ($product->hasData($searchValue)) {
                         $getProperty = 'get' . str_replace('_', '', ucwords($searchValue, '_'));

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/Block/Cart.php
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/Block/Cart.php
@@ -132,7 +132,7 @@ class Cart extends Block
     public function getCartItem(FixtureInterface $product)
     {
         $dataConfig = $product->getDataConfig();
-        $typeId = isset($dataConfig['type_id']) ? $dataConfig['type_id'] : null;
+        $typeId = $dataConfig['type_id'] ?? null;
         $cartItem = null;
 
         if ($this->hasRender($typeId)) {

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/Block/Cart/Sidebar.php
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/Block/Cart/Sidebar.php
@@ -232,7 +232,7 @@ class Sidebar extends Block
     {
         $this->openMiniCart();
         $dataConfig = $product->getDataConfig();
-        $typeId = isset($dataConfig['type_id']) ? $dataConfig['type_id'] : null;
+        $typeId = $dataConfig['type_id'] ?? null;
         $cartItem = null;
 
         if ($this->hasRender($typeId)) {

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/Constraint/AssertCartItemsOptions.php
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/Constraint/AssertCartItemsOptions.php
@@ -98,7 +98,7 @@ class AssertCartItemsOptions extends AbstractAssertForm
                 continue;
             }
 
-            $formValue = isset($formData[$key]) ? $formData[$key] : null;
+            $formValue = $formData[$key] ?? null;
             if ($formValue && !is_array($formValue)) {
                 $formValue = trim($formValue, '. ');
             }

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/Fixture/Cart/Items.php
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/Fixture/Cart/Items.php
@@ -33,7 +33,7 @@ class Items extends DataSource
     public function __construct(array $params, array $data = [])
     {
         $this->params = $params;
-        $this->products = isset($data['products']) ? $data['products'] : [];
+        $this->products = $data['products'] ?? [];
     }
 
     /**
@@ -45,7 +45,7 @@ class Items extends DataSource
     protected function getModuleName(FixtureInterface $product)
     {
         preg_match('/^Magento\\\\([^\\\\]+)\\\\Test/', get_class($product), $match);
-        return isset($match[1]) ? $match[1] : '';
+        return $match[1] ?? '';
     }
 
     /**

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/TestCase/ShoppingCartPerCustomerTest.php
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/TestCase/ShoppingCartPerCustomerTest.php
@@ -159,7 +159,7 @@ class ShoppingCartPerCustomerTest extends Injectable
                 ['products' => $productsInCart]
             )->run();
 
-            $cart['data'] = isset($checkoutData['totals']) ? $checkoutData['totals'] : [];
+            $cart['data'] = $checkoutData['totals'] ?? [];
             $cart['data']['items'] = ['products' => $productsInCart];
             return $this->fixtureFactory->createByCode('cart', $cart);
         }

--- a/dev/tests/functional/tests/app/Magento/CheckoutAgreements/Test/Handler/CheckoutAgreement/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/CheckoutAgreements/Test/Handler/CheckoutAgreement/Curl.php
@@ -59,7 +59,7 @@ class Curl extends AbstractCurl implements CheckoutAgreementInterface
             throw new \Exception("Checkout agreement creating by curl handler was not successful! Response: $response");
         }
         preg_match('~id\/(\d*?)\/~', $response, $matches);
-        $id = isset($matches[1]) ? $matches[1] : null;
+        $id = $matches[1] ?? null;
 
         return ['agreement_id' => $id];
     }

--- a/dev/tests/functional/tests/app/Magento/Cms/Test/Block/Adminhtml/Page/Edit/Tab/Content.php
+++ b/dev/tests/functional/tests/app/Magento/Cms/Test/Block/Adminhtml/Page/Edit/Tab/Content.php
@@ -74,7 +74,7 @@ class Content extends Tab
      */
     public function clickInsertVariable(SimpleElement $element = null)
     {
-        $context = $element === null ? $this->_rootElement : $element;
+        $context = $element ?? $this->_rootElement;
         $addVariableButton = $context->find($this->addVariableButton);
         if ($addVariableButton->isVisible()) {
             $addVariableButton->click();
@@ -89,7 +89,7 @@ class Content extends Tab
      */
     public function clickInsertWidget(SimpleElement $element = null)
     {
-        $context = $element === null ? $this->_rootElement : $element;
+        $context = $element ?? $this->_rootElement;
         $addWidgetButton = $context->find($this->addWidgetButton);
         if ($addWidgetButton->isVisible()) {
             try {
@@ -136,7 +136,7 @@ class Content extends Tab
      */
     public function setFieldsData(array $fields, SimpleElement $element = null)
     {
-        $context = $element === null ? $this->_rootElement : $element;
+        $context = $element ?? $this->_rootElement;
         $context->find($this->content)->setValue($fields['content']['value']['content']);
         if (isset($fields['content_heading']['value'])) {
             $element->find($this->contentHeading)->setValue($fields['content_heading']['value']);

--- a/dev/tests/functional/tests/app/Magento/Cms/Test/Handler/CmsBlock/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Cms/Test/Handler/CmsBlock/Curl.php
@@ -64,7 +64,7 @@ class Curl extends AbstractCurl implements CmsBlockInterface
         }
 
         preg_match("`block_id\/(\d*?)\/`", $response, $matches);
-        $id = isset($matches[1]) ? $matches[1] : null;
+        $id = $matches[1] ?? null;
 
         return ['block_id' => $id];
     }
@@ -81,7 +81,7 @@ class Curl extends AbstractCurl implements CmsBlockInterface
         if (isset($data['stores'])) {
             $stores = [];
             foreach ($data['stores'] as $store) {
-                $stores[] = isset($this->stores[$store]) ? $this->stores[$store] : $store;
+                $stores[] = $this->stores[$store] ?? $store;
             }
             $data['stores'] = $stores;
         }

--- a/dev/tests/functional/tests/app/Magento/Cms/Test/Handler/CmsPage/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Cms/Test/Handler/CmsPage/Curl.php
@@ -84,7 +84,7 @@ class Curl extends Conditions implements CmsPageInterface
             throw new \Exception("Cms page entity creating by curl handler was not successful! Response: $response");
         }
         preg_match("~page_id\/(\d*?)\/~", $response, $matches);
-        $id = isset($matches[1]) ? $matches[1] : null;
+        $id = $matches[1] ?? null;
 
         return ['page_id' => $id];
     }

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Block/Adminhtml/Product/Edit/Section/Variations/Config.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Block/Adminhtml/Product/Edit/Section/Variations/Config.php
@@ -84,9 +84,7 @@ class Config extends Section
             ? $fields['configurable_attributes_data']['value']
             : [];
 
-        $attributeSource = isset($fields['configurable_attributes_data']['source'])
-            ? $fields['configurable_attributes_data']['source']
-            : null;
+        $attributeSource = $fields['configurable_attributes_data']['source'] ?? null;
         $attributesValue = $attributeSource !== null ? $attributeSource->getAttributesData() : [];
 
         foreach ($attributesValue as $key => $value) {

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Block/Adminhtml/Product/Edit/Section/Variations/Config/Attribute.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Block/Adminhtml/Product/Edit/Section/Variations/Config/Attribute.php
@@ -339,7 +339,7 @@ class Attribute extends Form
 
         foreach ($attribute['options'] as $option) {
             $count++;
-            $label = isset($option['admin']) ? $option['admin'] : $option['label'];
+            $label = $option['admin'] ?? $option['label'];
             $optionContainer = $attributeBlock->find(sprintf($this->attributeOptionByName, $label));
 
             //Create option

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Block/Product/View.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Block/Product/View.php
@@ -76,9 +76,7 @@ class View extends \Magento\Catalog\Test\Block\Product\View
         }
         $attributesData = array_values($attributesData);
 
-        $configurableCheckoutData = isset($checkoutData['options']['configurable_options'])
-            ? $checkoutData['options']['configurable_options']
-            : [];
+        $configurableCheckoutData = $checkoutData['options']['configurable_options'] ?? [];
         $checkoutOptionsData = $this->prepareCheckoutData($attributesData, $configurableCheckoutData);
         $this->getCustomOptionsBlock()->fillCustomOptions($checkoutOptionsData);
 

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Block/Product/View/ConfigurableOptions.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Block/Product/View/ConfigurableOptions.php
@@ -144,8 +144,8 @@ class ConfigurableOptions extends CustomOptions
         foreach ($tierPricesNodes as $node) {
             preg_match('#^[^\d]+(\d+)[^\d]+(\d+(?:(?:,\d+)*)+(?:.\d+)*).*#i', $node->getText(), $matches);
             $prices[] = [
-                'qty' => isset($matches[1]) ? $matches[1] : null,
-                'price_qty' => isset($matches[2]) ? $matches[2] : null,
+                'qty' => $matches[1] ?? null,
+                'price_qty' => $matches[2] ?? null,
             ];
         }
         return $prices;

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Constraint/AssertConfigurableProductInCategory.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Constraint/AssertConfigurableProductInCategory.php
@@ -27,7 +27,7 @@ class AssertConfigurableProductInCategory extends AssertProductInCategory
     {
         $priceBlock = $catalogCategoryView->getListProductBlock()->getProductItem($product)->getPriceBlock();
         $priceData = $product->getDataFieldConfig('price')['source']->getPriceData();
-        $price = isset($priceData['category_price']) ? $priceData['category_price'] : $product->getPrice();
+        $price = $priceData['category_price'] ?? $product->getPrice();
         \PHPUnit\Framework\Assert::assertEquals(
             number_format($price, 2, '.', ''),
             $priceBlock->isOldPriceVisible() ? $priceBlock->getOldPrice() : $priceBlock->getPrice(),

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Constraint/AssertConfigurableProductOutOfStockPage.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Constraint/AssertConfigurableProductOutOfStockPage.php
@@ -73,7 +73,7 @@ class AssertConfigurableProductOutOfStockPage extends AssertProductPage
             $products = $this->product->getDataFieldConfig('configurable_attributes_data')['source']->getProducts();
             foreach ($configurableOptions['matrix'] as $key => $option) {
                 if ($products[$key]->getQuantityAndStockStatus()['is_in_stock'] !== 'Out of Stock') {
-                    $price = $price === null ? $option['price'] : $price;
+                    $price = $price ?? $option['price'];
                     if ($price > $option['price']) {
                         $price = $option['price'];
                     }

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Constraint/AssertConfigurableProductPage.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Constraint/AssertConfigurableProductPage.php
@@ -144,7 +144,7 @@ class AssertConfigurableProductPage extends AssertProductPage
         if (null === $price) {
             $configurableOptions = $this->product->getConfigurableAttributesData();
             foreach ($configurableOptions['matrix'] as $option) {
-                $price = $price === null ? $option['price'] : $price;
+                $price = $price ?? $option['price'];
                 if ($price > $option['price']) {
                     $price = $option['price'];
                 }

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Constraint/AssertProductTierPriceOnProductPage.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Constraint/AssertProductTierPriceOnProductPage.php
@@ -28,7 +28,7 @@ class AssertProductTierPriceOnProductPage extends AssertProductPage
         $products = ($this->product->getDataFieldConfig('configurable_attributes_data')['source'])->getProducts();
         foreach ($products as $key => $product) {
             $configuredTierPrice = [];
-            $actualTierPrices = isset($formTierPrices[$key]['tierPrices']) ? $formTierPrices[$key]['tierPrices'] : [];
+            $actualTierPrices = $formTierPrices[$key]['tierPrices'] ?? [];
             $tierPrices = $product->getTierPrice() ?: [];
             foreach ($tierPrices as $tierPrice) {
                 $configuredTierPrice[] = [

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Fixture/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Fixture/Cart/Item.php
@@ -27,11 +27,9 @@ class Item extends \Magento\Catalog\Test\Fixture\Cart\Item
         parent::getData($key);
         $productData = $this->product->getData();
         $checkoutData = $this->product->getCheckoutData();
-        $cartItem = isset($checkoutData['cartItem']) ? $checkoutData['cartItem'] : [];
+        $cartItem = $checkoutData['cartItem'] ?? [];
         $attributesData = $this->product->getConfigurableAttributesData()['attributes_data'];
-        $checkoutConfigurableOptions = isset($checkoutData['options']['configurable_options'])
-            ? $checkoutData['options']['configurable_options']
-            : [];
+        $checkoutConfigurableOptions = $checkoutData['options']['configurable_options'] ?? [];
 
         $attributeKey = [];
         foreach ($checkoutConfigurableOptions as $key => $checkoutConfigurableOption) {
@@ -39,12 +37,8 @@ class Item extends \Magento\Catalog\Test\Fixture\Cart\Item
             $option = $checkoutConfigurableOption['value'];
             $attributeKey[] = "$attribute:$option";
             $checkoutConfigurableOptions[$key] = [
-                'title' => isset($attributesData[$attribute]['label'])
-                    ? $attributesData[$attribute]['label']
-                    : $attribute,
-                'value' => isset($attributesData[$attribute]['options'][$option]['label'])
-                    ? $attributesData[$attribute]['options'][$option]['label']
-                    : $option,
+                'title' => $attributesData[$attribute]['label'] ?? $attribute,
+                'value' => $attributesData[$attribute]['options'][$option]['label'] ?? $option,
             ];
         }
         $attributeKey = implode(' ', $attributeKey);

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Fixture/ConfigurableProduct/ConfigurableAttributesData.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Fixture/ConfigurableProduct/ConfigurableAttributesData.php
@@ -165,7 +165,7 @@ class ConfigurableAttributesData extends DataSource
         }
 
         $this->attributesData = array_replace_recursive(
-            isset($data['attributes_data']) ? $data['attributes_data'] : [],
+            $data['attributes_data'] ?? [],
             $this->attributesData
         );
     }
@@ -206,7 +206,7 @@ class ConfigurableAttributesData extends DataSource
             if (is_string($product)) {
                 list($fixture, $dataset) = explode('::', $product);
                 $attributeData = ['attributes' => $this->getProductAttributeData($key)];
-                $productData = isset($this->variationsMatrix[$key]) ? $this->variationsMatrix[$key] : [];
+                $productData = $this->variationsMatrix[$key] ?? [];
 
                 $product = $this->fixtureFactory->createByCode(
                     $fixture,
@@ -281,9 +281,7 @@ class ConfigurableAttributesData extends DataSource
     protected function getAttributeOptionId($compositeKey)
     {
         list($attributeKey, $optionKey) = explode(':', $compositeKey);
-        return isset($this->attributesData[$attributeKey]['options'][$optionKey]['id'])
-            ? $this->attributesData[$attributeKey]['options'][$optionKey]['id']
-            : null;
+        return $this->attributesData[$attributeKey]['options'][$optionKey]['id'] ?? null;
     }
 
     /**
@@ -477,12 +475,10 @@ class ConfigurableAttributesData extends DataSource
 
         foreach ($this->attributesData as $attributeKey => $attribute) {
             foreach ($attribute['options'] as $optionKey => $option) {
-                $option['label'] = isset($option['view']) ? $option['view'] : $option['label'];
+                $option['label'] = $option['view'] ?? $option['label'];
                 $attribute['options'][$optionKey] = array_intersect_key($option, array_flip($optionFields));
             }
-            $attribute['label'] = isset($attribute['label'])
-                ? $attribute['label']
-                : (isset($attribute['frontend_label']) ? $attribute['frontend_label'] : null);
+            $attribute['label'] = $attribute['label'] ?? ($attribute['frontend_label'] ?? null);
             $attribute = array_intersect_key($attribute, array_flip($attributeFields));
 
             $this->data['attributes_data'][$attributeKey] = $attribute;

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Handler/ConfigurableProduct/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/Handler/ConfigurableProduct/Curl.php
@@ -117,11 +117,11 @@ class Curl extends ProductCurl implements ConfigurableProductInterface
         $result = [];
 
         foreach ($configurableAttributesData->getAttributesData() as $attribute) {
-            $attributeId = isset($attribute['attribute_id']) ? $attribute['attribute_id'] : null;
+            $attributeId = $attribute['attribute_id'] ?? null;
             $dataOptions = [];
 
             foreach ($attribute['options'] as $option) {
-                $optionId = isset($option['id']) ? $option['id'] : null;
+                $optionId = $option['id'] ?? null;
 
                 $dataOption = array_intersect_key($option, array_flip($optionFields));
                 $dataOption['value_index'] = $optionId;
@@ -172,7 +172,7 @@ class Curl extends ProductCurl implements ConfigurableProductInterface
                 $keyIds[] = $attribute['options'][$optionKey]['id'];
                 $configurableAttribute[] = sprintf(
                     '"%s":"%s"',
-                    isset($attribute['attribute_code']) ? $attribute['attribute_code'] : $attribute['frontend_label'],
+                    $attribute['attribute_code'] ?? $attribute['frontend_label'],
                     $attribute['options'][$optionKey]['id']
                 );
             }

--- a/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/TestStep/UpdateChildProductStep.php
+++ b/dev/tests/functional/tests/app/Magento/ConfigurableProduct/Test/TestStep/UpdateChildProductStep.php
@@ -172,7 +172,7 @@ class UpdateChildProductStep implements TestStepInterface
     {
         $configurableOptions = $product['configurable_attributes_data'];
         $attributeOption = reset($configurableOptions['matrix']);
-        $price = isset($attributeOption['price']) ? $attributeOption['price'] : "0";
+        $price = $attributeOption['price'] ?? "0";
 
         foreach ($configurableOptions['matrix'] as $option) {
             if ($price > $option['price']) {

--- a/dev/tests/functional/tests/app/Magento/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnCatalogPage.php
+++ b/dev/tests/functional/tests/app/Magento/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnCatalogPage.php
@@ -40,7 +40,7 @@ class AssertCurrencySymbolOnCatalogPage extends AbstractConstraint
         $price = $catalogCategoryView->getListProductBlock()->getProductItem($product)->getPriceBlock()->getPrice('');
         preg_match('`(.*?)\d`', $price, $matches);
 
-        $symbolOnPage = isset($matches[1]) ? $matches[1] : null;
+        $symbolOnPage = $matches[1] ?? null;
         \PHPUnit\Framework\Assert::assertEquals(
             $currencySymbol->getCustomCurrencySymbol(),
             $symbolOnPage,

--- a/dev/tests/functional/tests/app/Magento/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnProductPage.php
+++ b/dev/tests/functional/tests/app/Magento/CurrencySymbol/Test/Constraint/AssertCurrencySymbolOnProductPage.php
@@ -41,7 +41,7 @@ class AssertCurrencySymbolOnProductPage extends AbstractConstraint
         $price = $catalogProductView->getViewBlock()->getPriceBlock()->getPrice();
         preg_match('`(.*?)\d`', $price, $matches);
 
-        $symbolOnPage = isset($matches[1]) ? $matches[1] : null;
+        $symbolOnPage = $matches[1] ?? null;
         \PHPUnit\Framework\Assert::assertEquals(
             $currencySymbol->getCustomCurrencySymbol(),
             $symbolOnPage,

--- a/dev/tests/functional/tests/app/Magento/Customer/Test/Block/Adminhtml/Group/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Magento/Customer/Test/Block/Adminhtml/Group/Edit/Form.php
@@ -26,9 +26,7 @@ class Form extends \Magento\Mtf\Block\Form
             throw new \Exception("Cannot find field $field. Check for field mapping in " . self::class);
         }
         $disabledField = $this->mapping[$field]['selector'];
-        $strategy = isset($this->mapping[$field]['strategy'])
-            ? $this->mapping[$field]['strategy']
-            : Locator::SELECTOR_CSS;
+        $strategy = $this->mapping[$field]['strategy'] ?? Locator::SELECTOR_CSS;
         return $this->_rootElement->find($disabledField, $strategy)->isDisabled();
     }
 }

--- a/dev/tests/functional/tests/app/Magento/CustomerImportExport/Test/Constraint/AssertImportCustomerAddresses.php
+++ b/dev/tests/functional/tests/app/Magento/CustomerImportExport/Test/Constraint/AssertImportCustomerAddresses.php
@@ -141,7 +141,7 @@ class AssertImportCustomerAddresses extends AbstractConstraint
 
         $csvKeys = [];
         foreach (array_shift($csvData) as $csvKey) {
-            $csvKeys[] = isset($this->mappingKeys[$csvKey]) ? $this->mappingKeys[$csvKey] : $csvKey;
+            $csvKeys[] = $this->mappingKeys[$csvKey] ?? $csvKey;
         }
 
         $resultCsvData = [];

--- a/dev/tests/functional/tests/app/Magento/Downloadable/Test/Block/Catalog/Product/View.php
+++ b/dev/tests/functional/tests/app/Magento/Downloadable/Test/Block/Catalog/Product/View.php
@@ -70,18 +70,14 @@ class View extends \Magento\Catalog\Test\Block\Product\View
     {
         /** @var DownloadableProduct $product */
         $productData = $product->getData();
-        $downloadableLinks = isset($productData['downloadable_links']['downloadable']['link'])
-            ? $productData['downloadable_links']['downloadable']['link']
-            : [];
+        $downloadableLinks = $productData['downloadable_links']['downloadable']['link'] ?? [];
         $checkoutData = $product->getCheckoutData();
         if (isset($checkoutData['options'])) {
             // Replace link key to label
             foreach ($checkoutData['options']['links'] as $key => $linkData) {
                 $linkKey = str_replace('link_', '', $linkData['label']);
 
-                $linkData['label'] = isset($downloadableLinks[$linkKey]['title'])
-                    ? $downloadableLinks[$linkKey]['title']
-                    : $linkData['label'];
+                $linkData['label'] = $downloadableLinks[$linkKey]['title'] ?? $linkData['label'];
 
                 $checkoutData['options']['links'][$key] = $linkData;
             }

--- a/dev/tests/functional/tests/app/Magento/Downloadable/Test/Handler/DownloadableProduct/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Downloadable/Test/Handler/DownloadableProduct/Curl.php
@@ -120,7 +120,7 @@ class Curl extends ProductCurl implements DownloadableProductInterface
             throw new \Exception("Product creation by curl handler was not successful! Response: $response");
         }
         preg_match("~Location: [^\s]*\/id\/(\d+)~", $response, $matches);
-        $checkoutData = isset($data['product']['checkout_data']) ? $data['product']['checkout_data'] : null;
+        $checkoutData = $data['product']['checkout_data'] ?? null;
         if (isset($data['downloadable']['link'])) {
             foreach ($data['downloadable']['link'] as $key => $link) {
                 preg_match('`"link_id":"(\d*?)","title":"' . $link['title'] . '"`', $response, $linkId);

--- a/dev/tests/functional/tests/app/Magento/Downloadable/Test/Handler/DownloadableProduct/Webapi.php
+++ b/dev/tests/functional/tests/app/Magento/Downloadable/Test/Handler/DownloadableProduct/Webapi.php
@@ -104,10 +104,10 @@ class Webapi extends SimpleProductWebapi implements DownloadableProductInterface
     {
         return [
             'title' => $sample['title'],
-            'sort_order' => isset($sample['sort_order']) ? $sample['sort_order'] : 0,
+            'sort_order' => $sample['sort_order'] ?? 0,
             'sample_type' => $sample['type'],
-            'sample_url' => isset($sample['sample_url']) ? $sample['sample_url'] : null,
-            'sample_file' => isset($sample['sample_file']) ? $sample['sample_file'] : null,
+            'sample_url' => $sample['sample_url'] ?? null,
+            'sample_file' => $sample['sample_file'] ?? null,
         ];
     }
 
@@ -127,9 +127,7 @@ class Webapi extends SimpleProductWebapi implements DownloadableProductInterface
         $this->fields['product']['links_exist'] = 1;
         $this->fields['product']['links_purchased_separately'] =
             $this->fields['product']['downloadable_links']['links_purchased_separately'];
-        $this->fields['product']['links_title'] = isset($this->fields['product']['downloadable_links']['title'])
-            ? $this->fields['product']['downloadable_links']['title']
-            : null;
+        $this->fields['product']['links_title'] = $this->fields['product']['downloadable_links']['title'] ?? null;
         $this->fields['product']['extension_attributes']['downloadable_product_links'] = $downloadableProductLinks;
 
         unset($this->fields['downloadable']);
@@ -146,16 +144,16 @@ class Webapi extends SimpleProductWebapi implements DownloadableProductInterface
     {
         return [
             'title' => $link['title'],
-            'sort_order' => isset($link['sort_order']) ? $link['sort_order'] : 0,
+            'sort_order' => $link['sort_order'] ?? 0,
             'is_shareable' => $link['is_shareable'],
             'price' => (float)$link['price'],
-            'number_of_downloads' => isset($link['number_of_downloads']) ? $link['number_of_downloads'] : 0,
+            'number_of_downloads' => $link['number_of_downloads'] ?? 0,
             'link_type' => $link['type'],
-            'link_url' => isset($link['link_url']) ? $link['link_url'] : null,
-            'link_file' => isset($link['link_file']) ? $link['link_file'] : null,
-            'sample_type' => isset($link['sample']['type']) ? $link['sample']['type'] : null,
-            'sample_url' => isset($link['sample']['url']) ? $link['sample']['url'] : null,
-            'sample_file' => isset($link['sample']['file']) ? $link['sample']['file'] : null,
+            'link_url' => $link['link_url'] ?? null,
+            'link_file' => $link['link_file'] ?? null,
+            'sample_type' => $link['sample']['type'] ?? null,
+            'sample_url' => $link['sample']['url'] ?? null,
+            'sample_file' => $link['sample']['file'] ?? null,
         ];
     }
 }

--- a/dev/tests/functional/tests/app/Magento/GroupedProduct/Test/Fixture/Cart/Item.php
+++ b/dev/tests/functional/tests/app/Magento/GroupedProduct/Test/Fixture/Cart/Item.php
@@ -23,7 +23,7 @@ class Item extends \Magento\Catalog\Test\Fixture\Cart\Item
     public function getData($key = null)
     {
         $checkoutData = $this->product->getCheckoutData();
-        $this->data = isset($checkoutData['cartItem']) ? $checkoutData['cartItem'] : [];
+        $this->data = $checkoutData['cartItem'] ?? [];
         $associatedProducts = [];
         $cartItem = [];
 

--- a/dev/tests/functional/tests/app/Magento/GroupedProduct/Test/Handler/GroupedProduct/Webapi.php
+++ b/dev/tests/functional/tests/app/Magento/GroupedProduct/Test/Handler/GroupedProduct/Webapi.php
@@ -64,7 +64,7 @@ class Webapi extends SimpleProductWebapi implements GroupedProductInterface
                 'link_type' => 'associated',
                 'linked_product_sku' => $product->getSku(),
                 'linked_product_type' => $productConfig['type_id'],
-                'position' => isset($associatedProductData['position']) ? $associatedProductData['position'] : 0,
+                'position' => $associatedProductData['position'] ?? 0,
                 'extension_attributes' => [
                     'qty' => $associatedProductData['qty']
                 ],

--- a/dev/tests/functional/tests/app/Magento/ImportExport/Test/Block/Adminhtml/Export/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Magento/ImportExport/Test/Block/Adminhtml/Export/Edit/Form.php
@@ -26,7 +26,7 @@ class Form extends AbstractForm
     public function fill(FixtureInterface $fixture, SimpleElement $element = null, $attributes = [])
     {
         $data = $fixture->getData();
-        $fields = isset($data['fields']) ? $data['fields'] : $data;
+        $fields = $data['fields'] ?? $data;
         if (!empty($attributes)) {
             foreach ($attributes as $attribute) {
                 $fields['product'] = [$attribute => $fixture->getDataExport()[$attribute]];

--- a/dev/tests/functional/tests/app/Magento/ImportExport/Test/Block/Adminhtml/Import/Edit/Form.php
+++ b/dev/tests/functional/tests/app/Magento/ImportExport/Test/Block/Adminhtml/Import/Edit/Form.php
@@ -29,7 +29,7 @@ class Form extends \Magento\Mtf\Block\Form
         unset($data['import_file']);
         $data['import_file'] = $importFile;
 
-        $fields = isset($data['fields']) ? $data['fields'] : $data;
+        $fields = $data['fields'] ?? $data;
         $mapping = $this->dataMapping($fields);
         $this->_fill($mapping, $element);
 

--- a/dev/tests/functional/tests/app/Magento/ImportExport/Test/Constraint/AssertImportCheckData.php
+++ b/dev/tests/functional/tests/app/Magento/ImportExport/Test/Constraint/AssertImportCheckData.php
@@ -31,9 +31,7 @@ class AssertImportCheckData extends AbstractConstraint
     {
         $file = $import->getDataFieldConfig('import_file')['source'];
         $rowsCount = $file->getValue()['template']['count'];
-        $entitiesCount = isset($file->getValue()['template']['entities'])
-            ? $file->getValue()['template']['entities']
-            : count($file->getEntities());
+        $entitiesCount = $file->getValue()['template']['entities'] ?? count($file->getEntities());
 
         $message = $adminImportIndex->getMessagesBlock()->getNoticeMessage();
         \PHPUnit\Framework\Assert::assertEquals(

--- a/dev/tests/functional/tests/app/Magento/ImportExport/Test/Fixture/Import/File.php
+++ b/dev/tests/functional/tests/app/Magento/ImportExport/Test/Fixture/Import/File.php
@@ -215,9 +215,7 @@ class File extends DataSource
                     }
                     if (isset($entityData['code'])) {
                         $placeholders['entity_' . $key][$entityKey][$entityData['code']]
-                            = isset($entityData[$entityData['code']])
-                            ? $entityData[$entityData['code']]
-                            : 'Main Website';
+                            = $entityData[$entityData['code']] ?? 'Main Website';
                     }
                 }
             }
@@ -266,9 +264,7 @@ class File extends DataSource
         $websites = $entity->getDataFieldConfig('website_ids')['source']->getWebsites();
         foreach ($websites as $website) {
             if ($website->getCode() === 'base') {
-                $currency = isset($this->value['template']['mainWebsiteCurrency'])
-                    ? $this->value['template']['mainWebsiteCurrency']
-                    : '[USD]';
+                $currency = $this->value['template']['mainWebsiteCurrency'] ?? '[USD]';
                 $this->mainWebsiteMapping['base'] = $website->getName() . "[{$currency}]";
                 break;
             }

--- a/dev/tests/functional/tests/app/Magento/Install/Test/Constraint/AssertSuccessInstall.php
+++ b/dev/tests/functional/tests/app/Magento/Install/Test/Constraint/AssertSuccessInstall.php
@@ -59,10 +59,10 @@ class AssertSuccessInstall extends AbstractConstraint
         $allData = array_merge($user->getData(), $installConfig->getData());
 
         foreach ($installConfig->getData() as $key => $value) {
-            $allData[$key] = isset($value['value']) ? $value['value'] : $value;
+            $allData[$key] = $value['value'] ?? $value;
         }
 
-        $allData['baseUrl'] = (isset($allData['https']) ? $allData['https'] : $allData['baseUrl']);
+        $allData['baseUrl'] = ($allData['https'] ?? $allData['baseUrl']);
         $allData['admin'] = $allData['baseUrl'] . $allData['admin'] . '/';
 
         $this->checkInstallData($allData, $adminData, $dbData);

--- a/dev/tests/functional/tests/app/Magento/Integration/Test/Handler/Integration/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Integration/Test/Handler/Integration/Curl.php
@@ -89,7 +89,7 @@ class Curl extends AbstractCurl implements IntegrationInterface
         $curl->close();
 
         preg_match('~<td.*?>.*?' . $name . '.*?/integration/edit/id/(\d+)/~siu', $response, $matches);
-        return isset($matches[1]) ? $matches[1] : null;
+        return $matches[1] ?? null;
     }
 
     /**
@@ -115,7 +115,7 @@ class Curl extends AbstractCurl implements IntegrationInterface
         foreach ($this->fields as $field) {
             $pattern = sprintf($this->patternField, $field);
             preg_match($pattern, $response, $matches);
-            $result[$field] = isset($matches[1]) ? $matches[1] : null;
+            $result[$field] = $matches[1] ?? null;
         }
 
         return $result;

--- a/dev/tests/functional/tests/app/Magento/Msrp/Test/Constraint/AssertMapOnCategoryPage.php
+++ b/dev/tests/functional/tests/app/Magento/Msrp/Test/Constraint/AssertMapOnCategoryPage.php
@@ -43,7 +43,7 @@ class AssertMapOnCategoryPage extends AbstractConstraint
             'Displayed on Category page MAP is incorrect.'
         );
         $priceData = $product->getDataFieldConfig('price')['source']->getPriceData();
-        $price = isset($priceData['category_price']) ? $priceData['category_price'] : $product->getPrice();
+        $price = $priceData['category_price'] ?? $product->getPrice();
         \PHPUnit\Framework\Assert::assertEquals(
             $price,
             $mapBlock->getActualPrice(),

--- a/dev/tests/functional/tests/app/Magento/Msrp/Test/Constraint/AssertMapOnProductView.php
+++ b/dev/tests/functional/tests/app/Magento/Msrp/Test/Constraint/AssertMapOnProductView.php
@@ -47,7 +47,7 @@ class AssertMapOnProductView extends AbstractConstraint
             'Displayed on Product view page MAP is incorrect.'
         );
         $priceData = $product->getDataFieldConfig('price')['source']->getPriceData();
-        $price = isset($priceData['category_price']) ? $priceData['category_price'] : $product->getPrice();
+        $price = $priceData['category_price'] ?? $product->getPrice();
         \PHPUnit\Framework\Assert::assertEquals(
             $price,
             $mapBlock->getActualPrice(),

--- a/dev/tests/functional/tests/app/Magento/Msrp/Test/Constraint/AssertMsrpInShoppingCart.php
+++ b/dev/tests/functional/tests/app/Magento/Msrp/Test/Constraint/AssertMsrpInShoppingCart.php
@@ -52,7 +52,7 @@ class AssertMsrpInShoppingCart extends AbstractConstraint
         $checkoutCart->open();
 
         $priceData = $product->getDataFieldConfig('price')['source']->getPriceData();
-        $productPrice = isset($priceData['category_price']) ? $priceData['category_price'] : $product->getPrice();
+        $productPrice = $priceData['category_price'] ?? $product->getPrice();
         $unitPrice = $checkoutCart->getCartBlock()->getCartItem($product)->getPrice();
         \PHPUnit\Framework\Assert::assertEquals($productPrice, $unitPrice, 'Incorrect unit price is displayed in Cart');
     }

--- a/dev/tests/functional/tests/app/Magento/Reports/Test/Constraint/AssertOrderedProductReportForConfigurableProduct.php
+++ b/dev/tests/functional/tests/app/Magento/Reports/Test/Constraint/AssertOrderedProductReportForConfigurableProduct.php
@@ -32,8 +32,7 @@ class AssertOrderedProductReportForConfigurableProduct extends AbstractConstrain
         foreach ($products as $product) {
             /** @var ConfigurableProduct $product */
             if ($product->hasData('configurable_attributes_data')) {
-                $matrix = isset($product->getConfigurableAttributesData()['matrix']) ?
-                    $product->getConfigurableAttributesData()['matrix'] : [];
+                $matrix = $product->getConfigurableAttributesData()['matrix'] ?? [];
                 foreach ($matrix as $variation) {
                     $filters[] = $variation['sku'];
                 }

--- a/dev/tests/functional/tests/app/Magento/Review/Test/Constraint/AssertProductReviewInGrid.php
+++ b/dev/tests/functional/tests/app/Magento/Review/Test/Constraint/AssertProductReviewInGrid.php
@@ -86,13 +86,13 @@ class AssertProductReviewInGrid extends AbstractConstraint
                     $value = isset($review[$param]) ? $review[$param][0] : null;
                     break;
                 case 'status_id':
-                    $value = $gridStatus != '' ? $gridStatus : (isset($review[$param]) ? $review[$param] : null);
+                    $value = $gridStatus != '' ? $gridStatus : ($review[$param] ?? null);
                     break;
                 case 'type':
-                    $value = isset($review[$param]) ? $review[$param] : 'Administrator';
+                    $value = $review[$param] ?? 'Administrator';
                     break;
                 default:
-                    $value = isset($review[$param]) ? $review[$param] : null;
+                    $value = $review[$param] ?? null;
                     break;
             }
             if ($value !== null) {

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/AbstractItems.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/AbstractItems.php
@@ -164,7 +164,7 @@ class AbstractItems extends Block
         $data = array_map('trim', explode('SKU:', str_replace("\n", '', $product)));
         return [
             'product' => $data[0],
-            'sku' => isset($data[1]) ? $data[1] : ''
+            'sku' => $data[1] ?? ''
         ];
     }
 }

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Create/CustomerActivities/Sidebar.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Adminhtml/Order/Create/CustomerActivities/Sidebar.php
@@ -48,7 +48,7 @@ abstract class Sidebar extends Block
             $this->_rootElement->find(sprintf($this->addToOrderProductName, $name), Locator::SELECTOR_XPATH)->click();
 
             $dataConfig = $product->getDataConfig();
-            $typeId = isset($dataConfig['type_id']) ? $dataConfig['type_id'] : null;
+            $typeId = $dataConfig['type_id'] ?? null;
 
             if ($this->hasRender($typeId)) {
                 $this->_rootElement->find(sprintf($this->addToOrderConfigure, $name), Locator::SELECTOR_XPATH)->click();

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Widget/Guest/Form.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Block/Widget/Guest/Form.php
@@ -60,7 +60,7 @@ class Form extends \Magento\Mtf\Block\Form
             $data['billing_zip_code'] = $fixture->getDataFieldConfig('billing_address_id')['source']->getPostcode();
         }
 
-        $fields = isset($data['fields']) ? $data['fields'] : $data;
+        $fields = $data['fields'] ?? $data;
         $mapping = $this->dataMapping($fields);
 
         $this->waitLoadForm();

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertCreditMemoItems.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertCreditMemoItems.php
@@ -33,7 +33,7 @@ class AssertCreditMemoItems extends AbstractAssertItems
         $creditMemoIndex->open();
         $orderId = $order->getId();
         $refundsData = $order->getRefund();
-        $data = isset($refundsData[0]['items_data']) ? $refundsData[0]['items_data'] : [];
+        $data = $refundsData[0]['items_data'] ?? [];
         $productsData = $this->prepareOrderProducts($order, $data);
         foreach ($ids['creditMemoIds'] as $creditMemoId) {
             $filter = [

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertInvoiceItems.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertInvoiceItems.php
@@ -35,7 +35,7 @@ class AssertInvoiceItems extends AbstractAssertItems
     ) {
         $orderId = $order->getId();
         $invoicesData = $order->getInvoice();
-        $data = isset($invoicesData[0]['items_data']) ? $invoicesData[0]['items_data'] : [];
+        $data = $invoicesData[0]['items_data'] ?? [];
         $productsData = $this->prepareOrderProducts($order, $data, $cart);
         foreach ($ids['invoiceIds'] as $invoiceId) {
             $filter = [

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertOrderInOrdersGridOnFrontend.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertOrderInOrdersGridOnFrontend.php
@@ -47,7 +47,7 @@ class AssertOrderInOrdersGridOnFrontend extends AbstractConstraint
     ) {
         $filter = [
             'id' => $order->hasData('id') ? $order->getId() : $orderId,
-            'status' => $statusToCheck === null ? $status : $statusToCheck,
+            'status' => $statusToCheck ?? $status,
         ];
 
         $objectManager->create(

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertProductInItemsOrderedGrid.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertProductInItemsOrderedGrid.php
@@ -110,9 +110,7 @@ class AssertProductInItemsOrderedGrid extends AbstractAssertForm
      */
     protected function getProductPrice(FixtureInterface $product)
     {
-        return isset($product->getCheckoutData()['cartItem']['price'])
-            ? $product->getCheckoutData()['cartItem']['price']
-            : $product->getPrice();
+        return $product->getCheckoutData()['cartItem']['price'] ?? $product->getPrice();
     }
 
     /**

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertProductQtyDecreased.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertProductQtyDecreased.php
@@ -85,7 +85,7 @@ class AssertProductQtyDecreased extends AbstractConstraint
     {
         $product = $order->getEntityId()['products'][$index];
         $productData = $product->getData();
-        $checkoutDataQty = isset($productData['checkout_data']['qty']) ? $productData['checkout_data']['qty'] : 1;
+        $checkoutDataQty = $productData['checkout_data']['qty'] ?? 1;
         $productData['quantity_and_stock_status']['qty'] -= $checkoutDataQty;
 
         $productData = array_diff_key($productData, array_flip($this->skipFields));

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertReorderButtonIsNotVisibleOnFrontend.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Constraint/AssertReorderButtonIsNotVisibleOnFrontend.php
@@ -47,7 +47,7 @@ class AssertReorderButtonIsNotVisibleOnFrontend extends AbstractConstraint
     ) {
         $filter = [
             'id' => $order->hasData('id') ? $order->getId() : $orderId,
-            'status' => $statusToCheck === null ? $status : $statusToCheck,
+            'status' => $statusToCheck ?? $status,
         ];
 
         $objectManager->create(

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Handler/OrderInjectable/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Handler/OrderInjectable/Curl.php
@@ -197,9 +197,7 @@ class Curl extends AbstractCurl implements OrderInjectableInterface
     {
         $result = [];
         $checkoutData = $product->getCheckoutData();
-        $bundleOptions = isset($checkoutData['options']['bundle_options'])
-            ? $checkoutData['options']['bundle_options']
-            : [];
+        $bundleOptions = $checkoutData['options']['bundle_options'] ?? [];
         $bundleSelections = $product->getBundleSelections();
         $bundleSelectionsData = [];
         $result['qty'] = $checkoutData['qty'];
@@ -279,7 +277,7 @@ class Curl extends AbstractCurl implements OrderInjectableInterface
                     'group_id' => $customerGroupId,
                     'email' => $this->customer->getEmail(),
                 ],
-                'shipping_method' => isset($data['shipping_method']) ? $data['shipping_method'] : '',
+                'shipping_method' => $data['shipping_method'] ?? '',
             ],
             'item' => $this->prepareOrderProductsData($data['entity_id']),
             'billing_address' => $this->prepareBillingAddress($data['billing_address_id']),
@@ -369,6 +367,6 @@ class Curl extends AbstractCurl implements OrderInjectableInterface
         }
         preg_match("~<h1 class=\"page-title\">#(.*)</h1>~", $response, $matches);
 
-        return isset($matches[1]) ? $matches[1] : null;
+        return $matches[1] ?? null;
     }
 }

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/Handler/OrderInjectable/Webapi.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/Handler/OrderInjectable/Webapi.php
@@ -131,7 +131,7 @@ class Webapi extends AbstractWebapi implements OrderInjectableInterface
             $data = [
                 'cartItem' => [
                     'sku' => $product->getSku(),
-                    'qty' => isset($product->getCheckoutData()['qty']) ? $product->getCheckoutData()['qty'] : 1,
+                    'qty' => $product->getCheckoutData()['qty'] ?? 1,
                     'quote_id' => $this->quote
                 ]
             ];
@@ -326,9 +326,7 @@ class Webapi extends AbstractWebapi implements OrderInjectableInterface
                     $option = [];
                     foreach ($productOption['assigned_products'] as $productData) {
                         if (strpos($productData['search_data']['name'], $checkoutOption['value']['name']) !== false) {
-                            $qty = isset($checkoutOption['qty'])
-                                ? $checkoutOption['qty']
-                                : $productData['data']['selection_qty'];
+                            $qty = $checkoutOption['qty'] ?? $productData['data']['selection_qty'];
                             $option['option_id'] = $productData['option_id'];
                             $option['option_selections'][] = $productData['selection_id'];
                             $option['option_qty'] = $qty;

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/TestStep/CreateCreditMemoStep.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/TestStep/CreateCreditMemoStep.php
@@ -86,7 +86,7 @@ class CreateCreditMemoStep implements TestStepInterface
     {
         $this->orderIndex->open();
         $this->orderIndex->getSalesOrderGrid()->searchAndOpen(['id' => $this->order->getId()]);
-        $refundsData = $this->order->getRefund() !== null ? $this->order->getRefund() : ['refundData' => []];
+        $refundsData = $this->order->getRefund() ?? ['refundData' => []];
         foreach ($refundsData as $refundData) {
             $this->salesOrderView->getPageActions()->orderCreditMemo();
 

--- a/dev/tests/functional/tests/app/Magento/Sales/Test/TestStep/CreateInvoiceStep.php
+++ b/dev/tests/functional/tests/app/Magento/Sales/Test/TestStep/CreateInvoiceStep.php
@@ -121,7 +121,7 @@ class CreateInvoiceStep implements TestStepInterface
         }
         $this->orderIndex->open();
         $this->orderIndex->getSalesOrderGrid()->searchAndOpen(['id' => $this->order->getId()]);
-        $invoicesData = $this->order->getInvoice() !== null ? $this->order->getInvoice() : ['invoiceData' => []];
+        $invoicesData = $this->order->getInvoice() ?? ['invoiceData' => []];
         foreach ($invoicesData as $invoiceData) {
             $this->salesOrderView->getPageActions()->invoice();
 
@@ -140,7 +140,7 @@ class CreateInvoiceStep implements TestStepInterface
         return [
             'ids' => [
                 'invoiceIds' => $invoiceIds,
-                'shipmentIds' => isset($shipmentIds) ? $shipmentIds : null,
+                'shipmentIds' => $shipmentIds ?? null,
             ]
         ];
     }

--- a/dev/tests/functional/tests/app/Magento/SalesRule/Test/Block/Adminhtml/Promo/Quote/Edit/Section/Labels.php
+++ b/dev/tests/functional/tests/app/Magento/SalesRule/Test/Block/Adminhtml/Promo/Quote/Edit/Section/Labels.php
@@ -49,7 +49,7 @@ class Labels extends Section
      */
     public function getFieldsData($fields = null, SimpleElement $element = null)
     {
-        $context = $element === null ? $this->_rootElement : $element;
+        $context = $element ?? $this->_rootElement;
         $storeLabels = [];
         $count = 0;
         $field = $context->find(sprintf(self::STORE_LABEL_NAME, $count));

--- a/dev/tests/functional/tests/app/Magento/SalesRule/Test/Handler/SalesRule/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/SalesRule/Test/Handler/SalesRule/Curl.php
@@ -229,7 +229,7 @@ class Curl extends Conditions implements SalesRuleInterface
         $websiteIds = [];
         if (!empty($this->data['website_ids'])) {
             foreach ($this->data['website_ids'] as $name) {
-                $websiteIds[] = isset($this->websiteIds[$name]) ? $this->websiteIds[$name] : $name;
+                $websiteIds[] = $this->websiteIds[$name] ?? $name;
             }
         }
 
@@ -246,7 +246,7 @@ class Curl extends Conditions implements SalesRuleInterface
         $groupIds = [];
         if (!empty($this->data['customer_group_ids'])) {
             foreach ($this->data['customer_group_ids'] as $name) {
-                $groupIds[] = isset($this->customerIds[$name]) ? $this->customerIds[$name] : $name;
+                $groupIds[] = $this->customerIds[$name] ?? $name;
             }
         }
 

--- a/dev/tests/functional/tests/app/Magento/SalesRule/Test/Handler/SalesRule/Webapi.php
+++ b/dev/tests/functional/tests/app/Magento/SalesRule/Test/Handler/SalesRule/Webapi.php
@@ -219,12 +219,8 @@ class Webapi extends AbstractWebapi implements SalesRuleInterface
                 'rule_id' => $ruleId,
                 'code' => $this->fixture->getCouponCode(),
                 'type' => $this->mappingData['coupon_type'][$this->fixture->getCouponType()],
-                'usage_limit' => isset($this->data['uses_per_coupon'])
-                    ? $this->data['uses_per_coupon']
-                    : null,
-                'usage_per_customer' => isset($this->data['usage_per_customer'])
-                    ? $this->data['usage_per_customer']
-                    : null,
+                'usage_limit' => $this->data['uses_per_coupon'] ?? null,
+                'usage_per_customer' => $this->data['usage_per_customer'] ?? null,
                 'is_primary' => true
             ])
         ];
@@ -259,15 +255,9 @@ class Webapi extends AbstractWebapi implements SalesRuleInterface
             $childCondition = $this->convertCondition($condition, "{$prefix}{$indent}--", 1);
             $result[] = array_filter([
                 'condition_type' => $condition[$key]['type'],
-                'aggregator_type' => isset($condition[$key]['aggregator'])
-                    ? $condition[$key]['aggregator']
-                    : null,
-                'attribute_name' => isset($condition[$key]['attribute'])
-                    ? $condition[$key]['attribute']
-                    : null,
-                'operator' => isset($condition[$key]['operator'])
-                    ? $condition[$key]['operator']
-                    : null,
+                'aggregator_type' => $condition[$key]['aggregator'] ?? null,
+                'attribute_name' => $condition[$key]['attribute'] ?? null,
+                'operator' => $condition[$key]['operator'] ?? null,
                 'value' => $condition[$key]['value'],
                 'conditions' => empty($childCondition) ? null : $childCondition
             ], [$this, 'filterCondition']);

--- a/dev/tests/functional/tests/app/Magento/Search/Test/Constraint/AssertSynonymGroupInGrid.php
+++ b/dev/tests/functional/tests/app/Magento/Search/Test/Constraint/AssertSynonymGroupInGrid.php
@@ -64,12 +64,8 @@ class AssertSynonymGroupInGrid extends AbstractConstraint
         $data = $synonymGroup->getData();
         $this->filter = [
             'synonyms' => $data['synonyms'],
-            'website_id' => isset($synonymFilter['data']['website'])
-                ? $synonymFilter['data']['website']
-                : '',
-            'group_id' => isset($synonymFilter['data']['id'])
-                ? $synonymFilter['data']['id']
-                : '',
+            'website_id' => $synonymFilter['data']['website'] ?? '',
+            'group_id' => $synonymFilter['data']['id'] ?? '',
         ];
     }
 

--- a/dev/tests/functional/tests/app/Magento/Search/Test/Handler/SynonymGroup/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Search/Test/Handler/SynonymGroup/Curl.php
@@ -63,7 +63,7 @@ class Curl extends AbstractCurl implements SynonymGroupInterface
         }
 
         preg_match("`group_id\/(\d*?)\/`", $response, $matches);
-        $id = isset($matches[1]) ? $matches[1] : null;
+        $id = $matches[1] ?? null;
 
         return ['group_id' => $id];
     }

--- a/dev/tests/functional/tests/app/Magento/Store/Test/Fixture/StoreGroup/CategoryId.php
+++ b/dev/tests/functional/tests/app/Magento/Store/Test/Fixture/StoreGroup/CategoryId.php
@@ -32,7 +32,7 @@ class CategoryId extends DataSource
     {
         $this->params = $params;
         if (isset($data['fixture']) || isset($data['category'])) {
-            $this->category = isset($data['fixture']) ? $data['fixture'] : $data['category'];
+            $this->category = $data['fixture'] ?? $data['category'];
             $this->data = $this->category->getName();
         } elseif (isset($data['dataset'])) {
             $category = $fixtureFactory->createByCode('category', ['dataset' => $data['dataset']]);

--- a/dev/tests/functional/tests/app/Magento/Store/Test/Handler/Store/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Store/Test/Handler/Store/Curl.php
@@ -76,7 +76,7 @@ class Curl extends AbstractCurl implements StoreInterface
             'store_type' => 'store',
         ];
         $data['store']['group_id'] = $fixture->getDataFieldConfig('group_id')['source']->getStoreGroup()->getGroupId();
-        $data['store']['store_id'] = isset($data['store']['store_id']) ? $data['store']['store_id'] : '';
+        $data['store']['store_id'] = $data['store']['store_id'] ?? '';
 
         return $data;
     }

--- a/dev/tests/functional/tests/app/Magento/Store/Test/Handler/Website/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Store/Test/Handler/Website/Curl.php
@@ -135,7 +135,7 @@ class Curl extends AbstractCurl implements WebsiteInterface
             'store_action' => 'add',
             'store_type' => 'website',
         ];
-        $data['website']['website_id'] = isset($data['website']['website_id']) ? $data['website']['website_id'] : '';
+        $data['website']['website_id'] = $data['website']['website_id'] ?? '';
 
         return $data;
     }

--- a/dev/tests/functional/tests/app/Magento/Tax/Test/Handler/TaxRule/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Tax/Test/Handler/TaxRule/Curl.php
@@ -52,7 +52,7 @@ class Curl extends AbstractCurl implements TaxRuleInterface
         }
 
         preg_match("~Location: [^\s]*\/rule\/(\d+)~", $response, $matches);
-        $id = isset($matches[1]) ? $matches[1] : null;
+        $id = $matches[1] ?? null;
 
         return ['id' => $id];
     }
@@ -84,7 +84,7 @@ class Curl extends AbstractCurl implements TaxRuleInterface
      */
     public function prepareFieldData(TaxRule $fixture, array $data, $fixtureField, $newField = null)
     {
-        $newField = $newField === null ? $fixtureField : $newField;
+        $newField = $newField ?? $fixtureField;
         unset($data[$fixtureField]);
 
         if (!$fixture->hasData($fixtureField)) {

--- a/dev/tests/functional/tests/app/Magento/Ui/Test/Block/Adminhtml/AbstractFormContainers.php
+++ b/dev/tests/functional/tests/app/Magento/Ui/Test/Block/Adminhtml/AbstractFormContainers.php
@@ -73,7 +73,7 @@ abstract class AbstractFormContainers extends Form
             throw new \Exception('Wrong Container Class.');
         }
         $container->setWrapper(
-            isset($this->containers[$containerName]['wrapper']) ? $this->containers[$containerName]['wrapper'] : ''
+            $this->containers[$containerName]['wrapper'] ?? ''
         );
         $container->setMapping(
             isset($this->containers[$containerName]['fields']) ? (array)$this->containers[$containerName]['fields'] : []
@@ -226,9 +226,7 @@ abstract class AbstractFormContainers extends Form
     protected function getContainerElement($containerName)
     {
         $selector = $this->containers[$containerName]['selector'];
-        $strategy = isset($this->containers[$containerName]['strategy'])
-            ? $this->containers[$containerName]['strategy']
-            : Locator::SELECTOR_CSS;
+        $strategy = $this->containers[$containerName]['strategy'] ?? Locator::SELECTOR_CSS;
         return $this->_rootElement->find($selector, $strategy);
     }
 

--- a/dev/tests/functional/tests/app/Magento/Variable/Test/Handler/SystemVariable/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Variable/Test/Handler/SystemVariable/Curl.php
@@ -39,7 +39,7 @@ class Curl extends AbstractCurl implements SystemVariableInterface
         }
 
         preg_match("~Location: [^\\s]*system_variable\\/edit\\/variable_id\\/(\\d+)~", $response, $matches);
-        $id = isset($matches[1]) ? $matches[1] : null;
+        $id = $matches[1] ?? null;
         return ['variable_id' => $id];
     }
 }

--- a/dev/tests/functional/tests/app/Magento/Vault/Test/TestCase/DeleteSavedCreditCardTest.php
+++ b/dev/tests/functional/tests/app/Magento/Vault/Test/TestCase/DeleteSavedCreditCardTest.php
@@ -96,7 +96,7 @@ class DeleteSavedCreditCardTest extends Injectable
             if ($key >= 2) { // if this order will be placed via stored credit card
                 $this->useSavedCreditCard($payment['vault']);
             } else {
-                $arguments = isset($payment['arguments']) ? $payment['arguments'] : [];
+                $arguments = $payment['arguments'] ?? [];
                 $this->selectPaymentMethod($payment, $payment['creditCard'], $arguments);
                 $this->saveCreditCard($payment, $creditCardSave);
             }

--- a/dev/tests/functional/tests/app/Magento/Weee/Test/Block/Cart.php
+++ b/dev/tests/functional/tests/app/Magento/Weee/Test/Block/Cart.php
@@ -24,7 +24,7 @@ class Cart extends \Magento\Checkout\Test\Block\Cart
     public function getCartItem(FixtureInterface $product)
     {
         $dataConfig = $product->getDataConfig();
-        $typeId = isset($dataConfig['type_id']) ? $dataConfig['type_id'] : null;
+        $typeId = $dataConfig['type_id'] ?? null;
         $cartItem = null;
 
         if ($this->hasRender($typeId)) {

--- a/dev/tests/functional/tests/app/Magento/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/ParametersType/ParametersForm.php
+++ b/dev/tests/functional/tests/app/Magento/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/ParametersType/ParametersForm.php
@@ -54,7 +54,7 @@ class ParametersForm extends Form
      */
     public function fillForm(array $parametersFields, SimpleElement $element = null)
     {
-        $element = $element === null ? $this->_rootElement : $element;
+        $element = $element ?? $this->_rootElement;
         $mapping = $this->dataMapping($parametersFields);
         $this->_fill(array_diff_key($mapping, ['entities' => '']), $element);
         if (isset($parametersFields['entities'])) {
@@ -71,7 +71,7 @@ class ParametersForm extends Form
      */
     public function getDataOptions(array $fields = null, SimpleElement $element = null)
     {
-        $element = $element === null ? $this->_rootElement : $element;
+        $element = $element ?? $this->_rootElement;
         $mapping = $this->dataMapping($fields);
         return $this->_getData($mapping, $element);
     }

--- a/dev/tests/functional/tests/app/Magento/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetInstanceType/Categories.php
+++ b/dev/tests/functional/tests/app/Magento/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetInstanceType/Categories.php
@@ -24,7 +24,7 @@ class Categories extends WidgetInstanceForm
      */
     public function fillForm(array $parametersFields, SimpleElement $element = null)
     {
-        $element = $element === null ? $this->_rootElement : $element;
+        $element = $element ?? $this->_rootElement;
         $fields = $this->dataMapping(array_diff_key($parametersFields, ['entities' => '']));
         foreach ($fields as $key => $values) {
             $this->_fill([$key => $values], $element);

--- a/dev/tests/functional/tests/app/Magento/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetInstanceType/Products.php
+++ b/dev/tests/functional/tests/app/Magento/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetInstanceType/Products.php
@@ -32,7 +32,7 @@ class Products extends WidgetInstanceForm
      */
     public function fillForm(array $parametersFields, SimpleElement $element = null)
     {
-        $element = $element === null ? $this->_rootElement : $element;
+        $element = $element ?? $this->_rootElement;
         $fields = $this->dataMapping(array_diff_key($parametersFields, ['entities' => '']));
         foreach ($fields as $key => $values) {
             $this->_fill([$key => $values], $element);

--- a/dev/tests/functional/tests/app/Magento/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetInstanceType/WidgetInstanceForm.php
+++ b/dev/tests/functional/tests/app/Magento/Widget/Test/Block/Adminhtml/Widget/Instance/Edit/Tab/WidgetInstanceType/WidgetInstanceForm.php
@@ -59,7 +59,7 @@ class WidgetInstanceForm extends Form
      */
     public function fillForm(array $layoutFields, SimpleElement $element = null)
     {
-        $element = $element === null ? $this->_rootElement : $element;
+        $element = $element ?? $this->_rootElement;
         $mapping = $this->dataMapping($layoutFields);
         foreach ($mapping as $key => $values) {
             $this->_fill([$key => $values], $element);
@@ -76,7 +76,7 @@ class WidgetInstanceForm extends Form
      */
     public function getDataOptions(array $fields = null, SimpleElement $element = null)
     {
-        $element = $element === null ? $this->_rootElement : $element;
+        $element = $element ?? $this->_rootElement;
         $mapping = $this->dataMapping($fields);
         return $this->_getData($mapping, $element);
     }

--- a/dev/tests/functional/tests/app/Magento/Widget/Test/Handler/Widget/Curl.php
+++ b/dev/tests/functional/tests/app/Magento/Widget/Test/Handler/Widget/Curl.php
@@ -195,14 +195,10 @@ class Curl extends AbstractCurl
      */
     protected function prepareAllPagesGroup(array $widgetInstancePageGroup)
     {
-        $widgetInstance['layout_handle'] = isset($widgetInstancePageGroup['layout_handle'])
-            ? $widgetInstancePageGroup['layout_handle']
-            : 'default';
+        $widgetInstance['layout_handle'] = $widgetInstancePageGroup['layout_handle'] ?? 'default';
         $widgetInstance['for'] = 'all';
         $widgetInstance['block'] = $widgetInstancePageGroup['block'];
-        $widgetInstance['template'] = isset($widgetInstancePageGroup['template'])
-            ? $widgetInstancePageGroup['template']
-            : $this->widgetInstanceTemplate;
+        $widgetInstance['template'] = $widgetInstancePageGroup['template'] ?? $this->widgetInstanceTemplate;
 
         return $widgetInstance;
     }

--- a/dev/tests/functional/tests/app/Magento/Wishlist/Test/Constraint/AssertProductInCustomerWishlistOnBackendGrid.php
+++ b/dev/tests/functional/tests/app/Magento/Wishlist/Test/Constraint/AssertProductInCustomerWishlistOnBackendGrid.php
@@ -45,7 +45,7 @@ class AssertProductInCustomerWishlistOnBackendGrid extends AbstractConstraint
     protected function prepareFilter(FixtureInterface $product)
     {
         $checkoutData = $product->getCheckoutData();
-        $qty = isset($checkoutData['qty']) ? $checkoutData['qty'] : 1;
+        $qty = $checkoutData['qty'] ?? 1;
         $options = $this->prepareOptions($product);
 
         return ['product_name' => $product->getName(), 'qty_from' => $qty, 'qty_to' => $qty, 'options' => $options];
@@ -68,9 +68,7 @@ class AssertProductInCustomerWishlistOnBackendGrid extends AbstractConstraint
                 $valueKey = str_replace('option_key_', '', $option['value']);
                 $productOptions[] = [
                     'option_name' => $customOptions[$optionKey]['title'],
-                    'value' => isset($customOptions[$optionKey]['options'][$valueKey]['title'])
-                        ? $customOptions[$optionKey]['options'][$valueKey]['title']
-                        : $valueKey,
+                    'value' => $customOptions[$optionKey]['options'][$valueKey]['title'] ?? $valueKey,
                 ];
             }
         }

--- a/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests.php
+++ b/dev/tests/functional/testsuites/Magento/Mtf/TestSuite/InjectableTests.php
@@ -83,7 +83,7 @@ class InjectableTests extends \PHPUnit\Framework\TestSuite
         if (!isset($this->objectManager)) {
             $objectManagerFactory = new ObjectManagerFactory();
 
-            $configFileName = isset($_ENV['testsuite_rule']) ? $_ENV['testsuite_rule'] : 'basic';
+            $configFileName = $_ENV['testsuite_rule'] ?? 'basic';
             $configFilePath = realpath(MTF_BP . '/testsuites/' . $_ENV['testsuite_rule_path']);
 
             /** @var \Magento\Mtf\Config\DataInterface $configData */

--- a/dev/tests/integration/framework/Magento/TestFramework/Annotation/DataFixture.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Annotation/DataFixture.php
@@ -194,9 +194,7 @@ class DataFixture
     protected function getDbIsolationState(\PHPUnit\Framework\TestCase $test)
     {
         $annotations = $this->getAnnotations($test);
-        return isset($annotations[DbIsolation::MAGENTO_DB_ISOLATION])
-            ? $annotations[DbIsolation::MAGENTO_DB_ISOLATION]
-            : null;
+        return $annotations[DbIsolation::MAGENTO_DB_ISOLATION] ?? null;
     }
 
     /**

--- a/dev/tests/integration/framework/Magento/TestFramework/Annotation/DataFixtureBeforeTransaction.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Annotation/DataFixtureBeforeTransaction.php
@@ -159,9 +159,7 @@ class DataFixtureBeforeTransaction
     protected function getDbIsolationState(\PHPUnit\Framework\TestCase $test)
     {
         $annotations = $this->getAnnotations($test);
-        return isset($annotations[DbIsolation::MAGENTO_DB_ISOLATION])
-            ? $annotations[DbIsolation::MAGENTO_DB_ISOLATION]
-            : null;
+        return $annotations[DbIsolation::MAGENTO_DB_ISOLATION] ?? null;
     }
 
     /**

--- a/dev/tests/integration/framework/Magento/TestFramework/App/Config.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/App/Config.php
@@ -127,7 +127,7 @@ class Config extends \Magento\Framework\App\Config
      */
     public function get($configType, $path = null, $default = null)
     {
-        $path = $path === null ? '' : $path;
+        $path = $path ?? '';
         if (!isset($this->data[$configType]) || $this->data[$configType]->getData($path) === null) {
             return parent::get($configType, $path, $default);
         }

--- a/dev/tests/integration/framework/Magento/TestFramework/Application.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Application.php
@@ -343,9 +343,7 @@ class Application
     {
         $overriddenParams[\Magento\Framework\App\State::PARAM_MODE] = $this->_appMode;
         $overriddenParams = $this->_customizeParams($overriddenParams);
-        $directories = isset($overriddenParams[\Magento\Framework\App\Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS])
-            ? $overriddenParams[\Magento\Framework\App\Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS]
-            : [];
+        $directories = $overriddenParams[\Magento\Framework\App\Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS] ?? [];
         $directoryList = new DirectoryList(BP, $directories);
         /** @var \Magento\TestFramework\ObjectManager $objectManager */
         $objectManager = Helper\Bootstrap::getObjectManager();

--- a/dev/tests/integration/framework/Magento/TestFramework/Helper/Factory.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Helper/Factory.php
@@ -41,7 +41,7 @@ class Factory
      */
     public static function setHelper($name, $helper)
     {
-        $old = isset(self::$_instances[$name]) ? self::$_instances[$name] : null;
+        $old = self::$_instances[$name] ?? null;
         self::$_instances[$name] = $helper;
         return $old;
     }

--- a/dev/tests/integration/framework/bootstrap.php
+++ b/dev/tests/integration/framework/bootstrap.php
@@ -139,7 +139,7 @@ function setCustomErrorHandler()
                     E_USER_DEPRECATED => 'User Deprecated',
                 ];
 
-                $errName = isset($errorNames[$errNo]) ? $errorNames[$errNo] : "";
+                $errName = $errorNames[$errNo] ?? "";
 
                 throw new \PHPUnit\Framework\Exception(
                     sprintf("%s: %s in %s:%s.", $errName, $errStr, $errFile, $errLine),

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/BootstrapTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/BootstrapTest.php
@@ -121,7 +121,7 @@ class BootstrapTest extends \PHPUnit\Framework\TestCase
             ->with($this->identicalTo($_SERVER));
         $this->_envBootstrap->expects($this->once())
             ->method('emulateSession')
-            ->with($this->identicalTo(isset($_SESSION) ? $_SESSION : null));
+            ->with($this->identicalTo($_SESSION ?? null));
 
         $memUsageLimit = '100B';
         $memLeakLimit = '60B';

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/AbstractProductExportImportTestCase.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/AbstractProductExportImportTestCase.php
@@ -203,7 +203,7 @@ abstract class AbstractProductExportImportTestCase extends \PHPUnit\Framework\Te
 
             $this->assertEquals(
                 $value,
-                isset($actual[$key]) ? $actual[$key] : null,
+                $actual[$key] ?? null,
                 'Assert value at key - ' . $key . ' failed'
             );
         }

--- a/dev/tests/integration/testsuite/Magento/Customer/Block/Adminhtml/Edit/Tab/View/PersonalInfoTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Block/Adminhtml/Edit/Tab/View/PersonalInfoTest.php
@@ -111,7 +111,7 @@ class PersonalInfoTest extends \PHPUnit\Framework\TestCase
         );
         foreach ($expectedCustomerData as $property => $value) {
             $expectedValue = is_numeric($value) ? (int)$value : $value;
-            $actualValue = isset($actualCustomerData[$property]) ? $actualCustomerData[$property] : null;
+            $actualValue = $actualCustomerData[$property] ?? null;
             $actualValue = is_numeric($actualValue) ? (int)$actualValue : $actualValue;
             $this->assertEquals($expectedValue, $actualValue);
         }

--- a/dev/tests/integration/testsuite/Magento/Elasticsearch/Model/Client/ElasticsearchTest.php
+++ b/dev/tests/integration/testsuite/Magento/Elasticsearch/Model/Client/ElasticsearchTest.php
@@ -91,7 +91,7 @@ class ElasticsearchTest extends \PHPUnit\Framework\TestCase
             ],
         ];
         $queryResult = $this->client->query($searchQuery);
-        return isset($queryResult['hits']['hits']) ? $queryResult['hits']['hits'] : [];
+        return $queryResult['hits']['hits'] ?? [];
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Elasticsearch/Model/Indexer/IndexHandlerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Elasticsearch/Model/Indexer/IndexHandlerTest.php
@@ -250,7 +250,7 @@ class IndexHandlerTest extends \PHPUnit\Framework\TestCase
             ],
         ];
         $queryResult = $this->client->query($searchQuery);
-        $products = isset($queryResult['hits']['hits']) ? $queryResult['hits']['hits'] : [];
+        $products = $queryResult['hits']['hits'] ?? [];
 
         return $products;
     }

--- a/dev/tests/integration/testsuite/Magento/Elasticsearch/Model/Indexer/ReindexAllTest.php
+++ b/dev/tests/integration/testsuite/Magento/Elasticsearch/Model/Indexer/ReindexAllTest.php
@@ -122,7 +122,7 @@ class ReindexAllTest extends \PHPUnit\Framework\TestCase
             ],
         ];
         $queryResult = $this->client->query($searchQuery);
-        return isset($queryResult['hits']['hits']) ? $queryResult['hits']['hits'] : [];
+        return $queryResult['hits']['hits'] ?? [];
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Framework/GraphQl/GraphQlConfigTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/GraphQl/GraphQlConfigTest.php
@@ -208,15 +208,13 @@ class GraphQlConfigTest extends \PHPUnit\Framework\TestCase
     private function assertResponseFields($actualResponse, $assertionMap)
     {
         foreach ($assertionMap as $key => $assertionData) {
-            $expectedValue = isset($assertionData['expected_value'])
-                ? $assertionData['expected_value']
-                : $assertionData;
-            $responseField = isset($assertionData['response_field']) ? $assertionData['response_field'] : $key;
+            $expectedValue = $assertionData['expected_value'] ?? $assertionData;
+            $responseField = $assertionData['response_field'] ?? $key;
             $this->assertNotNull(
                 $expectedValue,
                 "Value of '{$responseField}' field must not be NULL"
             );
-            $optionalField = isset($assertionData['optional']) ? $assertionData['optional'] : false;
+            $optionalField = $assertionData['optional'] ?? false;
             if (!$optionalField || isset($actualResponse[$responseField])) {
                 $this->assertEquals(
                     $expectedValue,

--- a/dev/tests/integration/testsuite/Magento/Signifyd/Model/CaseServices/CreationServiceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Signifyd/Model/CaseServices/CreationServiceTest.php
@@ -240,6 +240,6 @@ class CreationServiceTest extends \PHPUnit\Framework\TestCase
             ->getItems();
         $result = array_pop($items);
 
-        return isset($result['signifyd_guarantee_status']) ? $result['signifyd_guarantee_status'] : null;
+        return $result['signifyd_guarantee_status'] ?? null;
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Signifyd/Model/CaseServices/UpdatingServiceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Signifyd/Model/CaseServices/UpdatingServiceTest.php
@@ -181,6 +181,6 @@ class UpdatingServiceTest extends \PHPUnit\Framework\TestCase
             ->getItems();
         $result = array_pop($items);
 
-        return isset($result['signifyd_guarantee_status']) ? $result['signifyd_guarantee_status'] : null;
+        return $result['signifyd_guarantee_status'] ?? null;
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Tax/Model/Sales/Total/Quote/SetupUtil.php
+++ b/dev/tests/integration/testsuite/Magento/Tax/Model/Sales/Total/Quote/SetupUtil.php
@@ -652,9 +652,9 @@ class SetupUtil
         foreach ($itemsData as $itemData) {
             $sku = $itemData['sku'];
             $price = $itemData['price'];
-            $qty = isset($itemData['qty']) ? $itemData['qty'] : 1;
+            $qty = $itemData['qty'] ?? 1;
             $taxClassName =
-                isset($itemData['tax_class_name']) ? $itemData['tax_class_name'] : self::PRODUCT_TAX_CLASS_1;
+                $itemData['tax_class_name'] ?? self::PRODUCT_TAX_CLASS_1;
             $taxClassId = $this->productTaxClasses[$taxClassName];
             $product = $this->createSimpleProduct($sku, $price, $taxClassId);
             $quote->addProduct($product, $qty);

--- a/dev/tests/integration/testsuite/Magento/Ui/Config/FileResolverStub.php
+++ b/dev/tests/integration/testsuite/Magento/Ui/Config/FileResolverStub.php
@@ -65,7 +65,7 @@ class FileResolverStub implements \Magento\Framework\Config\FileResolverInterfac
         } else {
             $path = realpath(__DIR__ . '/../_files/view');
         }
-        $files = isset($this->files[$filename]) ? $this->files[$filename] : [];
+        $files = $this->files[$filename] ?? [];
         $realPaths = [];
         foreach ($files as $filePath) {
             $realPaths[] = $path . '/' . $filePath;

--- a/dev/tests/static/framework/Magento/TestFramework/Dependency/LayoutRule.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Dependency/LayoutRule.php
@@ -235,7 +235,7 @@ class LayoutRule implements \Magento\TestFramework\Dependency\RuleInterface
         $result = [];
         foreach ((array)$xml->xpath('/layout/child::*') as $element) {
             $check = $this->_checkDependencyLayoutHandle($currentModule, $area, $element->getName());
-            $modules = isset($check['module']) ? $check['module'] : null;
+            $modules = $check['module'] ?? null;
             if ($modules) {
                 if (!is_array($modules)) {
                     $modules = [$modules];
@@ -273,7 +273,7 @@ class LayoutRule implements \Magento\TestFramework\Dependency\RuleInterface
         $result = [];
         foreach ((array)$xml->xpath('/layout/child::*/@parent') as $element) {
             $check = $this->_checkDependencyLayoutHandle($currentModule, $area, (string)$element);
-            $modules = isset($check['module']) ? $check['module'] : null;
+            $modules = $check['module'] ?? null;
             if ($modules) {
                 if (!is_array($modules)) {
                     $modules = [$modules];
@@ -311,7 +311,7 @@ class LayoutRule implements \Magento\TestFramework\Dependency\RuleInterface
         $result = [];
         foreach ((array)$xml->xpath('//update/@handle') as $element) {
             $check = $this->_checkDependencyLayoutHandle($currentModule, $area, (string)$element);
-            $modules = isset($check['module']) ? $check['module'] : null;
+            $modules = $check['module'] ?? null;
             if ($modules) {
                 if (!is_array($modules)) {
                     $modules = [$modules];
@@ -349,7 +349,7 @@ class LayoutRule implements \Magento\TestFramework\Dependency\RuleInterface
         $result = [];
         foreach ((array)$xml->xpath('//reference/@name') as $element) {
             $check = $this->_checkDependencyLayoutBlock($currentModule, $area, (string)$element);
-            $module = isset($check['module']) ? $check['module'] : null;
+            $module = $check['module'] ?? null;
             if ($module) {
                 $result[$module] = [
                     'type' => \Magento\TestFramework\Dependency\RuleInterface::TYPE_SOFT,

--- a/dev/tests/static/framework/Magento/TestFramework/Dependency/PhpRule.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Dependency/PhpRule.php
@@ -262,9 +262,7 @@ class PhpRule implements RuleInterface
     private function isPluginDependency($dependent, $dependency)
     {
         $pluginMap = $this->loadPluginMap();
-        $subject = isset($pluginMap[$dependent])
-            ? $pluginMap[$dependent]
-            : null;
+        $subject = $pluginMap[$dependent] ?? null;
         if ($subject === $dependency) {
             return true;
         } elseif ($subject) {
@@ -361,7 +359,7 @@ class PhpRule implements RuleInterface
                 continue;
             }
             $check = $this->_checkDependencyLayoutBlock($currentModule, $area, $match['block']);
-            $module = isset($check['module']) ? $check['module'] : null;
+            $module = $check['module'] ?? null;
             if ($module) {
                 $result[$module] = [
                     'type' => RuleInterface::TYPE_HARD,

--- a/dev/tests/static/framework/Magento/TestFramework/Utility/ChangedFiles.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Utility/ChangedFiles.php
@@ -69,7 +69,7 @@ class ChangedFiles
             $data = json_decode($changedContent, true);
         }
 
-        return isset($data[$fileName]) ? $data[$fileName] : '';
+        return $data[$fileName] ?? '';
     }
 
     /**
@@ -81,6 +81,6 @@ class ChangedFiles
     public static function getFileExtension($fileName)
     {
         $fileInfo = pathinfo($fileName);
-        return isset($fileInfo['extension']) ? $fileInfo['extension'] : 'unknown';
+        return $fileInfo['extension'] ?? 'unknown';
     }
 }

--- a/dev/tests/static/framework/bootstrap.php
+++ b/dev/tests/static/framework/bootstrap.php
@@ -55,7 +55,7 @@ function setCustomErrorHandler()
                     E_USER_DEPRECATED => 'User Deprecated',
                 ];
 
-                $errName = isset($errorNames[$errNo]) ? $errorNames[$errNo] : "";
+                $errName = $errorNames[$errNo] ?? "";
 
                 throw new \PHPUnit\Framework\Exception(
                     sprintf("%s: %s in %s:%s.", $errName, $errStr, $errFile, $errLine),

--- a/dev/tests/static/get_github_changes.php
+++ b/dev/tests/static/get_github_changes.php
@@ -30,7 +30,7 @@ if (!validateInput($options, $requiredOptions)) {
     exit(1);
 }
 
-$fileExtensions = explode(',', isset($options['file-extensions']) ? $options['file-extensions'] : 'php');
+$fileExtensions = explode(',', $options['file-extensions'] ?? 'php');
 
 include_once __DIR__ . '/framework/autoload.php';
 

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/DependencyTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/DependencyTest.php
@@ -436,7 +436,7 @@ class DependencyTest extends \PHPUnit\Framework\TestCase
      */
     private function collectDependency($dependency, $currentModule, &$undeclared)
     {
-        $type = isset($dependency['type']) ? $dependency['type'] : self::TYPE_HARD;
+        $type = $dependency['type'] ?? self::TYPE_HARD;
 
         $soft = $this->_getDependencies($currentModule, self::TYPE_SOFT, self::MAP_TYPE_DECLARED);
         $hard = $this->_getDependencies($currentModule, self::TYPE_HARD, self::MAP_TYPE_DECLARED);

--- a/dev/tests/unit/framework/bootstrap.php
+++ b/dev/tests/unit/framework/bootstrap.php
@@ -49,7 +49,7 @@ function setCustomErrorHandler()
                     E_USER_DEPRECATED => 'User Deprecated',
                 ];
 
-                $errName = isset($errorNames[$errNo]) ? $errorNames[$errNo] : "";
+                $errName = $errorNames[$errNo] ?? "";
 
                 throw new \PHPUnit\Framework\Exception(
                     sprintf("%s: %s in %s:%s.", $errName, $errStr, $errFile, $errLine),

--- a/lib/internal/Magento/Framework/Amqp/Config.php
+++ b/lib/internal/Magento/Framework/Amqp/Config.php
@@ -185,11 +185,9 @@ class Config
         if (null === $this->data) {
             $queueConfig = $this->deploymentConfig->getConfigData(self::QUEUE_CONFIG);
             if ($this->connectionName == self::AMQP_CONFIG) {
-                $this->data = isset($queueConfig[self::AMQP_CONFIG]) ? $queueConfig[self::AMQP_CONFIG] : [];
+                $this->data = $queueConfig[self::AMQP_CONFIG] ?? [];
             } else {
-                $this->data = isset($queueConfig['connections'][$this->connectionName])
-                    ? $queueConfig['connections'][$this->connectionName]
-                    : [];
+                $this->data = $queueConfig['connections'][$this->connectionName] ?? [];
             }
             if (empty($this->data)) {
                 throw  new \LogicException('Unknown connection name ' . $this->connectionName);

--- a/lib/internal/Magento/Framework/Amqp/Connection/Factory.php
+++ b/lib/internal/Magento/Framework/Amqp/Connection/Factory.php
@@ -31,13 +31,11 @@ class Factory
             'port' => $options->getPort(),
             'user' => $options->getUsername(),
             'password' => $options->getPassword(),
-            'vhost' => $options->getVirtualHost() !== null ? $options->getVirtualHost() : '/',
+            'vhost' => $options->getVirtualHost() ?? '/',
         ];
 
         if ($options->isSslEnabled()) {
-            $parameters['ssl_options'] = $options->getSslOptions() !== null
-                ? $options->getSslOptions()
-                : ['verify_peer' => true];
+            $parameters['ssl_options'] = $options->getSslOptions() ?? ['verify_peer' => true];
         }
 
         return ObjectManager::getInstance()->create($connectionType, $parameters);

--- a/lib/internal/Magento/Framework/Amqp/Test/Unit/Connection/FactoryTest.php
+++ b/lib/internal/Magento/Framework/Amqp/Test/Unit/Connection/FactoryTest.php
@@ -89,7 +89,7 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
         $this->optionsMock->expects($this->once())
             ->method('getPassword')
             ->willReturn('guest');
-        $this->optionsMock->expects($this->exactly(2))
+        $this->optionsMock->expects($this->once())
             ->method('getVirtualHost')
             ->willReturn('/');
         $this->optionsMock->expects($this->any())

--- a/lib/internal/Magento/Framework/Api/CombinedFilterGroup.php
+++ b/lib/internal/Magento/Framework/Api/CombinedFilterGroup.php
@@ -35,7 +35,7 @@ class CombinedFilterGroup extends AbstractSimpleObject
     public function getFilters()
     {
         $filters = $this->_get(self::FILTERS);
-        return $filters === null ? [] : $filters;
+        return $filters ?? [];
     }
 
     /**

--- a/lib/internal/Magento/Framework/Api/Search/FilterGroup.php
+++ b/lib/internal/Magento/Framework/Api/Search/FilterGroup.php
@@ -25,7 +25,7 @@ class FilterGroup extends AbstractSimpleObject
     public function getFilters()
     {
         $filters = $this->_get(self::FILTERS);
-        return $filters === null ? [] : $filters;
+        return $filters ?? [];
     }
 
     /**

--- a/lib/internal/Magento/Framework/Api/SearchResults.php
+++ b/lib/internal/Magento/Framework/Api/SearchResults.php
@@ -25,7 +25,7 @@ class SearchResults extends AbstractSimpleObject implements SearchResultsInterfa
      */
     public function getItems()
     {
-        return $this->_get(self::KEY_ITEMS) === null ? [] : $this->_get(self::KEY_ITEMS);
+        return $this->_get(self::KEY_ITEMS) ?? [];
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
+++ b/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
@@ -118,7 +118,7 @@ class Factory
             }
         }
 
-        $idPrefix = isset($options['id_prefix']) ? $options['id_prefix'] : '';
+        $idPrefix = $options['id_prefix'] ?? '';
         if (!$idPrefix && isset($options['prefix'])) {
             $idPrefix = $options['prefix'];
         }
@@ -191,7 +191,7 @@ class Factory
                 throw new \LogicException('Class has to be specified for a cache frontend decorator.');
             }
             $decoratorClass = $decoratorConfig['class'];
-            $decoratorParams = isset($decoratorConfig['parameters']) ? $decoratorConfig['parameters'] : [];
+            $decoratorParams = $decoratorConfig['parameters'] ?? [];
             $decoratorParams['frontend'] = $frontend;
             // conventionally, 'frontend' argument is a decoration subject
             $frontend = $this->_objectManager->create($decoratorClass, $decoratorParams);
@@ -213,7 +213,7 @@ class Factory
     protected function _getBackendOptions(array $cacheOptions)
     {
         $enableTwoLevels = false;
-        $type = isset($cacheOptions['backend']) ? $cacheOptions['backend'] : $this->_defaultBackend;
+        $type = $cacheOptions['backend'] ?? $this->_defaultBackend;
         if (isset($cacheOptions['backend_options']) && is_array($cacheOptions['backend_options'])) {
             $options = $cacheOptions['backend_options'];
         } else {
@@ -380,20 +380,18 @@ class Factory
      */
     protected function _getFrontendOptions(array $cacheOptions)
     {
-        $options = isset($cacheOptions['frontend_options']) ? $cacheOptions['frontend_options'] : [];
+        $options = $cacheOptions['frontend_options'] ?? [];
         if (!array_key_exists('caching', $options)) {
             $options['caching'] = true;
         }
         if (!array_key_exists('lifetime', $options)) {
-            $options['lifetime'] = isset(
-                $cacheOptions['lifetime']
-            ) ? $cacheOptions['lifetime'] : self::DEFAULT_LIFETIME;
+            $options['lifetime'] = $cacheOptions['lifetime'] ?? self::DEFAULT_LIFETIME;
         }
         if (!array_key_exists('automatic_cleaning_factor', $options)) {
             $options['automatic_cleaning_factor'] = 0;
         }
         $options['type'] =
-            isset($cacheOptions['frontend']) ? $cacheOptions['frontend'] : \Magento\Framework\Cache\Core::class;
+            $cacheOptions['frontend'] ?? \Magento\Framework\Cache\Core::class;
         return $options;
     }
 }

--- a/lib/internal/Magento/Framework/App/Cache/Type/FrontendPool.php
+++ b/lib/internal/Magento/Framework/App/Cache/Type/FrontendPool.php
@@ -105,8 +105,7 @@ class FrontendPool
         $result = null;
         $cacheInfo = $this->deploymentConfig->getConfigData(self::KEY_CACHE);
         if (null !== $cacheInfo) {
-            $result = isset($cacheInfo[self::KEY_CACHE_TYPE][$cacheType][self::KEY_FRONTEND_CACHE]) ?
-                $cacheInfo[self::KEY_CACHE_TYPE][$cacheType][self::KEY_FRONTEND_CACHE] : null;
+            $result = $cacheInfo[self::KEY_CACHE_TYPE][$cacheType][self::KEY_FRONTEND_CACHE] ?? null;
         }
         if (!$result) {
             if (isset($this->_typeFrontendMap[$cacheType])) {

--- a/lib/internal/Magento/Framework/App/Config.php
+++ b/lib/internal/Magento/Framework/App/Config.php
@@ -132,6 +132,6 @@ class Config implements ScopeConfigInterface
             $result = $this->types[$configType]->get($path);
         }
 
-        return $result !== null ? $result : $default;
+        return $result ?? $default;
     }
 }

--- a/lib/internal/Magento/Framework/App/ErrorHandler.php
+++ b/lib/internal/Magento/Framework/App/ErrorHandler.php
@@ -56,7 +56,7 @@ class ErrorHandler
             return false;
         }
 
-        $msg = isset($this->errorPhrases[$errorNo]) ? $this->errorPhrases[$errorNo] : "Unknown error ({$errorNo})";
+        $msg = $this->errorPhrases[$errorNo] ?? "Unknown error ({$errorNo})";
         $msg .= ": {$errorStr} in {$errorFile} on line {$errorLine}";
         throw new \Exception($msg);
     }

--- a/lib/internal/Magento/Framework/App/ObjectManagerFactory.php
+++ b/lib/internal/Magento/Framework/App/ObjectManagerFactory.php
@@ -127,7 +127,7 @@ class ObjectManagerFactory
         /** @var ConfigInterface $diConfig */
         $diConfig = $env->getDiConfig();
 
-        $appMode = isset($arguments[State::PARAM_MODE]) ? $arguments[State::PARAM_MODE] : State::MODE_DEFAULT;
+        $appMode = $arguments[State::PARAM_MODE] ?? State::MODE_DEFAULT;
         $booleanUtils = new \Magento\Framework\Stdlib\BooleanUtils();
         $argInterpreter = $this->createArgumentInterpreter($booleanUtils);
         $argumentMapper = new \Magento\Framework\ObjectManager\Config\Mapper\Dom($argInterpreter);
@@ -177,9 +177,7 @@ class ObjectManagerFactory
 
         $generatorParams = $diConfig->getArguments(\Magento\Framework\Code\Generator::class);
         /** Arguments are stored in different format when DI config is compiled, thus require custom processing */
-        $generatedEntities = isset($generatorParams['generatedEntities']['_v_'])
-            ? $generatorParams['generatedEntities']['_v_']
-            : (isset($generatorParams['generatedEntities']) ? $generatorParams['generatedEntities'] : []);
+        $generatedEntities = $generatorParams['generatedEntities']['_v_'] ?? ($generatorParams['generatedEntities'] ?? []);
         $definitionFactory->getCodeGenerator()
             ->setObjectManager($objectManager)
             ->setGeneratedEntities($generatedEntities);
@@ -202,12 +200,8 @@ class ObjectManagerFactory
         ConfigFilePool $configFilePool,
         array $arguments
     ) {
-        $customFile = isset($arguments[self::INIT_PARAM_DEPLOYMENT_CONFIG_FILE])
-            ? $arguments[self::INIT_PARAM_DEPLOYMENT_CONFIG_FILE]
-            : null;
-        $customData = isset($arguments[self::INIT_PARAM_DEPLOYMENT_CONFIG])
-            ? $arguments[self::INIT_PARAM_DEPLOYMENT_CONFIG]
-            : [];
+        $customFile = $arguments[self::INIT_PARAM_DEPLOYMENT_CONFIG_FILE] ?? null;
+        $customData = $arguments[self::INIT_PARAM_DEPLOYMENT_CONFIG] ?? [];
         $reader = new DeploymentConfig\Reader($directoryList, $this->driverPool, $configFilePool, $customFile);
         return new DeploymentConfig($reader, $customData);
     }

--- a/lib/internal/Magento/Framework/App/Response/Http/FileFactory.php
+++ b/lib/internal/Magento/Framework/App/Response/Http/FileFactory.php
@@ -81,7 +81,7 @@ class FileFactory
             ->setHeader('Pragma', 'public', true)
             ->setHeader('Cache-Control', 'must-revalidate, post-check=0, pre-check=0', true)
             ->setHeader('Content-type', $contentType, true)
-            ->setHeader('Content-Length', $contentLength === null ? strlen($fileContent) : $contentLength, true)
+            ->setHeader('Content-Length', $contentLength ?? strlen($fileContent), true)
             ->setHeader('Content-Disposition', 'attachment; filename="' . $fileName . '"', true)
             ->setHeader('Last-Modified', date('r'), true);
 

--- a/lib/internal/Magento/Framework/App/Router/NoRouteHandler.php
+++ b/lib/internal/Magento/Framework/App/Router/NoRouteHandler.php
@@ -39,9 +39,9 @@ class NoRouteHandler implements \Magento\Framework\App\Router\NoRouteHandlerInte
             $noRoute = [];
         }
 
-        $moduleName = isset($noRoute[0]) ? $noRoute[0] : 'core';
-        $actionPath = isset($noRoute[1]) ? $noRoute[1] : 'index';
-        $actionName = isset($noRoute[2]) ? $noRoute[2] : 'index';
+        $moduleName = $noRoute[0] ?? 'core';
+        $actionPath = $noRoute[1] ?? 'index';
+        $actionName = $noRoute[2] ?? 'index';
 
         $request->setModuleName($moduleName)->setControllerName($actionPath)->setActionName($actionName);
 

--- a/lib/internal/Magento/Framework/Archive.php
+++ b/lib/internal/Magento/Framework/Archive.php
@@ -63,7 +63,7 @@ class Archive
     protected function _getArchiver($extension)
     {
         $extension = strtolower($extension);
-        $format = isset($this->_formats[$extension]) ? $this->_formats[$extension] : self::DEFAULT_ARCHIVER;
+        $format = $this->_formats[$extension] ?? self::DEFAULT_ARCHIVER;
         $class = '\\Magento\Framework\Archive\\' . ucfirst($format);
         $this->_archiver = new $class();
         return $this->_archiver;

--- a/lib/internal/Magento/Framework/Archive/Helper/File.php
+++ b/lib/internal/Magento/Framework/Archive/Helper/File.php
@@ -65,8 +65,8 @@ class File
         $pathInfo = pathinfo($filePath);
 
         $this->_filePath = $filePath;
-        $this->_fileLocation = isset($pathInfo['dirname']) ? $pathInfo['dirname'] : '';
-        $this->_fileName = isset($pathInfo['basename']) ? $pathInfo['basename'] : '';
+        $this->_fileLocation = $pathInfo['dirname'] ?? '';
+        $this->_fileName = $pathInfo['basename'] ?? '';
     }
 
     /**

--- a/lib/internal/Magento/Framework/Cache/Backend/Memcached.php
+++ b/lib/internal/Magento/Framework/Cache/Backend/Memcached.php
@@ -117,7 +117,7 @@ class Memcached extends \Zend_Cache_Backend_Memcached implements \Zend_Cache_Bac
             // Seems we've got chunked data
 
             $arr = explode('|', $data);
-            $chunks = isset($arr[1]) ? $arr[1] : false;
+            $chunks = $arr[1] ?? false;
             $chunkData = [];
 
             if ($chunks && is_numeric($chunks)) {

--- a/lib/internal/Magento/Framework/Cache/Backend/MongoDb.php
+++ b/lib/internal/Magento/Framework/Cache/Backend/MongoDb.php
@@ -200,7 +200,7 @@ class MongoDb extends \Zend_Cache_Backend implements \Zend_Cache_Backend_Extende
             ['_id' => $this->_quoteString($cacheId)],
             ['expire', 'tags', 'mtime']
         );
-        return $result === null ? false : $result;
+        return $result ?? false;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Code/Test/Unit/Generator/ClassGeneratorTest.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/Generator/ClassGeneratorTest.php
@@ -248,7 +248,7 @@ class ClassGeneratorTest extends \PHPUnit\Framework\TestCase
         array $expectedData,
         \Zend\Code\Generator\AbstractMemberGenerator $actualObject
     ) {
-        $expectedVisibility = isset($expectedData['visibility']) ? $expectedData['visibility'] : 'public';
+        $expectedVisibility = $expectedData['visibility'] ?? 'public';
         $this->assertEquals($expectedVisibility, $actualObject->getVisibility());
     }
 

--- a/lib/internal/Magento/Framework/Code/Validator/ArgumentSequence.php
+++ b/lib/internal/Magento/Framework/Code/Validator/ArgumentSequence.php
@@ -150,9 +150,7 @@ class ArgumentSequence implements ValidatorInterface
         $migrated = [];
         foreach ($parentArgumentList[self::REQUIRED] as $name => $argument) {
             if (!isset($classArgumentList[self::OPTIONAL][$name])) {
-                $output[$name] = isset(
-                    $classArgumentList[self::REQUIRED][$name]
-                ) ? $classArgumentList[self::REQUIRED][$name] : $argument;
+                $output[$name] = $classArgumentList[self::REQUIRED][$name] ?? $argument;
             } else {
                 $migrated[$name] = $classArgumentList[self::OPTIONAL][$name];
             }
@@ -173,9 +171,7 @@ class ArgumentSequence implements ValidatorInterface
 
         foreach ($parentArgumentList[self::OPTIONAL] as $name => $argument) {
             if (!isset($output[$name])) {
-                $output[$name] = isset(
-                    $classArgumentList[self::OPTIONAL][$name]
-                ) ? $classArgumentList[self::OPTIONAL][$name] : $argument;
+                $output[$name] = $classArgumentList[self::OPTIONAL][$name] ?? $argument;
             }
         }
 

--- a/lib/internal/Magento/Framework/Console/GenerationDirectoryAccess.php
+++ b/lib/internal/Magento/Framework/Console/GenerationDirectoryAccess.php
@@ -39,9 +39,7 @@ class GenerationDirectoryAccess
     public function check()
     {
         $initParams = $this->serviceManager->get(InitParamListener::BOOTSTRAP_PARAM);
-        $filesystemDirPaths = isset($initParams[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS])
-            ? $initParams[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS]
-            : [];
+        $filesystemDirPaths = $initParams[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS] ?? [];
         $directoryList = new DirectoryList(BP, $filesystemDirPaths);
         $driverPool = new DriverPool();
         $fileWriteFactory = new WriteFactory($driverPool);

--- a/lib/internal/Magento/Framework/DB/AbstractMapper.php
+++ b/lib/internal/Magento/Framework/DB/AbstractMapper.php
@@ -163,7 +163,7 @@ abstract class AbstractMapper implements MapperInterface
         if (is_array($field)) {
             $conditions = [];
             foreach ($field as $key => $value) {
-                $conditions[] = $this->translateCondition($value, isset($condition[$key]) ? $condition[$key] : null);
+                $conditions[] = $this->translateCondition($value, $condition[$key] ?? null);
             }
 
             $resultCondition = '(' . implode(') ' . \Magento\Framework\DB\Select::SQL_OR . ' (', $conditions) . ')';

--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -1245,7 +1245,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
                     'SCHEMA_NAME'       => $schemaName,
                     'TABLE_NAME'        => $tableName,
                     'COLUMN_NAME'       => $match[2],
-                    'REF_SHEMA_NAME'    => isset($match[4]) ? $match[4] : $schemaName,
+                    'REF_SHEMA_NAME'    => $match[4] ?? $schemaName,
                     'REF_TABLE_NAME'    => $match[5],
                     'REF_COLUMN_NAME'   => $match[6],
                     'ON_DELETE'         => isset($match[7]) ? $match[8] : ''

--- a/lib/internal/Magento/Framework/DB/GenericMapper.php
+++ b/lib/internal/Magento/Framework/DB/GenericMapper.php
@@ -95,7 +95,7 @@ class GenericMapper extends AbstractMapper
         $selectedUniqueNames = [];
         foreach ($fields as $fieldInfo) {
             if (is_string($fieldInfo)) {
-                $fieldInfo = isset($this->map[$fieldInfo]) ? $this->map[$fieldInfo] : $fieldInfo;
+                $fieldInfo = $this->map[$fieldInfo] ?? $fieldInfo;
             }
             list($correlationName, $field, $alias) = $fieldInfo;
             if (!is_string($alias)) {

--- a/lib/internal/Magento/Framework/DB/Helper.php
+++ b/lib/internal/Magento/Framework/DB/Helper.php
@@ -222,7 +222,7 @@ class Helper extends \Magento\Framework\DB\Helper\AbstractHelper
                         $preparedColumns[strtoupper($col)] = [$correlationName, $col, null];
                     }
                 } else {
-                    $columnKey = $alias === null ? $column : $alias;
+                    $columnKey = $alias ?? $column;
                     $preparedColumns[strtoupper($columnKey)] = [$correlationName, $column, $alias];
                 }
             }

--- a/lib/internal/Magento/Framework/DB/Sql/ConcatExpression.php
+++ b/lib/internal/Magento/Framework/DB/Sql/ConcatExpression.php
@@ -58,7 +58,7 @@ class ConcatExpression extends Expression
             } else {
                 $column = $this->adapter->quoteIdentifier(
                     (isset($part['tableAlias']) ? $part['tableAlias'] . '.' : '')
-                    . (isset($part['columnName']) ? $part['columnName'] : $key)
+                    . ($part['columnName'] ?? $key)
                 );
             }
             $columns[] = $this->adapter->getCheckSql($column . " <> ''", $column, 'NULL');

--- a/lib/internal/Magento/Framework/Data/Argument/Interpreter/ArrayType.php
+++ b/lib/internal/Magento/Framework/Data/Argument/Interpreter/ArrayType.php
@@ -34,7 +34,7 @@ class ArrayType implements InterpreterInterface
      */
     public function evaluate(array $data)
     {
-        $items = isset($data['item']) ? $data['item'] : [];
+        $items = $data['item'] ?? [];
         if (!is_array($items)) {
             throw new \InvalidArgumentException('Array items are expected.');
         }

--- a/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
+++ b/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
@@ -389,7 +389,7 @@ abstract class AbstractDb extends \Magento\Framework\Data\Collection
         if (is_array($field)) {
             $conditions = [];
             foreach ($field as $key => $value) {
-                $conditions[] = $this->_translateCondition($value, isset($condition[$key]) ? $condition[$key] : null);
+                $conditions[] = $this->_translateCondition($value, $condition[$key] ?? null);
             }
 
             $resultCondition = '(' . implode(') ' . \Magento\Framework\DB\Select::SQL_OR . ' (', $conditions) . ')';
@@ -734,7 +734,7 @@ abstract class AbstractDb extends \Magento\Framework\Data\Collection
     {
         if ($printQuery || $this->getFlag('print_query')) {
             //phpcs:ignore Magento2.Security.LanguageConstruct
-            echo $sql === null ? $this->getSelect()->__toString() : $sql;
+            echo $sql ?? $this->getSelect()->__toString();
         }
 
         if ($logQuery || $this->getFlag('log_query')) {
@@ -751,7 +751,7 @@ abstract class AbstractDb extends \Magento\Framework\Data\Collection
      */
     protected function _logQuery($sql)
     {
-        $this->_logger->info($sql === null ? $this->getSelect()->__toString() : $sql);
+        $this->_logger->info($sql ?? $this->getSelect()->__toString());
     }
 
     /**

--- a/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Editor.php
@@ -387,7 +387,7 @@ class Editor extends Textarea
     protected function _getButtonHtml($data)
     {
         $html = '<button type="button"';
-        $html .= ' class="scalable ' . (isset($data['class']) ? $data['class'] : '') . '"';
+        $html .= ' class="scalable ' . ($data['class'] ?? '') . '"';
         $html .= isset($data['onclick']) ? ' onclick="' . $data['onclick'] . '"' : '';
         $html .= isset($data['style']) ? ' style="' . $data['style'] . '"' : '';
         $html .= isset($data['id']) ? ' id="' . $data['id'] . '"' : '';

--- a/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/AbstractElementTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/AbstractElementTest.php
@@ -291,7 +291,7 @@ class AbstractElementTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetLabelHtml(array $initialData, $expectedValue)
     {
-        $idSuffix = isset($initialData['id_suffix']) ? $initialData['id_suffix'] : null;
+        $idSuffix = $initialData['id_suffix'] ?? null;
         $this->_model->setData($initialData);
         $this->_model->setForm(
             $this->createMock(\Magento\Framework\Data\Form\AbstractForm::class)

--- a/lib/internal/Magento/Framework/Data/Tree/Dbp.php
+++ b/lib/internal/Magento/Framework/Data/Tree/Dbp.php
@@ -225,7 +225,7 @@ class Dbp extends \Magento\Framework\Data\Tree
     {
         if (isset($children[$path])) {
             foreach ($children[$path] as $child) {
-                $nodeId = isset($child[$this->_idField]) ? $child[$this->_idField] : false;
+                $nodeId = $child[$this->_idField] ?? false;
                 if ($parentNode && $nodeId && ($node = $parentNode->getChildren()->searchById($nodeId))) {
                     $node->addData($child);
                 } else {
@@ -422,7 +422,7 @@ class Dbp extends \Magento\Framework\Data\Tree
     {
         if (isset($children[$path])) {
             foreach ($children[$path] as $child) {
-                $nodeId = isset($child[$this->_idField]) ? $child[$this->_idField] : false;
+                $nodeId = $child[$this->_idField] ?? false;
                 if ($parentNode && $nodeId && ($node = $parentNode->getChildren()->searchById($nodeId))) {
                     $node->addData($child);
                 } else {

--- a/lib/internal/Magento/Framework/DataObject.php
+++ b/lib/internal/Magento/Framework/DataObject.php
@@ -130,10 +130,10 @@ class DataObject implements \ArrayAccess
 
         if ($index !== null) {
             if ($data === (array)$data) {
-                $data = isset($data[$index]) ? $data[$index] : null;
+                $data = $data[$index] ?? null;
             } elseif (is_string($data)) {
                 $data = explode(PHP_EOL, $data);
-                $data = isset($data[$index]) ? $data[$index] : null;
+                $data = $data[$index] ?? null;
             } elseif ($data instanceof \Magento\Framework\DataObject) {
                 $data = $data->getData($index);
             } else {
@@ -382,11 +382,11 @@ class DataObject implements \ArrayAccess
         switch (substr($method, 0, 3)) {
             case 'get':
                 $key = $this->_underscore(substr($method, 3));
-                $index = isset($args[0]) ? $args[0] : null;
+                $index = $args[0] ?? null;
                 return $this->getData($key, $index);
             case 'set':
                 $key = $this->_underscore(substr($method, 3));
-                $value = isset($args[0]) ? $args[0] : null;
+                $value = $args[0] ?? null;
                 return $this->setData($key, $value);
             case 'uns':
                 $key = $this->_underscore(substr($method, 3));

--- a/lib/internal/Magento/Framework/DataObject/Cache.php
+++ b/lib/internal/Magento/Framework/DataObject/Cache.php
@@ -398,9 +398,9 @@ class Cache
         $debug = [];
         foreach ($bt as $i => $step) {
             $debug[$i] = [
-                'file' => isset($step['file']) ? $step['file'] : null,
-                'line' => isset($step['line']) ? $step['line'] : null,
-                'function' => isset($step['function']) ? $step['function'] : null,
+                'file' => $step['file'] ?? null,
+                'line' => $step['line'] ?? null,
+                'function' => $step['function'] ?? null,
             ];
         }
         $this->_debug[$idx] = $debug;

--- a/lib/internal/Magento/Framework/DataObject/Copy.php
+++ b/lib/internal/Magento/Framework/DataObject/Copy.php
@@ -204,7 +204,7 @@ class Copy
     {
         switch (true) {
             case is_array($source):
-                $value = isset($source[$code]) ? $source[$code] : null;
+                $value = $source[$code] ?? null;
                 break;
             case $source instanceof ExtensibleDataInterface:
                 $value = $this->getAttributeValueFromExtensibleObject($source, $code);
@@ -214,7 +214,7 @@ class Copy
                 break;
             case $source instanceof AbstractSimpleObject:
                 $sourceArray = $source->__toArray();
-                $value = isset($sourceArray[$code]) ? $sourceArray[$code] : null;
+                $value = $sourceArray[$code] ?? null;
                 break;
             default:
                 throw new \InvalidArgumentException(
@@ -309,7 +309,7 @@ class Copy
 
         if ($source instanceof AbstractSimpleObject) {
             $sourceArray = $source->__toArray();
-            return isset($sourceArray[$code]) ? $sourceArray[$code] : null;
+            return $sourceArray[$code] ?? null;
         }
 
         throw new \InvalidArgumentException('Attribute in object does not exist.');

--- a/lib/internal/Magento/Framework/Debug.php
+++ b/lib/internal/Magento/Framework/Debug.php
@@ -99,7 +99,7 @@ class Debug
                 $methodName = sprintf(
                     '%s%s%s(%s)',
                     $className,
-                    isset($data['type']) ? $data['type'] : '->',
+                    $data['type'] ?? '->',
                     $data['function'],
                     join(', ', $args)
                 );

--- a/lib/internal/Magento/Framework/EntityManager/MapperPool.php
+++ b/lib/internal/Magento/Framework/EntityManager/MapperPool.php
@@ -41,7 +41,7 @@ class MapperPool
      */
     public function getMapper($entityType)
     {
-        $className = isset($this->mappers[$entityType]) ? $this->mappers[$entityType] : MapperInterface::class;
+        $className = $this->mappers[$entityType] ?? MapperInterface::class;
         return $this->objectManager->get($className);
     }
 }

--- a/lib/internal/Magento/Framework/EntityManager/MetadataPool.php
+++ b/lib/internal/Magento/Framework/EntityManager/MetadataPool.php
@@ -65,15 +65,9 @@ class MetadataPool
     private function createMetadata($entityType)
     {
         //@todo: use ID as default if , check is type has EAV attributes
-        $connectionName = isset($this->metadata[$entityType]['connectionName'])
-            ? $this->metadata[$entityType]['connectionName']
-            : 'default';
-        $eavEntityType = isset($this->metadata[$entityType]['eavEntityType'])
-            ? $this->metadata[$entityType]['eavEntityType']
-            : null;
-        $entityContext = isset($this->metadata[$entityType]['entityContext'])
-            ? $this->metadata[$entityType]['entityContext']
-            : [];
+        $connectionName = $this->metadata[$entityType]['connectionName'] ?? 'default';
+        $eavEntityType = $this->metadata[$entityType]['eavEntityType'] ?? null;
+        $entityContext = $this->metadata[$entityType]['entityContext'] ?? [];
         return $this->objectManager->create(
             EntityMetadataInterface::class,
             [

--- a/lib/internal/Magento/Framework/File/Csv.php
+++ b/lib/internal/Magento/Framework/File/Csv.php
@@ -117,7 +117,7 @@ class Csv
         $csvData = $this->getData($file);
         foreach ($csvData as $rowData) {
             if (isset($rowData[$keyIndex])) {
-                $data[$rowData[$keyIndex]] = isset($rowData[$valueIndex]) ? $rowData[$valueIndex] : null;
+                $data[$rowData[$keyIndex]] = $rowData[$valueIndex] ?? null;
             }
         }
         return $data;

--- a/lib/internal/Magento/Framework/File/CsvMulty.php
+++ b/lib/internal/Magento/Framework/File/CsvMulty.php
@@ -42,7 +42,7 @@ class CsvMulty extends \Magento\Framework\File\Csv
                 } else {
                     $data[$rowData[$keyIndex]] = [];
                     $data[$rowData[$keyIndex]]['line'] = $lineNumber;
-                    $data[$rowData[$keyIndex]]['value'] = isset($rowData[$valueIndex]) ? $rowData[$valueIndex] : null;
+                    $data[$rowData[$keyIndex]]['value'] = $rowData[$valueIndex] ?? null;
                 }
             }
         }

--- a/lib/internal/Magento/Framework/File/Uploader.php
+++ b/lib/internal/Magento/Framework/File/Uploader.php
@@ -206,7 +206,7 @@ class Uploader
 
         $this->_result = false;
         $destinationFile = $destinationFolder;
-        $fileName = isset($newFileName) ? $newFileName : $this->_file['name'];
+        $fileName = $newFileName ?? $this->_file['name'];
         $fileName = static::getCorrectFileName($fileName);
         if ($this->_enableFilesDispersion) {
             $fileName = $this->correctFileNameCase($fileName);

--- a/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
@@ -64,10 +64,10 @@ class Http extends File
             'ctime' => 0,
             'blksize' => 0,
             'blocks' => 0,
-            'size' => isset($headers['content-length']) ? $headers['content-length'] : 0,
-            'type' => isset($headers['content-type']) ? $headers['content-type'] : '',
-            'mtime' => isset($headers['last-modified']) ? $headers['last-modified'] : 0,
-            'disposition' => isset($headers['content-disposition']) ? $headers['content-disposition'] : null,
+            'size' => $headers['content-length'] ?? 0,
+            'type' => $headers['content-type'] ?? '',
+            'mtime' => $headers['last-modified'] ?? 0,
+            'disposition' => $headers['content-disposition'] ?? null,
         ];
         return $result;
     }

--- a/lib/internal/Magento/Framework/Filesystem/Io/File.php
+++ b/lib/internal/Magento/Framework/Filesystem/Io/File.php
@@ -376,13 +376,13 @@ class File extends AbstractIo
             if (!is_callable($callback)) {
                 throw new \InvalidArgumentException("'dirCallback' parameter is not callable");
             }
-            $parameters = isset($dirCallback[1]) ? $dirCallback[1] : [];
+            $parameters = $dirCallback[1] ?? [];
         } else {
             $callback = $fileCallback[0];
             if (!is_callable($callback)) {
                 throw new \InvalidArgumentException("'fileCallback' parameter is not callable");
             }
-            $parameters = isset($fileCallback[1]) ? $fileCallback[1] : [];
+            $parameters = $fileCallback[1] ?? [];
         }
         array_unshift($parameters, $dir);
         $result = @call_user_func_array($callback, $parameters);

--- a/lib/internal/Magento/Framework/Filter/Input.php
+++ b/lib/internal/Magento/Framework/Filter/Input.php
@@ -346,7 +346,7 @@ class Input implements \Zend_Filter_Interface
             if (!is_a($filterClassName, \Zend_Filter_Interface::class, true)) {
                 throw new \Exception('Filter is not instance of \Zend_Filter_Interface');
             }
-            $filterClassOptions = isset($filterData['args']) ? $filterData['args'] : [];
+            $filterClassOptions = $filterData['args'] ?? [];
             $filter = new $filterClassName(...array_values($filterClassOptions));
         }
 

--- a/lib/internal/Magento/Framework/GraphQl/Config/Element/ArgumentFactory.php
+++ b/lib/internal/Magento/Framework/GraphQl/Config/Element/ArgumentFactory.php
@@ -44,15 +44,15 @@ class ArgumentFactory
             Argument::class,
             [
                 'name' => $argumentData['name'],
-                'type' => isset($argumentData['itemType']) ? $argumentData['itemType'] : $argumentData['type'],
-                'baseType' => isset($argumentData['baseType']) ? $argumentData['baseType'] : '',
-                'description' => isset($argumentData['description']) ? $argumentData['description'] : '',
-                'required' => isset($argumentData['required']) ? $argumentData['required'] : false,
+                'type' => $argumentData['itemType'] ?? $argumentData['type'],
+                'baseType' => $argumentData['baseType'] ?? '',
+                'description' => $argumentData['description'] ?? '',
+                'required' => $argumentData['required'] ?? false,
                 'isList' => isset($argumentData['itemType']),
-                'itemType' => isset($argumentData['itemType']) ? $argumentData['itemType'] : '',
-                'itemsRequired' => isset($argumentData['itemsRequired']) ? $argumentData['itemsRequired'] : false,
-                'defaultValue' => isset($argumentData['defaultValue']) ? $argumentData['defaultValue'] : null,
-                'deprecated' => isset($argumentData['deprecated']) ? $argumentData['deprecated'] : [],
+                'itemType' => $argumentData['itemType'] ?? '',
+                'itemsRequired' => $argumentData['itemsRequired'] ?? false,
+                'defaultValue' => $argumentData['defaultValue'] ?? null,
+                'deprecated' => $argumentData['deprecated'] ?? [],
             ]
         );
     }

--- a/lib/internal/Magento/Framework/GraphQl/Config/Element/EnumFactory.php
+++ b/lib/internal/Magento/Framework/GraphQl/Config/Element/EnumFactory.php
@@ -71,14 +71,14 @@ class EnumFactory implements ConfigElementFactoryInterface
             $values[$item['_value']] = $this->enumValueFactory->create(
                 $item['name'],
                 $item['_value'],
-                isset($item['description']) ? $item['description'] : '',
-                isset($item['deprecationReason']) ? $item['deprecationReason'] : ''
+                $item['description'] ?? '',
+                $item['deprecationReason'] ?? ''
             );
         }
         return $this->create(
             $data['name'],
             $values,
-            isset($data['description']) ? $data['description'] : ''
+            $data['description'] ?? ''
         );
     }
 }

--- a/lib/internal/Magento/Framework/GraphQl/Config/Element/FieldFactory.php
+++ b/lib/internal/Magento/Framework/GraphQl/Config/Element/FieldFactory.php
@@ -58,14 +58,14 @@ class FieldFactory
             [
                 'name' => $fieldData['name'],
                 'type' => $fieldData['type'],
-                'required' => isset($fieldData['required']) ? $fieldData['required'] : false,
+                'required' => $fieldData['required'] ?? false,
                 'isList' => isset($fieldData['itemType']) || $isList,
-                'itemType' => isset($fieldData['itemType']) ? $fieldData['itemType'] : '',
-                'resolver' => isset($fieldData['resolver']) ? $fieldData['resolver'] : '',
-                'description' => isset($fieldData['description']) ? $fieldData['description'] : '',
+                'itemType' => $fieldData['itemType'] ?? '',
+                'resolver' => $fieldData['resolver'] ?? '',
+                'description' => $fieldData['description'] ?? '',
                 'arguments' => $arguments,
-                'cache' => isset($fieldData['cache']) ? $fieldData['cache'] : [],
-                'deprecated' => isset($fieldData['deprecated']) ? $fieldData['deprecated'] : [],
+                'cache' => $fieldData['cache'] ?? [],
+                'deprecated' => $fieldData['deprecated'] ?? [],
             ]
         );
     }

--- a/lib/internal/Magento/Framework/GraphQl/Config/Element/InputFactory.php
+++ b/lib/internal/Magento/Framework/GraphQl/Config/Element/InputFactory.php
@@ -72,8 +72,8 @@ class InputFactory implements ConfigElementFactoryInterface
             [
                 'name' => $typeData['name'],
                 'fields' => $fields,
-                'description' => isset($typeData['description']) ? $typeData['description'] : '',
-                'deprecated' => isset($typeData['deprecated']) ? $typeData['deprecated'] : []
+                'description' => $typeData['description'] ?? '',
+                'deprecated' => $typeData['deprecated'] ?? []
             ]
         );
     }

--- a/lib/internal/Magento/Framework/GraphQl/Config/Element/InterfaceFactory.php
+++ b/lib/internal/Magento/Framework/GraphQl/Config/Element/InterfaceFactory.php
@@ -82,7 +82,7 @@ class InterfaceFactory implements ConfigElementFactoryInterface
                 'name' => $interfaceData['name'],
                 'typeResolver' => $interfaceData['typeResolver'],
                 'fields' => $fields,
-                'description' => isset($interfaceData['description']) ? $interfaceData['description'] : ''
+                'description' => $interfaceData['description'] ?? ''
             ]
         );
     }

--- a/lib/internal/Magento/Framework/GraphQl/Config/Element/TypeFactory.php
+++ b/lib/internal/Magento/Framework/GraphQl/Config/Element/TypeFactory.php
@@ -73,8 +73,8 @@ class TypeFactory implements ConfigElementFactoryInterface
             [
                 'name' => $typeData['name'],
                 'fields' => $fields,
-                'interfaces' => isset($typeData['implements']) ? $typeData['implements'] : [],
-                'description' => isset($typeData['description']) ? $typeData['description'] : ''
+                'interfaces' => $typeData['implements'] ?? [],
+                'description' => $typeData['description'] ?? ''
             ]
         );
     }

--- a/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
@@ -191,7 +191,7 @@ class Curl implements \Zend_Http_Client_Adapter_Interface
         /**
          * @internal Curl options setter have to be re-factored
          */
-        $header = isset($this->_config['header']) ? $this->_config['header'] : true;
+        $header = $this->_config['header'] ?? true;
         curl_setopt($this->_getResource(), CURLOPT_HEADER, $header);
 
         return $body;

--- a/lib/internal/Magento/Framework/HTTP/PhpEnvironment/Response.php
+++ b/lib/internal/Magento/Framework/HTTP/PhpEnvironment/Response.php
@@ -141,8 +141,8 @@ class Response extends \Zend\Http\PhpEnvironment\Response implements \Magento\Fr
      */
     public function setStatusHeader($httpCode, $version = null, $phrase = null)
     {
-        $version = $version === null ? $this->detectVersion() : $version;
-        $phrase = $phrase === null ? $this->getReasonPhrase() : $phrase;
+        $version = $version ?? $this->detectVersion();
+        $phrase = $phrase ?? $this->getReasonPhrase();
 
         $this->setVersion($version);
         $this->setHttpResponseCode($httpCode);

--- a/lib/internal/Magento/Framework/Indexer/Action/Base.php
+++ b/lib/internal/Magento/Framework/Indexer/Action/Base.php
@@ -342,7 +342,7 @@ class Base implements ActionInterface
                 $this->data['fieldsets'][$fieldsetName]['fields'][$fieldName]['handler'] =
                     $this->handlerPool->get($field['handler']);
                 $this->data['fieldsets'][$fieldsetName]['fields'][$fieldName]['dataType'] =
-                    isset($field['dataType']) ? $field['dataType'] : 'varchar';
+                    $field['dataType'] ?? 'varchar';
             }
         }
     }

--- a/lib/internal/Magento/Framework/Indexer/Config/Converter.php
+++ b/lib/internal/Magento/Framework/Indexer/Config/Converter.php
@@ -74,7 +74,7 @@ class Converter implements ConverterInterface
      */
     protected function convertChild(\DOMElement $childNode, $data)
     {
-        $data['fieldsets'] = isset($data['fieldsets']) ? $data['fieldsets'] : [];
+        $data['fieldsets'] = $data['fieldsets'] ?? [];
         switch ($childNode->nodeName) {
             case 'title':
                 $data['title'] = $childNode->nodeValue;
@@ -108,7 +108,7 @@ class Converter implements ConverterInterface
      */
     protected function convertFieldset(\DOMElement $node, $data)
     {
-        $data['fieldsets'] = isset($data['fieldsets']) ? $data['fieldsets'] : [];
+        $data['fieldsets'] = $data['fieldsets'] ?? [];
 
         $data['fieldsets'][$this->getAttributeValue($node, 'name')] = [
             'source'   => $this->getAttributeValue($node, 'source'),

--- a/lib/internal/Magento/Framework/Indexer/GridStructure.php
+++ b/lib/internal/Magento/Framework/Indexer/GridStructure.php
@@ -100,7 +100,7 @@ class GridStructure implements IndexStructureInterface
             }
             $columnMap = isset($field['dataType']) && isset($this->columnTypesMap[$field['dataType']])
                 ? $this->columnTypesMap[$field['dataType']]
-                : ['type' => $field['dataType'], 'size' => isset($field['size']) ? $field['size'] : null];
+                : ['type' => $field['dataType'], 'size' => $field['size'] ?? null];
             $name = $field['name'];
             $type = $columnMap['type'];
             $size = $columnMap['size'];

--- a/lib/internal/Magento/Framework/Indexer/IndexStructure.php
+++ b/lib/internal/Magento/Framework/Indexer/IndexStructure.php
@@ -157,7 +157,7 @@ class IndexStructure implements IndexStructureInterface
             }
             $columnMap = isset($field['dataType']) && isset($this->columnTypesMap[$field['dataType']])
                 ? $this->columnTypesMap[$field['dataType']]
-                : ['type' => $field['type'], 'size' => isset($field['size']) ? $field['size'] : null];
+                : ['type' => $field['type'], 'size' => $field['size'] ?? null];
             $name = $field['name'];
             $type = $columnMap['type'];
             $size = $columnMap['size'];

--- a/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
+++ b/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
@@ -182,7 +182,7 @@ class PluginList extends Scoped implements InterceptionPluginList
                         throw new \InvalidArgumentException('Plugin class ' . $pluginType . ' doesn\'t exist');
                     }
                     foreach ($this->_definitions->getMethodList($pluginType) as $pluginMethod => $methodTypes) {
-                        $current = isset($lastPerMethod[$pluginMethod]) ? $lastPerMethod[$pluginMethod] : '__self';
+                        $current = $lastPerMethod[$pluginMethod] ?? '__self';
                         $currentKey = $type . '_' . $pluginMethod . '_' . $current;
                         if ($methodTypes & DefinitionInterface::LISTENER_AROUND) {
                             $this->_processed[$currentKey][DefinitionInterface::LISTENER_AROUND] = $key;

--- a/lib/internal/Magento/Framework/MessageQueue/Code/Generator/RemoteServiceGenerator.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Code/Generator/RemoteServiceGenerator.php
@@ -139,8 +139,7 @@ class RemoteServiceGenerator extends \Magento\Framework\Code\Generator\EntityAbs
                     'type' => $methodParameter->getType(),
                 ];
                 if ($methodParameter->isDefaultValueAvailable()) {
-                    $parameter['defaultValue'] = $methodParameter->getDefaultValue() !== null
-                        ? $methodParameter->getDefaultValue() : $this->_getNullDefaultValue();
+                    $parameter['defaultValue'] = $methodParameter->getDefaultValue() ?? $this->_getNullDefaultValue();
                 }
                 $methodParameters[] = $parameter;
                 $topicParameters[] = "'{$parameterName}' => \${$parameterName}";

--- a/lib/internal/Magento/Framework/MessageQueue/Config.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Config.php
@@ -44,9 +44,7 @@ class Config implements ConfigInterface
     public function getQueuesByTopic($topic)
     {
         $publisherConfig = $this->getPublisherConfigByTopic($topic);
-        $exchange = isset($publisherConfig[ConfigInterface::PUBLISHER_NAME])
-            ? $publisherConfig[ConfigInterface::PUBLISHER_NAME]
-            : null;
+        $exchange = $publisherConfig[ConfigInterface::PUBLISHER_NAME] ?? null;
         /**
          * Exchange should be taken into account here to avoid retrieving queues, related to another exchange,
          * which is not currently associated with topic, but is configured in binds

--- a/lib/internal/Magento/Framework/MessageQueue/Config/Reader/Env/Converter/Publisher.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Config/Reader/Env/Converter/Publisher.php
@@ -31,9 +31,7 @@ class Publisher implements \Magento\Framework\Config\ConverterInterface
      */
     public function convert($source)
     {
-        $publishersConfig = isset($source[\Magento\Framework\MessageQueue\Config\Reader\Env::ENV_PUBLISHERS])
-            ? $source[\Magento\Framework\MessageQueue\Config\Reader\Env::ENV_PUBLISHERS]
-            : [];
+        $publishersConfig = $source[\Magento\Framework\MessageQueue\Config\Reader\Env::ENV_PUBLISHERS] ?? [];
         $connections = [];
         if (!empty($publishersConfig)) {
             foreach ($publishersConfig as $configuration) {

--- a/lib/internal/Magento/Framework/MessageQueue/Config/Reader/Env/Validator.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Config/Reader/Env/Validator.php
@@ -60,8 +60,7 @@ class Validator extends ConfigValidator
         }
         if (isset($configData[QueueConfig::CONSUMERS])) {
             foreach ($configData[QueueConfig::CONSUMERS] as $consumerName => $configDataItem) {
-                $handlers = isset($configDataItem[QueueConfig::CONSUMER_HANDLERS])
-                    ? $configDataItem[QueueConfig::CONSUMER_HANDLERS] : [];
+                $handlers = $configDataItem[QueueConfig::CONSUMER_HANDLERS] ?? [];
                 foreach ($handlers as $handler) {
                     $this->validateHandlerType(
                         $handler[QueueConfig::CONSUMER_CLASS],
@@ -90,9 +89,8 @@ class Validator extends ConfigValidator
      */
     private function getAvailablePublishers($configData, $xmlConfigData)
     {
-        $envConfigPublishers = isset($configData[QueueConfig::PUBLISHERS]) ? $configData[QueueConfig::PUBLISHERS] : [];
-        $xmlConfigPublishers = isset($xmlConfigData[QueueConfig::PUBLISHERS])
-            ? $xmlConfigData[QueueConfig::PUBLISHERS] : [];
+        $envConfigPublishers = $configData[QueueConfig::PUBLISHERS] ?? [];
+        $xmlConfigPublishers = $xmlConfigData[QueueConfig::PUBLISHERS] ?? [];
         return array_unique(
             array_merge(
                 array_keys($xmlConfigPublishers),
@@ -110,8 +108,8 @@ class Validator extends ConfigValidator
      */
     private function getAvailableTopics($configData, $xmlConfigData)
     {
-        $envConfigTopics = isset($configData[QueueConfig::TOPICS]) ? $configData[QueueConfig::TOPICS] : [];
-        $xmlConfigTopics = isset($xmlConfigData[QueueConfig::TOPICS]) ? $xmlConfigData[QueueConfig::TOPICS] : [];
+        $envConfigTopics = $configData[QueueConfig::TOPICS] ?? [];
+        $xmlConfigTopics = $xmlConfigData[QueueConfig::TOPICS] ?? [];
         return array_unique(
             array_merge(
                 array_keys($xmlConfigTopics),

--- a/lib/internal/Magento/Framework/MessageQueue/Publisher/Config/Env/Reader.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Publisher/Config/Env/Reader.php
@@ -57,9 +57,7 @@ class Reader implements \Magento\Framework\Config\ReaderInterface
     {
         $configData = $this->deploymentConfig->getConfigData(MessageQueueEnvReader::ENV_QUEUE);
         if (isset($configData['config'])) {
-            $configData = isset($configData['config'][MessageQueueEnvReader::ENV_PUBLISHERS])
-                ? $configData['config'][MessageQueueEnvReader::ENV_PUBLISHERS]
-                : [];
+            $configData = $configData['config'][MessageQueueEnvReader::ENV_PUBLISHERS] ?? [];
         } else {
             $configData = isset($configData[MessageQueueEnvReader::ENV_PUBLISHERS])
                 ? $this->convertConfigData($scope)
@@ -89,7 +87,7 @@ class Reader implements \Magento\Framework\Config\ReaderInterface
                 $connectionName = $this->publisherNameToConnectionMap[$publisherName];
                 $config['name'] = $config['connection'];
                 unset($config['connection']);
-                $disabled = isset($config['disabled']) ? $config['disabled'] : false;
+                $disabled = $config['disabled'] ?? false;
                 $config['disabled'] = $disabled;
                 $configData[$topicName]['connections'][$connectionName] = $config;
             }

--- a/lib/internal/Magento/Framework/MessageQueue/PublisherPool.php
+++ b/lib/internal/Magento/Framework/MessageQueue/PublisherPool.php
@@ -98,8 +98,8 @@ class PublisherPool implements PublisherInterface, BulkPublisherInterface
      */
     private function initializePublishers(array $publishers)
     {
-        $asyncPublishers = isset($publishers[self::MODE_ASYNC]) ? $publishers[self::MODE_ASYNC] : [];
-        $syncPublishers = isset($publishers[self::MODE_SYNC]) ? $publishers[self::MODE_SYNC] : [];
+        $asyncPublishers = $publishers[self::MODE_ASYNC] ?? [];
+        $syncPublishers = $publishers[self::MODE_SYNC] ?? [];
         foreach ($asyncPublishers as $connectionType => $publisher) {
             $this->addPublisherToPool(
                 self::MODE_ASYNC,

--- a/lib/internal/Magento/Framework/Model/AbstractExtensibleModel.php
+++ b/lib/internal/Magento/Framework/Model/AbstractExtensibleModel.php
@@ -253,9 +253,7 @@ abstract class AbstractExtensibleModel extends AbstractModel implements
             throw new \LogicException("Custom attributes array should be retrieved via getCustomAttributes() only.");
         } elseif ($key === '') {
             /** Represent model data and custom attributes as a flat array */
-            $customAttributes = isset($this->_data[self::CUSTOM_ATTRIBUTES])
-                ? $this->_data[self::CUSTOM_ATTRIBUTES]
-                : [];
+            $customAttributes = $this->_data[self::CUSTOM_ATTRIBUTES] ?? [];
             $this->convertCustomAttributeValues($customAttributes);
             $data = array_merge($this->_data, $customAttributes);
             unset($data[self::CUSTOM_ATTRIBUTES]);
@@ -263,9 +261,7 @@ abstract class AbstractExtensibleModel extends AbstractModel implements
             $data = parent::getData($key, $index);
             if ($data === null) {
                 /** Try to find necessary data in custom attributes */
-                $data = isset($this->_data[self::CUSTOM_ATTRIBUTES][$key])
-                    ? $this->_data[self::CUSTOM_ATTRIBUTES][$key]
-                    : null;
+                $data = $this->_data[self::CUSTOM_ATTRIBUTES][$key] ?? null;
                 if ($data instanceof \Magento\Framework\Api\AttributeValue) {
                     $data = $data->getValue();
                 }

--- a/lib/internal/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php
@@ -218,7 +218,7 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
                 if ($column instanceof \Zend_Db_Expr) {
                     $column = $column->__toString();
                 }
-                $key = $alias !== null ? $alias : $column;
+                $key = $alias ?? $column;
                 $columnsToSelect[$key] = $columnEntry;
             }
         }

--- a/lib/internal/Magento/Framework/Module/ConflictChecker.php
+++ b/lib/internal/Magento/Framework/Module/ConflictChecker.php
@@ -48,7 +48,7 @@ class ConflictChecker
      */
     public function checkConflictsWhenEnableModules($moduleNames, $currentlyEnabledModules = null)
     {
-        $masterList = isset($currentlyEnabledModules) ? $currentlyEnabledModules: $this->list->getNames();
+        $masterList = $currentlyEnabledModules ?? $this->list->getNames();
         // union of currently enabled modules and to-be-enabled modules
         $enabledModules = array_unique(array_merge($masterList, $moduleNames));
         $conflictsAll = [];

--- a/lib/internal/Magento/Framework/Module/DbVersionInfo.php
+++ b/lib/internal/Magento/Framework/Module/DbVersionInfo.php
@@ -142,7 +142,7 @@ class DbVersionInfo
     private function isModuleVersionEqual($moduleName, $version)
     {
         $module = $this->moduleList->getOne($moduleName);
-        $configVer = isset($module['setup_version']) ? $module['setup_version'] : null;
+        $configVer = $module['setup_version'] ?? null;
 
         if (empty($configVer)) {
             /**

--- a/lib/internal/Magento/Framework/Module/DependencyChecker.php
+++ b/lib/internal/Magento/Framework/Module/DependencyChecker.php
@@ -61,7 +61,7 @@ class DependencyChecker
      */
     public function checkDependenciesWhenDisableModules($toBeDisabledModules, $currentlyEnabledModules = null)
     {
-        $masterList = isset($currentlyEnabledModules) ? $currentlyEnabledModules : $this->enabledModuleList;
+        $masterList = $currentlyEnabledModules ?? $this->enabledModuleList;
         // assume disable succeeds: currently enabled modules - to-be-disabled modules
         $enabledModules = array_diff($masterList, $toBeDisabledModules);
         return $this->checkDependencyGraph(false, $toBeDisabledModules, $enabledModules);
@@ -76,7 +76,7 @@ class DependencyChecker
      */
     public function checkDependenciesWhenEnableModules($toBeEnabledModules, $currentlyEnabledModules = null)
     {
-        $masterList = isset($currentlyEnabledModules) ? $currentlyEnabledModules : $this->enabledModuleList;
+        $masterList = $currentlyEnabledModules ?? $this->enabledModuleList;
         // assume enable succeeds: union of currently enabled modules and to-be-enabled modules
         $enabledModules = array_unique(array_merge($masterList, $toBeEnabledModules));
         return $this->checkDependencyGraph(true, $toBeEnabledModules, $enabledModules);

--- a/lib/internal/Magento/Framework/Mview/View.php
+++ b/lib/internal/Magento/Framework/Mview/View.php
@@ -292,9 +292,7 @@ class View extends DataObject implements ViewInterface
     private function executeAction(ActionInterface $action, int $lastVersionId, int $currentVersionId)
     {
         $versionBatchSize = self::$maxVersionQueryBatch;
-        $batchSize = isset($this->changelogBatchSize[$this->getChangelog()->getViewId()])
-            ? $this->changelogBatchSize[$this->getChangelog()->getViewId()]
-            : self::DEFAULT_BATCH_SIZE;
+        $batchSize = $this->changelogBatchSize[$this->getChangelog()->getViewId()] ?? self::DEFAULT_BATCH_SIZE;
 
         for ($vsFrom = $lastVersionId; $vsFrom < $currentVersionId; $vsFrom += $versionBatchSize) {
             // Don't go past the current version for atomicity.

--- a/lib/internal/Magento/Framework/Mview/View/SubscriptionFactory.php
+++ b/lib/internal/Magento/Framework/Mview/View/SubscriptionFactory.php
@@ -18,7 +18,7 @@ class SubscriptionFactory extends AbstractFactory
      */
     public function create(array $data = [])
     {
-        $instanceName = isset($data['subscriptionModel']) ? $data['subscriptionModel'] : self::INSTANCE_NAME;
+        $instanceName = $data['subscriptionModel'] ?? self::INSTANCE_NAME;
         unset($data['subscriptionModel']);
         return $this->objectManager->create($instanceName, $data);
     }

--- a/lib/internal/Magento/Framework/Profiler.php
+++ b/lib/internal/Magento/Framework/Profiler.php
@@ -363,9 +363,9 @@ class Profiler
             $config = array_merge($config, $profilerConfig);
         }
 
-        $driverConfigs = (array)(isset($config['drivers']) ? $config['drivers'] : []);
-        $driverFactory = isset($config['driverFactory']) ? $config['driverFactory'] : new Factory();
-        $tagFilters = (array)(isset($config['tagFilters']) ? $config['tagFilters'] : []);
+        $driverConfigs = (array)($config['drivers'] ?? []);
+        $driverFactory = $config['driverFactory'] ?? new Factory();
+        $tagFilters = (array)($config['tagFilters'] ?? []);
 
         $result = [
             'driverConfigs' => self::_parseDriverConfigs($driverConfigs, $config['baseDir']),

--- a/lib/internal/Magento/Framework/Profiler/Driver/Factory.php
+++ b/lib/internal/Magento/Framework/Profiler/Driver/Factory.php
@@ -48,7 +48,7 @@ class Factory
      */
     public function create(array $config = null)
     {
-        $type = isset($config['type']) ? $config['type'] : $this->_defaultDriverType;
+        $type = $config['type'] ?? $this->_defaultDriverType;
         if (class_exists($type)) {
             $class = $type;
         } else {

--- a/lib/internal/Magento/Framework/Profiler/Driver/Standard/Output/Csvfile.php
+++ b/lib/internal/Magento/Framework/Profiler/Driver/Standard/Output/Csvfile.php
@@ -39,8 +39,8 @@ class Csvfile extends AbstractOutput
     {
         parent::__construct($config);
         $this->_filePath = $this->_parseFilePath($config);
-        $this->_delimiter = isset($config['delimiter']) ? $config['delimiter'] : ',';
-        $this->_enclosure = isset($config['enclosure']) ? $config['enclosure'] : '"';
+        $this->_delimiter = $config['delimiter'] ?? ',';
+        $this->_enclosure = $config['enclosure'] ?? '"';
     }
 
     /**
@@ -51,7 +51,7 @@ class Csvfile extends AbstractOutput
      */
     protected function _parseFilePath(array $config = null)
     {
-        $result = isset($config['filePath']) ? $config['filePath'] : self::DEFAULT_FILEPATH;
+        $result = $config['filePath'] ?? self::DEFAULT_FILEPATH;
         if (isset($config['baseDir'])) {
             $result = rtrim($config['baseDir'], '/') . '/' . ltrim($result, '/');
         }

--- a/lib/internal/Magento/Framework/Profiler/Driver/Standard/Output/Factory.php
+++ b/lib/internal/Magento/Framework/Profiler/Driver/Standard/Output/Factory.php
@@ -48,7 +48,7 @@ class Factory
      */
     public function create(array $config)
     {
-        $type = isset($config['type']) ? $config['type'] : $this->_defaultOutputType;
+        $type = $config['type'] ?? $this->_defaultOutputType;
         if (class_exists($type)) {
             $class = $type;
         } else {

--- a/lib/internal/Magento/Framework/Reflection/AttributeTypeResolver.php
+++ b/lib/internal/Magento/Framework/Reflection/AttributeTypeResolver.php
@@ -41,7 +41,7 @@ class AttributeTypeResolver implements AttributeTypeResolverInterface
         }
         $data = $this->config->get();
         $context = trim($context, '\\');
-        $config = isset($data[$context]) ? $data[$context] : [];
+        $config = $data[$context] ?? [];
         $output = get_class($value);
         if (isset($config[$attributeCode])) {
             $type = $config[$attributeCode]['type'];

--- a/lib/internal/Magento/Framework/Search/Adapter/Mysql/TemporaryStorage.php
+++ b/lib/internal/Magento/Framework/Search/Adapter/Mysql/TemporaryStorage.php
@@ -45,7 +45,7 @@ class TemporaryStorage
         DeploymentConfig $config = null
     ) {
         $this->resource = $resource;
-        $this->config = $config !== null ? $config : ObjectManager::getInstance()->get(DeploymentConfig::class);
+        $this->config = $config ?? ObjectManager::getInstance()->get(DeploymentConfig::class);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Search/Dynamic/Algorithm.php
+++ b/lib/internal/Magento/Framework/Search/Dynamic/Algorithm.php
@@ -172,7 +172,7 @@ class Algorithm
         $result = [];
         $lastCount = 0;
         $intervalFirstValue = $this->_minValue;
-        $lastSeparator = $this->_lowerLimit === null ? 0 : $this->_lowerLimit;
+        $lastSeparator = $this->_lowerLimit ?? 0;
 
         for ($intervalNumber = 1; $intervalNumber < $this->getIntervalsNumber(); ++$intervalNumber) {
             $separator = $this->_findValueSeparator($intervalNumber, $interval);
@@ -234,7 +234,7 @@ class Algorithm
             $isEqualValue = $intervalFirstValue == $this->_maxValue ? $intervalFirstValue : false;
             $result[$this->getIntervalsNumber()] = [
                 'from' => $isEqualValue ? $isEqualValue : $lastSeparator,
-                'to' => $isEqualValue ? $isEqualValue : ($this->_upperLimit === null ? '' : $this->_upperLimit),
+                'to' => $isEqualValue ? $isEqualValue : ($this->_upperLimit ?? ''),
                 'count' => $this->_count - $lastCount,
             ];
         }

--- a/lib/internal/Magento/Framework/Search/Request/Builder.php
+++ b/lib/internal/Magento/Framework/Search/Request/Builder.php
@@ -228,7 +228,7 @@ class Builder
             'from' => $data['from'],
             'size' => $data['size'],
             'query' => $mapper->getRootQuery(),
-            'dimensions' => $this->buildDimensions(isset($data['dimensions']) ? $data['dimensions'] : []),
+            'dimensions' => $this->buildDimensions($data['dimensions'] ?? []),
             'buckets' => $mapper->getBuckets()
         ];
         if (isset($data['sort'])) {

--- a/lib/internal/Magento/Framework/Search/Request/Mapper.php
+++ b/lib/internal/Magento/Framework/Search/Request/Mapper.php
@@ -127,7 +127,7 @@ class Mapper
                     [
                         'name' => $query['name'],
                         'value' => $query['value'],
-                        'boost' => isset($query['boost']) ? $query['boost'] : 1,
+                        'boost' => $query['boost'] ?? 1,
                         'matches' => $query['match']
                     ]
                 );
@@ -146,7 +146,7 @@ class Mapper
                     \Magento\Framework\Search\Request\Query\Filter::class,
                     [
                         'name' => $query['name'],
-                        'boost' => isset($query['boost']) ? $query['boost'] : 1,
+                        'boost' => $query['boost'] ?? 1,
                         'reference' => $reference,
                         'referenceType' => $referenceType
                     ]
@@ -157,7 +157,7 @@ class Mapper
                 $query = $this->objectManager->create(
                     \Magento\Framework\Search\Request\Query\BoolExpression::class,
                     array_merge(
-                        ['name' => $query['name'], 'boost' => isset($query['boost']) ? $query['boost'] : 1],
+                        ['name' => $query['name'], 'boost' => $query['boost'] ?? 1],
                         $aggregatedByType
                     )
                 );
@@ -209,8 +209,8 @@ class Mapper
                     [
                         'name' => $filter['name'],
                         'field' => $filter['field'],
-                        'from' => isset($filter['from']) ? $filter['from'] : null,
-                        'to' => isset($filter['to']) ? $filter['to'] : null
+                        'from' => $filter['from'] ?? null,
+                        'to' => $filter['to'] ?? null
                     ]
                 );
                 break;

--- a/lib/internal/Magento/Framework/Search/Test/Unit/Request/MapperTest.php
+++ b/lib/internal/Magento/Framework/Search/Test/Unit/Request/MapperTest.php
@@ -111,7 +111,7 @@ class MapperTest extends \PHPUnit\Framework\TestCase
                     [
                         'name' => $query['name'],
                         'value' => $query['value'],
-                        'boost' => isset($query['boost']) ? $query['boost'] : 1,
+                        'boost' => $query['boost'] ?? 1,
                         'matches' => $query['match'],
                     ]
                 )
@@ -162,7 +162,7 @@ class MapperTest extends \PHPUnit\Framework\TestCase
                     [
                         'name' => $query['name'],
                         'value' => $query['value'],
-                        'boost' => isset($query['boost']) ? $query['boost'] : 1,
+                        'boost' => $query['boost'] ?? 1,
                         'matches' => $query['match'],
                     ]
                 )
@@ -242,7 +242,7 @@ class MapperTest extends \PHPUnit\Framework\TestCase
                 $this->equalTo(
                     [
                         'name' => $query['name'],
-                        'boost' => isset($query['boost']) ? $query['boost'] : 1,
+                        'boost' => $query['boost'] ?? 1,
                         'reference' => $this->queryMatch,
                         'referenceType' => Filter::REFERENCE_QUERY,
                     ]
@@ -317,7 +317,7 @@ class MapperTest extends \PHPUnit\Framework\TestCase
                 $this->equalTo(
                     [
                         'name' => $query['name'],
-                        'boost' => isset($query['boost']) ? $query['boost'] : 1,
+                        'boost' => $query['boost'] ?? 1,
                         'someClause' => ['someQueryMatch' => $this->queryMatch],
                     ]
                 )

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -218,7 +218,7 @@ class SessionManager implements SessionManagerInterface
                 $this->_addHost();
                 \Magento\Framework\Profiler::stop('session_start');
             }
-            $this->storage->init(isset($_SESSION) ? $_SESSION : []);
+            $this->storage->init($_SESSION ?? []);
         }
         return $this;
     }
@@ -555,7 +555,7 @@ class SessionManager implements SessionManagerInterface
             session_start();
         }
 
-        $this->storage->init(isset($_SESSION) ? $_SESSION : []);
+        $this->storage->init($_SESSION ?? []);
 
         if ($this->sessionConfig->getUseCookies()) {
             $this->clearSubDomainSessionCookie();

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Factories/Timestamp.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Factories/Timestamp.php
@@ -63,7 +63,7 @@ class Timestamp implements FactoryInterface
      */
     public function create(array $data)
     {
-        $data['onUpdate'] = isset($data['on_update']) ? $data['on_update'] : null;
+        $data['onUpdate'] = $data['on_update'] ?? null;
         //OnUpdate is boolean as there is only one possible value for onUpdate statement.
         if ($data['onUpdate'] && $data['onUpdate'] !== 'CURRENT_TIMESTAMP') {
             if ($this->booleanUtils->toBoolean($data['onUpdate'])) {

--- a/lib/internal/Magento/Framework/TestFramework/Unit/Block/Adminhtml.php
+++ b/lib/internal/Magento/Framework/TestFramework/Unit/Block/Adminhtml.php
@@ -207,7 +207,7 @@ class Adminhtml extends \PHPUnit\Framework\TestCase
         $return = null,
         $expects = null
     ) {
-        $expects = isset($expects) ? $expects : $this->any();
+        $expects = $expects ?? $this->any();
         $return = isset($return) ? $this->returnValue($return) : $this->returnSelf();
 
         return $object->expects($expects)->method($stubName)->will($return);

--- a/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php
+++ b/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php
@@ -282,7 +282,7 @@ class ObjectManager
                 }
             }
 
-            $constructArguments[$parameterName] = null === $object ? $defaultValue : $object;
+            $constructArguments[$parameterName] = $object ?? $defaultValue;
         }
         return $constructArguments;
     }

--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -1069,7 +1069,7 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             function ($match) {
                 if ($this->useSessionIdForUrl($match[2] == 'S' ? true : false)) {
                     return $match[1] . $this->_sidResolver->getSessionIdQueryParam($this->_session) . '='
-                        . $this->_session->getSessionId() . (isset($match[3]) ? $match[3] : '');
+                        . $this->_session->getSessionId() . ($match[3] ?? '');
                 } else {
                     if ($match[1] == '?') {
                         return isset($match[3]) ? '?' : '';
@@ -1144,7 +1144,7 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
     {
         $httpHostWithPort = $this->_request->getHttpHost(false);
         $httpHostWithPort = explode(':', $httpHostWithPort);
-        $httpHost = isset($httpHostWithPort[0]) ? $httpHostWithPort[0] : '';
+        $httpHost = $httpHostWithPort[0] ?? '';
         $port = '';
         if (isset($httpHostWithPort[1])) {
             $defaultPorts = [

--- a/lib/internal/Magento/Framework/Validator/Config.php
+++ b/lib/internal/Magento/Framework/Validator/Config.php
@@ -64,9 +64,7 @@ class Config extends \Magento\Framework\Config\AbstractXml
             );
         }
 
-        $builderClass = isset(
-            $this->_data[$entityName][$groupName]['builder']
-        ) ? $this->_data[$entityName][$groupName]['builder'] : $this->_defaultBuilderClass;
+        $builderClass = $this->_data[$entityName][$groupName]['builder'] ?? $this->_defaultBuilderClass;
 
         if (!class_exists($builderClass)) {
             throw new \InvalidArgumentException(sprintf('Builder class "%s" was not found', $builderClass));

--- a/lib/internal/Magento/Framework/View/Asset/PreProcessor/Helper/Sort.php
+++ b/lib/internal/Magento/Framework/View/Asset/PreProcessor/Helper/Sort.php
@@ -41,7 +41,7 @@ class Sort implements SortInterface
         $nodes = [];
         $structure = [];
         foreach ($this->array as $name => $item) {
-            $nodes[$name] = isset($nodes[$name]) ? $nodes[$name] : [self::NEXT_KEY => null];
+            $nodes[$name] = $nodes[$name] ?? [self::NEXT_KEY => null];
             if (isset($item[self::DIRECTIVE])) {
                 $nodes[$item[self::DIRECTIVE]][self::NEXT_KEY][$name] = &$nodes[$name];
                 continue;

--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -223,7 +223,7 @@ class Repository
         }
 
         $isSecure = isset($params['_secure']) ? (bool) $params['_secure'] : null;
-        $themePath = isset($params['theme']) ? $params['theme'] : $this->design->getThemePath($params['themeModel']);
+        $themePath = $params['theme'] ?? $this->design->getThemePath($params['themeModel']);
         $context = $this->getFallbackContext(
             UrlInterface::URL_TYPE_STATIC,
             $isSecure,

--- a/lib/internal/Magento/Framework/View/Asset/RepositoryMap.php
+++ b/lib/internal/Magento/Framework/View/Asset/RepositoryMap.php
@@ -77,7 +77,7 @@ class RepositoryMap
     {
         $area = $params['area'];
         $locale =  $params['locale'];
-        $themePath = isset($params['theme']) ? $params['theme'] : $this->design->getThemePath($params['themeModel']);
+        $themePath = $params['theme'] ?? $this->design->getThemePath($params['themeModel']);
 
         $path = "$area/$themePath/$locale/" . self::MAP_NAME;
         if (!isset($this->maps[$path])) {

--- a/lib/internal/Magento/Framework/View/Element/Html/Select.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Select.php
@@ -156,7 +156,7 @@ class Select extends \Magento\Framework\View\Element\AbstractBlock
             if ($isArrayOption && is_array($option)) {
                 $value = $option['value'];
                 $label = (string)$option['label'];
-                $optgroupName = isset($option['optgroup-name']) ? $option['optgroup-name'] : $label;
+                $optgroupName = $option['optgroup-name'] ?? $label;
                 $params = !empty($option['params']) ? $option['params'] : [];
             } else {
                 $value = (string)$key;

--- a/lib/internal/Magento/Framework/View/Element/UiComponent/Config/DomMerger.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponent/Config/DomMerger.php
@@ -347,7 +347,7 @@ class DomMerger implements DomMergerInterface
      */
     protected function validateDomDocument(\DOMDocument $domDocument, $schema = null)
     {
-        $schema = $schema !== null ? $schema : $this->schema;
+        $schema = $schema ?? $this->schema;
         libxml_use_internal_errors(true);
         try {
             $errors = \Magento\Framework\Config\Dom::validateDomDocument($domDocument, $schema);

--- a/lib/internal/Magento/Framework/View/Element/UiComponent/ContentType/Json.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponent/ContentType/Json.php
@@ -69,7 +69,7 @@ class Json extends AbstractContentType
             $data = $component->getContext()->getDataSourceData($component);
             $data = reset($data);
             return $this->encoder->encode(
-                isset($data['config']['data']) ? $data['config']['data'] : []
+                $data['config']['data'] ?? []
             );
         }
     }

--- a/lib/internal/Magento/Framework/View/Element/UiComponentFactory.php
+++ b/lib/internal/Magento/Framework/View/Element/UiComponentFactory.php
@@ -220,13 +220,11 @@ class UiComponentFactory extends DataObject
             $rawComponentData = $this->definitionData->get($name);
             list($className, $componentArguments) = $this->argumentsResolver($identifier, $rawComponentData);
             $componentArguments = array_replace_recursive($componentArguments, $arguments);
-            $children = isset($componentArguments['data']['config']['children']) ?
-                        $componentArguments['data']['config']['children'] : [];
+            $children = $componentArguments['data']['config']['children'] ?? [];
             $children = $this->getBundleChildren($children);
         }
 
-        $className = isset($componentArguments['config']['class']) ?
-            $componentArguments['config']['class'] : $className;
+        $className = $componentArguments['config']['class'] ?? $className;
         $components = [];
 
         foreach ($children as $childrenIdentifier => $childrenData) {

--- a/lib/internal/Magento/Framework/View/Layout/Argument/Interpreter/NamedParams.php
+++ b/lib/internal/Magento/Framework/View/Layout/Argument/Interpreter/NamedParams.php
@@ -34,7 +34,7 @@ class NamedParams implements InterpreterInterface
      */
     public function evaluate(array $data)
     {
-        $params = isset($data['param']) ? $data['param'] : [];
+        $params = $data['param'] ?? [];
         if (!is_array($params)) {
             throw new \InvalidArgumentException('Layout argument parameters are expected to be an array.');
         }

--- a/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
+++ b/lib/internal/Magento/Framework/View/Layout/Generator/Block.php
@@ -252,7 +252,7 @@ class Block implements Layout\GeneratorInterface
         $block = $this->getBlockInstance($block, $arguments);
         $block->setType(get_class($block));
         $block->setNameInLayout($name);
-        $block->addData(isset($arguments['data']) ? $arguments['data'] : []);
+        $block->addData($arguments['data'] ?? []);
         return $block;
     }
 

--- a/lib/internal/Magento/Framework/View/Layout/Pool.php
+++ b/lib/internal/Magento/Framework/View/Layout/Pool.php
@@ -54,7 +54,7 @@ class Pool
             throw new \InvalidArgumentException(sprintf('Unknown layout type "%s"', $layoutType));
         }
         $defArgs = $this->types[$layoutType];
-        $class = isset($defArgs['class']) ? $defArgs['class'] : self::DEFAULT_CLASS;
+        $class = $defArgs['class'] ?? self::DEFAULT_CLASS;
         unset($defArgs['class']);
         if ($defArgs) {
             $arguments = array_merge($defArgs, $arguments);

--- a/lib/internal/Magento/Framework/View/Page/Config/Generator/Head.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Generator/Head.php
@@ -124,7 +124,7 @@ class Head implements Layout\GeneratorInterface
 
                 $this->pageConfig->addRemotePageAsset(
                     $data['src'],
-                    isset($data['content_type']) ? $data['content_type'] : self::VIRTUAL_CONTENT_TYPE_LINK,
+                    $data['content_type'] ?? self::VIRTUAL_CONTENT_TYPE_LINK,
                     $this->getAssetProperties($data),
                     $name
                 );

--- a/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
@@ -156,9 +156,7 @@ class ServiceInputProcessor implements ServicePayloadConverterInterface
             $paramName = $param[MethodsMap::METHOD_META_NAME];
             $snakeCaseParamName = strtolower(preg_replace("/(?<=\\w)(?=[A-Z])/", "_$1", $paramName));
             if (isset($inputArray[$paramName]) || isset($inputArray[$snakeCaseParamName])) {
-                $paramValue = isset($inputArray[$paramName])
-                    ? $inputArray[$paramName]
-                    : $inputArray[$snakeCaseParamName];
+                $paramValue = $inputArray[$paramName] ?? $inputArray[$snakeCaseParamName];
 
                 try {
                     $inputData[] = $this->convertValue($paramValue, $param[MethodsMap::METHOD_META_TYPE]);


### PR DESCRIPTION
### Description (*)
Use Null Coalesce Operator (`??`) for the two scenarios:
```diff
-$foo = isset($bar) ? $bar : $defaultValue;
+$foo = $bar ?? $defaultValue;
```
and
```diff
-$foo = $bar !== null ? $bar : $defaultValue;
+$foo = $bar ?? $defaultValue;
```

### Fixed Issues (if relevant)
None

### Manual testing scenarios (*)
Not applied.

### Questions or comments
We have a rule for that in `php-cs-fixer`: `ternary_to_null_coalescing`. Should we add it to our `.php_cs.dist`?

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
