### PR TITLE
Moving Ui message.js hide speed and timeout into variables for easier…

### DIFF
--- a/app/code/Magento/Ui/view/frontend/web/js/view/messages.js
+++ b/app/code/Magento/Ui/view/frontend/web/js/view/messages.js
@@ -65,13 +65,11 @@ define([
          * @param {Boolean} isHidden
          */
         onHiddenChange: function (isHidden) {
-            var self = this;
-
             // Hide message block if needed
             if (isHidden) {
                 setTimeout(function () {
-                    $(self.selector).hide('blind', {}, self.hideSpeed);
-                }, self.hideTimeout);
+                    $(this.selector).hide('blind', {}, this.hideSpeed);
+                }.bind(this), this.hideTimeout);
             }
         }
     });

--- a/app/code/Magento/Ui/view/frontend/web/js/view/messages.js
+++ b/app/code/Magento/Ui/view/frontend/web/js/view/messages.js
@@ -20,6 +20,8 @@ define([
             template: 'Magento_Ui/messages',
             selector: '[data-role=checkout-messages]',
             isHidden: false,
+            hideTimeout: 5000,
+            hideSpeed: 500,
             listens: {
                 isHidden: 'onHiddenChange'
             }
@@ -68,8 +70,8 @@ define([
             // Hide message block if needed
             if (isHidden) {
                 setTimeout(function () {
-                    $(self.selector).hide('blind', {}, 500);
-                }, 5000);
+                    $(self.selector).hide('blind', {}, self.hideSpeed);
+                }, self.hideTimeout);
             }
         }
     });


### PR DESCRIPTION
… overriding

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Magento Ui message speed and timeout values should be variables instead of hardcoded so they can be overwritten without having to write a whole mixin overwriting the entire `onHiddenChange` function

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
