### PR TITLE
update a way the match is applied

### DIFF
--- a/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Match.php
+++ b/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Match.php
@@ -134,7 +134,7 @@ class Match implements QueryInterface
         // Checking for quoted phrase \"phrase test\", trim escaped surrounding quotes if found
         $count = 0;
         $value = preg_replace('#^"(.*)"$#m', '$1', $queryValue['value'], -1, $count);
-        $count = count(explode(' ', trim($value)));
+        $count = count(explode(' ',trim($value)));
         $condition = ($count) ? 'match_phrase' : 'match';
 
         $transformedTypes = [];

--- a/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Match.php
+++ b/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Match.php
@@ -3,7 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 namespace Magento\Elasticsearch\SearchAdapter\Query\Builder;
 
 use Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\AttributeProvider;
@@ -65,8 +64,7 @@ class Match implements QueryInterface
         AttributeProvider $attributeProvider = null,
         TypeResolver $fieldTypeResolver = null,
         ValueTransformerPool $valueTransformerPool = null
-    )
-    {
+    ) {
         $this->fieldMapper = $fieldMapper;
         $this->preprocessorContainer = $preprocessorContainer;
         $this->attributeProvider = $attributeProvider ?? ObjectManager::getInstance()
@@ -136,7 +134,7 @@ class Match implements QueryInterface
         // Checking for quoted phrase \"phrase test\", trim escaped surrounding quotes if found
         $count = 0;
         $value = preg_replace('#^"(.*)"$#m', '$1', $queryValue['value'], -1, $count);
-        $count = count(explode(' ', trim($value)));
+        $count = count(explode(' ',trim($value)));
         $condition = ($count) ? 'match_phrase' : 'match';
 
         $transformedTypes = [];
@@ -177,10 +175,10 @@ class Match implements QueryInterface
     /**
      * Escape a value for special query characters such as ':', '(', ')', '*', '?', etc.
      *
-     * @param string $value
-     * @return string
      * @deprecated
      * @see \Magento\Elasticsearch\SearchAdapter\Query\ValueTransformer\TextTransformer
+     * @param string $value
+     * @return string
      */
     protected function escape($value)
     {

--- a/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Match.php
+++ b/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Match.php
@@ -134,12 +134,17 @@ class Match implements QueryInterface
         // Checking for quoted phrase \"phrase test\", trim escaped surrounding quotes if found
         $count = 0;
         $value = preg_replace('#^"(.*)"$#m', '$1', $queryValue['value'], -1, $count);
-        $count = count(explode(' ',trim($value)));
+        $count = count(explode(' ', trim($value)));
         $condition = ($count) ? 'match_phrase' : 'match';
 
         $transformedTypes = [];
         foreach ($matches as $match) {
-            $attributeAdapter = $this->attributeProvider->getByAttributeCode($match['field']);
+            $resolvedField = $this->fieldMapper->getFieldName(
+                $match['field'],
+                ['type' => FieldMapperInterface::TYPE_QUERY]
+            );
+
+            $attributeAdapter = $this->attributeProvider->getByAttributeCode($resolvedField);
             $fieldType = $this->fieldTypeResolver->getFieldType($attributeAdapter);
             $valueTransformer = $this->valueTransformerPool->get($fieldType ?? 'text');
             $valueTransformerHash = \spl_object_hash($valueTransformer);
@@ -152,10 +157,6 @@ class Match implements QueryInterface
                 continue;
             }
 
-            $resolvedField = $this->fieldMapper->getFieldName(
-                $match['field'],
-                ['type' => FieldMapperInterface::TYPE_QUERY]
-            );
             $conditions[] = [
                 'condition' => $queryValue['condition'],
                 'body' => [

--- a/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Match.php
+++ b/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Match.php
@@ -134,8 +134,8 @@ class Match implements QueryInterface
         // Checking for quoted phrase \"phrase test\", trim escaped surrounding quotes if found
         $count = 0;
         $value = preg_replace('#^"(.*)"$#m', '$1', $queryValue['value'], -1, $count);
-        $count = count(explode(' ',trim($value)));
-        $condition = ($count) ? 'match_phrase' : 'match';
+        $count = explode(' ', $value);
+        $condition = count($count) ? 'match_phrase' : 'match';
 
         $transformedTypes = [];
         foreach ($matches as $match) {

--- a/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Match.php
+++ b/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Match.php
@@ -130,11 +130,12 @@ class Match implements QueryInterface
     protected function buildQueries(array $matches, array $queryValue)
     {
         $conditions = [];
-
-        // Checking for quoted phrase \"phrase test\", trim escaped surrounding quotes if found
-        $count = 0;
-        $value = preg_replace('#^"(.*)"$#m', '$1', $queryValue['value'], -1, $count);
-        $condition = ($count) ? 'match_phrase' : 'match';
+ 
+         // Checking for quoted phrase \"phrase test\", trim escaped surrounding quotes if found
+         $count = 0;
+         $value = preg_replace('#^"(.*)"$#m', '$1', $queryValue['value'], -1, $count);
+         $count = count(explode(' ',trim($value)));
+         $condition = ($count) ? 'match_phrase' : 'match';
 
         $transformedTypes = [];
         foreach ($matches as $match) {

--- a/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Match.php
+++ b/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Match.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Elasticsearch\SearchAdapter\Query\Builder;
 
 use Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\AttributeProvider;
@@ -64,15 +65,16 @@ class Match implements QueryInterface
         AttributeProvider $attributeProvider = null,
         TypeResolver $fieldTypeResolver = null,
         ValueTransformerPool $valueTransformerPool = null
-    ) {
+    )
+    {
         $this->fieldMapper = $fieldMapper;
         $this->preprocessorContainer = $preprocessorContainer;
         $this->attributeProvider = $attributeProvider ?? ObjectManager::getInstance()
-            ->get(AttributeProvider::class);
+                ->get(AttributeProvider::class);
         $this->fieldTypeResolver = $fieldTypeResolver ?? ObjectManager::getInstance()
-            ->get(TypeResolver::class);
+                ->get(TypeResolver::class);
         $this->valueTransformerPool = $valueTransformerPool ?? ObjectManager::getInstance()
-            ->get(ValueTransformerPool::class);
+                ->get(ValueTransformerPool::class);
     }
 
     /**
@@ -130,12 +132,12 @@ class Match implements QueryInterface
     protected function buildQueries(array $matches, array $queryValue)
     {
         $conditions = [];
- 
-         // Checking for quoted phrase \"phrase test\", trim escaped surrounding quotes if found
-         $count = 0;
-         $value = preg_replace('#^"(.*)"$#m', '$1', $queryValue['value'], -1, $count);
-         $count = count(explode(' ',trim($value)));
-         $condition = ($count) ? 'match_phrase' : 'match';
+
+        // Checking for quoted phrase \"phrase test\", trim escaped surrounding quotes if found
+        $count = 0;
+        $value = preg_replace('#^"(.*)"$#m', '$1', $queryValue['value'], -1, $count);
+        $count = count(explode(' ', trim($value)));
+        $condition = ($count) ? 'match_phrase' : 'match';
 
         $transformedTypes = [];
         foreach ($matches as $match) {
@@ -175,10 +177,10 @@ class Match implements QueryInterface
     /**
      * Escape a value for special query characters such as ':', '(', ')', '*', '?', etc.
      *
-     * @deprecated
-     * @see \Magento\Elasticsearch\SearchAdapter\Query\ValueTransformer\TextTransformer
      * @param string $value
      * @return string
+     * @deprecated
+     * @see \Magento\Elasticsearch\SearchAdapter\Query\ValueTransformer\TextTransformer
      */
     protected function escape($value)
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When elasticsearch is enabled and the search has two strings, the "match" attribute is enabled the search is not matching.
In attachament , the patch with some result


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. The counter that activates the elasticsearch "match_phrase" attribute has been set


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. use sample data with elasticsearch 6.5 enabled
2. perform two-string search
3. The return should be just what you entered
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
