### PR TITLE
Corrected scope of _construct to protected

### DIFF
--- a/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
+++ b/app/code/Magento/Cron/Model/ResourceModel/Schedule.php
@@ -18,7 +18,7 @@ class Schedule extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      *
      * @return void
      */
-    public function _construct()
+    protected function _construct()
     {
         $this->_init('cron_schedule', 'schedule_id');
     }


### PR DESCRIPTION
### Description

Corrects the scope of _construct() method in `Magento\Cron\Model\ResourceModel\Schedule.php`.

> _construct() is intended to act as a "mock" constructor and not supposed to be accessed outside of the context of $this

### Fixed Issues (if relevant)

None.

### Manual testing scenarios (*)

No tests performed. However I did perform a scan of the code base to ensure _construct() is never currently called outside of the context of `$this`. 

```
grep -r \>_construct .
./lib/internal/Magento/Framework/View/Element/AbstractBlock.php:        $this->_construct();
./lib/internal/Magento/Framework/Model/ResourceModel/Db/Collection/AbstractCollection.php:        $this->_construct();
./lib/internal/Magento/Framework/Model/ResourceModel/AbstractResource.php:        $this->_construct();
./lib/internal/Magento/Framework/Model/AbstractModel.php:        $this->_construct();
./lib/internal/Magento/Framework/Data/Form/AbstractForm.php:        $this->_construct();
./app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php:        $this->_construct();
```

### Questions or comments

This should really be a PR into 2.4-develop as this is a non-backwards compatible change. However no such branch exists for me to open a PR to.

While this does not break any functionality within Magento itself, it is potentially possible that developers have (against best practices) performed in their code something similar to the following:

```php
<?php

namespace VendorName\ModuleName\Model\FooBar;

class BadPractice
{
    private $schedule;

    public function __construct(\Magento\Core\Model\Cron\ResourceModel\Schedule $schedule)
    {
        $this->schedule = $schedule;
    }

    public function notSureWhyAnyoneWouldEverDoThis()
    {
        $this->schedule->_construct();
    }

    // ... remaining class contents...
}
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29643: Corrected scope of _construct to protected