### PR TITLE
Fix for #23577. Check if db tables for config data exists before fetch

### DIFF
--- a/app/code/Magento/Store/App/Config/Source/RuntimeConfigSource.php
+++ b/app/code/Magento/Store/App/Config/Source/RuntimeConfigSource.php
@@ -44,6 +44,7 @@ class RuntimeConfigSource implements ConfigSourceInterface
 
     /**
      * Return whole scopes config data from db.
+     *
      * Ignore $path argument due to config source must return all config data
      *
      * @param string $path
@@ -64,6 +65,8 @@ class RuntimeConfigSource implements ConfigSourceInterface
     }
 
     /**
+     * Retrieve default connection
+     *
      * @return AdapterInterface
      */
     private function getConnection()
@@ -86,7 +89,7 @@ class RuntimeConfigSource implements ConfigSourceInterface
         $data = [];
         $tableName = $this->resourceConnection->getTableName($table);
         // Check if db table exists before fetch data
-        if($this->resourceConnection->getConnection()->isTableExists($tableName)) {
+        if ($this->resourceConnection->getConnection()->isTableExists($tableName)) {
             $entities = $this->getConnection()->fetchAll(
                 $this->getConnection()->select()->from($tableName)
             );

--- a/app/code/Magento/Store/App/Config/Source/RuntimeConfigSource.php
+++ b/app/code/Magento/Store/App/Config/Source/RuntimeConfigSource.php
@@ -83,12 +83,17 @@ class RuntimeConfigSource implements ConfigSourceInterface
      */
     private function getEntities($table, $keyField)
     {
-        $entities = $this->getConnection()->fetchAll(
-            $this->getConnection()->select()->from($this->resourceConnection->getTableName($table))
-        );
         $data = [];
-        foreach ($entities as $entity) {
-            $data[$entity[$keyField]] = $entity;
+        $tableName = $this->resourceConnection->getTableName($table);
+        // Check if db table exists before fetch data
+        if($this->resourceConnection->getConnection()->isTableExists($tableName)) {
+            $entities = $this->getConnection()->fetchAll(
+                $this->getConnection()->select()->from($tableName)
+            );
+
+            foreach ($entities as $entity) {
+                $data[$entity[$keyField]] = $entity;
+            }
         }
 
         return $data;

--- a/app/code/Magento/Store/Model/ResourceModel/Store.php
+++ b/app/code/Magento/Store/Model/ResourceModel/Store.php
@@ -166,11 +166,16 @@ class Store extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      */
     public function readAllStores()
     {
-        $select = $this->getConnection()
-            ->select()
-            ->from($this->getTable('store'));
+        $stores = [];
+        if ($this->getConnection()->isTableExists($this->getMainTable())) {
+            $select = $this->getConnection()
+                ->select()
+                ->from($this->getTable($this->getMainTable()));
 
-        return $this->getConnection()->fetchAll($select);
+            $stores = $this->getConnection()->fetchAll($select);
+        }
+
+        return $stores;
     }
 
     /**

--- a/app/code/Magento/Store/Model/ResourceModel/Website.php
+++ b/app/code/Magento/Store/Model/ResourceModel/Website.php
@@ -117,7 +117,7 @@ class Website extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 
     /**
      * Retrieve default stores select object
-     * 
+     *
      * Select fields website_id, store_id
      *
      * @param bool $includeDefault include/exclude default admin website

--- a/app/code/Magento/Store/Model/ResourceModel/Website.php
+++ b/app/code/Magento/Store/Model/ResourceModel/Website.php
@@ -47,10 +47,11 @@ class Website extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     public function readAllWebsites()
     {
         $websites = [];
-        if ($this->getConnection()->isTableExists($this->getMainTable())) {
+        $tableName = $this->getMainTable();
+        if ($this->getConnection()->isTableExists($tableName)) {
             $select = $this->getConnection()
                 ->select()
-                ->from($this->getTable($this->getMainTable()));
+                ->from($tableName);
 
             foreach ($this->getConnection()->fetchAll($select) as $websiteData) {
                 $websites[$websiteData['code']] = $websiteData;

--- a/app/code/Magento/Store/Model/ResourceModel/Website.php
+++ b/app/code/Magento/Store/Model/ResourceModel/Website.php
@@ -117,6 +117,7 @@ class Website extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 
     /**
      * Retrieve default stores select object
+     * 
      * Select fields website_id, store_id
      *
      * @param bool $includeDefault include/exclude default admin website

--- a/app/code/Magento/Store/Model/ResourceModel/Website.php
+++ b/app/code/Magento/Store/Model/ResourceModel/Website.php
@@ -47,12 +47,14 @@ class Website extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     public function readAllWebsites()
     {
         $websites = [];
-        $select = $this->getConnection()
-            ->select()
-            ->from($this->getTable('store_website'));
+        if ($this->getConnection()->isTableExists($this->getMainTable())) {
+            $select = $this->getConnection()
+                ->select()
+                ->from($this->getTable($this->getMainTable()));
 
-        foreach ($this->getConnection()->fetchAll($select) as $websiteData) {
-            $websites[$websiteData['code']] = $websiteData;
+            foreach ($this->getConnection()->fetchAll($select) as $websiteData) {
+                $websites[$websiteData['code']] = $websiteData;
+            }
         }
 
         return $websites;

--- a/app/code/Magento/Store/Test/Unit/App/Config/Source/RuntimeConfigSourceTest.php
+++ b/app/code/Magento/Store/Test/Unit/App/Config/Source/RuntimeConfigSourceTest.php
@@ -53,11 +53,11 @@ class RuntimeConfigSourceTest extends \PHPUnit\Framework\TestCase
 
     public function testGet()
     {
-        $this->deploymentConfig->expects($this->once())
+        $this->deploymentConfig->expects($this->any())
             ->method('get')
             ->with('db')
             ->willReturn(true);
-        $this->resourceConnection->expects($this->once())->method('getConnection')->willReturn($this->connection);
+        $this->resourceConnection->expects($this->any())->method('getConnection')->willReturn($this->connection);
 
         $selectMock = $this->getMockBuilder(Select::class)->disableOriginalConstructor()->getMock();
         $selectMock->expects($this->any())->method('from')->willReturnSelf();

--- a/app/code/Magento/Store/Test/Unit/Model/ResourceModel/StoreTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/ResourceModel/StoreTest.php
@@ -6,7 +6,6 @@
 
 namespace Magento\Store\Test\Unit\Model\ResourceModel;
 
-
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Select;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;

--- a/app/code/Magento/Store/Test/Unit/Model/ResourceModel/StoreTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/ResourceModel/StoreTest.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Store\Test\Unit\Model\ResourceModel;
+
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Select;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Store\Model\ResourceModel\Store;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+
+class StoreTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var Store */
+    protected $model;
+
+    /**
+     * @var ResourceConnection|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $resourceMock;
+
+    /** @var  Select | \PHPUnit_Framework_MockObject_MockObject */
+    protected $select;
+
+    /**
+     * @var AdapterInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $connectionMock;
+
+    public function setUp()
+    {
+        $objectManagerHelper = new ObjectManager($this);
+        $this->select =  $this->createMock(Select::class);
+        $this->resourceMock = $this->createPartialMock(
+            ResourceConnection::class,
+            [
+                'getConnection',
+                'getTableName'
+            ]
+        );
+        $this->connectionMock = $this->createPartialMock(
+            \Magento\Framework\DB\Adapter\Pdo\Mysql::class,
+            [
+                'isTableExists',
+                'select',
+                'fetchAll',
+                'fetchOne',
+                'from',
+                'getCheckSql',
+                'where',
+                'quoteIdentifier',
+                'quote'
+            ]
+        );
+
+        $contextMock = $this->createMock(\Magento\Framework\Model\ResourceModel\Db\Context::class);
+        $contextMock->expects($this->once())->method('getResources')->willReturn($this->resourceMock);
+        $configCacheTypeMock = $this->createMock('\Magento\Framework\App\Cache\Type\Config');
+        $this->model = $objectManagerHelper->getObject(
+            Store::class,
+            [
+                'context' => $contextMock,
+                'configCacheType' => $configCacheTypeMock
+            ]
+        );
+    }
+
+    public function testCountAll($countAdmin = false)
+    {
+        $mainTable = 'store';
+        $tableIdentifier = 'code';
+        $tableIdentifierValue = 'admin';
+        $count = 1;
+
+        $this->resourceMock->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($this->connectionMock);
+
+        $this->connectionMock->expects($this->once())
+            ->method('select')
+            ->willReturn($this->select);
+
+        $this->resourceMock->expects($this->once())
+            ->method('getTableName')
+            ->willReturn($mainTable);
+
+        $this->select->expects($this->once())
+            ->method('from')
+            ->with($mainTable, 'COUNT(*)')
+            ->willReturnSelf();
+
+        $this->connectionMock->expects($this->any())
+            ->method('quoteIdentifier')
+            ->with($tableIdentifier)
+            ->willReturn($tableIdentifier);
+
+        $this->connectionMock->expects($this->once())
+            ->method('quote')
+            ->with($tableIdentifierValue)
+            ->willReturn($tableIdentifierValue);
+
+        $this->select->expects($this->any())
+            ->method('where')
+            ->with(sprintf('%s <> %s', $tableIdentifier, $tableIdentifierValue))
+            ->willReturnSelf();
+
+        $this->connectionMock->expects($this->once())
+            ->method('fetchOne')
+            ->with($this->select)
+            ->willReturn($count);
+
+        $this->assertEquals($count, $this->model->countAll($countAdmin));
+    }
+
+    public function testReadAllStores()
+    {
+        $mainTable = 'store';
+        $data = [
+            ["store_id" => "0", "code" => "admin", "website_id" => 0, "name" => "Admin"],
+            ["store_id" => "1", "code" => "default", "website_id" => 1, "name" => "Default Store View"]
+        ];
+
+        $this->resourceMock->expects($this->atLeastOnce())
+            ->method('getConnection')
+            ->willReturn($this->connectionMock);
+
+        $this->resourceMock->expects($this->atLeastOnce())
+            ->method('getTableName')
+            ->willReturn($mainTable);
+
+        $this->connectionMock->expects($this->once())
+            ->method('isTableExists')
+            ->with($mainTable)
+            ->willReturn(true);
+
+        $this->connectionMock->expects($this->once())
+            ->method('select')
+            ->willReturn($this->select);
+
+        $this->select->expects($this->once())
+            ->method('from')
+            ->with($mainTable)
+            ->willReturnSelf();
+
+        $this->connectionMock->expects($this->once())
+            ->method('fetchAll')
+            ->with($this->select)
+            ->willReturn($data);
+
+        $this->assertEquals($data, $this->model->readAllStores());
+    }
+
+    public function testReadAllStoresNoDbTable()
+    {
+        $mainTable = 'no_store_table';
+        $data = [];
+
+        $this->resourceMock->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($this->connectionMock);
+
+        $this->resourceMock->expects($this->once())
+            ->method('getTableName')
+            ->willReturn($mainTable);
+
+        $this->connectionMock->expects($this->once())
+            ->method('isTableExists')
+            ->with($mainTable)
+            ->willReturn(false);
+
+        $this->connectionMock->expects($this->never())
+            ->method('select')
+            ->willReturn($this->select);
+
+        $this->select->expects($this->never())
+            ->method('from')
+            ->with($mainTable)
+            ->willReturnSelf();
+
+        $this->connectionMock->expects($this->never())
+            ->method('fetchAll')
+            ->with($this->select)
+            ->willReturn($data);
+
+        $this->assertEquals($data, $this->model->readAllStores());
+    }
+}

--- a/app/code/Magento/Store/Test/Unit/Model/ResourceModel/WebsiteTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/ResourceModel/WebsiteTest.php
@@ -1,0 +1,207 @@
+<?php
+
+
+namespace Magento\Store\Test\Unit\Model\ResourceModel;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Select;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Store\Model\ResourceModel\Website;
+
+class WebsiteTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var  Website */
+    private $model;
+
+    /**
+     * @var \Magento\Framework\App\ResourceConnection|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $resourceMock;
+
+    /** @var  Select | \PHPUnit_Framework_MockObject_MockObject */
+    private $select;
+
+    /**
+     * @var \Magento\Framework\DB\Adapter\AdapterInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $connectionMock;
+
+    public function setUp()
+    {
+        $objectManagerHelper = new ObjectManager($this);
+        $this->select =  $this->createMock(\Magento\Framework\DB\Select::class);
+        $this->resourceMock = $this->createPartialMock(ResourceConnection::class, [
+            'getConnection',
+            'getMainTable',
+            'getTable',
+            'getTableName'
+        ]);
+        $this->connectionMock = $this->createPartialMock(\Magento\Framework\DB\Adapter\Pdo\Mysql::class, [
+            'isTableExists',
+            'select',
+            'fetchAll',
+            'fetchOne',
+            'from',
+            'getCheckSql',
+            'joinLeft',
+            'where'
+        ]);
+        $contextMock = $this->createMock(\Magento\Framework\Model\ResourceModel\Db\Context::class);
+        $contextMock->expects($this->once())->method('getResources')->willReturn($this->resourceMock);
+        $this->model = $objectManagerHelper->getObject(Website::class, [
+            'context' => $contextMock
+        ]);
+    }
+
+    public function testReadAllWebsites()
+    {
+        $data = [
+            "admin" => ["website_id" => "0", "code" => "admin", "name" => "Admin"],
+            "base" => ["website_id" => "1", "code" => "base", "name" => "Main Website"]
+        ];
+        $mainTable = 'store_website';
+
+        $this->resourceMock->expects($this->once())
+            ->method('getTableName')
+            ->willReturn($mainTable);
+
+        $this->resourceMock->expects($this->atLeastOnce())
+            ->method('getConnection')
+            ->willReturn($this->connectionMock);
+
+        $this->connectionMock->expects($this->once())
+            ->method('isTableExists')
+            ->with($mainTable)
+            ->willReturn(true);
+
+        $this->connectionMock->expects($this->once())
+            ->method('select')
+            ->willReturn($this->select);
+
+        $this->select->expects($this->once())
+            ->method('from')
+            ->with($mainTable)
+            ->willReturnSelf();
+
+        $this->connectionMock->expects($this->once())
+            ->method('fetchAll')
+            ->with($this->select)
+            ->willReturn($data);
+
+        $this->assertEquals($data, $this->model->readAllWebsites());
+    }
+
+    public function testReadAllWebsitesNoDbTable()
+    {
+        $data = [];
+        $mainTable = 'no_store_website_table';
+
+        $this->resourceMock->expects($this->once())
+            ->method('getTableName')
+            ->willReturn($mainTable);
+
+        $this->resourceMock->expects($this->atLeastOnce())
+            ->method('getConnection')
+            ->willReturn($this->connectionMock);
+
+        $this->connectionMock->expects($this->once())
+            ->method('isTableExists')
+            ->with($mainTable)
+            ->willReturn(false);
+
+        $this->connectionMock->expects($this->never())
+            ->method('select')
+            ->willReturn($this->select);
+
+        $this->select->expects($this->never())
+            ->method('from')
+            ->with($mainTable)
+            ->willReturnSelf();
+
+        $this->connectionMock->expects($this->never())
+            ->method('fetchAll')
+            ->with($this->select)
+            ->willReturn($data);
+
+        $this->assertEquals($data, $this->model->readAllWebsites());
+    }
+
+    public function testGetDefaultStoresSelect($includeDefault = false)
+    {
+        $storeId = 1;
+        $storeWebsiteTable = 'store_website';
+        $storeGroupTable = 'store_group';
+
+        $this->resourceMock->expects($this->atLeastOnce())
+            ->method('getConnection')
+            ->willReturn($this->connectionMock);
+
+        $this->connectionMock->expects($this->once())
+            ->method('getCheckSql')
+            ->with(
+                'store_group_table.default_store_id IS NULL',
+                '0',
+                'store_group_table.default_store_id'
+            )
+            ->willReturn($storeId);
+
+        $this->connectionMock->expects($this->once())
+            ->method('select')
+            ->willReturn($this->select);
+
+        $this->resourceMock->expects($this->atLeastOnce())
+            ->method('getTableName')
+            ->withConsecutive([$storeWebsiteTable], [$storeGroupTable])
+            ->willReturnOnConsecutiveCalls($storeWebsiteTable, $storeGroupTable);
+
+        $this->select->expects($this->once())
+            ->method('from')
+            ->with(
+                ['website_table' => $storeWebsiteTable],
+                ['website_id']
+            )
+            ->willReturnSelf();
+
+        $this->select->expects($this->once())
+            ->method('joinLeft')
+            ->with(
+                ['store_group_table' => $storeGroupTable],
+                'website_table.website_id=store_group_table.website_id' .
+                ' AND website_table.default_group_id = store_group_table.group_id',
+                ['store_id' => $storeId]
+            )
+            ->willReturnSelf();
+
+        $this->assertInstanceOf('\Magento\Framework\DB\Select', $this->model->getDefaultStoresSelect($includeDefault));
+    }
+
+    public function testCountAll($includeDefault = false)
+    {
+        $count = 2;
+        $mainTable = 'store_website';
+
+        $this->resourceMock->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($this->connectionMock);
+
+        $this->connectionMock->expects($this->once())
+            ->method('select')
+            ->willReturn($this->select);
+
+        $this->resourceMock->expects($this->once())
+            ->method('getTableName')
+            ->willReturn($mainTable);
+
+        $this->select->expects($this->once())
+            ->method('from')
+            ->with($mainTable, 'COUNT(*)')
+            ->willReturnSelf();
+
+        $this->connectionMock->expects($this->once())
+            ->method('fetchOne')
+            ->with($this->select)
+            ->willReturn($count);
+
+        $this->assertEquals($count, $this->model->countAll($includeDefault));
+    }
+}

--- a/app/code/Magento/Store/Test/Unit/Model/ResourceModel/WebsiteTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/ResourceModel/WebsiteTest.php
@@ -1,5 +1,8 @@
 <?php
-
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 
 namespace Magento\Store\Test\Unit\Model\ResourceModel;
 
@@ -11,7 +14,7 @@ use Magento\Store\Model\ResourceModel\Website;
 class WebsiteTest extends \PHPUnit\Framework\TestCase
 {
     /** @var  Website */
-    private $model;
+    protected $model;
 
     /**
      * @var \Magento\Framework\App\ResourceConnection|\PHPUnit_Framework_MockObject_MockObject
@@ -19,7 +22,7 @@ class WebsiteTest extends \PHPUnit\Framework\TestCase
     protected $resourceMock;
 
     /** @var  Select | \PHPUnit_Framework_MockObject_MockObject */
-    private $select;
+    protected $select;
 
     /**
      * @var \Magento\Framework\DB\Adapter\AdapterInterface|\PHPUnit_Framework_MockObject_MockObject
@@ -30,27 +33,34 @@ class WebsiteTest extends \PHPUnit\Framework\TestCase
     {
         $objectManagerHelper = new ObjectManager($this);
         $this->select =  $this->createMock(\Magento\Framework\DB\Select::class);
-        $this->resourceMock = $this->createPartialMock(ResourceConnection::class, [
-            'getConnection',
-            'getMainTable',
-            'getTable',
-            'getTableName'
-        ]);
-        $this->connectionMock = $this->createPartialMock(\Magento\Framework\DB\Adapter\Pdo\Mysql::class, [
-            'isTableExists',
-            'select',
-            'fetchAll',
-            'fetchOne',
-            'from',
-            'getCheckSql',
-            'joinLeft',
-            'where'
-        ]);
+        $this->resourceMock = $this->createPartialMock(
+            ResourceConnection::class,
+            [
+                'getConnection',
+                'getTableName'
+            ]
+        );
+        $this->connectionMock = $this->createPartialMock(
+            \Magento\Framework\DB\Adapter\Pdo\Mysql::class,
+            [
+                'isTableExists',
+                'select',
+                'fetchAll',
+                'fetchOne',
+                'from',
+                'getCheckSql',
+                'joinLeft',
+                'where'
+            ]
+        );
         $contextMock = $this->createMock(\Magento\Framework\Model\ResourceModel\Db\Context::class);
         $contextMock->expects($this->once())->method('getResources')->willReturn($this->resourceMock);
-        $this->model = $objectManagerHelper->getObject(Website::class, [
+        $this->model = $objectManagerHelper->getObject(
+            Website::class,
+            [
             'context' => $contextMock
-        ]);
+            ]
+        );
     }
 
     public function testReadAllWebsites()


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added checking if db table exists before fetch config data from db table. This fix for issue in case db data defined in configuration but required tables not exists in db.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23577: Since 2.3.2, we can no longer switch maintenance modes with an empty database

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Clone clean 2.3-develop branch
2. Install composer packages (`composer install`)
3. Install Magento application (`bin/magento setup:install {config}`)
4. Remove all tables from DB to get empty DB (drop database and create new database with same name)
5. Try to enable maintenance mode: `bin/magento maintenance:enable`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
This issue appear in case when env.php file exists and contain credentials for db connection but db has no required tables to fetch config data used on deployment steps. Current fix contain update for checking if table exists before fetch data in `\Magento\Store\App\Config\Source\RuntimeConfigSource::getEntities` (app/code/Magento/Store/App/Config/Source/RuntimeConfigSource.php: Line 84). 
Code execution for enabling maintenance mode have validation if db available several times but this validation checks if db credentials available on config and has no checking if db tables available: `\Magento\Framework\App\DeploymentConfig::isDbAvailable` and  `\Magento\Store\App\Config\Source\RuntimeConfigSource::canUseDatabase`. Maybe would be good to make checking if required to fetch config data db tables exist in `\Magento\Framework\App\DeploymentConfig::isDbAvailable` to get more global solution in this case.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
