### PR TITLE
Fix bound nodes

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/knockout/extender/bound-nodes.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/knockout/extender/bound-nodes.js
@@ -74,7 +74,7 @@ define([
         index = nodes.indexOf(node);
 
         if (~index) {
-            nodes.splice(index, 0);
+            nodes.splice(index, 1);
 
             Events.trigger.call(model, 'removeNode', node);
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes https://github.com/magento/magento2/issues/7939. As it turns out not only the wrapper for `applyBindingsToDescendant` was missing but I also adjusted `removeBounded` implementation and some inline documentation in the comments.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#7939: The `Magento_Ui/js/lib/knockout/extender/bound-nodes` RequireJS Module does not Work as Intended

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open the shop with this fix applied and wait for it to load.
2. Open the console and run following code:
```javascript
boundNodes = requirejs('Magento_Ui/js/lib/knockout/extender/bound-nodes');
reg = requirejs('uiRegistry');    
viewModel = reg.get('customer');
console.log( boundNodes.get(viewModel) );
```
3. The result should be all DOM elements that have their scope bind, so in case of:
```html
<div id="first" data-bind="scope: 'foo'"></div>
<div id="second" data-bind="scope: 'foo'"></div>
```
both `#first` and `#second` should be returned.
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
