### PR TITLE
Update JsonSerializer.php

### DIFF
--- a/app/code/Magento/User/ViewModel/JsonSerializer.php
+++ b/app/code/Magento/User/ViewModel/JsonSerializer.php
@@ -35,6 +35,10 @@ class JsonSerializer implements \Magento\Framework\View\Element\Block\ArgumentIn
      */
     public function serialize(array $data): string
     {
-        return $this->serializer->serialize($data);
+        $result = json_encode($data, JSON_HEX_APOS);
+        if (false === $result) {
+            throw new \InvalidArgumentException("Unable to serialize value. Error: " . json_last_error_msg());
+        }
+        return $result;
     }
 }


### PR DESCRIPTION
Escape single quotes (') to avoid rolesTree json parsing errors when using another backend interface language.
For example, the Dutch translation file can contain the following lines:
"Manage Pages","Beheer pagina's",module,Magento_Cms
"CMS Pages","CMS pagina's",module,Magento_VersionsCms

