### PR TITLE
JSON fields support

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -1453,6 +1453,7 @@
                 <item name="primary" xsi:type="object">\Magento\Framework\Setup\Declaration\Schema\Dto\Factories\Primary</item>
                 <item name="foreign" xsi:type="object">\Magento\Framework\Setup\Declaration\Schema\Dto\Factories\Foreign</item>
                 <item name="index" xsi:type="object">\Magento\Framework\Setup\Declaration\Schema\Dto\Factories\Index</item>
+                <item name="json" xsi:type="object">\Magento\Framework\Setup\Declaration\Schema\Dto\Factories\Json</item>
             </argument>
         </arguments>
     </type>
@@ -1480,6 +1481,7 @@
                 <item name="varchar" xsi:type="object">\Magento\Framework\Setup\Declaration\Schema\Db\MySQL\Definition\Columns\StringBinary</item>
                 <item name="binary" xsi:type="object">\Magento\Framework\Setup\Declaration\Schema\Db\MySQL\Definition\Columns\StringBinary</item>
                 <item name="varbinary" xsi:type="object">\Magento\Framework\Setup\Declaration\Schema\Db\MySQL\Definition\Columns\StringBinary</item>
+                <item name="json" xsi:type="object">\Magento\Framework\Setup\Declaration\Schema\Db\MySQL\Definition\Columns\Json</item>
                 <item name="index" xsi:type="object">\Magento\Framework\Setup\Declaration\Schema\Db\MySQL\Definition\Index</item>
                 <item name="unique" xsi:type="object">\Magento\Framework\Setup\Declaration\Schema\Db\MySQL\Definition\Constraints\Internal</item>
                 <item name="primary" xsi:type="object">\Magento\Framework\Setup\Declaration\Schema\Db\MySQL\Definition\Constraints\Internal</item>
@@ -1593,6 +1595,7 @@
                 <item name="datetime" xsi:type="object">Magento\Framework\Setup\SchemaListenerDefinition\TimestampDefinition</item>
                 <item name="date" xsi:type="object">Magento\Framework\Setup\SchemaListenerDefinition\DateDefinition</item>
                 <item name="boolean" xsi:type="object">Magento\Framework\Setup\SchemaListenerDefinition\BooleanDefinition</item>
