### PR TITLE
Optimize config data traversal in Store/Config/Placeholder

### DIFF
--- a/app/code/Magento/Store/Model/Config/Placeholder.php
+++ b/app/code/Magento/Store/Model/Config/Placeholder.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Store\Model\Config;
 
 /**
@@ -32,8 +33,8 @@ class Placeholder
      */
     public function __construct(\Magento\Framework\App\RequestInterface $request, $urlPaths, $urlPlaceholder)
     {
-        $this->request = $request;
-        $this->urlPaths = $urlPaths;
+        $this->request        = $request;
+        $this->urlPaths       = $urlPaths;
         $this->urlPlaceholder = $urlPlaceholder;
     }
 
@@ -45,14 +46,45 @@ class Placeholder
      */
     public function process(array $data = [])
     {
-        foreach (array_keys($data) as $key) {
-            $this->_processData($data, $key);
+        // check provided arguments
+        if (empty($data)) {
+            return [];
         }
+
+        // initialize $pointer, $parents and $level variable
+        reset($data);
+        $pointer = &$data;
+        $parents = [];
+        $level   = 0;
+
+        while ($level >= 0) {
+            $current = &$pointer[key($pointer)];
+            if (is_array($current)) {
+                reset($current);
+                $parents[$level] = &$pointer;
+                $pointer         = &$current;
+                $level++;
+            } else {
+                $current = $this->_processPlaceholders($current, $data);
+
+                // move pointer of last queue layer to next element
+                // or remove layer if all path elements were processed
+                while ($level >= 0 && next($pointer) === false) {
+                    $level--;
+                    // removal of last element of $parents is skipped here for better performance
+                    // on next iteration that element will be overridden
+                    $pointer = &$parents[$level];
+                }
+            }
+        }
+
         return $data;
     }
 
     /**
      * Process array data recursively
+     *
+     * @deprecated This method isn't used in process() implementation anymore
      *
      * @param array &$data
      * @param string $path
@@ -90,7 +122,7 @@ class Placeholder
 
             if ($url) {
                 $value = str_replace('{{' . $placeholder . '}}', $url, $value);
-            } elseif (strpos($value, (string) $this->urlPlaceholder) !== false) {
+            } elseif (strpos($value, (string)$this->urlPlaceholder) !== false) {
                 $distroBaseUrl = $this->request->getDistroBaseUrl();
 
                 $value = str_replace($this->urlPlaceholder, $distroBaseUrl, $value);
@@ -113,10 +145,9 @@ class Placeholder
     {
         if (is_string($value) && preg_match('/{{(.*)}}.*/', $value, $matches)) {
             $placeholder = $matches[1];
-            if ($placeholder == 'unsecure_base_url' || $placeholder == 'secure_base_url' || strpos(
-                $value,
-                (string) $this->urlPlaceholder
-            ) !== false
+            if ($placeholder == 'unsecure_base_url' ||
+                $placeholder == 'secure_base_url' ||
+                strpos($value, (string)$this->urlPlaceholder) !== false
             ) {
                 return $placeholder;
             }
@@ -147,6 +178,8 @@ class Placeholder
     /**
      * Set array value by path
      *
+     * @deprecated This method isn't used in process() implementation anymore
+     *
      * @param array &$container
      * @param string $path
      * @param string $value
@@ -154,13 +187,13 @@ class Placeholder
      */
     protected function _setValue(array &$container, $path, $value)
     {
-        $segments = explode('/', $path);
-        $currentPointer = & $container;
+        $segments       = explode('/', $path);
+        $currentPointer = &$container;
         foreach ($segments as $segment) {
             if (!isset($currentPointer[$segment])) {
                 $currentPointer[$segment] = [];
             }
-            $currentPointer = & $currentPointer[$segment];
+            $currentPointer = &$currentPointer[$segment];
         }
         $currentPointer = $value;
     }

--- a/app/code/Magento/Store/Test/Unit/Model/Config/PlaceholderTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/Config/PlaceholderTest.php
@@ -23,7 +23,7 @@ class PlaceholderTest extends \PHPUnit\Framework\TestCase
     {
         $this->_requestMock = $this->createMock(\Magento\Framework\App\Request\Http::class);
         $this->_requestMock->expects(
-            $this->once()
+            $this->any()
         )->method(
             'getDistroBaseUrl'
         )->will(
@@ -54,11 +54,27 @@ class PlaceholderTest extends \PHPUnit\Framework\TestCase
             ],
             'path' => 'value',
             'some_url' => '{{base_url}}some',
+            'level1' => [
+                'level2' => [
+                    'level3' => [
+                        // test that all levels are processed (i.e. implementation is not hardcoded to 3 levels)
+                        'level4' => '{{secure_base_url}}level4'
+                    ]
+                ]
+            ]
         ];
         $expectedResult = $data;
         $expectedResult['web']['unsecure']['base_link_url'] = 'http://localhost/website/de';
         $expectedResult['web']['secure']['base_link_url'] = 'https://localhost/website/de';
+        $expectedResult['level1']['level2']['level3']['level4'] = 'https://localhost/level4';
         $expectedResult['some_url'] = 'http://localhost/some';
+        $this->assertEquals($expectedResult, $this->_model->process($data));
+    }
+
+    public function testProcessEmptyArray()
+    {
+        $data = [];
+        $expectedResult = [];
         $this->assertEquals($expectedResult, $this->_model->process($data));
     }
 }


### PR DESCRIPTION
### Description (*)
Optimizations:
 - get rid of a lot of string concatenation and then explode()
 - replace recursion with iterative algorithm to avoid data copying via parameters
 - utilize builtin array iterator functionality to avoid creation of additional variables
 - read/set data directly to current $data item, skip loops in _getData() and _setData()

My benchmarks for method process() on empty Magento cache have shown reduction in total time spent from 0.291 sec to 0.077 sec (-73%)
Tests were done on PHP 7.2 inside docker, XDebug=Off

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
General regression testing

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
