### PR TITLE
Fix for Mysql MessageQueue

### DIFF
--- a/app/code/Magento/MysqlMq/Model/Driver/Bulk/Exchange.php
+++ b/app/code/Magento/MysqlMq/Model/Driver/Bulk/Exchange.php
@@ -3,10 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\MysqlMq\Model\Driver\Bulk;
 
 use Magento\Framework\MessageQueue\Bulk\ExchangeInterface;
-use Magento\Framework\MessageQueue\ConfigInterface as MessageQueueConfig;
+use Magento\Framework\MessageQueue\Topology\ConfigInterface as MessageQueueConfig;
+use Magento\MysqlMq\Model\ConnectionTypeResolver;
 use Magento\MysqlMq\Model\QueueManagement;
 
 /**
@@ -14,6 +16,10 @@ use Magento\MysqlMq\Model\QueueManagement;
  */
 class Exchange implements ExchangeInterface
 {
+    /**
+     * @var ConnectionTypeResolver
+     */
+    protected $connectionTypeResolver;
     /**
      * @var MessageQueueConfig
      */
@@ -27,13 +33,18 @@ class Exchange implements ExchangeInterface
     /**
      * Initialize dependencies.
      *
+     * @param ConnectionTypeResolver $connectionTypeResolver
      * @param MessageQueueConfig $messageQueueConfig
      * @param QueueManagement $queueManagement
      */
-    public function __construct(MessageQueueConfig $messageQueueConfig, QueueManagement $queueManagement)
-    {
+    public function __construct(
+        ConnectionTypeResolver $connectionTypeResolver,
+        MessageQueueConfig $messageQueueConfig,
+        QueueManagement $queueManagement
+    ) {
         $this->messageQueueConfig = $messageQueueConfig;
         $this->queueManagement = $queueManagement;
+        $this->connectionTypeResolver = $connectionTypeResolver;
     }
 
     /**
@@ -41,7 +52,20 @@ class Exchange implements ExchangeInterface
      */
     public function enqueue($topic, array $envelopes)
     {
-        $queueNames = $this->messageQueueConfig->getQueuesByTopic($topic);
+        $queueNames = [];
+        $exchanges = $this->messageQueueConfig->getExchanges();
+        foreach ($exchanges as $exchange) {
+            $connection = $exchange->getConnection();
+            if ($this->connectionTypeResolver->getConnectionType($connection)) {
+                foreach ($exchange->getBindings() as $binding) {
+                    // This only supports exact matching of topics.
+                    if ($binding->getTopic() === $topic) {
+                        $queueNames[] = $binding->getDestination();
+                    }
+                }
+            }
+        }
+
         $messages = array_map(
             function ($envelope) {
                 return $envelope->getBody();

--- a/app/code/Magento/MysqlMq/Model/Driver/Exchange.php
+++ b/app/code/Magento/MysqlMq/Model/Driver/Exchange.php
@@ -12,6 +12,10 @@ use Magento\Framework\MessageQueue\Topology\ConfigInterface as MessageQueueConfi
 use Magento\MysqlMq\Model\ConnectionTypeResolver;
 use Magento\MysqlMq\Model\QueueManagement;
 
+/**
+ * Class Exchange
+ * @package Magento\MysqlMq\Model\Driver
+ */
 class Exchange implements ExchangeInterface
 {
     /**

--- a/app/code/Magento/MysqlMq/Model/Driver/Exchange.php
+++ b/app/code/Magento/MysqlMq/Model/Driver/Exchange.php
@@ -3,15 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\MysqlMq\Model\Driver;
 
 use Magento\Framework\MessageQueue\EnvelopeInterface;
 use Magento\Framework\MessageQueue\ExchangeInterface;
-use Magento\Framework\MessageQueue\ConfigInterface as MessageQueueConfig;
+use Magento\Framework\MessageQueue\Topology\ConfigInterface as MessageQueueConfig;
+use Magento\MysqlMq\Model\ConnectionTypeResolver;
 use Magento\MysqlMq\Model\QueueManagement;
 
 class Exchange implements ExchangeInterface
 {
+    /**
+     * @var ConnectionTypeResolver
+     */
+    protected $connectionTypeResolver;
     /**
      * @var MessageQueueConfig
      */
@@ -25,13 +31,18 @@ class Exchange implements ExchangeInterface
     /**
      * Initialize dependencies.
      *
+     * @param ConnectionTypeResolver $connectionTypeResolver
      * @param MessageQueueConfig $messageQueueConfig
      * @param QueueManagement $queueManagement
      */
-    public function __construct(MessageQueueConfig $messageQueueConfig, QueueManagement $queueManagement)
-    {
+    public function __construct(
+        ConnectionTypeResolver $connectionTypeResolver,
+        MessageQueueConfig $messageQueueConfig,
+        QueueManagement $queueManagement
+    ) {
         $this->messageQueueConfig = $messageQueueConfig;
         $this->queueManagement = $queueManagement;
+        $this->connectionTypeResolver = $connectionTypeResolver;
     }
 
     /**
@@ -43,7 +54,18 @@ class Exchange implements ExchangeInterface
      */
     public function enqueue($topic, EnvelopeInterface $envelope)
     {
-        $queueNames = $this->messageQueueConfig->getQueuesByTopic($topic);
+        $queueNames = [];
+        $exchanges = $this->messageQueueConfig->getExchanges();
+        foreach ($exchanges as $exchange) {
+            $connection = $exchange->getConnection();
+            if ($this->connectionTypeResolver->getConnectionType($connection)) {
+                foreach ($exchange->getBindings() as $binding) {
+                    if ($binding->getTopic() == $topic) {
+                        $queueNames[] = $binding->getDestination();
+                    }
+                }
+            }
+        }
         $this->queueManagement->addMessageToQueues($topic, $envelope->getBody(), $queueNames);
         return null;
     }

--- a/app/code/Magento/MysqlMq/Setup/Recurring.php
+++ b/app/code/Magento/MysqlMq/Setup/Recurring.php
@@ -29,7 +29,8 @@ class Recurring implements InstallSchemaInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param SchemaSetupInterface $setup
+     * @param ModuleContextInterface $context
      */
     public function install(SchemaSetupInterface $setup, ModuleContextInterface $context)
     {

--- a/app/code/Magento/MysqlMq/Setup/Recurring.php
+++ b/app/code/Magento/MysqlMq/Setup/Recurring.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\MysqlMq\Setup;
 
+use Magento\Framework\MessageQueue\Topology\ConfigInterface as MessageQueueConfig;
 use Magento\Framework\Setup\InstallSchemaInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
-use Magento\Framework\MessageQueue\ConfigInterface as MessageQueueConfig;
 
 /**
  * Class Recurring
@@ -35,11 +35,11 @@ class Recurring implements InstallSchemaInterface
     {
         $setup->startSetup();
 
-        $binds = $this->messageQueueConfig->getBinds();
         $queues = [];
-        foreach ($binds as $bind) {
-            $queues[] = $bind[MessageQueueConfig::BIND_QUEUE];
+        foreach ($this->messageQueueConfig->getQueues() as $queue) {
+            $queues[] = $queue->getName();
         }
+
         $connection = $setup->getConnection();
         $existingQueues = $connection->fetchCol($connection->select()->from($setup->getTable('queue'), 'name'));
         $queues = array_unique(array_diff($queues, $existingQueues));

--- a/app/code/Magento/MysqlMq/Test/Unit/Model/Driver/Bulk/ExchangeTest.php
+++ b/app/code/Magento/MysqlMq/Test/Unit/Model/Driver/Bulk/ExchangeTest.php
@@ -101,7 +101,6 @@ class ExchangeTest extends \PHPUnit\Framework\TestCase
         $exchange2->expects($this->never())
             ->method('getBindings');
 
-
         $this->connnectionTypeResolver->method('getConnectionType')->willReturnOnConsecutiveCalls(['db', null]);
         $envelopeBody = 'serializedMessage';
         $this->messageQueueConfig->expects($this->once())

--- a/app/code/Magento/MysqlMq/Test/Unit/Model/Driver/Bulk/ExchangeTest.php
+++ b/app/code/Magento/MysqlMq/Test/Unit/Model/Driver/Bulk/ExchangeTest.php
@@ -37,7 +37,9 @@ class ExchangeTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUp()
     {
-        $this->messageQueueConfig = $this->getMockBuilder(\Magento\Framework\MessageQueue\Topology\ConfigInterface::class)
+        $this->messageQueueConfig = $this->getMockBuilder(
+            \Magento\Framework\MessageQueue\Topology\ConfigInterface::class
+        )
             ->disableOriginalConstructor()->getMock();
         $this->queueManagement = $this->getMockBuilder(\Magento\MysqlMq\Model\QueueManagement::class)
             ->disableOriginalConstructor()->getMock();
@@ -64,27 +66,35 @@ class ExchangeTest extends \PHPUnit\Framework\TestCase
     {
         $topicName = 'topic.name';
         $queueNames = ['queue0'];
-        $binding1 = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItem\BindingInterface::class);
+        $binding1 = $this->createMock(
+            \Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItem\BindingInterface::class
+        );
         $binding1->expects($this->once())
             ->method('getTopic')
             ->willReturn($topicName);
         $binding1->expects($this->once())
             ->method('getDestination')
             ->willReturn($queueNames[0]);
-        $binding2 = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItem\BindingInterface::class);
+        $binding2 = $this->createMock(
+            \Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItem\BindingInterface::class
+        );
         $binding2->expects($this->once())
             ->method('getTopic')
             ->willReturn('different.topic');
         $binding2->expects($this->never())
             ->method('getDestination');
-        $exchange1 = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItemInterface::class);
+        $exchange1 = $this->createMock(
+            \Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItemInterface::class
+        );
         $exchange1->expects($this->once())
             ->method('getConnection')
             ->willReturn('db');
         $exchange1->expects($this->once())
             ->method('getBindings')
             ->willReturn([$binding1, $binding2]);
-        $exchange2 = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItemInterface::class);
+        $exchange2 = $this->createMock(
+            \Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItemInterface::class
+        );
         $exchange2->expects($this->once())
             ->method('getConnection')
             ->willReturn('amqp');

--- a/app/code/Magento/MysqlMq/Test/Unit/Model/Driver/Bulk/ExchangeTest.php
+++ b/app/code/Magento/MysqlMq/Test/Unit/Model/Driver/Bulk/ExchangeTest.php
@@ -25,6 +25,10 @@ class ExchangeTest extends \PHPUnit\Framework\TestCase
      * @var \Magento\MysqlMq\Model\Driver\Bulk\Exchange
      */
     private $exchange;
+    /**
+     * @var \Magento\MysqlMq\Model\ConnectionTypeResolver|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $connnectionTypeResolver;
 
     /**
      * Set up.
@@ -33,15 +37,18 @@ class ExchangeTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUp()
     {
-        $this->messageQueueConfig = $this->getMockBuilder(\Magento\Framework\MessageQueue\ConfigInterface::class)
+        $this->messageQueueConfig = $this->getMockBuilder(\Magento\Framework\MessageQueue\Topology\ConfigInterface::class)
             ->disableOriginalConstructor()->getMock();
         $this->queueManagement = $this->getMockBuilder(\Magento\MysqlMq\Model\QueueManagement::class)
+            ->disableOriginalConstructor()->getMock();
+        $this->connnectionTypeResolver = $this->getMockBuilder(\Magento\MysqlMq\Model\ConnectionTypeResolver::class)
             ->disableOriginalConstructor()->getMock();
 
         $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
         $this->exchange = $objectManager->getObject(
             \Magento\MysqlMq\Model\Driver\Bulk\Exchange::class,
             [
+                'connectionTypeResolver' => $this->connnectionTypeResolver,
                 'messageQueueConfig' => $this->messageQueueConfig,
                 'queueManagement' => $this->queueManagement,
             ]
@@ -56,10 +63,39 @@ class ExchangeTest extends \PHPUnit\Framework\TestCase
     public function testEnqueue()
     {
         $topicName = 'topic.name';
-        $queueNames = ['queue0', 'queue1'];
+        $queueNames = ['queue0'];
+        $binding1 = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItem\BindingInterface::class);
+        $binding1->expects($this->once())
+            ->method('getTopic')
+            ->willReturn($topicName);
+        $binding1->expects($this->once())
+            ->method('getDestination')
+            ->willReturn($queueNames[0]);
+        $binding2 = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItem\BindingInterface::class);
+        $binding2->expects($this->once())
+            ->method('getTopic')
+            ->willReturn('different.topic');
+        $binding2->expects($this->never())
+            ->method('getDestination');
+        $exchange1 = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItemInterface::class);
+        $exchange1->expects($this->once())
+            ->method('getConnection')
+            ->willReturn('db');
+        $exchange1->expects($this->once())
+            ->method('getBindings')
+            ->willReturn([$binding1, $binding2]);
+        $exchange2 = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItemInterface::class);
+        $exchange2->expects($this->once())
+            ->method('getConnection')
+            ->willReturn('amqp');
+        $exchange2->expects($this->never())
+            ->method('getBindings');
+
+
+        $this->connnectionTypeResolver->method('getConnectionType')->willReturnOnConsecutiveCalls(['db', null]);
         $envelopeBody = 'serializedMessage';
         $this->messageQueueConfig->expects($this->once())
-            ->method('getQueuesByTopic')->with($topicName)->willReturn($queueNames);
+            ->method('getExchanges')->willReturn([$exchange1, $exchange2]);
         $envelope = $this->getMockBuilder(\Magento\Framework\MessageQueue\EnvelopeInterface::class)
             ->disableOriginalConstructor()->getMock();
         $envelope->expects($this->once())->method('getBody')->willReturn($envelopeBody);

--- a/app/code/Magento/MysqlMq/Test/Unit/Setup/RecurringTest.php
+++ b/app/code/Magento/MysqlMq/Test/Unit/Setup/RecurringTest.php
@@ -34,7 +34,7 @@ class RecurringTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $this->objectManager = new ObjectManager($this);
-        $this->messageQueueConfig = $this->getMockBuilder(\Magento\Framework\MessageQueue\ConfigInterface::class)
+        $this->messageQueueConfig = $this->getMockBuilder(\Magento\Framework\MessageQueue\Topology\ConfigInterface::class)
             ->getMockForAbstractClass();
         $this->model = $this->objectManager->getObject(
             \Magento\MysqlMq\Setup\Recurring::class,
@@ -49,23 +49,14 @@ class RecurringTest extends \PHPUnit\Framework\TestCase
      */
     public function testInstall()
     {
-        $binds = [
-            'first_bind' => [
-                'queue' => 'queue_name_1',
-                'exchange' => 'magento-db',
-                'topic' => 'queue.topic.1'
-            ],
-            'second_bind' => [
-                'queue' => 'queue_name_2',
-                'exchange' => 'magento-db',
-                'topic' => 'queue.topic.2'
-            ],
-            'third_bind' => [
-                'queue' => 'queue_name_3',
-                'exchange' => 'magento-db',
-                'topic' => 'queue.topic.3'
-            ]
-        ];
+        for ($i = 1; $i <=3; $i++) {
+            $queue = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\QueueConfigItemInterface::class);
+            $queue->expects($this->once())
+                ->method('getName')
+                ->willReturn('queue_name_' . $i);
+            $queues[] = $queue;
+        }
+
         $dbQueues = [
             'queue_name_1',
             'queue_name_2',
@@ -81,7 +72,7 @@ class RecurringTest extends \PHPUnit\Framework\TestCase
             ->getMockForAbstractClass();
 
         $setup->expects($this->once())->method('startSetup')->willReturnSelf();
-        $this->messageQueueConfig->expects($this->once())->method('getBinds')->willReturn($binds);
+        $this->messageQueueConfig->expects($this->once())->method('getQueues')->willReturn($queues);
         $connection = $this->getMockBuilder(\Magento\Framework\DB\Adapter\AdapterInterface::class)
             ->getMockForAbstractClass();
         $setup->expects($this->once())->method('getConnection')->willReturn($connection);

--- a/app/code/Magento/MysqlMq/Test/Unit/Setup/RecurringTest.php
+++ b/app/code/Magento/MysqlMq/Test/Unit/Setup/RecurringTest.php
@@ -34,7 +34,9 @@ class RecurringTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $this->objectManager = new ObjectManager($this);
-        $this->messageQueueConfig = $this->getMockBuilder(\Magento\Framework\MessageQueue\Topology\ConfigInterface::class)
+        $this->messageQueueConfig = $this->getMockBuilder(
+            \Magento\Framework\MessageQueue\Topology\ConfigInterface::class
+        )
             ->getMockForAbstractClass();
         $this->model = $this->objectManager->getObject(
             \Magento\MysqlMq\Setup\Recurring::class,
@@ -49,7 +51,7 @@ class RecurringTest extends \PHPUnit\Framework\TestCase
      */
     public function testInstall()
     {
-        for ($i = 1; $i <=3; $i++) {
+        for ($i = 1; $i <= 3; $i++) {
             $queue = $this->createMock(\Magento\Framework\MessageQueue\Topology\Config\QueueConfigItemInterface::class);
             $queue->expects($this->once())
                 ->method('getName')


### PR DESCRIPTION
### Description (*)
I've re-applied PR #21942 from @Berdir, this PR has the solution for #21904, however it was closed due to inactivity. I applied the comments from @nuzil.

### Fixed Issues (if relevant)
#21904 

### Manual testing scenarios (*)
Add a new module that implements a new queue_consumer. Try to add something to the queue. First it will trigger an error: 'Exception: Message queue topic "X" is not configured.', after applying this PR it will work again.

I've created [a sample module](https://github.com/Vendic/magento2-mysql-queue-sample-module) to test the queue functionality. Go to  https://yourmagentoinstance.test/newcustomer (after installation) to add an item to the custom queue.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
