### PR TITLE
Reflection: Fix null as first return type

### DIFF
--- a/lib/internal/Magento/Framework/Reflection/Test/Unit/Fixture/TSample.php
+++ b/lib/internal/Magento/Framework/Reflection/Test/Unit/Fixture/TSample.php
@@ -22,4 +22,20 @@ class TSample implements TSampleInterface
     {
         return '';
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getWithNull()
+    {
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getOnlyNull()
+    {
+        return null;
+    }
 }

--- a/lib/internal/Magento/Framework/Reflection/Test/Unit/Fixture/TSampleInterface.php
+++ b/lib/internal/Magento/Framework/Reflection/Test/Unit/Fixture/TSampleInterface.php
@@ -18,4 +18,16 @@ interface TSampleInterface
      * Doc block without return tag.
      */
     public function getName();
+
+    /**
+     * return annotation with a null type at first position
+     * @return null|string
+     */
+    public function getWithNull();
+
+    /**
+     * return annotation with only null type
+     * @return null
+     */
+    public function getOnlyNull();
 }

--- a/lib/internal/Magento/Framework/Reflection/Test/Unit/TypeProcessorTest.php
+++ b/lib/internal/Magento/Framework/Reflection/Test/Unit/TypeProcessorTest.php
@@ -384,20 +384,6 @@ class TypeProcessorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Checks a case when method return annotation has a null-type at first position,
-     * and no other valid return type.
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage No valid return type for Magento\Framework\Reflection\Test\Unit\Fixture\TSample::getOnlyNull() specified. Verify the return type and try again.
-     */
-    public function testGetReturnTypeNullAtFirstPosNoValidType()
-    {
-        $classReflection = new ClassReflection(TSample::class);
-        $methodReflection = $classReflection->getMethod('getOnlyNull');
-        $this->typeProcessor->getGetterReturnType($methodReflection);
-    }
-
-    /**
      * Simple and complex data provider
      *
      * @return array

--- a/lib/internal/Magento/Framework/Reflection/Test/Unit/TypeProcessorTest.php
+++ b/lib/internal/Magento/Framework/Reflection/Test/Unit/TypeProcessorTest.php
@@ -365,6 +365,39 @@ class TypeProcessorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Checks a case when method return annotation has a null-type at first position,
+     * and a valid type at second.
+     */
+    public function testGetReturnTypeNullAtFirstPos()
+    {
+        $expected = [
+            'type' => 'string',
+            'isRequired' => false,
+            'description' => null,
+            'parameterCount' => 0
+        ];
+
+        $classReflection = new ClassReflection(TSample::class);
+        $methodReflection = $classReflection->getMethod('getWithNull');
+
+        self::assertEquals($expected, $this->typeProcessor->getGetterReturnType($methodReflection));
+    }
+
+    /**
+     * Checks a case when method return annotation has a null-type at first position,
+     * and no other valid return type.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage No valid return type for Magento\Framework\Reflection\Test\Unit\Fixture\TSample::getOnlyNull() specified. Verify the return type and try again.
+     */
+    public function testGetReturnTypeNullAtFirstPosNoValidType()
+    {
+        $classReflection = new ClassReflection(TSample::class);
+        $methodReflection = $classReflection->getMethod('getOnlyNull');
+        $this->typeProcessor->getGetterReturnType($methodReflection);
+    }
+
+    /**
      * Simple and complex data provider
      *
      * @return array

--- a/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
@@ -293,15 +293,7 @@ class TypeProcessor
                 break;
             }
         }
-        if (!$returnType) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'No valid return type for %s::%s() specified. Verify the return type and try again.',
-                    $methodReflection->getDeclaringClass()->getName(),
-                    $methodReflection->getName()
-                )
-            );
-        }
+
         $nullable = in_array('null', $types);
 
         return [

--- a/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
@@ -327,6 +327,7 @@ class TypeProcessor
             if (is_array($throwsTypes)) {
                 /** @var $throwsType \Zend\Code\Reflection\DocBlock\Tag\ThrowsTag */
                 foreach ($throwsTypes as $throwsType) {
+                    // phpcs:ignore
                     $exceptions = array_merge($exceptions, $throwsType->getTypes());
                 }
             }
@@ -528,13 +529,15 @@ class TypeProcessor
     {
         $type = $param->detectType();
         if ($type === 'null') {
-            throw new \LogicException(sprintf(
-                '@param annotation is incorrect for the parameter "%s" in the method "%s:%s".'
-                . ' First declared type should not be null. E.g. string|null',
-                $param->getName(),
-                $param->getDeclaringClass()->getName(),
-                $param->getDeclaringFunction()->name
-            ));
+            throw new \LogicException(
+                sprintf(
+                    '@param annotation is incorrect for the parameter "%s" in the method "%s:%s".'
+                    . ' First declared type should not be null. E.g. string|null',
+                    $param->getName(),
+                    $param->getDeclaringClass()->getName(),
+                    $param->getDeclaringFunction()->name
+                )
+            );
         }
         if ($type === 'array') {
             // try to determine class, if it's array of objects

--- a/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
@@ -286,7 +286,22 @@ class TypeProcessor
     {
         $returnAnnotation = $this->getMethodReturnAnnotation($methodReflection);
         $types = $returnAnnotation->getTypes();
-        $returnType = current($types);
+        $returnType = null;
+        foreach ($types as $type) {
+            if ($type != 'null') {
+                $returnType = $type;
+                break;
+            }
+        }
+        if (!$returnType) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'No valid return type for %s::%s() specified. Verify the return type and try again.',
+                    $methodReflection->getDeclaringClass()->getName(),
+                    $methodReflection->getName()
+                )
+            );
+        }
         $nullable = in_array('null', $types);
 
         return [

--- a/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/TypeProcessor.php
@@ -288,7 +288,7 @@ class TypeProcessor
         $types = $returnAnnotation->getTypes();
         $returnType = null;
         foreach ($types as $type) {
-            if ($type != 'null') {
+            if ($type !== 'null') {
                 $returnType = $type;
                 break;
             }


### PR DESCRIPTION
### Description (*)
This fixes null as the first return type for methods used in the service layer.

The examples given in #25656 are now working. Additionally the Swagger schema generation no longer fails with the exception ```The "" data type isn't declared. Verify the type and try again.```.

~If null is the only return type, a new exception will be thrown.~ It's not, see comments below

### Fixed Issues
1. magento/magento2#25656: M2.3.2 : Nullable getters in Service Contracts will throw a reflection error when used in the web API

### Manual testing scenarios (*)
1. Create a simple REST WebAPI endpoint, with a getter Method as described in #25656 
2. Try to open the Swagger documentation (should work now)
3. Try to execute the API endpoint (should work now)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
