### PR TITLE
Resolved AdobeStock issue 641

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/overlay.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/overlay.js
@@ -26,6 +26,17 @@ define([
          */
         getLabel: function (row) {
             return row[this.index];
+        },
+
+        /**
+         * Returns top displacement of overlay according to image height
+         *
+         * @param {Object} record - Data to be preprocessed.
+         * @returns {Object}
+         */
+        getStyles: function (record) {
+            var height = record.styles()['height'].replace('px', '');
+            return {top: (height - 50) + 'px'};
         }
     });
 });

--- a/app/code/Magento/Ui/view/base/web/templates/grid/columns/overlay.html
+++ b/app/code/Magento/Ui/view/base/web/templates/grid/columns/overlay.html
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 -->
-<div if="$col.isVisible($row())" class="masonry-image-overlay">
+<div if="$col.isVisible($row())" ko-style="$col.getStyles($row())" class="masonry-image-overlay">
     <span text="$col.getLabel($row())"/>
 </div>


### PR DESCRIPTION
### Description
Resolved https://github.com/magento/adobe-stock-integration/issues/641. Please refer to https://github.com/magento/adobe-stock-integration/pull/670 for more information

### Fixed Issues
-  magento/adobe-stock-integration#641: The licensed label is shown under the image if the row of images has small height

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
