### PR TITLE
Fix escape less calc

### DIFF
--- a/lib/web/css/source/lib/_navigation.less
+++ b/lib/web/css/source/lib/_navigation.less
@@ -338,7 +338,7 @@
                     top: 0;
                     left: 100%;
                     width: 10px;
-                    height: calc(100% + 3px);
+                    height: calc(~'100% + 3px');
                     z-index: 1;
                 }
             }


### PR DESCRIPTION
### Description (*)
We've escaped the content in the calc, this way the calc in the css file will be `calc(100% + 3px)` instead of `calc(103%)`

### Manual testing scenarios (*)
1. Hover over root category in main navigation and inspect the height of the after element being added.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
