### PR TITLE
[ImportExport] Fixing the Export page that has a large amount of exported files

### DIFF
--- a/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminAssertVisiblePagerActionGroup.xml
+++ b/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminAssertVisiblePagerActionGroup.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminAssertVisiblePagerActionGroup">
+        <see selector=".admin__data-grid-header .admin__control-support-text" userInput="records found" stepKey="seeRecordsLabel"/>
+        <seeElement selector=".admin__data-grid-header div.admin__data-grid-pager-wrap" stepKey="seeGridPager"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminAssertVisiblePagerActionGroup.xml
+++ b/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminAssertVisiblePagerActionGroup.xml
@@ -9,10 +9,7 @@
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="AdminAssertVisiblePagerActionGroup">
-        <arguments>
-            <argument name="recordsLabel" type="string" defaultValue="records found"/>
-        </arguments>
-        <see selector="{{AdminExportGridPagerSection.recordsLabel}}" userInput="{{recordsLabel}}" stepKey="seeRecordsLabel"/>
         <seeElement selector="{{AdminExportGridPagerSection.pager}}" stepKey="seeGridPager"/>
+        <seeElement selector="{{AdminGridRowsPerPage.count}}" stepKey="seeCountPerPageElement"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminAssertVisiblePagerActionGroup.xml
+++ b/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminAssertVisiblePagerActionGroup.xml
@@ -9,7 +9,10 @@
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="AdminAssertVisiblePagerActionGroup">
-        <see selector=".admin__data-grid-header .admin__control-support-text" userInput="records found" stepKey="seeRecordsLabel"/>
-        <seeElement selector=".admin__data-grid-header div.admin__data-grid-pager-wrap" stepKey="seeGridPager"/>
+        <arguments>
+            <argument name="recordsLabel" type="string" defaultValue="records found"/>
+        </arguments>
+        <see selector="{{AdminExportGridPagerSection.recordsLabel}}" userInput="{{recordsLabel}}" stepKey="seeRecordsLabel"/>
+        <seeElement selector="{{AdminExportGridPagerSection.pager}}" stepKey="seeGridPager"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminNavigateToExportPageActionGroup.xml
+++ b/app/code/Magento/ImportExport/Test/Mftf/ActionGroup/AdminNavigateToExportPageActionGroup.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminNavigateToExportPageActionGroup">
+        <amOnPage url="{{AdminExportIndexPage.url}}" stepKey="navigateToExportPage"/>
+        <waitForPageLoad stepKey="waitForExportPageOpened"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/ImportExport/Test/Mftf/Page/AdminExportIndexPage.xml
+++ b/app/code/Magento/ImportExport/Test/Mftf/Page/AdminExportIndexPage.xml
@@ -10,5 +10,6 @@
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/PageObject.xsd">
     <page name="AdminExportIndexPage" url="admin/export/" area="admin" module="Magento_ImportExport">
         <section name="AdminExportMainSection"/>
+        <section name="AdminExportGridPagerSection"/>
     </page>
 </pages>

--- a/app/code/Magento/ImportExport/Test/Mftf/Section/AdminExportGridPagerSection.xml
+++ b/app/code/Magento/ImportExport/Test/Mftf/Section/AdminExportGridPagerSection.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminExportGridPagerSection">
+        <element name="pager" type="text" selector=".admin__data-grid-header div.admin__data-grid-pager-wrap"/>
+        <element name="recordsLabel" type="text" selector=".admin__data-grid-header .admin__control-support-text"/>
+    </section>
+</sections>

--- a/app/code/Magento/ImportExport/Test/Mftf/Test/AdminExportPagerGridTest.xml
+++ b/app/code/Magento/ImportExport/Test/Mftf/Test/AdminExportPagerGridTest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminExportPagerGridTest">
+        <annotations>
+            <features value="ImportExport"/>
+            <stories value="Export Grid"/>
+            <title value="Testing if the grid is present on export page"/>
+            <description value="Admin should be able to see the grid onn export page"/>
+            <severity value="CRITICAL"/>
+            <group value="importExport"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="LoginAsAdmin"/>
+        </before>
+        <after>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+        <actionGroup ref="AdminNavigateToExportPageActionGroup" stepKey="navigateToExportPage"/>
+        <actionGroup ref="AdminAssertVisiblePagerActionGroup" stepKey="seeGridPager"/>
+    </test>
+</tests>

