### PR TITLE
Prevent adding form keys to forms with external action URLs

### DIFF
--- a/lib/web/mage/common.js
+++ b/lib/web/mage/common.js
@@ -20,8 +20,14 @@ define([
             var formKeyElement,
                 existingFormKeyElement,
                 isKeyPresentInForm,
+                isActionExternal,
+                baseUrl = window.BASE_URL,
                 form = $(e.target),
-                formKey = $('input[name="form_key"]').val();
+                formKey = $('input[name="form_key"]').val(),
+                formMethod = form.prop('method'),
+                formAction = form.prop('action');
+
+            isActionExternal = formAction.indexOf(baseUrl) !== 0;
 
             existingFormKeyElement = form.find('input[name="form_key"]');
             isKeyPresentInForm = existingFormKeyElement.length;
@@ -32,7 +38,7 @@ define([
                 isKeyPresentInForm = form.find('> input[name="form_key"]').length;
             }
 
-            if (formKey && !isKeyPresentInForm && form[0].method !== 'get') {
+            if (formKey && !isKeyPresentInForm && !isActionExternal && formMethod !== 'get') {
                 formKeyElement = document.createElement('input');
                 formKeyElement.setAttribute('type', 'hidden');
                 formKeyElement.setAttribute('name', 'form_key');


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This issue fixes the case where `form_key` field was being added to POST forms that had external (not belonging to shop's base URL) action URL.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#23382: form_key parameter gets added to all forms

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Prepare a static block with following text content (with editor disabled):
```html
<form action="https://google.com" method="POST"><input type="submit" value="Submit test form"></form>
```
2. Add above static block to any CMS page.
3. Go to the CMS page, open developer tools under `Network` tab with `Preserve log` checkbox checked.
4. Click `Submit test form` button and verify that no `form_key` field was added to request parameters.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
