### PR TITLE
M2C-21765 Output N/A if attribute has no value in Compare List

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
@@ -130,6 +130,8 @@
                                             default :?>
                                                 <?php if (is_string($block->getProductAttributeValue($item, $attribute))) :?>
                                                     <?= /* @noEscape */ $helper->productAttribute($item, $block->getProductAttributeValue($item, $attribute), $attribute->getAttributeCode()) ?>
+                                                <?php else: ?>
+                                                    <?=  $block->escapeHtml($helper->productAttribute($item, $block->getProductAttributeValue($item, $attribute), $attribute->getAttributeCode())) ?>
                                                 <?php endif; ?>
                                                 <?php break;
                                         } ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
@@ -130,7 +130,7 @@
                                             default :?>
                                                 <?php if (is_string($block->getProductAttributeValue($item, $attribute))) :?>
                                                     <?= /* @noEscape */ $helper->productAttribute($item, $block->getProductAttributeValue($item, $attribute), $attribute->getAttributeCode()) ?>
-                                                <?php else: ?>
+                                                <?php else : ?>
                                                     <?=  $block->escapeHtml($helper->productAttribute($item, $block->getProductAttributeValue($item, $attribute), $attribute->getAttributeCode())) ?>
                                                 <?php endif; ?>
                                                 <?php break;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The product attribute that has no value should output 'N/A' like in Magento's previous version.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25008: Issue in compare page

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add some products to Compare List
1. Add additional attribute to one of the products
3. Attribute that is not available for other products will output value: N/A

![image](https://user-images.githubusercontent.com/34317830/68777920-b4d1c800-0632-11ea-9592-442f3c9a4a88.png)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
Comment:
If we remove is_string and then escape the output, HTML tags like <p> in description will appear. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
