### PR TITLE
Quality Assurance > The use of function sizeof() is discouraged; use count() instead

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid.php
@@ -300,7 +300,10 @@ class Grid extends \Magento\Backend\Block\Widget
         if ($this->getCollection()) {
             $field = $column->getFilterIndex() ? $column->getFilterIndex() : $column->getIndex();
             if ($column->getFilterConditionCallback()) {
-                call_user_func($column->getFilterConditionCallback(), $this->getCollection(), $column);
+                $column->getFilterConditionCallback()[0]->{$column->getFilterConditionCallback()[1]}(
+                    $this->getCollection(),
+                    $column
+                );
             } else {
                 $condition = $column->getFilter()->getCondition();
                 if ($field && isset($condition)) {
@@ -363,7 +366,7 @@ class Grid extends \Magento\Backend\Block\Widget
                 $this->_setFilterValues($data);
             } elseif ($filter && is_array($filter)) {
                 $this->_setFilterValues($filter);
-            } elseif (0 !== sizeof($this->_defaultFilter)) {
+            } elseif (0 !== count($this->_defaultFilter)) {
                 $this->_setFilterValues($this->_defaultFilter);
             }
 

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Action.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Action.php
@@ -104,6 +104,7 @@ class Action extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Text
         $this->_transformActionData($action, $actionCaption, $row);
 
         if (isset($action['confirm'])) {
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
             $action['onclick'] = 'return window.confirm(\'' . addslashes(
                 $this->escapeHtml($action['confirm'])
             ) . '\')';
@@ -144,7 +145,7 @@ class Action extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Text
                     if (is_array($action['url']) && isset($action['field'])) {
                         $params = [$action['field'] => $this->_getValue($row)];
                         if (isset($action['url']['params'])) {
-                            $params = array_merge($action['url']['params'], $params);
+                            $params[] = $action['url']['params'];
                         }
                         $action['href'] = $this->getUrl($action['url']['base'], $params);
                         unset($action['field']);

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Action.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Renderer/Action.php
@@ -47,7 +47,7 @@ class Action extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Text
             return '&nbsp;';
         }
 
-        if (sizeof($actions) == 1 && !$this->getColumn()->getNoLink()) {
+        if (count($actions) == 1 && !$this->getColumn()->getNoLink()) {
             foreach ($actions as $action) {
                 if (is_array($action)) {
                     return $this->_toLinkHtml($action, $row);
@@ -117,8 +117,8 @@ class Action extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Text
     /**
      * Prepares action data for html render
      *
-     * @param array &$action
-     * @param string &$actionCaption
+     * @param &array $action
+     * @param &string $actionCaption
      * @param \Magento\Framework\DataObject $row
      * @return $this
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)

--- a/app/code/Magento/Backend/Helper/Dashboard/AbstractDashboard.php
+++ b/app/code/Magento/Backend/Helper/Dashboard/AbstractDashboard.php
@@ -58,7 +58,7 @@ abstract class AbstractDashboard extends \Magento\Framework\App\Helper\AbstractH
      */
     public function getCount()
     {
-        return sizeof($this->getItems());
+        return count($this->getItems());
     }
 
     /**

--- a/app/code/Magento/Backend/Helper/Dashboard/AbstractDashboard.php
+++ b/app/code/Magento/Backend/Helper/Dashboard/AbstractDashboard.php
@@ -8,6 +8,7 @@ namespace Magento\Backend\Helper\Dashboard;
 /**
  * Adminhtml abstract  dashboard helper.
  *
+ * phpcs:disable Magento2.Classes.AbstractApi
  * @api
  * @since 100.0.2
  */
@@ -28,6 +29,8 @@ abstract class AbstractDashboard extends \Magento\Framework\App\Helper\AbstractH
     protected $_params = [];
 
     /**
+     * Return collections
+     *
      * @return array|\Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
      */
     public function getCollection()
@@ -39,6 +42,8 @@ abstract class AbstractDashboard extends \Magento\Framework\App\Helper\AbstractH
     }
 
     /**
+     * Init collections
+     *
      * @return void
      */
     abstract protected function _initCollection();
@@ -54,6 +59,8 @@ abstract class AbstractDashboard extends \Magento\Framework\App\Helper\AbstractH
     }
 
     /**
+     * Return items count
+     *
      * @return int
      */
     public function getCount()
@@ -62,6 +69,8 @@ abstract class AbstractDashboard extends \Magento\Framework\App\Helper\AbstractH
     }
 
     /**
+     * Return column
+     *
      * @param string $index
      * @return array
      */
@@ -85,6 +94,8 @@ abstract class AbstractDashboard extends \Magento\Framework\App\Helper\AbstractH
     }
 
     /**
+     * Set params with value
+     *
      * @param string $name
      * @param mixed $value
      * @return void
@@ -95,6 +106,8 @@ abstract class AbstractDashboard extends \Magento\Framework\App\Helper\AbstractH
     }
 
     /**
+     * Set params
+     *
      * @param array $params
      * @return void
      */
@@ -104,6 +117,8 @@ abstract class AbstractDashboard extends \Magento\Framework\App\Helper\AbstractH
     }
 
     /**
+     * Get params with name
+     *
      * @param string $name
      * @return mixed
      */
@@ -117,6 +132,8 @@ abstract class AbstractDashboard extends \Magento\Framework\App\Helper\AbstractH
     }
 
     /**
+     * Get params
+     *
      * @return array
      */
     public function getParams()

--- a/app/code/Magento/Backend/Helper/Dashboard/Data.php
+++ b/app/code/Magento/Backend/Helper/Dashboard/Data.php
@@ -68,7 +68,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function countStores()
     {
-        return sizeof($this->_stores->getItems());
+        return count($this->_stores->getItems());
     }
 
     /**
@@ -88,8 +88,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     }
 
     /**
-     * Create data hash to ensure that we got valid
-     * data and it is not changed by some one else.
+     * Create data hash to ensure that we got valid data and it is not changed by some one else.
      *
      * @param string $data
      * @return string
@@ -97,6 +96,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getChartDataHash($data)
     {
         $secret = $this->_installDate;
+        // phpcs:disable Magento2.Security.InsecureFunction.FoundWithAlternative
         return md5($data . $secret);
     }
 }

--- a/app/code/Magento/Catalog/Model/Entity/Product/Attribute/Design/Options/Container.php
+++ b/app/code/Magento/Catalog/Model/Entity/Product/Attribute/Design/Options/Container.php
@@ -21,7 +21,7 @@ class Container extends \Magento\Eav\Model\Entity\Attribute\Source\Config
     public function getOptionText($value)
     {
         $options = $this->getAllOptions();
-        if (sizeof($options) > 0) {
+        if (count($options) > 0) {
             foreach ($options as $option) {
                 if (isset($option['value']) && $option['value'] == $value) {
                     return __($option['label']);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Type/PriceTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Type/PriceTest.php
@@ -165,9 +165,13 @@ class PriceTest extends \PHPUnit\Framework\TestCase
         $this->websiteMock->expects($this->any())->method('getId')->will($this->returnValue($expectedWebsiteId));
         $this->tpFactory->expects($this->any())
             ->method('create')
-            ->will($this->returnCallback(function () {
-                return $this->objectManagerHelper->getObject(\Magento\Catalog\Model\Product\TierPrice::class);
-            }));
+            ->will(
+                $this->returnCallback(
+                    function () {
+                        return $this->objectManagerHelper->getObject(\Magento\Catalog\Model\Product\TierPrice::class);
+                    }
+                )
+            );
 
         // create sample TierPrice objects that would be coming from a REST call
         $tierPriceExtensionMock = $this->getMockBuilder(ProductTierPriceExtensionInterface::class)
@@ -198,9 +202,10 @@ class PriceTest extends \PHPUnit\Framework\TestCase
         $tpArray = $this->product->getData($this::KEY_TIER_PRICE);
         $this->assertNotNull($tpArray);
         $this->assertTrue(is_array($tpArray));
-        $this->assertEquals(sizeof($tps), sizeof($tpArray));
+        $this->assertEquals(count($tps), count($tpArray));
 
-        for ($i = 0; $i < sizeof($tps); $i++) {
+        $count = count($tps);
+        for ($i = 0; $i < $count; $i++) {
             $tpData = $tpArray[$i];
             $this->assertEquals($expectedWebsiteId, $tpData['website_id'], 'Website Id does not match');
             $this->assertEquals($tps[$i]->getValue(), $tpData['price'], 'Price/Value does not match');
@@ -226,12 +231,13 @@ class PriceTest extends \PHPUnit\Framework\TestCase
         $tpRests = $this->model->getTierPrices($this->product);
         $this->assertNotNull($tpRests);
         $this->assertTrue(is_array($tpRests));
-        $this->assertEquals(sizeof($tps), sizeof($tpRests));
+        $this->assertEquals(count($tps), count($tpRests));
         foreach ($tpRests as $tpRest) {
             $this->assertEquals(50, $tpRest->getExtensionAttributes()->getPercentageValue());
         }
 
-        for ($i = 0; $i < sizeof($tps); $i++) {
+        $count = count($tps);
+        for ($i = 0; $i < $count; $i++) {
             $this->assertEquals(
                 $tps[$i]->getValue(),
                 $tpRests[$i]->getValue(),

--- a/app/code/Magento/Cms/Test/Unit/Model/Wysiwyg/Images/StorageTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Model/Wysiwyg/Images/StorageTest.php
@@ -454,7 +454,7 @@ class StorageTest extends \PHPUnit\Framework\TestCase
         $storageCollectionMock->expects($this->once())
             ->method('getIterator')
             ->willReturn(new \ArrayIterator($collectionArray));
-        $storageCollectionInvMock = $storageCollectionMock->expects($this->exactly(sizeof($expectedRemoveKeys)))
+        $storageCollectionInvMock = $storageCollectionMock->expects($this->exactly(count($expectedRemoveKeys)))
             ->method('removeItemByKey');
         call_user_func_array([$storageCollectionInvMock, 'withConsecutive'], $expectedRemoveKeys);
 

--- a/app/code/Magento/Cron/Model/Schedule.php
+++ b/app/code/Magento/Cron/Model/Schedule.php
@@ -97,7 +97,7 @@ class Schedule extends \Magento\Framework\Model\AbstractModel
     public function setCronExpr($expr)
     {
         $e = preg_split('#\s+#', $expr, null, PREG_SPLIT_NO_EMPTY);
-        if (sizeof($e) < 5 || sizeof($e) > 6) {
+        if (count($e) < 5 || count($e) > 6) {
             throw new CronException(__('Invalid cron expression: %1', $expr));
         }
 
@@ -168,7 +168,7 @@ class Schedule extends \Magento\Framework\Model\AbstractModel
         // handle modulus
         if (strpos($expr, '/') !== false) {
             $e = explode('/', $expr);
-            if (sizeof($e) !== 2) {
+            if (count($e) !== 2) {
                 throw new CronException(__('Invalid cron expression, expecting \'match/modulus\': %1', $expr));
             }
             if (!is_numeric($e[1])) {
@@ -187,7 +187,7 @@ class Schedule extends \Magento\Framework\Model\AbstractModel
         } elseif (strpos($expr, '-') !== false) {
             // handle range
             $e = explode('-', $expr);
-            if (sizeof($e) !== 2) {
+            if (count($e) !== 2) {
                 throw new CronException(__('Invalid cron expression, expecting \'from-to\' structure: %1', $expr));
             }
 

--- a/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Matrix.php
+++ b/app/code/Magento/CurrencySymbol/Block/Adminhtml/System/Currency/Rate/Matrix.php
@@ -11,6 +11,9 @@
  */
 namespace Magento\CurrencySymbol\Block\Adminhtml\System\Currency\Rate;
 
+/**
+ * Manage currency block
+ */
 class Matrix extends \Magento\Backend\Block\Template
 {
     /**
@@ -105,7 +108,7 @@ class Matrix extends \Magento\Backend\Block\Template
         foreach ($array as $key => $rate) {
             foreach ($rate as $code => $value) {
                 $parts = explode('.', $value);
-                if (sizeof($parts) == 2) {
+                if (count($parts) == 2) {
                     $parts[1] = str_pad(rtrim($parts[1], 0), 4, '0', STR_PAD_RIGHT);
                     $array[$key][$code] = join('.', $parts);
                 } elseif ($value > 0) {

--- a/app/code/Magento/Directory/Model/ResourceModel/Currency.php
+++ b/app/code/Magento/Directory/Model/ResourceModel/Currency.php
@@ -138,7 +138,7 @@ class Currency extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      */
     public function saveRates($rates)
     {
-        if (is_array($rates) && sizeof($rates) > 0) {
+        if (is_array($rates) && count($rates) > 0) {
             $connection = $this->getConnection();
             $data = [];
             foreach ($rates as $currencyCode => $rate) {
@@ -176,7 +176,7 @@ class Currency extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $result = [];
         $rowSet = $connection->fetchAll($select, $bind);
         foreach ($rowSet as $row) {
-            $result = array_merge($result, explode(',', $row['value']));
+            $result[] = explode(',', $row['value']);
         }
         sort($result);
 

--- a/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
+++ b/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
@@ -11,21 +11,22 @@ use Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend;
 use Magento\Eav\Model\Entity\Attribute\Frontend\AbstractFrontend;
 use Magento\Eav\Model\Entity\Attribute\Source\AbstractSource;
 use Magento\Eav\Model\Entity\Attribute\UniqueValidationInterface;
+use Magento\Eav\Model\ResourceModel\Attribute\DefaultEntityAttributes\ProviderInterface as DefaultAttributesProvider;
 use Magento\Framework\App\Config\Element;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\DataObject;
 use Magento\Framework\DB\Adapter\DuplicateException;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Model\AbstractModel;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
 use Magento\Framework\Model\ResourceModel\Db\ObjectRelationProcessor;
 use Magento\Framework\Model\ResourceModel\Db\TransactionManagerInterface;
-use Magento\Eav\Model\ResourceModel\Attribute\DefaultEntityAttributes\ProviderInterface as DefaultAttributesProvider;
-use Magento\Framework\Model\ResourceModel\AbstractResource;
-use Magento\Framework\App\ObjectManager;
 
 /**
  * Entity/Attribute/Model - entity abstract
  *
+ * phpcs:disable Magento2.Classes.AbstractApi
  * @api
  * @author     Magento Core Team <core@magentocommerce.com>
  * @SuppressWarnings(PHPMD.TooManyFields)
@@ -265,6 +266,8 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
 
     /**
      * Resource initialization
+     *
+     * phpcs:disable Magento2.CodeAnalysis.EmptyBlock
      *
      * @return void
      */
@@ -687,6 +690,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
             }
 
             try {
+                // phpcs:disable Magento2.Functions.DiscouragedFunction
                 $results[$attrCode] = call_user_func_array([$instance, $method], $args);
             } catch (\Magento\Eav\Model\Entity\Attribute\Exception $e) {
                 if ($collectExceptionMessages) {
@@ -826,9 +830,9 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
             $prefix = (string) $this->getEntityType()->getValueTablePrefix();
             if (!empty($prefix)) {
                 $this->_valueTablePrefix = $prefix;
-                /**
-                 * entity type prefix include DB table name prefix
-                 */
+            /**
+             * entity type prefix include DB table name prefix
+             */
                 //$this->_resource->getTableName($prefix);
             } else {
                 $this->_valueTablePrefix = $this->getEntityTable();
@@ -991,9 +995,9 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Load entity's attributes into the object
      *
-     * @param   AbstractModel $object
-     * @param   int $entityId
-     * @param   array|null $attributes
+     * @param AbstractModel $object
+     * @param int $entityId
+     * @param array|null $attributes
      * @return $this
      */
     public function load($object, $entityId, $attributes = [])
@@ -1131,8 +1135,8 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Initialize attribute value for object
      *
-     * @param   DataObject $object
-     * @param   array $valueRow
+     * @param DataObject $object
+     * @param array $valueRow
      * @return $this
      */
     protected function _setAttributeValue($object, $valueRow)
@@ -1237,7 +1241,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Aggregate Data for attributes that will be deleted
      *
-     * @param array &$delete
+     * @param &array $delete
      * @param AbstractAttribute $attribute
      * @param AbstractEntity $object
      * @return void
@@ -1248,6 +1252,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
             if (!isset($delete[$tableName])) {
                 $delete[$tableName] = [];
             }
+            // phpcs:ignore Magento2.Performance.ForeachArrayMerge
             $delete[$tableName] = array_merge((array)$delete[$tableName], $valuesData);
         }
     }
@@ -1422,7 +1427,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Save object collected data
      *
-     * @param   array $saveData array('newObject', 'entityRow', 'insert', 'update', 'delete')
+     * @param array $saveData array('newObject', 'entityRow', 'insert', 'update', 'delete')
      * @return $this
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
@@ -1517,9 +1522,9 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Insert entity attribute value
      *
-     * @param   DataObject $object
-     * @param   AbstractAttribute $attribute
-     * @param   mixed $value
+     * @param DataObject $object
+     * @param AbstractAttribute $attribute
+     * @param mixed $value
      * @return $this
      */
     protected function _insertAttribute($object, $attribute, $value)
@@ -1530,10 +1535,10 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     /**
      * Update entity attribute value
      *
-     * @param   DataObject $object
-     * @param   AbstractAttribute $attribute
-     * @param   mixed $valueId
-     * @param   mixed $value
+     * @param DataObject $object
+     * @param AbstractAttribute $attribute
+     * @param mixed $valueId
+     * @param mixed $value
      * @return $this
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
@@ -1892,10 +1897,12 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
      */
     public function getDefaultAttributes()
     {
-        return array_unique(array_merge(
-            $this->_getDefaultAttributes(),
-            [$this->getEntityIdField(), $this->getLinkField()]
-        ));
+        return array_unique(
+            array_merge(
+                $this->_getDefaultAttributes(),
+                [$this->getEntityIdField(), $this->getLinkField()]
+            )
+        );
     }
 
     /**

--- a/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
+++ b/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
@@ -640,7 +640,7 @@ abstract class AbstractEntity extends AbstractResource implements EntityInterfac
     public function walkAttributes($partMethod, array $args = [], $collectExceptionMessages = null)
     {
         $methodArr = explode('/', $partMethod);
-        switch (sizeof($methodArr)) {
+        switch (count($methodArr)) {
             case 1:
                 $part = 'attribute';
                 $method = $methodArr[0];

--- a/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerReindexCommandTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerReindexCommandTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Indexer\Test\Unit\Console\Command;
 
 use Magento\Framework\Console\Cli;
@@ -85,23 +86,31 @@ class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
         $this->stateMock->expects($this->never())->method('setAreaCode');
         $this->command = new IndexerReindexCommand($this->objectManagerFactory);
         $optionsList = $this->command->getInputList();
-        $this->assertSame(1, sizeof($optionsList));
+        $this->assertSame(1, count($optionsList));
         $this->assertSame('index', $optionsList[0]->getName());
     }
 
     public function testExecuteAll()
     {
-        $this->configMock->expects($this->once())->method('getIndexer')->will($this->returnValue([
-            'title' => 'Title_indexerOne',
-            'shared_index' => null
-        ]));
+        $this->configMock->expects($this->once())
+            ->method('getIndexer')
+            ->will(
+                $this->returnValue(
+                    [
+                        'title' => 'Title_indexerOne',
+                        'shared_index' => null
+                    ]
+                )
+            );
         $this->configureAdminArea();
-        $this->initIndexerCollectionByItems([
-            $this->getIndexerMock(
-                ['reindexAll', 'getStatus'],
-                ['indexer_id' => 'id_indexerOne', 'title' => 'Title_indexerOne']
-            )
-        ]);
+        $this->initIndexerCollectionByItems(
+            [
+                $this->getIndexerMock(
+                    ['reindexAll', 'getStatus'],
+                    ['indexer_id' => 'id_indexerOne', 'title' => 'Title_indexerOne']
+                )
+            ]
+        );
         $this->indexerFactory->expects($this->never())->method('create');
         $this->command = new IndexerReindexCommand($this->objectManagerFactory);
         $commandTester = new CommandTester($this->command);
@@ -118,6 +127,7 @@ class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
      * @param array $reindexAllCallMatchers
      * @param array $executedIndexers
      * @param array $executedSharedIndexers
+     *
      * @dataProvider executeWithIndexDataProvider
      */
     public function testExecuteWithIndex(
@@ -210,6 +220,7 @@ class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
     /**
      * @param array|null $methods
      * @param array $data
+     *
      * @return \PHPUnit_Framework_MockObject_MockObject|StateInterface
      */
     private function getStateMock(array $methods = null, array $data = [])
@@ -329,7 +340,7 @@ class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
                     'indexer_5' => $this->once(),
                 ],
                 'executed_indexers' => ['indexer_3', 'indexer_1', 'indexer_5'],
-                'executed_shared_indexers' => [['indexer_2'],['indexer_3']],
+                'executed_shared_indexers' => [['indexer_2'], ['indexer_3']],
             ],
             'With dependencies and multiple indexers in request' => [
                 'inputIndexers' => [
@@ -445,13 +456,16 @@ class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
             "The following requested index types are not supported: '"
             . join("', '", $inputIndexers)
             . "'." . PHP_EOL . 'Supported types: '
-            . join(", ", array_map(
-                function ($item) {
-                    /** @var IndexerInterface $item */
-                    $item->getId();
-                },
-                $this->indexerCollectionMock->getItems()
-            ))
+            . join(
+                ", ",
+                array_map(
+                    function ($item) {
+                        /** @var IndexerInterface $item */
+                        $item->getId();
+                    },
+                    $this->indexerCollectionMock->getItems()
+                )
+            )
         );
         $this->command = new IndexerReindexCommand($this->objectManagerFactory);
         $commandTester = new CommandTester($this->command);

--- a/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerSetModeCommandTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerSetModeCommandTest.php
@@ -26,7 +26,7 @@ class IndexerSetModeCommandTest extends AbstractIndexerCommandCommonSetup
         $this->stateMock->expects($this->never())->method('setAreaCode')->with(FrontNameResolver::AREA_CODE);
         $this->command = new IndexerSetModeCommand($this->objectManagerFactory);
         $optionsList = $this->command->getInputList();
-        $this->assertSame(2, sizeof($optionsList));
+        $this->assertSame(2, count($optionsList));
         $this->assertSame('mode', $optionsList[0]->getName());
         $this->assertSame('index', $optionsList[1]->getName());
     }

--- a/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerShowModeCommandTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerShowModeCommandTest.php
@@ -23,7 +23,7 @@ class IndexerShowModeCommandTest extends AbstractIndexerCommandCommonSetup
         $this->stateMock->expects($this->never())->method('setAreaCode')->with(FrontNameResolver::AREA_CODE);
         $this->command = new IndexerShowModeCommand($this->objectManagerFactory);
         $optionsList = $this->command->getInputList();
-        $this->assertSame(1, sizeof($optionsList));
+        $this->assertSame(1, count($optionsList));
         $this->assertSame('index', $optionsList[0]->getName());
     }
 

--- a/app/code/Magento/Rule/Model/AbstractModel.php
+++ b/app/code/Magento/Rule/Model/AbstractModel.php
@@ -12,6 +12,7 @@ use Magento\Framework\Api\ExtensionAttributesFactory;
  * Abstract Rule entity data model
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * phpcs:disable Magento2.Classes.AbstractApi
  * @api
  * @since 100.0.2
  */
@@ -342,7 +343,7 @@ abstract class AbstractModel extends \Magento\Framework\Model\AbstractExtensible
                 foreach ($value as $id => $data) {
                     $path = explode('--', $id);
                     $node = & $arr;
-                    for ($i = 0, $l = sizeof($path); $i < $l; $i++) {
+                    for ($i = 0, $l = count($path); $i < $l; $i++) {
                         if (!isset($node[$key][$path[$i]])) {
                             $node[$key][$path[$i]] = [];
                         }
@@ -483,6 +484,8 @@ abstract class AbstractModel extends \Magento\Framework\Model\AbstractExtensible
     }
 
     /**
+     * Get extension factory
+     *
      * @return \Magento\Framework\Api\ExtensionAttributesFactory
      * @deprecated 100.1.0
      */
@@ -493,6 +496,8 @@ abstract class AbstractModel extends \Magento\Framework\Model\AbstractExtensible
     }
 
     /**
+     * Get custom attribute factory
+     *
      * @return \Magento\Framework\Api\AttributeValueFactory
      * @deprecated 100.1.0
      */

--- a/app/code/Magento/Rule/Model/Action/Collection.php
+++ b/app/code/Magento/Rule/Model/Action/Collection.php
@@ -91,7 +91,7 @@ class Collection extends AbstractAction
 
         $actions[] = $action;
         if (!$action->getId()) {
-            $action->setId($this->getId() . '.' . sizeof($actions));
+            $action->setId($this->getId() . '.' . count($actions));
         }
 
         $this->setActions($actions);

--- a/app/code/Magento/Rule/Model/Action/Collection.php
+++ b/app/code/Magento/Rule/Model/Action/Collection.php
@@ -3,9 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Rule\Model\Action;
 
 /**
+ * Collections
+ *
  * @api
  * @since 100.0.2
  */
@@ -61,6 +64,8 @@ class Collection extends AbstractAction
     }
 
     /**
+     * Load array
+     *
      * @param array $arr
      * @return $this
      */
@@ -80,6 +85,8 @@ class Collection extends AbstractAction
     }
 
     /**
+     * Add actions
+     *
      * @param ActionInterface $action
      * @return $this
      */
@@ -99,6 +106,8 @@ class Collection extends AbstractAction
     }
 
     /**
+     * As html
+     *
      * @return string
      */
     public function asHtml()
@@ -111,6 +120,8 @@ class Collection extends AbstractAction
     }
 
     /**
+     * Return new child element
+     *
      * @return $this
      */
     public function getNewChildElement()
@@ -129,6 +140,8 @@ class Collection extends AbstractAction
     }
 
     /**
+     * Return as html recursive
+     *
      * @return string
      */
     public function asHtmlRecursive()
