### PR TITLE
MFTF: Extract Action Groups to separate files - magento/module-shipping

### DIFF
--- a/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminChangeTableRatesShippingMethodStatusActionGroup.xml
+++ b/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminChangeTableRatesShippingMethodStatusActionGroup.xml
@@ -17,14 +17,4 @@
         <uncheckOption selector="{{AdminShippingMethodTableRatesSection.enabledUseSystemValue}}" stepKey="uncheckUseSystemValue"/>
         <selectOption selector="{{AdminShippingMethodTableRatesSection.carriersTableRateActive}}" userInput="{{status}}" stepKey="changeTableRatesMethodStatus"/>
     </actionGroup>
-    <actionGroup name="AdminImportFileTableRatesShippingMethodActionGroup">
-        <annotations>
-            <description>Import a file in Table Rates tab in Shipping Method config page.</description>
-        </annotations>
-        <arguments>
-            <argument name="file" type="string" defaultValue="test_tablerates.csv"/>
-        </arguments>
-        <conditionalClick selector="{{AdminShippingMethodTableRatesSection.carriersTableRateTab}}" dependentSelector="{{AdminShippingMethodTableRatesSection.carriersTableRateActive}}" visible="false" stepKey="expandTab"/>
-        <attachFile selector="{{AdminShippingMethodTableRatesSection.importFile}}" userInput="{{file}}" stepKey="attachFileForImport"/>
-    </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminImportFileTableRatesShippingMethodActionGroup.xml
+++ b/app/code/Magento/Shipping/Test/Mftf/ActionGroup/AdminImportFileTableRatesShippingMethodActionGroup.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminImportFileTableRatesShippingMethodActionGroup">
+        <annotations>
+            <description>Import a file in Table Rates tab in Shipping Method config page.</description>
+        </annotations>
+        <arguments>
+            <argument name="file" type="string" defaultValue="test_tablerates.csv"/>
+        </arguments>
+        <conditionalClick selector="{{AdminShippingMethodTableRatesSection.carriersTableRateTab}}" dependentSelector="{{AdminShippingMethodTableRatesSection.carriersTableRateActive}}" visible="false" stepKey="expandTab"/>
+        <attachFile selector="{{AdminShippingMethodTableRatesSection.importFile}}" userInput="{{file}}" stepKey="attachFileForImport"/>
+    </actionGroup>
+</actionGroups>


### PR DESCRIPTION
### Description (*)
Extract each Action Group to separate file, to follow MFTF Best Practices.

### Fixed Issues (if relevant)
1. magento/magento2#22853

### Questions or comments
Had to extract the changes per-module. The previous try failed, because of conflicts.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)