### PR TITLE
Issue #23465 display double quote in order id field in order CSV export time 

### DIFF
--- a/app/code/Magento/Ui/Model/Export/MetadataProvider.php
+++ b/app/code/Magento/Ui/Model/Export/MetadataProvider.php
@@ -15,6 +15,7 @@ use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 
 /**
+ * Metadata Provider
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class MetadataProvider
@@ -84,7 +85,7 @@ class MetadataProvider
                 return $childComponent;
             }
         }
-        throw new \Exception('No columns found');
+        throw new \Exception('No columns found'); // @codingStandardsIgnoreLine
     }
 
     /**

--- a/app/code/Magento/Ui/Model/Export/MetadataProvider.php
+++ b/app/code/Magento/Ui/Model/Export/MetadataProvider.php
@@ -119,12 +119,6 @@ class MetadataProvider
             $row[] = $column->getData('config/label');
         }
 
-        array_walk($row, function (&$header) {
-            if (mb_strpos($header, 'ID') === 0) {
-                $header = '"' . $header . '"';
-            }
-        });
-
         return $row;
     }
 

--- a/app/code/Magento/Ui/Test/Unit/Model/Export/MetadataProviderTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Model/Export/MetadataProviderTest.php
@@ -97,7 +97,7 @@ class MetadataProviderTest extends \PHPUnit\Framework\TestCase
     public function getColumnsDataProvider(): array
     {
         return [
-            [['ID'],['"ID"']],
+            [['ID'],['ID']],
             [['Name'],['Name']],
             [['Id'],['Id']],
             [['id'],['id']],

--- a/app/code/Magento/Ui/Test/Unit/Model/Export/MetadataProviderTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Model/Export/MetadataProviderTest.php
@@ -101,8 +101,8 @@ class MetadataProviderTest extends \PHPUnit\Framework\TestCase
             [['Name'],['Name']],
             [['Id'],['Id']],
             [['id'],['id']],
-            [['IDTEST'],['"IDTEST"']],
-            [['ID TEST'],['"ID TEST"']],
+            [['IDTEST'],['IDTEST']],
+            [['ID TEST'],['ID TEST']],
         ];
     }
 


### PR DESCRIPTION
### Description (*)
 Display double quote in order id field in order CSV export time 

### Fixed Issues (if relevant)
1. magento/magento2#23465 : Display double quote in order id field in order CSV export time

### Manual testing scenarios (*)

    1. Go to admin panel
    2. Select sales ->Order
    3. Export the order CSV

### Questions or comments
 According to @rogyar  there is another issue  at Magento Commerce edition for archived orders and system data collector modules. (https://github.com/magento/magento2/pull/23479)

After discussion at https://github.com/magento/magento2/pull/23468 @sidolov  and @hostep it should be fixed in Commerce modules instead of Magento_Ui module.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
