### PR TITLE
Resolve "Enable Single-Store Mode" is "Yes" but the create New Rating has store view title issue25060

### DIFF
--- a/app/code/Magento/Review/Block/Adminhtml/Rating/Edit/Tab/Form.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Rating/Edit/Tab/Form.php
@@ -111,13 +111,16 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             ]
         );
 
-        foreach ($this->systemStore->getStoreCollection() as $store) {
-            $this->getFieldset('rating_form')->addField(
-                'rating_code_' . $store->getId(),
-                'text',
-                ['label' => $store->getName(), 'name' => 'rating_codes[' . $store->getId() . ']']
-            );
+        if (!$this->_storeManager->isSingleStoreMode()) {
+            foreach ($this->systemStore->getStoreCollection() as $store) {
+                $this->getFieldset('rating_form')->addField(
+                    'rating_code_' . $store->getId(),
+                    'text',
+                    ['label' => $store->getName(), 'name' => 'rating_codes[' . $store->getId() . ']']
+                );
+            }
         }
+
         $this->setRatingData();
     }
 

--- a/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsNoActionGroup.xml
+++ b/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsNoActionGroup.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsNoActionGroup">
+        <annotations>
+            <description>If Single Store Mode is disabled, default store view title label should be displayed.</description>
+        </annotations>
+        <seeElement selector="{{AdminEditAndNewRatingSection.defaultStoreViewTitleLabel}}" stepKey="seeLabel"/>
+        <seeElement selector="{{AdminEditAndNewRatingSection.defaultStoreViewTitleInput}}" stepKey="seeInput"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsYesActionGroup.xml
+++ b/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsYesActionGroup.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsYesActionGroup">
+        <annotations>
+            <description>If Single Store Mode is enabled, default store view title label should be displayed.</description>
+        </annotations>
+        <dontSeeElement selector="{{AdminEditAndNewRatingSection.defaultStoreViewTitleLabel}}" stepKey="seeLabel"/>
+        <dontSeeElement selector="{{AdminEditAndNewRatingSection.defaultStoreViewTitleInput}}" stepKey="seeInput"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsYesActionGroup.xml
+++ b/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsYesActionGroup.xml
@@ -9,9 +9,9 @@
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsYesActionGroup">
         <annotations>
-            <description>If Single Store Mode is enabled, default store view title label should be displayed.</description>
+            <description>If Single Store Mode is enabled, default store view title label should not be displayed.</description>
         </annotations>
-        <dontSeeElement selector="{{AdminEditAndNewRatingSection.defaultStoreViewTitleLabel}}" stepKey="seeLabel"/>
-        <dontSeeElement selector="{{AdminEditAndNewRatingSection.defaultStoreViewTitleInput}}" stepKey="seeInput"/>
+        <dontSeeElement selector="{{AdminEditAndNewRatingSection.defaultStoreViewTitleLabel}}" stepKey="dontSeeLabel"/>
+        <dontSeeElement selector="{{AdminEditAndNewRatingSection.defaultStoreViewTitleInput}}" stepKey="dontSeeInput"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminNavigateToNewRatingFormActionGroup.xml
+++ b/app/code/Magento/Review/Test/Mftf/ActionGroup/AdminNavigateToNewRatingFormActionGroup.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminNavigateToNewRatingFormActionGroup">
+        <annotations>
+            <description>Open New Rating Form</description>
+        </annotations>
+        <amOnPage url="{{AdminNewRatingPage.url}}" stepKey="amOnUrlNewRatingPage"/>
+        <waitForPageLoad stepKey="waitForNewRatingPage"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Review/Test/Mftf/Page/AdminNewRatingPage.xml
+++ b/app/code/Magento/Review/Test/Mftf/Page/AdminNewRatingPage.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/PageObject.xsd">
+    <page name="AdminNewRatingPage" url="review/rating/new/" area="admin" module="Review">
+        <section name="AdminEditAndNewRatingSection"/>
+    </page>
+</pages>

