### PR TITLE
Allow autoplay for vimeo thumb click

### DIFF
--- a/app/code/Magento/ProductVideo/view/frontend/web/js/load-player.js
+++ b/app/code/Magento/ProductVideo/view/frontend/web/js/load-player.js
@@ -344,6 +344,7 @@ define([
                     .attr('mozallowfullscreen', '')
                     .attr('allowfullscreen', '')
                     .attr('referrerPolicy', 'origin')
+                    .attr('allow', 'autoplay')
             );
             this._player = window.$f(this.element.children(':first')[0]);
 


### PR DESCRIPTION
Currently on click a video thumb  the video does not start,  but the code to autoplay is incorrect since 2017
https://developers.google.com/web/updates/2017/09/autoplay-policy-changes

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
On the product page when you click the video thumbnail, it should autoplay, but it does not and remains unplayed. Looking at the implementation, this uses the old method of autoplayer parameter.

src="https://player.vimeo.com/video/56282283?api=1&player_id=vimeo562822831571866224063&autoplay=1"

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
With a Vimeo video set up on a product do the following

1. View that product page with the Vimeo video
2. User clicks the video thumbnail 
3. User should have the video autoplay, but it does not due to old way in autoplaying being implemented.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
