### PR TITLE
Adjust order address form to improve its styling

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/order/address/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/address/form.phtml
@@ -10,12 +10,13 @@
     </div>
 </div>
 
-<fieldset class="fieldset admin__fieldset-wrapper">
-    <legend class="legend admin__legend">
-        <span><?= $block->escapeHtml($block->getHeaderText()) ?></span>
-    </legend>
-    <br>
-    <div class="form-inline" data-mage-init='{"Magento_Sales/order/edit/address/form":{}}'>
-        <?= $block->getForm()->toHtml() ?>
+<section class="admin__page-section order-view-billing-shipping">
+    <div class="admin__page-section-title">
+        <span class="title"><?= $block->escapeHtml($block->getHeaderText()) ?></span>
     </div>
-</fieldset>
+    <div class="admin__page-section-content">
+        <div class="order-address admin__fieldset" data-mage-init='{"Magento_Sales/order/edit/address/form":{}}'>
+            <?= $block->getForm()->toHtml() ?>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR aligns the looks of order address edit form with a new order creation shipping and billing
address forms as they share block's class parent and logic.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19805: Sales order Address Information edit form layout design improvement.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open order information and edit shipping or billing address.
2. Address edit form styling shouldn't look broken and be simillar with new order creation address forms.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
My initial idea was to align the looks of the form to customer address edition which is opened inside a modal but it turns out that the same logic and blocks' parent is shared between existing and new order address edit forms so I just made sure they look similar:

<img width="585" alt="obraz" src="https://user-images.githubusercontent.com/829189/68545592-daf72e00-03ce-11ea-877b-aea1bbb0796b.png">
<img width="840" alt="obraz" src="https://user-images.githubusercontent.com/829189/68545619-08dc7280-03cf-11ea-8e01-ea8265317ca9.png">

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
