### PR TITLE
fixed #24652

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_index_index.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_index_index.xml
@@ -118,7 +118,7 @@
                                                         </item>
                                                         <item name="component" xsi:type="string">Magento_Checkout/js/view/shipping</item>
                                                         <item name="provider" xsi:type="string">checkoutProvider</item>
-                                                        <item name="sortOrder" xsi:type="string">1</item>
+                                                        <item name="sortOrder" xsi:type="string">10</item>
                                                         <item name="children" xsi:type="array">
                                                             <item name="customer-email" xsi:type="array">
                                                                 <item name="component" xsi:type="string">Magento_Checkout/js/view/form/element/email</item>
@@ -246,6 +246,7 @@
                                                         <item name="component" xsi:type="string">Magento_Checkout/js/view/payment</item>
                                                         <item name="config" xsi:type="array">
                                                             <item name="title" xsi:type="string" translate="true">Payment</item>
+                                                            <item name="sortOrder" xsi:type="string">20</item>
                                                         </item>
                                                         <item name="children" xsi:type="array">
                                                             <item name="renders" xsi:type="array">

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/payment.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/payment.js
@@ -54,7 +54,7 @@ define([
                 $t('Review & Payments'),
                 this.isVisible,
                 _.bind(this.navigate, this),
-                20
+                this.sortOrder
             );
 
             return this;

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
@@ -87,7 +87,7 @@ define([
                     '',
                     $t('Shipping'),
                     this.visible, _.bind(this.navigate, this),
-                    10
+                    this.sortOrder
                 );
             }
             checkoutDataResolver.resolveShippingAddress();


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Magento Checkout UI Component SortOrder issue fixed.
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed the hardcoded sort order from the shipping and payment steps by using the layout.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2 #24652 : Magento Checkout UI Component SortOrder

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set the sort order in the checkout_index_index layout and It's working fine now.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
Finally, the sort order is coming from the layout and easily can be override using the layout only.
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
