### PR TITLE
[Shipping] Changing the tracking number confirmation modal style

### DIFF
--- a/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminDeleteTrackingNumberActionGroup.xml
+++ b/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminDeleteTrackingNumberActionGroup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminDeleteTrackingNumberActionGroup">
+        <arguments>
+            <argument name="message" type="string" defaultValue="Are you sure?"/>
+        </arguments>
+
+        <click selector="{{AdminShipmentTrackingSection.deleteTrackingNumber}}" stepKey="clickDeleteButton"/>
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+        <waitForElementVisible selector="{{AdminGridConfirmActionSection.message}}" stepKey="waitForConfirmModal"/>
+        <see selector="{{AdminGridConfirmActionSection.message}}" userInput="{{message}}" stepKey="seeRemoveMessage"/>
+        <click selector="{{AdminGridConfirmActionSection.ok}}" stepKey="clickOkButton"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Shipping/Test/Mftf/Section/AdminShipmentTrackingSection.xml
+++ b/app/code/Magento/Shipping/Test/Mftf/Section/AdminShipmentTrackingSection.xml
@@ -12,6 +12,7 @@
         <element name="trackingNumber" type="text" selector="#tracking-shipping-form #tracking_number"/>
         <element name="trackingTitle" type="text" selector="#tracking-shipping-form #tracking_title"/>
         <element name="addTrackingNumber" type="button" selector="#tracking-shipping-form button.save"/>
+        <element name="deleteTrackingNumber" type="button" selector="#tracking-shipping-form button.action-delete"/>
         <element name="trackingInfoErrorElement" type="text" selector="#tracking-shipping-form #{{inputName}}-error" parameterized="true" />
     </section>
 </sections>

--- a/app/code/Magento/Shipping/Test/Mftf/Test/AdminCheckTheConfirmationPopupTest.xml
+++ b/app/code/Magento/Shipping/Test/Mftf/Test/AdminCheckTheConfirmationPopupTest.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminCheckTheConfirmationPopupTest">
+        <annotations>
+            <stories value="Admin confirmation modal should be in Magento style"/>
+            <title value="Admin confirmation modal should be in Magento style"/>
+            <description value="Testing the confirmation modal for removing the tracking number"/>
+            <severity value="CRITICAL"/>
+            <group value="shipping"/>
+        </annotations>
+        <before>
+            <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
+            <createData entity="SimpleProduct2" stepKey="createSimpleProduct"/>
+            <actionGroup ref="LoginAsAdmin" stepKey="LoginAsAdmin"/>
+        </before>
+        <after>
+            <deleteData createDataKey="createCustomer" stepKey="deleteCustomer"/>
+            <deleteData createDataKey="createSimpleProduct" stepKey="deleteSimpleProduct"/>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+        <actionGroup ref="CreateOrderActionGroup" stepKey="goToCreateOrderPage">
+            <argument name="customer" value="$$createCustomer$$"/>
+            <argument name="product" value="$$createSimpleProduct$$"/>
+        </actionGroup>
+        <grabTextFrom selector="|Order # (\d+)|" stepKey="orderId"/>
+        <actionGroup ref="AdminShipThePendingOrderActionGroup" stepKey="createShipmentForOrder"/>
+        <actionGroup ref="FilterShipmentGridByOrderIdActionGroup" stepKey="filterForNewlyCreatedShipment">
+            <argument name="orderId" value="$orderId"/>
+        </actionGroup>
+        <actionGroup ref="AdminSelectFirstGridRowActionGroup" stepKey="selectShipmentFromGrid"/>
+        <actionGroup ref="AdminAddTrackingNumberToShipmentActionGroup" stepKey="addTrackingNumber">
+            <argument name="trackingNumber" value="123123"/>
+        </actionGroup>
+        <actionGroup ref="AdminDeleteTrackingNumberActionGroup" stepKey="deleteTrackingNumber"/>
+    </test>
+</tests>

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking/view.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking/view.phtml
@@ -73,7 +73,7 @@
 </div>
 
 <script>
-require(['prototype', 'jquery'], function(prototype, $j) {
+require(['prototype', 'jquery', 'Magento_Ui/js/modal/confirm'], function(prototype, $j, confirm) {
 //<![CDATA[
 function selectCarrier(elem) {
     var option = elem.options[elem.selectedIndex];
@@ -89,9 +89,17 @@ function saveTrackingInfo(node, url) {
 }
 
 function deleteTrackingNumber(url) {
-    if (confirm('<?= $block->escapeJs($block->escapeHtml(__('Are you sure?'))) ?>')) {
-        submitAndReloadArea($('shipment_tracking_info').parentNode, url)
-    }
+    confirm({
+        content: '<?= $block->escapeJs($block->escapeHtml(__('Are you sure?'))) ?>',
+        actions: {
+            /**
+             * Confirm action.
+             */
+            confirm: function () {
+                submitAndReloadArea($('shipment_tracking_info').parentNode, url);
+            }
+        }
+    });
 }
 
 window.selectCarrier = selectCarrier;


### PR DESCRIPTION

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR changes the delete confirmation type while removing the Tracking Number, by using the confirm widget instead the browser one.

### Fixed Issues (if relevant)

1. N/A

### Manual testing scenarios (*)
1. Create a new order
2. Create a shipment for that order
3. Navigate to the shipment
3. Add a new tracking carrier
4. Remove the tracking number

![image](https://user-images.githubusercontent.com/15868188/66921764-814d4f00-f02e-11e9-99b5-93da4e021737.png)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
