### PR TITLE
Removes hardcoded references to country selector component

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
@@ -60,7 +60,10 @@ define([
             template: 'Magento_Checkout/shipping',
             shippingFormTemplate: 'Magento_Checkout/shipping-address/form',
             shippingMethodListTemplate: 'Magento_Checkout/shipping-address/shipping-method-list',
-            shippingMethodItemTemplate: 'Magento_Checkout/shipping-address/shipping-method-item'
+            shippingMethodItemTemplate: 'Magento_Checkout/shipping-address/shipping-method-item',
+            imports: {
+                countryOptions: '${ $.parentName }.shippingAddress.shipping-address-fieldset.country_id:indexedOptions'
+            }
         },
         visible: ko.observable(!quote.isVirtual()),
         errorValidationMessage: ko.observable(false),
@@ -276,9 +279,7 @@ define([
                 loginFormSelector = 'form[data-role=email-with-possible-login]',
                 emailValidationResult = customer.isLoggedIn(),
                 field,
-                country = registry.get(this.parentName + '.shippingAddress.shipping-address-fieldset.country_id'),
-                countryIndexedOptions = country.indexedOptions,
-                option = countryIndexedOptions[quote.shippingAddress().countryId],
+                option = _.isObject(this.countryOptions) && this.countryOptions[quote.shippingAddress().countryId],
                 messageContainer = registry.get('checkout.errors').messageContainer;
 
             if (!quote.shippingMethod()) {

--- a/app/code/Magento/Ui/view/base/web/js/form/element/post-code.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/post-code.js
@@ -8,14 +8,14 @@
  */
 define([
     'underscore',
-    'uiRegistry',
     './abstract'
-], function (_, registry, Abstract) {
+], function (_, Abstract) {
     'use strict';
 
     return Abstract.extend({
         defaults: {
             imports: {
+                countryOptions: '${ $.parentName }.country_id:indexedOptions',
                 update: '${ $.parentName }.country_id:value'
             }
         },
@@ -41,31 +41,32 @@ define([
         },
 
         /**
-         * @param {String} value
+         * Method called every time country selector's value gets changed.
+         * Updates all validations and requirements for certain country.
+         * @param {String} value - Selected country ID.
          */
         update: function (value) {
-            var country = registry.get(this.parentName + '.' + 'country_id'),
-                options = country.indexedOptions,
-                option = null;
+            var isZipCodeOptional,
+                option;
 
             if (!value) {
                 return;
             }
 
-            option = options[value];
+            option = _.isObject(this.countryOptions) && this.countryOptions[value];
 
             if (!option) {
                 return;
             }
 
-            if (option['is_zipcode_optional']) {
+            isZipCodeOptional = !!option['is_zipcode_optional'];
+
+            if (isZipCodeOptional) {
                 this.error(false);
-                this.validation = _.omit(this.validation, 'required-entry');
-            } else {
-                this.validation['required-entry'] = true;
             }
 
-            this.required(!option['is_zipcode_optional']);
+            this.validation['required-entry'] = !isZipCodeOptional;
+            this.required(!isZipCodeOptional);
         }
     });
 });

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/view/shipping.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/view/shipping.test.js
@@ -174,16 +174,13 @@ define(['squire', 'ko', 'jquery', 'uiRegistry', 'jquery/validate'], function (Sq
 
         describe('"validateShippingInformation" method', function () {
             it('Check method call on negative cases.', function () {
+                /* jscs:disable */
                 var country = {
-                    'indexedOptions': {
-                        'AD':
-                            {
-                                label: 'Andorra',
-                                labeltitle: 'Andorra',
-                                value: 'AD'
-                            }
-                    }
+                    on: function () {},
+                    get: function () {},
+                    set: function () {}
                 };
+                /* jscs:enable */
 
                 registry.set('test.shippingAddress.shipping-address-fieldset.country_id', country);
                 registry.set('checkout.errors', {});
@@ -202,9 +199,20 @@ define(['squire', 'ko', 'jquery', 'uiRegistry', 'jquery/validate'], function (Sq
                 expect(obj.validateShippingInformation()).toBeFalsy();
             });
             it('Check method call on positive case.', function () {
+                /* jscs:disable */
+                var country = {
+                    on: function () {},
+                    get: function () {},
+                    set: function () {}
+                };
+                /* jscs:enable */
+
                 $('body').append('<form data-role="email-with-possible-login">' +
                     '<input type="text" name="username" />' +
                     '</form>');
+
+                registry.set('test.shippingAddress.shipping-address-fieldset.country_id', country);
+                registry.set('checkout.errors', {});
                 obj.source = {
                     get: jasmine.createSpy().and.returnValue(true),
                     set: jasmine.createSpy(),

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/form/element/post-code.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/form/element/post-code.test.js
@@ -47,21 +47,70 @@ define([
         });
 
         describe('update method', function () {
-            it('check for default', function () {
-                var value = 'Value',
-                    country = {
-                        indexedOptions: {
-                            'Value': {
-                                'is_zipcode_optional': true
-                            }
-                        }
-                    };
+            it('makes field optional when there is no corresponding country', function () {
+                var value = 'Value';
 
-                spyOn(mocks['Magento_Ui/js/lib/registry/registry'], 'get').and.returnValue(country);
+                model.countryOptions = {};
+
                 model.update(value);
-                expect(mocks['Magento_Ui/js/lib/registry/registry'].get).toHaveBeenCalled();
-                expect(model.error()).toEqual(false);
+
                 expect(model.required()).toEqual(false);
+            });
+
+            it('makes field optional when post code is optional for certain country', function () {
+                var value = 'Value';
+
+                model.countryOptions = {
+                    'Value': {
+                        'is_zipcode_optional': true
+                    }
+                };
+
+                model.update(value);
+
+                expect(model.required()).toEqual(false);
+            });
+
+            it('removes field required validation when post code is optional for certain country', function () {
+                var value = 'Value';
+
+                model.countryOptions = {
+                    'Value': {
+                        'is_zipcode_optional': true
+                    }
+                };
+
+                model.update(value);
+
+                expect(model.validation['required-entry']).toBeFalsy();
+            });
+
+            it('makes field required when post code is required for certain country', function () {
+                var value = 'Value';
+
+                model.countryOptions = {
+                    'Value': {
+                        'is_zipcode_optional': false
+                    }
+                };
+
+                model.update(value);
+
+                expect(model.required()).toEqual(true);
+            });
+
+            it('sets field required validation when post code is required for certain country', function () {
+                var value = 'Value';
+
+                model.countryOptions = {
+                    'Value': {
+                        'is_zipcode_optional': false
+                    }
+                };
+
+                model.update(value);
+
+                expect(model.validation['required-entry']).toEqual(true);
             });
         });
     });

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/form/element/region.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/form/element/region.test.js
@@ -48,21 +48,126 @@ define([
         });
 
         describe('update method', function () {
-            it('check for default', function () {
-                var value = 'Value',
-                    country = {
-                        indexedOptions: {
-                            'Value': {
-                                'is_zipcode_optional': true
-                            }
-                        }
-                    };
+            it('makes field optional when there is no corresponding country', function () {
+                var value = 'Value';
 
-                spyOn(mocks['Magento_Ui/js/lib/registry/registry'], 'get').and.returnValue(country);
+                model.countryOptions = {};
+
                 model.update(value);
-                expect(mocks['Magento_Ui/js/lib/registry/registry'].get).toHaveBeenCalled();
-                expect(model.error()).toEqual(false);
+
                 expect(model.required()).toEqual(false);
+            });
+
+            it('makes field optional when region is optional for certain country', function () {
+                var value = 'Value';
+
+                model.countryOptions = {
+                    'Value': {
+                        'is_region_required': false
+                    }
+                };
+
+                model.update(value);
+
+                expect(model.required()).toEqual(false);
+            });
+
+            it('removes field required validation when region is optional for certain country', function () {
+                var value = 'Value';
+
+                model.countryOptions = {
+                    'Value': {
+                        'is_region_required': false
+                    }
+                };
+
+                model.update(value);
+
+                expect(model.validation['required-entry']).toBeFalsy();
+            });
+
+            it('makes field required when region is required for certain country', function () {
+                var value = 'Value';
+
+                model.countryOptions = {
+                    'Value': {
+                        'is_region_required': true
+                    }
+                };
+
+                model.update(value);
+
+                expect(model.required()).toEqual(true);
+            });
+
+            it('sets field required validation when region is required for certain country', function () {
+                var value = 'Value';
+
+                model.countryOptions = {
+                    'Value': {
+                        'is_region_required': true
+                    }
+                };
+
+                model.update(value);
+
+                expect(model.validation['required-entry']).toEqual(true);
+            });
+
+            it('keeps region visible by default', function () {
+                var value = 'Value';
+
+                model.countryOptions = {
+                    'Value': {}
+                };
+
+                model.update(value);
+
+                expect(model.visible()).toEqual(true);
+            });
+
+            it('hides region field when it should be hidden for certain country', function () {
+                var value = 'Value';
+
+                model.countryOptions = {
+                    'Value': {
+                        'is_region_visible': false
+                    }
+                };
+
+                model.update(value);
+
+                expect(model.visible()).toEqual(false);
+            });
+
+            it('makes field optional when validation should be skipped', function () {
+                var value = 'Value';
+
+                model.countryOptions = {
+                    'Value': {
+                        'is_region_required': true
+                    }
+                };
+
+                model.skipValidation = true;
+                model.update(value);
+
+                expect(model.required()).toEqual(false);
+            });
+
+            it('removes field validation when validation should be skipped', function () {
+                var value = 'Value';
+
+                model.countryOptions = {
+                    'Value': {
+                        'is_region_required': true
+                    }
+                };
+
+                model.skipValidation = true;
+                model.update(value);
+
+                expect(model.validation['required-entry']).toBeFalsy();
             });
         });
     });


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This change is aimed to fix https://github.com/magento/magento2/issues/22416 and loosen up the coupling between shipping and country selector components in case they are moved around in the hierarchy. Applying this patch makes it possible to at least change their paths through component configuration.

Additionally, region and postcode components were refactored a bit to simplify how validation logic is written.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#22416: Coupling beetwen Magento_Checkout::js/view/shipping.js:validateShippingInformation() and layout definition or view.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to the checkout.
2. Switch through different countries through select input.
2. Make sure that region and postcode fields retain their validation for selected countries.

### Questions or comments
This chain is meant purely to improve developer experience when adjusting the checkout structure and shouldn't change any of the business logic.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
