### PR TITLE
#25043 - Since   2.3.3 Store logo automatic resize on mobile/smaller displays does not respect aspect ratio

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Theme/web/css/source/_module.less
@@ -89,6 +89,7 @@
 
         img {
             display: block;
+            height: auto;
         }
 
         .page-print & {

--- a/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
@@ -148,6 +148,7 @@
 
         img {
             display: block;
+            height: auto;
         }
 
         .page-print & {


### PR DESCRIPTION
### Description (*)
Fixed resize logo img when mobile resolution

### Fixed Issues (if relevant)
magento/magento2#25043: Since 2.3.3 Store logo automatic resize on mobile/smaller displays does not respect aspect ratio

### Manual testing scenarios (*)

1- Create a test logo image of size 400x100 pixels
2 - Deploy 2.3-develop
3 - Content->Configuration->Global->Edit->Header->Upload Logo Image
4 - Content->Configuration->Global->Edit->Header->Height = 100
5 - Content->Configuration->Global->Edit->Header->Width = 400
6 - Use browser developer tools to simulate resizing screen to small sizes.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
