### PR TITLE
ISSUE 25680 Fixes console error on index page

### DIFF
--- a/app/code/Magento/Swagger/view/frontend/layout/swagger_index_index.xml
+++ b/app/code/Magento/Swagger/view/frontend/layout/swagger_index_index.xml
@@ -30,6 +30,7 @@
         <!--Remove Magento page content-->
         <referenceContainer name="page.wrapper" remove="true"/>
         <referenceBlock name="translate" remove="true"/>
+        <referenceBlock name="theme.active.editor" remove="true" />
         <referenceBlock name="requirejs-config" remove="true"/>
         <referenceContainer name="root">
             <block name="swaggerUiContent" class="Magento\Swagger\Block\Index" template="Magento_Swagger::swagger-ui/index.phtml" />


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Since the requirejs-config block got removed in the layout file of the swagger index page, errors are thrown in the console log. To fix this, we also remove the `theme.active.editor` block for the swagger index page, which is defined in the `Magento/Ui/view/base/layout/default.xml` file.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25680: Console log error on Swagger page in 2.3.3

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ... Go to /swagger endpoint of clean magento 2.3-develop instance 
2. ... Check the console log on the following error: `require.config is not a function`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
