### PR TITLE
Issue/25057

### DIFF
--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -453,7 +453,6 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
             self::XML_PATH_CONFIRMATION_FLAG,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         ) == 1 ? true : false;
-
         $isSubscribeOwnEmail = $this->_customerSession->isLoggedIn()
             && $this->_customerSession->getCustomerDataObject()->getEmail() == $email;
 
@@ -471,6 +470,8 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
         if ($isSubscribeOwnEmail) {
             try {
                 $customer = $this->customerRepository->getById($this->_customerSession->getCustomerId());
+                $this->setCustomerFirstName($customer->getFirstname());
+                $this->setCustomerLastName($customer->getLastname());
                 $this->setStoreId($customer->getStoreId());
                 $this->setCustomerId($customer->getId());
             } catch (NoSuchEntityException $e) {

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -453,6 +453,7 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
             self::XML_PATH_CONFIRMATION_FLAG,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         ) == 1 ? true : false;
+
         $isSubscribeOwnEmail = $this->_customerSession->isLoggedIn()
             && $this->_customerSession->getCustomerDataObject()->getEmail() == $email;
 

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -471,8 +471,6 @@ class Subscriber extends \Magento\Framework\Model\AbstractModel
         if ($isSubscribeOwnEmail) {
             try {
                 $customer = $this->customerRepository->getById($this->_customerSession->getCustomerId());
-                $this->setCustomerFirstName($customer->getFirstname());
-                $this->setCustomerLastName($customer->getLastname());
                 $this->setStoreId($customer->getStoreId());
                 $this->setCustomerId($customer->getId());
             } catch (NoSuchEntityException $e) {

--- a/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_subscriber_block.xml
+++ b/app/code/Magento/Newsletter/view/adminhtml/layout/newsletter_subscriber_block.xml
@@ -90,7 +90,6 @@
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Customer First Name</argument>
                             <argument name="index" xsi:type="string">firstname</argument>
-                            <argument name="default" xsi:type="string">----</argument>
                             <argument name="header_css_class" xsi:type="string">col-first-name</argument>
                             <argument name="column_css_class" xsi:type="string">col-first-name</argument>
                         </arguments>
@@ -99,7 +98,6 @@
                         <arguments>
                             <argument name="header" xsi:type="string" translate="true">Customer Last Name</argument>
                             <argument name="index" xsi:type="string">lastname</argument>
-                            <argument name="default" xsi:type="string">----</argument>
                             <argument name="header_css_class" xsi:type="string">col-last-name</argument>
                             <argument name="column_css_class" xsi:type="string">col-last-name</argument>
                         </arguments>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
<!--- Please provide a general summary of the Pull Request in the Title above -->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
"Customer First Name" and "Customer Last Name" should display empty instead of "----" in Newsletter Subscribers for logged in users
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25057:"Customer First Name" and "Customer Last Name" should display empty instead of "----" in Newsletter Subscribers
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.subscribed for news letter subscription as logged in user as well as guest
2. ...
### Questions or comments
<!---
    If relevant, here you can ask questions or provide comments on your pull request for the reviewer
    For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)