### PR TITLE
Removed box-shadow on clicking disabled swatch option

### DIFF
--- a/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/frontend/web/js/swatch-renderer.js
@@ -840,7 +840,10 @@ define([
          */
         _Rewind: function (controls) {
             controls.find('div[option-id], option[option-id]').removeClass('disabled').removeAttr('disabled');
-            controls.find('div[option-empty], option[option-empty]').attr('disabled', true).addClass('disabled');
+            controls.find('div[option-empty], option[option-empty]')
+                .attr('disabled', true)
+                .addClass('disabled')
+                .attr('tabindex', '-1');
         },
 
         /**

--- a/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
@@ -120,7 +120,7 @@
                     &.selected {
                         .lib-css(background, @attr-swatch-option__selected__background);
                         .lib-css(border, @attr-swatch-option__selected__border);
-                        .lib-css(color, @attr-swatch-option__selected__color);  
+                        .lib-css(color, @attr-swatch-option__selected__color);
                     }
                 }
             }
@@ -180,7 +180,9 @@
             }
 
             &.disabled {
+                box-shadow: unset;
                 cursor: default;
+                pointer-events: none;
 
                 &:after {
                     //  ToDo: improve .lib-background-gradient() to support diagonal gradient


### PR DESCRIPTION
### Description
Disabled product swatch option (out of stock) should not display a box-shadow on click

### Fixed Issues
1. magento/magento2#25144: Disabled swatch option shouldn't show box-shadow on click

### Manual testing scenarios
1. Login to Admin panel
2. Navigate to Stores -> Catalog -> Inventory
3. Change _Display Out of Stock Products_ dropdown to _Yes_
4. Navigate to Stores -> Attributes -> Product
5. Edit `color` attribute's _Catalog Input Type for Store Owner_ to _Visual Swatch_
6. Add multiple swatches with colors
7. Create a new configurable product
8. Click _Create Configurations_
9. Choose `color` and click _Next_
10. Select the created attribute values and click _Next_
11. Provide positive quantities for swatches except, set 0 for one swatch, and click _Next_
12. Click _Generate Products_
13. Save product and choose _Add configurable attributes to the current Attribute Set_ in the popup
14. Flush the cache, and navigate to the product in Storefront
15. Click the disabled swatch

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
