### PR TITLE
Restore checkboxes alignment in admin data grids

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Ui/web/css/source/module/_data-grid.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Ui/web/css/source/module/_data-grid.less
@@ -1075,7 +1075,6 @@ body._in-resize {
     }
 
     .data-grid-checkbox-cell-inner {
-        display: unset;
         margin: 0 @data-grid-checkbox-cell-inner__padding-horizontal 0;
         padding: 0;
         text-align: center;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes checkboxes alignment in data grids in Magento admin panel. Without it, they are either not fully centred (Firefox, Safari, older Chrome) or totally shifted to the left (newest Chrome).

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25429: Magento 2.3.3 : Under Cache Management section, cache type checkboxes are not aligned

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open admin panel and check data grids, e.g. cache management, index management, products in category etc.
2. Checkboxes should be centred within first column on the left.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
