### PR TITLE
Change generated/code from PSR-0 to PSR-4

### DIFF
--- a/lib/internal/Magento/Framework/Code/Generator/Io.php
+++ b/lib/internal/Magento/Framework/Code/Generator/Io.php
@@ -76,7 +76,7 @@ class Io
      */
     public function generateResultFileName($className)
     {
-        return $this->_generationDirectory . ltrim(str_replace(['\\', '_'], '/', $className), '/') . '.php';
+        return $this->_generationDirectory . ltrim(str_replace('\\', '/', $className), '/') . '.php';
     }
 
     /**


### PR DESCRIPTION
### Description (*)
This pull request includes one small change in the \Magento\Framework\Code\Generator\Io class to not change DIRECTORY_SEPARATOR to '\'. This changes the generated/code directory to PSR-4 (currently is PSR-0) and brings it inline with the rest of Magento 2.

This is an issue for certain system when module uses an underscore in the module name. This is allowed in PSR-4 but in not in PSR-0.

MyCompany/Module_SubModule

This becomes:

> generated/code/MyCompany/Module/SubModule

I have found some systems can retrieve generated classes from this directory where as some systems cannot. I have not been able to find the different between the systems to figure out why some can and some can't read generated classes.
