### PR TITLE
Fixed #24731 Error message "This element is not expected" with no element. 

### DIFF
--- a/app/code/Magento/Cms/view/adminhtml/ui_component/cms_page_form.xml
+++ b/app/code/Magento/Cms/view/adminhtml/ui_component/cms_page_form.xml
@@ -336,5 +336,17 @@
                 </select>
             </formElements>
         </field>
+        <field name="layout_update_xml" formElement="textarea">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">page</item>
+                </item>
+            </argument>
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Custom Layout Update XML</label>
+                <dataScope>custom_layout_update_xml</dataScope>
+            </settings>
+        </field>
     </fieldset>
 </form>

--- a/app/code/Magento/Cms/view/adminhtml/ui_component/cms_page_form.xml
+++ b/app/code/Magento/Cms/view/adminhtml/ui_component/cms_page_form.xml
@@ -336,17 +336,5 @@
                 </select>
             </formElements>
         </field>
-        <field name="layout_update_xml" formElement="textarea">
-            <argument name="data" xsi:type="array">
-                <item name="config" xsi:type="array">
-                    <item name="source" xsi:type="string">page</item>
-                </item>
-            </argument>
-            <settings>
-                <dataType>text</dataType>
-                <label translate="true">Custom Layout Update XML</label>
-                <dataScope>custom_layout_update_xml</dataScope>
-            </settings>
-        </field>
     </fieldset>
 </form>

--- a/app/code/Magento/Cms/view/adminhtml/ui_component/cms_page_form.xml
+++ b/app/code/Magento/Cms/view/adminhtml/ui_component/cms_page_form.xml
@@ -336,5 +336,17 @@
                 </select>
             </formElements>
         </field>
+        <field name="custom_layout_update_xml" formElement="textarea">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">page</item>
+                </item>
+            </argument>
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Custom Layout Update XML</label>
+                <dataScope>custom_layout_update_xml</dataScope>
+            </settings>
+        </field>
     </fieldset>
 </form>


### PR DESCRIPTION
Fixed #24731 Error message "This element is not expected" with no element. 
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)

Magento 2.3.x

### Steps to reproduce (*)

Insert via database this code below in the **cms_page** table in the **custom_layout_update_xml** column.

```
    <reference name="content"></reference>
```



### Expected result (*)

It should be rendered in the CMS Page via admin panel to be removed or edited following the new syntax.

### Actual result (*)

Today, it's not rendered but when I try to save the page shows the syntax error message below.

![Screen Shot 2019-09-25 at 6 15 05 PM](https://user-images.githubusercontent.com/610598/65641689-d4019100-dfc3-11e9-8853-8515133c9df4.png)

![admin-cms-page-error-message](https://user-images.githubusercontent.com/610598/65641675-ce0bb000-dfc3-11e9-9144-758c3907b472.jpg)



### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
