### PR TITLE
Corrects the list of regions in Belgium + an introduction to the complex Belgium geographical regions

### DIFF
--- a/app/code/Magento/Directory/Setup/Patch/Data/AddDataForBelgium.php
+++ b/app/code/Magento/Directory/Setup/Patch/Data/AddDataForBelgium.php
@@ -60,17 +60,15 @@ class AddDataForBelgium implements DataPatchInterface
         return [
             ['BE', 'VAN', 'Antwerpen'],
             ['BE', 'WBR', 'Brabant wallon'],
-            ['BE', 'BRU', 'Brussels Hoofdstedelijk Gewest'],
+            ['BE', 'BRU', 'Brussels-Capital Region'],
             ['BE', 'WHT', 'Hainaut'],
             ['BE', 'VLI', 'Limburg'],
-            ['BE', 'WLG', 'Liege'],
+            ['BE', 'WLG', 'Liège'],
             ['BE', 'WLX', 'Luxembourg'],
             ['BE', 'WNA', 'Namur'],
             ['BE', 'VOV', 'Oost-Vlaanderen'],
-            ['BE', 'VLG', 'Vlaams Gewest'],
             ['BE', 'VBR', 'Vlaams-Brabant'],
             ['BE', 'VWV', 'West-Vlaanderen'],
-            ['BE', 'WAL', 'Wallonne, Region']
         ];
     }
 


### PR DESCRIPTION
### Description (*)
Very recently [a new commit](https://github.com/magento/magento2/commit/5cd7496e76773f953ffcad102aa3111d4d4747d6) was added to `2.3-develop` introducing the Belgian regions in scope of MC-20346.

I believe there are some mistakes in those regions and as a Belgian citizen I can probably claim I know maybe a little bit more about these regions then the one implementing them originally.

Fixes:
- Changed province name "Liege" to "Liège" which is the correct French naming
- Changed "Brussels Hoofdstedelijk Gewest" to "Brussels-Capital Region" because Brussels is officially bilingual (Dutch & French) and "Brussels Hoofdstedelijk Gewest" is the Dutch name which the French-speaking population might not appreciate, so I've chose the English name instead
- Removed "Vlaams Gewest" and "Wallonne, Region" because those are bigger regions spanning multiple provinces and make no sense to have in the regions list

Coincidentally, I was filling in a form today on Kickstarter to have something shipped to me and over there, the region list for Belgium was rendered like this:
<img width="1122" alt="Screenshot 2019-10-19 at 15 01 09" src="https://user-images.githubusercontent.com/85479/67146112-de900d00-f287-11e9-8e5d-420c4b8ae3b0.png">

Which is exactly the same list like I'm proposing here (except for the capital letter 'W' in 'Brabant Wallon', but according to [wikipedia](https://fr.wikipedia.org/wiki/Province_du_Brabant_wallon) it should be without a capital letter).

Question: since https://github.com/magento/magento2/commit/5cd7496e76773f953ffcad102aa3111d4d4747d6 isn't part of a Magento release yet, is it ok to change the region list like this without creating a new Patch? If both the original commit + this PR gets released in Magento 2.3.4, all should be fine in the database.

### Intro to Belgians complex region system

- There are [10 official provinces in Belgium](https://en.wikipedia.org/wiki/Provinces_of_Belgium), in 5 of them the main language spoken is Dutch, in the other 5, the main language spoken is French, and in one of those 5 French provinces (Liège), there is a small German speaking minority.
- Brussels - while geographically [surrounded by the Dutch province Vlaams-Brabant](https://en.wikipedia.org/wiki/Flemish_Brabant) - is not part of any province, it's basically a separate entity which isn't a province by itself and also not part of a province.
- We have a [Flemish and Walloon region](https://en.wikipedia.org/wiki/Communities,_regions_and_language_areas_of_Belgium), which each consists of the 5 provinces, and the Brussels region also exists, which solely consists of the city Brussels
- We then also have the Flemish, French and German communities which are also different regions/entities but aren't important here.

### Fixed Issues (if relevant)
Not relevant

### Manual testing scenarios (*)
1. In the backend of Magento, go to Stores > Configuration > General > Store Information
2. Select Country Belgium
3. Make sure you only see 11 regions instead of 13

### Questions or comments
I wonder if somebody with insight to MC-20346 ticket can tell me where the source of the original regions came from, because they don't look quite right to me.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
