### PR TITLE
magento/magento2#24781: Elasticsearch 6 works with Elasticsearch 5 client on frontend

### DIFF
--- a/app/code/Magento/Elasticsearch/etc/di.xml
+++ b/app/code/Magento/Elasticsearch/etc/di.xml
@@ -267,7 +267,7 @@
     </type>
     <virtualType name="Magento\Elasticsearch\Elasticsearch5\SearchAdapter\ConnectionManager" type="Magento\Elasticsearch\SearchAdapter\ConnectionManager">
         <arguments>
-            <argument name="clientFactory" xsi:type="object">Magento\Elasticsearch\Elasticsearch5\Model\Client\ElasticsearchFactory</argument>
+            <argument name="clientFactory" xsi:type="object">Magento\Elasticsearch\Elasticsearch5\Model\Client\ClientFactoryProxy</argument>
             <argument name="clientConfig" xsi:type="object">Magento\Elasticsearch\Model\Config</argument>
         </arguments>
     </virtualType>

--- a/dev/tests/integration/testsuite/Magento/Elasticsearch6/SearchAdapter/ConnectionManagerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Elasticsearch6/SearchAdapter/ConnectionManagerTest.php
@@ -33,12 +33,27 @@ class ConnectionManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test if 'elasticsearch5' search engine returned by connection manager.
+     *
+     * @magentoAppIsolation enabled
+     * @magentoConfigFixture default/catalog/search/engine elasticsearch5
+     */
+    public function testCorrectElasticsearchClientEs5()
+    {
+        $connection = $this->connectionManager->getConnection();
+        $this->assertInstanceOf(
+            \Magento\Elasticsearch\Elasticsearch5\Model\Client\Elasticsearch::class,
+            $connection
+        );
+    }
+
+    /**
      * Test if 'elasticsearch6' search engine returned by connection manager.
      *
      * @magentoAppIsolation enabled
      * @magentoConfigFixture default/catalog/search/engine elasticsearch6
      */
-    public function testCorrectElasticsearchClient()
+    public function testCorrectElasticsearchClientEs6()
     {
         $connection = $this->connectionManager->getConnection();
         $this->assertInstanceOf(

--- a/dev/tests/integration/testsuite/Magento/Elasticsearch6/SearchAdapter/ConnectionManagerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Elasticsearch6/SearchAdapter/ConnectionManagerTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Elasticsearch6\SearchAdapter;
+
+use Magento\Elasticsearch\Elasticsearch5\SearchAdapter\ConnectionManager;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/**
+ * Test for \Magento\Elasticsearch\SearchAdapter\ConnectionManager class.
+ */
+class ConnectionManagerTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var \Magento\Elasticsearch\SearchAdapter\ConnectionManager
+     */
+    private $connectionManager;
+
+    protected function setUp()
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+
+        $this->connectionManager = $this->objectManager->create(ConnectionManager::class);
+    }
+
+    /**
+     * Test if 'elasticsearch6' search engine returned by connection manager.
+     *
+     * @magentoAppIsolation enabled
+     * @magentoConfigFixture default/catalog/search/engine elasticsearch6
+     */
+    public function testCorrectElasticsearchClient()
+    {
+        $connection = $this->connectionManager->getConnection();
+        $this->assertInstanceOf(
+            \Magento\Elasticsearch6\Model\Client\Elasticsearch::class,
+            $connection
+        );
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24781: Elasticsearch 6 works with Elasticsearch 5 client on frontend

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open PhpStorm, add breakpoints in:
- Elasticsearch 6.x client: https://github.com/magento/magento2/blob/6d6f11b3ff4dc290c1e53c8822e136547b38f05e/app/code/Magento/Elasticsearch6/Model/Client/Elasticsearch.php#L66
- Elasticsearch 5.x client: https://github.com/magento/magento2/blob/6d6f11b3ff4dc290c1e53c8822e136547b38f05e/app/code/Magento/Elasticsearch/Elasticsearch5/Model/Client/Elasticsearch.php#L71
2. Go to Admin >> Stores >> Configurations >> Catalog >> Catalog >> Search
3. Configure Elasticsearch settings to use "Elasticsearch 6.0+" option
4. Click "Test connection", see that code paused at Elasticsearch 6.x client
5. Save all configs, do reindex
6. Go to any category page, see that code paused at Elasticsearch 6.x client
7. Go to any search page, see that code paused at Elasticsearch 6.x client

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
