### PR TITLE
Fixed issue #24687 Contact us: Form doesn't render the cms page

### DIFF
--- a/app/code/Magento/Contact/Controller/Index/Post.php
+++ b/app/code/Magento/Contact/Controller/Index/Post.php
@@ -69,7 +69,7 @@ class Post extends \Magento\Contact\Controller\Index implements HttpPostActionIn
     public function execute()
     {
         if (!$this->getRequest()->isPost()) {
-            return $this->resultRedirectFactory->create()->setPath('*/*/');
+            return $this->resultRedirectFactory->create()->setPath('contact');
         }
         try {
             $this->sendEmail($this->validatedParams());
@@ -87,7 +87,7 @@ class Post extends \Magento\Contact\Controller\Index implements HttpPostActionIn
             );
             $this->dataPersistor->set('contact_us', $this->getRequest()->getParams());
         }
-        return $this->resultRedirectFactory->create()->setPath('contact/index');
+        return $this->resultRedirectFactory->create()->setPath('contact');
     }
 
     /**

--- a/app/code/Magento/Contact/Test/Mftf/Test/StorefrontVerifySecureURLRedirectContactTest.xml
+++ b/app/code/Magento/Contact/Test/Mftf/Test/StorefrontVerifySecureURLRedirectContactTest.xml
@@ -34,7 +34,7 @@
         <executeJS function="return window.location.host" stepKey="hostname"/>
         <amOnUrl url="http://{$hostname}/contact" stepKey="goToUnsecureContactURL"/>
         <seeCurrentUrlEquals url="https://{$hostname}/contact" stepKey="seeSecureContactURL"/>
-        <amOnUrl url="http://{$hostname}/contact/index/post" stepKey="goToUnsecureContactFormURL"/>
-        <seeCurrentUrlEquals url="https://{$hostname}/contact/index/post" stepKey="seeSecureContactFormURL"/>
+        <amOnUrl url="http://{$hostname}/contact/post" stepKey="goToUnsecureContactFormURL"/>
+        <seeCurrentUrlEquals url="https://{$hostname}/contact/post" stepKey="seeSecureContactFormURL"/>
     </test>
 </tests>

--- a/app/code/Magento/Contact/Test/Unit/Block/ContactFormTest.php
+++ b/app/code/Magento/Contact/Test/Unit/Block/ContactFormTest.php
@@ -63,7 +63,7 @@ class ContactFormTest extends \PHPUnit\Framework\TestCase
     {
         $this->urlBuilderMock->expects($this->once())
             ->method('getUrl')
-            ->with('contact/post', ['_secure' => true]);
+            ->with('contact/index/post', ['_secure' => true]);
         $this->contactForm->getFormAction();
     }
 }

--- a/app/code/Magento/Contact/Test/Unit/Block/ContactFormTest.php
+++ b/app/code/Magento/Contact/Test/Unit/Block/ContactFormTest.php
@@ -63,7 +63,7 @@ class ContactFormTest extends \PHPUnit\Framework\TestCase
     {
         $this->urlBuilderMock->expects($this->once())
             ->method('getUrl')
-            ->with('contact/index/post', ['_secure' => true]);
+            ->with('contact/post', ['_secure' => true]);
         $this->contactForm->getFormAction();
     }
 }


### PR DESCRIPTION
Fixed issue #24687
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->
### Summary
Contact us: Form doesn't render the cms page

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento version: 2.3
2. PHP version: 7.2.22
3. MySQL version: 5.7.27

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Install Magento 2.3
2. Install Sample Data
3. Follow this tutorial from oficial documentation (Method 2):
https://docs.magento.com/m2/ce/user_guide/stores/contact-us.html
4. (Optional) Enable Captcha for Contact Us Form
5. Fill the form
6. He will throw a _Exception_ with **Unable to send mail: Unknown error** OR **Invalid Captcha** OR **Thanks for contacting us with your comments and questions. We'll respond to you very soon.**
7. Magento will redirect you to **magento/contact/index** OR **magento/contact/index/index**
8. Magento will render the **Magento_Contact::form.phtml**

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. Should render the custom CMS page

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Magento is rendering **Magento_Contact::form.phtml** not the CMS page
