### PR TITLE
Fix exception handling and cover with unit tests the GetById media asset command

### DIFF
--- a/app/code/Magento/MediaGallery/Model/Asset/Command/GetById.php
+++ b/app/code/Magento/MediaGallery/Model/Asset/Command/GetById.php
@@ -7,12 +7,12 @@ declare(strict_types=1);
 
 namespace Magento\MediaGallery\Model\Asset\Command;
 
-use Magento\MediaGalleryApi\Api\Data\AssetInterface;
-use Magento\MediaGalleryApi\Api\Data\AssetInterfaceFactory;
-use Magento\MediaGalleryApi\Model\Asset\Command\GetByIdInterface;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\IntegrationException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\MediaGalleryApi\Api\Data\AssetInterface;
+use Magento\MediaGalleryApi\Api\Data\AssetInterfaceFactory;
+use Magento\MediaGalleryApi\Model\Asset\Command\GetByIdInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -71,20 +71,29 @@ class GetById implements GetByIdInterface
             $select = $connection->select()
                 ->from(['amg' => $mediaAssetTable])
                 ->where('amg.id = ?', $mediaAssetId);
-            $data = $connection->query($select)->fetch();
-
-            if (empty($data)) {
-                $message = __('There is no such media asset with id "%1"', $mediaAssetId);
-                throw new NoSuchEntityException($message);
-            }
-
-            return $this->assetFactory->create(['data' => $data]);
+            $mediaAssetData = $connection->query($select)->fetch();
         } catch (\Exception $exception) {
             $message = __(
-                'En error occurred during get media asset with id %id: %error',
+                'En error occurred during get media asset data by id %id: %error',
                 ['id' => $mediaAssetId, 'error' => $exception->getMessage()]
             );
             $this->logger->critical($message);
+            throw new IntegrationException($message, $exception);
+        }
+
+        if (empty($mediaAssetData)) {
+            $message = __('There is no such media asset with id "%1"', $mediaAssetId);
+            throw new NoSuchEntityException($message);
+        }
+
+        try {
+            return $this->assetFactory->create(['data' => $mediaAssetData]);
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception->getMessage());
+            $message = __(
+                'En error occurred during initialize media asset with id %id: %error',
+                ['id' => $mediaAssetId, 'error' => $exception->getMessage()]
+            );
             throw new IntegrationException($message, $exception);
         }
     }

