### PR TITLE
Fixed required class is missing in load template

### DIFF
--- a/app/code/Magento/Email/view/adminhtml/templates/template/edit.phtml
+++ b/app/code/Magento/Email/view/adminhtml/templates/template/edit.phtml
@@ -13,8 +13,8 @@ use Magento\Framework\App\TemplateTypesInterface;
     <?= $block->getBlockHtml('formkey') ?>
     <fieldset class="admin__fieldset form-inline">
         <legend class="admin__legend"><span><?= $block->escapeHtml(__('Load Default Template')) ?></span></legend><br>
-        <div class="admin__field">
-            <label class="admin__field-label" for="template_select"><?= $block->escapeHtml(__('Template')) ?></label>
+        <div class="admin__field required">
+            <label class="admin__field-label" for="template_select"><span><?= $block->escapeHtml(__('Template')) ?></span></label>
             <div class="admin__field-control">
                 <select id="template_select" name="code" class="admin__control-select required-entry">
                     <?php foreach ($block->getTemplateOptions() as $group => $options) : ?>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Required class is missing in load template

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Marketing -> Email Template -> Load Template 
2. Template is required field but required class is missing.

![Screenshot_2019-10-11_15-20-31](https://user-images.githubusercontent.com/37572719/66642604-b3c80800-ec3a-11e9-95c9-f9a0c007e140.png)
