### PR TITLE
fix ordering of plugin list for after plugins

### DIFF
--- a/app/code/Magento/CmsUrlRewrite/Plugin/Cms/Model/Store/View.php
+++ b/app/code/Magento/CmsUrlRewrite/Plugin/Cms/Model/Store/View.php
@@ -67,7 +67,7 @@ class View
      * @param ResourceStore $object
      * @param ResourceStore $result
      * @param ResourceStore $store
-     * @return void
+     * @return ResourceStore
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function afterSave(ResourceStore $object, ResourceStore $result, AbstractModel $store): void
@@ -77,6 +77,7 @@ class View
                 $this->generateCmsPagesUrls((int)$store->getId())
             );
         }
+        return $result;
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Framework/Interception/TwoPluginTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Interception/TwoPluginTest.php
@@ -45,7 +45,7 @@ class TwoPluginTest extends AbstractPlugin
     public function testPluginAfterWins()
     {
         $subject = $this->_objectManager->create(\Magento\Framework\Interception\Fixture\Intercepted::class);
-        $this->assertEquals('<P:aZ/>', $subject->Z('test'));
+        $this->assertEquals('<F:aZ/>', $subject->Z('test'));
     }
 
     public function testPluginBeforeAroundWins()

--- a/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
+++ b/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
@@ -192,7 +192,14 @@ class PluginList extends Scoped implements InterceptionPluginList
                             $this->_processed[$currentKey][DefinitionInterface::LISTENER_BEFORE][] = $key;
                         }
                         if ($methodTypes & DefinitionInterface::LISTENER_AFTER) {
-                            $this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER][] = $key;
+                            if (!isset($this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER])) {
+                                $this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER][] = $key;
+                            } else {
+                                array_unshift(
+                                    $this->_processed[$currentKey][DefinitionInterface::LISTENER_AFTER],
+                                    $key
+                                );
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Description (*)

as described in https://devdocs.magento.com/guides/v2.2/extension-dev-guide/plugins.html#prioritizing-plugins the order of the after plugin is inversed to the before plugin sorting. currently before and after plugins are not inverse sorted on execution

Manual testing scenarios (*)

add a plugin like the \Magento\Customer\Model\Layout\DepersonalizePlugin which depends on a customer session value
add the plugin with the sort order below 10 (execute beforeGenerateXml before the customer plugin and execute afterGenerateXml after the customer plugin) in order to restore correctly the values within the customer session (needed for page cache segmentation)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)



also see closed not finished pull request https://github.com/magento/magento2/pull/19227 for 2.2 release line