### PR TITLE
[Forward Port] magento/magento2#12205: Stock inventory reindex bug.

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/Stock/DefaultStock.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Indexer/Stock/DefaultStock.php
@@ -292,6 +292,7 @@ class DefaultStock extends AbstractIndexer implements StockInterface
      */
     protected function _updateIndex($entityIds)
     {
+        $this->deleteOldRecords($entityIds);
         $connection = $this->getConnection();
         $select = $this->_getStockStatusSelect($entityIds, true);
         $select = $this->getQueryProcessorComposite()->processQuery($select, $entityIds, true);
@@ -314,7 +315,6 @@ class DefaultStock extends AbstractIndexer implements StockInterface
             }
         }
 
-        $this->deleteOldRecords($entityIds);
         $this->_updateIndexTable($data);
 
         return $this;


### PR DESCRIPTION
(cherry picked from commit 20d7afbe75fed9b8f45e3231848aae40b1c06a3a)

### Description (*)
This is a forward port of https://github.com/magento-engcom/magento2ce/pull/1134 to Magento 2.3-develop (since this is a non-public PR, I can't see the discussion in there unfortunately)
It looks like this fix got included in Magento 2.2.5, but was forgotten to be forward ported to Magento 2.3

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/12205: Stock inventory reindex bug
2. https://github.com/magento/magento2/issues/15984: Random products show out of stock until manual reindex

### Manual testing scenarios (*)
1. Setup vanilla 2.3-develop installation including sample data
2. Run `bin/magento indexer:set-mode schedule`
3. In the frontend of the shop, go to Gear > Bags. Notice there are 14 products visible here => **good**
4. Execute the following SQL query which will simulate that 1891 products stock data was updated and schedules them for reindexing: `INSERT INTO cataloginventory_stock_cl(entity_id) SELECT a.entity_id FROM catalog_product_entity a INNER JOIN cataloginventory_stock_status b ON a.entity_id=b.product_id AND b.website_id=0 WHERE a.type_id='simple'`
5. Run `bin/magento indexer:status` to verify this
6. If you have [magerun2](https://files.magerun.net) installed, run: `php n98-magerun2.phar sys:cron:run indexer_update_all_views`, otherwise run `bin/magento cron:run`
7. Run `bin/magento indexer:status` to verify that all scheduled updates were processed
8. In the frontend of the shop, go to Gear > Bags. Notice there are 0 products visible here => **not good**
9. Notice the amount of entries in the `cataloginventory_stock_status` database table, there are 1046 in here
10. Now perform a manual full reindex of the stock: `bin/magento indexer:reindex cataloginventory_stock`
11. In the frontend of the shop, go to Gear > Bags. Notice there are 14 products visible here => **good**
12. Notice the amount of entries in the `cataloginventory_stock_status` database table, there are 2046 in here

Now repeat the same but with this PR applied, and you'll notice that in step 8 and 9 the correct thing happens and further steps are no longer needed

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
