### PR TITLE
DI Compile - Sort DI metadata output to make diff between builds easier

### DIFF
--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/Reader.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/Reader.php
@@ -15,6 +15,7 @@ use Magento\Setup\Module\Di\Definition\Collection as DefinitionsCollection;
 
 /**
  * Class Reader
+ *
  * @package Magento\Setup\Module\Di\Compiler\Config
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
@@ -84,7 +85,7 @@ class Reader
         }
 
         $config = [];
-        
+
         $this->fillThirdPartyInterfaces($areaConfig, $definitionsCollection);
         $config['arguments'] = $this->getConfigForScope($definitionsCollection, $areaConfig);
 

--- a/setup/src/Magento/Setup/Module/Di/Compiler/Config/Reader.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/Config/Reader.php
@@ -98,6 +98,12 @@ class Reader
         foreach (array_keys($areaConfig->getVirtualTypes()) as $virtualType) {
             $config['instanceTypes'][$virtualType] = $areaConfig->getInstanceType($virtualType);
         }
+
+        // sort configuration to have it in the same order on every build
+        ksort($config['arguments']);
+        ksort($config['preferences']);
+        ksort($config['instanceTypes']);
+
         return $config;
     }
 


### PR DESCRIPTION
### Description (*)
We've faced an issue on BitBucket Pipelines: every build had own unique order of keys inside DI Metadata files.
We couldn't see the real diff between builds because of it.
Simple alphabetical sorting of metadata keys resolves this issue and makes builds repeatable.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Run DI compile on base branch then copy folder "generated/" to "generated-old/"
2. Run DI compile on this branch then copy folder "generated/" to "generated-new/"
3. Compare folders. You should not see diff in metadata.

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
