### PR TITLE
[GiftMessage] Covering the SalesEventOrderToQuoteObserver by Unit Test

### DIFF
--- a/app/code/Magento/GiftMessage/Test/Unit/Observer/SalesEventOrderToQuoteObserverTest.php
+++ b/app/code/Magento/GiftMessage/Test/Unit/Observer/SalesEventOrderToQuoteObserverTest.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\GiftMessage\Test\Unit\Observer;
+
+use Magento\Framework\Event;
+use Magento\Framework\Message\MessageInterface;
+use Magento\GiftMessage\Helper\Message;
+use Magento\GiftMessage\Model\Message as MessageModel;
+use Magento\GiftMessage\Model\MessageFactory;
+use Magento\GiftMessage\Observer\SalesEventOrderToQuoteObserver;
+use Magento\Framework\Event\Observer;
+use Magento\Quote\Model\Quote;
+use Magento\Sales\Model\Order;
+use Magento\Store\Model\Store;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ *  SalesEventOrderToQuoteObserverTest
+ */
+class SalesEventOrderToQuoteObserverTest extends TestCase
+{
+    /**
+     * @var SalesEventOrderToQuoteObserver
+     */
+    private $observer;
+
+    /**
+     * @var MessageFactory|MockObject
+     */
+    private $messageFactoryMock;
+
+    /**
+     * @var Message|MockObject
+     */
+    private $giftMessageMock;
+
+    /**
+     * @var Observer|MockObject
+     */
+    private $observerMock;
+
+    /**
+     * @var Event|MockObject
+     */
+    private $eventMock;
+
+    /**
+     * @var Order|MockObject
+     */
+    private $orderMock;
+
+    /**
+     * @var Store|MockObject
+     */
+    private $storeMock;
+
+    /**
+     * @var MessageInterface|MockObject
+     */
+    private $messageMock;
+
+    /**
+     * @var Quote|MockObject
+     */
+    private $quoteMock;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        $this->messageFactoryMock = $this->createMock(MessageFactory::class);
+        $this->giftMessageMock = $this->createMock(Message::class);
+        $this->observerMock = $this->createMock(Observer::class);
+        $this->eventMock = $this->getMockBuilder(Event::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getOrder', 'getQuote'])
+            ->getMock();
+        $this->orderMock = $this->getMockBuilder(Order::class)
+            ->setMethods(['getReordered', 'getStore', 'getGiftMessageId'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->quoteMock = $this->getMockBuilder(Quote::class)
+            ->setMethods(['setGiftMessageId'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->storeMock = $this->createMock(Store::class);
+        $this->messageMock = $this->createMock(MessageModel::class);
+
+        $this->observer = new SalesEventOrderToQuoteObserver(
+            $this->messageFactoryMock,
+            $this->giftMessageMock
+        );
+    }
+
+    /**
+     * Tests duplicating gift message from order to quote
+     *
+     * @dataProvider giftMessageDataProvider
+     *
+     * @param bool $orderIsReordered
+     * @param bool $isMessagesAllowed
+     */
+    public function testExecute(bool $orderIsReordered, bool $isMessagesAllowed): void
+    {
+        $giftMessageId = 1;
+        $newGiftMessageId = 2;
+
+        $this->eventMock
+            ->expects($this->atLeastOnce())
+            ->method('getOrder')
+            ->willReturn($this->orderMock);
+        $this->observerMock
+            ->expects($this->atLeastOnce())
+            ->method('getEvent')
+            ->willReturn($this->eventMock);
+
+        if (!$orderIsReordered && $isMessagesAllowed) {
+            $this->eventMock
+                ->expects($this->atLeastOnce())
+                ->method('getQuote')
+                ->willReturn($this->quoteMock);
+            $this->orderMock->expects($this->once())
+                ->method('getReordered')
+                ->willReturn($orderIsReordered);
+            $this->orderMock->expects($this->once())
+                ->method('getGiftMessageId')
+                ->willReturn($giftMessageId);
+            $this->giftMessageMock->expects($this->once())
+                ->method('isMessagesAllowed')
+                ->willReturn($isMessagesAllowed);
+            $this->messageFactoryMock->expects($this->once())
+                ->method('create')
+                ->willReturn($this->messageMock);
+            $this->messageMock->expects($this->once())
+                ->method('load')
+                ->with($giftMessageId)
+                ->willReturnSelf();
+            $this->messageMock->expects($this->once())
+                ->method('setId')
+                ->with(null)
+                ->willReturnSelf();
+            $this->messageMock->expects($this->once())
+                ->method('save')
+                ->willReturnSelf();
+            $this->messageMock->expects($this->once())
+                ->method('getId')
+                ->willReturn($newGiftMessageId);
+            $this->quoteMock->expects($this->once())
+                ->method('setGiftMessageId')
+                ->with($newGiftMessageId)
+                ->willReturnSelf();
+        }
+
+        $this->observer->execute($this->observerMock);
+    }
+
+    /**
+     * Providing gift message data
+     *
+     * @return array
+     */
+    public function giftMessageDataProvider(): array
+    {
+        return [
+            [false, true],
+            [true, true],
+            [false, true],
+            [false, false],
+        ];
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR adds missing unit tests for the following class:
- `\Magento\GiftMessage\Observer\SalesEventOrderToQuoteObserver`

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
