### PR TITLE
#20463 Fix summary view details label for checkout in tablet view

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
@@ -315,7 +315,7 @@
             .toggle {
                 &:extend(.abs-toggling-title all);
                 border: 0;
-                padding: 0 @indent__xl @indent__xs 0;
+                padding: 0 0 @indent__xs 0;
 
                 &:after {
                     .lib-css(color, @color-gray56);

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
@@ -274,7 +274,7 @@
         }
 
         .product-item-details {
-            padding-left: 88px;
+            padding-left: 87px;
 
             .price {
                 font-weight: @font-weight__bold;

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_order-summary.less
@@ -127,9 +127,9 @@
 
         //  Cart items
         .minicart-items-wrapper {
-            .lib-css(margin, 0 -(@checkout-summary-items__padding) 0 0);
+            .lib-css(margin, 0);
             .lib-css(max-height, @checkout-summary-items__max-height);
-            .lib-css(padding, @checkout-summary-items__padding @checkout-summary-items__padding 0 0);
+            .lib-css(padding, @checkout-summary-items__padding 0 0 0);
             border: 0;
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
Fix by css label for tablet view
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

I fixed this PR removing padding right and margin right from .opc-block-summary .minicart-items-wrapper and removing padding right from .minicart-items .product .toggle
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20463: On order sumary view details label misalign on tablet

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Active the tablet view on your browser 
2. Add to cart a configurable product
3. Go to checkout and check that in the order summary block the view details button is in one line

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [] All new or changed code is covered with unit/integration tests (if applicable)
 - [] All automated tests passed successfully (all builds are green)
