### PR TITLE
magento/magento2#: Remove redundant use=“optional” from INDEXER XSD schema

### DIFF
--- a/lib/internal/Magento/Framework/Indexer/etc/indexer.xsd
+++ b/lib/internal/Magento/Framework/Indexer/etc/indexer.xsd
@@ -14,19 +14,19 @@
         </xs:annotation>
         <xs:sequence>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element name="title" type="translatableType" />
-                <xs:element name="description" type="translatableType" />
-                <xs:element name="saveHandler" type="saveHandlerType" />
-                <xs:element name="structure" type="structureType" />
+                <xs:element name="title" type="translatableType"/>
+                <xs:element name="description" type="translatableType"/>
+                <xs:element name="saveHandler" type="saveHandlerType"/>
+                <xs:element name="structure" type="structureType"/>
                 <xs:group ref="fieldset"/>
             </xs:choice>
             <xs:group ref="dependencies"/>
         </xs:sequence>
-        <xs:attribute name="id" type="xs:string" use="required" />
-        <xs:attribute name="primary" type="nameType" use="optional" />
-        <xs:attribute name="view_id" type="viewIdType" use="optional" />
-        <xs:attribute name="class" type="classType" use="optional" />
-        <xs:attribute name="shared_index" type="xs:string" use="optional" />
+        <xs:attribute name="id" type="xs:string" use="required"/>
+        <xs:attribute name="primary" type="nameType"/>
+        <xs:attribute name="view_id" type="viewIdType"/>
+        <xs:attribute name="class" type="classType"/>
+        <xs:attribute name="shared_index" type="xs:string"/>
     </xs:complexType>
 
     <xs:group name="fieldset">
@@ -48,7 +48,7 @@
     <xs:complexType name="translatableType">
         <xs:simpleContent>
             <xs:extension base="xs:string">
-                <xs:attribute name="translate" use="optional" fixed="true" type="xs:boolean"/>
+                <xs:attribute name="translate" fixed="true" type="xs:boolean"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
@@ -60,7 +60,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z0-9_]+" />
+            <xs:pattern value="[a-zA-Z0-9_]+"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -71,7 +71,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z|\\]+[a-zA-Z0-9\\]+" />
+            <xs:pattern value="[a-zA-Z|\\]+[a-zA-Z0-9\\]+"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -82,7 +82,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z0-9_]+" />
+            <xs:pattern value="[a-zA-Z0-9_]+"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -93,7 +93,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z0-9_]+" />
+            <xs:pattern value="[a-zA-Z0-9_]+"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -104,7 +104,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z0-9_]+" />
+            <xs:pattern value="[a-zA-Z0-9_]+"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -115,7 +115,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z0-9_]+" />
+            <xs:pattern value="[a-zA-Z0-9_]+"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -126,8 +126,8 @@
             </xs:documentation>
         </xs:annotation>
         <xs:attribute name="name" type="nameType" use="required"/>
-        <xs:attribute name="handler" type="classType" use="optional"/>
-        <xs:attribute name="origin" type="originType" use="optional"/>
+        <xs:attribute name="handler" type="classType"/>
+        <xs:attribute name="origin" type="originType"/>
     </xs:complexType>
 
     <xs:complexType name="fieldsetType" mixed="true">
@@ -137,11 +137,11 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:element type="referenceType" name="reference" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element type="referenceType" name="reference" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="field" type="fieldType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
-        <xs:attribute name="source" type="classType" use="optional"/>
-        <xs:attribute name="provider" type="classType" use="optional"/>
+        <xs:attribute name="source" type="classType"/>
+        <xs:attribute name="provider" type="classType"/>
         <xs:attribute name="name" type="nameType" use="required"/>
     </xs:complexType>
 
@@ -149,9 +149,9 @@
         <xs:complexContent>
             <xs:extension base="fieldTypeAbstract">
                 <xs:choice>
-                    <xs:element type="filterType" name="filter" minOccurs="0" maxOccurs="1" />
+                    <xs:element type="filterType" name="filter" minOccurs="0" maxOccurs="1"/>
                 </xs:choice>
-                <xs:attribute type="dataType" name="dataType" use="optional" />
+                <xs:attribute type="dataType" name="dataType"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -190,20 +190,20 @@
             </xs:documentation>
         </xs:annotation>
         <xs:attribute name="fieldset" type="nameType" use="required"/>
-        <xs:attribute name="from" type="fromType" use="optional"/>
-        <xs:attribute name="to" type="toType" use="optional"/>
+        <xs:attribute name="from" type="fromType"/>
+        <xs:attribute name="to" type="toType"/>
     </xs:complexType>
 
     <xs:simpleType name="dataType">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="int" />
-            <xs:enumeration value="float" />
-            <xs:enumeration value="varchar" />
-            <xs:enumeration value="text" />
-            <xs:enumeration value="mediumtext" />
-            <xs:enumeration value="timestamp" />
-            <xs:enumeration value="datetime" />
-            <xs:enumeration value="date" />
+            <xs:enumeration value="int"/>
+            <xs:enumeration value="float"/>
+            <xs:enumeration value="varchar"/>
+            <xs:enumeration value="text"/>
+            <xs:enumeration value="mediumtext"/>
+            <xs:enumeration value="timestamp"/>
+            <xs:enumeration value="datetime"/>
+            <xs:enumeration value="date"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -226,8 +226,8 @@
                     Indexer Id must be unique.
                 </xs:documentation>
             </xs:annotation>
-            <xs:selector xpath="indexer" />
-            <xs:field xpath="@id" />
+            <xs:selector xpath="indexer"/>
+            <xs:field xpath="@id"/>
         </xs:unique>
         <xs:unique name="uniqueViewId">
             <xs:annotation>
@@ -235,8 +235,8 @@
                     Indexer Id must be unique.
                 </xs:documentation>
             </xs:annotation>
-            <xs:selector xpath="indexer" />
-            <xs:field xpath="@view_id" />
+            <xs:selector xpath="indexer"/>
+            <xs:field xpath="@view_id"/>
         </xs:unique>
     </xs:element>
     <xs:complexType name="configType">
@@ -266,8 +266,8 @@
                             Related indexer id must be unique.
                         </xs:documentation>
                     </xs:annotation>
-                    <xs:selector xpath="indexer" />
-                    <xs:field xpath="@id" />
+                    <xs:selector xpath="indexer"/>
+                    <xs:field xpath="@id"/>
                 </xs:unique>
             </xs:element>
         </xs:choice>
@@ -287,7 +287,7 @@
                             Indexer dependency that represents another indexer.
                         </xs:documentation>
                     </xs:annotation>
-                    <xs:attribute name="id" type="xs:string" use="required" />
+                    <xs:attribute name="id" type="xs:string" use="required"/>
                 </xs:complexType>
             </xs:element>
         </xs:sequence>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

PR removes the redundant `use=“optional”` in the `indexer.xsd`. Regarding to https://www.w3.org/TR/xmlschema-1/ attribute **use** has a default **optional** value:

```
<xs:attribute name="use" use="optional" default="optional">
```

Also, PR removes the redundant spaces.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)

Thank you!