### PR TITLE
Resolved Issue #25135

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Sales/web/css/source/module/_order.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Sales/web/css/source/module/_order.less
@@ -327,4 +327,43 @@
     }
 }
 
+//
+//  Create Order - Add Product with Custom Options Modal
+//  ----------------------------------------------------
+
+#product_composite_configure_form_fields {
+    .admin__field {
+        &.required {
+            .admin__field-label {
+                &:after {
+                    color: #e22626;
+                    content: '*';
+                    display: inline-block;
+                    font-size: 1.6rem;
+                    font-weight: 500;
+                    line-height: 1;
+                    margin-left: 10px;
+                    margin-top: .2rem;
+                    position: absolute;
+                    z-index: 1;
+                }
+            }
+            .price-container, .price-notice, .price-wrapper {
+                &:after {
+                    color: unset;
+                    content: unset;
+                    display: unset;
+                    font-size: unset;
+                    font-weight: unset;
+                    line-height: unset;
+                    margin-left: unset;
+                    margin-top: unset;
+                    position: unset;
+                    z-index: unset;
+                }
+            }
+        }
+    }
+}
+
 //  ToDo: MAGETWO-32299 UI: review the collapsible block


### PR DESCRIPTION
### Description
This PR resolves the below mentioned issue of duplicate asterisks indicating a single required field. This happens only when price is set for a custom option in the product. This has been resolved by unsetting the styles rendering the asterisk for the price fields and setting a single style rendering the asterisk for the label field.

### Fixed Issues
1. magento/magento2#25135: [UI Issue] when select Product with custom option (datetime) at backend

### Manual testing scenarios (from issue)
1. Go to backend
2. Create New Product with Custom Option (date time and required it)
3. Create New Order at backend
4. Add Product with custom option

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
