### PR TITLE
Fix "Creating a product through API doesn't accept gallery entries at the same time"

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -546,6 +546,13 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $productDataArray['store_id'] = (int)$this->storeManager->getStore()->getId();
         $product = $this->initializeProductData($productDataArray, empty($existingProduct));
 
+        $validationResult = $this->resourceModel->validate($product);
+        if (true !== $validationResult) {
+            throw new \Magento\Framework\Exception\CouldNotSaveException(
+                __('Invalid product data: %1', implode(',', $validationResult))
+            );
+        }
+
         $this->processLinks($product, $productLinks);
         if (isset($productDataArray['media_gallery'])) {
             $this->processMediaGallery($product, $productDataArray['media_gallery']['images']);
@@ -553,13 +560,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
 
         if (!$product->getOptionsReadonly()) {
             $product->setCanSaveCustomOptions(true);
-        }
-
-        $validationResult = $this->resourceModel->validate($product);
-        if (true !== $validationResult) {
-            throw new \Magento\Framework\Exception\CouldNotSaveException(
-                __('Invalid product data: %1', implode(',', $validationResult))
-            );
         }
 
         if ($tierPrices !== null) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fix "Create a product in Magento using the API with POST (/rest/V1/products) with base64 encoded image to the media_gallery_entries attribute".
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24337: Creating a product through API doesn't accept gallery entries at the same time

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a product in Magento using the API with POST (/rest/V1/products) with base64 encoded image to the media_gallery_entries attribute

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
