### PR TITLE
Resolved issue #12855

### DIFF
--- a/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderAddProductCheckboxTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderAddProductCheckboxTest.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminCreateOrderAddProductCheckboxTest">
+        <annotations>
+            <title value="Create Order in Admin and Add Product"/>
+            <stories value="Create order and add product using checkbox"/>
+            <description value="Create order in Admin panel, add product by clicking checkbox, and verify it is checked"/>
+            <features value="Sales"/>
+            <severity value="AVERAGE"/>
+            <group value="Sales"/>
+        </annotations>
+
+        <before>
+            <!-- Create simple customer -->
+            <createData entity="Simple_US_Customer_CA" stepKey="createSimpleCustomer"/>
+
+            <!-- Create simple product -->
+            <createData entity="ApiProductWithDescription" stepKey="createSimpleProduct"/>
+
+            <!-- Login to Admin Panel -->
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+        </before>
+
+        <!-- Initiate create new order -->
+        <actionGroup ref="navigateToNewOrderPageExistingCustomer" stepKey="navigateToNewOrderWithExistingCustomer">
+            <argument name="customer" value="$$createSimpleCustomer$$"/>
+        </actionGroup>
+
+        <click selector="{{AdminOrderFormItemsSection.addProducts}}" stepKey="clickAddProducts"/>
+        <fillField selector="{{AdminOrderFormItemsSection.skuFilter}}" userInput="$$createSimpleProduct.sku$$" stepKey="fillSkuFilterBundle"/>
+        <click selector="{{AdminOrderFormItemsSection.search}}" stepKey="clickSearchBundle"/>
+        <scrollTo selector="{{AdminOrderFormItemsSection.rowCheck('1')}}" x="0" y="-100" stepKey="scrollToCheckColumn"/>
+        <checkOption selector="{{AdminOrderFormItemsSection.rowCheck('1')}}" stepKey="selectProduct"/>
+        <seeCheckboxIsChecked selector="{{AdminOrderFormItemsSection.rowCheck('1')}}" stepKey="verifyProductChecked"/>
+
+        <after>
+            <actionGroup ref="logout" stepKey="logout"/>
+            <deleteData createDataKey="createSimpleProduct" stepKey="deleteSimpleProduct"/>
+            <deleteData createDataKey="createSimpleCustomer" stepKey="deleteSimpleCustomer"/>
+        </after>
+    </test>
+</tests>

--- a/app/design/adminhtml/Magento/backend/Magento_Sales/web/css/source/module/_order.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Sales/web/css/source/module/_order.less
@@ -308,4 +308,23 @@
     }
 }
 
+//
+//  Create Order - Add Product Grid
+//  ---------------------------------------------
+
+#sales_order_create_search_grid {
+    .col-in_products {
+        .data-grid-checkbox-cell-inner {
+            position: relative;
+        }
+        .checkbox {
+            width: 1.6rem;
+            height: 1.6rem;
+            left: 0;
+            right: 0;
+            margin: auto;
+        }
+    }
+}
+
 //  ToDo: MAGETWO-32299 UI: review the collapsible block


### PR DESCRIPTION
### Description
Resolved issue #12855 
- Fixed CSS of checkbox in Sales -> Orders -> Create New Order -> Add Products -> Grid
- Made checkbox consistent across all browsers
- Added MFTF test

### Fixed Issues
1. magento/magento2#12855: IE11 - Checkbox does not work correctly when adding products to a new sales order through the admin site

### Manual testing scenarios
> Tested on IE11, Firefox (latest), Chromium (latest)
1. Log in to Admin panel
2. Create sample product and customer
2. Navigate to Sales -> Orders -> Create New Order
3. Click Add Products
4. Click checkbox to select product to add
5. Verify checkbox is clicked and quantity field is active

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
