### PR TITLE
Make email preview responsive (#23754)

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/styles-old.less
+++ b/app/design/adminhtml/Magento/backend/web/css/styles-old.less
@@ -4070,6 +4070,21 @@
     }
 }
 
+.adminhtml-email_template-preview {
+    .cms-revision-preview {
+        padding-top: 56.25%;
+        position: relative;
+
+        #preview_iframe {
+            height: 100%;
+            left: 0;
+            position: absolute;
+            top: 0;
+            width: 100%;
+        }
+    }
+}
+
 .admin__scope-old {
     .buttons-set {
         margin: 0 0 15px;


### PR DESCRIPTION
### Description (*)
Fixed email previews being cut-off because of no styling on the iframe. I made it fully responsive.

### Fixed Issues (if relevant)

1. magento/magento2#23754: Preview Email Template cut off

### Manual testing scenarios (*)

1. Create an email template in the backend.
2. Preview it.
3. It now should display fully responsive and not cut-off.

### Questions or comments
None

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
