### PR TITLE
Quality Assurance > Reports the PHPDoc tags that have elements listed in non-canonical order

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/StoreResolver.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/StoreResolver.php
@@ -57,7 +57,7 @@ class StoreResolver
      */
     protected function _initWebsites()
     {
-        /** @var $website \Magento\Store\Model\Website */
+        /** @var \Magento\Store\Model\Website $website */
         foreach ($this->storeManager->getWebsites() as $website) {
             $this->websiteCodeToId[$website->getCode()] = $website->getId();
             $this->websiteCodeToStoreIds[$website->getCode()] = array_flip($website->getStoreCodes());

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/TaxClassProcessor.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/TaxClassProcessor.php
@@ -59,7 +59,7 @@ class TaxClassProcessor
         if (empty($this->taxClasses)) {
             $collection = $this->collectionFactory->create();
             $collection->addFieldToFilter('class_type', ClassModel::TAX_CLASS_TYPE_PRODUCT);
-            /* @var $collection \Magento\Tax\Model\ResourceModel\TaxClass\Collection */
+            /* @var \Magento\Tax\Model\ResourceModel\TaxClass\Collection $collection */
             foreach ($collection as $taxClass) {
                 $this->taxClasses[$taxClass->getClassName()] = $taxClass->getId();
             }

--- a/app/code/Magento/CatalogImportExport/Model/StockItemImporter.php
+++ b/app/code/Magento/CatalogImportExport/Model/StockItemImporter.php
@@ -45,7 +45,7 @@ class StockItemImporter implements StockItemImporterInterface
      */
     public function import(array $stockData)
     {
-        /** @var $stockItemResource Item */
+        /** @var Item $stockItemResource */
         $stockItemResource = $this->stockResourceItemFactory->create();
         $entityTable = $stockItemResource->getMainTable();
         try {

--- a/app/code/Magento/CatalogInventory/Model/StockIndex.php
+++ b/app/code/Magento/CatalogInventory/Model/StockIndex.php
@@ -150,7 +150,7 @@ class StockIndex implements StockIndexInterface
         $websitesWithStores = $this->getWebsitesWithDefaultStores($websiteId);
 
         foreach (array_keys($websitesWithStores) as $websiteId) {
-            /* @var $website \Magento\Store\Model\Website */
+            /* @var \Magento\Store\Model\Website $website */
             $statuses[$websiteId] = $status;
         }
 
@@ -223,7 +223,7 @@ class StockIndex implements StockIndexInterface
     {
         $parentIds = [];
         foreach ($this->getProductTypeInstances() as $typeInstance) {
-            /* @var $typeInstance AbstractType */
+            /* @var AbstractType $typeInstance */
             $parentIds = array_merge($parentIds, $typeInstance->getParentIdsByChild($productId));
         }
 

--- a/app/code/Magento/CatalogRule/Plugin/Indexer/Product/Attribute.php
+++ b/app/code/Magento/CatalogRule/Plugin/Indexer/Product/Attribute.php
@@ -87,12 +87,12 @@ class Attribute
      */
     protected function checkCatalogRulesAvailability($attributeCode)
     {
-        /* @var $collection RuleCollectionFactory */
+        /* @var RuleCollectionFactory $collection */
         $collection = $this->ruleCollectionFactory->create()->addAttributeInConditionFilter($attributeCode);
 
         $disabledRulesCount = 0;
         foreach ($collection as $rule) {
-            /* @var $rule Rule */
+            /* @var Rule $rule */
             $rule->setIsActive(0);
             /* @var $rule->getConditions() Combine */
             $this->removeAttributeFromConditions($rule->getConditions(), $attributeCode);

--- a/app/code/Magento/CatalogSearch/Controller/SearchTermsLog/Save.php
+++ b/app/code/Magento/CatalogSearch/Controller/SearchTermsLog/Save.php
@@ -68,7 +68,7 @@ class Save extends \Magento\Framework\App\Action\Action
      */
     public function execute()
     {
-        /* @var $query \Magento\Search\Model\Query */
+        /* @var \Magento\Search\Model\Query $query */
         $query = $this->queryFactory->get();
 
         $query->setStoreId($this->storeManager->getStore()->getId());

--- a/app/code/Magento/CatalogWidget/Block/Product/ProductsList.php
+++ b/app/code/Magento/CatalogWidget/Block/Product/ProductsList.php
@@ -253,7 +253,7 @@ class ProductsList extends \Magento\Catalog\Block\Product\AbstractProduct implem
     protected function getDetailsRendererList()
     {
         if (empty($this->rendererListBlock)) {
-            /** @var $layout \Magento\Framework\View\LayoutInterface */
+            /** @var \Magento\Framework\View\LayoutInterface $layout */
             $layout = $this->layoutFactory->create(['cacheable' => false]);
             $layout->getUpdate()->addHandle('catalog_widget_product_list')->load();
             $layout->generateXml();
@@ -299,7 +299,7 @@ class ProductsList extends \Magento\Catalog\Block\Product\AbstractProduct implem
      */
     public function createCollection()
     {
-        /** @var $collection \Magento\Catalog\Model\ResourceModel\Product\Collection */
+        /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $collection */
         $collection = $this->productCollectionFactory->create();
 
         if ($this->getData('store_id') !== null) {

--- a/app/code/Magento/Checkout/Block/Cart.php
+++ b/app/code/Magento/Checkout/Block/Cart.php
@@ -76,7 +76,7 @@ class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
     public function prepareItemUrls()
     {
         $products = [];
-        /* @var $item \Magento\Quote\Model\Quote\Item */
+        /* @var \Magento\Quote\Model\Quote\Item $item */
         foreach ($this->getItems() as $item) {
             $product = $item->getProduct();
             $option = $item->getOptionByCode('product_type');

--- a/app/code/Magento/Checkout/Model/Cart.php
+++ b/app/code/Magento/Checkout/Model/Cart.php
@@ -263,7 +263,7 @@ class Cart extends DataObject implements CartInterface
      */
     public function addOrderItem($orderItem, $qtyFlag = null)
     {
-        /* @var $orderItem \Magento\Sales\Model\Order\Item */
+        /* @var \Magento\Sales\Model\Order\Item $orderItem */
         if ($orderItem->getParentItem() === null) {
             $storeId = $this->_storeManager->getStore()->getId();
             try {

--- a/app/code/Magento/Checkout/Model/GuestShippingInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/GuestShippingInformationManagement.php
@@ -37,7 +37,7 @@ class GuestShippingInformationManagement implements \Magento\Checkout\Api\GuestS
         $cartId,
         \Magento\Checkout\Api\Data\ShippingInformationInterface $addressInformation
     ) {
-        /** @var $quoteIdMask \Magento\Quote\Model\QuoteIdMask */
+        /** @var \Magento\Quote\Model\QuoteIdMask $quoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
         return $this->shippingInformationManagement->saveAddressInformation(
             $quoteIdMask->getQuoteId(),

--- a/app/code/Magento/Checkout/Model/GuestTotalsInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/GuestTotalsInformationManagement.php
@@ -37,7 +37,7 @@ class GuestTotalsInformationManagement implements \Magento\Checkout\Api\GuestTot
         $cartId,
         \Magento\Checkout\Api\Data\TotalsInformationInterface $addressInformation
     ) {
-        /** @var $quoteIdMask \Magento\Quote\Model\QuoteIdMask */
+        /** @var \Magento\Quote\Model\QuoteIdMask $quoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
         return $this->totalsInformationManagement->calculate(
             $quoteIdMask->getQuoteId(),

--- a/app/code/Magento/Checkout/Model/Session.php
+++ b/app/code/Magento/Checkout/Model/Session.php
@@ -308,7 +308,7 @@ class Session extends \Magento\Framework\Session\SessionManager
 
         if (!$this->isQuoteMasked() && !$this->_customerSession->isLoggedIn() && $this->getQuoteId()) {
             $quoteId = $this->getQuoteId();
-            /** @var $quoteIdMask \Magento\Quote\Model\QuoteIdMask */
+            /** @var \Magento\Quote\Model\QuoteIdMask $quoteIdMask */
             $quoteIdMask = $this->quoteIdMaskFactory->create()->load($quoteId, 'quote_id');
             if ($quoteIdMask->getMaskedId() === null) {
                 $quoteIdMask->setQuoteId($quoteId)->save();

--- a/app/code/Magento/CheckoutAgreements/Model/CheckoutAgreementsList.php
+++ b/app/code/Magento/CheckoutAgreements/Model/CheckoutAgreementsList.php
@@ -48,7 +48,7 @@ class CheckoutAgreementsList implements \Magento\CheckoutAgreements\Api\Checkout
      */
     public function getList(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria) : array
     {
-        /** @var $collection \Magento\CheckoutAgreements\Model\ResourceModel\Agreement\Collection */
+        /** @var \Magento\CheckoutAgreements\Model\ResourceModel\Agreement\Collection $collection */
         $collection = $this->collectionFactory->create();
         $this->collectionProcessor->process($searchCriteria, $collection);
         $this->extensionAttributesJoinProcessor->process($collection);

--- a/app/code/Magento/Cms/Block/Adminhtml/Page/Grid.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Page/Grid.php
@@ -66,7 +66,7 @@ class Grid extends \Magento\Backend\Block\Widget\Grid\Extended
     protected function _prepareCollection()
     {
         $collection = $this->_collectionFactory->create();
-        /* @var $collection \Magento\Cms\Model\ResourceModel\Page\Collection */
+        /* @var \Magento\Cms\Model\ResourceModel\Page\Collection $collection */
         $collection->setFirstStoreFlag(true);
         $this->setCollection($collection);
 

--- a/app/code/Magento/Cms/Block/Adminhtml/Page/Widget/Chooser.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Page/Widget/Chooser.php
@@ -141,7 +141,7 @@ class Chooser extends \Magento\Backend\Block\Widget\Grid\Extended
     protected function _prepareCollection()
     {
         $collection = $this->_collectionFactory->create();
-        /* @var $collection \Magento\Cms\Model\ResourceModel\Page\CollectionFactory */
+        /* @var \Magento\Cms\Model\ResourceModel\Page\CollectionFactory $collection */
         $collection->setFirstStoreFlag(true);
         $this->setCollection($collection);
 

--- a/app/code/Magento/Cms/Controller/Adminhtml/Page/PostDataProcessor.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Page/PostDataProcessor.php
@@ -84,7 +84,7 @@ class PostDataProcessor
     public function validate($data)
     {
         if (!empty($data['layout_update_xml']) || !empty($data['custom_layout_update_xml'])) {
-            /** @var $layoutXmlValidator \Magento\Framework\View\Model\Layout\Update\Validator */
+            /** @var \Magento\Framework\View\Model\Layout\Update\Validator $layoutXmlValidator */
             $layoutXmlValidator = $this->validatorFactory->create(
                 [
                     'validationState' => $this->validationState,
@@ -140,7 +140,7 @@ class PostDataProcessor
             if (!empty($data['layout_update_xml']) && !$layoutXmlValidator->isValid($data['layout_update_xml'])) {
                 return false;
             }
-            
+
             if (!empty($data['custom_layout_update_xml']) &&
                 !$layoutXmlValidator->isValid($data['custom_layout_update_xml'])
             ) {

--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFiles.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFiles.php
@@ -66,7 +66,7 @@ class DeleteFiles extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images imple
             }
             $files = $this->getRequest()->getParam('files');
 
-            /** @var $helper \Magento\Cms\Helper\Wysiwyg\Images */
+            /** @var \Magento\Cms\Helper\Wysiwyg\Images $helper */
             $helper = $this->_objectManager->get(\Magento\Cms\Helper\Wysiwyg\Images::class);
             $path = $this->getStorage()->getSession()->getCurrentPath();
             if (!$this->directoryResolver->validatePath($path, DirectoryList::MEDIA)) {
@@ -84,7 +84,7 @@ class DeleteFiles extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images imple
                     $this->getStorage()->deleteFile($filePath);
                 }
             }
-            
+
             return $this->resultRawFactory->create();
         } catch (\Exception $e) {
             $result = ['error' => true, 'message' => $e->getMessage()];

--- a/app/code/Magento/CmsUrlRewrite/Observer/ProcessUrlRewriteSavingObserver.php
+++ b/app/code/Magento/CmsUrlRewrite/Observer/ProcessUrlRewriteSavingObserver.php
@@ -41,7 +41,7 @@ class ProcessUrlRewriteSavingObserver implements ObserverInterface
      */
     public function execute(EventObserver $observer)
     {
-        /** @var $cmsPage \Magento\Cms\Model\Page */
+        /** @var \Magento\Cms\Model\Page $cmsPage */
         $cmsPage = $observer->getEvent()->getObject();
 
         if ($cmsPage->dataHasChangedFor('identifier') || $cmsPage->dataHasChangedFor('store_id')) {

--- a/app/code/Magento/Config/Block/System/Config/Dwstree.php
+++ b/app/code/Magento/Config/Block/System/Config/Dwstree.php
@@ -40,7 +40,7 @@ class Dwstree extends \Magento\Backend\Block\Widget\Tabs
             ]
         );
 
-        /** @var $website \Magento\Store\Model\Website */
+        /** @var \Magento\Store\Model\Website $website */
         foreach ($this->_storeManager->getWebsites(true) as $website) {
             $wCode = $website->getCode();
             $wName = $website->getName();
@@ -53,7 +53,7 @@ class Dwstree extends \Magento\Backend\Block\Widget\Tabs
                     $this->_addBreadcrumb($wName);
                 }
             }
-            /** @var $store \Magento\Store\Model\Store */
+            /** @var \Magento\Store\Model\Store $store */
             foreach ($website->getStores() as $store) {
                 $sCode = $store->getCode();
                 $sName = $store->getName();

--- a/app/code/Magento/Config/Block/System/Config/Edit.php
+++ b/app/code/Magento/Config/Block/System/Config/Edit.php
@@ -73,7 +73,7 @@ class Edit extends \Magento\Backend\Block\Widget
      */
     protected function _prepareLayout()
     {
-        /** @var $section \Magento\Config\Model\Config\Structure\Element\Section */
+        /** @var \Magento\Config\Model\Config\Structure\Element\Section $section */
         $section = $this->_configStructure->getElement($this->getRequest()->getParam('section'));
         $this->_formBlockName = $section->getFrontendModel();
         if (empty($this->_formBlockName)) {


### PR DESCRIPTION
Quality Assurance > Reports the PHPDoc tags that have elements listed in non-canonical order

### Description (*)
Correct positioning of tag order according to PHPDoc documentation and standardization for correct generation of project documentation

For such tags as @param, or @var, the inspection will report the usages of [name] ["Type"] instead of ["Type"] [name]

Follow documentation:

https://docs.phpdoc.org/references/phpdoc/tags/var.html

https://docs.phpdoc.org/references/phpdoc/tags/param.html

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
