### PR TITLE
Fix 'promotion' region not rendering #25373

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/minicart/content.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/minicart/content.html
@@ -97,7 +97,7 @@
         </div>
     </div>
 
-    <div id="minicart-widgets" class="minicart-widgets" if="getRegion('promotion').length">
+    <div id="minicart-widgets" class="minicart-widgets" if="getRegion('promotion')().length">
         <each args="getRegion('promotion')" render=""/>
     </div>
 </div>


### PR DESCRIPTION
The getRegion(name) method returns a knockoutjs observable array which is a function, so the check used in the template will always resolve to false (as function `length` property is the number of arguments a function takes, which for the observable array is 0). Therefore the region is never rendered.

### Description (*)
The fix in this PR follows the current convention used in Magento and adds the missing parentheses to the if condition.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/25373: The 'promotion' region of the minicart is never rendered

### Manual testing scenarios (*)
See related issue

### Questions and comments
This PR is an alternative to https://github.com/magento/magento2/pull/25375. The fix implement in this PR simple and follows the existing code conventions in Magento, but does nothing to prevent a similar mistake from happening in the future.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
