### PR TITLE
#20463 Fix order summary view details label misalign

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
@@ -263,6 +263,7 @@
                 );
                 cursor: pointer;
                 position: relative;
+                white-space: nowrap;
 
                 &:after {
                     position: static;

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
@@ -315,7 +315,8 @@
             .toggle {
                 &:extend(.abs-toggling-title all);
                 border: 0;
-                padding: 0 @indent__m @indent__xs 0;
+                padding: 0 0 @indent__xs 0;
+                white-space: nowrap;
 
                 &:after {
                     .lib-css(color, @color-gray56);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This fixes possible misalignment of "View Details" label for configurable products in the order summary, which happens on tablet-sized screens, especially just above the mobile breakpoint (width of 769px).

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#20463: On order sumary view details label misalign on tablet

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add configurable product to cart
2. Go to checkout shipping step
3. "View Details" label of order summary items should not misalign on desktop screens of varying screen widths, especially 769px.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
