### PR TITLE
Fixed scheduled indexation with MySQL 8

### DIFF
--- a/lib/internal/Magento/Framework/Mview/View/Changelog.php
+++ b/lib/internal/Magento/Framework/Mview/View/Changelog.php
@@ -7,7 +7,6 @@
 namespace Magento\Framework\Mview\View;
 
 use Magento\Framework\DB\Adapter\ConnectionException;
-use Magento\Framework\Exception\RuntimeException;
 use Magento\Framework\Phrase;
 
 /**
@@ -170,7 +169,6 @@ class Changelog implements ChangelogInterface
      *
      * @return int
      * @throws ChangelogTableNotExistsException
-     * @throws RuntimeException
      */
     public function getVersion()
     {
@@ -178,14 +176,12 @@ class Changelog implements ChangelogInterface
         if (!$this->connection->isTableExists($changelogTableName)) {
             throw new ChangelogTableNotExistsException(new Phrase("Table %1 does not exist", [$changelogTableName]));
         }
-        $row = $this->connection->fetchRow('SHOW TABLE STATUS LIKE ?', [$changelogTableName]);
-        if (isset($row['Auto_increment'])) {
-            return (int)$row['Auto_increment'] - 1;
-        } else {
-            throw new RuntimeException(
-                new Phrase("Table status for %1 is incorrect. Can`t fetch version id.", [$changelogTableName])
-            );
-        }
+        return (int)$this->connection->fetchOne(
+            $this->connection->select()
+                ->from($changelogTableName, ['version_id'])
+                ->order('version_id DESC')
+                ->limit(1)
+        );
     }
 
     /**


### PR DESCRIPTION
### Description (*)
Magento indexation by schedule does not work correctly with MySQL 8

### Fixed Issues (if relevant)
https://github.com/magento/architecture/pull/301

### Manual testing scenarios (*)
MySQL 8 has enabled metadata caching by default. As a result, Magento functionality that expects accurate reading frequently changing values ​​fails.
The most devastating consequence of this change has on scheduled indexation, which tries to read the most recent changelog version from the MySQL metadata.
To resolve the issue a materialized view engine has to rely on real changelog table data instead of MySQL metadata.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
