### PR TITLE
Paypal: Remove header data from cURL output

### DIFF
--- a/app/code/Magento/Paypal/Model/Api/Nvp.php
+++ b/app/code/Magento/Paypal/Model/Api/Nvp.php
@@ -1178,7 +1178,7 @@ class Nvp extends \Magento\Paypal\Model\Api\AbstractApi
 
         try {
             $http = $this->_curlFactory->create();
-            $config = ['timeout' => 60, 'verifypeer' => $this->_config->getValue('verifyPeer')];
+            $config = ['timeout' => 60, 'verifypeer' => $this->_config->getValue('verifyPeer'), 'header' => false];
             if ($this->getUseProxy()) {
                 $config['proxy'] = $this->getProxyHost() . ':' . $this->getProxyPort();
             }
@@ -1200,8 +1200,6 @@ class Nvp extends \Magento\Paypal\Model\Api\AbstractApi
             throw $e;
         }
 
-        $response = preg_split('/^\r?$/m', $response, 2);
-        $response = trim($response[1]);
         $response = $this->_deformatNVP($response);
 
         $debugData['response'] = $response;
@@ -1425,8 +1423,6 @@ class Nvp extends \Magento\Paypal\Model\Api\AbstractApi
     {
         $intial = 0;
         $nvpArray = [];
-
-        $nvpstr = strpos($nvpstr, "\r\n\r\n") !== false ? substr($nvpstr, strpos($nvpstr, "\r\n\r\n") + 4) : $nvpstr;
 
         while (strlen($nvpstr)) {
             //position of Key

--- a/app/code/Magento/Paypal/Test/Unit/Model/Api/NvpTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/Api/NvpTest.php
@@ -163,21 +163,21 @@ class NvpTest extends \PHPUnit\Framework\TestCase
         return [
             ['', [], null],
             [
-                "\r\n" . 'ACK=Failure&L_ERRORCODE0=10417&L_SHORTMESSAGE0=Message.&L_LONGMESSAGE0=Long%20Message.',
+                'ACK=Failure&L_ERRORCODE0=10417&L_SHORTMESSAGE0=Message.&L_LONGMESSAGE0=Long%20Message.',
                 [],
                 LocalizedException::class,
                 'PayPal gateway has rejected request. Long Message (#10417: Message).',
                 0
             ],
             [
-                "\r\n" . 'ACK=Failure&L_ERRORCODE0=10417&L_SHORTMESSAGE0=Message.&L_LONGMESSAGE0=Long%20Message.',
+                'ACK=Failure&L_ERRORCODE0=10417&L_SHORTMESSAGE0=Message.&L_LONGMESSAGE0=Long%20Message.',
                 [10417, 10422],
                 \Magento\Paypal\Model\Api\ProcessableException::class,
                 'PayPal gateway has rejected request. Long Message (#10417: Message).',
                 10417
             ],
             [
-                "\r\n" . 'ACK[7]=Failure&L_ERRORCODE0[5]=10417'
+                'ACK[7]=Failure&L_ERRORCODE0[5]=10417'
                     . '&L_SHORTMESSAGE0[8]=Message.&L_LONGMESSAGE0[15]=Long%20Message.',
                 [10417, 10422],
                 \Magento\Paypal\Model\Api\ProcessableException::class,
@@ -185,7 +185,7 @@ class NvpTest extends \PHPUnit\Framework\TestCase
                 10417
             ],
             [
-                "\r\n" . 'ACK[7]=Failure&L_ERRORCODE0[5]=10417&L_SHORTMESSAGE0[8]=Message.',
+                'ACK[7]=Failure&L_ERRORCODE0[5]=10417&L_SHORTMESSAGE0[8]=Message.',
                 [10417, 10422],
                 \Magento\Paypal\Model\Api\ProcessableException::class,
                 'PayPal gateway has rejected request. #10417: Message.',
@@ -226,7 +226,7 @@ class NvpTest extends \PHPUnit\Framework\TestCase
     {
         return [
             [
-                "\r\n" . 'ACK=Success&SHIPTONAME=Jane%20Doe'
+                'ACK=Success&SHIPTONAME=Jane%20Doe'
                 . '&SHIPTOSTREET=testStreet'
                 . '&SHIPTOSTREET2=testApartment'
                 . '&BUSINESS=testCompany'
@@ -298,7 +298,7 @@ class NvpTest extends \PHPUnit\Framework\TestCase
      */
     public function testCallTransactionHasBeenCompleted()
     {
-        $response =    "\r\n" . 'ACK[7]=Failure&L_ERRORCODE0[5]=10415'
+        $response =    'ACK[7]=Failure&L_ERRORCODE0[5]=10415'
             . '&L_SHORTMESSAGE0[8]=Message.&L_LONGMESSAGE0[15]=Long%20Message.';
         $processableErrors =[10415];
         $this->curl->expects($this->once())

--- a/dev/tests/integration/testsuite/Magento/Paypal/Model/Api/PayflowNvpTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Model/Api/PayflowNvpTest.php
@@ -107,7 +107,7 @@ class PayflowNvpTest extends \PHPUnit\Framework\TestCase
             );
 
         $this->httpClient->method('read')
-            ->willReturn("HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nRESULT=0&RESPMSG=Approved");
+            ->willReturn("RESULT=0&RESPMSG=Approved");
 
         $this->nvpApi->setAmount($quote->getBaseGrandTotal());
         $this->nvpApi->setPaypalCart($cart);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This fixes an issue with the paypal integration when too many parameters are being posted to Paypal using a proxy. Normally, when posting something to paypal, the output of `var_dump($response)` will look like this:
```
HTTP/1.1 200 Connection established

HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Content-Length: 137
Connection: keep-alive
Cache-Control: max-age=0, no-cache, no-store, must-revalidate
Date: Thu, 28 Nov 2019 09:48:54 GMT
Paypal-Debug-Id: debugtoken
X-Paypal-Api-Rc: 
X-Paypal-Operation-Name: SetExpressCheckout
X-Slr-Retry-Api: SetExpressCheckout
Strict-Transport-Security: max-age=31536000; includeSubDomains

TOKEN=EC%2dTHEREWASATOKENHERE&TIMESTAMP=2019%2d11%2d28T09%3a48%3a54Z&CORRELATIONID=debugtoken&ACK=Success&VERSION=72%2e0&BUILD=53842365
```
However, when you have too many parameters set, the `var_dump($response)` output will look like this instead:
```
HTTP/1.1 200 Connection established

HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Content-Length: 137
Connection: keep-alive
Cache-Control: max-age=0, no-cache, no-store, must-revalidate
Date: Thu, 28 Nov 2019 09:41:13 GMT
Paypal-Debug-Id: debugtoken
Pragma: no-cache
X-Paypal-Api-Rc: 
X-Paypal-Operation-Name: SetExpressCheckout
X-Slr-Retry-Api: SetExpressCheckout
Strict-Transport-Security: max-age=31536000; includeSubDomains

TOKEN=EC%2dTHEREWASATOKENHERE&TIMESTAMP=2019%2d11%2d28T09%3a41%3a13Z&CORRELATIONID=debugtoken&ACK=Success&VERSION=72%2e0&BUILD=53842365
```
Due to `HTTP/1.1 100 Continue` being added in the obtained data from the server, the parser messes up and returns an array looking like this:
```  
array (
    'HTTP/1.1 200 OK
Content-Type: text/plain; charset' => 'utf-8
Content-Length: 137
Connection: keep-alive
Cache-Control: max-age=0, no-cache, no-store, must-revalidate
Date: Tue, 26 Nov 2019 15:41:08 GMT
Paypal-Debug-Id: debugtoken
X-Paypal-Api-Rc: 
X-Paypal-Operation-Name: SetExpressCheckout
X-Slr-Retry-Api: SetExpressCheckout
Strict-Transport-Security: max-age=31536000; includeSubDomains
TOKEN=EC-THEREWASATOKENHERE',
    'TIMESTAMP' => '2019-11-26T15:41:09Z',
    'CORRELATIONID' => 'debugtoken',
    'ACK' => 'Success',
    'VERSION' => '72.0',
    'BUILD' => '53842365',
  )
```

This fix removes all headers via a cURL option instead, which means the logic to split the body from the headers will not be needed anymore.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Enable the Paypal express checkout integration
2. Login as a customer with their contact details filled out (for example: city, street, etc)
3. Try to perform a Paypal express checkout. Instead of the Paypal form disappearing (current situation when enough data is being posted), you should instead now see a paypal dialog asking for user input.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
