### PR TITLE
Fix GraphQL schema @cache declaration argument typo

### DIFF
--- a/app/code/Magento/GraphQl/etc/schema.graphqls
+++ b/app/code/Magento/GraphQl/etc/schema.graphqls
@@ -36,10 +36,10 @@ directive @resolver(class: String="") on QUERY
     | ENUM_VALUE
     | INPUT_OBJECT
     | INPUT_FIELD_DEFINITION
-    
+
 directive @typeResolver(class: String="") on INTERFACE | OBJECT
 
-directive @cache(cacheIdentity: String="" cachable: Boolean=true) on QUERY
+directive @cache(cacheIdentity: String="" cacheable: Boolean=true) on QUERY
 
 type Query {
 }


### PR DESCRIPTION
### Description (*)

The `@cache` directive argument name is `cacheable`, not `cachable`.

Reference line 1 of the method `\Magento\GraphQlCache\Model\CacheableQueryHandler::handleCacheFromResolverResponse`:

```
public function handleCacheFromResolverResponse(array $resolvedValue, array $cacheAnnotation) : void
{
    $cacheable = $cacheAnnotation['cacheable'] ?? true;
    $cacheIdentityClass = $cacheAnnotation['cacheIdentity'] ?? '';

    if ($this->request instanceof Http && $this->request->isGet() && !empty($cacheIdentityClass)) {
        $cacheIdentity = $this->identityPool->get($cacheIdentityClass);
        $cacheTags = $cacheIdentity->getIdentities($resolvedValue);
        $this->cacheableQuery->addCacheTags($cacheTags);
    } else {
        $cacheable = false;
    }
    $this->setCacheValidity($cacheable);
}
```

In the context of Magento, the directive declaration is only for documentation purposes.
The directive itself is used by the GraphQL API implementation, but the directive declaration is not.
As such this PR is backward compatible. The effect is only that, once merged, valid directive are no longer highlighted as an error in PHPStorm.

Before:
<img width="187" alt="before" src="https://user-images.githubusercontent.com/72463/66644575-92a6ed80-ec21-11e9-8935-ce07b241496d.png">
After:
<img width="186" alt="after" src="https://user-images.githubusercontent.com/72463/66644587-98043800-ec21-11e9-9216-a13e1cd69271.png">

### Manual testing scenarios (*)
Add a `@cache(cacheable: false)` directive to a `schema.grapghqls` file and validate it against the schema, for example using the PHPStorm graphqljs plugin.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)

