### PR TITLE
Fix issue when requirejs/domReady could delay rendering of content

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/layout/default.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/default.xml
@@ -10,7 +10,8 @@
         <title>Magento Admin</title>
         <meta name="viewport" content="width=1024"/>
         <meta name="format-detection" content="telephone=no"/>
-        <link src="requirejs/require.js"/>
+        <script src="requirejs/require.js"/>
+        <script src="requirejs/domReady.js"/>
         <css src="extjs/resources/css/ext-all.css"/>
         <css src="extjs/resources/css/ytheme-magento.css"/>
     </head>

--- a/app/code/Magento/Search/Test/Mftf/Test/StorefrontVerifySearchSuggestionByProductDescriptionTest.xml
+++ b/app/code/Magento/Search/Test/Mftf/Test/StorefrontVerifySearchSuggestionByProductDescriptionTest.xml
@@ -16,6 +16,9 @@
             <severity value="CRITICAL"/>
             <testCaseId value="MC-14765"/>
             <group value="mtf_migrated"/>
+            <skip>
+                <issueId value="MC-19868"/>
+            </skip>
         </annotations>
         <before>
             <!-- Login as admin -->

--- a/app/code/Magento/Swagger/view/frontend/layout/swagger_index_index.xml
+++ b/app/code/Magento/Swagger/view/frontend/layout/swagger_index_index.xml
@@ -23,6 +23,7 @@
         <remove src="css/styles-m.css"/>
         <remove src="css/styles-s.css"/>
         <remove src="requirejs/require.js"/>
+        <remove src="requirejs/domReady.js"/>
         <remove src="mage/requirejs/mixins.js"/>
         <remove src="requirejs-config.js"/>
     </head>

--- a/app/code/Magento/Theme/view/frontend/layout/default_head_blocks.xml
+++ b/app/code/Magento/Theme/view/frontend/layout/default_head_blocks.xml
@@ -10,6 +10,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <css src="mage/calendar.css"/>
         <script src="requirejs/require.js"/>
+        <script src="requirejs/domReady.js"/>
         <script src="mage/polyfill.js"/>
     </head>
     <body>

--- a/lib/web/requirejs/domReady.js
+++ b/lib/web/requirejs/domReady.js
@@ -9,7 +9,7 @@
   self: false, setInterval: false */
 
 
-define(function () {
+define('domReady', function () {
     'use strict';
 
     var isTop, testDiv, scrollIntervalId,

--- a/lib/web/requirejs/domReady.js
+++ b/lib/web/requirejs/domReady.js
@@ -84,12 +84,10 @@ define('domReady', function () {
         //entering "interactive" or "complete". More details:
         //http://dev.w3.org/html5/spec/the-end.html#the-end
         //http://stackoverflow.com/questions/3665561/document-readystate-of-interactive-vs-ondomcontentloaded
-        //Hmm, this is more complicated on further use, see "firing too early"
-        //bug: https://github.com/requirejs/domReady/issues/1
-        //so removing the || document.readyState === "interactive" test.
-        //There is still a window.onload binding that should get fired if
-        //DOMContentLoaded is missed.
-        if (document.readyState === "complete") {
+        //Changes from https://github.com/requirejs/domReady/commit/a3e0dd8b6d3d3ee636ff0ca6a5a7c302d6ab33bf
+        //were reverted because IE9 isn't supported by Magento 2
+        if (document.readyState === "complete" ||
+            document.readyState === "interactive") {
             pageLoaded();
         }
     }


### PR DESCRIPTION
### Description (*)
This PR adds requirejs/domReady to head section just after requirejs library, so requirejs will not load requirejs/domReady himself. 
As result browser starting loading all magento scripts earlier as there is no delay for loading domReady file anymore.

More info (including benchmarks): https://github.com/magento/magento2/pull/23313#discussion_r344084716

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/22909 : requirejs/domReady.js can severely delay rendering of content
2. https://github.com/magento/magento2/pull/23313#discussion_r344084716

### Manual testing scenarios (*)
1. Add a non blocking asset to the page with a severe delay e.g. `<img src="https://httpstat.us/404?sleep=10000" />` (I added this to `Magento_Theme::html/absolute_footer.phtml`)
2. Visit the homepage
3. The loading status indicator in the browser should be visible for at least the time set in the `sleep` value of the asset, however private / JavaScript content should render before this finishes (I used the `Default welcome msg!` text in the header to verify this)

### Questions or comments


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
