### PR TITLE
Fixed  #24802 Custom customer datetime attribute not saves

### DIFF
--- a/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
+++ b/app/code/Magento/Customer/Controller/Adminhtml/Index/Save.php
@@ -189,6 +189,7 @@ class Save extends \Magento\Customer\Controller\Adminhtml\Index implements HttpP
         /** @var \Magento\Framework\DataObject $object */
         $object = $this->_objectFactory->create(['data' => $this->getRequest()->getPostValue()]);
         $requestData = $object->getData($scope);
+        $formData = array_replace_recursive($formData,$requestData);
         foreach ($additionalAttributes as $attributeCode) {
             $formData[$attributeCode] = isset($requestData[$attributeCode]) ? $requestData[$attributeCode] : false;
         }


### PR DESCRIPTION
Fixed  #24802 Custom customer datetime attribute not saves
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->
### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where bug is reproducible.
-->
1. Magento 2.3.0
2. PHP 7.2.22

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Create a new attribute with type DateTime for a customer using InstallData.php
2. do bin/magento setup:upgrade

### Expected result (*)
<!--- Tell us what do you expect to happen. -->

1. the attribute shows up in  "Account information" section
2. save the attribute value

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. No error at all
2. the value is not saved 
3. I created a gist with my [InstallData ](https://gist.github.com/med-amin/f71e1246a8adbe2ebabe61a7137ad547)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
