### PR TITLE
Better error message on failed customer login

### DIFF
--- a/app/code/Magento/Customer/Controller/Account/LoginPost.php
+++ b/app/code/Magento/Customer/Controller/Account/LoginPost.php
@@ -19,6 +19,7 @@ use Magento\Framework\Controller\Result\Redirect;
 use Magento\Framework\Exception\EmailNotConfirmedException;
 use Magento\Framework\Exception\AuthenticationException;
 use Magento\Framework\Data\Form\FormKey\Validator;
+use Magento\Framework\Exception\InvalidEmailOrPasswordException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\State\UserLockedException;
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -208,6 +209,10 @@ class LoginPost extends AbstractAccount implements CsrfAwareActionInterface, Htt
                     $message = __(
                         'The account sign-in was incorrect or your account is disabled temporarily. '
                         . 'Please wait and try again later.'
+                    );
+                } catch (InvalidEmailOrPasswordException $e) {
+                    $message = __(
+                        'Invalid login or password.'
                     );
                 } catch (AuthenticationException $e) {
                     $message = __(


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Previously,  the user would just see the message "The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later." which is irritating for the user. We had customers complain about this when their account was unlocked, but they entered a bad password.
This PR changes this, so the user sees a more clear message "Invalid login or password.".

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Enter incorrect customer login information, from a customer who is unlocked
2. See "Incorrect login or password." message

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
