### PR TITLE
Resovled issue #25137

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
@@ -110,7 +110,7 @@
         @_dropdown-list-position-right: 0,
         @_dropdown-list-pointer-position: right,
         @_dropdown-list-pointer-position-left-right: 26px,
-        @_dropdown-list-z-index: 101,   
+        @_dropdown-list-z-index: 101,
         @_dropdown-toggle-icon-content: @icon-cart,
         @_dropdown-toggle-active-icon-content: @icon-cart,
         @_dropdown-list-item-padding: false,
@@ -304,7 +304,7 @@
 
             .weee[data-label] {
                 .lib-font-size(11);
-                
+
                 .label {
                     &:extend(.abs-no-display all);
                 }
@@ -340,7 +340,6 @@
         }
 
         .item-qty {
-            margin-right: @indent__s;
             text-align: center;
             width: 45px;
         }
@@ -390,6 +389,16 @@
 .media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__s) {
     .minicart-wrapper {
         margin-top: @indent__s;
+        .lib-clearfix();
+        .product {
+            .actions {
+                float: left;
+                margin: 10px 0 0 0;
+            }
+        }
+        .update-cart-item {
+            float: right;
+        }
     }
 }
 
@@ -400,7 +409,7 @@
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .minicart-wrapper {
         margin-left: 13px;
-        
+
         .block-minicart {
             right: -15px;
             width: 390px;

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
@@ -120,7 +120,7 @@
             @_dropdown-list-position-right: -10px,
             @_dropdown-list-pointer-position: right,
             @_dropdown-list-pointer-position-left-right: 12px,
-            @_dropdown-list-z-index: 101,              
+            @_dropdown-list-z-index: 101,
             @_dropdown-toggle-icon-content: @icon-cart,
             @_dropdown-toggle-active-icon-content: @icon-cart,
             @_dropdown-list-item-padding: false,
@@ -136,7 +136,7 @@
 
         .block-minicart {
             .lib-css(padding, 25px @minicart__padding-horizontal);
-            
+
             .block-title {
                 display: none;
             }
@@ -233,7 +233,7 @@
 
     .minicart-items {
         .lib-list-reset-styles();
-        
+
         .product-item {
             padding: @indent__base 0;
 
@@ -316,7 +316,7 @@
                 &:extend(.abs-toggling-title all);
                 border: 0;
                 padding: 0 @indent__xl @indent__xs 0;
-                
+
                 &:after {
                     .lib-css(color, @color-gray56);
                     margin: 0 0 0 @indent__xs;
@@ -349,7 +349,7 @@
                             @_icon-font-position: after
                         );
                     }
-                    
+
                     > span {
                         &:extend(.abs-visually-hidden-reset all);
                     }
@@ -369,7 +369,6 @@
         }
 
         .item-qty {
-            margin-right: @indent__s;
             text-align: center;
             width: 60px;
         }
@@ -419,6 +418,16 @@
 .media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {
     .minicart-wrapper {
         margin-top: @indent__s;
+        .lib-clearfix();
+        .product {
+            .actions {
+                float: left;
+                margin: 10px 0 0 0;
+            }
+        }
+        .update-cart-item {
+            float: right;
+        }
     }
 }
 


### PR DESCRIPTION
### Description 

Resolved bug where minicart has alignment issues in mobile view when quantity is being updated

### Fixed Issues

1. magento/magento2#25137: In mobile view, go to mini cart and edit the quantity of product, at that time update button hide the delete button

### Manual testing scenarios

1. In mobile view
2. Add product to cart and open mini cart
3. Edit the product quantity
4. Update button **_no longer_** hides the product action buttons as in screenshot below

![Screen Shot 2019-10-22 at 13 59 26](https://user-images.githubusercontent.com/22623301/67269346-3458f500-f4d4-11e9-867b-42d78648af04.png)