--- a/app/code/Magento/Review/Test/Mftf/Section/AdminEditAndNewRatingSection.xml
+++ b/app/code/Magento/Review/Test/Mftf/Section/AdminEditAndNewRatingSection.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminEditAndNewRatingSection">
+        <element name="defaultStoreViewTitleLabel" type="text" selector=".field-rating_code_1 label"/>
+        <element name="defaultStoreViewTitleInput" type="input" selector=".field-rating_code_1 input"/>
+    </section>
+</sections>

--- a/app/code/Magento/Review/Test/Mftf/Test/AdminVerifyNewRatingFormSingleStoreModeNoTest.xml
+++ b/app/code/Magento/Review/Test/Mftf/Test/AdminVerifyNewRatingFormSingleStoreModeNoTest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminVerifyNewRatingFormSingleStoreModeNoTest">
+        <annotations>
+            <features value="Review"/>
+            <stories value="Rating Form"/>
+            <title value="Verify New Rating Form if single store mode is No"/>
+            <description value="New Rating Form should not have Default store view field if single store mode is No"/>
+            <severity value="MAJOR"/>
+            <testCaseId value="MC-21818"/>
+            <group value="review"/>
+        </annotations>
+        <before>
+            <magentoCLI command="config:set general/single_store_mode/enabled 0" stepKey="enabledSingleStoreMode"/>
+            <actionGroup ref="LoginAsAdmin" stepKey="LoginAsAdmin"/>
+        </before>
+        <after>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+        <actionGroup ref="AdminNavigateToNewRatingFormActionGroup" stepKey="navigateToNewRatingPage" />
+        <actionGroup ref="AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsNoActionGroup" stepKey="verifyForm" />
+    </test>
+</tests>

--- a/app/code/Magento/Review/Test/Mftf/Test/AdminVerifyNewRatingFormSingleStoreModeNoTest.xml
+++ b/app/code/Magento/Review/Test/Mftf/Test/AdminVerifyNewRatingFormSingleStoreModeNoTest.xml
@@ -13,7 +13,7 @@
             <features value="Review"/>
             <stories value="Rating Form"/>
             <title value="Verify New Rating Form if single store mode is No"/>
-            <description value="New Rating Form should not have Default store view field if single store mode is No"/>
+            <description value="New Rating Form should have Default store view field if single store mode is No"/>
             <severity value="MAJOR"/>
             <testCaseId value="MC-21818"/>
             <group value="review"/>

--- a/app/code/Magento/Review/Test/Mftf/Test/AdminVerifyNewRatingFormSingleStoreModeYesTest.xml
+++ b/app/code/Magento/Review/Test/Mftf/Test/AdminVerifyNewRatingFormSingleStoreModeYesTest.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminVerifyNewRatingFormSingleStoreModeYesTest">
+        <annotations>
+            <features value="Review"/>
+            <stories value="Rating Form"/>
+            <title value="Verify New Rating Form if single store mode is Yes"/>
+            <description value="New Rating Form should not have Default store view field if single store mode is Yes"/>
+            <severity value="MAJOR"/>
+            <testCaseId value="MC-21818"/>
+            <group value="review"/>
+        </annotations>
+        <before>
+            <magentoCLI command="config:set general/single_store_mode/enabled 1" stepKey="enabledSingleStoreMode"/>
+            <actionGroup ref="LoginAsAdmin" stepKey="LoginAsAdmin"/>
+        </before>
+        <after>
+            <magentoCLI command="config:set general/single_store_mode/enabled 0" stepKey="enabledSingleStoreMode"/>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+        <actionGroup ref="AdminNavigateToNewRatingFormActionGroup" stepKey="navigateToNewRatingPage" />
+        <actionGroup ref="AdminAssertStoreViewRatingTitleWhenSingleStoreModeIsYesActionGroup" stepKey="verifyForm" />
+    </test>
+</tests>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. Resolve magento/magento2#25060: "Enable Single-Store Mode" is "Yes" but the create New Rating has store view title

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25060: "Enable Single-Store Mode" is "Yes" but the create New Rating has store view title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Settings -> Configuration-> General, "Enable Single-Store Mode" is "Yes"
2. Store-> Ratings -> Add New Rating
3. View the form
=> No show the field store-view scope title 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
