### PR TITLE
Outuput for Exception in db-declaration:generate-whitelist command

### DIFF
--- a/app/code/Magento/Developer/Console/Command/TablesWhitelistGenerateCommand.php
+++ b/app/code/Magento/Developer/Console/Command/TablesWhitelistGenerateCommand.php
@@ -10,6 +10,7 @@ namespace Magento\Developer\Console\Command;
 use Magento\Developer\Model\Setup\Declaration\Schema\WhitelistGenerator;
 use Magento\Framework\Config\FileResolverByModule;
 use Magento\Framework\Exception\ConfigurationMismatchException;
+use Magento\Framework\Console\Cli;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -80,11 +81,12 @@ class TablesWhitelistGenerateCommand extends Command
             $this->whitelistGenerator->generate($moduleName);
         } catch (ConfigurationMismatchException $e) {
             $output->writeln($e->getMessage());
-            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
+            return Cli::RETURN_FAILURE;
         } catch (\Exception $e) {
-            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
+            $output->writeln($e->getMessage());
+            return Cli::RETURN_FAILURE;
         }
 
-        return \Magento\Framework\Console\Cli::RETURN_SUCCESS;
+        return Cli::RETURN_SUCCESS;
     }
 }

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/TablesWhitelistGenerateCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/TablesWhitelistGenerateCommandTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * Class TablesWhitelistGenerateCommandTest
  *
