### PR TITLE
Resolve Can not preview template when edit queue issue25570

### DIFF
--- a/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminNewsletterCreateNewTemplateActionGroup.xml
+++ b/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminNewsletterCreateNewTemplateActionGroup.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminNewsletterCreateNewTemplateActionGroup">
+        <annotations>
+            <description>Create New Template</description>
+        </annotations>
+        <arguments>
+            <argument name="template" defaultValue="_defaultNewsletter" type="entity"/>
+        </arguments>
+        <amOnPage url="{{NewsletterTemplateForm.url}}" stepKey="amOnNewsletterTemplatePage"/>
+        <waitForPageLoad stepKey="waitForPageLoad1"/>
+        <fillField selector="{{BasicFieldNewsletterSection.templateName}}" userInput="{{_defaultNewsletter.name}}" stepKey="fillTemplateName" />
+        <fillField selector="{{BasicFieldNewsletterSection.templateSubject}}" userInput="{{_defaultNewsletter.subject}}" stepKey="fillTemplateSubject" />
+        <fillField selector="{{BasicFieldNewsletterSection.senderName}}" userInput="{{_defaultNewsletter.senderName}}" stepKey="fillSenderName" />
+        <fillField selector="{{BasicFieldNewsletterSection.senderEmail}}" userInput="{{_defaultNewsletter.senderEmail}}" stepKey="fillSenderEmail" />
+        <click selector="{{BasicFieldNewsletterSection.save}}" stepKey="clickSavePage"/>
+        <waitForPageLoad stepKey="waitForPageLoad2" />
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminNewsletterPreviewTemplateActionGroup.xml
+++ b/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminNewsletterPreviewTemplateActionGroup.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminNewsletterPreviewTemplateActionGroup">
+        <annotations>
+            <description>Preview Template From Edit Form</description>
+        </annotations>
+        <arguments>
+            <argument name="template" defaultValue="_defaultNewsletter" type="entity"/>
+        </arguments>
+        <click selector="{{NewsletterTemplateSection.preview}}" stepKey="preview"/>
+        <switchToNextTab stepKey="switchToNewOpenedTab"/>
+        <executeJS function="document.getElementById('preview_iframe').sandbox.add('allow-scripts')" stepKey="addSandboxValue"/>
+        <wait time="10" stepKey="waitBeforeSwitchToIframe"/>
+        <switchToIFrame userInput="preview_iframe" stepKey="switchToIframe" />
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+        <see userInput="{{_defaultNewsletter.containContent}}" stepKey="seeContent" />
+        <closeTab stepKey="closeTab"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminNewsletterQueueTemplateFromGridActionGroup.xml
+++ b/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminNewsletterQueueTemplateFromGridActionGroup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminNewsletterQueueTemplateFromGridActionGroup">
+        <annotations>
+            <description>Queue Template From Grid Newsletter Template</description>
+        </annotations>
+        <arguments>
+            <argument name="template" defaultValue="_defaultNewsletter" type="entity"/>
+        </arguments>
+        <amOnPage url="{{NewsletterTemplateGrid.url}}" stepKey="amOnTemplateGrid" />
+        <waitForPageLoad stepKey="waitForPageLoad1"/>
+        <click selector="{{NewsletterWYSIWYGSection.Queue(_defaultNewsletter.name)}}" stepKey="clickQueue" />
+        <waitForPageLoad stepKey="waitForPageLoad2"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminNewsletterTemplateActionGroup.xml
+++ b/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminNewsletterTemplateActionGroup.xml
@@ -8,7 +8,6 @@
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="SwitchToPreviewIframeActionGroup">
-        <executeJS function="document.getElementById('preview_iframe').sandbox.add('allow-scripts')" stepKey="addSandboxValue"/>
         <wait time="10" stepKey="waitBeforeSwitchToIframe"/>
         <switchToIFrame userInput="preview_iframe" stepKey="switchToIframe" />
         <waitForPageLoad stepKey="waitForPageLoad"/>

--- a/app/code/Magento/Newsletter/Test/Mftf/Data/NewsletterTemplateData.xml
+++ b/app/code/Magento/Newsletter/Test/Mftf/Data/NewsletterTemplateData.xml
@@ -13,5 +13,6 @@
         <data key="subject">Test Newsletter Subject</data>
         <data key="senderName">Admin</data>
         <data key="senderEmail">admin@magento.com</data>
+        <data key="containContent">Follow this link to unsubscribe</data>
     </entity>
 </entities>

--- a/app/code/Magento/Newsletter/Test/Mftf/Section/NewsletterTemplateSection.xml
+++ b/app/code/Magento/Newsletter/Test/Mftf/Section/NewsletterTemplateSection.xml
@@ -52,5 +52,13 @@
         <element name="InsertTable" type="button" selector=".mce-i-table" />
         <element name="SpecialCharacter" type="button" selector=".mce-i-charmap" />
         <element name="Preview" type="text" selector="//td[contains(text(),'{{var1}}')]//following-sibling::td/select//option[contains(text(), 'Preview')]" parameterized="true" timeout="60"/>
