### PR TITLE
Fix document elements check to prevent WYSIWYG error on IE

### DIFF
--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentovariable/editor_plugin.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentovariable/editor_plugin.js
@@ -196,10 +196,8 @@ define([
                     }
                 });
 
-                returnval += doc.head.innerHTML ?
-                    doc.head.innerHTML.replace(/&amp;quot;/g, '&quot;') : '';
-                returnval += doc.body.innerHTML ?
-                    doc.body.innerHTML.replace(/&amp;quot;/g, '&quot;') : '';
+                returnval += doc.head ? doc.head.innerHTML.replace(/&amp;quot;/g, '&quot;') : '';
+                returnval += doc.body ? doc.body.innerHTML.replace(/&amp;quot;/g, '&quot;') : '';
 
                 return returnval ? returnval : content;
             },

--- a/lib/web/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
+++ b/lib/web/mage/adminhtml/wysiwyg/tiny_mce/plugins/magentowidget/editor_plugin.js
@@ -212,10 +212,8 @@ define([
                     widgetEl.parentNode.removeChild(widgetEl);
                 });
 
-                returnval += doc.head.innerHTML ?
-                    doc.head.innerHTML.replace(/&amp;quot;/g, '&quot;') : '';
-                returnval += doc.body.innerHTML ?
-                    doc.body.innerHTML.replace(/&amp;quot;/g, '&quot;') : '';
+                returnval += doc.head ? doc.head.innerHTML.replace(/&amp;quot;/g, '&quot;') : '';
+                returnval += doc.body ? doc.body.innerHTML.replace(/&amp;quot;/g, '&quot;') : '';
 
                 return returnval ? returnval : content;
             },


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When creating a document using `DomParser`'s `parseFromString` method from an empty string, IE 11 returns a document which both `head` and `body` elements are `null`, which caused the errors.

Fixes https://github.com/magento/magento2/issues/13209

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#13209: Wysiwyg editor fails on IE11

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open Magento admin panel on Internet Explorer 11.
2. Go to any WYSIWYG editor field, e.g. CMS page content editor.
3. Start typing.
4. No error popup is displayed.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
