### PR TITLE
Fix catalog page add configurable product to wishlist

### DIFF
--- a/app/code/Magento/Wishlist/view/frontend/web/js/add-to-wishlist.js
+++ b/app/code/Magento/Wishlist/view/frontend/web/js/add-to-wishlist.js
@@ -60,40 +60,28 @@ define([
          */
         _updateWishlistData: function (event) {
             var dataToAdd = {},
-                isFileUploaded = false,
-                self = this;
+                self = this,
+                element = $(event.target);
 
-            if (event.handleObj.selector == this.options.qtyInfo) { //eslint-disable-line eqeqeq
-                this._updateAddToWishlistButton({});
-                event.stopPropagation();
-
-                return;
-            }
-            $(event.handleObj.selector).each(function (index, element) {
-                if ($(element).is('input[type=text]') ||
-                    $(element).is('input[type=email]') ||
-                    $(element).is('input[type=number]') ||
-                    $(element).is('input[type=hidden]') ||
-                    $(element).is('input[type=checkbox]:checked') ||
-                    $(element).is('input[type=radio]:checked') ||
-                    $(element).is('textarea') ||
-                    $('#' + element.id + ' option:selected').length
-                ) {
-                    if ($(element).data('selector') || $(element).attr('name')) {
-                        dataToAdd = $.extend({}, dataToAdd, self._getElementData(element));
-                    }
-
-                    return;
-                }
-
-                if ($(element).is('input[type=file]') && $(element).val()) {
-                    isFileUploaded = true;
-                }
-            });
-
-            if (isFileUploaded) {
+            if (element.is('input[type=file]') && element.val()) {
                 this.bindFormSubmit();
             }
+
+            if (!element.is(this.options.qtyInfo) &&
+                element.is('input[type=text]') ||
+                element.is('input[type=email]') ||
+                element.is('input[type=number]') ||
+                element.is('input[type=hidden]') ||
+                element.is('input[type=checkbox]:checked') ||
+                element.is('input[type=radio]:checked') ||
+                element.is('textarea') ||
+                $('#' + element.id + ' option:selected').length
+            ) {
+                if (element.data('selector') || element.attr('name')) {
+                    dataToAdd = $.extend(dataToAdd, self._getElementData(element));
+                }
+            }
+
             this._updateAddToWishlistButton(dataToAdd);
             event.stopPropagation();
         },


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When changing a configurable product's options on the catalog page, the wishlist item option iterates over every option for every attribute and every product on the page, repeatedly overwriting the saved value and only remembering the last value on the page.
This fix changes the wishlist option update to only evaluate the single option that triggered the event.
The PR also includes some refactoring of the _updateWishlistData method.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25091: Product option not reflated at my wish list when added from listing page

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to a catalog page with several configurable products sharing the same attribute option. For the Magento sample data, this would be for example the women's jackets category.
2. Set the options of any product but the last and add this product to the wishlist.
3. Go to wishlist and click on the just added product
4. The options set on the catalog page should be set on the product detail page

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
Are there situations, where the removed iterations over every option was necessary, that could be negatively affected by this change?

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
