### PR TITLE
Static Content Deploy - Cleanup array_merge() in loop + don't format log message if logs are disabled

### DIFF
--- a/app/code/Magento/Deploy/Package/Package.php
+++ b/app/code/Magento/Deploy/Package/Package.php
@@ -459,17 +459,17 @@ class Package
      */
     public function getParentFiles($type = null)
     {
-        $files = [];
+        $files = [[]];
         foreach ($this->getParentPackages() as $parentPackage) {
             if ($type === null) {
                 // phpcs:ignore Magento2.Performance.ForeachArrayMerge.ForeachArrayMerge
-                $files = array_merge($files, $parentPackage->getFiles());
+                $files[] = $parentPackage->getFiles();
             } else {
                 // phpcs:ignore Magento2.Performance.ForeachArrayMerge.ForeachArrayMerge
-                $files = array_merge($files, $parentPackage->getFilesByType($type));
+                $files[] = $parentPackage->getFilesByType($type);
             }
         }
-        return $files;
+        return array_merge(...$files);
     }
 
     /**

--- a/app/code/Magento/Deploy/Service/DeployPackage.php
+++ b/app/code/Magento/Deploy/Service/DeployPackage.php
@@ -249,23 +249,6 @@ class DeployPackage
      */
     private function register(Package $package, PackageFile $file = null, $skipLogging = false)
     {
-        $logMessage = '.';
-        if ($file) {
-            $logMessage = "Processing file '{$file->getSourcePath()}'";
-            if ($file->getArea()) {
-                $logMessage .= "  for area '{$file->getArea()}'";
-            }
-            if ($file->getTheme()) {
-                $logMessage .= ", theme '{$file->getTheme()}'";
-            }
-            if ($file->getLocale()) {
-                $logMessage .= ", locale '{$file->getLocale()}'";
-            }
-            if ($file->getModule()) {
-                $logMessage .= "module '{$file->getModule()}'";
-            }
-        }
-
         $info = [
             'count' => $this->count,
             'last' => $file ? $file->getSourcePath() : ''
@@ -273,6 +256,23 @@ class DeployPackage
         $this->deployStaticFile->writeTmpFile('info.json', $package->getPath(), json_encode($info));
 
         if (!$skipLogging) {
+            $logMessage = '.';
+            if ($file) {
+                $logMessage = "Processing file '{$file->getSourcePath()}'";
+                if ($file->getArea()) {
+                    $logMessage .= "  for area '{$file->getArea()}'";
+                }
+                if ($file->getTheme()) {
+                    $logMessage .= ", theme '{$file->getTheme()}'";
+                }
+                if ($file->getLocale()) {
+                    $logMessage .= ", locale '{$file->getLocale()}'";
+                }
+                if ($file->getModule()) {
+                    $logMessage .= "module '{$file->getModule()}'";
+                }
+            }
+
             $this->logger->info($logMessage);
         }
     }


### PR DESCRIPTION
### Description (*)
Small optimizations:
 - get rid of array_merge() in array
 - if logs are disabled then do not prepare log message (it happens in worker-jobs inside static content deploy)

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
None

### Questions or comments
None

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
