### PR TITLE
Report page > Changing input phone type to tel

### DIFF
--- a/pub/errors/default/report.phtml
+++ b/pub/errors/default/report.phtml
@@ -49,7 +49,7 @@
         <div class="field telephone">
             <label for="telephone" class="label">Telephone</label>
             <div class="control">
-                <input type="text" name="telephone" id="telephone" value="<?= $this->postData['telephone'] ?>" title="Telephone" class="input-text" />
+                <input type="tel" name="telephone" id="telephone" value="<?= $this->postData['telephone'] ?>" title="Telephone" class="input-text" />
             </div>
         </div>
         <div class="field comment">


### PR DESCRIPTION
### Description (*)

I changed the phone input type from `text` to `tel`, it improves a lot the user experience. As it was applied in the email input, the field type `email` is in use already.

![Screen Shot 2019-10-27 at 12 18 15 PM](https://user-images.githubusercontent.com/610598/67637039-6217b280-f8b5-11e9-8171-a05c7b2ba5cc.png)

It will show like this image below.

![Screen Shot 2019-10-27 at 12 16 38 PM](https://user-images.githubusercontent.com/610598/67637036-5d52fe80-f8b5-11e9-9cf1-c34041a3a89b.png)

### Manual testing scenarios (*)

1. Accessing the form in a mobile device and clicking on the phone field.

### Comments (*)

This feature has high compatibility, but if it's opened in a browser without compatibility, the browsers fallback is returning it to text type.

![Screen Shot 2019-10-27 at 12 31 37 PM](https://user-images.githubusercontent.com/610598/67637078-bcb10e80-f8b5-11e9-83f4-fb3ba06d7d89.png)

**Reference:** https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/tel

**Related PRs:**
https://github.com/magento/magento2/pull/25322
https://github.com/magento/magento2/pull/25321

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
