### PR TITLE
Return HTTP response of example import file as CSV

### DIFF
--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Download.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Download.php
@@ -101,8 +101,8 @@ class Download extends ImportController
         $resultRaw = $this->resultRawFactory->create();
         $resultRaw->setContents($fileContents);
         $resultRaw->setHeader('Content-Type','text/csv');
-        $resultRaw->setHeader('Content-Disposition','attachment; filename="'.$fileName.'"');
-        $resultRaw->setHeader('Content-Length: '.$fileSize);
+        $resultRaw->setHeader('Content-Disposition', 'attachment; filename="'.$fileName.'"');
+        $resultRaw->setHeader('Content-Length', $fileSize);
         return $resultRaw;
     }
 

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Download.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Import/Download.php
@@ -97,17 +97,12 @@ class Download extends ImportController
         $fileSize = $this->sampleFileProvider->getSize($entityName);
         $fileName = $entityName . '.csv';
 
-        $this->fileFactory->create(
-            $fileName,
-            null,
-            DirectoryList::VAR_DIR,
-            'application/octet-stream',
-            $fileSize
-        );
-
         /** @var \Magento\Framework\Controller\Result\Raw $resultRaw */
         $resultRaw = $this->resultRawFactory->create();
         $resultRaw->setContents($fileContents);
+        $resultRaw->setHeader('Content-Type','text/csv');
+        $resultRaw->setHeader('Content-Disposition','attachment; filename="'.$fileName.'"');
+        $resultRaw->setHeader('Content-Length: '.$fileSize);
         return $resultRaw;
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
We are return content of CSV file here. So without these changes unnecessary file is created in "var" directory and default response type is returned. So file is not downloaded, just displayed in browser. This fix will allow to actually download example file and not use some "hacks" in other modules.
Eg. response type of this link: [https://{BASE_URL}/admin_123/admin/import/download/filename/catalog_product/key/{KEY}/](https://{BASE_URL}/admin_123/admin/import/download/filename/catalog_product/key/{KEY}/) is HTML. So when I click "Download Sample File" link eg. for Entity type = Products, CSV file is displayed in web browser instead of being downloaded.

### Manual testing scenarios (*)
1. Log in into Magento Admin panel
2. Go to System > Data Transfer > Import
3. Select eg. Entity Type = Products
4. Click the link "Download Sample File"
5. There should be started downloading of CSV example file


### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds are green)
