### PR TITLE
Error in vendor/magento/module-shipping/Model/Config/Source/Allmethod…

### DIFF
--- a/app/code/Magento/Shipping/Model/Config/Source/Allmethods.php
+++ b/app/code/Magento/Shipping/Model/Config/Source/Allmethods.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\Shipping\Model\Config\Source;
 
+/**
+ * @inheritdoc
+ */
 class Allmethods implements \Magento\Framework\Option\ArrayInterface
 {
     /**
@@ -33,6 +36,7 @@ class Allmethods implements \Magento\Framework\Option\ArrayInterface
 
     /**
      * Return array of carriers.
+     *
      * If $isActiveOnlyFlag is set to true, will return only active carriers
      *
      * @param bool $isActiveOnlyFlag
@@ -59,7 +63,7 @@ class Allmethods implements \Magento\Framework\Option\ArrayInterface
 
                 /** Check it $carrierMethods array was well formed */
                 if (!$methodCode) {
-                    continue;
+                     continue;
                 }
                 $methods[$carrierCode]['value'][] = [
                     'value' => $carrierCode . '_' . $methodCode,

--- a/app/code/Magento/Shipping/Model/Config/Source/Allmethods.php
+++ b/app/code/Magento/Shipping/Model/Config/Source/Allmethods.php
@@ -56,6 +56,11 @@ class Allmethods implements \Magento\Framework\Option\ArrayInterface
             );
             $methods[$carrierCode] = ['label' => $carrierTitle, 'value' => []];
             foreach ($carrierMethods as $methodCode => $methodTitle) {
+
+                /** Check it $carrierMethods array was well formed */
+                if (!$methodCode) {
+                    continue;
+                }
                 $methods[$carrierCode]['value'][] = [
                     'value' => $carrierCode . '_' . $methodCode,
                     'label' => '[' . $carrierCode . '] ' . $methodTitle,

--- a/app/code/Magento/Shipping/Test/Unit/Model/Config/Source/AllmethodsTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Model/Config/Source/AllmethodsTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Shipping\Test\Unit\Model;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Shipping\Model\Carrier\AbstractCarrierInterface;
+use Magento\Shipping\Model\Config;
+use Magento\Shipping\Model\Config\Source\Allmethods;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Tests for Allmethods Class
+ */
+class InfoTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var ScopeConfigInterface|MockObject $scopeConfig
+     */
+    private $scopeConfig;
+
+    /**
+     * @var Config|MockObject $shippingConfig
+     */
+    private $shippingConfig;
+
+    /**
+     * @var Allmethods $allmethods
+     */
+    private $allmethods;
+
+    /**
+     * @var MockObject
+     */
+    private $carriersMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->shippingConfig = $this->createMock(Config::class);
+        $this->carriersMock = $this->getMockBuilder(AbstractCarrierInterface::class)
+            ->setMethods(
+                [
+                    'isActive',
+                    'getAllowedMethods'
+                ]
+            )->getMockForAbstractClass();
+
+        $this->allmethods = new Allmethods(
+            $this->scopeConfig,
+            $this->shippingConfig
+        );
+    }
+
+    /**
+     * Ensure that options converted correctly
+     *
+     * @dataProvider getCarriersMethodsProvider
+     * @param array $expectedArray
+     * @return void
+     */
+    public function testToOptionArray(array $expectedArray): void
+    {
+        $expectedArray['getAllCarriers'] = [$this->carriersMock];
+
+        $this->shippingConfig->expects($this->once())
+                             ->method('getAllCarriers')
+                             ->willReturn($expectedArray['getAllCarriers']);
+        $this->carriersMock->expects($this->once())
+                             ->method('isActive')
+                             ->willReturn(true);
+        $this->carriersMock->expects($this->once())
+                             ->method('getAllowedMethods')
+                             ->willReturn($expectedArray['allowedMethods']);
+        $this->assertEquals([$expectedArray['expected_result']], $this->allmethods->toOptionArray());
+    }
+
+    /**
+     * Returns providers data for test
+     *
+     * @return array
+     */
+    public function getCarriersMethodsProvider(): array
+    {
+        return [
+            [
+                [
+                    'allowedMethods' => [null => 'method_title'],
+                    'expected_result' => [ 'value' => [], 'label' => null],
+                    'getAllCarriers'  => []
+                ],
+                [
+                    'allowedMethods' => ['method_code' => 'method_title'],
+                    'expected_result' => [ 'value' => [], 'label' => 'method_code'],
+                    'getAllCarriers'  => []
+                ]
+
+            ]
+        ];
+    }
+}

--- a/app/code/Magento/Shipping/Test/Unit/Model/Config/Source/AllmethodsTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Model/Config/Source/AllmethodsTest.php
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-namespace Magento\Shipping\Test\Unit\Model;
+namespace Magento\Shipping\Test\Unit\Model\Config\Source;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Shipping\Model\Carrier\AbstractCarrierInterface;
@@ -14,7 +14,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Tests for Allmethods Class
  */
-class InfoTest extends \PHPUnit\Framework\TestCase
+class AllmethodsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var ScopeConfigInterface|MockObject $scopeConfig


### PR DESCRIPTION
# Description (*)
If a module has a selectable configuration using the source app/code/Magento/Shipping/Model/Config/Source/Allmethods.php and one shipping method has the allowed shipping methods to null admin page won't render properly (Blank page)

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/13136: Error in vendor/magento/module-shipping/Model/Config/Source/Allmethods.php - public function toOptionArray

### Manual testing scenarios (*)

1. Made a composer require of the module described on the task (magmodules/magento2-channable)
2. Edited the configuration value **carriers/usps/allowed_methods** to NULL on core_config_data.
3. Open the admin configuration of channable module.
4. Checked that the configuration page throws and error and no content is rendered.
5. Reviewed how usps module returns the allowed methods on this file app/code/Magento/Usps/Model/Carrier.php
6. Modified the file app/code/Magento/Shipping/Model/Config/Source/Allmethods.php for control this error with all allowedmethods functions.

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds are green)