+        <element name="Queue" type="text" selector="//td[contains(text(),'{{var1}}')]//following-sibling::td/select//option[contains(text(), 'Queue Newsletter')]" parameterized="true" timeout="60"/>
+    </section>
+    <section name="NewsletterTemplateSection">
+        <element name="templateName" type="input" selector="#template_code"/>
+        <element name="templateSubject" type="input" selector="#template_subject"/>
+        <element name="senderContent" type="input" selector="#template_text"/>
+        <element name="save" type="button" selector="button[data-role='template-save']" timeout="60"/>
+        <element name="preview" type="button" selector=".page-actions-buttons button.preview" timeout="60"/>
     </section>
 </sections>

--- a/app/code/Magento/Newsletter/Test/Mftf/Test/AdminMarketingNewsletterQueuePreviewTemplateTest.xml
+++ b/app/code/Magento/Newsletter/Test/Mftf/Test/AdminMarketingNewsletterQueuePreviewTemplateTest.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminMarketingNewsletterQueuePreviewTemplateTest">
+        <annotations>
+            <features value="Newsletter"/>
+            <stories value="Preview Template"/>
+            <title value="Admin marketing newsletter preview template after queue"/>
+            <description value="Admin should be able to preview template after queue newsletter"/>
+            <severity value="CRITICAL"/>
+            <group value="Newsletter"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="LoginAsAdmin"/>
+            <actionGroup ref="AdminNewsletterCreateNewTemplateActionGroup" stepKey="CreateNewTemplate" />
+        </before>
+        <after>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+        <actionGroup ref="AdminNewsletterQueueTemplateFromGridActionGroup" stepKey="QueueNewsletter" />
+        <actionGroup ref="AdminNewsletterPreviewTemplateActionGroup" stepKey="PreviewTemplate" />
+    </test>
+</tests>

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/preview/iframeswitcher.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/preview/iframeswitcher.phtml
@@ -8,7 +8,7 @@
 ?>
 <div id="preview" class="cms-revision-preview">
     <div class="toolbar">
-        <?php if (!$block->isSingleStoreMode()) :?>
+        <?php if (!$block->isSingleStoreMode()):?>
         <div class="store-switcher">
             <?= $block->getChildHtml('store_switcher') ?>
         </div>

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/preview/iframeswitcher.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/preview/iframeswitcher.phtml
@@ -21,7 +21,7 @@
             frameborder="0"
             title="<?= $block->escapeHtmlAttr(__('Preview')) ?>"
             width="100%"
-            sandbox="allow-forms allow-pointer-lock"
+            sandbox="allow-same-origin allow-scripts allow-forms allow-pointer-lock"
     >
 
     </iframe>

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/queue/edit.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/queue/edit.phtml
@@ -10,11 +10,11 @@
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions">
     <?= $block->getBackButtonHtml() ?>
     <?= $block->getPreviewButtonHtml() ?>
-    <?php if (!$block->getIsPreview()) : ?>
+    <?php if (!$block->getIsPreview()): ?>
         <?= $block->getResetButtonHtml() ?>
         <?= $block->getSaveButtonHtml() ?>
     <?php endif ?>
-    <?php if ($block->getCanResume()) : ?>
+    <?php if ($block->getCanResume()): ?>
         <?= $block->getResumeButtonHtml() ?>
     <?php endif ?>
 </div>
@@ -23,10 +23,12 @@
     <?= $block->getBlockHtml('formkey') ?>
     <?= $block->getChildHtml('form') ?>
 </form>
-<form action="<?= $block->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="newsletter_queue_preview_form" target="_blank">
+<form action="<?= $block->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="newsletter_queue_preview_form"
+      target="_blank">
     <?= $block->getBlockHtml('formkey') ?>
     <div class="no-display">
-        <input type="hidden" id="preview_type" name="type" value="<?= /* @noEscape */ $block->getIsTextType() ? 1 : 2 ?>" />
+        <input type="hidden" id="preview_type" name="type"
+               value="<?= /* @noEscape */ $block->getIsTextType() ? 1 : 2 ?>" />
         <input type="hidden" id="preview_text" name="text" value="" />
         <input type="hidden" id="preview_styles" name="styles" value="" />
         <input type="hidden" id="preview_id" name="id" value="" />

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/queue/edit.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/queue/edit.phtml
@@ -48,9 +48,9 @@ queueControl = {
     id: 'text',
     preview: function() {
         if (this.isEditor() && wysiwyg.get(this.id)) {
-            wysiwyg.triggerSave();
+            tinyMCE.triggerSave();
             $('preview_text').value = wysiwyg.get(this.id).getContent();
-            wysiwyg.triggerSave();
+            tinyMCE.triggerSave();
         } else {
             $('preview_text').value = $(this.id).value;
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. Fixes magento/magento2#25570: Can not preview template when edit queue

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25570: Can not preview template when edit queue

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to backend
2. Marketing->Newsletter Templates
3. Create New Template
4. Go to grid, in the row of the template which is created,  choose "Queue Newsletter"
5. Click "Preview Template"

#### Expected result
<!--- Tell us what do you expect to happen. -->
1. Show the preview of template

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
