### PR TITLE
Fixing #24807 - Changed accordion transition method when closing

### DIFF
--- a/lib/web/mage/accordion.js
+++ b/lib/web/mage/accordion.js
@@ -82,8 +82,9 @@ define([
          * @private
          */
         _closeOthers: function () {
+            var self = this;
+
             if (!this.options.multipleCollapsible) {
-                var self = this;
                 $.each(this.collapsibles, function () {
                     $(this).on('beforeOpen', function () {
                         self.collapsibles.not(this).collapsible('deactivate');

--- a/lib/web/mage/accordion.js
+++ b/lib/web/mage/accordion.js
@@ -83,7 +83,12 @@ define([
          */
         _closeOthers: function () {
             if (!this.options.multipleCollapsible) {
-                this._super();
+                var self = this;
+                $.each(this.collapsibles, function () {
+                    $(this).on('beforeOpen', function () {
+                        self.collapsibles.not(this).collapsible('deactivate');
+                    });
+                });
             }
             $.each(this.collapsibles, function () {
                 $(this).on('beforeOpen', function () {


### PR DESCRIPTION
### Description
When using the code sample from https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_accordion.html for an accordion widget - but setting the animate property to a numeric value - the transition works correctly for individual collapse elements, but when clicking to open a closed element the currently open element closes instantaneously without a transition. 

The reason for it is that the tabs widget has a forceDeactivate call to close the other tabs, the accordion element is based on the tabs and inherited the same behavior. To fix the issue I basically used the function that was already overridden and called the method deactivate instead.

### Fixed Issues
1. magento/magento2#24807: Accordion widget buggy transition

### Manual testing scenarios
1. Add an accordion widget to any page using the code sample from https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_accordion.html
2. Assign a numeric value to the 'animate' option e.g. "animate": {"duration": 600}
3. Open a closed element and observe the transition of both, the accordion that was opened has a force deactivation, so it closes instantly, the one that has been selected opens with the animation.

