### PR TITLE
Add right arrow to show some items have children

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/source/_actions.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/_actions.less
@@ -444,6 +444,20 @@ button {
             > .action-menu-item {
                 min-width: 100%;
             }
+
+            &::after {
+                border-color: transparent transparent transparent #000;
+                border-style: solid;
+                border-width: 0.4rem 0 0.4rem 0.5rem;
+                content: '';
+                height: 0;
+                margin-top: -0.2rem;
+                position: absolute;
+                right: 1rem;
+                top: 50%;
+                transition: all .2s linear;
+                width: 0;
+            }
         }
     }
 

--- a/app/design/adminhtml/Magento/backend/web/css/source/_actions.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/_actions.less
@@ -446,12 +446,12 @@ button {
             }
 
             &::after {
-                border-color: transparent transparent transparent #000;
+                border-color: transparent transparent transparent @color-black;
                 border-style: solid;
-                border-width: 0.4rem 0 0.4rem 0.5rem;
+                border-width: .4rem 0 .4rem .5rem;
                 content: '';
                 height: 0;
-                margin-top: -0.2rem;
+                margin-top: -.2rem;
                 position: absolute;
                 right: 1rem;
                 top: 50%;

--- a/app/design/adminhtml/Magento/backend/web/css/source/_actions.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/_actions.less
@@ -451,11 +451,9 @@ button {
                 border-width: .4rem 0 .4rem .5rem;
                 content: '';
                 height: 0;
-                margin-top: -.2rem;
-                position: absolute;
-                right: 1rem;
-                top: 50%;
-                transition: all .2s linear;
+                position: relative;
+                right: 1.2rem;
+                top: 1.4rem;
                 width: 0;
             }
         }


### PR DESCRIPTION
### Description (*)
This pull request adds a right-facing arrow to the drop-down options where an item has child options. Without this, it is not clear that clicking on (for example) 'Change status' has a very different next step than 'Update attributes' in the 'Actions' menu of the admin grid for products.

![Screenshot_2019-11-16_14-55-06](https://user-images.githubusercontent.com/334786/68995046-68c89280-0881-11ea-840b-1ccdf296f3a7.png)


### Fixed Issues (if relevant)
No known open issues for this.

### Manual testing scenarios (*)
1. Log into admin
1. Navigate to Product grid
1. Open the 'action' menu
1. Observe difference between 'Change status' and 'Update attributes' options.

### Questions or comments
I do not know if a unit test is required for `.less` changes. Please advise how I can do this should it be required.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
