### PR TITLE
Fix item prices not beeing displayed in order summary on checkout

### DIFF
--- a/app/code/Magento/Tax/view/frontend/web/template/checkout/summary/item/details/subtotal.html
+++ b/app/code/Magento/Tax/view/frontend/web/template/checkout/summary/item/details/subtotal.html
@@ -5,13 +5,13 @@
  */
 -->
 <div class="subtotal">
-    <!-- ko if: isPriceInclTaxDisplayed() && !getRegion('row_incl_tax') -->
+    <!-- ko if: isPriceInclTaxDisplayed() && !getRegion('row_incl_tax').length -->
     <span class="price-including-tax"
           data-bind ="text: getValueInclTax($parents[1]), attr:{'data-label': $t('Incl. Tax')}">
     </span>
     <!-- /ko -->
 
-    <!-- ko if: isPriceInclTaxDisplayed() && getRegion('row_incl_tax') -->
+    <!-- ko if: isPriceInclTaxDisplayed() && getRegion('row_incl_tax').length -->
     <span class="price-including-tax" data-bind ="attr:{'data-label': $t('Incl. Tax')}">
             <!-- ko foreach: getRegion('row_incl_tax') -->
                 <!-- ko template: getTemplate() --><!-- /ko -->
@@ -19,12 +19,12 @@
     </span>
     <!-- /ko -->
 
-    <!-- ko if: isPriceExclTaxDisplayed() && !getRegion('row_excl_tax') -->
+    <!-- ko if: isPriceExclTaxDisplayed() && !getRegion('row_excl_tax').length -->
     <span class="price-excluding-tax"
           data-bind ="text: getValueExclTax($parents[1]), attr:{'data-label': $t('Excl. Tax')}">
     </span>
     <!-- /ko -->
-    <!-- ko if: isPriceExclTaxDisplayed() && getRegion('row_excl_tax') -->
+    <!-- ko if: isPriceExclTaxDisplayed() && getRegion('row_excl_tax').length -->
     <span class="price-excluding-tax" data-bind ="attr:{'data-label': $t('Excl. Tax')}">
             <!-- ko foreach: getRegion('row_excl_tax') -->
                 <!-- ko template: getTemplate() --><!-- /ko -->


### PR DESCRIPTION
### Description (*)

Magento_Tax/checkout/summary/item/details/summary template
does checks if `getRegion(..)` is truish.

getRegion(region) always returns array therefore the above check
always gives same result.

Fixed by changed if expression to check length truthiness.

### Manual testing scenarios (*)

Not sure.

### Questions or comments

Didn't check that on clean Magento install, although with using browser debugger I ensured file is not changed by any module, no mixin applied to that file there is no template updates.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
