### PR TITLE
Add escaping on meta properties for open graph

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/opengraph/general.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/opengraph/general.phtml
@@ -9,11 +9,11 @@
 
 <meta property="og:type" content="product" />
 <meta property="og:title"
-      content="<?= /* @noEscape */ $block->stripTags($block->getProduct()->getName()) ?>" />
+      content="<?= $block->escapeHtmlAttr($block->stripTags($block->getProduct()->getName())) ?>" />
 <meta property="og:image"
       content="<?= $block->escapeUrl($block->getImage($block->getProduct(), 'product_base_image')->getImageUrl()) ?>" />
 <meta property="og:description"
-      content="<?= /* @noEscape */ $block->stripTags($block->getProduct()->getShortDescription()) ?>" />
+      content="<?= $block->escapeHtmlAttr($block->stripTags($block->getProduct()->getShortDescription())) ?>" />
 <meta property="og:url" content="<?= $block->escapeUrl($block->getProduct()->getProductUrl()) ?>" />
 <?php if ($priceAmount = $block->getProduct()->getPriceInfo()->getPrice(\Magento\Catalog\Pricing\Price\FinalPrice::PRICE_CODE)->getAmount()) :?>
     <meta property="product:price:amount" content="<?= $block->escapeHtmlAttr($priceAmount) ?>"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Added block html attribute escaping on OpenGraph meta description / title due to content bleeding from double quotes

### Fixed Issues (if relevant)
1. magento/magento2#25654: Magento OpenGraph meta description / title content bleeding

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a product in the admin
2. Within the product description / title create a sample description that contains double quotes `"`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
