### PR TITLE
[#24903] Fix Type error in DynamicStorage

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/Storage/DynamicStorage.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Storage/DynamicStorage.php
@@ -148,7 +148,7 @@ class DynamicStorage extends BaseDbStorage
             CategoryUrlPathGenerator::XML_PATH_CATEGORY_URL_SUFFIX,
             ScopeInterface::SCOPE_STORE,
             $storeId
-        );
+        ) ?? '';
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This fixes the Uncaught TypeError: Return value of Magento\CatalogUrlRewrite\Model\Storage\DynamicStorage::getCategoryUrlSuffix() must be of the type string, null returned
When the suffix is removed you'll have a null value in the database.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24903: Uncaught TypeError: Return value of Magento\CatalogUrlRewrite\Model\Storage\DynamicStorage::getCategoryUrlSuffix() must be of the type string, null returned

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
None

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
None

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