@@ -142,6 +155,8 @@ class Collection extends AbstractAction
     }
 
     /**
+     * Add string
+     *
      * @param string $format
      * @return string
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
@@ -153,6 +168,8 @@ class Collection extends AbstractAction
     }
 
     /**
+     * Return string as recursive
+     *
      * @param int $level
      * @return string
      */
@@ -166,6 +183,8 @@ class Collection extends AbstractAction
     }
 
     /**
+     * Process
+     *
      * @return $this
      */
     public function process()

--- a/app/code/Magento/Rule/Model/Condition/Combine.php
+++ b/app/code/Magento/Rule/Model/Condition/Combine.php
@@ -134,7 +134,7 @@ class Combine extends AbstractCondition
         $conditions[] = $condition;
 
         if (!$condition->getId()) {
-            $condition->setId($this->getId() . '--' . sizeof($conditions));
+            $condition->setId($this->getId() . '--' . count($conditions));
         }
 
         $this->setData($this->getPrefix(), $conditions);

--- a/app/code/Magento/Rule/Model/Condition/Combine.php
+++ b/app/code/Magento/Rule/Model/Condition/Combine.php
@@ -6,6 +6,8 @@
 namespace Magento\Rule\Model\Condition;
 
 /**
+ * Combine
+ *
  * @api
  * @since 100.0.2
  */
