### PR TITLE
Added backticks to table names in mysql schema reader.

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/DbSchemaReader.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/DbSchemaReader.php
@@ -147,9 +147,10 @@ class DbSchemaReader implements DbSchemaReaderInterface
     }
 
     /**
+     * Read references (foreign keys) from Magento tables.
+     *
      * As MySQL has bug and do not show foreign keys during DESCRIBE and other directives required
-     * to take it from SHOW CREATE TABLE ...
-     * command
+     * to take it from "SHOW CREATE TABLE ..." command.
      *
      * @inheritdoc
      */
@@ -177,6 +178,7 @@ class DbSchemaReader implements DbSchemaReaderInterface
 
     /**
      * Reading DB constraints.
+     *
      * Primary and unique constraints are always non_unique=0.
      *
      * @inheritdoc

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/DbSchemaReader.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/DbSchemaReader.php
@@ -126,7 +126,7 @@ class DbSchemaReader implements DbSchemaReaderInterface
         $indexes = [];
         $adapter = $this->resourceConnection->getConnection($resource);
         $condition = sprintf('`Non_unique` = 1');
-        $sql = sprintf('SHOW INDEXES FROM %s WHERE %s', $tableName, $condition);
+        $sql = sprintf('SHOW INDEXES FROM `%s` WHERE %s', $tableName, $condition);
         $stmt = $adapter->query($sql);
 
         // Use FETCH_NUM so we are not dependent on the CASE attribute of the PDO connection
@@ -170,7 +170,7 @@ class DbSchemaReader implements DbSchemaReaderInterface
     public function getCreateTableSql($tableName, $resource)
     {
         $adapter = $this->resourceConnection->getConnection($resource);
-        $sql = sprintf('SHOW CREATE TABLE %s', $tableName);
+        $sql = sprintf('SHOW CREATE TABLE `%s`', $tableName);
         $stmt = $adapter->query($sql);
         return $stmt->fetch(\Zend_Db::FETCH_ASSOC);
     }
@@ -186,7 +186,7 @@ class DbSchemaReader implements DbSchemaReaderInterface
         $constraints = [];
         $adapter = $this->resourceConnection->getConnection($resource);
         $condition = sprintf('`Non_unique` = 0');
-        $sql = sprintf('SHOW INDEXES FROM %s WHERE %s', $tableName, $condition);
+        $sql = sprintf('SHOW INDEXES FROM `%s` WHERE %s', $tableName, $condition);
         $stmt = $adapter->query($sql);
 
         // Use FETCH_NUM so we are not dependent on the CASE attribute of the PDO connection


### PR DESCRIPTION
Added backticks to table names in mysql schema reader. Otherwise indexes cannot be added to tables whose name coincide with reserved mysql words.

### Description (*)
When using db_schema to add an index to a table the DbSchemaReader class is used to describe the table. If that table name coincides with a reserved mysql keyword this causes errors.

### Manual testing scenarios (*)
1. Use a db_schema.xml to create a table with a reserved name, e.g. 'order'. 
2. Run php bin/magento setup:upgrade

### Questions or comments
Before this fix this causes an error because mysql rejects the SHOW INDEXES and SHOW CREATE TABLE queries because the table name is unquoted. After this fix the changes are processed correctly.

### Contribution checklist (*)
 - [ y ] Pull request has a meaningful description of its purpose
 - [ y ] All commits are accompanied by meaningful commit messages
