### PR TITLE
Braintree - Don't request ClientToken if payment method is not active

### DIFF
--- a/app/code/Magento/Braintree/Model/Ui/ConfigProvider.php
+++ b/app/code/Magento/Braintree/Model/Ui/ConfigProvider.php
@@ -67,11 +67,12 @@ class ConfigProvider implements ConfigProviderInterface
     public function getConfig()
     {
         $storeId = $this->session->getStoreId();
+        $isActive = $this->config->isActive($storeId);
         return [
             'payment' => [
                 self::CODE => [
-                    'isActive' => $this->config->isActive($storeId),
-                    'clientToken' => $this->getClientToken(),
+                    'isActive' => $isActive,
+                    'clientToken' => $isActive ? $this->getClientToken() : null,
                     'ccTypesMapper' => $this->config->getCcTypesMapper(),
                     'sdkUrl' => $this->config->getSdkUrl(),
                     'hostedFieldsSdkUrl' => $this->config->getHostedFieldsSdkUrl(),

--- a/app/code/Magento/Braintree/Model/Ui/ConfigProvider.php
+++ b/app/code/Magento/Braintree/Model/Ui/ConfigProvider.php
@@ -3,215 +3,116 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-declare(strict_types=1);
-
-namespace Magento\Braintree\Test\Unit\Model\Ui;
+namespace Magento\Braintree\Model\Ui;
 
 use Magento\Braintree\Gateway\Config\Config;
-use Magento\Braintree\Model\Adapter\BraintreeAdapter;
+use Magento\Braintree\Gateway\Request\PaymentDataBuilder;
 use Magento\Braintree\Model\Adapter\BraintreeAdapterFactory;
-use Magento\Braintree\Model\Ui\ConfigProvider;
-use Magento\Customer\Model\Session;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Magento\Checkout\Model\ConfigProviderInterface;
+use Magento\Framework\Session\SessionManagerInterface;
 
 /**
- * Class ConfigProviderTest
+ * Class ConfigProvider
  *
- * Test for class \Magento\Braintree\Model\Ui\ConfigProvider
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  */
-class ConfigProviderTest extends \PHPUnit\Framework\TestCase
+class ConfigProvider implements ConfigProviderInterface
 {
-    const SDK_URL = 'https://js.braintreegateway.com/v2/braintree.js';
-    const CLIENT_TOKEN = 'token';
-    const MERCHANT_ACCOUNT_ID = '245345';
+    const CODE = 'braintree';
+
+    const CC_VAULT_CODE = 'braintree_cc_vault';
 
     /**
-     * @var Config|MockObject
+     * @var Config
      */
     private $config;
 
     /**
-     * @var BraintreeAdapter|MockObject
+     * @var BraintreeAdapterFactory
      */
-    private $braintreeAdapter;
+    private $adapterFactory;
 
     /**
-     * @var Session|MockObject
+     * @var string
+     */
+    private $clientToken = '';
+
+    /**
+     * @var SessionManagerInterface
      */
     private $session;
 
     /**
-     * @var ConfigProvider
-     */
-    private $configProvider;
-
-    protected function setUp()
-    {
-        $this->config = $this->getMockBuilder(Config::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->braintreeAdapter = $this->getMockBuilder(BraintreeAdapter::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        /** @var BraintreeAdapterFactory|MockObject $adapterFactoryMock */
-        $adapterFactoryMock = $this->getMockBuilder(BraintreeAdapterFactory::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $adapterFactoryMock->method('create')
-            ->willReturn($this->braintreeAdapter);
-
-        $this->session = $this->getMockBuilder(Session::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getStoreId'])
-            ->getMock();
-        $this->session->method('getStoreId')
-            ->willReturn(null);
-
-        $this->configProvider = new ConfigProvider(
-            $this->config,
-            $adapterFactoryMock,
-            $this->session
-        );
-    }
-
-    /**
-     * Ensure that get config returns correct data if payment is active or not
+     * Constructor
      *
-     * @param array $config
-     * @param array $expected
-     * @dataProvider getConfigDataProvider
+     * @param Config $config
+     * @param BraintreeAdapterFactory $adapterFactory
+     * @param SessionManagerInterface $session
      */
-    public function testGetConfig($config, $expected)
-    {
-        if ($config['isActive']) {
-            $this->braintreeAdapter->expects($this->once())
-                ->method('generate')
-                ->willReturn(self::CLIENT_TOKEN);
-        } else {
-            $config = array_replace_recursive(
-                $this->getConfigDataProvider()[0]['config'],
-                $config
-            );
-            $expected = array_replace_recursive(
-                $this->getConfigDataProvider()[0]['expected'],
-                $expected
-            );
-            $this->braintreeAdapter->expects($this->never())
-                ->method('generate');
-        }
-
-        foreach ($config as $method => $value) {
-            $this->config->expects($this->once())
-                ->method($method)
-                ->willReturn($value);
-        }
-
-        $this->assertEquals($expected, $this->configProvider->getConfig());
+    public function __construct(
+        Config $config,
+        BraintreeAdapterFactory $adapterFactory,
+        SessionManagerInterface $session
+    ) {
+        $this->config = $config;
+        $this->adapterFactory = $adapterFactory;
+        $this->session = $session;
     }
 
     /**
-     * @covers       \Magento\Braintree\Model\Ui\ConfigProvider::getClientToken
-     * @dataProvider getClientTokenDataProvider
-     * @param $merchantAccountId
-     * @param $params
-     */
-    public function testGetClientToken($merchantAccountId, $params)
-    {
-        $this->config->expects(static::once())
-            ->method('getMerchantAccountId')
-            ->willReturn($merchantAccountId);
-
-        $this->braintreeAdapter->expects(static::once())
-            ->method('generate')
-            ->with($params)
-            ->willReturn(self::CLIENT_TOKEN);
-
-        static::assertEquals(self::CLIENT_TOKEN, $this->configProvider->getClientToken());
-    }
-
-    /**
+     * Retrieve assoc array of checkout configuration
+     *
      * @return array
      */
-    public function getConfigDataProvider()
+    public function getConfig()
     {
+        $storeId = $this->session->getStoreId();
+        $isActive = $this->config->isActive($storeId);
         return [
-            [
-                'config' => [
-                    'isActive' => true,
-                    'getCcTypesMapper' => ['visa' => 'VI', 'american-express' => 'AE'],
-                    'getSdkUrl' => self::SDK_URL,
-                    'getHostedFieldsSdkUrl' => 'https://sdk.com/test.js',
-                    'getCountrySpecificCardTypeConfig' => [
-                        'GB' => ['VI', 'AE'],
-                        'US' => ['DI', 'JCB']
-                    ],
-                    'getAvailableCardTypes' => ['AE', 'VI', 'MC', 'DI', 'JCB'],
-                    'isCvvEnabled' => true,
-                    'isVerify3DSecure' => true,
-                    'getThresholdAmount' => 20,
-                    'get3DSecureSpecificCountries' => ['GB', 'US', 'CA'],
-                    'getEnvironment' => 'test-environment',
-                    'getMerchantId' => 'test-merchant-id',
-                    'hasFraudProtection' => true,
+            'payment' => [
+                self::CODE => [
+                    'isActive' => $isActive,
+                    'clientToken' => $isActive ? $this->getClientToken() : null,
+                    'ccTypesMapper' => $this->config->getCcTypesMapper(),
+                    'sdkUrl' => $this->config->getSdkUrl(),
+                    'hostedFieldsSdkUrl' => $this->config->getHostedFieldsSdkUrl(),
+                    'countrySpecificCardTypes' => $this->config->getCountrySpecificCardTypeConfig($storeId),
+                    'availableCardTypes' => $this->config->getAvailableCardTypes($storeId),
+                    'useCvv' => $this->config->isCvvEnabled($storeId),
+                    'environment' => $this->config->getEnvironment($storeId),
+                    'hasFraudProtection' => $this->config->hasFraudProtection($storeId),
+                    'merchantId' => $this->config->getMerchantId($storeId),
+                    'ccVaultCode' => self::CC_VAULT_CODE,
                 ],
-                'expected' => [
-                    'payment' => [
-                        ConfigProvider::CODE => [
-                            'isActive' => true,
-                            'clientToken' => self::CLIENT_TOKEN,
-                            'ccTypesMapper' => ['visa' => 'VI', 'american-express' => 'AE'],
-                            'sdkUrl' => self::SDK_URL,
-                            'hostedFieldsSdkUrl' => 'https://sdk.com/test.js',
-                            'countrySpecificCardTypes' => [
-                                'GB' => ['VI', 'AE'],
-                                'US' => ['DI', 'JCB']
-                            ],
-                            'availableCardTypes' => ['AE', 'VI', 'MC', 'DI', 'JCB'],
-                            'useCvv' => true,
-                            'environment' => 'test-environment',
-                            'merchantId' => 'test-merchant-id',
-                            'hasFraudProtection' => true,
-                            'ccVaultCode' => ConfigProvider::CC_VAULT_CODE
-                        ],
-                        Config::CODE_3DSECURE => [
-                            'enabled' => true,
-                            'thresholdAmount' => 20,
-                            'specificCountries' => ['GB', 'US', 'CA']
-                        ]
-                    ]
-                ]
+                Config::CODE_3DSECURE => [
+                    'enabled' => $this->config->isVerify3DSecure($storeId),
+                    'thresholdAmount' => $this->config->getThresholdAmount($storeId),
+                    'specificCountries' => $this->config->get3DSecureSpecificCountries($storeId),
+                ],
             ],
-            [
-                'config' => [
-                    'isActive' => false,
-                ],
-                'expected' => [
-                    'payment' => [
-                        ConfigProvider::CODE => [
-                            'isActive' => false,
-                            'clientToken' => null,
-                        ]
-                    ]
-                ]
-            ]
         ];
     }
 
     /**
-     * @return array
+     * Generate a new client token if necessary
+     *
+     * @return string
      */
-    public function getClientTokenDataProvider()
+    public function getClientToken()
     {
-        return [
-            [
-                'merchantAccountId' => '',
-                'params' => []
-            ],
-            [
-                'merchantAccountId' => self::MERCHANT_ACCOUNT_ID,
-                'params' => ['merchantAccountId' => self::MERCHANT_ACCOUNT_ID]
-            ]
-        ];
+        if (empty($this->clientToken)) {
+            $params = [];
+
+            $storeId = $this->session->getStoreId();
+            $merchantAccountId = $this->config->getMerchantAccountId($storeId);
+            if (!empty($merchantAccountId)) {
+                $params[PaymentDataBuilder::MERCHANT_ACCOUNT_ID] = $merchantAccountId;
+            }
+
+            $this->clientToken = $this->adapterFactory->create($storeId)
+                ->generate($params);
+        }
+
+        return $this->clientToken;
     }
 }


### PR DESCRIPTION
### Description (*)
If Braintree module is enabled then it requests ClientToken via Curl request on every shopping cart and checkout page load **regardless active/non-active configuration** of payment method.
Curl request takes 0.3-0.5 sec to respond for servers in N.Virginia which is making Shopping Cart and Checkout pages much slower.

My pull request disables requesting Braintree ClientToken if Braintree payment method is not enabled for current store view.

### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/25343

### Manual testing scenarios (*)
1. Test purchases with Braintree payment method.

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
