### PR TITLE
add the id of the category to the category tree names

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Tree.php
@@ -407,6 +407,7 @@ class Tree extends \Magento\Catalog\Block\Adminhtml\Category\AbstractCategory
     public function buildNodeName($node)
     {
         $result = $this->escapeHtml($node->getName());
+        $result .= ' (ID: ' . $node->getId() . ')';
         if ($this->_withProductCount) {
             $result .= ' (' . $node->getProductCount() . ')';
         }

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminFilteringCategoryProductsUsingScopeSelectorTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminFilteringCategoryProductsUsingScopeSelectorTest.xml
@@ -131,7 +131,7 @@
              userInput="$$createProduct1.name$$" stepKey="seeProductName4"/>
         <see selector="{{AdminCategoryProductsGridSection.productGridNameProduct($$createProduct12.name$$)}}"
              userInput="$$createProduct12.name$$" stepKey="seeProductName5"/>
-        <waitForText userInput="$$createCategory.name$$ (2)" stepKey="seeCorrectProductCount"/>
+        <waitForText userInput="$$createCategory.name$$ (ID: 6) (2)" stepKey="seeCorrectProductCount"/>
         <dontSee selector="{{AdminCategoryProductsGridSection.productGridNameProduct($$createProduct0.name$$)}}"
                  userInput="$$createProduct0.name$$" stepKey="dontSeeProductName"/>
         <dontSee selector="{{AdminCategoryProductsGridSection.productGridNameProduct($$createProduct2.name$$)}}"
@@ -151,7 +151,7 @@
              userInput="$$createProduct2.name$$" stepKey="seeProductName6"/>
         <see selector="{{AdminCategoryProductsGridSection.productGridNameProduct($$createProduct12.name$$)}}"
              userInput="$$createProduct12.name$$" stepKey="seeProductName7"/>
-        <waitForText userInput="$$createCategory.name$$ (2)" stepKey="seeCorrectProductCount2"/>
+        <waitForText userInput="$$createCategory.name$$ (ID: 6) (2)" stepKey="seeCorrectProductCount2"/>
         <dontSee selector="{{AdminCategoryProductsGridSection.productGridNameProduct($$createProduct0.name$$)}}"
                  userInput="$$createProduct0.name$$" stepKey="dontSeeProductName2"/>
         <dontSee selector="{{AdminCategoryProductsGridSection.productGridNameProduct($$createProduct2.name$$)}}"


### PR DESCRIPTION
### Description (*)
As categories do not have an external id and the id is sometimes needed (e.g. configuration of an external system, add new layout-update xmls for specific ids) the id should be shown in more places than the page title of the edit page in the backend.

### Manual testing scenarios (*)

1. login to the backend
2. go to the category detail pages (catalog -> categories)
3. every item in the category tree should be appended with its ID like in the page title

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
