### PR TITLE
#25211 Fix first load of RSS New Products, Special Products and Discounts

### DIFF
--- a/app/code/Magento/Catalog/Block/Rss/Product/NewProducts.php
+++ b/app/code/Magento/Catalog/Block/Rss/Product/NewProducts.php
@@ -78,7 +78,7 @@ class NewProducts extends \Magento\Framework\View\Element\AbstractBlock implemen
     {
         $storeModel = $this->storeManager->getStore($this->getStoreId());
         $newUrl = $this->rssUrlBuilder->getUrl(['store_id' => $this->getStoreId(), 'type' => 'new_products']);
-        $title = __('New Products from %1', $storeModel->getFrontendName());
+        $title = __('New Products from %1', $storeModel->getFrontendName())->render();
         $lang = $this->_scopeConfig->getValue(
             'general/locale/code',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,

--- a/app/code/Magento/Catalog/Block/Rss/Product/Special.php
+++ b/app/code/Magento/Catalog/Block/Rss/Product/Special.php
@@ -112,7 +112,7 @@ class Special extends \Magento\Framework\View\Element\AbstractBlock implements D
     public function getRssData()
     {
         $newUrl = $this->rssUrlBuilder->getUrl(['type' => 'special_products', 'store_id' => $this->getStoreId()]);
-        $title = __('%1 - Special Products', $this->storeManager->getStore()->getFrontendName());
+        $title = __('%1 - Special Products', $this->storeManager->getStore()->getFrontendName())->render();
         $lang = $this->_scopeConfig->getValue(
             'general/locale/code',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE

--- a/app/code/Magento/SalesRule/Block/Rss/Discounts.php
+++ b/app/code/Magento/SalesRule/Block/Rss/Discounts.php
@@ -73,7 +73,7 @@ class Discounts extends \Magento\Framework\View\Element\AbstractBlock implements
             'store_id' => $storeId,
             'cid' => $customerGroupId,
         ]);
-        $title = __('%1 - Discounts and Coupons', $storeModel->getFrontendName());
+        $title = __('%1 - Discounts and Coupons', $storeModel->getFrontendName())->render();
         $lang = $this->_scopeConfig->getValue(
             'general/locale/code',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

Fix first load of RSS New Products, Special Products and Discounts

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

The first time that try to load rss page, get `\Magento\Framework\Phrase` in `Zend\Feed\Writer\AbstractFeed->setTitle` and is not prepared for recieve `\Phrase`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25211: RSS Feed - first load not working

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Enable standard RSS Feed module.
2. Enable RSS Feed for New Products and Special Products.
3. Proceed to domain.tld/rss
4. Loads correctly

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [] All new or changed code is covered with unit/integration tests (if applicable)
 - [] All automated tests passed successfully (all builds are green)
