### PR TITLE
Fix date not being saved from the admin when the locale is a different language than english

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Filter/DateTime.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Filter/DateTime.php
@@ -42,7 +42,7 @@ class DateTime extends Date
     public function filter($value)
     {
         try {
-            $dateTime = $this->_localeDate->date($value, null, false);
+            $dateTime = $this->_localeDate->date($value, null, false, false);
             return $dateTime->format('Y-m-d H:i:s');
         } catch (\Exception $e) {
             throw new \Exception("Invalid input datetime format of value '$value'", $e->getCode(), $e);


### PR DESCRIPTION
The issue was that for some reason when saving a product entity and a date was added, the time was also calculate and it was always set to 0:00am. There is no point for a calculation like that.

By sending the value false as a last parameter during the call of ->date function, we allow magento to process a date without adding the dummy 0:00am in the datetime that is causing the whole saving process to fail.

### Fixed Issues (if relevant)
1. Possibility to save a date on product entities in the backend when locale is different that English

### Manual testing scenarios
1. Go to the backend and make sure your locale is not english (eg. el_GR)
2. Go to Catalog->Products and open a product entity
3. Add a new "Set Product as New From" date and save the product
4. The product should be possible to be saved

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
