### PR TITLE
The image details are not hidden when click on same image

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
@@ -102,11 +102,11 @@ define([
             var img;
 
             this.hide();
-            
+
             if (record._rowIndex === this.visibleRecord()) {
                 return;
             }
-            
+
             this.displayedRecord(record);
             this._selectRow(record.rowNumber || null);
             this.visibleRecord(record._rowIndex);

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
@@ -101,8 +101,7 @@ define([
         show: function (record) {
             var img;
 
-            if (record._rowIndex === this.visibleRecord() &&
-                this.isVisible(record)) {
+            if (record._rowIndex === this.visibleRecord()) {
                 this.hide();
 
                 return;

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
@@ -101,12 +101,13 @@ define([
         show: function (record) {
             var img;
 
-            this.hide();
-
             if (record._rowIndex === this.visibleRecord()) {
+                this.hide();
+
                 return;
             }
 
+            this.hide();
             this.displayedRecord(record);
             this._selectRow(record.rowNumber || null);
             this.visibleRecord(record._rowIndex);

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
@@ -100,10 +100,11 @@ define([
          */
         show: function (record) {
             var img;
-            
-            if (record._rowIndex === this.visibleRecord()
-                && this.isVisible(record)) {
+
+            if (record._rowIndex === this.visibleRecord() &&
+                this.isVisible(record)) {
                 this.hide();
+
                 return;
             }
 

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
@@ -101,13 +101,12 @@ define([
         show: function (record) {
             var img;
 
+            this.hide();
+            
             if (record._rowIndex === this.visibleRecord()) {
-                this.hide();
-
                 return;
             }
-
-            this.hide();
+            
             this.displayedRecord(record);
             this._selectRow(record.rowNumber || null);
             this.visibleRecord(record._rowIndex);

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
@@ -101,7 +101,7 @@ define([
         show: function (record) {
             var img;
             
-            if (record._rowIndex === this.lastOpenedImage()
+            if (record._rowIndex === this.visibleRecord()
                 && this.isVisible(record)) {
                 this.hide();
                 return;

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
@@ -100,6 +100,12 @@ define([
          */
         show: function (record) {
             var img;
+            
+            if (record._rowIndex === this.lastOpenedImage()
+                && this.isVisible(record)) {
+                this.hide();
+                return;
+            }
 
             this.hide();
             this.displayedRecord(record);

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/image-preview.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/image-preview.test.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+/* eslint-disable max-nested-callbacks, no-undef */
+
+define([
+    'Magento_Ui/js/grid/columns/image-preview',
+    'ko',
+    'jquery'
+], function (Preview, ko, $) {
+    'use strict';
+
+    describe('Ui/js/grid/columns/image-preview', function () {
+        var record = {
+            _rowIndex: 1,
+            rowNumber: 1
+        },
+           imagePreview;
+
+        beforeEach(function () {
+            imagePreview = new Preview();
+
+            /**
+             * @return {Object}
+             */
+            function getThumbnail()  {
+                return {
+                    previewRowId: ko.observable()
+                };
+            }
+
+            imagePreview.thumbnailComponent = getThumbnail;
+
+            imagePreview.visibleRecord = ko.observable(1);
+        });
+
+        describe('show method', function () {
+            it('show image', function () {
+                var mockImg = document.createElement('img'),
+                    hide = spyOn(imagePreview, 'hide');
+
+                spyOn($.fn, 'get').and.returnValue(mockImg);
+                imagePreview.show(record);
+                expect(hide).toHaveBeenCalledTimes(1);
+            });
+
+        });
+    });
+});


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#690 magento/adobe-stock-integration/issues/690

### Manual testing scenarios (*)

1. Login to admin panel
2. Navigate to Cms Pages
3. User clicks Add New Page button
4. Expand "Content" section
5. User clicks "Insert Image..." button
6. Click "Search Adobe Stock" button to open images grid
7. Click on an image to expand the preview

Expected result:
User sees that image details are hidden
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