+                <item name="json" xsi:type="object">Magento\Framework\Setup\SchemaListenerDefinition\JsonDefinition</item>
             </argument>
         </arguments>
     </type>

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/Definition/Columns/Json.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/Definition/Columns/Json.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Setup\Declaration\Schema\Db\MySQL\Definition\Columns;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Setup\Declaration\Schema\Db\DbDefinitionProcessorInterface;
+use Magento\Framework\Setup\Declaration\Schema\Dto\ElementInterface;
+
+/**
+ * Process json data type.
+ *
+ * @inheritdoc
+ */
+class Json implements DbDefinitionProcessorInterface
+{
+    /**
+     * @var Nullable
+     */
+    private $nullable;
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var Comment
+     */
+    private $comment;
+
+    /**
+     * Blob constructor.
+     *
+     * @param Nullable $nullable
+     * @param Comment $comment
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        Nullable $nullable,
+        Comment $comment,
+        ResourceConnection $resourceConnection
+    ) {
+        $this->nullable = $nullable;
+        $this->resourceConnection = $resourceConnection;
+        $this->comment = $comment;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function toDefinition(ElementInterface $column)
+    {
+        return sprintf(
+            '%s %s %s %s',
+            $this->resourceConnection->getConnection()->quoteIdentifier($column->getName()),
+            $column->getType(),
+            $this->nullable->toDefinition($column),
+            $this->comment->toDefinition($column)
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fromDefinition(array $data)
+    {
+        return $data;
+    }
+}

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/Definition/Columns/Json.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/Definition/Columns/Json.php
@@ -12,8 +12,6 @@ use Magento\Framework\Setup\Declaration\Schema\Dto\ElementInterface;
 
 /**
  * Process json data type.
- *
- * @inheritdoc
  */
 class Json implements DbDefinitionProcessorInterface
 {
@@ -64,7 +62,10 @@ class Json implements DbDefinitionProcessorInterface
     }
 
     /**
-     * @inheritdoc
+     * Returns an array of column definitions
+     *
+     * @param array $data
+     * @return array
      */
     public function fromDefinition(array $data)
     {

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Json.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Json.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Framework\Setup\Declaration\Schema\Dto\Columns;
 
 use Magento\Framework\Setup\Declaration\Schema\Dto\Column;
@@ -10,14 +11,14 @@ use Magento\Framework\Setup\Declaration\Schema\Dto\ElementDiffAwareInterface;
 use Magento\Framework\Setup\Declaration\Schema\Dto\Table;
 
 /**
+ * Json
+ *
  * Text column.
  * Declared in SQL, like: JSON
  */
-class Json extends Column implements
-    ElementDiffAwareInterface,
-    ColumnNullableAwareInterface
+class Json extends Column implements ElementDiffAwareInterface, ColumnNullableAwareInterface
 {
-    /**Json
+    /**
      * @var bool
      */
     private $nullable;

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Json.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Columns/Json.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Setup\Declaration\Schema\Dto\Columns;
+
+use Magento\Framework\Setup\Declaration\Schema\Dto\Column;
+use Magento\Framework\Setup\Declaration\Schema\Dto\ElementDiffAwareInterface;
+use Magento\Framework\Setup\Declaration\Schema\Dto\Table;
+
+/**
+ * Text column.
+ * Declared in SQL, like: JSON
+ */
+class Json extends Column implements
+    ElementDiffAwareInterface,
+    ColumnNullableAwareInterface
+{
+    /**Json
+     * @var bool
+     */
+    private $nullable;
+
+    /**
+     * Constructor.
+     *
+     * @param string $name
+     * @param string $type
+     * @param Table $table
+     * @param bool $nullable
+     * @param string|null $comment
+     * @param string|null $onCreate
+     */
+    public function __construct(
+        string $name,
+        string $type,
+        Table $table,
+        bool $nullable = true,
+        string $comment = null,
+        string $onCreate = null
+    ) {
+        parent::__construct($name, $type, $table, $comment, $onCreate);
+        $this->nullable = $nullable;
+    }
+
+    /**
+     * Check whether column can be nullable.
+     *
+     * @return bool
+     */
+    public function isNullable()
+    {
+        return $this->nullable;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDiffSensitiveParams()
+    {
+        return [
+            'type' => $this->getType(),
+            'nullable' => $this->isNullable(),
+            'comment' => $this->getComment()
+        ];
+    }
+}

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Factories/Json.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Factories/Json.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Framework\Setup\Declaration\Schema\Dto\Factories;
 
 use Magento\Framework\ObjectManagerInterface;
@@ -12,7 +13,6 @@ use Magento\Framework\ObjectManagerInterface;
  */
 class Json implements FactoryInterface
 {
-
     /**
      * @var ObjectManagerInterface
      */
@@ -27,7 +27,7 @@ class Json implements FactoryInterface
      * Constructor.
      *
      * @param ObjectManagerInterface $objectManager
-     * @param string                 $className
+     * @param string $className
      */
     public function __construct(
         ObjectManagerInterface $objectManager,
@@ -38,7 +38,10 @@ class Json implements FactoryInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Create element using definition data array.
+     *
+     * @param array $data
+     * @return \Magento\Framework\Setup\Declaration\Schema\Dto\ElementInterface|mixed
      */
     public function create(array $data)
     {

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Factories/Json.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Dto/Factories/Json.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Setup\Declaration\Schema\Dto\Factories;
+
+use Magento\Framework\ObjectManagerInterface;
+
+/**
+ * Class Json
+ */
+class Json implements FactoryInterface
+{
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var string
+     */
+    private $className;
+
+    /**
+     * Constructor.
+     *
+     * @param ObjectManagerInterface $objectManager
+     * @param string                 $className
+     */
+    public function __construct(
+        ObjectManagerInterface $objectManager,
+        $className = \Magento\Framework\Setup\Declaration\Schema\Dto\Columns\Blob::class
+    ) {
+        $this->objectManager = $objectManager;
+        $this->className = $className;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(array $data)
+    {
+        return $this->objectManager->create($this->className, $data);
+    }
+}

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/schema.xsd
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/schema.xsd
@@ -20,6 +20,7 @@
     <xs:include schemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/types/texts/longtext.xsd" />
     <xs:include schemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/types/texts/mediumtext.xsd" />
     <xs:include schemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/types/texts/varchar.xsd" />
+    <xs:include schemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/types/texts/json.xsd" />
     <xs:include schemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/types/binaries/blob.xsd" />
     <xs:include schemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/types/binaries/mediumblob.xsd" />
     <xs:include schemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/types/binaries/longblob.xsd" />

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/types/texts/json.xsd
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/types/texts/json.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xs:include schemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/types/column.xsd"/>
+
+    <xs:complexType name="json">
+        <xs:complexContent>
+            <xs:extension base="abstractColumnType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Well formatted Json object
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:attribute name="nullable" type="xs:boolean" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+</xs:schema>

--- a/lib/internal/Magento/Framework/Setup/SchemaListenerDefinition/JsonDefinition.php
+++ b/lib/internal/Magento/Framework/Setup/SchemaListenerDefinition/JsonDefinition.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework\Setup\SchemaListenerDefinition;
+
+/**
+ * Json type definition.
+ */
+class JsonDefinition implements DefinitionConverterInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function convertToDefinition(array $definition)
+    {
+        return [
+            'xsi:type' => $definition['type'],
+            'name' => $definition['name'],
+            'nullable' => $definition['nullable'] ?? true
+        ];
+    }
+}


### PR DESCRIPTION
### Description (*)
Starting MySQL 5.7 supports native JSON data type. https://dev.mysql.com/doc/refman/5.7/en/json.html
This pull request enables the possibility to use JSON fields with Magento declarative schema.

### Manual testing scenarios (*)

##### db_schema.xml
```
<?xml version="1.0"?>
<!--
/**
 * Copyright © Magento, Inc. All rights reserved.
 * See COPYING.txt for license details.
 */
-->
<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
    <table name="test_table" resource="default" engine="innodb" comment="Data">
        <column xsi:type="bigint" name="id" padding="20" unsigned="true" nullable="false" identity="true" comment="ID"/>
        <column xsi:type="json" name="data" nullable="false" comment="data"/>
        <constraint xsi:type="primary" referenceId="PRIMARY">
            <column name="id"/>
        </constraint>
    </table>
</schema>
```

##### Structure of created table 
```
mysql> show create table test_table\G
*************************** 1. row ***************************
       Table: test_table
Create Table: CREATE TABLE `test_table` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'ID',
  `data` json NOT NULL COMMENT 'data',
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Data'
1 row in set (0.00 sec)
```
### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
