### PR TITLE
Allow modal triggers to be added after module initialization

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/modal/modal.js
+++ b/app/code/Magento/Ui/view/base/web/js/modal/modal.js
@@ -131,7 +131,10 @@ define([
             this._createWrapper();
             this._renderModal();
             this._createButtons();
-            $(this.options.trigger).on('click', _.bind(this.toggleModal, this));
+
+            if (this.options.trigger) {
+                $(document).on('click', this.options.trigger, _.bind(this.toggleModal, this));
+            }
             this._on(this.modal.find(this.options.modalCloseBtn), {
                 'click': this.options.modalCloseBtnHandler ? this.options.modalCloseBtnHandler : this.closeModal
             });


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixes https://github.com/magento/magento2/issues/9671. Event delegation is used to allow different modal opening trigger elements to be added at any time as long as they match given selector.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#9671: Unable to bind modal to elements added dynamically in DOM.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a static block with following contents:
```html
<div id="test">
    <button class="modal-trigger">Sync Modal Trigger</button>
    <button class="modal-trigger">Async Modal Trigger</button>
</div>
<script>
require(['jquery', 'Magento_Ui/js/modal/modal'], function($) {
    $('#modal-content').modal({
        trigger: '.modal-trigger',
    });

    setTimeout(function() {
        $('#test').append('<button class="modal-trigger">Async Modal Trigger</button>');
    }, 2000);
});
</script>
```
2. Add above static block to CMS page and open it.
3. Without this fix only `Sync Modal Trigger` button would actually open a modal as it is already present in the DOM tree when modal is initialized. With this patch any button that matches the selector given in `trigger` option will work no matter when it appeared in DOM, which can be tested by clicking `Async Modal Trigger` button.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
