### PR TITLE
Remove UserLockedException catch.

### DIFF
--- a/app/code/Magento/Customer/Controller/Account/LoginPost.php
+++ b/app/code/Magento/Customer/Controller/Account/LoginPost.php
@@ -204,11 +204,6 @@ class LoginPost extends AbstractAccount implements CsrfAwareActionInterface, Htt
                         'This account is not confirmed. <a href="%1">Click here</a> to resend confirmation email.',
                         $value
                     );
-                } catch (UserLockedException $e) {
-                    $message = __(
-                        'The account sign-in was incorrect or your account is disabled temporarily. '
-                        . 'Please wait and try again later.'
-                    );
                 } catch (AuthenticationException $e) {
                     $message = __(
                         'The account sign-in was incorrect or your account is disabled temporarily. '


### PR DESCRIPTION
`UserLockedException` extends `AuthenticationException` and provides the same message, hence that catch is simply useless.

### Description (*)
Remove redundant code form code base.

### Questions or comments
None.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
