### PR TITLE
Fixed: customer_is_guest never goes to 1 in quote table.

### DIFF
--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -857,7 +857,7 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
             $this->setCustomerId($this->_customer->getId());
         }
 
-        if (!$this->_customer->getId()) {
+        if (!$this->getCustomerId()) {
             $this->setCustomerIsGuest(true);
         } else {
             $this->setCustomerIsGuest(false);

--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -857,6 +857,12 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
             $this->setCustomerId($this->_customer->getId());
         }
 
+        if (!$this->_customer->getId()) {
+            $this->setCustomerIsGuest(1);
+        } else {
+            $this->setCustomerIsGuest(0);
+        }
+
         //mark quote if it has virtual products only
         $this->setIsVirtual($this->getIsVirtual());
 

--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -858,9 +858,9 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
         }
 
         if (!$this->_customer->getId()) {
-            $this->setCustomerIsGuest(1);
+            $this->setCustomerIsGuest(true);
         } else {
-            $this->setCustomerIsGuest(0);
+            $this->setCustomerIsGuest(false);
         }
 
         //mark quote if it has virtual products only


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
Fixed issue Quote `customer_is_guest` set to 0 for guest.

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In this PR customer_is_guest set to 0 in quote table fixed.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #24736 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add a product as a guest `customer_is_guest =1` now. 
2. Now login in customer then `customer_is_guest=0` now.
3. Clear everything, add a product for logged in customer, `customer_is_guest=0`.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
