### PR TITLE
Add support to assign attribute_set when creating product attributes …

### DIFF
--- a/app/code/Magento/Eav/Setup/EavSetup.php
+++ b/app/code/Magento/Eav/Setup/EavSetup.php
@@ -844,7 +844,6 @@ class EavSetup
                 $select = $select->where(
                     'attribute_set_name = :attribute_set_name'
                 );
-
                 $select_args['attribute_set_name'] = $attr['attribute_set'];
             }
 

--- a/app/code/Magento/Eav/Setup/EavSetup.php
+++ b/app/code/Magento/Eav/Setup/EavSetup.php
@@ -845,8 +845,8 @@ class EavSetup
     /**
      * Assign attribute to a group and attribute set
      *
-     * @param $entityTypeId
-     * @param $code
+     * @param string|integer $entityTypeId
+     * @param string $code
      * @param array $attr
      * @throws LocalizedException
      */

--- a/app/code/Magento/Eav/Setup/EavSetup.php
+++ b/app/code/Magento/Eav/Setup/EavSetup.php
@@ -847,7 +847,7 @@ class EavSetup
                 $selectArgs['attribute_set_name'] = $attr['attribute_set'];
             }
 
-            $sets = $this->setup->getConnection()->fetchAll($select, $select_args);
+            $sets = $this->setup->getConnection()->fetchAll($select, $selectArgs);
             foreach ($sets as $set) {
                 if (!empty($attr['group'])) {
                     $this->addAttributeGroup($entityTypeId, $set['attribute_set_id'], $attr['group']);

--- a/app/code/Magento/Eav/Setup/EavSetup.php
+++ b/app/code/Magento/Eav/Setup/EavSetup.php
@@ -837,7 +837,18 @@ class EavSetup
             )->where(
                 'entity_type_id = :entity_type_id'
             );
-            $sets = $this->setup->getConnection()->fetchAll($select, ['entity_type_id' => $entityTypeId]);
+
+            $select_args = ['entity_type_id' => $entityTypeId];
+
+            if (!empty($attr['attribute_set'])) {
+                $select = $select->where(
+                    'attribute_set_name = :attribute_set_name'
+                );
+
+                $select_args['attribute_set_name'] = $attr['attribute_set'];
+            }
+
+            $sets = $this->setup->getConnection()->fetchAll($select, $select_args);
             foreach ($sets as $set) {
                 if (!empty($attr['group'])) {
                     $this->addAttributeGroup($entityTypeId, $set['attribute_set_id'], $attr['group']);

--- a/app/code/Magento/Eav/Setup/EavSetup.php
+++ b/app/code/Magento/Eav/Setup/EavSetup.php
@@ -844,7 +844,7 @@ class EavSetup
                 $select = $select->where(
                     'attribute_set_name = :attribute_set_name'
                 );
-                $select_args['attribute_set_name'] = $attr['attribute_set'];
+                $selectArgs['attribute_set_name'] = $attr['attribute_set'];
             }
 
             $sets = $this->setup->getConnection()->fetchAll($select, $select_args);

--- a/app/code/Magento/Eav/Setup/EavSetup.php
+++ b/app/code/Magento/Eav/Setup/EavSetup.php
@@ -838,7 +838,7 @@ class EavSetup
                 'entity_type_id = :entity_type_id'
             );
 
-            $select_args = ['entity_type_id' => $entityTypeId];
+            $selectArgs = ['entity_type_id' => $entityTypeId];
 
             if (!empty($attr['attribute_set'])) {
                 $select = $select->where(


### PR DESCRIPTION
…programatically

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
As documented here: https://devdocs.magento.com/guides/v2.3/extension-dev-guide/attributes.html#add-product-eav-attribute-options-reference, there is no way to target a particular attribute set, so all new attributes are blindly assigned to all the existing attribute sets.

Using this approach, it's possible to add the position `attribute_set` to the attributes array passed to the `addAttribute` method. This new position expects the attribute set name where the new attribute will be added to. 

### Fixed Issues (if relevant)
1. magento/magento2#14793: createAttribute not behaving as expected

### Manual testing scenarios (*)
1. Create a new attribute set (no matter its name). Let's say "**Glassware**"
2. Create a new attribute programatically using the following attributes:
````
$eavSetup->addAttribute(
            \Magento\Catalog\Model\Product::ENTITY,
            'sample_attribute_1',
            [
                'type' => 'text',
                'backend' => '',
                'frontend' => '',
                'label' => 'Sample Attribute 1',
                'input' => 'text',
                'class' => '',
                'source' => '',
                'global' => \Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface::SCOPE_WEBSITE,
                'visible' => true,
                'required' => true,
                'user_defined' => false,
                'default' => '',
                'searchable' => false,
                'filterable' => false,
                'comparable' => false,
                'visible_on_front' => false,
                'used_in_product_listing' => true,
                'unique' => false,
                'attribute_set' => 'Glassware',
                'group' => 'Content',
            ]
        );
````

### Questions or comments
There are no unit test created for the `addAttribute`, so I'm keeping it as it.

Not sure what to do when the attribute name provided doesn't exist. At this moment, the new attribute won't be added to any attribute set. So, maybe a slightly different approach in order to define a default behaviour for these cases would make sense.

### Contribution checklist (*)
 - [*] Pull request has a meaningful description of its purpose
 - [*] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
