### PR TITLE
Ui: log exception correctly

### DIFF
--- a/app/code/Magento/Ui/TemplateEngine/Xhtml/Result.php
+++ b/app/code/Magento/Ui/TemplateEngine/Xhtml/Result.php
@@ -16,7 +16,7 @@ use Magento\Framework\View\TemplateEngine\Xhtml\CompilerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- * Class Result
+ * @inheritdoc
  */
 class Result implements ResultInterface
 {

--- a/app/code/Magento/Ui/TemplateEngine/Xhtml/Result.php
+++ b/app/code/Magento/Ui/TemplateEngine/Xhtml/Result.php
@@ -5,18 +5,17 @@
  */
 namespace Magento\Ui\TemplateEngine\Xhtml;
 
-use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\State;
 use Magento\Framework\Serialize\Serializer\JsonHexTag;
-use Magento\Framework\View\Layout\Generator\Structure;
 use Magento\Framework\View\Element\UiComponentInterface;
-use Magento\Framework\View\TemplateEngine\Xhtml\Template;
-use Magento\Framework\View\TemplateEngine\Xhtml\ResultInterface;
+use Magento\Framework\View\Layout\Generator\Structure;
 use Magento\Framework\View\TemplateEngine\Xhtml\CompilerInterface;
+use Magento\Framework\View\TemplateEngine\Xhtml\ResultInterface;
+use Magento\Framework\View\TemplateEngine\Xhtml\Template;
 use Psr\Log\LoggerInterface;
 
 /**
- * @inheritdoc
+ * Convert DOMElement to string representation
  */
 class Result implements ResultInterface
 {
@@ -61,8 +60,8 @@ class Result implements ResultInterface
      * @param UiComponentInterface $component
      * @param Structure $structure
      * @param LoggerInterface $logger
-     * @param JsonHexTag|null $jsonSerializer
-     * @param State|null $state
+     * @param JsonHexTag $jsonSerializer
+     * @param State $state
      */
     public function __construct(
         Template $template,
@@ -70,16 +69,16 @@ class Result implements ResultInterface
         UiComponentInterface $component,
         Structure $structure,
         LoggerInterface $logger,
-        ?JsonHexTag $jsonSerializer = null,
-        ?State $state = null
+        JsonHexTag $jsonSerializer,
+        State $state
     ) {
         $this->template = $template;
         $this->compiler = $compiler;
         $this->component = $component;
         $this->structure = $structure;
         $this->logger = $logger;
-        $this->jsonSerializer = $jsonSerializer ?? ObjectManager::getInstance()->get(JsonHexTag::class);
-        $this->state = $state ?? ObjectManager::getInstance()->get(State::class);
+        $this->jsonSerializer = $jsonSerializer;
+        $this->state = $state;
     }
 
     /**
@@ -128,7 +127,7 @@ class Result implements ResultInterface
             $this->logger->critical($e);
             $result = $e->getMessage();
             if ($this->state->getMode() === State::MODE_DEVELOPER) {
-                $result .= "<pre><code>{$e->__toString()}</code></pre>";
+                $result .= "<pre><code>Exception in {$e->getFile()}:{$e->getLine()}</code></pre>";
             }
         }
         return $result;

--- a/app/code/Magento/Ui/Test/Unit/TemplateEngine/Xhtml/ResultTest.php
+++ b/app/code/Magento/Ui/Test/Unit/TemplateEngine/Xhtml/ResultTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Ui\Test\Unit\TemplateEngine\Xhtml;
+
+use Magento\Framework\App\State;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\Framework\View\Element\UiComponentInterface;
+use Magento\Framework\View\Layout\Generator\Structure;
+use Magento\Framework\View\TemplateEngine\Xhtml\CompilerInterface;
+use Magento\Framework\View\TemplateEngine\Xhtml\Template;
+use Magento\Ui\TemplateEngine\Xhtml\Result;
+use Magento\Framework\Serialize\Serializer\JsonHexTag;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Test for \Magento\Ui\TemplateEngine\Xhtml\Result.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ResultTest extends TestCase
+{
+    /**
+     * @var Result
+     */
+    private $model;
+
+    /**
+     * @var ObjectManagerHelper|MockObject
+     */
+    private $objectManagerHelper;
+
+    /**
+     * @var Template|MockObject
+     */
+    private $templateMock;
+
+    /**
+     * @var CompilerInterface|MockObject
+     */
+    private $compilerMock;
+
+    /**
+     * @var UiComponentInterface|MockObject
+     */
+    private $componentMock;
+
+    /**
+     * @var Structure|MockObject
+     */
+    private $structureMock;
+
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $loggerMock;
+
+    /**
+     * @var JsonHexTag|MockObject
+     */
+    private $jsonSerializerMock;
+
+    /**
+     * @var State|MockObject
+     */
+    private $stateMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->templateMock = $this->getMockBuilder(Template::class)
+            ->setMethods(['getDocumentElement'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->compilerMock = $this->getMockBuilder(CompilerInterface::class)
+            ->setMethods(['compile'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->componentMock = $this->getMockBuilder(UiComponentInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->structureMock = $this->getMockBuilder(Structure::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->stateMock = $this->getMockBuilder(State::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->jsonSerializerMock = $this->getMockBuilder(JsonHexTag::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->objectManagerHelper = new ObjectManagerHelper($this);
+        $this->model = $this->objectManagerHelper->getObject(
+            Result::class,
+            [
+                'template' => $this->templateMock,
+                'compiler' => $this->compilerMock,
+                'component' => $this->componentMock,
+                'structure' => $this->structureMock,
+                'logger' => $this->loggerMock,
+                'jsonSerializer' => $this->jsonSerializerMock,
+                'state' => $this->stateMock,
+            ]
+        );
+    }
+
+    /**
+     * To string method with exception message
+     *
+     * @return void
+     */
+    public function testToStringWithException(): void
+    {
+        $exception = new \Exception();
+        $this->templateMock->method('getDocumentElement')->willThrowException($exception);
+        $this->stateMock->method('getMode')->willReturn(State::MODE_DEVELOPER);
+
+        $this->assertEquals(
+            '<pre><code>' . $exception->__toString() . '</code></pre>',
+            $this->model->__toString()
+        );
+    }
+
+    /**
+     * To string method
+     *
+     * @return void
+     */
+    public function testToString(): void
+    {
+        $domElementMock = $this->getMockBuilder(\DOMElement::class)
+            ->enableOriginalConstructor()
+            ->setConstructorArgs(['new'])
+            ->getMock();
+        $this->templateMock->method('getDocumentElement')->willReturn($domElementMock);
+        $this->compilerMock->method('compile')
+            ->with($domElementMock, $this->componentMock, $this->componentMock)->willReturn(true);
+
+        $this->assertInternalType('string', $this->model->__toString());
+    }
+}

--- a/app/code/Magento/Ui/Test/Unit/TemplateEngine/Xhtml/ResultTest.php
+++ b/app/code/Magento/Ui/Test/Unit/TemplateEngine/Xhtml/ResultTest.php
@@ -4,13 +4,13 @@
  * See COPYING.txt for license details.
  */
 
+declare(strict_types=1);
+
 namespace Magento\Ui\Test\Unit\TemplateEngine\Xhtml;
 
 use Magento\Framework\App\State;
-use Magento\Framework\Serialize\Serializer\JsonHexTag;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Framework\View\Element\UiComponentInterface;
-use Magento\Framework\View\Layout\Generator\Structure;
 use Magento\Framework\View\TemplateEngine\Xhtml\CompilerInterface;
 use Magento\Framework\View\TemplateEngine\Xhtml\Template;
 use Magento\Ui\Component\Listing;
@@ -21,8 +21,6 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Test for \Magento\Ui\TemplateEngine\Xhtml\Result.
- *
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ResultTest extends TestCase
 {
@@ -57,19 +55,9 @@ class ResultTest extends TestCase
     private $componentMock;
 
     /**
-     * @var Structure|MockObject
-     */
-    private $structureMock;
-
-    /**
      * @var LoggerInterface|MockObject
      */
     private $loggerMock;
-
-    /**
-     * @var JsonHexTag|MockObject
-     */
-    private $jsonSerializerMock;
 
     /**
      * @var State|MockObject
@@ -84,10 +72,8 @@ class ResultTest extends TestCase
         $this->templateMock = $this->createMock(Template::class);
         $this->compilerMock = $this->createMock(CompilerInterface::class);
         $this->componentMock = $this->createMock(Listing::class);
-        $this->structureMock = $this->createMock(Structure::class);
         $this->loggerMock = $this->createMock(LoggerInterface::class);
         $this->stateMock = $this->createMock(State::class);
-        $this->jsonSerializerMock = $this->createMock(JsonHexTag::class);
 
         $this->objectManagerHelper = new ObjectManagerHelper($this);
         $this->model = $this->objectManagerHelper->getObject(
@@ -96,9 +82,7 @@ class ResultTest extends TestCase
                 'template' => $this->templateMock,
                 'compiler' => $this->compilerMock,
                 'component' => $this->componentMock,
-                'structure' => $this->structureMock,
                 'logger' => $this->loggerMock,
-                'jsonSerializer' => $this->jsonSerializerMock,
                 'state' => $this->stateMock,
             ]
         );

--- a/app/code/Magento/Ui/Test/Unit/TemplateEngine/Xhtml/ResultTest.php
+++ b/app/code/Magento/Ui/Test/Unit/TemplateEngine/Xhtml/ResultTest.php
@@ -111,20 +111,20 @@ class ResultTest extends TestCase
      */
     public function testToStringWithException(): void
     {
-        $exception = new \Exception();
+        $e = new \Exception();
 
         $this->templateMock->expects($this->once())
            ->method('getDocumentElement')
-           ->willThrowException($exception);
+           ->willThrowException($e);
         $this->stateMock->expects($this->once())
             ->method('getMode')
             ->willReturn(State::MODE_DEVELOPER);
 
         $this->loggerMock->expects($this->once())
             ->method('critical')
-            ->with($exception);
+            ->with($e);
         $this->assertEquals(
-            '<pre><code>' . $exception->__toString() . '</code></pre>',
+            '<pre><code>Exception in ' . $e->getFile() . ':' . $e->getLine() . '</code></pre>',
             $this->model->__toString()
         );
     }


### PR DESCRIPTION
### Description (*)
As a developer I like to have information about exception when it's occur.


### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Create an ui component with an error
2. Check log
3. See only unuseful message like this: 
```log
[2019-11-01 07:07:50] report.CRITICAL: Call to a member function addFieldToFilter() on null [] []
```

With this fix you will see something like this:
```log
[2019-11-01 07:12:28] report.CRITICAL: Call to a member function addFieldToFilter() on null {"exception":"[object] (Error(code: 0): Call to a member function addFieldToFilter() on null at /var/www/html/src/vendor/magento/module-ui/DataProvider/AbstractDataProvider.php:159
```

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
