### PR TITLE
Need margin bottom to new Widget in Checkout/Cart Summary box

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_cart.less
@@ -346,6 +346,10 @@
 
         .widget {
             float: left;
+            
+            &.block {
+                margin-bottom: @indent__base;
+            }
         }
     }
 

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
@@ -113,7 +113,7 @@
 
         .page-main & {
             .block {
-                margin-bottom: @indent__base;
+                margin-bottom: 0;
             }
         }
 
@@ -563,6 +563,9 @@
 
         .widget {
             float: left;
+            &.block {
+                margin-bottom: @indent__base;
+            }
         }
     }
 

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
@@ -563,6 +563,7 @@
 
         .widget {
             float: left;
+            
             &.block {
                 margin-bottom: @indent__base;
             }

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
@@ -113,7 +113,7 @@
 
         .page-main & {
             .block {
-                margin-bottom: 0;
+                margin-bottom: 20px;
             }
         }
 

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_cart.less
@@ -113,7 +113,7 @@
 
         .page-main & {
             .block {
-                margin-bottom: 20px;
+                margin-bottom: @indent__base;
             }
         }
 


### PR DESCRIPTION
**Description (*)**
Added margin-bottom for static cms block widget after cart totals in luma and blank theme.

**Fixed Issues (if relevant)**
https://github.com/magento/magento2/issues/25703 Need margin bottom to new Widget in Checkout/Cart Summary box

**Steps to reproduce**
Create one new BLOCK with text into this
![1](https://user-images.githubusercontent.com/51653844/69533374-769fa700-0f56-11ea-9ed4-023d27fdac2b.png)

Create one new WIDGET
![2](https://user-images.githubusercontent.com/51653844/69533378-7a332e00-0f56-11ea-9e32-589c8c7f7fc0.png)



Attributed the block in Widget Options
![3](https://user-images.githubusercontent.com/51653844/69533479-a77fdc00-0f56-11ea-93fb-4d06160916e5.png)

Then make login

Add product in your Cart

Go to your cart and then "VIEW AND EDIT CART"
![6](https://user-images.githubusercontent.com/51653844/69533505-b2d30780-0f56-11ea-85e1-e9185f40e28a.png)

Expected result (*)
The text need margin bottom like this
![result](https://user-images.githubusercontent.com/51653844/69533552-c1212380-0f56-11ea-82c1-3e94104e3c78.png)

Actual result (*)
The text dosen´t have margin bottom between the button PROCEED TO CHECKOUT

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
