### PR TITLE
DI Compile - Performance fixes

### DIFF
--- a/setup/src/Magento/Setup/Module/Di/Code/Reader/ClassesScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Reader/ClassesScanner.php
@@ -10,6 +10,11 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\FileSystemException;
 
+/**
+ * Class ClassesScanner
+ *
+ * @package Magento\Setup\Module\Di\Code\Reader
+ */
 class ClassesScanner implements ClassesScannerInterface
 {
     /**
@@ -29,7 +34,8 @@ class ClassesScanner implements ClassesScannerInterface
 
     /**
      * @param array $excludePatterns
-     * @param string $generationDirectory
+     * @param DirectoryList|null $directoryList
+     * @throws FileSystemException
      */
     public function __construct(array $excludePatterns = [], DirectoryList $directoryList = null)
     {
@@ -61,7 +67,7 @@ class ClassesScanner implements ClassesScannerInterface
      */
     public function getList($path)
     {
-
+        // phpcs:ignore
         $realPath = realpath($path);
         $isGeneration = strpos($realPath, $this->generationDirectory) === 0;
 
@@ -115,6 +121,8 @@ class ClassesScanner implements ClassesScannerInterface
     }
 
     /**
+     * Include classes from file path
+     *
      * @param array $classNames
      * @param string $fileItemPath
      * @return bool Whether the class is included or not
@@ -123,6 +131,7 @@ class ClassesScanner implements ClassesScannerInterface
     {
         foreach ($classNames as $className) {
             if (!class_exists($className)) {
+                // phpcs:ignore
                 require_once $fileItemPath;
                 return true;
             }

--- a/setup/src/Magento/Setup/Module/Di/Code/Reader/ClassesScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Reader/ClassesScanner.php
@@ -94,7 +94,7 @@ class ClassesScanner implements ClassesScannerInterface
      */
     private function extract(\RecursiveIteratorIterator $recursiveIterator)
     {
-        $classes = [];
+        $classes = [[]];
         foreach ($recursiveIterator as $fileItem) {
             /** @var $fileItem \SplFileInfo */
             if ($fileItem->isDir() || $fileItem->getExtension() !== 'php' || $fileItem->getBasename()[0] == '.') {
@@ -109,9 +109,9 @@ class ClassesScanner implements ClassesScannerInterface
             $fileScanner = new FileClassScanner($fileItemPath);
             $classNames = $fileScanner->getClassNames();
             $this->includeClasses($classNames, $fileItemPath);
-            $classes = array_merge($classes, $classNames);
+            $classes [] = $classNames;
         }
-        return $classes;
+        return array_merge(...$classes);
     }
 
     /**

--- a/setup/src/Magento/Setup/Module/Di/Code/Reader/FileClassScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Reader/FileClassScanner.php
@@ -6,6 +6,11 @@
 
 namespace Magento\Setup\Module\Di\Code\Reader;
 
+/**
+ * Class FileClassScanner
+ *
+ * @package Magento\Setup\Module\Di\Code\Reader
+ */
 class FileClassScanner
 {
     private const NAMESPACE_TOKENS = [
@@ -45,7 +50,9 @@ class FileClassScanner
      */
     public function __construct($filename)
     {
+        // phpcs:ignore
         $filename = realpath($filename);
+        // phpcs:ignore
         if (!file_exists($filename) || !\is_file($filename)) {
             throw new InvalidFileException(
                 sprintf(
@@ -64,12 +71,14 @@ class FileClassScanner
      */
     public function getFileContents()
     {
+        // phpcs:ignore
         return file_get_contents($this->filename);
     }
 
     /**
-     * Extracts the fully qualified class name from a file.  It only searches for the first match and stops looking
-     * as soon as it enters the class definition itself.
+     * Extracts the fully qualified class name from a file.
+     *
+     * It only searches for the first match and stops looking as soon as it enters the class definition itself.
      *
      * Warnings are suppressed for this method due to a micro-optimization that only really shows up when this logic
      * is called several millions of times, which can happen quite easily with even moderately sized codebases.
@@ -88,13 +97,14 @@ class FileClassScanner
         $braceLevel = 0;
         $bracedNamespace = false;
 
+        // phpcs:ignore
         $this->tokens = token_get_all($this->getFileContents());
         foreach ($this->tokens as $index => $token) {
             $tokenIsArray = is_array($token);
             // Is either a literal brace or an interpolated brace with a variable
             if ($token === '{' || ($tokenIsArray && isset(self::ALLOWED_OPEN_BRACES_TOKENS[$token[0]]))) {
                 $braceLevel++;
-            } else if ($token === '}') {
+            } elseif ($token === '}') {
                 $braceLevel--;
             }
             // The namespace keyword was found in the last loop
@@ -107,8 +117,8 @@ class FileClassScanner
                 }
                 $namespaceParts[] = $token[1];
 
-                // The class keyword was found in the last loop
-            } else if ($triggerClass && $token[0] === T_STRING) {
+            // The class keyword was found in the last loop
+            } elseif ($triggerClass && $token[0] === T_STRING) {
                 $triggerClass = false;
                 $class = $token[1];
             }
@@ -151,7 +161,7 @@ class FileClassScanner
             if (!is_array($this->tokens[$index])) {
                 if ($this->tokens[$index] === ';') {
                     return false;
-                } else if ($this->tokens[$index] === '{') {
+                } elseif ($this->tokens[$index] === '{') {
                     return true;
                 }
                 continue;
@@ -165,8 +175,9 @@ class FileClassScanner
     }
 
     /**
-     * Retrieves the first class found in a class file.  The return value is in an array format so it retains the
-     * same usage as the FileScanner.
+     * Retrieves the first class found in a class file.
+     *
+     * The return value is in an array format so it retains the same usage as the FileScanner.
      *
      * @return array
      */

--- a/setup/src/Magento/Setup/Module/Di/Code/Scanner/PhpScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Scanner/PhpScanner.php
@@ -170,19 +170,16 @@ class PhpScanner implements ScannerInterface
      */
     public function collectEntities(array $files)
     {
-        $output = [];
+        $output = [[]];
         foreach ($files as $file) {
             $classes = $this->_getDeclaredClasses($file);
             foreach ($classes as $className) {
                 $reflectionClass = new \ReflectionClass($className);
-                $output = array_merge(
-                    $output,
-                    $this->_fetchFactories($reflectionClass, $file),
-                    $this->_fetchMissingExtensionAttributesClasses($reflectionClass, $file)
-                );
+                $output [] = $this->_fetchFactories($reflectionClass, $file);
+                $output [] = $this->_fetchMissingExtensionAttributesClasses($reflectionClass, $file);
             }
         }
-        return array_unique($output);
+        return array_unique(array_merge(...$output));
     }
 
     /**

--- a/setup/src/Magento/Setup/Module/Di/Code/Scanner/PhpScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Scanner/PhpScanner.php
@@ -11,6 +11,11 @@ use Magento\Framework\ObjectManager\Code\Generator\Factory as FactoryGenerator;
 use Magento\Setup\Module\Di\Compiler\Log\Log;
 use \Magento\Framework\Reflection\TypeProcessor;
 
+/**
+ * Class PhpScanner
+ *
+ * @package Magento\Setup\Module\Di\Code\Scanner
+ */
 class PhpScanner implements ScannerInterface
 {
     /**
@@ -167,6 +172,7 @@ class PhpScanner implements ScannerInterface
      *
      * @param array $files
      * @return array
+     * @throws \ReflectionException
      */
     public function collectEntities(array $files)
     {
@@ -183,29 +189,34 @@ class PhpScanner implements ScannerInterface
     }
 
     /**
-     * @param $tokenIterator int
-     * @param $count int
-     * @param $tokens array
+     * Fetch namespaces from tokenized PHP file
+     *
+     * @param int $tokenIterator
+     * @param int $count
+     * @param array $tokens
      * @return string
      */
     protected function _fetchNamespace($tokenIterator, $count, $tokens)
     {
-        $namespace = '';
+        $namespaceParts = [];
         for ($tokenOffset = $tokenIterator + 1; $tokenOffset < $count; ++$tokenOffset) {
             if ($tokens[$tokenOffset][0] === T_STRING) {
-                $namespace .= "\\" . $tokens[$tokenOffset][1];
+                $namespaceParts[] = "\\";
+                $namespaceParts[] = $tokens[$tokenOffset][1];
             } elseif ($tokens[$tokenOffset] === '{' || $tokens[$tokenOffset] === ';') {
                 break;
             }
         }
-        return $namespace;
+        return join('', $namespaceParts);
     }
 
     /**
-     * @param $namespace string
-     * @param $tokenIterator int
-     * @param $count int
-     * @param $tokens array
+     * Fetch class names from tokenized PHP file
+     *
+     * @param string $namespace
+     * @param int $tokenIterator
+     * @param int $count
+     * @param array $tokens
      * @return array
      */
     protected function _fetchClasses($namespace, $tokenIterator, $count, $tokens)
@@ -227,23 +238,24 @@ class PhpScanner implements ScannerInterface
      */
     protected function _getDeclaredClasses($file)
     {
-        $classes = [];
-        $namespace = '';
+        $classes = [[]];
+        $namespaceParts = [];
+        // phpcs:ignore
         $tokens = token_get_all(file_get_contents($file));
         $count = count($tokens);
 
         for ($tokenIterator = 0; $tokenIterator < $count; $tokenIterator++) {
             if ($tokens[$tokenIterator][0] == T_NAMESPACE) {
-                $namespace .= $this->_fetchNamespace($tokenIterator, $count, $tokens);
+                $namespaceParts[] = $this->_fetchNamespace($tokenIterator, $count, $tokens);
             }
 
             if (($tokens[$tokenIterator][0] == T_CLASS || $tokens[$tokenIterator][0] == T_INTERFACE)
                 && $tokens[$tokenIterator - 1][0] != T_DOUBLE_COLON
             ) {
-                $classes = array_merge($classes, $this->_fetchClasses($namespace, $tokenIterator, $count, $tokens));
+                $classes[] = $this->_fetchClasses(join('', $namespaceParts), $tokenIterator, $count, $tokens);
             }
         }
-        return array_unique($classes);
+        return array_unique(array_merge(...$classes));
     }
 
     /**
@@ -260,7 +272,7 @@ class PhpScanner implements ScannerInterface
             if (class_exists($missingClassName)) {
                 return false;
             }
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException $e) { //phpcs:ignore
         }
         $sourceClassName = $this->getSourceClassName($missingClassName, $entityType);
         if (!class_exists($sourceClassName) && !interface_exists($sourceClassName)) {

--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/BackslashTrim.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/BackslashTrim.php
@@ -8,6 +8,11 @@ namespace Magento\Setup\Module\Di\Compiler\Config\Chain;
 
 use Magento\Setup\Module\Di\Compiler\Config\ModificationInterface;
 
+/**
+ * Class BackslashTrim
+ *
+ * @package Magento\Setup\Module\Di\Compiler\Config\Chain
+ */
 class BackslashTrim implements ModificationInterface
 {
     /**
@@ -71,6 +76,5 @@ class BackslashTrim implements ModificationInterface
 
             $this->resolveArguments($value);
         }
-        return;
     }
 }

--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/BackslashTrim.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/BackslashTrim.php
@@ -11,6 +11,14 @@ use Magento\Setup\Module\Di\Compiler\Config\ModificationInterface;
 class BackslashTrim implements ModificationInterface
 {
     /**
+     * Argument keys which require recursive resolving
+     */
+    private const RECURSIVE_ARGUMENT_KEYS = [
+        '_i_' => true, // shared instance of a class or interface
+        '_ins_' => true // non-shared instance of a class or interface
+    ];
+
+    /**
      * Modifies input config
      *
      * @param array $config
@@ -48,7 +56,6 @@ class BackslashTrim implements ModificationInterface
      * Resolves instances arguments
      *
      * @param array $argument
-     * @return array
      */
     private function resolveArguments(&$argument)
     {
@@ -57,14 +64,12 @@ class BackslashTrim implements ModificationInterface
         }
 
         foreach ($argument as $key => &$value) {
-            if (in_array($key, ['_i_', '_ins_'], true)) {
+            if (isset(self::RECURSIVE_ARGUMENT_KEYS[$key])) {
                 $value = ltrim($value, '\\');
                 continue;
             }
 
-            if (is_array($value)) {
-                $this->resolveArguments($value);
-            }
+            $this->resolveArguments($value);
         }
         return;
     }

--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/PreferencesResolving.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/PreferencesResolving.php
@@ -11,6 +11,14 @@ use Magento\Setup\Module\Di\Compiler\Config\ModificationInterface;
 class PreferencesResolving implements ModificationInterface
 {
     /**
+     * Argument keys which require recursive resolving
+     */
+    private const RECURSIVE_ARGUMENT_KEYS = [
+        '_i_' => true, // shared instance of a class or interface
+        '_ins_' => true // non-shared instance of a class or interface
+    ];
+
+    /**
      * Modifies input config
      *
      * @param array $config
@@ -32,7 +40,6 @@ class PreferencesResolving implements ModificationInterface
      *
      * @param array $argument
      * @param array $preferences
-     * @return array
      */
     private function resolvePreferences(&$argument, &$preferences)
     {
@@ -41,14 +48,12 @@ class PreferencesResolving implements ModificationInterface
         }
 
         foreach ($argument as $key => &$value) {
-            if (in_array($key, ['_i_', '_ins_'], true)) {
+            if (isset(self::RECURSIVE_ARGUMENT_KEYS[$key])) {
                 $value = $this->resolvePreferenceRecursive($value, $preferences);
                 continue;
             }
 
-            if (is_array($value)) {
-                $this->resolvePreferences($value, $preferences);
-            }
+            $this->resolvePreferences($value, $preferences);
         }
     }
 

--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/PreferencesResolving.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/Chain/PreferencesResolving.php
@@ -8,6 +8,11 @@ namespace Magento\Setup\Module\Di\Compiler\Config\Chain;
 
 use Magento\Setup\Module\Di\Compiler\Config\ModificationInterface;
 
+/**
+ * Class PreferencesResolving
+ *
+ * @package Magento\Setup\Module\Di\Compiler\Config\Chain
+ */
 class PreferencesResolving implements ModificationInterface
 {
     /**

--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/Reader.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/Reader.php
@@ -15,6 +15,7 @@ use Magento\Setup\Module\Di\Definition\Collection as DefinitionsCollection;
 
 /**
  * Class Reader
+ *
  * @package Magento\Setup\Module\Di\Compiler\Config
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */

--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/Reader.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/Reader.php
@@ -84,7 +84,7 @@ class Reader
         }
 
         $config = [];
-        
+
         $this->fillThirdPartyInterfaces($areaConfig, $definitionsCollection);
         $config['arguments'] = $this->getConfigForScope($definitionsCollection, $areaConfig);
 
@@ -113,11 +113,10 @@ class Reader
     {
         $constructors = [];
         $argumentsResolver = $this->argumentsResolverFactory->create($config);
-        foreach ($definitionsCollection->getInstancesNamesList() as $instanceType) {
+        foreach ($definitionsCollection->getCollection() as $instanceType => $constructor) {
             if (!$this->typeReader->isConcrete($instanceType)) {
                 continue;
             }
-            $constructor = $definitionsCollection->getInstanceArguments($instanceType);
             $constructors[$instanceType] = $argumentsResolver->getResolvedConstructorArguments(
                 $instanceType,
                 $constructor
@@ -151,14 +150,9 @@ class Reader
      */
     private function fillThirdPartyInterfaces(ConfigInterface $config, DefinitionsCollection $definitionsCollection)
     {
-        $definedInstances = $definitionsCollection->getInstancesNamesList();
-
-        foreach (array_keys($config->getPreferences()) as $interface) {
-            if (in_array($interface, $definedInstances)) {
-                continue;
-            }
-
-            $definitionsCollection->addDefinition($interface, []);
-        }
+        $definedInstances = $definitionsCollection->getCollection();
+        $newInstances = array_fill_keys(array_keys($config->getPreferences()), []);
+        $newCollection = array_merge($newInstances, $definedInstances);
+        $definitionsCollection->initialize($newCollection);
     }
 }


### PR DESCRIPTION
### Description (*)
I've run DI Compile process under XDebug Profiler to find a way to speed it up.
I've prepared several changes which result in 9-10% of speed improvement (according to my benchmarks).

List of changes:

 - move array_merge() out of loop
 - get rid of in_array usage
 - optimize string concatenation
 - use '===' instead of '=='

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Run DI compile on base branch then copy folder "generated/" to "generated-old/"
2. Run DI compile on this branch then copy folder "generated/" to "generated-new/"
3. Compare folders. You should not see diff in generated code.

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
