### PR TITLE
overlapping label in checkbox #25086 fixed

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Sales/web/css/source/module/order/_payment-shipping.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Sales/web/css/source/module/order/_payment-shipping.less
@@ -73,7 +73,7 @@
     }
     .order-shipping-address & {
         span {
-            top: 22px;
+            top: 0;
         }
     }
 }


### PR DESCRIPTION
If you going to reorder for Vertual product or Downloadable Product from admin panel **"You don't need to select a shipping address."** this label overlapping over the checkbox

### Preconditions (*)
1. php 7.2
2. Magento 2.3.x

### Steps to reproduce (*)
1. Go frontent and make an order for Vertual or Downloadable product
2. now login to admin panel and view same order you have done 
3. Now click on **Reorder** button in top and scroll page to Billing address section right side is Shipping address section, And refer screenshot bellow ..

### Expected result (*)

![image](https://user-images.githubusercontent.com/26018716/66907758-793de100-f027-11e9-9512-5aa37a3231e8.png)


### Actual result (*)
![image](https://user-images.githubusercontent.com/26018716/66907876-b1ddba80-f027-11e9-9814-d557dfab7794.png) 