### PR TITLE
#25832 Allow to set negative number for attribute position

### DIFF
--- a/app/code/Magento/LayeredNavigation/Observer/Edit/Tab/Front/ProductAttributeFormBuildFrontTabObserver.php
+++ b/app/code/Magento/LayeredNavigation/Observer/Edit/Tab/Front/ProductAttributeFormBuildFrontTabObserver.php
@@ -93,7 +93,7 @@ class ProductAttributeFormBuildFrontTabObserver implements ObserverInterface
                 'label' => __('Position'),
                 'title' => __('Position in Layered Navigation'),
                 'note' => __('Position of attribute in layered navigation block.'),
-                'class' => 'validate-digits'
+                'class' => 'integer'
             ]
         );
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Change attribute position field validation from validate-digits ("Please enter a valid number in this field") to integer ("A positive or negative non-decimal number please")

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25832: Allow to set negative number for attribute position in layered navigation

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to admin -> stores -> attributes -> product
2. Try to enter negative number for position in storefront properties
3. Clear cache and check if attribute has higher priority than attributes with position 0

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds are green)
