### PR TITLE
Uses > Used for Yes/No column in coupons grid

### DIFF
--- a/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Coupons/Grid.php
+++ b/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Coupons/Grid.php
@@ -100,7 +100,7 @@ class Grid extends \Magento\Backend\Block\Widget\Grid\Extended
         $this->addColumn(
             'used',
             [
-                'header' => __('Uses'),
+                'header' => __('Used'),
                 'index' => 'times_used',
                 'width' => '100',
                 'type' => 'options',

--- a/app/code/Magento/SalesRule/Test/Mftf/Section/AdminCartPriceRulesFormSection.xml
+++ b/app/code/Magento/SalesRule/Test/Mftf/Section/AdminCartPriceRulesFormSection.xml
@@ -98,5 +98,6 @@
         <element name="couponQty" type="input" selector="#coupons_qty"/>
         <element name="generateCouponsButton" type="button" selector="#coupons_generate_button" timeout="30"/>
         <element name="generatedCouponByIndex" type="text" selector="#couponCodesGrid_table > tbody > tr:nth-child({{var}}) > td.col-code" parameterized="true"/>
+        <element name="couponGridUsedHeader" type="text" selector="#couponCodesGrid thead th[data-sort='used']"/>
     </section>
 </sections>

--- a/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleForGeneratedCouponTest.xml
+++ b/app/code/Magento/SalesRule/Test/Mftf/Test/AdminCreateCartPriceRuleForGeneratedCouponTest.xml
@@ -62,6 +62,9 @@
         <waitForPageLoad stepKey="waitFormToReload1"/>
         <click selector="{{AdminCartPriceRulesFormSection.manageCouponCodesHeader}}" stepKey="expandCouponSection2"/>
 
+        <!-- Assert coupon codes grid header is correct -->
+        <see selector="{{AdminCartPriceRulesFormSection.couponGridUsedHeader}}" userInput="Used" stepKey="seeCorrectUsedHeader"/>
+
         <!-- Grab a coupon code and hold on to it for later -->
         <grabTextFrom selector="{{AdminCartPriceRulesFormSection.generatedCouponByIndex('1')}}" stepKey="grabCouponCode"/>
 

--- a/app/code/Magento/SalesRule/i18n/en_US.csv
+++ b/app/code/Magento/SalesRule/i18n/en_US.csv
@@ -22,7 +22,7 @@ Conditions,Conditions
 Generate,Generate
 "Coupon Code","Coupon Code"
 Created,Created
-Uses,Uses
+Used,Used
 No,No
 Yes,Yes
 "Times Used","Times Used"

--- a/app/code/Magento/SalesRule/i18n/en_US.csv
+++ b/app/code/Magento/SalesRule/i18n/en_US.csv
@@ -23,6 +23,7 @@ Generate,Generate
 "Coupon Code","Coupon Code"
 Created,Created
 Used,Used
+Uses,Uses
 No,No
 Yes,Yes
 "Times Used","Times Used"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In the grid for coupon codes on each Cart Price Rule entry, there is a column for 'Uses' with options for Yes/No. This column is intended to indicate if a coupon has been used or not, so the header should be 'Used'. 

![Screenshot 2019-11-19 16 13 04](https://user-images.githubusercontent.com/77671/69164396-d970e880-0ae7-11ea-880c-7e0f349cb6ca.png)

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Marketing > Promotions > Cart Price Rules
2. Create a new rule and save it
3. Generate some coupons against the rule
4. See amended 'Used' column header

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
