### PR TITLE
Resolve "Collapse All | Expand All" in Media Gallery has wrong Cursor Icon issue25108

### DIFF
--- a/app/code/Magento/Cms/Block/Adminhtml/Wysiwyg/Images/Content.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Wysiwyg/Images/Content.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Cms\Block\Adminhtml\Wysiwyg\Images;
 
 /**
@@ -45,8 +47,12 @@ class Content extends \Magento\Backend\Block\Widget\Container
         $this->buttonList->remove('edit');
         $this->buttonList->add(
             'cancel',
-            ['class' => 'cancel  action-quaternary', 'label' => __('Cancel'), 'type' => 'button',
-                'onclick' => 'MediabrowserUtility.closeDialog();'],
+            [
+                'class' => 'cancel action-quaternary',
+                'label' => __('Cancel'),
+                'type' => 'button',
+                'onclick' => 'MediabrowserUtility.closeDialog();'
+            ],
             0,
             0,
             'header'
@@ -54,7 +60,11 @@ class Content extends \Magento\Backend\Block\Widget\Container
 
         $this->buttonList->add(
             'delete_folder',
-            ['class' => 'delete no-display action-quaternary', 'label' => __('Delete Folder'), 'type' => 'button'],
+            [
+                'class' => 'delete no-display action-quaternary',
+                'label' => __('Delete Folder'),
+                'type' => 'button'
+            ],
             0,
             0,
             'header'
@@ -62,7 +72,11 @@ class Content extends \Magento\Backend\Block\Widget\Container
 
         $this->buttonList->add(
             'delete_files',
-            ['class' => 'delete no-display action-quaternary', 'label' => __('Delete Selected'), 'type' => 'button'],
+            [
+                'class' => 'delete no-display action-quaternary',
+                'label' => __('Delete Selected'),
+                'type' => 'button'
+            ],
             0,
             0,
             'header'
@@ -70,7 +84,11 @@ class Content extends \Magento\Backend\Block\Widget\Container
 
         $this->buttonList->add(
             'new_folder',
-            ['class' => 'save', 'label' => __('Create Folder'), 'type' => 'button'],
+            [
+                'class' => 'save new_folder',
+                'label' => __('Create Folder'),
+                'type' => 'button'
+            ],
             0,
             0,
             'header'
@@ -78,7 +96,11 @@ class Content extends \Magento\Backend\Block\Widget\Container
 
         $this->buttonList->add(
             'insert_files',
-            ['class' => 'save no-display action-primary', 'label' => __('Add Selected'), 'type' => 'button'],
+            [
+                'class' => 'save no-display action-primary',
+                'label' => __('Add Selected'),
+                'type' => 'button'
+            ],
             0,
             0,
             'header'
@@ -92,9 +114,7 @@ class Content extends \Magento\Backend\Block\Widget\Container
      */
     public function getContentsUrl()
     {
-        return $this->getUrl('cms/*/contents', [
-            'type' => $this->getRequest()->getParam('type'),
-        ]);
+        return $this->getUrl('cms/*/contents', ['type' => $this->getRequest()->getParam('type')]);
     }
 
     /**

--- a/app/code/Magento/Cms/view/adminhtml/web/css/source/_module.less
+++ b/app/code/Magento/Cms/view/adminhtml/web/css/source/_module.less
@@ -3,13 +3,20 @@
  * See COPYING.txt for license details.
  */
 .modal-slide {
-  .media-gallery-modal {
-    .page-main-actions {
-      margin-bottom: 3rem;
-    }
+    .media-gallery-modal {
+        .page-main-actions {
+            margin-bottom: 3rem;
+        }
 
-    #new_folder {
-      margin-right: 10px;
+        .new_folder {
+            margin-right: 10px;
+        }
     }
-  }
 }
+
+.tree-actions {
+    a {
+        cursor: pointer;
+    }
+}
+


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. Resolve magento/magento2#25108: "Collapse All | Expand All" in Media Gallery has wrong Cursor Icon

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25108: "Collapse All | Expand All" in Media Gallery has wrong Cursor Icon

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Backend
2. Catalog->Category
3. Click "Content"
4. Click "Select from Gallery"
5. Hover to "Collapse All | Expand All"

#### Expected result
<!--- Tell us what do you expect to happen. -->
1. Cursor icon is "Pointer" 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