@@ -22,6 +24,8 @@ class Combine extends AbstractCondition
     protected $_logger;
 
     /**
+     * Construct
+     *
      * @param Context $context
      * @param array $data
      */
@@ -54,6 +58,8 @@ class Combine extends AbstractCondition
     /* start aggregator methods */
 
     /**
+     * Load aggregation options
+     *
      * @return $this
      */
     public function loadAggregatorOptions()
@@ -63,6 +69,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * Return agregator selected options
+     *
      * @return array
      */
     public function getAggregatorSelectOptions()
@@ -75,6 +83,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * Get Agregator name
+     *
      * @return string
      */
     public function getAggregatorName()
@@ -83,6 +93,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * Return agregator element
+     *
      * @return object
      */
     public function getAggregatorElement()
@@ -112,6 +124,8 @@ class Combine extends AbstractCondition
     /* end aggregator methods */
 
     /**
+     * Load value options
+     *
      * @return $this
      */
     public function loadValueOptions()
@@ -121,6 +135,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * Adds condition
+     *
      * @param object $condition
      * @return $this
      */
@@ -142,6 +158,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * Return value element type
+     *
      * @return string
      */
     public function getValueElementType()
@@ -181,6 +199,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * As xml
+     *
      * @param string $containerKey
      * @param string $itemKey
      * @return string
