### PR TITLE
Remove usage of normalizeDate in favor of convertToMomentFormat

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
@@ -27,7 +27,7 @@ define([
         initConfig: function () {
             this._super();
 
-            this.dateFormat = utils.normalizeDate(this.dateFormat ? this.dateFormat : this.options.dateFormat);
+            this.dateFormat = utils.convertToMomentFormat(this.dateFormat ? this.dateFormat : this.options.dateFormat);
 
             return this;
         },

--- a/lib/web/mage/utils/misc.js
+++ b/lib/web/mage/utils/misc.js
@@ -35,12 +35,12 @@ define([
     map = {
         'D': 'DDD',
         'dd': 'DD',
-        'd': 'D',
+        'd': 'DD',
         'EEEE': 'dddd',
         'EEE': 'ddd',
         'e': 'd',
         'yyyy': 'YYYY',
-        'yy': 'YY',
+        'yy': 'YYYY',
         'y': 'YYYY',
         'a': 'A'
     };
@@ -81,22 +81,6 @@ define([
             var fn = owner[target];
 
             owner[target] = _.debounce(fn.bind(owner), limit);
-        },
-
-        /**
-         * Converts mage date format to a moment.js format.
-         *
-         * @param {String} mageFormat
-         * @returns {String}
-         */
-        normalizeDate: function (mageFormat) {
-            var result = mageFormat;
-
-            _.each(map, function (moment, mage) {
-                result = result.replace(mage, moment);
-            });
-
-            return result;
         },
 
         /**
@@ -269,12 +253,13 @@ define([
          * @returns {String} - moment compatible formatting
          */
         convertToMomentFormat: function (format) {
-            var newFormat;
+            var result = format;
 
-            newFormat = format.replace(/yyyy|yy|y/, 'YYYY'); // replace the year
-            newFormat = newFormat.replace(/dd|d/g, 'DD'); // replace the date
+            _.each(map, function (moment, mage) {
+                result = result.replace(mage, moment);
+            });
 
-            return newFormat;
+            return result;
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This change removes the usage of `normalizeDate` in favor of `convertToMomentFormat` because it seems to be used more widely. It is also making its implementation more universal based on `normalizeDate` contents.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14568: normalizeDate() and convertToMomentFormat() in misc.js is the same

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
I don't see any.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
