### PR TITLE
Fix issue #22240: Running cron jobs fails if database name is too long

### DIFF
--- a/lib/internal/Magento/Framework/Lock/Backend/Database.php
+++ b/lib/internal/Magento/Framework/Lock/Backend/Database.php
@@ -11,7 +11,6 @@ use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\Exception\AlreadyExistsException;
-use Magento\Framework\Exception\InputException;
 use Magento\Framework\Phrase;
 use Magento\Framework\DB\ExpressionConverter;
 
@@ -69,7 +68,6 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
      * @param string $name lock name
      * @param int $timeout How long to wait lock acquisition in seconds, negative value means infinite timeout
      * @return bool
-     * @throws InputException
      * @throws AlreadyExistsException
      * @throws \Zend_Db_Statement_Exception
      */
@@ -111,7 +109,6 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
      *
      * @param string $name lock name
      * @return bool
-     * @throws InputException
      * @throws \Zend_Db_Statement_Exception
      */
     public function unlock(string $name): bool
@@ -139,7 +136,6 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
      *
      * @param string $name lock name
      * @return bool
-     * @throws InputException
      * @throws \Zend_Db_Statement_Exception
      */
     public function isLocked(string $name): bool
@@ -163,16 +159,11 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
      *
      * @param string $name
      * @return string
-     * @throws InputException
      */
     private function addPrefix(string $name): string
     {
         $prefix = $this->getPrefix() ? $this->getPrefix() . '|' : '';
         $name = ExpressionConverter::shortenEntityName($prefix . $name, $prefix);
-
-        if (strlen($name) > 64) {
-            throw new InputException(new Phrase('Lock name too long: %1...', [substr($name, 0, 64)]));
-        }
 
         return $name;
     }

--- a/lib/internal/Magento/Framework/Lock/Backend/Database.php
+++ b/lib/internal/Magento/Framework/Lock/Backend/Database.php
@@ -13,6 +13,7 @@ use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Phrase;
+use Magento\Framework\DB\ExpressionConverter;
 
 /**
  * Implementation of the lock manager on the basis of MySQL.
@@ -166,7 +167,8 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
      */
     private function addPrefix(string $name): string
     {
-        $name = $this->getPrefix() . '|' . $name;
+        $prefix = $this->getPrefix() . '|';
+        $name = ExpressionConverter::shortenEntityName($prefix . $name, $prefix);
 
         if (strlen($name) > 64) {
             throw new InputException(new Phrase('Lock name too long: %1...', [substr($name, 0, 64)]));

--- a/lib/internal/Magento/Framework/Lock/Backend/Database.php
+++ b/lib/internal/Magento/Framework/Lock/Backend/Database.php
@@ -167,7 +167,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
      */
     private function addPrefix(string $name): string
     {
-        $prefix = $this->getPrefix() . '|';
+        $prefix = $this->getPrefix() ? $this->getPrefix() . '|' : '';
         $name = ExpressionConverter::shortenEntityName($prefix . $name, $prefix);
 
         if (strlen($name) > 64) {

--- a/lib/internal/Magento/Framework/Lock/Test/Unit/Backend/DatabaseTest.php
+++ b/lib/internal/Magento/Framework/Lock/Test/Unit/Backend/DatabaseTest.php
@@ -106,7 +106,6 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase
      * @throws \Magento\Framework\Exception\AlreadyExistsException
      * @throws \Magento\Framework\Exception\InputException
      * @throws \Zend_Db_Statement_Exception
-     * @expectedException \Magento\Framework\Exception\InputException
      */
     public function testlockWithTooLongName()
     {
@@ -114,7 +113,11 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase
             ->method('isDbAvailable')
             ->with()
             ->willReturn(true);
-        $this->database->lock('BbXbyf9rIY5xuAVdviQJmh76FyoeeVHTDpcjmcImNtgpO4Hnz4xk76ZGEyYALvrQu');
+            $this->statement->expects($this->once())
+            ->method('fetchColumn')
+            ->willReturn(true);
+
+        $this->assertTrue($this->database->lock('BbXbyf9rIY5xuAVdviQJmh76FyoeeVHTDpcjmcImNtgpO4Hnz4xk76ZGEyYALvrQu'));
     }
 
     /**

--- a/lib/internal/Magento/Framework/Lock/Test/Unit/Backend/DatabaseTest.php
+++ b/lib/internal/Magento/Framework/Lock/Test/Unit/Backend/DatabaseTest.php
@@ -86,7 +86,6 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @throws \Magento\Framework\Exception\AlreadyExistsException
-     * @throws \Magento\Framework\Exception\InputException
      * @throws \Zend_Db_Statement_Exception
      */
     public function testLock()
@@ -104,7 +103,6 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @throws \Magento\Framework\Exception\AlreadyExistsException
-     * @throws \Magento\Framework\Exception\InputException
      * @throws \Zend_Db_Statement_Exception
      */
     public function testlockWithTooLongName()
@@ -122,7 +120,6 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @throws \Magento\Framework\Exception\AlreadyExistsException
-     * @throws \Magento\Framework\Exception\InputException
      * @throws \Zend_Db_Statement_Exception
      * @expectedException \Magento\Framework\Exception\AlreadyExistsException
      */
@@ -142,7 +139,6 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @throws \Magento\Framework\Exception\AlreadyExistsException
-     * @throws \Magento\Framework\Exception\InputException
      * @throws \Zend_Db_Statement_Exception
      */
     public function testLockWithUnavailableDeploymentConfig()
@@ -156,7 +152,6 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\InputException
      * @throws \Zend_Db_Statement_Exception
      */
     public function testUnlockWithUnavailableDeploymentConfig()
@@ -170,7 +165,6 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\InputException
      * @throws \Zend_Db_Statement_Exception
      */
     public function testIsLockedWithUnavailableDB()


### PR DESCRIPTION
### Description (*)
Create short name for Database Lock name.
Use same logic to generate name as Foreign keys if name is longer than 64 characters.

### Fixed Issues (if relevant)
1. magento/magento2#22240: Running cron jobs fails if database name is too long

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
