### PR TITLE
Fixes #25120 stores the attribute url_path for non-default Stores

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Observer/CategoryUrlPathAutogeneratorObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/CategoryUrlPathAutogeneratorObserver.php
@@ -94,7 +94,7 @@ class CategoryUrlPathAutogeneratorObserver implements ObserverInterface
             $resultUrlKey = $this->categoryUrlPathGenerator->getUrlKey($category);
             $this->updateUrlKey($category, $resultUrlKey);
         } elseif ($useDefaultAttribute) {
-            if (!$category->isObjectNew()) {
+            if (!$category->isObjectNew() && $category->getStoreId() === Store::DEFAULT_STORE_ID) {
                 $resultUrlKey = $category->formatUrlKey($category->getOrigData('name'));
                 $this->updateUrlKey($category, $resultUrlKey);
             }

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryUrlPathAutogeneratorObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryUrlPathAutogeneratorObserverTest.php
@@ -159,6 +159,9 @@ class CategoryUrlPathAutogeneratorObserverTest extends \PHPUnit\Framework\TestCa
         $this->expectExceptionMessage('Invalid URL key');
         $categoryData = ['use_default' => ['url_key' => $useDefaultUrlKey], 'url_key' => '', 'url_path' => ''];
         $this->category->setData($categoryData);
+        $this->category
+            ->method('getStoreId')
+            ->willReturn(\Magento\Store\Model\Store::DEFAULT_STORE_ID);
         $this->category->isObjectNew($isObjectNew);
         $this->assertEquals($isObjectNew, $this->category->isObjectNew());
         $this->assertEquals($categoryData['url_key'], $this->category->getUrlKey());

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/CategoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/CategoryTest.php
@@ -15,8 +15,8 @@ use Magento\Framework\App\Request\Http as HttpRequest;
 use Magento\Framework\Message\MessageInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Store\Api\StoreRepositoryInterface;
-use Magento\TestFramework\TestCase\AbstractBackendController;
 use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\TestCase\AbstractBackendController;
 
 /**
  * Test for category backend actions
@@ -63,6 +63,7 @@ class CategoryTest extends AbstractBackendController
      * @param array $defaultAttributes
      * @param array $attributesSaved
      * @return void
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function testSaveAction(array $inputData, array $defaultAttributes, array $attributesSaved = []): void
     {
@@ -107,6 +108,8 @@ class CategoryTest extends AbstractBackendController
      * @magentoDbIsolation enabled
      * @magentoDataFixture Magento/CatalogUrlRewrite/_files/categories.php
      * @return void
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function testDefaultValueForCategoryUrlPath(): void
     {
@@ -125,11 +128,12 @@ class CategoryTest extends AbstractBackendController
         // set default url_path and check it
         $this->getRequest()->setMethod(HttpRequest::METHOD_POST);
         $postData = $category->getData();
-        $postData['use_default'] = [
-            'available_sort_by' => 1,
-            'default_sort_by' => 1,
-            'url_key' => 1,
-        ];
+        $postData['use_default'] =
+            [
+                'available_sort_by' => 1,
+                'default_sort_by' => 1,
+                'url_key' => 1,
+            ];
         $this->getRequest()->setPostValue($postData);
         $this->dispatch('backend/catalog/category/save');
         $this->assertSessionMessages(
@@ -137,7 +141,7 @@ class CategoryTest extends AbstractBackendController
             MessageInterface::TYPE_SUCCESS
         );
         $category = $this->categoryRepository->get($categoryId);
-        $this->assertEquals($defaultUrlPath, $category->getData('url_path'));
+        $this->assertEquals($defaultUrlPath, $category->getData('url_key'));
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fix for issue 25120
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25120: Magento2 incorrectly stores the attribute url_path for non-default Stores

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create second store view.
2. Go to categories and switch to a second store view.
3. Change the name of a child category (Root -> 1st Parent -> 1st Child -> 1st Grandchild) for that store view only (url_key still same as others). For example, change the name for category "1st Child" to "1st Child second store view".
4. Check attribute url_path in table ''catalog_category_entity_varchar'.
5. Attribute url_path should now be stored correctly.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
