### PR TITLE
Fix #23031: Check data\schema patch aliases

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Patch/PatchApplier.php
+++ b/lib/internal/Magento/Framework/Setup/Patch/PatchApplier.php
@@ -161,6 +161,9 @@ class PatchApplier
                     $this->moduleDataSetup->getConnection()->beginTransaction();
                     $dataPatch->apply();
                     $this->patchHistory->fixPatch(get_class($dataPatch));
+                    foreach ($dataPatch->getAliases() as $patchAlias) {
+                        $this->patchHistory->fixPatch($patchAlias);
+                    }
                     $this->moduleDataSetup->getConnection()->commit();
                 } catch (\Exception $e) {
                     $this->moduleDataSetup->getConnection()->rollBack();
@@ -237,6 +240,9 @@ class PatchApplier
                 $schemaPatch = $this->patchFactory->create($schemaPatch, ['schemaSetup' => $this->schemaSetup]);
                 $schemaPatch->apply();
                 $this->patchHistory->fixPatch(get_class($schemaPatch));
+                foreach ($schemaPatch->getAliases() as $patchAlias) {
+                    $this->patchHistory->fixPatch($patchAlias);
+                }
             } catch (\Exception $e) {
                 throw new SetupException(
                     new Phrase(


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
If a data or schema patch has an alias that is already present in `patch_list`, the patch is assumed to be the same patch and should not be applied (again).

### Fixed Issues (if relevant)
1. magento/magento2#23031: [Magento 2.3.x] Declarative Schema :: Data/Schema Patches getAliases() not working as expected

### Manual testing scenarios (*)
Please see #23031 for detailed steps.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
