### PR TITLE
Static Content Deploy - Get rid of in_array(array_keys($array))

### DIFF
--- a/lib/internal/Magento/Framework/View/Asset/PreProcessor/AlternativeSource.php
+++ b/lib/internal/Magento/Framework/View/Asset/PreProcessor/AlternativeSource.php
@@ -139,11 +139,13 @@ class AlternativeSource implements AlternativeSourceInterface
                 ->setTheme($context->getThemePath())
                 ->setLocale($context->getLocale())
                 ->setModule($module)
-                ->setPath(preg_replace(
-                    '#\.' . preg_quote(pathinfo($path, PATHINFO_EXTENSION)) . '$#',
-                    '.' . $name,
-                    $path
-                ))->build();
+                ->setPath(
+                    preg_replace(
+                        '#\.' . preg_quote(pathinfo($path, PATHINFO_EXTENSION)) . '$#',
+                        '.' . $name,
+                        $path
+                    )
+                )->build();
 
             $processor = $this->objectManager->get($alternative[self::PROCESSOR_CLASS]);
             if (!$processor  instanceof ContentProcessorInterface) {

--- a/lib/internal/Magento/Framework/View/Asset/PreProcessor/AlternativeSource.php
+++ b/lib/internal/Magento/Framework/View/Asset/PreProcessor/AlternativeSource.php
@@ -168,4 +168,14 @@ class AlternativeSource implements AlternativeSourceInterface
     {
         return array_keys($this->alternatives);
     }
+
+    /**
+     * Check if file extension supported
+     * @param $ext string
+     * @return bool
+     */
+    public function isExtensionSupported($ext)
+    {
+        return isset($this->alternatives[$ext]);
+    }
 }

--- a/lib/internal/Magento/Framework/View/Asset/PreProcessor/AlternativeSource.php
+++ b/lib/internal/Magento/Framework/View/Asset/PreProcessor/AlternativeSource.php
@@ -6,9 +6,9 @@
 namespace Magento\Framework\View\Asset\PreProcessor;
 
 use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\View\Asset\ContentProcessorInterface;
 use Magento\Framework\View\Asset\File\FallbackContext;
 use Magento\Framework\View\Asset\LockerProcessInterface;
-use Magento\Framework\View\Asset\ContentProcessorInterface;
 use Magento\Framework\View\Asset\PreProcessor\AlternativeSource\AssetBuilder;
 
 /**
@@ -171,7 +171,8 @@ class AlternativeSource implements AlternativeSourceInterface
 
     /**
      * Check if file extension supported
-     * @param $ext string
+     *
+     * @param string $ext
      * @return bool
      */
     public function isExtensionSupported($ext)

--- a/lib/internal/Magento/Framework/View/Asset/PreProcessor/FileNameResolver.php
+++ b/lib/internal/Magento/Framework/View/Asset/PreProcessor/FileNameResolver.php
@@ -38,7 +38,7 @@ class FileNameResolver
         $compiledFile = $fileName;
         $extension = pathinfo($fileName, PATHINFO_EXTENSION);
         foreach ($this->alternativeSources as $name => $alternative) {
-            if (in_array($extension, $alternative->getAlternativesExtensionsNames(), true)
+            if ($alternative->isExtensionSupported($extension)
                 && strpos(basename($fileName), '_') !== 0
             ) {
                 $compiledFile = substr($fileName, 0, strlen($fileName) - strlen($extension) - 1);

--- a/lib/internal/Magento/Framework/View/Asset/PreProcessor/FileNameResolver.php
+++ b/lib/internal/Magento/Framework/View/Asset/PreProcessor/FileNameResolver.php
@@ -5,6 +5,11 @@
  */
 namespace Magento\Framework\View\Asset\PreProcessor;
 
+/**
+ * Class FileNameResolver
+ *
+ * @package Magento\Framework\View\Asset\PreProcessor
+ */
 class FileNameResolver
 {
     /**


### PR DESCRIPTION
### Description (*)
Performance fix - Replace in_array(array_keys($array)) by isset($array)

### Fixed Issues (if relevant)
None

### Manual testing scenarios (*)
None

### Questions or comments
I understand that adding public methods isn't great, but doing in_array(array_keys($array)) isn't cool from performance point of view.
If it's absolutely not possible to add it to 2.3 then please take it to 2.4.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
