### PR TITLE
Fix incorrect PHPDoc in email transport

### DIFF
--- a/app/code/Magento/Email/Model/Transport.php
+++ b/app/code/Magento/Email/Model/Transport.php
@@ -10,7 +10,6 @@ namespace Magento\Email\Model;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\MailException;
 use Magento\Framework\Mail\EmailMessageInterface;
-use Magento\Framework\Mail\MessageInterface;
 use Magento\Framework\Mail\TransportInterface;
 use Magento\Framework\Phrase;
 use Magento\Store\Model\ScopeInterface;
@@ -57,7 +56,7 @@ class Transport implements TransportInterface
     private $zendTransport;
 
     /**
-     * @var MessageInterface
+     * @var EmailMessageInterface
      */
     private $message;
 

--- a/lib/internal/Magento/Framework/Mail/TransportInterface.php
+++ b/lib/internal/Magento/Framework/Mail/TransportInterface.php
@@ -23,7 +23,7 @@ interface TransportInterface
     /**
      * Get message
      *
-     * @return \Magento\Framework\Mail\MessageInterface
+     * @return \Magento\Framework\Mail\EmailMessageInterface
      * @since 100.2.0
      */
     public function getMessage();


### PR DESCRIPTION
### Description (*)
After changes to email transport and message interface, not all phpdoc was updated

### Manual testing scenarios (*)
1. Try to send an email
2. Check variable and return types in email transport

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
