### PR TITLE
Fixed issue #25039 Product detail did not scroll to review tab after click on 'Review' anchor link

### DIFF
--- a/app/code/Magento/Review/view/frontend/web/js/process-reviews.js
+++ b/app/code/Magento/Review/view/frontend/web/js/process-reviews.js
@@ -54,7 +54,7 @@ define([
 
                 event.preventDefault();
                 anchor = $(this).attr('href').replace(/^.*?(#|$)/, '');
-                addReviewBlock = $('.block.review-add .block-content #' + anchor);
+                addReviewBlock = $('#' + anchor);
 
                 if (addReviewBlock.length) {
                     $('.product.data.items [data-role="content"]').each(function (index) { //eslint-disable-line


### PR DESCRIPTION
Fixed issue magento/magento2#25039
**Preconditions**
1. Magento 2.3.3

**Steps to reproduce**
1. Go to product detail page
2. Click on 'review' or 'add your review' link (http://prntscr.com/pj0bg6)

**Expected result**
1. Auto scroll  to review tab at bottom.

**Actual result**
1. Did not scroll to review tab and encountered javascript error (http://prntscr.com/pj0d4g)

**Suspect**
1. Code issue on line 51-72 of Magento_Review/js/process-reviews.js (http://prntscr.com/pj0djj)