### PR TITLE
Changing confirm password field class

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
@@ -67,7 +67,7 @@
                 </div>
             </div>
         </div>
-        <div class="field confirm password required" data-container="confirm-password">
+        <div class="field confirmation password required" data-container="confirm-password">
             <label class="label" for="password-confirmation"><span><?= $block->escapeHtml(__('Confirm New Password')) ?></span></label>
             <div class="control">
                 <input type="password" class="input-text" name="password_confirmation" id="password-confirmation"
@@ -93,7 +93,7 @@
     ], function($){
         var dataForm = $('#form-validate');
         var ignore = <?= /* @noEscape */ $_dob->isEnabled() ? '\'input[id$="full"]\'' : 'null' ?>;
-        
+
         dataForm.mage('validation', {
         <?php if ($_dob->isEnabled()) : ?>
             errorPlacement: function(error, element) {


### PR DESCRIPTION
### Description (*)

The confirmation password in the customer account page isn't following the same pattern present into the forgotten password form and create an account form.

### Manual testing scenarios (*)
1. You can access the forgotten password and create an account form and check the classes in the confirmation field.
2. Then open the customer account page and go to the form to reset the password.

### Questions or comments

There is no JS or CSS depending on this specific name that we have today.

![Screen Shot 2019-11-11 at 1 45 24 PM](https://user-images.githubusercontent.com/610598/68605285-e60f9400-048a-11ea-8b1e-dd2f6d100ab2.png)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
