### PR TITLE
Add Cache-Control header to knockout partials

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -109,7 +109,7 @@ location /static/ {
         rewrite ^/static/(version\d*/)?(.*)$ /static/$2 last;
     }
 
-    location ~* \.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2|json)$ {
+    location ~* \.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2|html|json)$ {
         add_header Cache-Control "public";
         add_header X-Frame-Options "SAMEORIGIN";
         expires +1y;

--- a/pub/static/.htaccess
+++ b/pub/static/.htaccess
@@ -72,7 +72,7 @@ AddType application/xml xml
 
 <IfModule mod_headers.c>
 
-    <FilesMatch .*\.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2|json)$>
+    <FilesMatch .*\.(ico|jpg|jpeg|png|gif|svg|js|css|swf|eot|ttf|otf|woff|woff2|html|json)$>
         Header append Cache-Control public
     </FilesMatch>
 


### PR DESCRIPTION
### Description (*)
This PR adds Cache-Control headers to knockout partials (.html static content files). Previous PR https://github.com/magento/magento2/pull/8000 failed to add this.

### Fixed Issues
Without Cache-Control header in same cases when using caching proxies such as Cloudflare to serve files, end user browser does 304 check each time on every page. This highly depends on proxy configuration, but there should not be any reason not to set Cache-Control header. Is seems with just Expires header set, there's different interpretations what logic should be used for revalidation.

In this PR we set Cache-Control to public, which is same value for all static content files. There is no need for browser to revalidate these requests, as invalidation is handled by static content versioning.

### Manual testing scenarios (*)
1. Open category page
2. Open browser inspector
3. Verify that returned response to .html static content file has Cache-Control header
4. Open another category page
5. Verify that the same .html file is retrieved from browser disk cache


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [not applicable] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