--- a/app/code/Magento/MediaGallery/Model/Asset/Command/GetById.php
+++ b/app/code/Magento/MediaGallery/Model/Asset/Command/GetById.php
@@ -66,9 +66,10 @@ class GetById implements GetByIdInterface
     public function execute(int $mediaAssetId): AssetInterface
     {
         try {
+            $mediaAssetTable = $this->resourceConnection->getTableName(self::TABLE_MEDIA_GALLERY_ASSET);
             $connection = $this->resourceConnection->getConnection();
             $select = $connection->select()
-                ->from(['amg' => $this->resourceConnection->getTableName(self::TABLE_MEDIA_GALLERY_ASSET)])
+                ->from(['amg' => $mediaAssetTable])
                 ->where('amg.id = ?', $mediaAssetId);
             $data = $connection->query($select)->fetch();
 
@@ -80,7 +81,7 @@ class GetById implements GetByIdInterface
             return $this->assetFactory->create(['data' => $data]);
         } catch (\Exception $exception) {
             $message = __(
-                'En error occurred during get media asset with id %id by id: %error',
+                'En error occurred during get media asset with id %id: %error',
                 ['id' => $mediaAssetId, 'error' => $exception->getMessage()]
             );
             $this->logger->critical($message);

--- a/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionDuringMediaAssetInitializationTest.php
+++ b/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionDuringMediaAssetInitializationTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGallery\Test\Unit\Model\Asset\Command;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Exception\IntegrationException;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\MediaGallery\Model\Asset\Command\GetById;
+use Magento\MediaGalleryApi\Api\Data\AssetInterfaceFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Zend\Db\Adapter\Driver\Pdo\Statement;
+
+/**
+ * Test the GetById command model with exception during media asset initialization
+ */
+class GetByIdExceptionDuringMediaAssetInitializationTest extends \PHPUnit\Framework\TestCase
+{
+    private const MEDIA_ASSET_STUB_ID = 1;
+
+    private const MEDIA_ASSET_DATA = ['id' => 1];
+
+    /**
+     * @var GetById|MockObject
+     */
+    private $getMediaAssetById;
+
+    /**
+     * @var AssetInterfaceFactory|MockObject
+     */
+    private $assetFactory;
+
+    /**
+     * @var AdapterInterface|MockObject
+     */
+    private $adapter;
+
+    /**
+     * @var Select|MockObject
+     */
+    private $selectStub;
+
+    /**
+     * @var Statement|MockObject
+     */
+    private $statementMock;
+
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $logger;
+
+    /**
+     * Initialize basic test class mocks
+     */
+    protected function setUp(): void
+    {
+        $resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->assetFactory = $this->createMock(AssetInterfaceFactory::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->getMediaAssetById = (new ObjectManager($this))->getObject(
+            GetById::class,
+            [
+                'resourceConnection' => $resourceConnection,
+                'assetFactory' => $this->assetFactory,
+                'logger' =>  $this->logger,
+            ]
+        );
+        $this->adapter = $this->createMock(AdapterInterface::class);
+        $resourceConnection->method('getConnection')->willReturn($this->adapter);
+
+        $this->selectStub = $this->createMock(Select::class);
+        $this->selectStub->method('from')->willReturnSelf();
+        $this->selectStub->method('where')->willReturnSelf();
+        $this->adapter->method('select')->willReturn($this->selectStub);
+
+        $this->statementMock = $this->getMockBuilder(\Zend_Db_Statement_Interface::class)->getMock();
+    }
+
+    /**
+     * Test case when a problem occurred during asset initialization from received data.
+     */
+    public function testErrorDuringMediaAssetInitializationException(): void
+    {
+        $this->statementMock->method('fetch')->willReturn(self::MEDIA_ASSET_DATA);
+        $this->adapter->method('query')->willReturn($this->statementMock);
+
+        $this->assetFactory->expects($this->once())->method('create')->willThrowException(new \Exception());
+
+        $this->expectException(IntegrationException::class);
+        $this->logger->expects($this->any())
+            ->method('critical')
+            ->willReturnSelf();
+
+        $this->getMediaAssetById->execute(self::MEDIA_ASSET_STUB_ID);
+    }
+}

--- a/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionDuringMediaAssetInitializationTest.php
+++ b/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionDuringMediaAssetInitializationTest.php
@@ -19,7 +19,7 @@ use Psr\Log\LoggerInterface;
 use Zend\Db\Adapter\Driver\Pdo\Statement;
 
 /**
- * Test the GetById command model with exception during media asset initialization
+ * Test the GetById command with exception during media asset initialization
  */
 class GetByIdExceptionDuringMediaAssetInitializationTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionNoSuchEntityTest.php
+++ b/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionNoSuchEntityTest.php
@@ -25,8 +25,6 @@ class GetByIdExceptionNoSuchEntityTest extends \PHPUnit\Framework\TestCase
 {
     private const MEDIA_ASSET_STUB_ID = 1;
 
-    private const MEDIA_ASSET_DATA = ['id' => 1];
-
     /**
      * @var GetById|MockObject
      */

--- a/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionNoSuchEntityTest.php
+++ b/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionNoSuchEntityTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGallery\Test\Unit\Model\Asset\Command;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\MediaGallery\Model\Asset\Command\GetById;
+use Magento\MediaGalleryApi\Api\Data\AssetInterfaceFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Zend\Db\Adapter\Driver\Pdo\Statement;
+
+/**
+ * Test the GetById command with exception thrown in case when there is no such entity
+ */
+class GetByIdExceptionNoSuchEntityTest extends \PHPUnit\Framework\TestCase
+{
+    private const MEDIA_ASSET_STUB_ID = 1;
+
+    private const MEDIA_ASSET_DATA = ['id' => 1];
+
+    /**
+     * @var GetById|MockObject
+     */
+    private $getMediaAssetById;
+
+    /**
+     * @var AssetInterfaceFactory|MockObject
+     */
+    private $assetFactory;
+
+    /**
+     * @var AdapterInterface|MockObject
+     */
+    private $adapter;
+
+    /**
+     * @var Select|MockObject
+     */
+    private $selectStub;
+
+    /**
+     * @var Statement|MockObject
+     */
+    private $statementMock;
+
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $logger;
+
+    /**
+     * Initialize basic test class mocks
+     */
+    protected function setUp(): void
+    {
+        $resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->assetFactory = $this->createMock(AssetInterfaceFactory::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->getMediaAssetById = (new ObjectManager($this))->getObject(
+            GetById::class,
+            [
+                'resourceConnection' => $resourceConnection,
+                'assetFactory' => $this->assetFactory,
+                'logger' =>  $this->logger,
+            ]
+        );
+        $this->adapter = $this->createMock(AdapterInterface::class);
+        $resourceConnection->method('getConnection')->willReturn($this->adapter);
+
+        $this->selectStub = $this->createMock(Select::class);
+        $this->selectStub->method('from')->willReturnSelf();
+        $this->selectStub->method('where')->willReturnSelf();
+        $this->adapter->method('select')->willReturn($this->selectStub);
+
+        $this->statementMock = $this->getMockBuilder(\Zend_Db_Statement_Interface::class)->getMock();
+    }
+
+    /**
+     * Test case when there is no found media asset by id.
+     */
+    public function testNotFoundMediaAssetException(): void
+    {
+        $this->statementMock->method('fetch')->willReturn([]);
+        $this->adapter->method('query')->willReturn($this->statementMock);
+
+        $this->expectException(NoSuchEntityException::class);
+
+        $this->getMediaAssetById->execute(self::MEDIA_ASSET_STUB_ID);
+    }
+}

--- a/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionNoSuchEntityTest.php
+++ b/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionNoSuchEntityTest.php
@@ -53,25 +53,20 @@ class GetByIdExceptionNoSuchEntityTest extends \PHPUnit\Framework\TestCase
     private $statementMock;
 
     /**
-     * @var LoggerInterface|MockObject
-     */
-    private $logger;
-
-    /**
      * Initialize basic test class mocks
      */
     protected function setUp(): void
     {
         $resourceConnection = $this->createMock(ResourceConnection::class);
         $this->assetFactory = $this->createMock(AssetInterfaceFactory::class);
-        $this->logger = $this->createMock(LoggerInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
 
         $this->getMediaAssetById = (new ObjectManager($this))->getObject(
             GetById::class,
             [
                 'resourceConnection' => $resourceConnection,
                 'assetFactory' => $this->assetFactory,
-                'logger' =>  $this->logger,
+                'logger' =>  $logger,
             ]
         );
         $this->adapter = $this->createMock(AdapterInterface::class);

--- a/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionOnGetDataTest.php
+++ b/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionOnGetDataTest.php
@@ -42,6 +42,11 @@ class GetByIdExceptionOnGetDataTest extends \PHPUnit\Framework\TestCase
     private $selectStub;
 
     /**
+     * @var LoggerInterface|MockObject
+     */
+    private $logger;
+
+    /**
      * @var Statement|MockObject
      */
     private $statementMock;
@@ -53,14 +58,14 @@ class GetByIdExceptionOnGetDataTest extends \PHPUnit\Framework\TestCase
     {
         $resourceConnection = $this->createMock(ResourceConnection::class);
         $assetFactory = $this->createMock(AssetInterfaceFactory::class);
-        $logger = $this->createMock(LoggerInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
 
         $this->getMediaAssetById = (new ObjectManager($this))->getObject(
             GetById::class,
             [
                 'resourceConnection' => $resourceConnection,
                 'assetFactory' => $assetFactory,
-                'logger' =>  $logger,
+                'logger' =>  $this->logger,
             ]
         );
         $this->adapter = $this->createMock(AdapterInterface::class);
@@ -83,6 +88,9 @@ class GetByIdExceptionOnGetDataTest extends \PHPUnit\Framework\TestCase
         $this->adapter->method('query')->willThrowException(new \Exception());
 
         $this->expectException(IntegrationException::class);
+        $this->logger->expects($this->any())
+            ->method('critical')
+            ->willReturnSelf();
 
         $this->getMediaAssetById->execute(self::MEDIA_ASSET_STUB_ID);
     }

--- a/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionOnGetDataTest.php
+++ b/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdExceptionOnGetDataTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGallery\Test\Unit\Model\Asset\Command;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Exception\IntegrationException;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\MediaGallery\Model\Asset\Command\GetById;
+use Magento\MediaGalleryApi\Api\Data\AssetInterfaceFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Zend\Db\Adapter\Driver\Pdo\Statement;
+
+/**
+ * Test the GetById command with exception during get media data
+ */
+class GetByIdExceptionOnGetDataTest extends \PHPUnit\Framework\TestCase
+{
+    private const MEDIA_ASSET_STUB_ID = 1;
+
+    private const MEDIA_ASSET_DATA = ['id' => 1];
+
+    /**
+     * @var GetById|MockObject
+     */
+    private $getMediaAssetById;
+    /**
+     * @var AdapterInterface|MockObject
+     */
+    private $adapter;
+
+    /**
+     * @var Select|MockObject
+     */
+    private $selectStub;
+
+    /**
+     * @var Statement|MockObject
+     */
+    private $statementMock;
+
+    /**
+     * Initialize basic test class mocks
+     */
+    protected function setUp(): void
+    {
+        $resourceConnection = $this->createMock(ResourceConnection::class);
+        $assetFactory = $this->createMock(AssetInterfaceFactory::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $this->getMediaAssetById = (new ObjectManager($this))->getObject(
+            GetById::class,
+            [
+                'resourceConnection' => $resourceConnection,
+                'assetFactory' => $assetFactory,
+                'logger' =>  $logger,
+            ]
+        );
+        $this->adapter = $this->createMock(AdapterInterface::class);
+        $resourceConnection->method('getConnection')->willReturn($this->adapter);
+
+        $this->selectStub = $this->createMock(Select::class);
+        $this->selectStub->method('from')->willReturnSelf();
+        $this->selectStub->method('where')->willReturnSelf();
+        $this->adapter->method('select')->willReturn($this->selectStub);
+
+        $this->statementMock = $this->getMockBuilder(\Zend_Db_Statement_Interface::class)->getMock();
+    }
+
+    /**
+     * Test an exception during the get asset data query.
+     */
+    public function testExceptionDuringGetMediaAssetData(): void
+    {
+        $this->statementMock->method('fetch')->willReturn(self::MEDIA_ASSET_DATA);
+        $this->adapter->method('query')->willThrowException(new \Exception());
+
+        $this->expectException(IntegrationException::class);
+
+        $this->getMediaAssetById->execute(self::MEDIA_ASSET_STUB_ID);
+    }
+}

--- a/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdSuccessfulTest.php
+++ b/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdSuccessfulTest.php
@@ -19,9 +19,9 @@ use Psr\Log\LoggerInterface;
 use Zend\Db\Adapter\Driver\Pdo\Statement;
 
 /**
- * Test the GetById command model
+ * Test the GetById command successful scenario
  */
-class GetByIdTest extends \PHPUnit\Framework\TestCase
+class GetByIdSuccessfulTest extends \PHPUnit\Framework\TestCase
 {
     private const MEDIA_ASSET_STUB_ID = 1;
 

--- a/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdSuccessfulTest.php
+++ b/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdSuccessfulTest.php
@@ -10,22 +10,18 @@ namespace Magento\MediaGallery\Test\Unit\Model\Asset\Command;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\DB\Select;
-use Magento\Framework\Exception\IntegrationException;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\MediaGallery\Model\Asset\Command\GetById;
 use Magento\MediaGalleryApi\Api\Data\AssetInterface;
 use Magento\MediaGalleryApi\Api\Data\AssetInterfaceFactory;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Zend\Db\Adapter\Driver\Pdo\Statement;
 
 /**
  * Test the GetById command model
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class GetByIdTest extends TestCase
+class GetByIdTest extends \PHPUnit\Framework\TestCase
 {
     private const MEDIA_ASSET_STUB_ID = 1;
 
@@ -57,25 +53,20 @@ class GetByIdTest extends TestCase
     private $statementMock;
 
     /**
-     * @var LoggerInterface|MockObject
-     */
-    private $logger;
-
-    /**
      * Initialize basic test class mocks
      */
     protected function setUp(): void
     {
         $resourceConnection = $this->createMock(ResourceConnection::class);
         $this->assetFactory = $this->createMock(AssetInterfaceFactory::class);
-        $this->logger = $this->createMock(LoggerInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
 
         $this->getMediaAssetById = (new ObjectManager($this))->getObject(
             GetById::class,
             [
                 'resourceConnection' => $resourceConnection,
                 'assetFactory' => $this->assetFactory,
-                'logger' =>  $this->logger,
+                'logger' =>  $logger,
             ]
         );
         $this->adapter = $this->createMock(AdapterInterface::class);
@@ -104,49 +95,5 @@ class GetByIdTest extends TestCase
             $mediaAssetStub,
             $this->getMediaAssetById->execute(self::MEDIA_ASSET_STUB_ID)
         );
-    }
-
-    /**
-     * Test an exception during the get asset data query.
-     */
-    public function testExceptionDuringGetMediaAssetData(): void
-    {
-        $this->statementMock->method('fetch')->willReturn(self::MEDIA_ASSET_DATA);
-        $this->adapter->method('query')->willThrowException(new \Exception());
-
-        $this->expectException(IntegrationException::class);
-
-        $this->getMediaAssetById->execute(self::MEDIA_ASSET_STUB_ID);
-    }
-
-    /**
-     * Test case when there is no found media asset by id.
-     */
-    public function testNotFoundMediaAssetException(): void
-    {
-        $this->statementMock->method('fetch')->willReturn([]);
-        $this->adapter->method('query')->willReturn($this->statementMock);
-
-        $this->expectException(NoSuchEntityException::class);
-
-        $this->getMediaAssetById->execute(self::MEDIA_ASSET_STUB_ID);
-    }
-
-    /**
-     * Test case when a problem occurred during asset initialization from received data.
-     */
-    public function testErrorDuringMediaAssetInitializationException(): void
-    {
-        $this->statementMock->method('fetch')->willReturn(self::MEDIA_ASSET_DATA);
-        $this->adapter->method('query')->willReturn($this->statementMock);
-
-        $this->assetFactory->expects($this->once())->method('create')->willThrowException(new \Exception());
-
-        $this->expectException(IntegrationException::class);
-        $this->logger->expects($this->any())
-            ->method('critical')
-            ->willReturnSelf();
-
-        $this->getMediaAssetById->execute(self::MEDIA_ASSET_STUB_ID);
     }
 }

--- a/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdTest.php
+++ b/app/code/Magento/MediaGallery/Test/Unit/Model/Asset/Command/GetByIdTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaGallery\Test\Unit\Model\Asset\Command;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Exception\IntegrationException;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\MediaGallery\Model\Asset\Command\GetById;
+use Magento\MediaGalleryApi\Api\Data\AssetInterface;
+use Magento\MediaGalleryApi\Api\Data\AssetInterfaceFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Zend\Db\Adapter\Driver\Pdo\Statement;
+
+/**
+ * Test the GetById command model
+ */
+class GetByIdTest extends TestCase
+{
+    private const MEDIA_ASSET_STUB_ID = 1;
+
+    private const MEDIA_ASSET_DATA = ['id' => 1];
+
+    /**
+     * @var GetById|MockObject
+     */
+    private $getMediaAssetById;
+
+    /**
+     * @var AssetInterfaceFactory|MockObject
+     */
+    private $assetFactory;
+
+    /**
+     * @var AdapterInterface|MockObject
+     */
+    private $adapter;
+
+    /**
+     * @var Select|MockObject
+     */
+    private $selectStub;
+
+    /**
+     * @var Statement|MockObject
+     */
+    private $statementMock;
+
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $logger;
+
+    /**
+     * Initialize basic test class mocks
+     */
+    protected function setUp(): void
+    {
+        $resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->assetFactory = $this->createMock(AssetInterfaceFactory::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->getMediaAssetById = (new ObjectManager($this))->getObject(
+            GetById::class,
+            [
+                'resourceConnection' => $resourceConnection,
+                'assetFactory' => $this->assetFactory,
+                'logger' =>  $this->logger,
+            ]
+        );
+        $this->adapter = $this->createMock(AdapterInterface::class);
+        $resourceConnection->method('getConnection')->willReturn($this->adapter);
+
+        $this->selectStub = $this->createMock(Select::class);
+        $this->selectStub->method('from')->willReturnSelf();
+        $this->selectStub->method('where')->willReturnSelf();
+        $this->adapter->method('select')->willReturn($this->selectStub);
+
+        $this->statementMock = $this->getMockBuilder(\Zend_Db_Statement_Interface::class)->getMock();
+    }
+
+    /**
+     * Test successful get media asset by id command execution.
+     */
+    public function testSuccessfulGetByIdExecution(): void
+    {
+        $this->statementMock->method('fetch')->willReturn(self::MEDIA_ASSET_DATA);
+        $this->adapter->method('query')->willReturn($this->statementMock);
+
+        $mediaAssetStub = $this->getMockBuilder(AssetInterface::class)->getMock();
+        $this->assetFactory->expects($this->once())->method('create')->willReturn($mediaAssetStub);
+
+        $this->getMediaAssetById->execute(self::MEDIA_ASSET_STUB_ID);
+    }
+
+    /**
+     * Test case when there is no found media asset by id.
+     */
+    public function testNotFoundMediaAssetException(): void
+    {
+        $this->statementMock->method('fetch')->willReturn([]);
+        $this->adapter->method('query')->willReturn($this->statementMock);
+
+        $this->expectException(IntegrationException::class);
+        $this->logger->expects($this->once())
+            ->method('critical')
+            ->willReturnSelf();
+
+        $this->getMediaAssetById->execute(self::MEDIA_ASSET_STUB_ID);
+    }
+}


### PR DESCRIPTION
### Description (*)
Cover with unit test the `GetById` command of the Media Gallery functionality. Provide two tests: successful action execution and fail at the not found entity by id. 

### Fixed Issues (if relevant)

https://github.com/magento/adobe-stock-integration/issues/585

### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