- * @package Magento\Developer\Console\Command
+ * @package Magento\Developer\Test\Unit\Console\Command
  */
 class TablesWhitelistGenerateCommandTest extends TestCase
 {

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/TablesWhitelistGenerateCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/TablesWhitelistGenerateCommandTest.php
@@ -119,7 +119,7 @@ class TablesWhitelistGenerateCommandTest extends TestCase
                 self::CONFIG_EXCEPTION
             ],
             [
-                'Module_Namer',
+                'Module_Name',
                 Cli::RETURN_FAILURE,
                 new ConfigException(__(self::CONFIG_EXCEPTION)),
                 self::CONFIG_EXCEPTION
@@ -143,6 +143,7 @@ class TablesWhitelistGenerateCommandTest extends TestCase
      * Execute command test class for symphony
      *
      * @param string $arguments
+     *
      * @return CommandTester
      */
     private function execute(string $arguments)

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/TablesWhitelistGenerateCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/TablesWhitelistGenerateCommandTest.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Developer\Console\Command;
+
+use Magento\Developer\Console\Command\TablesWhitelistGenerateCommand as GenerateCommand;
+use Magento\Developer\Model\Setup\Declaration\Schema\WhitelistGenerator;
+use Magento\Framework\Console\Cli;
+use Magento\Framework\Exception\ConfigurationMismatchException as ConfigException;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class TablesWhitelistGenerateCommandTest
+ *
+ * @package Magento\Developer\Console\Command
+ */
+class TablesWhitelistGenerateCommandTest extends TestCase
+{
+    // Exception Messages!
+    const CONFIG_EXCEPTION = 'Configuration Exception';
+    const EXCEPTION = 'General Exception';
+
+    /** @var WhitelistGenerator|MockObject $whitelistGenerator */
+    private $whitelistGenerator;
+
+    /** @var TablesWhitelistGenerateCommand $instance */
+    private $instance;
+
+    protected function setUp()
+    {
+        $this->whitelistGenerator = $this->getMockBuilder(WhitelistGenerator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->instance = new GenerateCommand($this->whitelistGenerator);
+    }
+
+    /**
+     * Test case for success scenario
+     *
+     * @param string $arguments
+     * @param string $expected
+     *
+     * @dataProvider successDataProvider
+     */
+    public function testCommandSuccess(string $arguments, string $expected)
+    {
+        $this->whitelistGenerator->expects($this->once())
+            ->method('generate')
+            ->with($arguments);
+
+        $commandTest = $this->execute($arguments);
+        $this->assertEquals($expected, $commandTest->getStatusCode());
+        $this->assertEquals('', $commandTest->getDisplay());
+    }
+
+    /**
+     * Test case for failure scenario
+     *
+     * @param string $arguments
+     * @param string $expected
+     * @param \Exception|ConfigException $exception
+     * @param string $output
+     *
+     * @dataProvider failureDataProvider
+     */
+    public function testCommandFailure(string $arguments, string $expected, $exception, string $output)
+    {
+        $this->whitelistGenerator->expects($this->once())
+            ->method('generate')
+            ->with($arguments)
+            ->willReturnCallback(function () use ($exception) {
+                throw $exception;
+            });
+
+        $commandTest = $this->execute($arguments);
+        $this->assertEquals($expected, $commandTest->getStatusCode());
+        $this->assertEquals($output . PHP_EOL, $commandTest->getDisplay());
+    }
+
+    /**
+     * Data provider for success test case
+     *
+     * @return array
+     */
+    public function successDataProvider()
+    {
+        return [
+            [
+                'all',
+                Cli::RETURN_SUCCESS,
+
+            ],
+            [
+                'Module_Name',
+                Cli::RETURN_SUCCESS
+            ]
+        ];
+    }
+
+    /**
+     * Data provider for failure test case
+     *
+     * @return array
+     */
+    public function failureDataProvider()
+    {
+        return [
+            [
+                'all',
+                Cli::RETURN_FAILURE,
+                new ConfigException(__(self::CONFIG_EXCEPTION)),
+                self::CONFIG_EXCEPTION
+            ],
+            [
+                'Module_Namer',
+                Cli::RETURN_FAILURE,
+                new ConfigException(__(self::CONFIG_EXCEPTION)),
+                self::CONFIG_EXCEPTION
+            ],
+            [
+                'all',
+                Cli::RETURN_FAILURE,
+                new \Exception(self::EXCEPTION),
+                self::EXCEPTION
+            ],
+            [
+                'Module_Name',
+                Cli::RETURN_FAILURE,
+                new \Exception(self::EXCEPTION),
+                self::EXCEPTION
+            ]
+        ];
+    }
+
+    /**
+     * Execute command test class for symphony
+     *
+     * @param string $arguments
+     * @return CommandTester
+     */
+    private function execute(string $arguments)
+    {
+        $commandTest = new CommandTester($this->instance);
+        $commandTest->execute(['--' . GenerateCommand::MODULE_NAME_KEY => $arguments]);
+
+        return $commandTest;
+    }
+}

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/TablesWhitelistGenerateCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/TablesWhitelistGenerateCommandTest.php
@@ -11,8 +11,8 @@ use Magento\Developer\Console\Command\TablesWhitelistGenerateCommand as Generate
 use Magento\Developer\Model\Setup\Declaration\Schema\WhitelistGenerator;
 use Magento\Framework\Console\Cli;
 use Magento\Framework\Exception\ConfigurationMismatchException as ConfigException;
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -29,7 +29,7 @@ class TablesWhitelistGenerateCommandTest extends TestCase
     /** @var WhitelistGenerator|MockObject $whitelistGenerator */
     private $whitelistGenerator;
 
-    /** @var TablesWhitelistGenerateCommand $instance */
+    /** @var GenerateCommand $instance */
     private $instance;
 
     protected function setUp()

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/TablesWhitelistGenerateCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/TablesWhitelistGenerateCommandTest.php
@@ -23,8 +23,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 class TablesWhitelistGenerateCommandTest extends TestCase
 {
     // Exception Messages!
-    const CONFIG_EXCEPTION = 'Configuration Exception';
-    const EXCEPTION = 'General Exception';
+    const CONFIG_EXCEPTION_MESSAGE = 'Configuration Exception Message';
+    const EXCEPTION_MESSAGE = 'General Exception Message';
 
     /** @var WhitelistGenerator|MockObject $whitelistGenerator */
     private $whitelistGenerator;
@@ -75,9 +75,11 @@ class TablesWhitelistGenerateCommandTest extends TestCase
         $this->whitelistGenerator->expects($this->once())
             ->method('generate')
             ->with($arguments)
-            ->willReturnCallback(function () use ($exception) {
-                throw $exception;
-            });
+            ->willReturnCallback(
+                function () use ($exception) {
+                    throw $exception;
+                }
+            );
 
         $commandTest = $this->execute($arguments);
         $this->assertEquals($expected, $commandTest->getStatusCode());
@@ -115,26 +117,26 @@ class TablesWhitelistGenerateCommandTest extends TestCase
             [
                 'all',
                 Cli::RETURN_FAILURE,
-                new ConfigException(__(self::CONFIG_EXCEPTION)),
-                self::CONFIG_EXCEPTION
+                new ConfigException(__('Configuration Exception Message')),
+                self::CONFIG_EXCEPTION_MESSAGE
             ],
             [
                 'Module_Name',
                 Cli::RETURN_FAILURE,
-                new ConfigException(__(self::CONFIG_EXCEPTION)),
-                self::CONFIG_EXCEPTION
+                new ConfigException(__('Configuration Exception Message')),
+                self::CONFIG_EXCEPTION_MESSAGE
             ],
             [
                 'all',
                 Cli::RETURN_FAILURE,
-                new \Exception(self::EXCEPTION),
-                self::EXCEPTION
+                new \Exception(self::EXCEPTION_MESSAGE),
+                self::EXCEPTION_MESSAGE
             ],
             [
                 'Module_Name',
                 Cli::RETURN_FAILURE,
-                new \Exception(self::EXCEPTION),
-                self::EXCEPTION
+                new \Exception(self::EXCEPTION_MESSAGE),
+                self::EXCEPTION_MESSAGE
             ]
         ];
     }

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/TablesWhitelistGenerateCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/TablesWhitelistGenerateCommandTest.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-namespace Magento\Developer\Console\Command;
+namespace Magento\Developer\Test\Unit\Console\Command;
 
 use Magento\Developer\Console\Command\TablesWhitelistGenerateCommand as GenerateCommand;
 use Magento\Developer\Model\Setup\Declaration\Schema\WhitelistGenerator;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Just making a minor _"feature"_ to the db schema whitelist generate command. Now the **CLI** will print if catch some general **Exception**

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Follow the [documentation](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/declarative-schema/db-schema.html) to create a **db_schema**
2. Try to use something that it's not defined in the **urn** schema, like this:
`<table name="test" resource="default" engine="innodb" comments="testing">`
3. Note that comment**S** don't exist, just comment in singular
4. You can run the whitelist command:

> bin/magento setup:db-declaration:generate-whitelist --module-name=Vendor_ModuleName
5. It's display nothing

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
I think it's a good pratice to always give output information in the **CLI** commands if they somehow fail. Now the whitelist commando will print something like this:

> The XML in file "<magento_root>/app/code/<Vendor>/<Module>/etc/db_schema.xml" is invalid:
Element 'table', attribute 'comments': The attribute 'comments' is not allowed.
Line: 3

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
