### PR TITLE
Fixed broken resources page when acl has quote (') in title.

### DIFF
--- a/app/code/Magento/Integration/view/adminhtml/templates/resourcetree.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/resourcetree.phtml
@@ -39,12 +39,12 @@
 
         <div class="control">
             <div class="tree x-tree" data-role="resource-tree" data-mage-init='<?= /* @noEscape */
-                $block->getJsonSerializer()->serialize([
+                $block->escapeHtmlAttr($block->getJsonSerializer()->serialize([
                     'rolesTree' => [
                         "treeInitData" => $block->getTree(),
                         "treeInitSelectedData" => $block->getSelectedResources(),
                     ],
-                ]); ?>'>
+                ])); ?>'>
             </div>
         </div>
     </div>

--- a/app/code/Magento/Integration/view/adminhtml/templates/resourcetree.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/resourcetree.phtml
@@ -38,7 +38,7 @@
         <label class="label"><span><?= $block->escapeHtml(__('Resources')) ?></span></label>
 
         <div class="control">
-            <div class="tree x-tree" data-role="resource-tree" data-mage-init='<?= /* @noEscape */
+            <div class="tree x-tree" data-role="resource-tree" data-mage-init='<?=
                 $block->escapeHtmlAttr($block->getJsonSerializer()->serialize([
                     'rolesTree' => [
                         "treeInitData" => $block->getTree(),

--- a/app/code/Magento/User/view/adminhtml/templates/role/edit.phtml
+++ b/app/code/Magento/User/view/adminhtml/templates/role/edit.phtml
@@ -39,12 +39,12 @@
 
         <div class="control">
             <div class="tree x-tree" data-role="resource-tree" data-mage-init='<?= /* @noEscape */
-                $block->getJsonSerializer()->serialize([
+                $block->escapeHtmlAttr($block->getJsonSerializer()->serialize([
                     'rolesTree' => [
                         "treeInitData" => $block->getTree(),
                         "treeInitSelectedData" => $block->getSelectedResources(),
                     ],
-                ]); ?>'>
+                ])); ?>'>
             </div>
         </div>
     </div>

--- a/app/code/Magento/User/view/adminhtml/templates/role/edit.phtml
+++ b/app/code/Magento/User/view/adminhtml/templates/role/edit.phtml
@@ -38,7 +38,7 @@
         <label class="label"><span><?= $block->escapeHtml(__('Resources')) ?></span></label>
 
         <div class="control">
-            <div class="tree x-tree" data-role="resource-tree" data-mage-init='<?= /* @noEscape */
+            <div class="tree x-tree" data-role="resource-tree" data-mage-init='<?=
                 $block->escapeHtmlAttr($block->getJsonSerializer()->serialize([
                     'rolesTree' => [
                         "treeInitData" => $block->getTree(),


### PR DESCRIPTION
### Description
Added missing escape for `data-mage-init` attribute to allow to use quote (') in resource title.

### Manual testing scenarios
1. Open `app/code/Magento/Backend/etc/acl.xml`.
2. Replace `title="Dashboard"` with `title="'Dashboard"`.
3. Clear cache.
4. Open _System > Permissions > User Roles_ and press "Add new Role".
5. Switch to the "Role Resources" tab. It's broken.

> The second changed file is used at _System > Extensions > Integrations_.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
