### PR TITLE
[ProductVideo] Validating the Product Video Url

### DIFF
--- a/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminAssertVideoNoValidationErrorActionGroup.xml
+++ b/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminAssertVideoNoValidationErrorActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminAssertVideoNoValidationErrorActionGroup">
+        <arguments>
+            <argument name="inputName" type="string"/>
+        </arguments>
+
+        <dontSeeElement selector="{{AdminProductNewVideoSection.errorElement(inputName)}}"
+                        stepKey="seeElementValidationError"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminAssertVideoValidationErrorActionGroup.xml
+++ b/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminAssertVideoValidationErrorActionGroup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminAssertVideoValidationErrorActionGroup">
+        <arguments>
+            <argument name="inputName" type="string"/>
+            <argument name="errorMessage" type="string" defaultValue="This is a required field."/>
+        </arguments>
+
+        <see selector="{{AdminProductNewVideoSection.errorElement(inputName)}}" userInput="{{errorMessage}}"
+             stepKey="seeElementValidationError"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminFillProductVideoFieldActionGroup.xml
+++ b/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminFillProductVideoFieldActionGroup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminFillProductVideoFieldActionGroup">
+        <arguments>
+            <argument name="input" type="string"/>
+            <argument name="value" type="string"/>
+        </arguments>
+
+        <fillField selector="{{input}}" userInput="{{value}}" stepKey="fillVideoField"/>
+    </actionGroup>
+</actionGroups>
+
+
+

--- a/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminGetVideoInformationActionGroup.xml
+++ b/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminGetVideoInformationActionGroup.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminGetVideoInformationActionGroup">
+        <click selector="{{AdminProductNewVideoSection.getVideoInformationButton}}" stepKey="getVideoInformation"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminOpenProductVideoModalActionGroup.xml
+++ b/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AdminOpenProductVideoModalActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminOpenProductVideoModalActionGroup">
+        <scrollTo selector="{{AdminProductImagesSection.productImagesToggle}}" x="0" y="-100" stepKey="scrollToArea"/>
+        <conditionalClick selector="{{AdminProductImagesSection.productImagesToggle}}" dependentSelector="{{AdminProductImagesSection.imageUploadButton}}" visible="false" stepKey="openProductVideoSection"/>
+        <waitForElementVisible selector="{{AdminProductImagesSection.addVideoButton}}" stepKey="waitForAddVideoButtonVisible" time="30"/>
+        <click selector="{{AdminProductImagesSection.addVideoButton}}" stepKey="addVideo"/>
+        <waitForElementVisible selector=".modal-slide.mage-new-video-dialog.form-inline._show" stepKey="waitForUrlElementVisibleslide" time="30"/>
+        <waitForElementVisible selector="{{AdminProductNewVideoSection.videoUrlTextField}}" stepKey="waitForUrlElementVisible" time="60"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AssertAdminVideoValidationErrorActionGroup.xml
+++ b/app/code/Magento/ProductVideo/Test/Mftf/ActionGroup/AssertAdminVideoValidationErrorActionGroup.xml
@@ -8,7 +8,7 @@
 
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
-    <actionGroup name="AdminAssertVideoValidationErrorActionGroup">
+    <actionGroup name="AssertAdminVideoValidationErrorActionGroup">
         <arguments>
             <argument name="inputName" type="string"/>
             <argument name="errorMessage" type="string" defaultValue="This is a required field."/>

--- a/app/code/Magento/ProductVideo/Test/Mftf/Section/AdminProductNewVideoSection.xml
+++ b/app/code/Magento/ProductVideo/Test/Mftf/Section/AdminProductNewVideoSection.xml
@@ -12,6 +12,7 @@
         <element name="saveButton" type="button" selector=".action-primary.video-create-button" timeout="30"/>
         <element name="saveButtonDisabled" type="text" selector="//button[@class='action-primary video-create-button' and @disabled='disabled']"/>
         <element name="cancelButton" type="button" selector=".video-cancel-button" timeout="30"/>
+        <element name="getVideoInformationButton" type="button" selector="#new_video_get"/>
         <element name="videoUrlTextField" type="input" selector="#video_url"/>
         <element name="videoTitleTextField" type="input" selector="#video_title"/>
         <element name="videoDescriptionTextField" type="input" selector="#video_description"/>
@@ -20,5 +21,6 @@
         <element name="swatchCheckbox" type="checkbox" selector="#video_swatch_image"/>
         <element name="thumbnailCheckbox" type="checkbox" selector="#video_thumbnail"/>
         <element name="hideFromProductPageCheckbox" type="checkbox" selector="#new_video_disabled"/>
+        <element name="errorElement" type="text" selector="#{{inputName}}-error" parameterized="true" />
     </section>
 </sections>

--- a/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminValidateUrlOnGetVideoInformationTest.xml
+++ b/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminValidateUrlOnGetVideoInformationTest.xml
@@ -30,11 +30,13 @@
         </actionGroup>
         <actionGroup ref="AdminOpenProductVideoModalActionGroup" stepKey="openAddProductVideoModal"/>
         <actionGroup ref="AdminGetVideoInformationActionGroup" stepKey="clickOnGetVideoInformation"/>
