### PR TITLE
Static Content Deploy - Add command line argument to disable JS Bundles

### DIFF
--- a/app/code/Magento/Deploy/Console/DeployStaticOptions.php
+++ b/app/code/Magento/Deploy/Console/DeployStaticOptions.php
@@ -79,6 +79,11 @@ class DeployStaticOptions
     const NO_JAVASCRIPT = 'no-javascript';
 
     /**
+     * Key for js-bundle option
+     */
+    const NO_JS_BUNLDE = 'no-js-bundle';
+
+    /**
      * Key for css option
      */
     const NO_CSS = 'no-css';
@@ -274,6 +279,12 @@ class DeployStaticOptions
                 null,
                 InputOption::VALUE_NONE,
                 'Do not deploy JavaScript files.'
+            ),
+            new InputOption(
+                self::NO_JS_BUNLDE,
+                null,
+                InputOption::VALUE_NONE,
+                'Do not deploy JavaScript bundle files.'
             ),
             new InputOption(
                 self::NO_CSS,

--- a/app/code/Magento/Deploy/Console/DeployStaticOptions.php
+++ b/app/code/Magento/Deploy/Console/DeployStaticOptions.php
@@ -81,7 +81,7 @@ class DeployStaticOptions
     /**
      * Key for js-bundle option
      */
-    const NO_JS_BUNLDE = 'no-js-bundle';
+    const NO_JS_BUNDLE = 'no-js-bundle';
 
     /**
      * Key for css option
@@ -281,7 +281,7 @@ class DeployStaticOptions
                 'Do not deploy JavaScript files.'
             ),
             new InputOption(
-                self::NO_JS_BUNLDE,
+                self::NO_JS_BUNDLE,
                 null,
                 InputOption::VALUE_NONE,
                 'Do not deploy JavaScript bundle files.'

--- a/app/code/Magento/Deploy/Console/DeployStaticOptions.php
+++ b/app/code/Magento/Deploy/Console/DeployStaticOptions.php
@@ -127,9 +127,6 @@ class DeployStaticOptions
      */
     const NO_LESS = 'no-less';
 
-    /**
-     * Default jobs amount
-     */
     const DEFAULT_JOBS_AMOUNT = 0;
 
     /**

--- a/app/code/Magento/Deploy/Service/DeployStaticContent.php
+++ b/app/code/Magento/Deploy/Service/DeployStaticContent.php
@@ -120,13 +120,20 @@ class DeployStaticContent
             $deployI18n = $this->objectManager->create(DeployTranslationsDictionary::class, [
                 'logger' => $this->logger
             ]);
+            foreach ($packages as $package) {
+                if (!$package->isVirtual()) {
+                    $deployRjsConfig->deploy($package->getArea(), $package->getTheme(), $package->getLocale());
+                    $deployI18n->deploy($package->getArea(), $package->getTheme(), $package->getLocale());
+                }
+            }
+        }
+
+        if ($options[Options::NO_JAVASCRIPT] !== true && $options[Options::NO_JS_BUNLDE] !== true ) {
             $deployBundle = $this->objectManager->create(Bundle::class, [
                 'logger' => $this->logger
             ]);
             foreach ($packages as $package) {
                 if (!$package->isVirtual()) {
-                    $deployRjsConfig->deploy($package->getArea(), $package->getTheme(), $package->getLocale());
-                    $deployI18n->deploy($package->getArea(), $package->getTheme(), $package->getLocale());
                     $deployBundle->deploy($package->getArea(), $package->getTheme(), $package->getLocale());
                 }
             }

--- a/app/code/Magento/Deploy/Service/DeployStaticContent.php
+++ b/app/code/Magento/Deploy/Service/DeployStaticContent.php
@@ -128,7 +128,7 @@ class DeployStaticContent
             }
         }
 
-        if ($options[Options::NO_JAVASCRIPT] !== true && $options[Options::NO_JS_BUNLDE] !== true) {
+        if ($options[Options::NO_JAVASCRIPT] !== true && $options[Options::NO_JS_BUNDLE] !== true) {
             $deployBundle = $this->objectManager->create(Bundle::class, [
                 'logger' => $this->logger
             ]);

--- a/app/code/Magento/Deploy/Service/DeployStaticContent.php
+++ b/app/code/Magento/Deploy/Service/DeployStaticContent.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\Deploy\Service;
 
-use Magento\Deploy\Strategy\DeployStrategyFactory;
-use Magento\Deploy\Process\QueueFactory;
 use Magento\Deploy\Console\DeployStaticOptions as Options;
+use Magento\Deploy\Process\QueueFactory;
+use Magento\Deploy\Strategy\DeployStrategyFactory;
 use Magento\Framework\App\View\Deployment\Version\StorageInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\ObjectManagerInterface;
@@ -128,7 +128,7 @@ class DeployStaticContent
             }
         }
 
-        if ($options[Options::NO_JAVASCRIPT] !== true && $options[Options::NO_JS_BUNLDE] !== true ) {
+        if ($options[Options::NO_JAVASCRIPT] !== true && $options[Options::NO_JS_BUNLDE] !== true) {
             $deployBundle = $this->objectManager->create(Bundle::class, [
                 'logger' => $this->logger
             ]);

--- a/app/code/Magento/Deploy/Service/DeployStaticContent.php
+++ b/app/code/Magento/Deploy/Service/DeployStaticContent.php
@@ -75,6 +75,9 @@ class DeployStaticContent
      * @param array $options
      * @throws LocalizedException
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
      */
     public function deploy(array $options)
     {
@@ -106,20 +109,20 @@ class DeployStaticContent
 
         $deployStrategy = $this->deployStrategyFactory->create(
             $options[Options::STRATEGY],
-            [
-                'queue' => $this->queueFactory->create($queueOptions)
-            ]
+            ['queue' => $this->queueFactory->create($queueOptions)]
         );
 
         $packages = $deployStrategy->deploy($options);
 
         if ($options[Options::NO_JAVASCRIPT] !== true) {
-            $deployRjsConfig = $this->objectManager->create(DeployRequireJsConfig::class, [
-                'logger' => $this->logger
-            ]);
-            $deployI18n = $this->objectManager->create(DeployTranslationsDictionary::class, [
-                'logger' => $this->logger
-            ]);
+            $deployRjsConfig = $this->objectManager->create(
+                DeployRequireJsConfig::class,
+                ['logger' => $this->logger]
+            );
+            $deployI18n      = $this->objectManager->create(
+                DeployTranslationsDictionary::class,
+                ['logger' => $this->logger]
+            );
             foreach ($packages as $package) {
                 if (!$package->isVirtual()) {
                     $deployRjsConfig->deploy($package->getArea(), $package->getTheme(), $package->getLocale());
@@ -129,9 +132,10 @@ class DeployStaticContent
         }
 
         if ($options[Options::NO_JAVASCRIPT] !== true && $options[Options::NO_JS_BUNDLE] !== true) {
-            $deployBundle = $this->objectManager->create(Bundle::class, [
-                'logger' => $this->logger
-            ]);
+            $deployBundle = $this->objectManager->create(
+                Bundle::class,
+                ['logger' => $this->logger]
+            );
             foreach ($packages as $package) {
                 if (!$package->isVirtual()) {
                     $deployBundle->deploy($package->getArea(), $package->getTheme(), $package->getLocale());

--- a/app/code/Magento/Deploy/Test/Unit/Service/DeployStaticContentTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Service/DeployStaticContentTest.php
@@ -228,13 +228,13 @@ class DeployStaticContentTest extends \PHPUnit\Framework\TestCase
     public function testMaxExecutionTimeOptionPassed()
     {
         $options = [
-            DeployStaticOptions::MAX_EXECUTION_TIME => 100,
+            DeployStaticOptions::MAX_EXECUTION_TIME           => 100,
             DeployStaticOptions::REFRESH_CONTENT_VERSION_ONLY => false,
-            DeployStaticOptions::JOBS_AMOUNT => 3,
-            DeployStaticOptions::STRATEGY => 'compact',
-            DeployStaticOptions::NO_JAVASCRIPT => true,
-            DeployStaticOptions::NO_JS_BUNLDE => true,
-            DeployStaticOptions::NO_HTML_MINIFY => true,
+            DeployStaticOptions::JOBS_AMOUNT                  => 3,
+            DeployStaticOptions::STRATEGY                     => 'compact',
+            DeployStaticOptions::NO_JAVASCRIPT                => true,
+            DeployStaticOptions::NO_JS_BUNDLE                 => true,
+            DeployStaticOptions::NO_HTML_MINIFY               => true,
         ];
 
         $queueMock = $this->createMock(Queue::class);

--- a/app/code/Magento/Deploy/Test/Unit/Service/DeployStaticContentTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Service/DeployStaticContentTest.php
@@ -103,7 +103,7 @@ class DeployStaticContentTest extends \PHPUnit\Framework\TestCase
             $package->expects($this->never())->method('getTheme');
             $package->expects($this->never())->method('getLocale');
         } else {
-            $package->expects($this->exactly(1))->method('isVirtual')->willReturn(false);
+            $package->expects($this->exactly(2))->method('isVirtual')->willReturn(false);
             $package->expects($this->exactly(3))->method('getArea')->willReturn('area');
             $package->expects($this->exactly(3))->method('getTheme')->willReturn('theme');
             $package->expects($this->exactly(3))->method('getLocale')->willReturn('locale');
@@ -198,6 +198,7 @@ class DeployStaticContentTest extends \PHPUnit\Framework\TestCase
                 [
                     'strategy' =>  'compact',
                     'no-javascript' => false,
+                    'no-js-bundle' => false,
                     'no-html-minify' => false,
                     'refresh-content-version-only' => false,
                 ],
@@ -207,6 +208,7 @@ class DeployStaticContentTest extends \PHPUnit\Framework\TestCase
                 [
                     'strategy' =>  'compact',
                     'no-javascript' => false,
+                    'no-js-bundle' => false,
                     'no-html-minify' => false,
                     'refresh-content-version-only' => false,
                     'content-version' =>  '123456',
@@ -231,6 +233,7 @@ class DeployStaticContentTest extends \PHPUnit\Framework\TestCase
             DeployStaticOptions::JOBS_AMOUNT => 3,
             DeployStaticOptions::STRATEGY => 'compact',
             DeployStaticOptions::NO_JAVASCRIPT => true,
+            DeployStaticOptions::NO_JS_BUNLDE => true,
             DeployStaticOptions::NO_HTML_MINIFY => true,
         ];
 

--- a/app/code/Magento/Deploy/Test/Unit/Service/DeployStaticContentTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Service/DeployStaticContentTest.php
@@ -241,13 +241,15 @@ class DeployStaticContentTest extends \PHPUnit\Framework\TestCase
         $strategyMock = $this->createMock(CompactDeploy::class);
         $this->queueFactory->expects($this->once())
             ->method('create')
-            ->with([
-                'logger' => $this->logger,
-                'maxExecTime' => 100,
-                'maxProcesses' => 3,
-                'options' => $options,
-                'deployPackageService' => null
-            ])
+            ->with(
+                [
+                    'logger'               => $this->logger,
+                    'maxExecTime'          => 100,
+                    'maxProcesses'         => 3,
+                    'options'              => $options,
+                    'deployPackageService' => null
+                ]
+            )
             ->willReturn($queueMock);
         $this->deployStrategyFactory->expects($this->once())
             ->method('create')

--- a/dev/tests/integration/testsuite/Magento/Deploy/DeployTest.php
+++ b/dev/tests/integration/testsuite/Magento/Deploy/DeployTest.php
@@ -71,6 +71,7 @@ class DeployTest extends \PHPUnit\Framework\TestCase
     private $options = [
         Options::DRY_RUN => false,
         Options::NO_JAVASCRIPT => false,
+        Options::NO_JS_BUNDLE => false,
         Options::NO_CSS => false,
         Options::NO_LESS => false,
         Options::NO_IMAGES => false,

--- a/dev/tests/integration/testsuite/Magento/Deploy/DeployTest.php
+++ b/dev/tests/integration/testsuite/Magento/Deploy/DeployTest.php
@@ -101,9 +101,10 @@ class DeployTest extends \PHPUnit\Framework\TestCase
         $this->rootDir = $this->filesystem->getDirectoryRead(DirectoryList::ROOT);
 
         $logger = $objectManager->get(\Psr\Log\LoggerInterface::class);
-        $this->deployService = $objectManager->create(DeployStaticContent::class, [
-            'logger' => $logger
-        ]);
+        $this->deployService = $objectManager->create(
+            DeployStaticContent::class,
+            ['logger' => $logger]
+        );
 
         $this->bundleConfig = $objectManager->create(BundleConfig::class);
         $this->config = $objectManager->create(View::class);


### PR DESCRIPTION
### Description (*)
There were no way to disable JS bundles even if you don't use them on frontend.
Disabling generation of JS bundles improves speed of Static Content Deploy and makes build package smaller in MB.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Run static content deploy with option --no-js-bundle
2. JS bundles should not be generated

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
