### PR TITLE
Magento Framework message-queue change suggestion

### DIFF
--- a/lib/internal/Magento/Framework/MessageQueue/ConnectionTypeResolver.php
+++ b/lib/internal/Magento/Framework/MessageQueue/ConnectionTypeResolver.php
@@ -6,7 +6,7 @@
 namespace Magento\Framework\MessageQueue;
 
 /**
- * {@inheritdoc}
+ * @inheritdoc
  */
 class ConnectionTypeResolver
 {
@@ -26,7 +26,9 @@ class ConnectionTypeResolver
     }
 
     /**
-     * @param $connectionName
+     * Get connection type based on connection name
+     *
+     * @param string $connectionName
      * @return string|null
      */
     public function getConnectionType($connectionName)

--- a/lib/internal/Magento/Framework/MessageQueue/ConnectionTypeResolver.php
+++ b/lib/internal/Magento/Framework/MessageQueue/ConnectionTypeResolver.php
@@ -40,10 +40,9 @@ if(is_array($this->resolvers)){
             }
 }
         }
-
-
+        
         if ($type === null) {
-            throw new \LogicException('Unknown connection name ' . $connectionName . ' check if Magento_Amqp module enabled');
+            throw new \LogicException('Unknown connection name ' . $connectionName);
         }
         return $type;
     }

--- a/lib/internal/Magento/Framework/MessageQueue/ConnectionTypeResolver.php
+++ b/lib/internal/Magento/Framework/MessageQueue/ConnectionTypeResolver.php
@@ -26,24 +26,26 @@ class ConnectionTypeResolver
     }
 
     /**
-     * {@inheritdoc}
+     * @param $connectionName
+     * @return string|null
      */
     public function getConnectionType($connectionName)
     {
         $type = null;
 
-if(is_array($this->resolvers)){
-        foreach ($this->resolvers as $resolver) {
-            $type = $resolver->getConnectionType($connectionName);
-            if ($type != null) {
-                break;
+        if (is_array($this->resolvers)) {
+            foreach ($this->resolvers as $resolver) {
+                $type = $resolver->getConnectionType($connectionName);
+                if ($type != null) {
+                    break;
+                }
             }
-}
         }
-        
+
         if ($type === null) {
             throw new \LogicException('Unknown connection name ' . $connectionName);
         }
+
         return $type;
     }
 }

--- a/lib/internal/Magento/Framework/MessageQueue/ConnectionTypeResolver.php
+++ b/lib/internal/Magento/Framework/MessageQueue/ConnectionTypeResolver.php
@@ -32,15 +32,18 @@ class ConnectionTypeResolver
     {
         $type = null;
 
+if(is_array($this->resolvers)){
         foreach ($this->resolvers as $resolver) {
             $type = $resolver->getConnectionType($connectionName);
             if ($type != null) {
                 break;
             }
+}
         }
 
+
         if ($type === null) {
-            throw new \LogicException('Unknown connection name ' . $connectionName);
+            throw new \LogicException('Unknown connection name ' . $connectionName . ' check if Magento_Amqp module enabled');
         }
         return $type;
     }


### PR DESCRIPTION
I've made some codebase updates that are going to allow proper error display when Magento_Amqp and Magento_AmqpStore are disabled to prevent PHP error (warning message) displayed.

Description (*)
Scenario. Keep Magento_Amqp and Magento_AmqpStore modules disabled, add/config env.php as per https://devdocs.magento.com/guides/v2.3/install-gde/prereq/install-rabbitmq.html instruction, and try to run consumer queue manually.

**Output:**
$ php bin/magento queue:consumer:start async.operations.all
In ErrorHandler.php line 61:
Warning: Invalid argument supplied for foreach() in vendor/magento/framework-message-queue/ConnectionTypeResolver.php on line 35

Expected results:
$ php bin/magento queue:consumer:start async.operations.all
In ConnectionTypeResolver.php line 43:

Unknown connection name amqp

Fixed Issues (if relevant)
file lib/internal/Magento/Framework/MessageQueue/ConnectionTypeResolver.php or vendor/magento/framework-message-queue/ConnectionTypeResolver.php updated with the following:

if(is_array($this->resolvers)){
        foreach ($this->resolvers as $resolver) {
            $type = $resolver->getConnectionType($connectionName);
            if ($type != null) {
                break;
            }
}
        }

        if ($type === null) {
            throw new \LogicException('Unknown connection name ' . $connectionName . ' check if Magento_Amqp module enabled');
        }
        return $type;
    }
}

Manual testing scenarios (*)
1) Magento 2.3.2 and 2.3.3 disable Magento_Amqp and Magento_AmqpStore
2) Configure env.php file with https://devdocs.magento.com/guides/v2.3/install-gde/prereq/install-rabbitmq.html instruction.
3) Fire up one consumer, example:
4) php bin/magento queue:consumer:start async.operations.all

**Expected results:**
In ConnectionTypeResolver.php line 43:
Unknown connection name amqp

Real results:
In ErrorHandler.php line 61:
Warning: Invalid argument supplied for foreach() in vendor/magento/framework-message-queue/ConnectionTypeResolver.php on line 35

Questions or comments
Replicated/fixed on Magento 2.3.2 and 2.3.3 EE and CE

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
