### PR TITLE
Cast changelogBatchSize to int

### DIFF
--- a/lib/internal/Magento/Framework/Mview/View.php
+++ b/lib/internal/Magento/Framework/Mview/View.php
@@ -293,7 +293,7 @@ class View extends DataObject implements ViewInterface
     {
         $versionBatchSize = self::$maxVersionQueryBatch;
         $batchSize = isset($this->changelogBatchSize[$this->getChangelog()->getViewId()])
-            ? $this->changelogBatchSize[$this->getChangelog()->getViewId()]
+            ? (int) $this->changelogBatchSize[$this->getChangelog()->getViewId()]
             : self::DEFAULT_BATCH_SIZE;
 
         for ($vsFrom = $lastVersionId; $vsFrom < $currentVersionId; $vsFrom += $versionBatchSize) {


### PR DESCRIPTION
### Description (*)
Custom changelog batchsize set in di.xml is used as string and throws an exception in Magento v2.3.3 running on PHP7.3.

```
TypeError: array_chunk() expects parameter 2 to be integer, string given
 
 /data/web/magento2/vendor/magento/framework/Mview/View.php:306
 /data/web/magento2/vendor/magento/framework/Mview/View.php:259
 /data/web/magento2/vendor/magento/framework/Mview/Processor.php:44
 /data/web/magento2/vendor/magento/module-indexer/Model/Processor.php:104
 /data/web/magento2/vendor/magento/framework/Interception/Interceptor.php:58
 /data/web/magento2/vendor/magento/framework/Interception/Interceptor.php:138
 /data/web/magento2/vendor/magento/framework/Interception/Interceptor.php:153
 /data/web/magento2/generated/code/Magento/Indexer/Model/Processor/Interceptor.php:52
 /data/web/magento2/vendor/*/*/Test/Integration/DeleteOfferTest.php:64
```

### Fixed Issues (if relevant)
1. None I could find.

### Manual testing scenarios (*)
1. Create custom indexer
2. Set changelog batch size in di.xml
```XML
<type name="Magento\Framework\Mview\View">
    <arguments>
        <argument name="changelogBatchSize" xsi:type="array">
            <item name="indexer_name" xsi:type="number">50</item>
        </argument>
    </arguments>
</type>
```
3. Call `\Magento\Indexer\Model\Processor::updateMview()`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
