### PR TITLE
Fix phpdoc in ItemConverter.php

### DIFF
--- a/app/code/Magento/Quote/Model/Cart/Totals/ItemConverter.php
+++ b/app/code/Magento/Quote/Model/Cart/Totals/ItemConverter.php
@@ -71,7 +71,7 @@ class ItemConverter
      * Converts a specified rate model to a shipping method data object.
      *
      * @param \Magento\Quote\Model\Quote\Item $item
-     * @return \Magento\Quote\Model\Cart\Totals\Item
+     * @return \Magento\Quote\Api\Data\TotalsItemInterface
      * @throws \Exception
      */
     public function modelToDataObject($item)

--- a/app/code/Magento/Quote/Model/Cart/Totals/ItemConverter.php
+++ b/app/code/Magento/Quote/Model/Cart/Totals/ItemConverter.php
@@ -71,7 +71,7 @@ class ItemConverter
      * Converts a specified rate model to a shipping method data object.
      *
      * @param \Magento\Quote\Model\Quote\Item $item
-     * @return array
+     * @return \Magento\Quote\Model\Cart\Totals\Item
      * @throws \Exception
      */
     public function modelToDataObject($item)


### PR DESCRIPTION
### Description (*)
Method modelToDataObject in ItemConverter.php said it returns an array, but it actually returns an object of type \Magento\Quote\Model\Cart\Totals\Item.  Fixing the PHPDoc for the method.


### Fixed Issues (if relevant)


### Manual testing scenarios (*)


### Questions or comments


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds are green)
