### PR TITLE
ASI #Issue-723 Fixed the issue: "Image preview should be closed when the page is changed"

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
@@ -30,7 +30,8 @@ define([
             },
             listens: {
                 '${ $.provider }:params.filters': 'hide',
-                '${ $.provider }:params.search': 'hide'
+                '${ $.provider }:params.search': 'hide',
+                '${ $.provider }:params.paging': 'hide'
             },
             exports: {
                 height: '${ $.parentName }.thumbnail_url:previewHeight'


### PR DESCRIPTION
### Description (*)
This PR fixes the issue magento/adobe-stock-integration#723: Image preview should be closed when the page is changed.
![issue-723](https://user-images.githubusercontent.com/31502344/69494618-8e2f4f00-0ec6-11ea-9c19-58c0351f6a78.gif)

### Fixed Issues (if relevant)

1. magento/adobe-stock-integration#723: Image preview should be closed when the page is changed

### Manual testing scenarios (*)

1. Login to admin panel
2. Navigate to Cms Pages
3. User clicks Add New Page button
4. Expand "Content" section
5. User clicks "Insert Image..." button
6. Click "Search Adobe Stock" button to open images grid
7. Click on an first image to expand the preview on first page
8. Change grid page.

### Questions or comments


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
