### PR TITLE
fix for Issue #25434 Mail address email constructor argument type inc…

### DIFF
--- a/lib/internal/Magento/Framework/Mail/Address.php
+++ b/lib/internal/Magento/Framework/Mail/Address.php
@@ -29,7 +29,7 @@ class Address
      * @param string|null $name
      */
     public function __construct(
-        ?string $email,
+        string $email,
         ?string $name
     ) {
         $this->email = $email;

--- a/lib/internal/Magento/Framework/Mail/Address.php
+++ b/lib/internal/Magento/Framework/Mail/Address.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 namespace Magento\Framework\Mail;
 
 /**
- * Class MailAddress
+ * Class Address
  */
 class Address
 {
@@ -23,13 +23,13 @@ class Address
     private $email;
 
     /**
-     * MailAddress constructor
+     * Address constructor
      *
      * @param string|null $email
      * @param string|null $name
      */
     public function __construct(
-        string $email,
+        ?string $email,
         ?string $name
     ) {
         $this->email = $email;
@@ -49,9 +49,9 @@ class Address
     /**
      * Email getter
      *
-     * @return string
+     * @return string|null
      */
-    public function getEmail(): string
+    public function getEmail(): ?string
     {
         return $this->email;
     }

--- a/lib/internal/Magento/Framework/Mail/Test/Unit/AddressTest.php
+++ b/lib/internal/Magento/Framework/Mail/Test/Unit/AddressTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Mail\Test\Unit;
+
+use Magento\Framework\Mail\Address;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * test Magento\Framework\Mail\Address
+ */
+class AddressTest extends TestCase
+{
+    /**
+     * @var Address
+     */
+    protected $message;
+
+    /**
+     * Address object with nullable email parameter passed should not throw an exception.
+     *
+     * @return void
+     */
+    public function testGetEmailEmpty()
+    {
+        $address = new Address(null, "Test name");
+        $this->assertNull($address->getEmail());
+    }
+}


### PR DESCRIPTION
### Description (*)
fix for Issue #25434 Mail address email constructor argument type incorrect

### Fixed Issues (if relevant)
1. magento/magento2#25434: Mail address email constructor argument type incorrect

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