@@ -202,6 +222,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * Load array
+     *
      * @param array $arr
      * @param string $key
      * @return $this
@@ -230,6 +252,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * Load xml
+     *
      * @param array|string $xml
      * @return $this
      */
@@ -247,6 +271,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * As html
+     *
      * @return string
      */
     public function asHtml()
@@ -263,6 +289,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * Get new child element
+     *
      * @return $this
      */
     public function getNewChildElement()
@@ -282,6 +310,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * As html recursive
+     *
      * @return string
      */
     public function asHtmlRecursive()
@@ -300,6 +330,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * As string
+     *
      * @param string $format
      * @return string
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
@@ -311,6 +343,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * As string recursive
+     *
      * @param int $level
      * @return string
      */
@@ -324,6 +358,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * Validate
+     *
      * @param \Magento\Framework\Model\AbstractModel $model
      * @return bool
      */
@@ -374,6 +410,8 @@ class Combine extends AbstractCondition
     }
 
     /**
+     * Set js From object
+     *
      * @param \Magento\Framework\Data\Form $form
      * @return $this
      */

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Giftmessage.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Giftmessage.php
@@ -97,7 +97,7 @@ class Giftmessage extends \Magento\Sales\Block\Adminhtml\Order\Create\AbstractCr
             }
         }
 
