### PR TITLE
issue/25771 : Fix wysiwyg image browser always calling php instead of…

### DIFF
--- a/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
@@ -592,7 +592,7 @@ class Storage extends \Magento\Framework\DataObject
         $mediaRootDir = $this->_cmsWysiwygImages->getStorageRoot();
 
         if (strpos($filePath, (string) $mediaRootDir) === 0) {
-            $thumbSuffix = self::THUMBS_DIRECTORY_NAME . substr($filePath, strlen($mediaRootDir));
+            $thumbSuffix = self::THUMBS_DIRECTORY_NAME . '/' . substr($filePath, strlen($mediaRootDir));
             if (!$checkFile || $this->_directory->isExist(
                 $this->_directory->getRelativePath($mediaRootDir . '/' . $thumbSuffix)
             )


### PR DESCRIPTION
… directy linking to thumbnail image file

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
See: https://github.com/magento/magento2/issues/25771

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25771: Backend wysiwyg image browser always calls php instead of loading directly the image file

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a symlink to pub/media: `mkdir symlink && mv pub/media symlink && cd pub && ln -s ../symlink/media media`
2. Go to backend and open up a wysiwyg image browser and have a few images in there.
3. Note that all src to the image are in the format of admin/cms/wysiwyg_images/thumbnail/file/
4. Reload the image browser. By now all the images should have gotten a thumbnail.
5. Verify that src goes to the image directly instead of going to the php admin/cms/wysiwyg_images/thumbnail/file/ again.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
