### PR TITLE
Refactor JavaScript mixins module

### DIFF
--- a/dev/tests/js/jasmine/tests/lib/mage/requirejs/mixins.test.js
+++ b/dev/tests/js/jasmine/tests/lib/mage/requirejs/mixins.test.js
@@ -1,0 +1,148 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/* eslint max-nested-callbacks: 0 */
+require.config({
+    paths: {
+        'mixins': 'mage/requirejs/mixins'
+    }
+});
+
+define(['rjsResolver', 'mixins'], function (resolver, mixins) {
+    'use strict';
+
+    var context = {
+        config: {}
+    };
+
+    describe('mixins module', function () {
+        beforeEach(function (done) {
+            // Wait for all modules to be loaded so they don't interfere with testing.
+            resolver(function () {
+                done();
+            });
+        });
+
+        describe('processNames method', function () {
+            beforeEach(function () {
+                spyOn(mixins, 'processNames').and.callThrough();
+                spyOn(mixins, 'hasMixins').and.callThrough();
+            });
+
+            it('gets called when module is both required and defined', function (done) {
+                var name = 'tests/assets/mixins/defined-module',
+                    dependencyName = 'tests/assets/mixins/defined-module-dependency';
+
+                define(dependencyName, [], function () {});
+                define(name, [dependencyName], function () {});
+
+                require([name], function () {
+                    expect(mixins.processNames.calls.argsFor(0)[0]).toEqual([]);
+                    expect(mixins.processNames.calls.argsFor(1)[0]).toEqual([dependencyName]);
+                    expect(mixins.processNames.calls.argsFor(2)[0]).toEqual([name]);
+                    done();
+                });
+            });
+
+            it('keeps name intact when it already contains another plugin', function () {
+                mixins.hasMixins.and.returnValue(true);
+
+                expect(mixins.processNames('plugin!module', context)).toBe('plugin!module');
+            });
+
+            it('keeps name intact when it has no mixins', function () {
+                mixins.hasMixins.and.returnValue(false);
+
+                expect(mixins.processNames('module', context)).toBe('module');
+            });
+
+            it('keeps names intact when they have no mixins', function () {
+                mixins.hasMixins.and.returnValue(false);
+
+                expect(mixins.processNames(['module'], context)).toEqual(['module']);
+            });
+
+            it('adds prefix to name when it has mixins', function () {
+                mixins.hasMixins.and.returnValue(true);
+
+                expect(mixins.processNames('module', context)).toBe('mixins!module');
+            });
+
+            it('adds prefix to name when it contains a relative path', function () {
+                mixins.hasMixins.and.returnValue(false);
+
+                expect(mixins.processNames('./module', context)).toBe('mixins!./module');
+            });
+
+            it('adds prefix to names when they contain a relative path', function () {
+                mixins.hasMixins.and.returnValue(false);
+
+                expect(mixins.processNames(['./module'], context)).toEqual(['mixins!./module']);
+            });
+
+            it('adds prefix to names when they have mixins', function () {
+                mixins.hasMixins.and.returnValue(true);
+
+                expect(mixins.processNames(['module'], context)).toEqual(['mixins!module']);
+            });
+        });
+
+        describe('load method', function () {
+            it('is not called when module has mixins', function (done) {
+                var name = 'tests/assets/mixins/load-not-called';
+
+                spyOn(mixins, 'hasMixins').and.returnValue(false);
+                spyOn(mixins, 'load').and.callThrough();
+
+                define(name, [], function () {});
+
+                require([name], function () {
+                    expect(mixins.load.calls.any()).toBe(false);
+                    done();
+                });
+            });
+
+            it('is called when module has mixins', function (done) {
+                var name = 'tests/assets/mixins/load-called';
+
+                spyOn(mixins, 'hasMixins').and.returnValue(true);
+                spyOn(mixins, 'load').and.callThrough();
+
+                define(name, [], function () {});
+
+                require([name], function () {
+                    expect(mixins.load.calls.mostRecent().args[0]).toEqual(name);
+                    done();
+                });
+            });
+
+            it('applies mixins for loaded module', function (done) {
+                var name = 'tests/assets/mixins/mixins-applied',
+                    mixinName = 'tests/assets/mixins/mixins-applied-ext';
+
+                spyOn(mixins, 'hasMixins').and.returnValue(true);
+                spyOn(mixins, 'load').and.callThrough();
+                spyOn(mixins, 'getMixins').and.returnValue([mixinName]);
+
+                define(name, [], function () {
+                    return { value: 'original' };
+                });
+
+                define(mixinName, [], function () {
+                    return function(module) {
+                        module.value = 'changed';
+
+                        return module;
+                    };
+                });
+
+                require([name], function (module) {
+                    expect(module.value).toBe('changed');
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/lib/web/mage/requirejs/mixins.js
+++ b/lib/web/mage/requirejs/mixins.js
@@ -71,7 +71,7 @@ define('mixins', [
      * from a module name ignoring the fact that it may be bundled.
      *
      * @param {String} name - Name, path or alias of a module.
-     * @param {Object} config - Context's configuartion.
+     * @param {Object} config - Context's configuration.
      * @returns {String}
      */
     function getPath(name, config) {

--- a/lib/web/mage/requirejs/mixins.js
+++ b/lib/web/mage/requirejs/mixins.js
@@ -7,7 +7,25 @@ define('mixins', [
 ], function (module) {
     'use strict';
 
-    var rjsMixins;
+    var contexts = require.s.contexts,
+        defContextName = '_',
+        defContext = contexts[defContextName],
+        unbundledContext = require.s.newContext('$'),
+        defaultConfig = defContext.config,
+        unbundledConfig = {
+            baseUrl: defaultConfig.baseUrl,
+            paths: defaultConfig.paths,
+            shim: defaultConfig.shim,
+            config: defaultConfig.config,
+            map: defaultConfig.map
+        },
+        rjsMixins;
+
+    /**
+     * Prepare a separate context where modules are not assigned to bundles
+     * so we are able to get their true path and corresponding mixins.
+     */
+    unbundledContext.configure(unbundledConfig);
 
     /**
      * Checks if specified string contains
@@ -50,14 +68,14 @@ define('mixins', [
 
     /**
      * Extracts url (without baseUrl prefix)
-     * from a modules' name.
+     * from a module name ignoring the fact that it may be bundled.
      *
      * @param {String} name - Name, path or alias of a module.
-     * @param {Object} config - Contexts' configuartion.
+     * @param {Object} config - Context's configuartion.
      * @returns {String}
      */
     function getPath(name, config) {
-        var url = require.toUrl(name);
+        var url = unbundledContext.require.toUrl(name);
 
         return removeBaseUrl(url, config);
     }
@@ -73,11 +91,11 @@ define('mixins', [
     }
 
     /**
-     * Iterativly calls mixins passing to them
+     * Iteratively calls mixins passing to them
      * current value of a 'target' parameter.
      *
      * @param {*} target - Value to be modified.
-     * @param {...Function} mixins
+     * @param {...Function} mixins - List of mixins to apply.
      * @returns {*} Modified 'target' value.
      */
     function applyMixins(target) {
@@ -94,8 +112,13 @@ define('mixins', [
 
         /**
          * Loads specified module along with its' mixins.
+         * This method is called for each module defined with "mixins!" prefix
+         * in its name that was added by processNames method.
          *
          * @param {String} name - Module to be loaded.
+         * @param {Function} req - Local "require" function to use to load other modules.
+         * @param {Function} onLoad - A function to call with the value for name.
+         * @param {Object} config - RequireJS configuration object.
          */
         load: function (name, req, onLoad, config) {
             var path     = getPath(name, config),
@@ -110,14 +133,14 @@ define('mixins', [
         /**
          * Retrieves list of mixins associated with a specified module.
          *
-         * @param {String} path - Path to the module (without base url).
+         * @param {String} path - Path to the module (without base URL).
          * @returns {Array} An array of paths to mixins.
          */
         getMixins: function (path) {
             var config = module.config() || {},
-            mixins;
+                mixins;
 
-            // fix for when urlArgs is set
+            // Fix for when urlArgs is set.
             if (path.indexOf('?') !== -1) {
                 path = path.substring(0, path.indexOf('?'));
             }
@@ -131,7 +154,7 @@ define('mixins', [
         /**
          * Checks if specified module has associated with it mixins.
          *
-         * @param {String} path - Path to the module (without base url).
+         * @param {String} path - Path to the module (without base URL).
          * @returns {Boolean}
          */
         hasMixins: function (path) {
@@ -139,11 +162,11 @@ define('mixins', [
         },
 
         /**
-         * Modifies provided names perpending to them
+         * Modifies provided names prepending to them
          * the 'mixins!' plugin prefix if it's necessary.
          *
          * @param {(Array|String)} names - Module names, paths or aliases.
-         * @param {Object} context - Current requirejs context.
+         * @param {Object} context - Current RequireJS context.
          * @returns {Array|String}
          */
         processNames: function (names, context) {
@@ -179,101 +202,40 @@ require([
 ], function (mixins) {
     'use strict';
 
-    var originalRequire  = window.require,
-        originalDefine   = window.define,
-        contexts         = originalRequire.s.contexts,
-        defContextName   = '_',
-        hasOwn           = Object.prototype.hasOwnProperty,
-        getLastInQueue;
-
-    getLastInQueue =
-        '(function () {' +
-            'var queue  = globalDefQueue,' +
-                'item   = queue[queue.length - 1];' +
-            '' +
-            'return item;' +
-        '})();';
+    var contexts = require.s.contexts,
+        defContextName = '_',
+        defContext = contexts[defContextName],
+        originalContextRequire = defContext.require,
+        processNames = mixins.processNames;
 
     /**
-     * Returns property of an object if
-     * it's not defined in it's prototype.
-     *
-     * @param {Object} obj - Object whose property should be retrieved.
-     * @param {String} prop - Name of the property.
-     * @returns {*} Value of the property or false.
+     * Wrap default context's require function which gets called every time
+     * module is requested using require call. The upside of this approach
+     * is that deps parameter is already normalized and guaranteed to be an array.
      */
-    function getOwn(obj, prop) {
-        return hasOwn.call(obj, prop) && obj[prop];
-    }
+    defContext.require = function (deps, callback, errback) {
+        deps = processNames(deps, defContext);
 
-    /**
-     * Overrides global 'require' method adding to it dependencies modfication.
-     */
-    window.require = function (deps, callback, errback, optional) {
-        var contextName = defContextName,
-            context,
-            config;
-
-        if (!Array.isArray(deps) && typeof deps !== 'string') {
-            config = deps;
-
-            if (Array.isArray(callback)) {
-                deps = callback;
-                callback = errback;
-                errback = optional;
-            } else {
-                deps = [];
-            }
-        }
-
-        if (config && config.context) {
-            contextName = config.context;
-        }
-
-        context = getOwn(contexts, contextName);
-
-        if (!context) {
-            context = contexts[contextName] = require.s.newContext(contextName);
-        }
-
-        if (config) {
-            context.configure(config);
-        }
-
-        deps = mixins.processNames(deps, context);
-
-        return context.require(deps, callback, errback);
-    };
-
-    /**
-     * Overrides global 'define' method adding to it dependencies modfication.
-     */
-    window.define = function (name, deps, callback) { // eslint-disable-line no-unused-vars
-        var context     = getOwn(contexts, defContextName),
-            result      = originalDefine.apply(this, arguments),
-            queueItem   = require.exec(getLastInQueue),
-            lastDeps    = queueItem && queueItem[1];
-
-        if (Array.isArray(lastDeps)) {
-            queueItem[1] = mixins.processNames(lastDeps, context);
-        }
-
-        return result;
+        return originalContextRequire(deps, callback, errback);
     };
 
     /**
      * Copy properties of original 'require' method.
      */
-    Object.keys(originalRequire).forEach(function (key) {
-        require[key] = originalRequire[key];
+    Object.keys(originalContextRequire).forEach(function (key) {
+        defContext.require[key] = originalContextRequire[key];
     });
 
     /**
-     * Copy properties of original 'define' method.
+     * Wrap shift method from context's definitions queue.
+     * Items are added to the queue when a new module is defined and taken
+     * from it every time require call happens.
      */
-    Object.keys(originalDefine).forEach(function (key) {
-        define[key] = originalDefine[key];
-    });
+    defContext.defQueue.shift = function () {
+        var queueItem = Array.prototype.shift.call(this);
 
-    window.requirejs = window.require;
+        queueItem[1] = processNames(queueItem[1], defContext);
+
+        return queueItem;
+    };
 });


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This refactor started as an attempt to fix the fact that mixins were not loaded and applied for bundled modules when using advanced bundling technique. During the process I decided to dive a bit deeper and see if it is possible to improve the way Magento extends RequireJS functionality.

#### Bundling bug
First of all, after a lot of investigation I found that the only way for the plugin to retrieve true modules' paths no matter if they are bundled or not, is to prepare a separate context which excludes any bundles configuration.

#### Leaking of `arguments`
In the previous implementation, functions like `applyMixins`, `load` and overwritten `define` were directly passing down special `arguments` object, which is considered a bad practice as it may leads to performance degradation and memory leaks so I refactored it away.

#### Usage of `require.eval`
Overwritten `define` method used `require.exec` which calls unsafe and poor-performing `eval` to be used.

I understand why this approach was used, the problem is that original RequireJS's `define` is able to append additional dependencies by analysing module's source code which happens [here](https://github.com/requirejs/requirejs/blob/master/require.js#L2090) for example for [bootstrap.js](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/bootstrap.js).

Indeed, pushing the transformed item to a private `globalDefQueue` doesn't leave much hope for intercepting it in any other way but then I had a breakthrough. Instead of processing dependency names when they are added to the queue, we can do the same when they [get transferred](https://github.com/requirejs/requirejs/blob/master/require.js#L566) from `globalDefQueue` to default context's `defQueue` (which we have direct access to) and [shifted from it](https://github.com/requirejs/requirejs/blob/master/require.js#L1252) by wrapping the `shift` method. All of this happens before any of the dependencies are actually loaded so thre is no performance degradation or delay in requests involved. No more eval, another win.

#### Wrapping global `require` and `define`
Solving the above point made it possible for me to actually get rid of overwriting global `define` function. Additionally, by wrapping default context's `require` method, which always gets the parameters in normalized order and shape I was able to remove a lot of code that recreated original logic in order to retain compatibility with all RequireJS features.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25586: Mixins are not applied for advanced bundled modules
2. magento/baler#23: Mixins are not applied for advanced bundled modules

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Apply this change.
2. Verify that modules are still properly loaded and executed.
3. Verify that mixins are properly loaded and applied no matter if advanced bundling is used or not.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
To be honest, I hoped that it would be possible to completely remove the need for plugin itself somehow while retaining it's functionality but I haven't figure out the way yet. That said, I'm very happy with the results of a few weeks worth of evenings and digging into RequireJS internals and the most important goal was achieved.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
