### PR TITLE
["Save in New Attribute Set"] : Form should be validated before prompt the popup

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAssertProductEditPageCreateAttributeSaveInAttributeSetPopUpShownActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminAssertProductEditPageCreateAttributeSaveInAttributeSetPopUpShownActionGroup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+
+    <actionGroup name="AdminAssertProductEditPageCreateAttributeSaveInAttributeSetPopUpShownActionGroup">
+        <annotations>
+            <description>Asserts that after click on "Save In New Attribute Set" poup shown  .</description>
+        </annotations>
+        <see userInput="Enter Name for New Attribute Set" stepKey="seeContent"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminClickAddAttributeOnProductEditPageActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminClickAddAttributeOnProductEditPageActionGroup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+
+    <actionGroup name="AdminClickAddAttributeOnProductEditPageActionGroup">
+        <annotations>
+            <description>Clicks on 'Add Attribute'.  Admin Product creation/edit page .</description>
+        </annotations>
+        <click selector="{{AdminProductFormSection.addAttributeBtn}}" stepKey="clickAddAttributeBtn"/>
+        <waitForPageLoad stepKey="waitForSidePanel"/>
+        <see userInput="Select Attribute" stepKey="checkNewAttributePopUpAppeared"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminClickCreateNewAttributeFromProductEditPageActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminClickCreateNewAttributeFromProductEditPageActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+
+    <actionGroup name="AdminClickCreateNewAttributeFromProductEditPageActionGroup">
+        <annotations>
+            <description>Clicks on 'Create New Attribute'.  Admin Product creation/edit page .</description>
+        </annotations>
+        <click selector="{{AdminProductFormAttributeSection.createNewAttribute}}" stepKey="clickCreateNewAttribute"/>
+        <waitForPageLoad stepKey="waitForSidePanel"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminFillAttributeDataProductFormNewAttributeActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminFillAttributeDataProductFormNewAttributeActionGroup.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+
+    <actionGroup name="AdminFillAttributeDataProductFormNewAttributeActionGroup">
+        <arguments>
+            <argument name="attributeName" type="string"  defaultValue="TestAttributeName"/>
+            <argument name="attributeType" type="string" defaultValue="Text Field"/>
+        </arguments>
+        <annotations>
+            <description>Fill attribute data on 'Create New Attribute' page  Admin Product creation/edit page .</description>
+        </annotations>
+        <fillField selector="{{AdminProductFormNewAttributeSection.attributeLabel}}" userInput="{{attributeName}}"
+                   stepKey="fillAttributeLabel"/>
+        <selectOption selector="{{AdminProductFormNewAttributeSection.attributeType}}" userInput="{{attributeType}}"
+                      stepKey="selectAttributeType"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateNewAttributeFromProductPageTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateNewAttributeFromProductPageTest.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminCreateNewAttributeFromProductPageTest">
+        <annotations>
+            <features value="Catalog"/>
+            <stories value="We should validate the form when the user click Save in New Attribute Set"/>
+            <title value="We should validate the form when the user click Save in New Attribute Set"/>
+            <description
+                    value="Admin should be able to create product attribute and validate the form when the user click Save in New Attribute Set"/>
+            <testCaseId value="https://github.com/magento/magento2/pull/25132"/>
+            <severity value="CRITICAL"/>
+            <group value="Catalog"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+
+        <actionGroup ref="GoToProductCatalogPage" stepKey="goToProductCatalogPage"/>
+        <actionGroup ref="goToCreateProductPage" stepKey="goToCreateProduct">
+            <argument name="product" value="SimpleProduct"/>
+        </actionGroup>
+        <actionGroup ref="AdminClickAddAttributeOnProductEditPageActionGroup" stepKey="clickAddAttribute"/>
+        <actionGroup ref="AdminClickCreateNewAttributeFromProductEditPageActionGroup" stepKey="clickCreateNewAttribute1" />
+        <actionGroup ref="AdminFillAttributeDataProductFormNewAttributeActionGroup" stepKey="fillAttributeData" />
+
+        <click selector="{{AdminProductFormNewAttributeSection.saveInNewSet}}" stepKey="saveAttributeInSet"/>
+        <actionGroup ref="AdminAssertProductEditPageCreateAttributeSaveInAttributeSetPopUpShownActionGroup" stepKey="assertPopUp"/>
+        <click selector="{{ModalConfirmationSection.CancelButton}}" stepKey="cancelButton"/>
+
+        <actionGroup ref="AdminFillAttributeDataProductFormNewAttributeActionGroup" stepKey="emptyAttributeData" >
+            <argument name="attributeName" value=" "/>
+            <argument name="attributeType" value=" "/>
+        </actionGroup>
+
+        <click selector="{{AdminProductFormNewAttributeSection.saveInNewSet}}" stepKey="clickSaveInSet"/>
+        <see userInput="This is a required field." stepKey="seeThisIsRequiredField"/>
+        <dontSee userInput="Enter Name for New Attribute Set" stepKey="dontSeePopUp" />
+
+    </test>
+</tests>

