### PR TITLE
Added #24934 Add REST Api endpoint to Contact module

### DIFF
--- a/app/code/Magento/Contact/Api/ContactInterface.php
+++ b/app/code/Magento/Contact/Api/ContactInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Contact\Api;
+
+/**
+ * Interface for sending contact form data.
+ * @api
+ */
+interface ContactInterface
+{
+    /**
+     * Send an email to the contact person with contact form data
+     *
+     * @param string $name
+     * @param string $email
+     * @param string $telephone
+     * @param string $comment
+     * @return bool true on success
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function send($name, $email, $telephone = null, $comment);
+
+}

--- a/app/code/Magento/Contact/Model/Contact.php
+++ b/app/code/Magento/Contact/Model/Contact.php
@@ -30,9 +30,26 @@ class Contact implements ContactInterface
 	*/
     public function send($name, $email, $telephone = null, $comment)
     {
-        if(!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            $params = ['fieldName' => 'email'];
-            throw new InputException(__('%fieldName is not a valid email address.', $params));
+        $params = [];
+        
+        if (!is_string($name) || empty($name)) {
+            $params[] = ['fieldName' => 'name'];
+        }
+        
+        if (!is_string($email) || empty($email)) {
+            $params[] = ['fieldName' => 'email'];
+        }
+    
+        if (!is_string($comment) || empty($comment)) {
+            $params[] = ['fieldName' => 'comment'];
+        }
+        
+        if(!empty($params)){
+            throw new InputException(__('%fieldName is a required field.', $params));
+        }
+        
+        if (false === \strpos($email, '@')) {
+            throw new InputException(__('Invalid email address'));
         }
         
         $contactData = ['name' => $name, 'email' => $email, 'telephone'=> $telephone, 'comment'=> $comment];

--- a/app/code/Magento/Contact/Model/Contact.php
+++ b/app/code/Magento/Contact/Model/Contact.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Contact\Model;
+use Magento\Contact\Api\ContactInterface;
+use Magento\Contact\Model\MailInterface;
+use Magento\Framework\DataObject;
+use Magento\Framework\Exception\InputException;
+
+class Contact implements ContactInterface
+{
+	/**
+	* @var MailInterface
+	*/
+    private $mail;
+
+	/**
+	* @param MailInterface $mail
+	*/
+    public function __construct(
+        MailInterface $mail
+    ) {
+        $this->mail = $mail;
+    }
+
+	/**
+	* {@inheritdoc}
+	*/
+    public function send($name, $email, $telephone = null, $comment)
+    {
+        if(!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $params = ['fieldName' => 'email'];
+            throw new InputException(__('%fieldName is not a valid email address.', $params));
+        }
+        
+        $contactData = ['name' => $name, 'email' => $email, 'telephone'=> $telephone, 'comment'=> $comment];
+        $this->sendEmail($contactData);
+        
+        return true;
+    }
+
+    /**
+     * @param array $contactData Contact data from contact form
+     * @return void
+     */
+    private function sendEmail($contactData)
+    {
+        $this->mail->send(
+            $contactData['email'],
+            ['data' => new DataObject($contactData)]
+        );
+    }
+}

--- a/app/code/Magento/Contact/etc/di.xml
+++ b/app/code/Magento/Contact/etc/di.xml
@@ -8,6 +8,8 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Magento\Contact\Model\MailInterface" type="Magento\Contact\Model\Mail" />
     <preference for="Magento\Contact\Model\ConfigInterface" type="Magento\Contact\Model\Config" />
+    <preference for="Magento\Contact\Api\ContactInterface"
+                type="Magento\Contact\Model\Contact" />
     <type name="Magento\Config\Model\Config\TypePool">
         <arguments>
             <argument name="sensitive" xsi:type="array">

--- a/app/code/Magento/Contact/etc/webapi.xml
+++ b/app/code/Magento/Contact/etc/webapi.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+    <!-- Contact Page -->
+    <route url="/V1/contact" method="POST">
+        <service class="Magento\Customer\Api\ContactInterface" method="send"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
+</routes>

--- a/app/code/Magento/Contact/etc/webapi.xml
+++ b/app/code/Magento/Contact/etc/webapi.xml
@@ -9,7 +9,7 @@
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
     <!-- Contact Page -->
     <route url="/V1/contact" method="POST">
-        <service class="Magento\Customer\Api\ContactInterface" method="send"/>
+        <service class="Magento\Contact\Api\ContactInterface" method="send"/>
         <resources>
             <resource ref="anonymous"/>
         </resources>


### PR DESCRIPTION
Added #24934 Add REST Api endpoint to Contact module

Description (*)
Add REST Api endpoint to Contact module, to have possibility send email from the contact form for projects which using PWA architecture.

Expected behavior (*)
Sending email through Rest Api endpoint with next params - Name, Telephone, Email, Comment

Benefits
Have possibility to send emails from contact page for projects with PWA architecture like Vue-storefront.