### PR TITLE
Fixes unstable email integration tests, by decoding the raw contents …

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Newsletter/Model/SubscriberTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Model/SubscriberTest.php
@@ -100,7 +100,7 @@ class SubscriberTest extends \PHPUnit\Framework\TestCase
 
         $this->assertContains(
             'You have been successfully subscribed to our newsletter.',
-            $transportBuilder->getSentMessage()->getRawMessage()
+            $transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent()
         );
     }
 }

--- a/dev/tests/integration/testsuite/Magento/ProductAlert/Model/EmailTest.php
+++ b/dev/tests/integration/testsuite/Magento/ProductAlert/Model/EmailTest.php
@@ -102,7 +102,7 @@ class EmailTest extends \PHPUnit\Framework\TestCase
 
         $this->assertContains(
             'John Smith,',
-            $this->transportBuilder->getSentMessage()->getRawMessage()
+            $this->transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent()
         );
     }
 

--- a/dev/tests/integration/testsuite/Magento/ProductAlert/Model/ObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/ProductAlert/Model/ObserverTest.php
@@ -71,7 +71,7 @@ class ObserverTest extends \PHPUnit\Framework\TestCase
         $this->observer->process();
         $this->assertContains(
             'John Smith,',
-            $this->transportBuilder->getSentMessage()->getRawMessage()
+            $this->transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent()
         );
     }
 
@@ -117,7 +117,7 @@ class ObserverTest extends \PHPUnit\Framework\TestCase
 
         // dispatch process() method and check sent message
         $this->observer->process();
-        $message = $this->transportBuilder->getSentMessage()->getRawMessage();
+        $message = $this->transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent();
         $expectedText = array_shift($translation);
         $this->assertContains('/frontend/Magento/luma/pt_BR/', $message);
         $this->assertContains(substr($expectedText, 0, 50), $message);

--- a/dev/tests/integration/testsuite/Magento/Wishlist/Controller/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Wishlist/Controller/IndexTest.php
@@ -175,7 +175,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractController
             \Magento\TestFramework\Mail\Template\TransportBuilderMock::class
         );
 
