### PR TITLE
magento/magento2#25866: Fixed negative number for out of stock threshold

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/System/Config/Backend/Minqty.php
+++ b/app/code/Magento/CatalogInventory/Model/System/Config/Backend/Minqty.php
@@ -19,7 +19,8 @@ class Minqty extends \Magento\Framework\App\Config\Value
     public function beforeSave()
     {
         parent::beforeSave();
-        $minQty = (int) $this->getValue() >= 0 ? (int) $this->getValue() : (int) $this->getOldValue();
+        $value = (int) $this->getValue();
+        $minQty = !empty($value) ? $value : 0;
         $this->setValue((string) $minQty);
         return $this;
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Improved the validation for minQty. It was using the old value if provided quantity threshold was negative.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25158: Can't set products' Out of Stock Threshold to a negative value
2. magento/magento2#25866: Can not set Negative number for Out of stock threshold

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Setted threshold to -10
2. Setted threshold to 50
3. Left threshold empty

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - ~[ ] All new or changed code is covered with unit/integration tests (if applicable)~
 - [x] All automated tests passed successfully (all builds are green)
