### PR TITLE
Fixes the problem with page reload when js prompt was closed with enter

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/modal/prompt.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/prompt.js
@@ -73,13 +73,14 @@ define([
          */
         _create: function () {
             var modalContent;
-            
+
             this.options.focus = this.options.promptField;
             this.options.validation = this.options.validation && this.options.validationRules.length;
             this._super();
             modalContent = this.modal.find(this.options.modalContent).append(this.getFormTemplate());
-            if(this.options.formSelector) {
-                modalContentElem.find(this.options.formSelector).on('submit', _.bind(this.submitForm, this));
+
+            if (this.options.formSelector) {
+                modalContent.find(this.options.formSelector).on('submit', _.bind(this.submitForm, this));
             }
             this.modal.find(this.options.modalCloseBtn).off().on('click',  _.bind(this.closeModal, this, false));
 
@@ -126,7 +127,7 @@ define([
 
         /**
          * Handle submit of the form inside prompt
-         * @param event {Event} Event triggered by submit
+         * @param {Event} event
          */
         submitForm: function (event) {
             event.preventDefault();

--- a/app/code/Magento/Ui/view/base/web/js/modal/prompt.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/prompt.js
@@ -22,6 +22,7 @@ define([
             modalClass: 'prompt',
             promptContentTmpl: promptContentTmpl,
             promptField: '[data-role="promptField"]',
+            formSelector: 'form',
             attributesForm: {},
             attributesField: {},
             value: '',
@@ -71,10 +72,15 @@ define([
          * Create widget.
          */
         _create: function () {
+            var modalContentElem;
+            
             this.options.focus = this.options.promptField;
             this.options.validation = this.options.validation && this.options.validationRules.length;
             this._super();
-            this.modal.find(this.options.modalContent).append(this.getFormTemplate());
+            modalContentElem = this.modal.find(this.options.modalContent).append(this.getFormTemplate());
+            if(this.options.formSelector) {
+                modalContentElem.find(this.options.formSelector).on('submit', _.bind(this.submitForm, this));
+            }
             this.modal.find(this.options.modalCloseBtn).off().on('click',  _.bind(this.closeModal, this, false));
 
             if (this.options.validation) {
@@ -116,6 +122,15 @@ define([
             }));
 
             return formTemplate;
+        },
+
+        /**
+         * Handle submit of the form inside prompt
+         * @param event {Event} Event triggered by submit
+         */
+        submitForm: function (event) {
+            event.preventDefault();
+            this.closeModal(true);
         },
 
         /**

--- a/app/code/Magento/Ui/view/base/web/js/modal/prompt.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/prompt.js
@@ -72,12 +72,12 @@ define([
          * Create widget.
          */
         _create: function () {
-            var modalContentElem;
+            var modalContent;
             
             this.options.focus = this.options.promptField;
             this.options.validation = this.options.validation && this.options.validationRules.length;
             this._super();
-            modalContentElem = this.modal.find(this.options.modalContent).append(this.getFormTemplate());
+            modalContent = this.modal.find(this.options.modalContent).append(this.getFormTemplate());
             if(this.options.formSelector) {
                 modalContentElem.find(this.options.formSelector).on('submit', _.bind(this.submitForm, this));
             }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Forms inside prompt.js did not have any submit action, so hitting enter
inside any of the inputs caused submission to the current page - reload of the page.
All the JS logic was lost.
I added a default submit handler (whenever there is a form in the content of the prompt)
and default action that is the same as pressing the OK button on the prompt.
If one does not want this behavior, he can pass an empty selector in options,
and it will disable the onSubmit listener.
This update will prevent faulty submission (by hitting Enter key) on all prompts.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24214: Hitting enter while creation of folder in media browser closes media browser

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

Go to Content > Blocks > New Block
Use Insert Image option -> Media Browser will open
Use the option to Create Folder
Type in folder name like "foobar" and hit Enter key
Folder shall be created - the dialog shall behave the same way as I would click on OK button


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
