### PR TITLE
#25042 Remove logo dimension parameters from layout files

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Header/Logo.php
+++ b/app/code/Magento/Theme/Block/Html/Header/Logo.php
@@ -98,7 +98,7 @@ class Logo extends \Magento\Framework\View\Element\Template
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             );
         }
-        return (int)$this->_data['logo_width'] ? : (int)$this->getLogoImgWidth();
+        return (int)$this->_data['logo_width'];
     }
 
     /**
@@ -114,7 +114,7 @@ class Logo extends \Magento\Framework\View\Element\Template
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             );
         }
-        return (int)$this->_data['logo_height'] ? : (int)$this->getLogoImgHeight();
+        return (int)$this->_data['logo_height'];
     }
 
     /**

--- a/app/code/Magento/Theme/Test/Unit/Block/Html/Header/LogoTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Block/Html/Header/LogoTest.php
@@ -44,4 +44,38 @@ class LogoTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('http://localhost/pub/media/logo/default/image.gif', $block->getLogoSrc());
     }
+
+    /**
+     * cover \Magento\Theme\Block\Html\Header\Logo::getLogoHeight
+     */
+    public function testGetLogoHeight()
+    {
+        $scopeConfig = $this->createMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
+        $scopeConfig->expects($this->once())->method('getValue')->willReturn(null);
+
+        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $arguments = [
+            'scopeConfig' => $scopeConfig,
+        ];
+        $block = $objectManager->getObject(\Magento\Theme\Block\Html\Header\Logo::class, $arguments);
+
+        $this->assertEquals(null, $block->getLogoHeight());
+    }
+
+    /**
+     * @covers \Magento\Theme\Block\Html\Header\Logo::getLogoWidth
+     */
+    public function testGetLogoWidth()
+    {
+        $scopeConfig = $this->createMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
+        $scopeConfig->expects($this->once())->method('getValue')->willReturn('170');
+
+        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $arguments = [
+            'scopeConfig' => $scopeConfig,
+        ];
+        $block = $objectManager->getObject(\Magento\Theme\Block\Html\Header\Logo::class, $arguments);
+
+        $this->assertEquals('170', $block->getLogoHeight());
+    }
 }

--- a/app/code/Magento/Theme/view/frontend/layout/default.xml
+++ b/app/code/Magento/Theme/view/frontend/layout/default.xml
@@ -50,12 +50,7 @@
                 </container>
             </container>
             <container name="header-wrapper" label="Page Header" as="header-wrapper" htmlTag="div" htmlClass="header content">
-                <block class="Magento\Theme\Block\Html\Header\Logo" name="logo">
-                    <arguments>
-                        <argument name="logo_img_width" xsi:type="number">189</argument>
-                        <argument name="logo_img_height" xsi:type="number">64</argument>
-                    </arguments>
-                </block>
+                <block class="Magento\Theme\Block\Html\Header\Logo" name="logo"/>
             </container>
         </referenceContainer>
         <referenceContainer name="page.top">

--- a/app/design/frontend/Magento/luma/Magento_Theme/layout/default.xml
+++ b/app/design/frontend/Magento/luma/Magento_Theme/layout/default.xml
@@ -14,12 +14,6 @@
                 </arguments>
             </block>
         </referenceContainer>
-        <referenceBlock name="logo">
-            <arguments>
-                <argument name="logo_img_width" xsi:type="number">148</argument>
-                <argument name="logo_img_height" xsi:type="number">43</argument>
-            </arguments>
-        </referenceBlock>
         <referenceContainer name="footer">
             <block class="Magento\Store\Block\Switcher" name="store_switcher" as="store_switcher" after="footer_links" template="Magento_Store::switch/stores.phtml"/>
         </referenceContainer>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes a problem where a new logo is uploaded in the backend, without specifying width and height parameters. Magento then used the `logo_img_width` and `logo_img_height` block arguments set in the layout file for the Logo block as fallback, possibly distorting the new logo. This is confusing behavior for the user, as the logo should be displayed with its native dimensions if no width and height parameters are explicitly set.

Notice that it is still possible to configure the logo dimension via layout files, using `logo_width` and `logo_height` instead of `logo_img_width` and `logo_img_height` as block arguments. With this changes, the `logo_img_width` and `logo_img_height` block arguments are no longer used by the block.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25042: Store logo inherits height and width from luma logo, if no height and width is provided

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Upload a new logo in the backend (Content > Design > Configuration > Global > Edit > Header > Upload Logo), don't set the height and width fields
2. Clear cache
3. Got to storefront homepage
4. Logo dimension should be native image dimension, not Luma logo dimension

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
