### PR TITLE
Add null return hint to RouterInterface docblock

### DIFF
--- a/lib/internal/Magento/Framework/App/RouterInterface.php
+++ b/lib/internal/Magento/Framework/App/RouterInterface.php
@@ -8,16 +8,17 @@
 namespace Magento\Framework\App;
 
 /**
- * Interface \Magento\Framework\App\RouterInterface
- *
+ * Main application route dispatcher
  */
 interface RouterInterface
 {
     /**
      * Match application action by request
      *
+     * Must either return an action capable of handling the request, or null
+     *
      * @param RequestInterface $request
-     * @return ActionInterface
+     * @return ActionInterface|null
      */
     public function match(RequestInterface $request);
 }


### PR DESCRIPTION
### Description (*)
In the wild, returns null in almost all implementations:
- https://github.com/magento/magento2/blob/c0ab1d9c7a3ee84b1c880ee3fb2d16793a7edb9d/lib/internal/Magento/Framework/App/Router/Base.php#L274
- https://github.com/magento/magento2/blob/c0ab1d9c7a3ee84b1c880ee3fb2d16793a7edb9d/app/code/Magento/Cms/Controller/Router.php#L108
- https://github.com/magento/magento2/blob/c0ab1d9c7a3ee84b1c880ee3fb2d16793a7edb9d/app/code/Magento/Robots/Controller/Router.php#L60
- https://github.com/magento/magento2/blob/c0ab1d9c7a3ee84b1c880ee3fb2d16793a7edb9d/app/code/Magento/UrlRewrite/Controller/Router.php#L89

The exception seems to be
https://github.com/magento/magento2/blob/c0ab1d9c7a3ee84b1c880ee3fb2d16793a7edb9d/app/code/Magento/Webapi/Controller/Rest/Router/Route.php#L107 which returns array|false (!?) and must be fixed,
 as well as https://github.com/magento/magento2/blob/c0ab1d9c7a3ee84b1c880ee3fb2d16793a7edb9d/app/code/Magento/Webapi/Controller/Rest/Router.php#L40 which returns RouterInterface

### Manual testing scenarios (*)
This fix should resolve issues detected by static analysis

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29645: Add null return hint to RouterInterface docblock