### PR TITLE
Add validation for sales cart rules max usage and customer max usage on order place/checkout

### DIFF
--- a/app/code/Magento/Checkout/Api/Data/PlaceOrderDetailsInterface.php
+++ b/app/code/Magento/Checkout/Api/Data/PlaceOrderDetailsInterface.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Checkout\Api\Data;
+
+/**
+ * Interface PlaceOrderDetailsInterface
+ * @api
+ */
+interface PlaceOrderDetailsInterface extends \Magento\Framework\Api\ExtensionAttributesInterface
+{
+    public const ORDER_ID    = 'order_id';
+    public const TOTALS      = 'totals';
+    public const ERRORS      = 'errors';
+
+    /**
+     * Set order id only on success
+     *
+     * @param int $orderId
+     * @return $this
+     */
+    public function setOrderId(int $orderId): self;
+
+    /**
+     * Get order id if success
+     *
+     * @return int
+     */
+    public function getOrderId(): int;
+
+    /**
+     * Get errors in order place process
+     *
+     * @return array
+     */
+    public function getErrors(): array;
+
+    /**
+     * Add error of order place process
+     *
+     * @param string $error
+     * @return $this
+     */
+    public function addError(string $error): self;
+
+    /**
+     * Get totals, but it may be null because is not needed to update totals on success
+     *
+     * @return \Magento\Quote\Api\Data\TotalsInterface|null
+     */
+    public function getTotals(): ?\Magento\Quote\Api\Data\TotalsInterface;
+
+    /**
+     * Set totals, in case of errors to allow checkout refresh totals
+     *
+     * @param \Magento\Quote\Api\Data\TotalsInterface $totals
+     * @return $this
+     */
+    public function setTotals(\Magento\Quote\Api\Data\TotalsInterface $totals): self;
+}

--- a/app/code/Magento/Checkout/Api/PaymentInformationManagementInterface.php
+++ b/app/code/Magento/Checkout/Api/PaymentInformationManagementInterface.php
@@ -18,6 +18,21 @@ interface PaymentInformationManagementInterface
      * @param \Magento\Quote\Api\Data\PaymentInterface $paymentMethod
      * @param \Magento\Quote\Api\Data\AddressInterface|null $billingAddress
      * @throws \Magento\Framework\Exception\CouldNotSaveException