-        <actionGroup ref="AdminAssertVideoValidationErrorActionGroup" stepKey="seeUrlValidationMessage">
+        <actionGroup ref="AssertAdminVideoValidationErrorActionGroup" stepKey="seeUrlValidationMessage">
             <argument name="inputName" value="video_url"/>
         </actionGroup>
-        <fillField selector="{{AdminProductNewVideoSection.videoUrlTextField}}"
-                   userInput="{{mftfTestProductVideo.videoUrl}}" stepKey="fillFieldVideoUrl"/>
+        <actionGroup ref="AdminFillProductVideoFieldActionGroup" stepKey="fillVideoUrlField">
+            <argument name="input" value="{{AdminProductNewVideoSection.videoUrlTextField}}"/>
+            <argument name="value" value="{{mftfTestProductVideo.videoUrl}}"/>
+        </actionGroup>
         <actionGroup ref="AdminGetVideoInformationActionGroup" stepKey="clickOnGetVideoInformation2"/>
         <actionGroup ref="AdminAssertVideoNoValidationErrorActionGroup" stepKey="dontSeeUrlValidationMessage">
             <argument name="inputName" value="video_url"/>

--- a/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminValidateUrlOnGetVideoInformationTest.xml
+++ b/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminValidateUrlOnGetVideoInformationTest.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminValidateUrlOnGetVideoInformationTest">
+        <annotations>
+            <stories value="Admin validates the url when getting video information"/>
+            <title value="Admin validates the url when getting video information"/>
+            <description value="Testing for a required video url when getting video information"/>
+            <severity value="CRITICAL"/>
+            <group value="ProductVideo"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+            <createData entity="ProductVideoYoutubeApiKeyConfig" stepKey="setStoreConfig"/>
+        </before>
+        <after>
+            <createData entity="DefaultProductVideoConfig" stepKey="setStoreDefaultConfig"/>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+        <actionGroup ref="AdminOpenProductIndexPageActionGroup" stepKey="navigateToProductIndexPage"/>
+        <actionGroup ref="goToCreateProductPage" stepKey="goToCreateProduct">
+            <argument name="product" value="SimpleProduct"/>
+        </actionGroup>
+        <actionGroup ref="AdminOpenProductVideoModalActionGroup" stepKey="openAddProductVideoModal"/>
+        <actionGroup ref="AdminGetVideoInformationActionGroup" stepKey="clickOnGetVideoInformation"/>
+        <actionGroup ref="AdminAssertVideoValidationErrorActionGroup" stepKey="seeUrlValidationMessage">
+            <argument name="inputName" value="video_url"/>
+        </actionGroup>
+        <fillField selector="{{AdminProductNewVideoSection.videoUrlTextField}}"
+                   userInput="{{mftfTestProductVideo.videoUrl}}" stepKey="fillFieldVideoUrl"/>
+        <actionGroup ref="AdminGetVideoInformationActionGroup" stepKey="clickOnGetVideoInformation2"/>
+        <actionGroup ref="AdminAssertVideoNoValidationErrorActionGroup" stepKey="dontSeeUrlValidationMessage">
+            <argument name="inputName" value="video_url"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/ProductVideo/view/adminhtml/web/js/new-video-dialog.js
+++ b/app/code/Magento/ProductVideo/view/adminhtml/web/js/new-video-dialog.js
@@ -283,6 +283,7 @@ define([
          */
         _onGetVideoInformationClick: function () {
             var videoForm = this.element.find(this._videoFormSelector);
+
             videoForm.validation();
 
             if (this.element.find(this._videoUrlSelector).valid()) {
@@ -304,8 +305,9 @@ define([
          * @private
          */
         _onGetVideoInformationStartRequest: function () {
+            var videoForm = this.element.find(this._videoFormSelector);
+
             try {
-                var videoForm = this.element.find(this._videoFormSelector);
                 videoForm.validation('clearError');
             } catch (e) {
                 // Do nothing

--- a/app/code/Magento/ProductVideo/view/adminhtml/web/js/new-video-dialog.js
+++ b/app/code/Magento/ProductVideo/view/adminhtml/web/js/new-video-dialog.js
@@ -282,9 +282,14 @@ define([
          * @private
          */
         _onGetVideoInformationClick: function () {
-            this._onlyVideoPlayer = false;
-            this._isEditPage = false;
-            this._videoUrlWidget.trigger('update_video_information');
+            var videoForm = this.element.find(this._videoFormSelector);
+            videoForm.validation();
+
+            if (this.element.find(this._videoUrlSelector).valid()) {
+                this._onlyVideoPlayer = false;
+                this._isEditPage = false;
+                this._videoUrlWidget.trigger('update_video_information');
+            }
         },
 
         /**
@@ -299,6 +304,13 @@ define([
          * @private
          */
         _onGetVideoInformationStartRequest: function () {
+            try {
+                var videoForm = this.element.find(this._videoFormSelector);
+                videoForm.validation('clearError');
+            } catch (e) {
+                // Do nothing
+            }
+
             this._videoRequestComplete = false;
         },
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR adds validation for getting the video information, after clicking on `Get Video Information` button.

### Fixed Issues (if relevant)

1. magento/magento2#25088: Get Video Information button doesn't do anything on clicked

### Manual testing scenarios (*)

1. Navigate to new product page
2. Scroll to Images And Videos
3. Click on Add Video
4. Click on Get Video Information

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
