### PR TITLE
Fix localized option price error (issue #22346)

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
@@ -243,6 +243,7 @@ class Helper
     public function initialize(Product $product)
     {
         $productData = $this->request->getPost('product', []);
+
         return $this->initializeFromData($product, $productData);
     }
 
@@ -392,6 +393,7 @@ class Helper
         if (!is_object($this->linkResolver)) {
             $this->linkResolver = ObjectManager::getInstance()->get(LinkResolver::class);
         }
+
         return $this->linkResolver;
     }
 
@@ -407,6 +409,7 @@ class Helper
             $this->dateTimeFilter = ObjectManager::getInstance()
                 ->get(\Magento\Framework\Stdlib\DateTime\Filter\DateTime::class);
         }
+
         return $this->dateTimeFilter;
     }
 

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
@@ -216,7 +216,7 @@ class Helper
         }
         $productData['tier_price'] = isset($productData['tier_price']) ? $productData['tier_price'] : [];
 
-        $useDefaults = (array)$this->request->getPost('use_default', []);
+        $useDefaults = (array) $this->request->getPost('use_default', []);
         $productData = $this->attributeFilter->prepareProductAttributes($product, $productData, $useDefaults);
         $product->addData($productData);
 
@@ -276,7 +276,7 @@ class Helper
 
         foreach ($linkTypes as $linkType => $readonly) {
             if (isset($links[$linkType]) && !$readonly) {
-                foreach ((array)$links[$linkType] as $linkData) {
+                foreach ((array) $links[$linkType] as $linkData) {
                     if (empty($linkData['id'])) {
                         continue;
                     }
@@ -286,7 +286,7 @@ class Helper
                     $link->setSku($product->getSku())
                         ->setLinkedProductSku($linkProduct->getSku())
                         ->setLinkType($linkType)
-                        ->setPosition(isset($linkData['position']) ? (int)$linkData['position'] : 0);
+                        ->setPosition(isset($linkData['position']) ? (int) $linkData['position'] : 0);
                     $productLinks[] = $link;
                 }
             }
@@ -422,7 +422,7 @@ class Helper
     private function filterWebsiteIds($websiteIds)
     {
         if (!$this->storeManager->isSingleStoreMode()) {
-            $websiteIds = array_filter((array)$websiteIds);
+            $websiteIds = array_filter((array) $websiteIds);
         } else {
             $websiteIds[$this->storeManager->getWebsite(true)->getId()] = 1;
         }
@@ -463,9 +463,12 @@ class Helper
             }
 
             if (isset($customOptionData['values'])) {
-                $customOptionData['values'] = array_filter($customOptionData['values'], function ($valueData) {
-                    return empty($valueData['is_delete']);
-                });
+                $customOptionData['values'] = array_filter(
+                    $customOptionData['values'],
+                    function ($valueData) {
+                        return empty($valueData['is_delete']);
+                    }
+                );
             }
 
             if (isset($customOptionData['price'])) {

--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Initialization/Helper.php
@@ -6,17 +6,24 @@
 
 namespace Magento\Catalog\Controller\Adminhtml\Product\Initialization;
 
+use DateTime;
+use Magento\Backend\Helper\Js;
 use Magento\Catalog\Api\Data\ProductCustomOptionInterfaceFactory as CustomOptionFactory;
 use Magento\Catalog\Api\Data\ProductLinkInterfaceFactory as ProductLinkFactory;
+use Magento\Catalog\Api\Data\ProductLinkTypeInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface\Proxy as ProductRepository;
-use Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper\AttributeDefaultValueFilter;
+use Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper\AttributeFilter;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Initialization\Helper\ProductLinks;
 use Magento\Catalog\Model\Product\Link\Resolver as LinkResolver;
 use Magento\Catalog\Model\Product\LinkTypeProvider;
 use Magento\Framework\App\ObjectManager;
-use Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper\AttributeFilter;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Locale\FormatInterface;
+use Magento\Framework\Stdlib\DateTime\Filter\Date;
+use Magento\Store\Model\StoreManagerInterface;
+use Zend_Filter_Input;
 
 /**
  * Product helper
@@ -28,12 +35,12 @@ use Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper\Attribute
 class Helper
 {
     /**
-     * @var \Magento\Framework\App\RequestInterface
+     * @var RequestInterface
      */
     protected $request;
 
     /**
-     * @var \Magento\Store\Model\StoreManagerInterface
+     * @var StoreManagerInterface
      */
     protected $storeManager;
 
@@ -43,12 +50,12 @@ class Helper
     protected $stockFilter;
 
     /**
-     * @var \Magento\Backend\Helper\Js
+     * @var Js
      */
     protected $jsHelper;
 
     /**
-     * @var \Magento\Framework\Stdlib\DateTime\Filter\Date
+     * @var Date
      * @deprecated 101.0.0
      */
     protected $dateFilter;
@@ -97,33 +104,40 @@ class Helper
     private $attributeFilter;
 
     /**
+     * @var FormatInterface
+     */
+    private $localeFormat;
+
+    /**
      * Constructor
      *
-     * @param \Magento\Framework\App\RequestInterface $request
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param RequestInterface $request
+     * @param StoreManagerInterface $storeManager
      * @param StockDataFilter $stockFilter
      * @param ProductLinks $productLinks
-     * @param \Magento\Backend\Helper\Js $jsHelper
-     * @param \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter
+     * @param Js $jsHelper
+     * @param Date $dateFilter
      * @param CustomOptionFactory|null $customOptionFactory
      * @param ProductLinkFactory|null $productLinkFactory
      * @param ProductRepositoryInterface|null $productRepository
      * @param LinkTypeProvider|null $linkTypeProvider
      * @param AttributeFilter|null $attributeFilter
+     * @param FormatInterface|null $localeFormat
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
-        \Magento\Framework\App\RequestInterface $request,
-        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        RequestInterface $request,
+        StoreManagerInterface $storeManager,
         StockDataFilter $stockFilter,
-        \Magento\Catalog\Model\Product\Initialization\Helper\ProductLinks $productLinks,
-        \Magento\Backend\Helper\Js $jsHelper,
-        \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter,
+        ProductLinks $productLinks,
+        Js $jsHelper,
+        Date $dateFilter,
         CustomOptionFactory $customOptionFactory = null,
         ProductLinkFactory $productLinkFactory = null,
         ProductRepositoryInterface $productRepository = null,
         LinkTypeProvider $linkTypeProvider = null,
-        AttributeFilter $attributeFilter = null
+        AttributeFilter $attributeFilter = null,
+        FormatInterface $localeFormat = null
     ) {
         $this->request = $request;
         $this->storeManager = $storeManager;
@@ -132,26 +146,27 @@ class Helper
         $this->jsHelper = $jsHelper;
         $this->dateFilter = $dateFilter;
 
-        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+        $objectManager = ObjectManager::getInstance();
         $this->customOptionFactory = $customOptionFactory ?: $objectManager->get(CustomOptionFactory::class);
         $this->productLinkFactory = $productLinkFactory ?: $objectManager->get(ProductLinkFactory::class);
         $this->productRepository = $productRepository ?: $objectManager->get(ProductRepositoryInterface::class);
         $this->linkTypeProvider = $linkTypeProvider ?: $objectManager->get(LinkTypeProvider::class);
         $this->attributeFilter = $attributeFilter ?: $objectManager->get(AttributeFilter::class);
+        $this->localeFormat = $localeFormat ?: $objectManager->get(FormatInterface::class);
     }
 
     /**
      * Initialize product from data
      *
-     * @param \Magento\Catalog\Model\Product $product
+     * @param Product $product
      * @param array $productData
-     * @return \Magento\Catalog\Model\Product
+     * @return Product
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      * @since 101.0.0
      */
-    public function initializeFromData(\Magento\Catalog\Model\Product $product, array $productData)
+    public function initializeFromData(Product $product, array $productData)
     {
         unset($productData['custom_attributes'], $productData['extension_attributes']);
 
@@ -190,7 +205,7 @@ class Helper
             }
         }
 
-        $inputFilter = new \Zend_Filter_Input($dateFieldFilters, [], $productData);
+        $inputFilter = new Zend_Filter_Input($dateFieldFilters, [], $productData);
         $productData = $inputFilter->getUnescaped();
 
         if (isset($productData['options'])) {
@@ -222,10 +237,10 @@ class Helper
     /**
      * Initialize product before saving
      *
-     * @param \Magento\Catalog\Model\Product $product
-     * @return \Magento\Catalog\Model\Product
+     * @param Product $product
+     * @return Product
      */
-    public function initialize(\Magento\Catalog\Model\Product $product)
+    public function initialize(Product $product)
     {
         $productData = $this->request->getPost('product', []);
         return $this->initializeFromData($product, $productData);
@@ -234,12 +249,12 @@ class Helper
     /**
      * Setting product links
      *
-     * @param \Magento\Catalog\Model\Product $product
-     * @return \Magento\Catalog\Model\Product
+     * @param Product $product
+     * @return Product
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @since 101.0.0
      */
-    protected function setProductLinks(\Magento\Catalog\Model\Product $product)
+    protected function setProductLinks(Product $product)
     {
         $links = $this->getLinkResolver()->getLinks();
 
@@ -249,7 +264,7 @@ class Helper
         $productLinks = $product->getProductLinks();
         $linkTypes = [];
 
-        /** @var \Magento\Catalog\Api\Data\ProductLinkTypeInterface $linkTypeObject */
+        /** @var ProductLinkTypeInterface $linkTypeObject */
         foreach ($this->linkTypeProvider->getItems() as $linkTypeObject) {
             $linkTypes[$linkTypeObject->getName()] = $product->getData($linkTypeObject->getName() . '_readonly');
         }
@@ -389,7 +404,7 @@ class Helper
     private function getDateTimeFilter()
     {
         if ($this->dateTimeFilter === null) {
-            $this->dateTimeFilter = \Magento\Framework\App\ObjectManager::getInstance()
+            $this->dateTimeFilter = ObjectManager::getInstance()
                 ->get(\Magento\Framework\Stdlib\DateTime\Filter\DateTime::class);
         }
         return $this->dateTimeFilter;
@@ -453,6 +468,11 @@ class Helper
                 });
             }
 
+            if (isset($customOptionData['price'])) {
+                // Make sure we're working with a number here and no localized value.
+                $customOptionData['price'] = $this->localeFormat->getNumber($customOptionData['price']);
+            }
+
             $customOption = $this->customOptionFactory->create(['data' => $customOptionData]);
             $customOption->setProductSku($product->getSku());
             $customOptions[] = $customOption;
@@ -471,7 +491,7 @@ class Helper
     {
         if (isset($productData['special_from_date']) && $productData['special_from_date'] != '') {
             $productData['special_from_date'] = $this->getDateTimeFilter()->filter($productData['special_from_date']);
-            $productData['special_from_date'] = new \DateTime($productData['special_from_date']);
+            $productData['special_from_date'] = new DateTime($productData['special_from_date']);
         }
 
         return $productData;

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Initialization/HelperTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Initialization/HelperTest.php
@@ -289,16 +289,18 @@ class HelperTest extends \PHPUnit\Framework\TestCase
         $secondExpectedCustomOption->setData($optionsData['option3']);
         $this->customOptionFactoryMock->expects($this->any())
             ->method('create')
-            ->willReturnMap([
+            ->willReturnMap(
                 [
-                    ['data' => $optionsData['option2']],
-                    $firstExpectedCustomOption,
-                ],
-                [
-                    ['data' => $optionsData['option3']],
-                    $secondExpectedCustomOption,
-                ],
-            ]);
+                    [
+                        ['data' => $optionsData['option2']],
+                        $firstExpectedCustomOption,
+                    ],
+                    [
+                        ['data' => $optionsData['option3']],
+                        $secondExpectedCustomOption,
+                    ],
+                ]
+            );
         $website = $this->getMockBuilder(WebsiteInterface::class)->getMockForAbstractClass();
         $website->expects($this->any())->method('getId')->willReturn(1);
         $this->storeManagerMock->expects($this->once())->method('isSingleStoreMode')->willReturn($isSingleStore);
@@ -311,12 +313,14 @@ class HelperTest extends \PHPUnit\Framework\TestCase
 
         $this->productLinkFactoryMock->expects($this->any())
             ->method('create')
-            ->willReturnCallback(function () {
-                return $this->getMockBuilder(ProductLink::class)
-                    ->setMethods(null)
-                    ->disableOriginalConstructor()
-                    ->getMock();
-            });
+            ->willReturnCallback(
+                function () {
+                    return $this->getMockBuilder(ProductLink::class)
+                        ->setMethods(null)
+                        ->disableOriginalConstructor()
+                        ->getMock();
+                }
+            );
 
         $this->attributeFilterMock->expects($this->any())->method('prepareProductAttributes')->willReturnArgument(1);
 

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Initialization/HelperTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Product/Initialization/HelperTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Catalog\Test\Unit\Controller\Adminhtml\Product\Initialization;
 
 use Magento\Catalog\Api\ProductRepositoryInterface as ProductRepository;
@@ -11,6 +12,8 @@ use Magento\Catalog\Controller\Adminhtml\Product\Initialization\StockDataFilter;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Option;
 use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Locale\Format;
+use Magento\Framework\Locale\FormatInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Store\Api\Data\WebsiteInterface;
 use Magento\Store\Model\StoreManagerInterface;
@@ -101,6 +104,11 @@ class HelperTest extends \PHPUnit\Framework\TestCase
     private $dateTimeFilterMock;
 
     /**
+     * @var FormatInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $localeFormatMock;
+
+    /**
      * @inheritdoc
      */
     protected function setUp()
@@ -152,6 +160,10 @@ class HelperTest extends \PHPUnit\Framework\TestCase
             ->setMethods(['prepareProductAttributes'])
             ->disableOriginalConstructor()
             ->getMock();
+        $this->localeFormatMock = $this->getMockBuilder(Format::class)
+            ->setMethods(['getNumber'])
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->helper = $this->objectManager->getObject(
             Helper::class,
@@ -164,7 +176,8 @@ class HelperTest extends \PHPUnit\Framework\TestCase
                 'productLinkFactory' => $this->productLinkFactoryMock,
                 'productRepository' => $this->productRepositoryMock,
                 'linkTypeProvider' => $this->linkTypeProviderMock,
-                'attributeFilter' => $this->attributeFilterMock
+                'attributeFilter' => $this->attributeFilterMock,
+                'localeFormat' => $this->localeFormatMock,
             ]
         );
 
@@ -207,9 +220,9 @@ class HelperTest extends \PHPUnit\Framework\TestCase
             ->willReturn($this->assembleLinkTypes($linkTypes));
 
         $optionsData = [
-            'option1' => ['is_delete' => true, 'name' => 'name1', 'price' => 'price1', 'option_id' => ''],
-            'option2' => ['is_delete' => false, 'name' => 'name1', 'price' => 'price1', 'option_id' => '13'],
-            'option3' => ['is_delete' => false, 'name' => 'name1', 'price' => 'price1', 'option_id' => '14']
+            'option1' => ['is_delete' => true, 'name' => 'name1', 'price' => '1', 'option_id' => ''],
+            'option2' => ['is_delete' => false, 'name' => 'name2', 'price' => '2', 'option_id' => '13'],
+            'option3' => ['is_delete' => false, 'name' => 'name3', 'price' => '3', 'option_id' => '14'],
         ];
         $specialFromDate = '2018-03-03 19:30:00';
         $productData = [
@@ -252,7 +265,7 @@ class HelperTest extends \PHPUnit\Framework\TestCase
         $this->requestMock->expects($this->any())->method('getPost')->willReturnMap(
             [
                 ['product', [], $productData],
-                ['use_default', null, $useDefaults]
+                ['use_default', null, $useDefaults],
             ]
         );
         $this->linkResolverMock->expects($this->once())->method('getLinks')->willReturn($links);
@@ -279,16 +292,20 @@ class HelperTest extends \PHPUnit\Framework\TestCase
             ->willReturnMap([
                 [
                     ['data' => $optionsData['option2']],
-                    $firstExpectedCustomOption
-                ], [
+                    $firstExpectedCustomOption,
+                ],
+                [
                     ['data' => $optionsData['option3']],
-                    $secondExpectedCustomOption
-                ]
+                    $secondExpectedCustomOption,
+                ],
             ]);
         $website = $this->getMockBuilder(WebsiteInterface::class)->getMockForAbstractClass();
         $website->expects($this->any())->method('getId')->willReturn(1);
         $this->storeManagerMock->expects($this->once())->method('isSingleStoreMode')->willReturn($isSingleStore);
         $this->storeManagerMock->expects($this->any())->method('getWebsite')->willReturn($website);
+        $this->localeFormatMock->expects($this->any())
+            ->method('getNumber')
+            ->willReturnArgument(0);
 
         $this->assembleProductRepositoryMock($links);
 
@@ -388,8 +405,8 @@ class HelperTest extends \PHPUnit\Framework\TestCase
                             'price' => 1.00,
                             'position' => 1,
                             'record_id' => 1,
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
                 'linkTypes' => ['related', 'upsell', 'crosssell'],
                 'expected_links' => [
@@ -533,16 +550,16 @@ class HelperTest extends \PHPUnit\Framework\TestCase
                             [
                                 'option_type_id' => '2',
                                 'key1' => 'val1',
-                                'default_key1' => 'val2'
-                            ]
-                        ]
-                    ]
+                                'default_key1' => 'val2',
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     4 => [
                         'key1' => '1',
-                        'values' => [3 => ['key1' => 1]]
-                    ]
+                        'values' => [3 => ['key1' => 1]],
+                    ],
                 ],
                 [
                     [
@@ -553,11 +570,11 @@ class HelperTest extends \PHPUnit\Framework\TestCase
                             [
                                 'option_type_id' => '2',
                                 'key1' => 'val1',
-                                'default_key1' => 'val2'
-                            ]
-                        ]
-                    ]
-                ]
+                                'default_key1' => 'val2',
+                            ],
+                        ],
+                    ],
+                ],
             ],
             'key2 is replaced, key1 is not (checkbox is not checked)' => [
                 [
@@ -573,17 +590,17 @@ class HelperTest extends \PHPUnit\Framework\TestCase
                                 'key1' => 'val1',
                                 'key2' => 'val2',
                                 'default_key1' => 'val11',
-                                'default_key2' => 'val22'
-                            ]
-                        ]
-                    ]
+                                'default_key2' => 'val22',
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     5 => [
                         'key1' => '0',
                         'title' => '1',
-                        'values' => [2 => ['key1' => 1]]
-                    ]
+                        'values' => [2 => ['key1' => 1]],
+                    ],
                 ],
                 [
                     [
@@ -599,11 +616,11 @@ class HelperTest extends \PHPUnit\Framework\TestCase
                                 'key1' => 'val11',
                                 'key2' => 'val2',
                                 'default_key1' => 'val11',
-                                'default_key2' => 'val22'
-                            ]
-                        ]
-                    ]
-                ]
+                                'default_key2' => 'val22',
+                            ],
+                        ],
+                    ],
+                ],
             ],
             'key1 is replaced, key2 has no default value' => [
                 [
@@ -618,17 +635,17 @@ class HelperTest extends \PHPUnit\Framework\TestCase
                                 'key1' => 'val1',
                                 'title' => 'val2',
                                 'default_key1' => 'val11',
-                                'default_title' => 'val22'
-                            ]
-                        ]
-                    ]
+                                'default_title' => 'val22',
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     7 => [
                         'key1' => '1',
                         'key2' => '1',
-                        'values' => [2 => ['key1' => 0, 'title' => 1]]
-                    ]
+                        'values' => [2 => ['key1' => 0, 'title' => 1]],
+                    ],
                 ],
                 [
                     [
@@ -643,10 +660,10 @@ class HelperTest extends \PHPUnit\Framework\TestCase
                                 'title' => 'val22',
                                 'default_key1' => 'val11',
                                 'default_title' => 'val22',
-                                'is_delete_store_title' => 1
-                            ]
-                        ]
-                    ]
+                                'is_delete_store_title' => 1,
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
Fix #22346 and improve overall code style of affected classes.

### Description (*)
Localized values were being loaded into product option data, like the price attribute. The price attribute will be used for calculation in places like [Option.php#L202](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Catalog/Model/ResourceModel/Product/Option.php#L202). When this situation occurs, it will cause fatal errors like described in #22346.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22346: Unable to save product when price si website defined and custom options

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create an admin on locale **nl_NL**, also log in as this admin. 
2. Set `Configuration -> Catalog -> Price -> Catalog Price Scope` to value **Website**.
3. Create a store view like **Dutch**.
4. Set locale for store view **Dutch** to **nl_NL**. 
4. Create a product with an option. The option price does not matter. 
5. Switch to store view **Dutch**, change the product price to something else and click save.
6. With this PR, no error should occur.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
