### PR TITLE
MFTF: Replace redundant Action Group with proper one - magento/module-page-cache

### DIFF
--- a/app/code/Magento/PageCache/Test/Mftf/ActionGroup/ClearCacheActionGroup.xml
+++ b/app/code/Magento/PageCache/Test/Mftf/ActionGroup/ClearCacheActionGroup.xml
@@ -12,23 +12,10 @@
         <annotations>
             <description>Goes to the Admin Cache Management page. Clicks on 'Flush Magento Cache'.</description>
         </annotations>
-        
+
         <amOnPage url="{{_ENV.MAGENTO_BACKEND_NAME}}/admin/cache/" stepKey="goToNewCustomVarialePage"/>
         <waitForPageLoad stepKey="waitForPageLoad"/>
         <click selector="{{AdminCacheManagementSection.FlushMagentoCache}}" stepKey="clickFlushMagentoCache"/>
-        <waitForPageLoad stepKey="waitForCacheFlush"/>
-    </actionGroup>
-    
-    <actionGroup name="clearPageCache">
-        <annotations>
-            <description>Goes to the Admin Cache Management page. Selects 'Refresh'. Checks the 'Page Cache' row. Clicks on Submit.</description>
-        </annotations>
-
-        <amOnPage url="{{_ENV.MAGENTO_BACKEND_NAME}}/admin/cache/" stepKey="amOnCacheManagementPage"/>
-        <waitForPageLoad stepKey="waitForCacheManagement"/>
-        <selectOption selector="{{AdminCacheManagementSection.massActionSelect}}" userInput="refresh" stepKey="selectRefresh"/>
-        <click selector="{{AdminCacheManagementSection.pageCacheCheckbox}}" stepKey="selectPageCache"/>
-        <click selector="{{AdminCacheManagementSection.massActionSubmit}}" stepKey="submitCacheForm"/>
         <waitForPageLoad stepKey="waitForCacheFlush"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/PageCache/Test/Mftf/ActionGroup/_Deprecated_ActionGroup.xml
+++ b/app/code/Magento/PageCache/Test/Mftf/ActionGroup/_Deprecated_ActionGroup.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<!--
+NOTICE: Action Groups in this file are DEPRECATED and SHOULD NOT BE USED anymore.
+        Please find the Comment with proper replacement for each of ActionGroups provided.
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="clearPageCache">
+        <annotations>
+            <description>Goes to the Admin Cache Management page. Selects 'Refresh'. Checks the 'Page Cache' row. Clicks on Submit.</description>
+        </annotations>
+
+        <!-- NOTICE: This ActionGroup is DEPRECATED! Use `ClearPageCacheActionGroup` instead -->
+        <amOnPage url="{{_ENV.MAGENTO_BACKEND_NAME}}/admin/cache/" stepKey="amOnCacheManagementPage"/>
+        <waitForPageLoad stepKey="waitForCacheManagement"/>
+        <selectOption selector="{{AdminCacheManagementSection.massActionSelect}}" userInput="refresh" stepKey="selectRefresh"/>
+        <click selector="{{AdminCacheManagementSection.pageCacheCheckbox}}" stepKey="selectPageCache"/>
+        <click selector="{{AdminCacheManagementSection.massActionSubmit}}" stepKey="submitCacheForm"/>
+        <waitForPageLoad stepKey="waitForCacheFlush"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/PageCache/Test/Mftf/Test/NewProductsListWidgetTest.xml
+++ b/app/code/Magento/PageCache/Test/Mftf/Test/NewProductsListWidgetTest.xml
@@ -9,21 +9,21 @@
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="NewProductsListWidgetSimpleProductTest">
-        <actionGroup ref="clearPageCache" stepKey="clearPageCache" before="amOnCmsPage"/>
+        <actionGroup ref="ClearPageCacheActionGroup" stepKey="clearPageCache" before="amOnCmsPage"/>
     </test>
     <test name="NewProductsListWidgetConfigurableProductTest">
-        <actionGroup ref="clearPageCache" stepKey="clearPageCache" after="clickSaveProduct"/>
+        <actionGroup ref="ClearPageCacheActionGroup" stepKey="clearPageCache" after="clickSaveProduct"/>
     </test>
     <test name="NewProductsListWidgetGroupedProductTest">
-        <actionGroup ref="clearPageCache" stepKey="clearPageCache" after="clickSaveProduct"/>
+        <actionGroup ref="ClearPageCacheActionGroup" stepKey="clearPageCache" after="clickSaveProduct"/>
     </test>
     <test name="NewProductsListWidgetVirtualProductTest">
-        <actionGroup ref="clearPageCache" stepKey="clearPageCache" before="amOnCmsPage"/>
+        <actionGroup ref="ClearPageCacheActionGroup" stepKey="clearPageCache" before="amOnCmsPage"/>
     </test>
     <test name="NewProductsListWidgetBundleProductTest">
-        <actionGroup ref="clearPageCache" stepKey="clearPageCache" after="clickSaveProduct"/>
+        <actionGroup ref="ClearPageCacheActionGroup" stepKey="clearPageCache" after="clickSaveProduct"/>
     </test>
     <test name="NewProductsListWidgetDownloadableProductTest">
-        <actionGroup ref="clearPageCache" stepKey="clearPageCache" after="clickSaveProduct"/>
+        <actionGroup ref="ClearPageCacheActionGroup" stepKey="clearPageCache" after="clickSaveProduct"/>
     </test>
 </tests>


### PR DESCRIPTION
### Description (*)
Remove one redundant Action Group 
Replace references to the right one.

@rogyar / @okolesnyk Please keep in mind that the tests there do not test anything!

### Fixed Issues (if relevant)
1. magento/magento2#22853

### Questions or comments
Had to extract the changes per-module. The previous try failed, because of conflicts.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)