### PR TITLE
Escaped ACL resource title when parsed via TreeBuilder

### DIFF
--- a/lib/internal/Magento/Framework/Acl/AclResource/TreeBuilder.php
+++ b/lib/internal/Magento/Framework/Acl/AclResource/TreeBuilder.php
@@ -5,8 +5,26 @@
  */
 namespace Magento\Framework\Acl\AclResource;
 
+use \Magento\Framework\Escaper;
+
 class TreeBuilder
 {
+    /**
+     * @var Escaper
+     */
+    private $escaper;
+
+    /**
+    * Class constructor
+    *
+    * @param Escaper $escaper
+    */
+    public function __construct(
+        Escaper $escaper
+    ) {
+        $this->escaper = $escaper;
+    }
+
     /**
      * Transform resource list into sorted resource tree that includes only active resources
      *
@@ -21,6 +39,9 @@ class TreeBuilder
                 continue;
             }
             unset($resource['disabled']);
+            if (isset($resource['title']) && !empty($resource['title'])) {
+                $resource['title'] = $this->escaper->escapeQuote($resource['title']);
+            }
             $resource['children'] = $this->build($resource['children']);
             $result[] = $resource;
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
### Description (*)

If the ACL title attribute from resource node in acl.xml files contains single quotes, the Backend interface from Role Resources will break down.

### Preconditions (*)
<!---
    Please provide as detailed information about your environment as possible.
    For example Magento version, tag, HEAD, PHP & MySQL version, etc..
-->
1. Magento 2.3.3

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create an acl.xml with a resource where the title contains single quotes or edit existing one.

#### Example:

```
module-checkout/etc/acl.xml
...
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
    <acl>
        <resources>
            <resource id="Magento_Backend::admin">
                <resource id="Magento_Backend::stores">
                    <resource id="Magento_Backend::stores_settings">
                        <resource id="Magento_Config::config">
                            <resource id="Magento_Checkout::checkout" title="Checkout's Section" translate="true" sortOrder="57" />
                        </resource>
                    </resource>
                </resource>
            </resource>
        </resources>
    </acl>
</config>
```
2. Access `System > Permissions > User Roles > Administrators > Roles Resources > Resource Access` and set it to `Custom`.
3. Open Browser console.

### Expected result (*)
<!--- Tell us what should happen -->

The list of ACL Resources shows up as normal.

![expected](https://user-images.githubusercontent.com/10816323/69832881-46e3ee00-1239-11ea-84a9-127594d26fc8.png)

### Actual result (*)
<!--- Tell us what happens instead -->

The interface is not showing up at all and a javascript error is thrown.

Backend Interface:
![interface](https://user-images.githubusercontent.com/10816323/69832374-94ab2700-1236-11ea-9bc8-a506636b7b85.png)

Javascript Error:
![javascript_error](https://user-images.githubusercontent.com/10816323/69832373-92e16380-1236-11ea-8305-aec18588ffbc.png)

View Page Source:
![page_source](https://user-images.githubusercontent.com/10816323/69832367-89f09200-1236-11ea-8f81-3cc000a9a0f2.png)

As we can see from the View Page Source screenshot, the JSON is invalid because it contains both double and singles quotes.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
