### PR TITLE
Telephone Widget > Template > Removing this and helper

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/widget/telephone.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/telephone.phtml
@@ -14,18 +14,14 @@
         </span>
     </label>
     <div class="control">
-            <?php
-            $_validationClass = $block->escapeHtmlAttr(
-                $this->helper(\Magento\Customer\Helper\Address::class)
-                     ->getAttributeValidationClass('telephone')
-            );
-            ?>
         <input type="text"
                name="telephone"
                id="telephone"
                value="<?= $block->escapeHtmlAttr($block->getTelephone()) ?>"
                title="<?= $block->escapeHtmlAttr(__('Phone Number')) ?>"
-               class="input-text <?= $_validationClass ?: '' ?>"
+               class="input-text <?= $block->escapeHtmlAttr(
+                   $block->getAttributeValidationClass('telephone')
+               ) ?>"
         >
     </div>
 </div>


### PR DESCRIPTION
### Description (*)
I provided this PR to fix the issue that I had in the PR https://github.com/magento/magento2/pull/25321, to follow the [Magento Coding Standards](https://github.com/magento/magento-coding-standard) I'm removing the `helper` and `$this` from the template file.
I used a method in block class to enable me to do it instead of calling the `helper` directly in the template file. I created a new method as well to get the telephone validation directly as this class and phtml are dedicated to the telephone widget.

### Fixed Issues (if relevant)

1. `helper` and `$this` into the template file

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
