### PR TITLE
TinyMCE4 hard to input double byte characters on chrome

### DIFF
--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js
@@ -607,7 +607,6 @@ define([
             }
 
             this.addContentEditableAttributeBackToNonEditableNodes();
-            //this.fixRangeSelection(editor);
 
             content = editor.getContent();
             content = this.decodeContent(content);

--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/tinymce4Adapter.js
@@ -607,7 +607,7 @@ define([
             }
 
             this.addContentEditableAttributeBackToNonEditableNodes();
-            this.fixRangeSelection(editor);
+            //this.fixRangeSelection(editor);
 
             content = editor.getContent();
             content = this.decodeContent(content);


### PR DESCRIPTION
### Description (*)
As @Consumewithadele  described on #24637, Magento2.3 with TinyMCE4 has serious issue on Chrome and double byte characters. This fix aims to be able to work the feature as expected on Chrome.

### Fixed Issues (if relevant)
1. magento/magento2#24637: Chinese input in tinymce 4

### Manual testing scenarios (*)
1. Open Magento admin panel via Google Chrome.
2. Create new cms page
3. Turn on Google IME or MS-IME (or others)
4. Input double byte characters
5. Insert widgets and continue typing

### Questions or comments
fixRangeSelection function was added for fixing Page Builder related issue. Even though remove the code, Page Builder works as expected. Is this function still needed?

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
