### PR TITLE
Replaced Model Save with Service Contract

### DIFF
--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/AddCommentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/AddCommentTest.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+declare(strict_types=1);
+
 namespace Magento\Sales\Test\Unit\Controller\Adminhtml\Order\Invoice;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
@@ -186,7 +189,8 @@ class AddCommentTest extends \PHPUnit\Framework\TestCase
                 'invoiceCommentSender' => $this->commentSenderMock,
                 'resultPageFactory' => $this->resultPageFactoryMock,
                 'resultRawFactory' => $this->resultRawFactoryMock,
-                'resultJsonFactory' => $this->resultJsonFactoryMock
+                'resultJsonFactory' => $this->resultJsonFactoryMock,
+                'invoiceRepository' => $this->invoiceRepository
             ]
         );
 
@@ -230,8 +234,9 @@ class AddCommentTest extends \PHPUnit\Framework\TestCase
         $invoiceMock->expects($this->once())
             ->method('addComment')
             ->with($data['comment'], false, false);
-        $invoiceMock->expects($this->once())
-            ->method('save');
+        $this->invoiceRepository->expects($this->once())
+            ->method('save')
+            ->with($invoiceMock);
 
         $this->invoiceRepository->expects($this->once())
             ->method('get')
@@ -307,11 +312,11 @@ class AddCommentTest extends \PHPUnit\Framework\TestCase
     public function testExecuteException()
     {
         $response = ['error' => true, 'message' => 'Cannot add new comment.'];
-        $e = new \Exception('test');
+        $error = new \Exception('test');
 
         $this->requestMock->expects($this->once())
             ->method('getParam')
-            ->will($this->throwException($e));
+            ->will($this->throwException($error));
 
         $this->resultJsonFactoryMock->expects($this->once())
             ->method('create')


### PR DESCRIPTION
### Description
Replaced deprecated `model->save()` with preferred service contract.
- Used parent class' service contract object
- Removed unnecessary _private deprecated_ method to obtain service contract object
- Removed `ObjectManager` usage in class method
- Added constructor DI of service contract object
- Fixed PHPUnit test according to changes

### Manual testing scenarios
1. Please refer to changed code

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
