### PR TITLE
Fixed issue #24922 "Create Permanent Redirect for URLs if URL Key Changed" for categories

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Block/Adminhtml/Category/Tab/Attributes.php
+++ b/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Block/Adminhtml/Category/Tab/Attributes.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\CatalogUrlRewrite\Plugin\Catalog\Block\Adminhtml\Category\Tab;
 
 /**
@@ -11,8 +12,35 @@ namespace Magento\CatalogUrlRewrite\Plugin\Catalog\Block\Adminhtml\Category\Tab;
 class Attributes
 {
     /**
+     * XML path for category rewrites history
+     */
+    const XML_PATH_CATEGORY_REWRITES_HISTORY = 'catalog/seo/save_rewrites_history';
+
+    /**
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    protected $storeManager;
+
+    /**
+     * @param \Magento\Store\Model\StoreManagerInterface         $storeManager
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+    ) {
+        $this->storeManager = $storeManager;
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
      * @param \Magento\Catalog\Model\Category\DataProvider $subject
-     * @param array $result
+     * @param array                                        $result
      *
      * @return array
      */
@@ -20,14 +48,24 @@ class Attributes
         \Magento\Catalog\Model\Category\DataProvider $subject,
         $result
     ) {
-        /** @var \Magento\Catalog\Model\Category $category */
+
+        /**
+ * @var \Magento\Catalog\Model\Category $category 
+*/
         $category = $subject->getCurrentCategory();
         if (isset($result['url_key'])) {
             if ($category && $category->getId()) {
                 if ($category->getLevel() == 1) {
                     $result['url_key_group']['componentDisabled'] = true;
                 } else {
-                    $result['url_key_create_redirect']['valueMap']['true'] = $category->getUrlKey();
+                    $storeId = $this->storeManager->getStore()->getId();
+                    $categoryRewritesHistory = (bool)$this->scopeConfig->getValue(
+                        self::XML_PATH_CATEGORY_REWRITES_HISTORY,
+                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                        $storeId
+                    );
+
+                    $result['url_key_create_redirect']['valueMap']['true'] = $categoryRewritesHistory ? $category->getUrlKey() : false;
                     $result['url_key_create_redirect']['value'] = $category->getUrlKey();
                     $result['url_key_create_redirect']['disabled'] = true;
                 }

--- a/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Block/Adminhtml/Category/Tab/Attributes.php
+++ b/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Block/Adminhtml/Category/Tab/Attributes.php
@@ -67,7 +67,8 @@ class Attributes
                         $storeId
                     );
 
-                    $result['url_key_create_redirect']['valueMap']['true'] = $categoryRewritesHistory ? $category->getUrlKey() : false;
+                    $result['url_key_create_redirect']['valueMap']['true'] = 
+                        $categoryRewritesHistory ? $category->getUrlKey() : false;
                     $result['url_key_create_redirect']['value'] = $category->getUrlKey();
                     $result['url_key_create_redirect']['disabled'] = true;
                 }

--- a/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Block/Adminhtml/Category/Tab/Attributes.php
+++ b/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Block/Adminhtml/Category/Tab/Attributes.php
@@ -67,7 +67,7 @@ class Attributes
                         $storeId
                     );
 
-                    $result['url_key_create_redirect']['valueMap']['true'] = 
+                    $result['url_key_create_redirect']['valueMap']['true'] =
                         $categoryRewritesHistory ? $category->getUrlKey() : false;
                     $result['url_key_create_redirect']['value'] = $category->getUrlKey();
                     $result['url_key_create_redirect']['disabled'] = true;

--- a/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Block/Adminhtml/Category/Tab/Attributes.php
+++ b/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Block/Adminhtml/Category/Tab/Attributes.php
@@ -19,12 +19,12 @@ class Attributes
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
-    protected $scopeConfig;
+    private $scopeConfig;
 
     /**
      * @var \Magento\Store\Model\StoreManagerInterface
      */
-    protected $storeManager;
+    private $storeManager;
 
     /**
      * @param \Magento\Store\Model\StoreManagerInterface         $storeManager

--- a/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Block/Adminhtml/Category/Tab/Attributes.php
+++ b/app/code/Magento/CatalogUrlRewrite/Plugin/Catalog/Block/Adminhtml/Category/Tab/Attributes.php
@@ -39,6 +39,8 @@ class Attributes
     }
 
     /**
+     * Plugin for url key create redirect
+     *
      * @param \Magento\Catalog\Model\Category\DataProvider $subject
      * @param array                                        $result
      *
@@ -50,8 +52,8 @@ class Attributes
     ) {
 
         /**
- * @var \Magento\Catalog\Model\Category $category 
-*/
+         * @var \Magento\Catalog\Model\Category $category
+         */
         $category = $subject->getCurrentCategory();
         if (isset($result['url_key'])) {
             if ($category && $category->getId()) {


### PR DESCRIPTION
Fixed issue #24922
When setting the config option `Stores > Configuration > Catalog > Catalog > SEO > Create Permanent Redirect for URLs if URL Key Changed` to "No". The "Create Permanent Redirect for old URL" is unchecked by default for products but is still checked by default when you change the URL key on a category.

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento 2.3.2

### Steps to reproduce (*)
1. Go to `Stores > Configuration > Catalog > Catalog > Search Engine Optimisation` and set `Create Permanent Redirect for URLs if URL Key Changed` to "No".
2. Go to any category and edit the URL key.

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. "Create Permanent Redirect for old URL" is **unchecked** by default (like products)

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. "Create Permanent Redirect for old URL" is **checked ** by default

![screenshot-magento staging edge-servers com-2019 10 08-12_41_44](https://user-images.githubusercontent.com/2035088/66392966-39dd1800-e9c9-11e9-9d8f-2ae60e40431d.png)

![screenshot-magento staging edge-servers com-2019 10 08-12_42_37](https://user-images.githubusercontent.com/2035088/66392969-3cd80880-e9c9-11e9-8a05-aca2e1bbd56f.png)