+     * @return \Magento\Checkout\Api\Data\PlaceOrderDetailsInterface
+     */
+    public function placeOrder(
+        $cartId,
+        \Magento\Quote\Api\Data\PaymentInterface $paymentMethod,
+        \Magento\Quote\Api\Data\AddressInterface $billingAddress = null
+    ): \Magento\Checkout\Api\Data\PlaceOrderDetailsInterface;
+
+    /**
+     * Set payment information and place order for a specified cart.
+     *
+     * @param int $cartId
+     * @param \Magento\Quote\Api\Data\PaymentInterface $paymentMethod
+     * @param \Magento\Quote\Api\Data\AddressInterface|null $billingAddress
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
      * @return int Order ID.
      */
     public function savePaymentInformationAndPlaceOrder(

--- a/app/code/Magento/Checkout/Model/PlaceOrderDetails.php
+++ b/app/code/Magento/Checkout/Model/PlaceOrderDetails.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Checkout\Model;
+
+use Magento\Checkout\Api\Data\PlaceOrderDetailsInterface;
+use Magento\Quote\Api\Data\TotalsInterface;
+
+/**
+ * Check order id if successfully placed order, in other cases use other fields
+ *
+ * @codeCoverageIgnoreStart
+ */
+class PlaceOrderDetails extends \Magento\Framework\Api\AbstractSimpleObject implements PlaceOrderDetailsInterface
+{
+
+    /**
+     * Initialize payment details
+     *
+     * PlaceOrderDetails constructor.
+     * @param array $data
+     */
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+        $this->_data[self::ERRORS] = [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setOrderId(int $orderId): PlaceOrderDetailsInterface
+    {
+        return $this->setData(self::ORDER_ID, $orderId);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getOrderId(): int
+    {
+        return $this->_get(self::ORDER_ID) ?? 0;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getErrors(): array
+    {
+        return $this->_get(self::ERRORS);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function hasErrors(): bool
+    {
+        return count($this->_get(self::ERRORS)) > 0;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addError(string $error): PlaceOrderDetailsInterface
+    {
+        $this->_data[self::ERRORS][] = $error;
+
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getTotals(): ?TotalsInterface
+    {
+        return $this->_get(self::TOTALS);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function hasTotals(): bool
+    {
+        return isset($this->_data[self::TOTALS]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setTotals($totals): PlaceOrderDetailsInterface
+    {
+        return $this->setData(self::TOTALS, $totals);
+    }
+}

--- a/app/code/Magento/Checkout/etc/di.xml
+++ b/app/code/Magento/Checkout/etc/di.xml
@@ -19,6 +19,7 @@
     <preference for="Magento\Checkout\Api\GuestShippingInformationManagementInterface" type="Magento\Checkout\Model\GuestShippingInformationManagement" />
     <preference for="Magento\Checkout\Api\ShippingInformationManagementInterface" type="Magento\Checkout\Model\ShippingInformationManagement" />
     <preference for="Magento\Checkout\Api\Data\ShippingInformationInterface" type="Magento\Checkout\Model\ShippingInformation" />
+    <preference for="Magento\Checkout\Api\Data\PlaceOrderDetailsInterface" type="Magento\Checkout\Model\PlaceOrderDetails" />
     <preference for="Magento\Checkout\Api\Data\PaymentDetailsInterface" type="Magento\Checkout\Model\PaymentDetails" />
     <preference for="Magento\Checkout\Api\GuestPaymentInformationManagementInterface" type="Magento\Checkout\Model\GuestPaymentInformationManagement" />
     <preference for="Magento\Checkout\Api\PaymentInformationManagementInterface" type="Magento\Checkout\Model\PaymentInformationManagement" />

--- a/app/code/Magento/Checkout/etc/webapi.xml
+++ b/app/code/Magento/Checkout/etc/webapi.xml
@@ -86,6 +86,16 @@
             <parameter name="cartId" force="true">%cart_id%</parameter>
         </data>
     </route>
+    <!-- My place order with payment information saving -->
+    <route url="/V1/carts/mine/place-order" method="POST">
+        <service class="Magento\Checkout\Api\PaymentInformationManagementInterface" method="placeOrder"/>
+        <resources>
+            <resource ref="self" />
+        </resources>
+        <data>
+            <parameter name="cartId" force="true">%cart_id%</parameter>
+        </data>
+    </route>
     <!-- Get payment information -->
     <route url="/V1/carts/mine/payment-information" method="GET">
         <service class="Magento\Checkout\Api\PaymentInformationManagementInterface" method="getPaymentInformation"/>

--- a/app/code/Magento/Checkout/view/frontend/web/js/action/place-order.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/action/place-order.js
@@ -24,7 +24,7 @@ define([
         };
 
         if (customer.isLoggedIn()) {
-            serviceUrl = urlBuilder.createUrl('/carts/mine/payment-information', {});
+            serviceUrl = urlBuilder.createUrl('/carts/mine/place-order', {});
         } else {
             serviceUrl = urlBuilder.createUrl('/guest-carts/:quoteId/payment-information', {
                 quoteId: quote.getQuoteId()

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/payment/after-place-order-callbacks.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/payment/after-place-order-callbacks.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define([
+    'ko'
+], function (ko) {
+    'use strict';
+
+    return ko.observableArray([]);
+});

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/place-order.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/place-order.js
@@ -37,7 +37,9 @@ define(
                         'newCustomerBillingAddress': null
                     };
 
-                    if (response.responseType !== 'error') {
+                    if (response.order_id !== undefined && response.order_id > 0 ||
+                        response.order_id === undefined && response.responseType !== 'error'
+                    ) {
                         customerData.set('checkout-data', clearData);
                     }
                 }

--- a/app/code/Magento/Quote/Model/CouponManagement.php
+++ b/app/code/Magento/Quote/Model/CouponManagement.php
@@ -72,7 +72,7 @@ class CouponManagement implements CouponManagementInterface
                 $e
             );
         }
-        if ($quote->getCouponCode() != $couponCode) {
+        if ($quote->getCouponCode() !== $couponCode) {
             throw new NoSuchEntityException(__("The coupon code isn't valid. Verify the code and try again."));
         }
         return true;
@@ -97,7 +97,7 @@ class CouponManagement implements CouponManagementInterface
                 __("The coupon code couldn't be deleted. Verify the coupon code and try again.")
             );
         }
-        if ($quote->getCouponCode() != '') {
+        if ($quote->getCouponCode() !== '') {
             throw new CouldNotDeleteException(
                 __("The coupon code couldn't be deleted. Verify the coupon code and try again.")
             );

--- a/app/code/Magento/Quote/Model/Quote/TotalsCollector.php
+++ b/app/code/Magento/Quote/Model/Quote/TotalsCollector.php
@@ -184,17 +184,19 @@ class TotalsCollector
     protected function _validateCouponCode(\Magento\Quote\Model\Quote $quote)
     {
         $code = $quote->getData('coupon_code');
-        if (strlen($code)) {
+        if (!empty($code)) {
             $addressHasCoupon = false;
             $addresses = $quote->getAllAddresses();
             if (count($addresses) > 0) {
                 foreach ($addresses as $address) {
-                    if ($address->hasCouponCode()) {
+                    if (!empty($address->getCouponCode())) {
                         $addressHasCoupon = true;
                     }
                 }
                 if (!$addressHasCoupon) {
                     $quote->setCouponCode('');
+                    $quote->setHasError(true);
+                    $quote->addMessage(__("The coupon code isn't valid. Verify the code and try again."));
                 }
             }
         }
@@ -273,7 +275,7 @@ class TotalsCollector
             /** @var CollectorInterface $collector */
             $collector->collect($quote, $shippingAssignment, $total);
         }
-        
+
         $this->eventManager->dispatch(
             'sales_quote_address_collect_totals_after',
             [

--- a/app/code/Magento/SalesRule/Api/CouponRepositoryInterface.php
+++ b/app/code/Magento/SalesRule/Api/CouponRepositoryInterface.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\SalesRule\Api;
 
+use Magento\SalesRule\Api\Data\CouponInterface;
+
 /**
  * Coupon CRUD interface
  *
@@ -33,6 +35,16 @@ interface CouponRepositoryInterface
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getById($couponId);
+
+    /**
+     * Get coupon by coupon code
+     *
+     * @param string $couponCode
+     * @return \Magento\SalesRule\Api\Data\CouponInterface
+     * @throws \Magento\Framework\Exception\NoSuchEntityException If $couponCode is not found
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getByCode(string $couponCode): CouponInterface;
 
     /**
      * Retrieve a coupon using the specified search criteria.

--- a/app/code/Magento/SalesRule/Exception/CouponUsageExceeded.php
+++ b/app/code/Magento/SalesRule/Exception/CouponUsageExceeded.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\SalesRule\Exception;
+
+use Magento\Framework\Exception\LocalizedException;
+
+/**
+ * Class CouponUsageExceeded
+ *
+ * @package Magento\SalesRule\Exception
+ */
+class CouponUsageExceeded extends LocalizedException
+{
+
+}

--- a/app/code/Magento/SalesRule/Model/Coupon/UpdateCouponUsages.php
+++ b/app/code/Magento/SalesRule/Model/Coupon/UpdateCouponUsages.php
@@ -8,8 +8,12 @@ declare(strict_types=1);
 namespace Magento\SalesRule\Model\Coupon;
 
 use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\SalesRule\Exception\CouponUsageExceeded;
 use Magento\SalesRule\Model\Coupon;
+use Magento\SalesRule\Model\CouponRepository;
 use Magento\SalesRule\Model\ResourceModel\Coupon\Usage;
+use Magento\SalesRule\Model\Rule;
 use Magento\SalesRule\Model\Rule\CustomerFactory;
 use Magento\SalesRule\Model\RuleFactory;
 
@@ -37,23 +41,30 @@ class UpdateCouponUsages
      * @var Usage
      */
     private $couponUsage;
+    /**
+     * @var CouponRepository
+     */
+    private $couponRepository;
 
     /**
      * @param RuleFactory $ruleFactory
      * @param CustomerFactory $ruleCustomerFactory
      * @param Coupon $coupon
      * @param Usage $couponUsage
+     * @param CouponRepository $couponRepository
      */
     public function __construct(
         RuleFactory $ruleFactory,
         CustomerFactory $ruleCustomerFactory,
         Coupon $coupon,
-        Usage $couponUsage
+        Usage $couponUsage,
+        CouponRepository $couponRepository
     ) {
         $this->ruleFactory = $ruleFactory;
         $this->ruleCustomerFactory = $ruleCustomerFactory;
         $this->coupon = $coupon;
         $this->couponUsage = $couponUsage;
+        $this->couponRepository = $couponRepository;
     }
 
     /**
@@ -62,6 +73,8 @@ class UpdateCouponUsages
      * @param OrderInterface $subject
      * @param bool $increment
      * @return OrderInterface
+     * @throws CouponUsageExceeded
+     * @throws LocalizedException
      */
     public function execute(OrderInterface $subject, bool $increment): OrderInterface
     {
@@ -90,6 +103,7 @@ class UpdateCouponUsages
      * @param bool $increment
      * @param int $ruleId
      * @param int $customerId
+     * @throws CouponUsageExceeded
      */
     private function updateRuleUsages(bool $increment, int $ruleId, int $customerId)
     {
@@ -98,12 +112,15 @@ class UpdateCouponUsages
         $rule->load($ruleId);
         if ($rule->getId()) {
             $rule->loadCouponCode();
+            if ($increment && $rule->getUsesPerCoupon() > 0 && $rule->getTimesUsed() >= $rule->getUsesPerCoupon()) {
+                throw new CouponUsageExceeded(__("The coupon code isn't valid. Verify the code and try again."));
+            }
             if ($increment || $rule->getTimesUsed() > 0) {
                 $rule->setTimesUsed($rule->getTimesUsed() + ($increment ? 1 : -1));
                 $rule->save();
             }
             if ($customerId) {
-                $this->updateCustomerRuleUsages($increment, $ruleId, $customerId);
+                $this->updateCustomerRuleUsages($rule, $increment, $ruleId, $customerId);
             }
         }
     }
@@ -111,15 +128,25 @@ class UpdateCouponUsages
     /**
      * Update the number of rule usages per customer.
      *
+     * @param Rule $rule
      * @param bool $increment
      * @param int $ruleId
      * @param int $customerId
+     * @throws CouponUsageExceeded
      */
-    private function updateCustomerRuleUsages(bool $increment, int $ruleId, int $customerId): void
+    private function updateCustomerRuleUsages(Rule $rule, bool $increment, int $ruleId, int $customerId): void
     {
         /** @var \Magento\SalesRule\Model\Rule\Customer $ruleCustomer */
         $ruleCustomer = $this->ruleCustomerFactory->create();
         $ruleCustomer->loadByCustomerRule($customerId, $ruleId);
+
+        if ($increment &&
+            $rule->getUsesPerCustomer() > 0 &&
+            $ruleCustomer->getTimesUsed() >= $rule->getUsesPerCustomer()
+        ) {
+            throw new CouponUsageExceeded(__("The coupon code isn't valid. Verify the code and try again."));
+        }
+
         if ($ruleCustomer->getId()) {
             if ($increment || $ruleCustomer->getTimesUsed() > 0) {
                 $ruleCustomer->setTimesUsed($ruleCustomer->getTimesUsed() + ($increment ? 1 : -1));
@@ -136,18 +163,50 @@ class UpdateCouponUsages
      * @param OrderInterface $subject
      * @param bool $increment
      * @param int $customerId
+     * @throws CouponUsageExceeded
+     * @throws LocalizedException
      */
     private function updateCouponUsages(OrderInterface $subject, bool $increment, int $customerId): void
     {
-        $this->coupon->load($subject->getCouponCode(), 'code');
-        if ($this->coupon->getId()) {
-            if ($increment || $this->coupon->getTimesUsed() > 0) {
-                $this->coupon->setTimesUsed($this->coupon->getTimesUsed() + ($increment ? 1 : -1));
-                $this->coupon->save();
-            }
-            if ($customerId) {
-                $this->couponUsage->updateCustomerCouponTimesUsed($customerId, $this->coupon->getId(), $increment);
-            }
+        $this->couponRepository->getByCode($subject->getCouponCode());
+        if (!$this->coupon->getId()) {
+            return;
+        }
+
+        if (
+            $increment &&
+            $this->coupon->getUsageLimit() > 0 &&
+            $this->coupon->getTimesUsed() >= $this->coupon->getUsageLimit()
+        ) {
+            throw new CouponUsageExceeded(__("The coupon code isn't valid. Verify the code and try again."));
+        }
+
+        if ($increment || $this->coupon->getTimesUsed() > 0) {
+            $this->coupon->setTimesUsed($this->coupon->getTimesUsed() + ($increment ? 1 : -1));
+            $this->couponRepository->save($this->coupon);
+        }
+
+        if ($customerId && $this->coupon->getUsagePerCustomer() > 0) {
+            $this->updateCouponUsagesPerCustomer($increment, $customerId);
+        }
+    }
+
+    /**
+     * @param bool $increment
+     * @param int $customerId
+     * @throws CouponUsageExceeded
+     * @throws LocalizedException
+     */
+    private function updateCouponUsagesPerCustomer(bool $increment, int $customerId): void {
+        $timesUsed = $this->couponUsage->getUsagePerCustomer((int)$this->coupon->getId(), $customerId);
+        if ($timesUsed > $this->coupon->getUsagePerCustomer()) {
+            throw new CouponUsageExceeded(__("The coupon code isn't valid. Verify the code and try again."));
+        }
+        if ($timesUsed !== 0 || $increment) {
+            $timesUsed += $increment ? 1 : -1;
+        }
+        if ($timesUsed) {
+            $this->couponUsage->updateUsagePerCustomer((int)$this->coupon->getId(), $customerId, $timesUsed);
         }
     }
 }

--- a/app/code/Magento/SalesRule/Model/CouponRepository.php
+++ b/app/code/Magento/SalesRule/Model/CouponRepository.php
@@ -8,6 +8,7 @@ namespace Magento\SalesRule\Model;
 
 use Magento\Framework\Api\Search\FilterGroup;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\SalesRule\Api\Data\CouponInterface;
 use Magento\SalesRule\Model\ResourceModel\Coupon\Collection;
 
 /**
@@ -145,6 +146,16 @@ class CouponRepository implements \Magento\SalesRule\Api\CouponRepositoryInterfa
         if (!$coupon->getCouponId()) {
             throw new \Magento\Framework\Exception\NoSuchEntityException();
         }
+        return $coupon;
+    }
+
+    /**
+     * @param string $couponCode
+     * @return CouponInterface
+     */
+    public function getByCode(string $couponCode): CouponInterface {
+        $coupon = $this->couponFactory->create();
+        $this->resourceModel->load($coupon, $couponCode, 'code');
         return $coupon;
     }
 

--- a/app/code/Magento/SalesRule/Model/Quote/Discount.php
+++ b/app/code/Magento/SalesRule/Model/Quote/Discount.php
@@ -86,6 +86,7 @@ class Discount extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
      * @return $this
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function collect(
         \Magento\Quote\Model\Quote $quote,

--- a/app/code/Magento/SalesRule/Model/RulesApplier.php
+++ b/app/code/Magento/SalesRule/Model/RulesApplier.php
@@ -159,17 +159,15 @@ class RulesApplier
         $label = '';
         if ($ruleLabel) {
             $label = $ruleLabel;
-        } else {
-            if (strlen($address->getCouponCode())) {
-                $label = $address->getCouponCode();
+        } elseif ($address->getCouponCode() !== '') {
+            $label = $address->getCouponCode();
 
-                if ($rule->getDescription()) {
-                    $label = $rule->getDescription();
-                }
+            if ($rule->getDescription()) {
+                $label = $rule->getDescription();
             }
         }
 
-        if (strlen($label)) {
+        if ('' !== $label) {
             $description[$rule->getId()] = $label;
         }
 
@@ -343,7 +341,7 @@ class RulesApplier
         $address = $item->getAddress();
         $quote = $item->getQuote();
 
-        $item->setAppliedRuleIds(join(',', $appliedRuleIds));
+        $item->setAppliedRuleIds(implode(',', $appliedRuleIds));
         $address->setAppliedRuleIds($this->validatorUtility->mergeIds($address->getAppliedRuleIds(), $appliedRuleIds));
         $quote->setAppliedRuleIds($this->validatorUtility->mergeIds($quote->getAppliedRuleIds(), $appliedRuleIds));
 

--- a/app/code/Magento/SalesRule/Model/Utility.php
+++ b/app/code/Magento/SalesRule/Model/Utility.php
@@ -91,7 +91,7 @@ class Utility
          */
         if ($rule->getCouponType() != \Magento\SalesRule\Model\Rule::COUPON_TYPE_NO_COUPON) {
             $couponCode = $address->getQuote()->getCouponCode();
-            if (strlen($couponCode)) {
+            if ('' !== $couponCode) {
                 /** @var \Magento\SalesRule\Model\Coupon $coupon */
                 $coupon = $this->couponFactory->create();
                 $coupon->load($couponCode, 'code');
@@ -99,6 +99,7 @@ class Utility
                     // check entire usage limit
                     if ($coupon->getUsageLimit() && $coupon->getTimesUsed() >= $coupon->getUsageLimit()) {
                         $rule->setIsValidForAddress($address, false);
+                        $address->setCouponCode('');
                         return false;
                     }
                     // check per customer usage limit
@@ -114,6 +115,7 @@ class Utility
                             $couponUsage->getTimesUsed() >= $coupon->getUsagePerCustomer()
                         ) {
                             $rule->setIsValidForAddress($address, false);
+                            $address->setCouponCode('');
                             return false;
                         }
                     }
@@ -153,6 +155,8 @@ class Utility
     }
 
     /**
+     * We can't use row total here because row total not include tax. Discount can be applied on price included tax
+     *
      * @param \Magento\SalesRule\Model\Rule\Action\Discount\Data $discountData
      * @param \Magento\Quote\Model\Quote\Item\AbstractItem $item
      * @param float $qty
@@ -293,6 +297,8 @@ class Utility
     }
 
     /**
+     * Reset deltas used in apply
+     *
      * @return void
      */
     public function resetRoundingDeltas()

--- a/app/code/Magento/SalesRule/Observer/DecrementCouponUsageObserver.php
+++ b/app/code/Magento/SalesRule/Observer/DecrementCouponUsageObserver.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\SalesRule\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\SalesRule\Exception\CouponUsageExceeded;
+use Magento\SalesRule\Model\Coupon\UpdateCouponUsages;
+use Throwable;
+
+/**
+ * Undo quote coupon usage update
+ */
+class DecrementCouponUsageObserver implements ObserverInterface
+{
+    /**
+     * @var UpdateCouponUsages
+     */
+    private $updateCouponUsages;
+
+    /**
+     * Initializes dependencies
+     *
+     * @param UpdateCouponUsages $updateCouponUsages
+     */
+    public function __construct(UpdateCouponUsages $updateCouponUsages)
+    {
+        $this->updateCouponUsages = $updateCouponUsages;
+    }
+
+    /**
+     * Forces related quotes to be recollected, if the rule was disabled or deleted.
+     *
+     * @param Observer $observer
+     * @return void
+     * @throws CouponUsageExceeded
+     * @throws LocalizedException
+     */
+    public function execute(Observer $observer): void
+    {
+        /** @var OrderInterface $order */
+        $order = $observer->getOrder();
+        try {
+            $this->updateCouponUsages->execute($order, false);
+        } catch (CouponUsageExceeded|LocalizedException $exception) {
+            throw $exception;
+        } catch (Throwable $throwable) {
+            throw new LocalizedException(__('Unable to cancel coupon code.'));
+        }
+    }
+}

--- a/app/code/Magento/SalesRule/Plugin/CouponUsagesIncrement.php
+++ b/app/code/Magento/SalesRule/Plugin/CouponUsagesIncrement.php
@@ -9,6 +9,8 @@ namespace Magento\SalesRule\Plugin;
 
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\Service\OrderService;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\SalesRule\Exception\CouponUsageExceeded;
 use Magento\SalesRule\Model\Coupon\UpdateCouponUsages;
 
 /**
@@ -34,14 +36,16 @@ class CouponUsagesIncrement
      * Increments number of coupon usages after placing order.
      *
      * @param OrderService $subject
-     * @param OrderInterface $result
-     * @return OrderInterface
+     * @param OrderInterface $order
+     * @return array
+     * @throws CouponUsageExceeded
+     * @throws LocalizedException
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterPlace(OrderService $subject, OrderInterface $result): OrderInterface
+    public function beforePlace(OrderService $subject, OrderInterface $order): array
     {
-        $this->updateCouponUsages->execute($result, true);
+        $this->updateCouponUsages->execute($order, true);
 
-        return $result;
+        return [$order];
     }
 }

--- a/app/code/Magento/SalesRule/etc/events.xml
+++ b/app/code/Magento/SalesRule/etc/events.xml
@@ -39,4 +39,7 @@
     <event name="sales_quote_collect_totals_before">
         <observer name="salesrule_sales_quote_collect_totals_before" instance="\Magento\SalesRule\Observer\QuoteResetAppliedRulesObserver" />
     </event>
+    <event name="sales_model_service_quote_submit_failure">
+        <observer name="salesrule_quote_failure_decrement_coupon" instance="\Magento\SalesRule\Observer\DecrementCouponUsageObserver" />
+    </event>
 </config>

--- a/app/code/Magento/SalesRule/view/frontend/web/js/action/on-order-place.js
+++ b/app/code/Magento/SalesRule/view/frontend/web/js/action/on-order-place.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * Customer store credit(balance) application
+ */
+define([
+    'jquery',
+    'Magento_Checkout/js/model/quote',
+    'Magento_Checkout/js/model/resource-url-manager',
+    'Magento_Checkout/js/model/error-processor',
+    'Magento_SalesRule/js/model/payment/discount-messages',
+    'mage/storage',
+    'Magento_Checkout/js/action/get-payment-information',
+    'Magento_Checkout/js/model/totals',
+    'mage/translate',
+    'Magento_Checkout/js/model/full-screen-loader'
+], function ($, quote, urlManager, errorProcessor, messageContainer, storage, getPaymentInformationAction, totals, $t,
+             fullScreenLoader
+) {
+    'use strict';
+
+    return function (paymentViewComponent, response, previousTotals, couponCode, isApplied) {
+        let totals = quote.getTotals();
+
+        if (parseInt(response.order_id) === 0) {
+            messageContainer.clear();
+            for (let i in response.errors) {
+                paymentViewComponent.messageContainer.addErrorMessage(
+                    {
+                        message: response.errors[i]
+                    }
+                );
+            }
+            if (totals()) {
+                let couponCodeStr = totals()['coupon_code'];
+
+                if (couponCodeStr !== previousTotals['coupon_code']) {
+                    paymentViewComponent.afterPlaceOrderCallbackResults.redirectAfterPlaceOrder = false;
+                    if (couponCodeStr.length === 0) {
+                        couponCode('');
+                        isApplied(false);
+                        messageContainer.addSuccessMessage({
+                            'message': $t('The coupon code isn\'t valid. Verify the code and try again.')
+                        });
+                    } else {
+                        couponCode(couponCodeStr);
+                        isApplied(true);
+                        messageContainer.addSuccessMessage({
+                            'message': $t('Your coupon was successfully applied.')
+                        });
+                    }
+                }
+            }
+        };
+    }
+});

--- a/app/code/Magento/SalesRule/view/frontend/web/js/view/payment/discount.js
+++ b/app/code/Magento/SalesRule/view/frontend/web/js/view/payment/discount.js
@@ -10,8 +10,20 @@ define([
     'Magento_Checkout/js/model/quote',
     'Magento_SalesRule/js/action/set-coupon-code',
     'Magento_SalesRule/js/action/cancel-coupon',
-    'Magento_SalesRule/js/model/coupon'
-], function ($, ko, Component, quote, setCouponCodeAction, cancelCouponAction, coupon) {
+    'Magento_SalesRule/js/model/coupon',
+    'Magento_SalesRule/js/action/on-order-place',
+    'Magento_Checkout/js/model/payment/after-place-order-callbacks'
+], function (
+    $,
+    ko,
+    Component,
+    quote,
+    setCouponCodeAction,
+    cancelCouponAction,
+    coupon,
+    onOrderPlaceAction,
+    orderPlaceCallbacks
+) {
     'use strict';
 
     var totals = quote.getTotals(),
@@ -23,6 +35,7 @@ define([
     }
     isApplied(couponCode() != null);
 
+
     return Component.extend({
         defaults: {
             template: 'Magento_SalesRule/payment/discount'
@@ -33,6 +46,11 @@ define([
          * Applied flag
          */
         isApplied: isApplied,
+
+        initialize: function () {
+            this._super();
+            orderPlaceCallbacks.push(this.afterOrderPlaced);
+        },
 
         /**
          * Coupon code application procedure
@@ -51,6 +69,16 @@ define([
                 couponCode('');
                 cancelCouponAction(isApplied);
             }
+        },
+
+        /**
+         *
+         * @param object paymentView
+         * @param object response
+         * @returns {*}
+         */
+        afterOrderPlaced: function (paymentView, response, previousTotals) {
+            return onOrderPlaceAction(paymentView, response, previousTotals, couponCode, isApplied);
         },
 
         /**


### PR DESCRIPTION
Changes in order place process:
- Add coupon code validation on order place stop process (and trigger coupon code removal) when coupon expired
- Show errors to user
- Update cart totals and advise user to review it
- Allow order place

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#21952: Able to use a single use coupon code on two orders

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Described in issue details

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
This is a draft pull request, and I need some advice regarding backward compatibility. 

I definitely consider the fix should be this "Second order should result in an error due to the coupon code" as described in issue. 

From backed point of view I see that I should add another method to API since the existing one should return an integer and I need to return new totals and error message on the new request.

I have to made some changes to make it backward compatible in frontend, but before I should hear some advices about it. 


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
