### PR TITLE
fixed issue #24214

### DIFF
--- a/lib/web/mage/dropdown_old.js
+++ b/lib/web/mage/dropdown_old.js
@@ -4,11 +4,15 @@
  */
 
 define([
-    'jquery'
-], function ($) {
+    'jquery',
+    'Magento_Ui/js/lib/key-codes'
+], function ($, keyCodes) {
     'use strict';
 
     var ESC_KEY_CODE = '27';
+
+    var key =Object.entries(keyCodes);
+    var enterKeycode = key[1][0];
 
     $(document)
         .on('click.dropdown', function (event) {
@@ -25,6 +29,12 @@ define([
         .on('keyup.dropdown', function (event) {
             if (event.keyCode == ESC_KEY_CODE) { //eslint-disable-line eqeqeq
                 $('[data-toggle=dropdown].active').trigger('close.dropdown');
+            }
+        })
+        .on("keypress",function(event){
+            if (event.which == enterKeycode) {
+                event.preventDefault();
+                $('.action-primary.action-accept').click();
             }
         });
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Hitting enter while creation of folder in media browser closes media browser
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24214: Hitting enter while creation of folder in media browser closes media browser

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1)Go to Content -> Blocks -> New Block
2)Use Insert Image option -> Media Browser will open
3)Use the option to Create Folder
4)Type in folder name like "foobar" and hit Enter key

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
