### PR TITLE
Fixed regex for validate action in admin menu

### DIFF
--- a/app/code/Magento/Backend/Model/Menu/Item/Validator.php
+++ b/app/code/Magento/Backend/Model/Menu/Item/Validator.php
@@ -5,7 +5,14 @@
  */
 namespace Magento\Backend\Model\Menu\Item;
 
+use BadMethodCallException;
+use InvalidArgumentException;
+use Zend_Validate;
+
 /**
+ * Class Validator
+ *
+ * @package Magento\Backend\Model\Menu\Item
  * @api
  * @since 100.0.2
  */
@@ -28,7 +35,7 @@ class Validator
     /**
      * The list of primitive validators
      *
-     * @var \Zend_Validate[]
+     * @var Zend_Validate[]
      */
     protected $_validators = [];
 
@@ -37,17 +44,17 @@ class Validator
      */
     public function __construct()
     {
-        $idValidator = new \Zend_Validate();
+        $idValidator = new Zend_Validate();
         $idValidator->addValidator(new \Zend_Validate_StringLength(['min' => 3]));
         $idValidator->addValidator(new \Zend_Validate_Regex('/^[A-Za-z0-9\/:_]+$/'));
 
-        $resourceValidator = new \Zend_Validate();
+        $resourceValidator = new Zend_Validate();
         $resourceValidator->addValidator(new \Zend_Validate_StringLength(['min' => 8]));
         $resourceValidator->addValidator(
             new \Zend_Validate_Regex('/^[A-Z][A-Za-z0-9]+_[A-Z][A-Za-z0-9]+::[A-Za-z_0-9]+$/')
         );
 
-        $attributeValidator = new \Zend_Validate();
+        $attributeValidator = new Zend_Validate();
         $attributeValidator->addValidator(new \Zend_Validate_StringLength(['min' => 3]));
         $attributeValidator->addValidator(new \Zend_Validate_Regex('/^[A-Za-z0-9\/_\-]+$/'));
 
@@ -70,8 +77,8 @@ class Validator
      *
      * @param array $data
      * @return void
-     * @throws \InvalidArgumentException
-     * @throws \BadMethodCallException
+     * @throws InvalidArgumentException
+     * @throws BadMethodCallException
      */
     public function validate($data)
     {
@@ -101,15 +108,16 @@ class Validator
 
     /**
      * Check that menu item contains all required data
+     *
      * @param array $data
      *
-     * @throws \BadMethodCallException
+     * @throws BadMethodCallException
      */
     private function assertContainsRequiredParameters($data)
     {
         foreach ($this->_required as $param) {
             if (!isset($data[$param])) {
-                throw new \BadMethodCallException('Missing required param ' . $param);
+                throw new BadMethodCallException('Missing required param ' . $param);
             }
         }
     }
@@ -118,12 +126,12 @@ class Validator
      * Check that menu item id is not used
      *
      * @param string $id
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     private function assertIdentifierIsNotUsed($id)
     {
         if (array_search($id, $this->_ids) !== false) {
-            throw new \InvalidArgumentException('Item with id ' . $id . ' already exists');
+            throw new InvalidArgumentException('Item with id ' . $id . ' already exists');
         }
     }
 
@@ -132,7 +140,7 @@ class Validator
      *
      * @param string $param
      * @param mixed $value
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     private function validateMenuItemParameter($param, $value)
     {
@@ -148,7 +156,7 @@ class Validator
             return;
         }
 
-        throw new \InvalidArgumentException(
+        throw new InvalidArgumentException(
             "Param " . $param . " doesn't pass validation: " . implode(
                 '; ',
                 $validator->getMessages()
@@ -162,16 +170,16 @@ class Validator
      * @param string $param
      * @param mixed $value
      * @return void
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function validateParam($param, $value)
     {
         if (in_array($param, $this->_required) && $value === null) {
-            throw new \InvalidArgumentException('Param ' . $param . ' is required');
+            throw new InvalidArgumentException('Param ' . $param . ' is required');
         }
 
         if ($value !== null && isset($this->_validators[$param]) && !$this->_validators[$param]->isValid($value)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Param ' . $param . ' doesn\'t pass validation: ' . implode(
                     '; ',
                     $this->_validators[$param]->getMessages()

--- a/app/code/Magento/Backend/Model/Menu/Item/Validator.php
+++ b/app/code/Magento/Backend/Model/Menu/Item/Validator.php
@@ -49,7 +49,7 @@ class Validator
 
         $attributeValidator = new \Zend_Validate();
         $attributeValidator->addValidator(new \Zend_Validate_StringLength(['min' => 3]));
-        $attributeValidator->addValidator(new \Zend_Validate_Regex('/^[A-Za-z0-9\/_]+$/'));
+        $attributeValidator->addValidator(new \Zend_Validate_Regex('/^[A-Za-z0-9\/_\-]+$/'));
 
         $textValidator = new \Zend_Validate_StringLength(['min' => 3, 'max' => 50]);
 

--- a/app/code/Magento/Backend/Model/Menu/Item/Validator.php
+++ b/app/code/Magento/Backend/Model/Menu/Item/Validator.php
@@ -5,10 +5,6 @@
  */
 namespace Magento\Backend\Model\Menu\Item;
 
-use BadMethodCallException;
-use InvalidArgumentException;
-use Zend_Validate;
-
 /**
  * Class Validator
  *
@@ -35,7 +31,7 @@ class Validator
     /**
      * The list of primitive validators
      *
-     * @var Zend_Validate[]
+     * @var \Zend_Validate[]
      */
     protected $_validators = [];
 
@@ -44,17 +40,17 @@ class Validator
      */
     public function __construct()
     {
-        $idValidator = new Zend_Validate();
+        $idValidator = new \Zend_Validate();
         $idValidator->addValidator(new \Zend_Validate_StringLength(['min' => 3]));
         $idValidator->addValidator(new \Zend_Validate_Regex('/^[A-Za-z0-9\/:_]+$/'));
 
-        $resourceValidator = new Zend_Validate();
+        $resourceValidator = new \Zend_Validate();
         $resourceValidator->addValidator(new \Zend_Validate_StringLength(['min' => 8]));
         $resourceValidator->addValidator(
             new \Zend_Validate_Regex('/^[A-Z][A-Za-z0-9]+_[A-Z][A-Za-z0-9]+::[A-Za-z_0-9]+$/')
         );
 
-        $attributeValidator = new Zend_Validate();
+        $attributeValidator = new \Zend_Validate();
         $attributeValidator->addValidator(new \Zend_Validate_StringLength(['min' => 3]));
         $attributeValidator->addValidator(new \Zend_Validate_Regex('/^[A-Za-z0-9\/_\-]+$/'));
 
@@ -77,8 +73,8 @@ class Validator
      *
      * @param array $data
      * @return void
-     * @throws InvalidArgumentException
-     * @throws BadMethodCallException
+     * @throws \InvalidArgumentException
+     * @throws \BadMethodCallException
      */
     public function validate($data)
     {
@@ -111,13 +107,13 @@ class Validator
      *
      * @param array $data
      *
-     * @throws BadMethodCallException
+     * @throws \BadMethodCallException
      */
     private function assertContainsRequiredParameters($data)
     {
         foreach ($this->_required as $param) {
             if (!isset($data[$param])) {
-                throw new BadMethodCallException('Missing required param ' . $param);
+                throw new \BadMethodCallException('Missing required param ' . $param);
             }
         }
     }
@@ -126,12 +122,12 @@ class Validator
      * Check that menu item id is not used
      *
      * @param string $id
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     private function assertIdentifierIsNotUsed($id)
     {
         if (array_search($id, $this->_ids) !== false) {
-            throw new InvalidArgumentException('Item with id ' . $id . ' already exists');
+            throw new \InvalidArgumentException('Item with id ' . $id . ' already exists');
         }
     }
 
@@ -140,7 +136,7 @@ class Validator
      *
      * @param string $param
      * @param mixed $value
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     private function validateMenuItemParameter($param, $value)
     {
@@ -156,7 +152,7 @@ class Validator
             return;
         }
 
-        throw new InvalidArgumentException(
+        throw new \InvalidArgumentException(
             "Param " . $param . " doesn't pass validation: " . implode(
                 '; ',
                 $validator->getMessages()
@@ -170,16 +166,16 @@ class Validator
      * @param string $param
      * @param mixed $value
      * @return void
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     public function validateParam($param, $value)
     {
         if (in_array($param, $this->_required) && $value === null) {
-            throw new InvalidArgumentException('Param ' . $param . ' is required');
+            throw new \InvalidArgumentException('Param ' . $param . ' is required');
         }
 
         if ($value !== null && isset($this->_validators[$param]) && !$this->_validators[$param]->isValid($value)) {
-            throw new InvalidArgumentException(
+            throw new \InvalidArgumentException(
                 'Param ' . $param . ' doesn\'t pass validation: ' . implode(
                     '; ',
                     $this->_validators[$param]->getMessages()

--- a/app/code/Magento/Backend/Test/Unit/Model/Menu/Config/_files/invalidMenuXmlArray.php
+++ b/app/code/Magento/Backend/Test/Unit/Model/Menu/Config/_files/invalidMenuXmlArray.php
@@ -10,7 +10,7 @@ return [
         ' resource="Test_Value::value"/></menu></config>',
         [
             "Element 'add', attribute 'action': [facet 'pattern'] The value '' is not accepted by the " .
-            "pattern '[a-zA-Z0-9/_]{3,}'.\nLine: 1\n",
+            "pattern '[a-zA-Z0-9/_\-]{3,}'.\nLine: 1\n",
             "Element 'add', attribute 'action': '' is not a valid value of the atomic type 'typeAction'.\nLine: 1\n"
         ],
     ],
@@ -20,7 +20,7 @@ return [
         'resource="Test_Value::value"/></menu></config>',
         [
             "Element 'add', attribute 'action': [facet 'pattern'] The value 'ad' is not accepted by the " .
-            "pattern '[a-zA-Z0-9/_]{3,}'.\nLine: 1\n",
+            "pattern '[a-zA-Z0-9/_\-]{3,}'.\nLine: 1\n",
             "Element 'add', attribute 'action': 'ad' is not a valid value of the atomic type 'typeAction'.\nLine: 1\n"
         ],
     ],
@@ -31,7 +31,7 @@ return [
         '</menu></config>',
         [
             "Element 'add', attribute 'action': [facet 'pattern'] The value 'adm$#@inhtml/notification' is not " .
-            "accepted by the pattern '[a-zA-Z0-9/_]{3,}'.\nLine: 1\n",
+            "accepted by the pattern '[a-zA-Z0-9/_\-]{3,}'.\nLine: 1\n",
             "Element 'add', attribute 'action': 'adm$#@inhtml/notification' is not a valid value of the atomic " .
             "type 'typeAction'.\nLine: 1\n"
         ],
@@ -452,7 +452,7 @@ return [
         '<?xml version="1.0"?><config><menu><update action="" ' . 'id="Test_Value::some_value"/></menu></config>',
         [
             "Element 'update', attribute 'action': [facet 'pattern'] The value '' is not accepted by the " .
-            "pattern '[a-zA-Z0-9/_]{3,}'.\nLine: 1\n",
+            "pattern '[a-zA-Z0-9/_\-]{3,}'.\nLine: 1\n",
             "Element 'update', attribute 'action': '' is not a valid value of the atomic type 'typeAction'.\nLine: 1\n"
         ],
     ],
@@ -462,7 +462,7 @@ return [
         'resource="Test_Value::value"/></menu></config>',
         [
             "Element 'update', attribute 'action': [facet 'pattern'] The value 'v' is not accepted by the " .
-            "pattern '[a-zA-Z0-9/_]{3,}'.\nLine: 1\n",
+            "pattern '[a-zA-Z0-9/_\-]{3,}'.\nLine: 1\n",
             "Element 'update', attribute 'action': 'v' is not a valid value of the atomic type 'typeAction'.\nLine: 1\n"
         ],
     ],
@@ -471,7 +471,7 @@ return [
         'id="Test_Value::some_value"/></menu></config>',
         [
             "Element 'update', attribute 'action': [facet 'pattern'] The value '/@##gt;' is not " .
-            "accepted by the pattern '[a-zA-Z0-9/_]{3,}'.\nLine: 1\n",
+            "accepted by the pattern '[a-zA-Z0-9/_\-]{3,}'.\nLine: 1\n",
             "Element 'update', attribute 'action': '/@##gt;' is not a valid value of the atomic" .
             " type 'typeAction'.\nLine: 1\n"
         ],

--- a/app/code/Magento/Backend/etc/menu.xsd
+++ b/app/code/Magento/Backend/etc/menu.xsd
@@ -100,7 +100,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z0-9/_]{3,}" />
+            <xs:pattern value="[a-zA-Z0-9/_\-]{3,}" />
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Validator for action menu doesn't accept "-".

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25635: Bug when create a new admin route wirh hyphen

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a new route for Admin with "-"
2. Create a new menu for Admin with "-" in action.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