-        if (sizeof($items)) {
+        if (count($items)) {
             return $items;
         }
 

--- a/app/code/Magento/Theme/Block/Html/Pager.php
+++ b/app/code/Magento/Theme/Block/Html/Pager.php
@@ -236,7 +236,7 @@ class Pager extends \Magento\Framework\View\Element\Template
      */
     public function isShowPerPage()
     {
-        if (sizeof($this->getAvailableLimit()) <= 1) {
+        if (count($this->getAvailableLimit()) <= 1) {
             return false;
         }
         return $this->_showPerPage;

--- a/app/code/Magento/Translation/Console/Command/UninstallLanguageCommand.php
+++ b/app/code/Magento/Translation/Console/Command/UninstallLanguageCommand.php
@@ -85,31 +85,33 @@ class UninstallLanguageCommand extends Command
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function configure()
     {
         $this->setName('i18n:uninstall')
             ->setDescription('Uninstalls language packages')
-            ->setDefinition([
-                new InputArgument(
-                    self::PACKAGE_ARGUMENT,
-                    InputArgument::IS_ARRAY | InputArgument::REQUIRED,
-                    'Language package name'
-                ),
-                new InputOption(
-                    self::BACKUP_CODE_OPTION,
-                    '-b',
-                    InputOption::VALUE_NONE,
-                    'Take code and configuration files backup (excluding temporary files)'
-                ),
-            ]);
+            ->setDefinition(
+                [
+                    new InputArgument(
+                        self::PACKAGE_ARGUMENT,
+                        InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+                        'Language package name'
+                    ),
+                    new InputOption(
+                        self::BACKUP_CODE_OPTION,
+                        '-b',
+                        InputOption::VALUE_NONE,
+                        'Take code and configuration files backup (excluding temporary files)'
+                    )
+                ]
+            );
 
         parent::configure();
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -121,7 +123,7 @@ class UninstallLanguageCommand extends Command
             if (!$this->validate($package)) {
                 $output->writeln("<info>Package $package is not a Magento language and will be skipped.</info>");
             } else {
-                if (sizeof($dependencies[$package]) > 0) {
+                if (count($dependencies[$package]) > 0) {
                     $output->writeln("<info>Package $package has dependencies and will be skipped.</info>");
                 } else {
                     $packagesToRemove[] = $package;

--- a/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite.php
+++ b/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite.php
@@ -80,8 +80,9 @@ class UrlRewrite implements ResolverInterface
     {
         $urlParameters = [];
         $targetPathParts = explode('/', trim($targetPath, '/'));
+        $count = count($targetPathParts) - 1;
 
-        for ($i = 3; ($i < sizeof($targetPathParts) - 1); $i += 2) {
+        for ($i = 3; $i < $count; $i += 2) {
             $urlParameters[] = [
                 'name' => $targetPathParts[$i],
                 'value' => $targetPathParts[$i + 1]

--- a/dev/tests/api-functional/testsuite/Magento/Bundle/Api/ProductServiceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Bundle/Api/ProductServiceTest.php
@@ -282,7 +282,6 @@ class ProductServiceTest extends WebapiAbstract
     protected function setBundleProductOptions(&$product, $bundleProductOptions)
     {
         $product["extension_attributes"]["bundle_product_options"] = $bundleProductOptions;
-        return;
     }
 
     /**
@@ -499,7 +498,8 @@ class ProductServiceTest extends WebapiAbstract
     protected function saveProduct($product)
     {
         if (isset($product['custom_attributes'])) {
-            for ($i=0; $i<sizeof($product['custom_attributes']); $i++) {
+            $count = count($product['custom_attributes']);
+            for ($i=0; $i < $count; $i++) {
                 if ($product['custom_attributes'][$i]['attribute_code'] == 'category_ids'
                     && !is_array($product['custom_attributes'][$i]['value'])
                 ) {

--- a/dev/tests/api-functional/testsuite/Magento/CatalogInventory/Api/ProductRepositoryInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/CatalogInventory/Api/ProductRepositoryInterfaceTest.php
@@ -306,7 +306,8 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
     protected function saveProduct($product)
     {
         if (isset($product['custom_attributes'])) {
-            for ($i=0; $i<sizeof($product['custom_attributes']); $i++) {
+            $count = count($product['custom_attributes']);
+            for ($i=0; $i < $count; $i++) {
                 if ($product['custom_attributes'][$i]['attribute_code'] == 'category_ids'
                     && !is_array($product['custom_attributes'][$i]['value'])
                 ) {
@@ -339,7 +340,8 @@ class ProductRepositoryInterfaceTest extends WebapiAbstract
     protected function updateProduct($product)
     {
         if (isset($product['custom_attributes'])) {
-            for ($i=0; $i<sizeof($product['custom_attributes']); $i++) {
+            $count = count($product['custom_attributes']);
+            for ($i=0; $i < $count; $i++) {
                 if ($product['custom_attributes'][$i]['attribute_code'] == 'category_ids'
                     && !is_array($product['custom_attributes'][$i]['value'])
                 ) {

--- a/dev/tests/api-functional/testsuite/Magento/ConfigurableProduct/Api/ProductRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/ConfigurableProduct/Api/ProductRepositoryTest.php
@@ -462,7 +462,8 @@ class ProductRepositoryTest extends WebapiAbstract
     protected function saveProduct($product)
     {
         if (isset($product['custom_attributes'])) {
-            for ($i=0; $i<sizeof($product['custom_attributes']); $i++) {
+            $count = count($product['custom_attributes']);
+            for ($i=0; $i < $count; $i++) {
                 if ($product['custom_attributes'][$i]['attribute_code'] == 'category_ids'
                     && !is_array($product['custom_attributes'][$i]['value'])
                 ) {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/UrlRewritesTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/UrlRewritesTest.php
@@ -140,8 +140,9 @@ QUERY;
     {
         $urlParameters = [];
         $targetPathParts = explode('/', trim($targetPath, '/'));
+        $count = count($targetPathParts) - 1;
 
-        for ($i = 3; ($i < sizeof($targetPathParts) - 1); $i += 2) {
+        for ($i = 3; $i < $count; $i += 2) {
             $urlParameters[] = [
                 'name' => $targetPathParts[$i],
                 'value' => $targetPathParts[$i + 1]

--- a/dev/tests/functional/tests/app/Magento/Backend/Test/Fixture/GlobalSearch/Query.php
+++ b/dev/tests/functional/tests/app/Magento/Backend/Test/Fixture/GlobalSearch/Query.php
@@ -32,7 +32,7 @@ class Query extends DataSource
     {
         $this->params = $params;
         $explodedData = explode('::', $data);
-        switch (sizeof($explodedData)) {
+        switch (count($explodedData)) {
             case 1:
                 $this->data = $explodedData[0];
                 break;

--- a/dev/tests/integration/testsuite/Magento/Braintree/Fixtures/assign_items_per_address.php
+++ b/dev/tests/integration/testsuite/Magento/Braintree/Fixtures/assign_items_per_address.php
@@ -30,7 +30,7 @@ foreach ($addressList as $key => $address) {
 
 // assign virtual product to the billing address
 $billingAddress = $quote->getBillingAddress();
-$virtualItem = $items[sizeof($items) - 1];
+$virtualItem = $items[count($items) - 1];
 $billingAddress->setTotalQty(1);
 $billingAddress->addItem($virtualItem);
 

--- a/dev/tests/integration/testsuite/Magento/Multishipping/Fixtures/quote_with_split_items.php
+++ b/dev/tests/integration/testsuite/Magento/Multishipping/Fixtures/quote_with_split_items.php
@@ -26,7 +26,7 @@ foreach ($addressList as $key => $address) {
 
 // assign virtual product to the billing address
 $billingAddress = $quote->getBillingAddress();
-$virtualItem = $items[sizeof($items) - 1];
+$virtualItem = $items[count($items) - 1];
 $billingAddress->setTotalQty(1);
 $billingAddress->addItem($virtualItem);
 

--- a/lib/internal/Magento/Framework/App/Router/Base.php
+++ b/lib/internal/Magento/Framework/App/Router/Base.php
@@ -184,7 +184,7 @@ class Base implements \Magento\Framework\App\RouterInterface
             $output[$paramName] = array_shift($params);
         }
 
-        for ($i = 0, $l = sizeof($params); $i < $l; $i += 2) {
+        for ($i = 0, $l = count($params); $i < $l; $i += 2) {
             $output['variables'][$params[$i]] = isset($params[$i + 1]) ? urldecode($params[$i + 1]) : '';
         }
         return $output;

--- a/lib/internal/Magento/Framework/Event/Observer/Cron.php
+++ b/lib/internal/Magento/Framework/Event/Observer/Cron.php
@@ -11,6 +11,9 @@
  */
 namespace Magento\Framework\Event\Observer;
 
+/**
+ * Event cron observer object
+ */
 class Cron extends \Magento\Framework\Event\Observer
 {
     /**
@@ -25,7 +28,7 @@ class Cron extends \Magento\Framework\Event\Observer
     public function isValidFor(\Magento\Framework\Event $event)
     {
         $e = preg_split('#\s+#', $this->getCronExpr(), null, PREG_SPLIT_NO_EMPTY);
-        if (sizeof($e) !== 5) {
+        if (count($e) !== 5) {
             return false;
         }
 
@@ -50,6 +53,8 @@ class Cron extends \Magento\Framework\Event\Observer
     }
 
     /**
+     * Return current time
+     *
      * @return int
      */
     public function getNow()
@@ -61,6 +66,8 @@ class Cron extends \Magento\Framework\Event\Observer
     }
 
     /**
+     * Match cron expression with current time (minutes, hours, day of the month, month, day of the week)
+     *
      * @param string $expr
      * @param int $num
      * @return bool
@@ -87,7 +94,7 @@ class Cron extends \Magento\Framework\Event\Observer
         // handle modulus
         if (strpos($expr, '/') !== false) {
             $e = explode('/', $expr);
-            if (sizeof($e) !== 2) {
+            if (count($e) !== 2) {
                 return false;
             }
             $expr = $e[0];
@@ -102,7 +109,7 @@ class Cron extends \Magento\Framework\Event\Observer
         // handle range
         if (strpos($expr, '-') !== false) {
             $e = explode('-', $expr);
-            if (sizeof($e) !== 2) {
+            if (count($e) !== 2) {
                 return false;
             }
 
@@ -118,6 +125,8 @@ class Cron extends \Magento\Framework\Event\Observer
     }
 
     /**
+     * Return month number
+     *
      * @param int|string $value
      * @return bool|string
      */

--- a/lib/internal/Magento/Framework/Simplexml/Element.php
+++ b/lib/internal/Magento/Framework/Simplexml/Element.php
@@ -451,7 +451,7 @@ class Element extends \SimpleXMLElement
                 $arr[] = $v;
             }
         }
-        $last = sizeof($arr) - 1;
+        $last = count($arr) - 1;
         $node = $this;
         foreach ($arr as $i => $nodeName) {
             if ($last === $i) {

--- a/setup/src/Magento/Setup/Controller/DataOption.php
+++ b/setup/src/Magento/Setup/Controller/DataOption.php
@@ -56,6 +56,6 @@ class DataOption extends AbstractActionController
         if (isset($params['moduleName'])) {
             $uninstallClasses = $this->uninstallCollector->collectUninstall([$params['moduleName']]);
         }
-        return new JsonModel(['hasUninstall' => isset($uninstallClasses) && sizeof($uninstallClasses) > 0]);
+        return new JsonModel(['hasUninstall' => isset($uninstallClasses) && count($uninstallClasses) > 0]);
     }
 }

--- a/setup/src/Magento/Setup/Model/ModuleStatus.php
+++ b/setup/src/Magento/Setup/Model/ModuleStatus.php
@@ -11,6 +11,9 @@ use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\Module\DependencyChecker;
 use Magento\Framework\Module\ModuleList\Loader as ModuleLoader;
 
+/**
+ * Setup module status
+ */
 class ModuleStatus
 {
     /**
@@ -104,7 +107,7 @@ class ModuleStatus
                 [$module['name']],
                 $enabledModules
             );
-            if (sizeof($errorMessages[$module['name']]) === 0) {
+            if (count($errorMessages[$module['name']]) === 0) {
                 $canBeDisabled[] = $module['name'];
             }
         }
@@ -128,6 +131,8 @@ class ModuleStatus
     }
 
     /**
+     * Set module status is enabled
+     *
      * @param bool $status
      * @param String $moduleName
      *

--- a/setup/src/Magento/Setup/Model/UninstallCollector.php
+++ b/setup/src/Magento/Setup/Model/UninstallCollector.php
@@ -55,7 +55,7 @@ class UninstallCollector
         /** @var \Magento\Setup\Module\DataSetup $setup */
         $setup = $this->dataSetupFactory->create();
         $result = $setup->getConnection()->select()->from($setup->getTable('setup_module'), ['module']);
-        if (isset($filterModules) && sizeof($filterModules) > 0) {
+        if (isset($filterModules) && count($filterModules) > 0) {
             $result->where('module in( ? )', $filterModules);
         }
         // go through modules

--- a/setup/src/Magento/Setup/Validator/IpValidator.php
+++ b/setup/src/Magento/Setup/Validator/IpValidator.php
@@ -42,12 +42,12 @@ class IpValidator
 
         $this->filterIps($ips);
 
-        if (sizeof($this->none) > 0 && !$noneAllowed) {
+        if (count($this->none) > 0 && !$noneAllowed) {
             $messages[] = "'none' is not allowed";
-        } elseif ($noneAllowed && sizeof($this->none) > 1) {
+        } elseif ($noneAllowed && count($this->none) > 1) {
             $messages[] = "'none' can be only used once";
-        } elseif ($noneAllowed && sizeof($this->none) > 0 &&
-            (sizeof($this->validIps) > 0 || sizeof($this->invalidIps) > 0)
+        } elseif ($noneAllowed && count($this->none) > 0 &&
+            (count($this->validIps) > 0 || count($this->invalidIps) > 0)
         ) {
             $messages[] = "Multiple values are not allowed when 'none' is used";
         } else {


### PR DESCRIPTION
Quality Assurance > The use of function sizeof() is discouraged; use count() instead

### Description (*)
According to PHP Code Sniffer + Magento Coding Standard

https://github.com/squizlabs/PHP_CodeSniffer/blob/ae3aae46a11e3978f088552160ccca13a01b28e1/src/Standards/Generic/Sniffs/PHP/ForbiddenFunctionsSniff.php#L30

Discourages the use of alias functions. Alias functions are kept in PHP for compatibility with older versions. Can be used to forbid the use of any function.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
