### PR TITLE
Fix loose switch comparison when adding links without content types

### DIFF
--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -349,19 +349,18 @@ class Renderer implements RendererInterface
      */
     protected function addDefaultAttributes($contentType, $attributes)
     {
-        switch ($contentType) {
-            case 'js':
-                $attributes = ' type="text/javascript" ' . $attributes;
-                break;
-
-            case 'css':
-                $attributes = ' rel="stylesheet" type="text/css" ' . ($attributes ?: ' media="all"');
-                break;
-
-            case $this->canTypeBeFont($contentType):
-                $attributes = 'rel="preload" as="font" crossorigin="anonymous"';
-                break;
+        if ($contentType === 'js') {
+            return ' type="text/javascript" ' . $attributes;
         }
+
+        if ($contentType === 'css') {
+            return ' rel="stylesheet" type="text/css" ' . ($attributes ?: ' media="all"');
+        }
+
+        if ($this->canTypeBeFont($contentType)) {
+            return 'rel="preload" as="font" crossorigin="anonymous"';
+        }
+
         return $attributes;
     }
 

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/RendererTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/RendererTest.php
@@ -427,4 +427,48 @@ class RendererTest extends \PHPUnit\Framework\TestCase
             ],
         ];
     }
+
+    public function testRenderAssetWithNoContentType() : void
+    {
+        $type = '';
+
+        $assetMockOne = $this->createMock(\Magento\Framework\View\Asset\AssetInterface::class);
+        $assetMockOne->expects($this->exactly(1))
+            ->method('getUrl')
+            ->willReturn('url');
+
+        $assetMockOne->expects($this->atLeastOnce())->method('getContentType')->willReturn($type);
+
+        $groupAssetsOne = [$assetMockOne];
+
+        $groupMockOne = $this->getMockBuilder(\Magento\Framework\View\Asset\PropertyGroup::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $groupMockOne->expects($this->once())
+            ->method('getAll')
+            ->willReturn($groupAssetsOne);
+        $groupMockOne->expects($this->any())
+            ->method('getProperty')
+            ->willReturnMap(
+                [
+                    [GroupedCollection::PROPERTY_CAN_MERGE, true],
+                    [GroupedCollection::PROPERTY_CONTENT_TYPE, $type],
+                    ['attributes', 'rel="some-rel"'],
+                    ['ie_condition', null],
+                ]
+            );
+
+        $this->pageConfigMock->expects($this->once())
+            ->method('getAssetCollection')
+            ->willReturn($this->assetsCollection);
+
+        $this->assetsCollection->expects($this->once())
+            ->method('getGroups')
+            ->willReturn([$groupMockOne]);
+
+        $this->assertEquals(
+            '<link  rel="some-rel" href="url" />' . "\n",
+            $this->renderer->renderAssets($this->renderer->getAvailableResultGroups())
+        );
+    }
 }


### PR DESCRIPTION
### Description (*)

Code introduced in https://github.com/magento/magento2/commit/f16692c020ad34d1cff7e4489799a2c33dfde995#diff-8575fd5827f2060a08d2189bb08361efR346 breaks adding links without a defined content type, by replacing their attributes with ones designed for fonts.

I've refactored the switch to a bunch of `if` blocks because switches perform loose comparisons. So in the `switch` version of the code, if `canTypeBeFont` returns false, and `$contentType` is equal to an empty string, then that switch block executes because an empty string and false are deemed to be the same.

This problem has caused issue https://github.com/shipperhq/module-shipper/issues/73.

Due to the fact that a link without a content type is found to be a font, the attributes passed are overwritten.

### Fixed Issues (if relevant)
1. shipperhq/module-shipper#73: Carriers logos are not displayed on shipping step (https://github.com/shipperhq/module-shipper/issues/73)

### Manual testing scenarios (*)
1. Add a link to the page head without a content type and with a custom attribute. Eg `https://github.com/shipperhq/module-shipper/blob/master/src/view/frontend/layout/checkout_index_index.xml#L13`
2. See that the attributes are replaced with `rel="preload" as="font" crossorigin="anonymous"` in the page source

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
