### PR TITLE
Relocate Watermark insert on image after resize. #25514

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
@@ -130,10 +130,12 @@ class ParamsBuilder
         );
 
         if ($file) {
-            $size = $this->scopeConfig->getValue(
-                "design/watermark/{$type}_size",
-                ScopeInterface::SCOPE_STORE,
-                $scopeId
+            $size = explode(
+                'x',
+                $this->scopeConfig->getValue(
+                    "design/watermark/{$type}_size",
+                    ScopeInterface::SCOPE_STORE
+                )
             );
             $opacity = $this->scopeConfig->getValue(
                 "design/watermark/{$type}_imageOpacity",
@@ -145,8 +147,8 @@ class ParamsBuilder
                 ScopeInterface::SCOPE_STORE,
                 $scopeId
             );
-            $width = !empty($size['width']) ? $size['width'] : null;
-            $height = !empty($size['height']) ? $size['height'] : null;
+            $width = !empty($size['0']) ? $size['0'] : null;
+            $height = !empty($size['1']) ? $size['1'] : null;
 
             return [
                 'watermark_file' => $file,

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -311,6 +311,10 @@ class ImageResize
             ]
         );
 
+        if ($imageParams['image_width'] !== null && $imageParams['image_height'] !== null) {
+            $image->resize($imageParams['image_width'], $imageParams['image_height']);
+        }
+
         if (isset($imageParams['watermark_file'])) {
             if ($imageParams['watermark_height'] !== null) {
                 $image->setWatermarkHeight($imageParams['watermark_height']);
@@ -331,9 +335,6 @@ class ImageResize
             $image->watermark($this->getWatermarkFilePath($imageParams['watermark_file']));
         }
 
-        if ($imageParams['image_width'] !== null && $imageParams['image_height'] !== null) {
-            $image->resize($imageParams['image_width'], $imageParams['image_height']);
-        }
         $image->save($imageAsset->getPath());
 
         if ($this->fileStorageDatabase->checkDbUsage()) {


### PR DESCRIPTION
### Description (*)
When using watermark on images in Magento 2.3.3, the watermark will be placed on top of the image and then the image will be resized.
If the user uses different size of images, the watermark on the frontend is not consistent on the site.

### Fixed Issues (if relevant)
1. magento/magento2#25514: Image resizing and watermarking do no take into consideration the relative dimensions of the watermark and watermarked image
2. magento/magento2#23515: The display watermark size is incorrect compared to the original watermark images on list product,product page on magento2.3.2

### Manual testing scenarios (*)
1. Create two products.
2. Give one product an image of size 400x400.
3. Give the second product an image of size 1200x1200.
4. Add a watermark with width 200px.
5. Refresh image cache.
6. Generate cached images by visiting the product's product detail page.
7. Notice that the watermarks are equal of size.

### Questions or comments
Maybe we need to add an option to have either the watermark before or after resizing the image.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
