### PR TITLE
[Signifyd] Making system configs dependent by Active field

### DIFF
--- a/app/code/Magento/Signifyd/etc/adminhtml/system.xml
+++ b/app/code/Magento/Signifyd/etc/adminhtml/system.xml
@@ -41,22 +41,34 @@
                         <comment><![CDATA[Your API key can be found on the <a href="http://signifyd.com/settings" target="_blank">settings page</a> in the Signifyd console]]></comment>
                         <config_path>fraud_protection/signifyd/api_key</config_path>
                         <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                        <depends>
+                            <field id="active">1</field>
+                        </depends>
                     </field>
                     <field id="api_url" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>API URL</label>
                         <config_path>fraud_protection/signifyd/api_url</config_path>
                         <comment>Don’t change unless asked to do so.</comment>
+                        <depends>
+                            <field id="active">1</field>
+                        </depends>
                     </field>
                     <field id="debug" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Debug</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>fraud_protection/signifyd/debug</config_path>
+                        <depends>
+                            <field id="active">1</field>
+                        </depends>
                     </field>
                     <field id="webhook_url" translate="label comment" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Webhook URL</label>
                         <comment><![CDATA[Your webhook URL will be used to <a href="https://app.signifyd.com/settings/notifications" target="_blank">configure</a> a guarantee completed webhook in Signifyd. Webhooks are used to sync Signifyd`s guarantee decisions back to Magento.]]></comment>
                         <attribute type="handler_url">signifyd/webhooks/handler</attribute>
                         <frontend_model>Magento\Signifyd\Block\Adminhtml\System\Config\Field\WebhookUrl</frontend_model>
+                        <depends>
+                            <field id="active">1</field>
+                        </depends>
                     </field>
                 </group>
             </group>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR makes all the Signifyd system configs dependent by `Enable this Solution` field. 

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Navigate to `Store / Configuration / Fraud Protection [Sales]`
2. All the configuration fields should be hidden if `Enable this Solution` -> `No`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