--- a/app/code/Magento/ImportExport/Ui/DataProvider/ExportFileDataProvider.php
+++ b/app/code/Magento/ImportExport/Ui/DataProvider/ExportFileDataProvider.php
@@ -78,7 +78,6 @@ class ExportFileDataProvider extends DataProvider
         );
 
         $this->fileIO = $fileIO ?: ObjectManager::getInstance()->get(File::class);
-        $this->request = $request;
     }
 
     /**

--- a/app/code/Magento/ImportExport/Ui/DataProvider/ExportFileDataProvider.php
+++ b/app/code/Magento/ImportExport/Ui/DataProvider/ExportFileDataProvider.php
@@ -7,16 +7,23 @@ declare(strict_types=1);
 
 namespace Magento\ImportExport\Ui\DataProvider;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Io\File;
 
 /**
  * Data provider for export grid.
  */
 class ExportFileDataProvider extends DataProvider
 {
+    /**
+     * @var File|null
+     */
+    private $fileIO;
+
     /**
      * @var DriverInterface
      */
@@ -37,6 +44,7 @@ class ExportFileDataProvider extends DataProvider
      * @param \Magento\Framework\Api\FilterBuilder $filterBuilder
      * @param DriverInterface $file
      * @param Filesystem $filesystem
+     * @param File|null $fileIO
      * @param array $meta
      * @param array $data
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -51,6 +59,7 @@ class ExportFileDataProvider extends DataProvider
         \Magento\Framework\Api\FilterBuilder $filterBuilder,
         DriverInterface $file,
         Filesystem $filesystem,
+        File $fileIO = null,
         array $meta = [],
         array $data = []
     ) {
@@ -67,6 +76,9 @@ class ExportFileDataProvider extends DataProvider
             $meta,
             $data
         );
+
+        $this->fileIO = $fileIO ?: ObjectManager::getInstance()->get(File::class);
+        $this->request = $request;
     }
 
     /**
@@ -89,10 +101,14 @@ class ExportFileDataProvider extends DataProvider
         }
         $result = [];
         foreach ($files as $file) {
-            $result['items'][]['file_name'] = basename($file);
+            $result['items'][]['file_name'] = $this->fileIO->getPathInfo($file)['basename'];
         }
 
+        $pageSize = (int) $this->request->getParam('paging')['pageSize'];
+        $pageCurrent = (int) $this->request->getParam('paging')['current'];
+        $pageOffset = ($pageCurrent - 1) * $pageSize;
         $result['totalRecords'] = count($result['items']);
+        $result['items'] = array_slice($result['items'], $pageOffset, $pageSize);
 
         return $result;
     }

--- a/app/code/Magento/ImportExport/view/adminhtml/ui_component/export_grid.xml
+++ b/app/code/Magento/ImportExport/view/adminhtml/ui_component/export_grid.xml
@@ -34,6 +34,9 @@
             </settings>
         </dataProvider>
     </dataSource>
+    <listingToolbar name="listing_top">
+        <paging name="listing_paging"/>
+    </listingToolbar>
     <columns name="export_grid_columns">
         <column name="file_name">
             <settings>


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR adds a grid for Export page, that fixes the issue if your grid has a large amount of data (more than 20k of records)

![image](https://user-images.githubusercontent.com/15868188/66509020-e35ffe80-eada-11e9-9936-1ad4991f417b.png)

### Fixed Issues (if relevant)

1. magento/magento2#24311: "CData section too big" on Export grid

### Manual testing scenarios (*)
1. Create a huge amount of csv files into the following folder: `var/export`
2. Try to open the `System / Export`
3. You'll get an error
![image](https://user-images.githubusercontent.com/15868188/66508945-b7447d80-eada-11e9-8daa-9ce272a113c0.png)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
