### PR TITLE
Marks Belgium as a country with no required states.

### DIFF
--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressBelgiumTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressBelgiumTest.xml
@@ -47,5 +47,13 @@
         <actionGroup ref="VerifyCustomerShippingAddressWithState" stepKey="verifyShippingAddress">
             <argument name="address" value="updateCustomerBelgiumAddress"/>
         </actionGroup>
+
+        <!-- Verify country Belgium can be saved without state as state not required -->
+        <actionGroup ref="StoreFrontClickEditDefaultShippingAddressActionGroup" stepKey="clickOnDefaultShippingAddress"/>
+        <selectOption selector="{{StorefrontCustomerAddressFormSection.country}}" userInput="Belgium" stepKey="selectCountry"/>
+        <selectOption selector="{{StorefrontCustomerAddressFormSection.state}}" userInput="Please select a region, state or province." stepKey="selectState"/>
+        <actionGroup ref="AdminSaveCustomerAddressActionGroup" stepKey="saveAddress"/>
+        <see selector="{{StorefrontCustomerAddressesSection.defaultShippingAddress}}" userInput="Belgium" stepKey="seeAssertCustomerDefaultShippingAddressCountry"/>
+
     </test>
 </tests>

--- a/app/code/Magento/Directory/etc/di.xml
+++ b/app/code/Magento/Directory/etc/di.xml
@@ -35,6 +35,7 @@
                 <item name="DE" xsi:type="string">DE</item>
                 <item name="AT" xsi:type="string">AT</item>
                 <item name="FI" xsi:type="string">FI</item>
+                <item name="BE" xsi:type="string">BE</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
### Description (*)
This is a follow up to https://github.com/magento/magento2/commit/5cd7496e76773f953ffcad102aa3111d4d4747d6 and https://github.com/magento/magento2/pull/25160

I didn't notice it before, but when running the [`addCountryRegions` method](https://github.com/magento/magento2/blob/68d21376fa18895276e00931fe382c120d7a4e17/app/code/Magento/Directory/Setup/Patch/Data/AddDataForBelgium.php#L47-L50), it also [sets up the countries with required states again](https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/Directory/Setup/DataInstaller.php#L63-L74).
That list [is generated](https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/Directory/Model/ResourceModel/Country/Collection.php#L339-L343) based on some configuration values [in the xml](https://github.com/magento/magento2/blob/2.3.3/app/code/Magento/Directory/etc/di.xml#L33-L38).

As Belgium doesn't require states/regions/provinces in its postal service, this country should not be marked as a country with required states.

Same question as in https://github.com/magento/magento2/pull/25160: since 5cd7496 and https://github.com/magento/magento2/pull/25160 aren't part of a Magento release yet, is it ok to change this like this without creating a new database migration patch? If all these changes gets released in Magento 2.3.4, all should be fine in the database.

### Fixed Issues (if relevant)
None

### Manual testing scenarios (*)
1. Setup Magento based on this PR
2. In the frontend, register a new customer
3. In his address book, add a new address, pick country Belgium and the state field should be not required.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