--- a/app/code/Magento/Catalog/view/adminhtml/web/js/components/new-attribute-form.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/components/new-attribute-form.js
@@ -41,42 +41,46 @@ define([
         saveAttributeInNewSet: function () {
 
             var self = this;
+            this.validate();
+            if (!this.additionalInvalid && !this.source.get('params.invalid')) {
+                prompt({
+                    content: this.newSetPromptMessage,
+                    actions: {
 
-            prompt({
-                content: this.newSetPromptMessage,
-                actions: {
+                        /**
+                         * @param {String} val
+                         * @this {actions}
+                         */
+                        confirm: function (val) {
+                            var rules = ['required-entry', 'validate-no-html-tags'],
+                                editForm = self,
+                                newAttributeSetName = val,
+                                i,
+                                params = {};
 
-                    /**
-                     * @param {String} val
-                     * @this {actions}
-                     */
-                    confirm: function (val) {
-                        var rules = ['required-entry', 'validate-no-html-tags'],
-                            editForm = self,
-                            newAttributeSetName = val,
-                            i,
-                            params = {};
-
-                        if (!newAttributeSetName) {
-                            return;
-                        }
-
-                        for (i = 0; i < rules.length; i++) {
-                            if (!$.validator.methods[rules[i]](newAttributeSetName)) {
-                                alert({
-                                    content: $.validator.messages[rules[i]]
-                                });
-
+                            if (!newAttributeSetName) {
                                 return;
                             }
-                        }
 
-                        params['new_attribute_set_name'] = newAttributeSetName;
-                        editForm.setAdditionalData(params);
-                        editForm.save();
+                            for (i = 0; i < rules.length; i++) {
+                                if (!$.validator.methods[rules[i]](newAttributeSetName)) {
+                                    alert({
+                                        content: $.validator.messages[rules[i]]
+                                    });
+
+                                    return;
+                                }
+                            }
+
+                            params['new_attribute_set_name'] = newAttributeSetName;
+                            editForm.setAdditionalData(params);
+                            editForm.save();
+                        }
                     }
-                }
-            });
+                });
+            } else {
+                this.focusInvalid();
+            }
         }
     });
 });

--- a/app/code/Magento/Catalog/view/adminhtml/web/js/components/new-attribute-form.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/components/new-attribute-form.js
@@ -41,6 +41,7 @@ define([
         saveAttributeInNewSet: function () {
 
             var self = this;
+
             this.validate();
             if (!this.additionalInvalid && !this.source.get('params.invalid')) {
                 prompt({

--- a/app/code/Magento/Catalog/view/adminhtml/web/js/components/new-attribute-form.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/components/new-attribute-form.js
@@ -9,7 +9,6 @@ define([
     'Magento_Ui/js/modal/prompt',
     'Magento_Ui/js/modal/alert'
 ], function ($, Form, prompt, alert) {
-    'use strict';
 
     return Form.extend({
         defaults: {

--- a/app/code/Magento/Catalog/view/adminhtml/web/js/components/new-attribute-form.js
+++ b/app/code/Magento/Catalog/view/adminhtml/web/js/components/new-attribute-form.js
@@ -9,6 +9,7 @@ define([
     'Magento_Ui/js/modal/prompt',
     'Magento_Ui/js/modal/alert'
 ], function ($, Form, prompt, alert) {
+    'use strict';
 
     return Form.extend({
         defaults: {
@@ -42,6 +43,7 @@ define([
             var self = this;
 
             this.validate();
+
             if (!this.additionalInvalid && !this.source.get('params.invalid')) {
                 prompt({
                     content: this.newSetPromptMessage,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
- In backend
- Go to create New Product form
- Add Attribute
- Create New Attribute
- "Save in New Attribute Set" without fill " Attribute Label"

We should validate the form when the user click "Save in New Attribute Set". Currently, the popup "Enter Name for New Attribute Set" is shown, and after the user fill the name and click ok, it validates => waste time for the user. We can save it by validate before the popup is shown.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
- In backend
- Go to create New Product form
- Add Attribute
- Create New Attribute
- "Save in New Attribute Set" without fill " Attribute Label"
=> The form is validated 
If the user fill  "Attribute Label", it will show the popup

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
