### PR TITLE
Fixed #24840 Drop down icon invisible for a moment if not select value and click on Load Template

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_controls.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_controls.less
@@ -59,15 +59,15 @@
 .admin__control-select {
     &:extend(.abs-form-control-pattern all);
     .lib-css(appearance, none, 1);
-    background-image+: url('../images/arrows-bg.svg');
+    background-image+: url('../images/arrows-bg.svg') !important;
     background-position+: ~'calc(100% - 12px)' -34px;
     background-size+: auto;
 
-    background-image+: linear-gradient(@color-gray89, @color-gray89);
+    background-image+: linear-gradient(@color-gray89, @color-gray89) !important;
     background-position+: 100%;
     background-size+: @field-control__height 100%;
 
-    background-image+: linear-gradient(@field-control__border-color,@field-control__border-color);
+    background-image+: linear-gradient(@field-control__border-color,@field-control__border-color) !important;
     background-position+: ~'calc(100% - @{field-control__height})' 0;
     background-size+: 1px 100%;
 
@@ -86,13 +86,13 @@
     }
 
     &:active {
-        background-image+: url('../images/arrows-bg.svg');
+        background-image+: url('../images/arrows-bg.svg') !important;
         background-position+: ~'calc(100% - 12px)' 13px;
 
-        background-image+: linear-gradient(@color-gray89, @color-gray89);
+        background-image+: linear-gradient(@color-gray89, @color-gray89) !important;
         background-position+: 100%;
 
-        background-image+: linear-gradient(@field-control__focus__border-color, @field-control__focus__border-color);
+        background-image+: linear-gradient(@field-control__focus__border-color, @field-control__focus__border-color) !important;
         background-position+: ~'calc(100% - @{field-control__height})' 0;
         border-color: @field-control__focus__border-color;
     }


### PR DESCRIPTION
Fixed magento/magento2#24840
### Preconditions (*)
M 2.3

### Steps to reproduce (*)
1. admin - email template - add new template
2. without select template click on Load Template

### Expected result (*)
drop down icon should be visible when click on Load Template

### Actual result (*)
![image](https://user-images.githubusercontent.com/56119534/66127383-23ba0b00-e609-11e9-8635-96680f71905c.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
