### PR TITLE
Remove old logic to make search by operation status possible

### DIFF
--- a/app/code/Magento/AsynchronousOperations/Model/BulkStatus.php
+++ b/app/code/Magento/AsynchronousOperations/Model/BulkStatus.php
@@ -87,22 +87,6 @@ class BulkStatus implements \Magento\Framework\Bulk\BulkStatusInterface
      */
     public function getOperationsCountByBulkIdAndStatus($bulkUuid, $status)
     {
-        if ($status === OperationInterface::STATUS_TYPE_OPEN) {
-            /**
-             * Total number of operations that has been scheduled within the given bulk
-             */
-            $allOperationsQty = $this->getOperationCount($bulkUuid);
-
-            /**
-             * Number of operations that has been processed (i.e. operations with any status but 'open')
-             */
-            $allProcessedOperationsQty = (int)$this->operationCollectionFactory->create()
-                ->addFieldToFilter('bulk_uuid', $bulkUuid)
-                ->getSize();
-
-            return $allOperationsQty - $allProcessedOperationsQty;
-        }
-
         /** @var \Magento\AsynchronousOperations\Model\ResourceModel\Operation\Collection $collection */
         $collection = $this->operationCollectionFactory->create();
         return $collection->addFieldToFilter('bulk_uuid', $bulkUuid)

--- a/dev/tests/api-functional/testsuite/Magento/AsynchronousOperations/Api/BulkStatusInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/AsynchronousOperations/Api/BulkStatusInterfaceTest.php
@@ -15,6 +15,7 @@ class BulkStatusInterfaceTest extends WebapiAbstract
 {
     const RESOURCE_PATH = '/V1/bulk/';
     const SERVICE_NAME = 'asynchronousOperationsBulkStatusV1';
+    const GET_COUNT_OPERATION_NAME = "GetOperationsCountByBulkIdAndStatus";
     const TEST_UUID = "bulk-uuid-searchable-6";
 
     /**
@@ -22,18 +23,22 @@ class BulkStatusInterfaceTest extends WebapiAbstract
      */
     public function testGetListByBulkStartTime()
     {
-
+        $resourcePath = self::RESOURCE_PATH . self::TEST_UUID . "/operation-status/" . OperationInterface::STATUS_TYPE_OPEN;
         $serviceInfo = [
             'rest' => [
-                'resourcePath' => self::RESOURCE_PATH . self::TEST_UUID . "/operation-status/" . OperationInterface::STATUS_TYPE_OPEN,
+                'resourcePath' => $resourcePath,
                 'httpMethod' => \Magento\Framework\Webapi\Rest\Request::HTTP_METHOD_GET
             ],
             'soap' => [
                 'service' => self::SERVICE_NAME,
-                'operation' => self::SERVICE_NAME . 'Get',
+                'serviceVersion' => 'V1',
+                'operation' => self::SERVICE_NAME . self::GET_COUNT_OPERATION_NAME
             ],
         ];
-        $qty = $this->_webApiCall($serviceInfo);
+        $qty = $this->_webApiCall(
+            $serviceInfo,
+            ['bulkUuid' => self::TEST_UUID, 'status' => OperationInterface::STATUS_TYPE_OPEN]
+        );
         $this->assertEquals(2, $qty);
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/AsynchronousOperations/Api/BulkStatusInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/AsynchronousOperations/Api/BulkStatusInterfaceTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\AsynchronousOperations\Api;
+
+use Magento\TestFramework\TestCase\WebapiAbstract;
+use Magento\Framework\Bulk\OperationInterface;
+
+class BulkStatusInterfaceTest extends WebapiAbstract
+{
+    const RESOURCE_PATH = '/V1/bulk/';
+    const SERVICE_NAME = 'asynchronousOperationsBulkStatusV1';
+    const TEST_UUID = "bulk-uuid-searchable-6";
+
+    /**
+     * @magentoApiDataFixture Magento/AsynchronousOperations/_files/operation_searchable.php
+     */
+    public function testGetListByBulkStartTime()
+    {
+
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => self::RESOURCE_PATH . self::TEST_UUID . "/operation-status/" . OperationInterface::STATUS_TYPE_OPEN,
+                'httpMethod' => \Magento\Framework\Webapi\Rest\Request::HTTP_METHOD_GET
+            ],
+            'soap' => [
+                'service' => self::SERVICE_NAME,
+                'operation' => self::SERVICE_NAME . 'Get',
+            ],
+        ];
+        $qty = $this->_webApiCall($serviceInfo);
+        $this->assertEquals(2, $qty);
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/AsynchronousOperations/Api/BulkStatusInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/AsynchronousOperations/Api/BulkStatusInterfaceTest.php
@@ -23,7 +23,7 @@ class BulkStatusInterfaceTest extends WebapiAbstract
      */
     public function testGetListByBulkStartTime()
     {
-        $resourcePath = self::RESOURCE_PATH 
+        $resourcePath = self::RESOURCE_PATH
             . self::TEST_UUID
             . "/operation-status/"
             . OperationInterface::STATUS_TYPE_OPEN;

--- a/dev/tests/api-functional/testsuite/Magento/AsynchronousOperations/Api/BulkStatusInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/AsynchronousOperations/Api/BulkStatusInterfaceTest.php
@@ -23,7 +23,10 @@ class BulkStatusInterfaceTest extends WebapiAbstract
      */
     public function testGetListByBulkStartTime()
     {
-        $resourcePath = self::RESOURCE_PATH . self::TEST_UUID . "/operation-status/" . OperationInterface::STATUS_TYPE_OPEN;
+        $resourcePath = self::RESOURCE_PATH 
+            . self::TEST_UUID
+            . "/operation-status/"
+            . OperationInterface::STATUS_TYPE_OPEN;
         $serviceInfo = [
             'rest' => [
                 'resourcePath' => $resourcePath,

--- a/dev/tests/api-functional/testsuite/Magento/AsynchronousOperations/Api/OperationRepositoryInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/AsynchronousOperations/Api/OperationRepositoryInterfaceTest.php
@@ -57,8 +57,8 @@ class OperationRepositoryInterfaceTest extends WebapiAbstract
         $this->assertArrayHasKey('items', $response);
 
         $this->assertEquals($searchCriteria['searchCriteria'], $response['search_criteria']);
-        $this->assertEquals(3, $response['total_count']);
-        $this->assertEquals(3, count($response['items']));
+        $this->assertEquals(5, $response['total_count']);
+        $this->assertEquals(5, count($response['items']));
 
         foreach ($response['items'] as $item) {
             $this->assertEquals('bulk-uuid-searchable-6', $item['bulk_uuid']);

--- a/dev/tests/integration/testsuite/Magento/AsynchronousOperations/_files/operation_searchable.php
+++ b/dev/tests/integration/testsuite/Magento/AsynchronousOperations/_files/operation_searchable.php
@@ -52,7 +52,22 @@ $operations = [
         'error_code' => 2222,
         'result_message' => 'Entity with ID=4 does not exist',
     ],
-
+    [
+        'bulk_uuid' => 'bulk-uuid-searchable-6',
+        'topic_name' => 'topic-5',
+        'serialized_data' => json_encode(['entity_id' => 5]),
+        'status' => OperationInterface::STATUS_TYPE_OPEN,
+        'error_code' => null,
+        'result_message' => '',
+    ],
+    [
+        'bulk_uuid' => 'bulk-uuid-searchable-6',
+        'topic_name' => 'topic-5',
+        'serialized_data' => json_encode(['entity_id' => 5]),
+        'status' => OperationInterface::STATUS_TYPE_OPEN,
+        'error_code' => null,
+        'result_message' => '',
+    ]
 ];
 
 $bulkQuery = "INSERT INTO {$bulkTable} (`uuid`, `user_id`, `description`, `operation_count`, `start_time`)"


### PR DESCRIPTION
### Description (*)
Idea of this PR is to make Search by operation statuses work again. 

Removed functionality with current Async Operations implementation will always return zero results if you will search by operation status = 4 (open).

### Manual testing scenarios (*)
Schedule some operation, for example Bulk API, but do not run consumers. 
1. Try to search by API: GET {{URL}}rest/V1/bulk/UUID/operation-status/4
2. You will receive same qty as amount of operations you sheduled
3. Run consumers 
4. Run call no 2 and see how QTY is reducing to 0

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
