### PR TITLE
[CmsUrlRewrite] Unit Test to cover Magento\CmsUrlRewrite\Model\CmsPageUrlPathGenerator class

### DIFF
--- a/app/code/Magento/CmsUrlRewrite/Test/Unit/Model/CmsPageUrlPathGeneratorTest.php
+++ b/app/code/Magento/CmsUrlRewrite/Test/Unit/Model/CmsPageUrlPathGeneratorTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CmsUrlRewrite\Test\Unit\Model;
+
+use Magento\CmsUrlRewrite\Model\CmsPageUrlPathGenerator;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\Framework\Filter\FilterManager;
+use Magento\Cms\Api\Data\PageInterface;
+
+/**
+ * Class \Magento\CmsUrlRewrite\Test\Unit\Model\CmsPageUrlPathGeneratorTest
+ */
+class CmsPageUrlPathGeneratorTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var ObjectManagerHelper
+     */
+    private $objectManager;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|FilterManager
+     */
+    private $filterManagerMock;
+
+    /**
+     * @var CmsPageUrlPathGenerator
+     */
+    private $model;
+
+    /**
+     * Setup environment for test
+     */
+    protected function setUp()
+    {
+        $this->objectManager = new ObjectManagerHelper($this);
+        $this->filterManagerMock = $this->getMockBuilder(FilterManager::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['translitUrl'])
+            ->getMock();
+
+        $this->model = $this->objectManager->getObject(
+            CmsPageUrlPathGenerator::class,
+            [
+                'filterManager' => $this->filterManagerMock
+            ]
+        );
+    }
+
+    /**
+     * Test getUrlPath with page has identifier = cms-cookie
+     */
+    public function testGetUrlPath()
+    {
+        /* @var PageInterface $cmsPageMock*/
+        $cmsPageMock = $this->getMockBuilder(PageInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $cmsPageMock->expects($this->any())
+            ->method('getIdentifier')
+            ->willReturn('cms-cookie');
+
+        $this->assertEquals('cms-cookie', $this->model->getUrlPath($cmsPageMock));
+    }
+
+    /**
+     * Test getCanonicalUrlPath() with page has id = 1
+     */
+    public function testGetCanonicalUrlPath()
+    {
+        /* @var PageInterface $cmsPageMock*/
+        $cmsPageMock = $this->getMockBuilder(PageInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $cmsPageMock->expects($this->any())
+            ->method('getId')
+            ->willReturn('1');
+
+        $this->assertEquals('cms/page/view/page_id/1', $this->model->getCanonicalUrlPath($cmsPageMock));
+    }
+
+    /**
+     * Test generateUrlKey() with page has no identifier
+     */
+    public function testGenerateUrlKeyWithNullIdentifier()
+    {
+        /**
+         * Data set
+         */
+        $page = [
+            'identifier' => null,
+            'title' => 'CMS Cookie'
+        ];
+
+        /* @var PageInterface $cmsPageMock*/
+        $cmsPageMock = $this->getMockBuilder(PageInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $cmsPageMock->expects($this->any())
+            ->method('getIdentifier')
+            ->willReturn($page['identifier']);
+
+        $cmsPageMock->expects($this->any())
+            ->method('getTitle')
+            ->willReturn($page['title']);
+
+        $this->filterManagerMock->expects($this->any())
+            ->method('translitUrl')
+            ->with($page['title'])
+            ->willReturn('cms-cookie');
+
+        $this->assertEquals('cms-cookie', $this->model->generateUrlKey($cmsPageMock));
+    }
+
+    /**
+     * Test generateUrlKey() with page has identifier
+     */
+    public function testGenerateUrlKeyWithIdentifier()
+    {
+        /**
+         * Data set
+         */
+        $page = [
+            'identifier' => 'home',
+            'title' => 'Home Page'
+        ];
+
+        /* @var PageInterface $cmsPageMock*/
+        $cmsPageMock = $this->getMockBuilder(PageInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $cmsPageMock->expects($this->any())
+            ->method('getIdentifier')
+            ->willReturn($page['identifier']);
+
+        $cmsPageMock->expects($this->any())
+            ->method('getTitle')
+            ->willReturn($page['title']);
+
+        $this->filterManagerMock->expects($this->any())
+            ->method('translitUrl')
+            ->with($page['identifier'])
+            ->willReturn('home');
+
+        $this->assertEquals('home', $this->model->generateUrlKey($cmsPageMock));
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Cover  Magento\CmsUrlRewrite\Model\CmsPageUrlPathGenerator class:

-Test getUrlPath with page has identifier = cms-cookie
-Test getCanonicalUrlPath() with page has id = 1
-Test generateUrlKey() with page has no identifier
-Test generateUrlKey() with page has identifier

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Covered by Unit Test

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