-        $actualResult = quoted_printable_decode($transportBuilder->getSentMessage()->getRawMessage());
+        $actualResult = $transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent();
 
         $this->assertStringMatchesFormat(
             '%A' . $this->_customerViewHelper->getCustomerName($this->_customerSession->getCustomerDataObject())


### PR DESCRIPTION
…which had a maximum line length of 76 to a parseable string without a maximum line length, so there is no chance a particular string used in an assertion is getting splitted over multiple lines.

### Description (*)
This problem was discovered during the contribution day in Amsterdam during Magento Live EU 2019
Here are some failing tests which shouldn't fail: https://testing-service.magento-community.engineering/reports/magento/magento2/pull/25183/7ec3a4e1ee9c98d60a692831691dfa57/Integration/allure-report-ce/index.html (only in `Magento\Newsletter\Model\SubscriberTest` & `Magento\ProductAlert\Model\ObserverTest`) related to PR https://github.com/magento/magento2/pull/25183

The problem here, is that the tests are trying to find a string (for example `You have been successfully subscribed to our newsletter.`) in the html of the email output. But the email output is [Quoted-printable](https://en.wikipedia.org/wiki/Quoted-printable). One of the characteristics of this, is that all lines of the email should be maximum 76 characters long. This means that sometimes the string which is being searched for in the integration tests, can be splitted over multiple lines and thus the integration test to fail if some parts of the email get changed by an unrelated change which shifts the characters a bit to the left or the right and causing the searched string to get splitted over 2 lines. So these integration tests are quite unstable.

This PR fixes this.

There are actually at least 2 solutions which could work:
- using `quoted_printable_decode`, [example test where this already used in Magento](https://github.com/magento/magento2/blob/2.3.3/dev/tests/integration/testsuite/Magento/Wishlist/Controller/IndexTest.php#L178)
- using `$transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent()` instead of `$transportBuilder->getSentMessage()->getRawMessage()`, [example test where this already used in Magento](https://github.com/magento/magento2/blob/2.3.3/dev/tests/integration/testsuite/Magento/Newsletter/Model/SubscriberTest.php#L41)

I've chosen the first one, but if it would be better to use the second one, or even another alternative, let me know!

/cc: @okorshenko, @Echron


Difference between the output:
```
Date: Sat, 26 Oct 2019 11:24:25 +0000
MIME-Version: 1.0
Content-Type: text/html;
 charset="utf-8"
Content-Transfer-Encoding: quoted-printable
Content-Disposition: =?utf-8?Q?inline?=
Subject: Newsletter subscription success
To: customer_confirm@example.com
From: =?utf-8?Q?Owner?= <owner@example.com>

<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.=
org/TR/xhtml1/DTD/xhtml1-strict.dtd">=0A<html xmlns=3D"http://www.w3.org=
/1999/xhtml" style=3D"font-size: 62.5%; -webkit-text-size-adjust: 100%;=20=
-ms-text-size-adjust: 100%; font-size-adjust: 100%; background-color: #f=
5f5f5;">=0A<head>=0A    <meta http-equiv=3D"Content-Type" content=3D"tex=
t/html; charset=3Dutf-8">=0A    <meta name=3D"viewport" content=3D"initi=
al-scale=3D1.0, width=3Ddevice-width">=0A    <meta http-equiv=3D"X-UA-Co=
mpatible" content=3D"IE=3Dedge">=0A    <style type=3D"text/css">=0A    =20=
   =0A=0A        @import url("http://localhost/pub/static/version1572088=
283/frontend/Magento/luma/en_US/css/email-fonts.css");=0Ahtml {=0A  font=
-size: 62.5%;=0A  -webkit-text-size-adjust: 100%;=0A  -ms-text-size-adju=
st: 100%;=0A  font-size-adjust: 100%;=0A}=0Abody {=0A  color: #333333;=
=0A  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-=
...
```

vs

```
Date: Sat, 26 Oct 2019 11:24:25 +0000
MIME-Version: 1.0
Content-Type: text/html;
 charset="utf-8"
Content-Transfer-Encoding: quoted-printable
Content-Disposition: =?utf-8?Q?inline?Subject: Newsletter subscription success
To: customer_confirm@example.com
From: =?utf-8?Q?Owner?= <owner@example.com>

<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" style="font-size: 62.5%; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-size-adjust: 100%; background-color: #f5f5f5;">
<head>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
    <meta name="viewport" content="initial-scale=1.0, width=device-width">
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
    <style type="text/css">


        @import url("http://localhost/pub/static/version1572088283/frontend/Magento/luma/en_US/css/email-fonts.css");
html {
  font-size: 62.5%;
  -webkit-text-size-adjust: 100%;
  -ms-text-size-adjust: 100%;
  font-size-adjust: 100%;
}
body {
  color: #333333;
  font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
...
```


### Fixed Issues (if relevant)
None that I could find

### Manual testing scenarios (*)
1. Put the following code in [`Magento\Newsletter\Model\SubscriberTest::testConfirm`](https://github.com/magento/magento2/blob/2.3.3/dev/tests/integration/testsuite/Magento/Newsletter/Model/SubscriberTest.php#L100) before the assert line

```
        echo $transportBuilder->getSentMessage()->getRawMessage() . "\n\n";
        echo " ======================== \n\n";
        echo quoted_printable_decode($transportBuilder->getSentMessage()->getRawMessage()) . "\n\n";
```
2. Run `cd dev/tests/integration`
3. Run `../../../vendor/bin/phpunit ../../../dev/tests/integration/testsuite/Magento/Newsletter/Model/SubscriberTest.php`
4. Look at the difference and notice that the second one is much more stable to do assertions on

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
