### PR TITLE
Fix: #20379 Calendar icon not aligned inside the textbox in Add Design Change page

### DIFF
--- a/app/code/Magento/Theme/view/adminhtml/page_layout/admin-2columns-left.xml
+++ b/app/code/Magento/Theme/view/adminhtml/page_layout/admin-2columns-left.xml
@@ -31,7 +31,7 @@
                     </container>
                     <container name="page.main.container" as="page_main_container" htmlId="page:main-container" htmlTag="div" htmlClass="page-columns">
                         <container name="main.col" as="main-col" htmlId="container" htmlTag="div" htmlClass="main-col">
-                            <container name="admin.scope.col.wrap" as="admin-scope-col-wrap" htmlTag="div" htmlClass="admin__scope-old"> <!-- ToDo UI: remove this wrapper remove with old styles removal -->
+                            <container name="admin.scope.col.wrap" as="admin-scope-col-wrap" htmlTag="div" htmlClass="form-inline"> <!-- ToDo UI: remove this wrapper remove with old styles removal -->
                                 <container name="content" as="content"/>
                             </container>
                         </container>


### PR DESCRIPTION
### Description (*)

Changed class admin__scope-old to form-inline.

### Fixed Issues (if relevant)

[#20379](https://github.com/magento/magento2/issues/20379): Issue title:calendar icon not aligned inside the textbox in Add Design Change page

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
