### PR TITLE
Static Content Deploy - Fix timing in multi-job mode

### DIFF
--- a/app/code/Magento/Deploy/Test/Unit/Process/QueueTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Process/QueueTest.php
@@ -112,7 +112,7 @@ class QueueTest extends \PHPUnit\Framework\TestCase
         $package->expects($this->any())->method('getArea')->willReturn('area');
         $package->expects($this->any())->method('getPath')->willReturn('path');
         $package->expects($this->any())->method('getFiles')->willReturn([]);
-         $this->logger->expects($this->exactly(2))->method('info')->willReturnSelf();
+        $this->logger->expects($this->exactly(2))->method('info')->willReturnSelf();
 
         $this->appState->expects($this->once())->method('emulateAreaCode');
 

--- a/app/code/Magento/Deploy/Test/Unit/Process/QueueTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Process/QueueTest.php
@@ -112,6 +112,7 @@ class QueueTest extends \PHPUnit\Framework\TestCase
         $package->expects($this->any())->method('getArea')->willReturn('area');
         $package->expects($this->any())->method('getPath')->willReturn('path');
         $package->expects($this->any())->method('getFiles')->willReturn([]);
+         $this->logger->expects($this->exactly(2))->method('info')->willReturnSelf();
 
         $this->appState->expects($this->once())->method('emulateAreaCode');
 


### PR DESCRIPTION
### Description (*)
Fixed two multi-process issues in Static Content Deploy:

Issue 1: Static content deploy waits 3 sec in single-job mode after finish
Fixed by moving this sleep() into if ($this->isCanBeParalleled()) { ... }

Issue 2: Static content deploy has 5 secs delay between checking if worker job finished processing.
It leads up to 5 sec time waste before next job will start.
Improved by decreasing time from 5 sec to 0.5 sec with saving log refresh rate (10*0.5 sec)

On 4 themes and 7 locales these fixes improve time of static content deploy by 10-15 secs

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Test Static Content Deploy in single-job mode
2. Test Static Content Deploy in multi-job mode

Results of static content deploy shouldn't be different from base branch (I've done recursive diff between folders)

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
