### PR TITLE
[Config] Giving the possibility to have a config dependency based on empty config value

### DIFF
--- a/app/code/Magento/Config/Model/Config/Structure/Element/Dependency/Field.php
+++ b/app/code/Magento/Config/Model/Config/Structure/Element/Dependency/Field.php
@@ -6,6 +6,8 @@
 namespace Magento\Config\Model\Config\Structure\Element\Dependency;
 
 /**
+ * Field
+ *
  * @api
  * @since 100.0.2
  */

--- a/app/code/Magento/Config/Model/Config/Structure/Element/Dependency/Field.php
+++ b/app/code/Magento/Config/Model/Config/Structure/Element/Dependency/Field.php
@@ -41,7 +41,7 @@ class Field
         if (isset($fieldData['separator'])) {
             $this->_values = explode($fieldData['separator'], $fieldData['value']);
         } else {
-            $this->_values = [$fieldData['value']];
+            $this->_values = [isset($fieldData['value']) ? $fieldData['value'] : ''];
         }
         $fieldId = $fieldPrefix . (isset(
             $fieldData['dependPath']

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Dependency/FieldTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Dependency/FieldTest.php
@@ -12,6 +12,8 @@ class FieldTest extends \PHPUnit\Framework\TestCase
      */
     const SIMPLE_VALUE = 'someValue';
 
+    const EMPTY_VALUE = '';
+
     const COMPLEX_VALUE1 = 'value_1';
 
     const COMPLEX_VALUE2 = 'value_2';
@@ -150,8 +152,19 @@ class FieldTest extends \PHPUnit\Framework\TestCase
         return [
             [$this->_getSimpleData(), true, [self::SIMPLE_VALUE]],
             [$this->_getSimpleData(), false, [self::SIMPLE_VALUE]],
+            [$this->_getSimpleEmptyData(), false, [static::EMPTY_VALUE]],
             [$this->_getComplexData(), true, $complexDataValues],
             [$this->_getComplexData(), false, $complexDataValues]
         ];
+    }
+
+    /**
+     * Providing a field data with no field value
+     *
+     * @return array
+     */
+    protected function _getSimpleEmptyData(): array
+    {
+        return ['dependPath' => ['section_2', 'group_3', 'field_4']];
     }
 }


### PR DESCRIPTION

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR provides a way to set a dependency to a field based on the empty value.

For example:
You have 2 input config fields, and you want to hide the 2nd one if the 1st one won't be empty.

![2019-11-27 15 25 13](https://user-images.githubusercontent.com/15868188/69726933-32650000-112a-11ea-8f5f-89a78c1f09b6.gif)

Our `system.xml` will look like:

```xml
<field id="first_input" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
    <label>First Input</label>
</field>
<field id="second_input" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
    <label>Second input</label>
    <comment><![CDATA[Dependent by 1st field]]></comment>
    <depends>
        <field id="*/*/first_input"/>
    </depends>
</field>
```

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Add to any system config group the provided sample code 
2. Open it in the admin panel
3. Type something in the 1st input
4. The second should be hidden

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
