### PR TITLE
Prevent RequireJS from adding .min.js suffix to external files

### DIFF
--- a/lib/internal/Magento/Framework/RequireJs/Config.php
+++ b/lib/internal/Magento/Framework/RequireJs/Config.php
@@ -196,11 +196,14 @@ config;
      */
     public function getMixinsFileRelativePath()
     {
-        $map = $this->getRepositoryFilesMap(Config::MIXINS_FILE_NAME, [
-            'area' => $this->staticContext->getAreaCode(),
-            'theme' => $this->staticContext->getThemePath(),
-            'locale' => $this->staticContext->getLocale(),
-        ]);
+        $map = $this->getRepositoryFilesMap(
+            Config::MIXINS_FILE_NAME,
+            [
+                'area' => $this->staticContext->getAreaCode(),
+                'theme' => $this->staticContext->getThemePath(),
+                'locale' => $this->staticContext->getLocale(),
+            ]
+        );
         if ($map) {
             $relativePath = implode('/', $map) . '/' . Config::MIXINS_FILE_NAME;
         } else {
@@ -254,11 +257,14 @@ config;
      */
     public function getUrlResolverFileRelativePath()
     {
-        $map = $this->getRepositoryFilesMap(Config::URL_RESOLVER_FILE_NAME, [
-            'area' => $this->staticContext->getAreaCode(),
-            'theme' => $this->staticContext->getThemePath(),
-            'locale' => $this->staticContext->getLocale(),
-        ]);
+        $map = $this->getRepositoryFilesMap(
+            Config::URL_RESOLVER_FILE_NAME,
+            [
+                'area' => $this->staticContext->getAreaCode(),
+                'theme' => $this->staticContext->getThemePath(),
+                'locale' => $this->staticContext->getLocale(),
+            ]
+        );
         if ($map) {
             $relativePath = implode('/', $map) . '/' . Config::URL_RESOLVER_FILE_NAME;
         } else {
@@ -278,6 +284,8 @@ config;
     }
 
     /**
+     * Get path to configuration file
+     *
      * @return string
      */
     protected function getConfigFileName()
@@ -286,11 +294,13 @@ config;
     }
 
     /**
+     * Get resolver code which RequireJS fetch minified files instead
+     *
      * @return string
      */
     public function getMinResolverCode()
     {
-        $excludes = [];
+        $excludes = ['url.indexOf(baseUrl) === 0'];
         foreach ($this->minification->getExcludes('js') as $expression) {
             $excludes[] = '!url.match(/' . str_replace('/', '\/', $expression) . '/)';
         }
@@ -298,7 +308,8 @@ config;
 
         $result = <<<code
     var ctx = require.s.contexts._,
-        origNameToUrl = ctx.nameToUrl;
+        origNameToUrl = ctx.nameToUrl,
+        baseUrl = ctx.config.baseUrl;
 
     ctx.nameToUrl = function() {
         var url = origNameToUrl.apply(ctx, arguments);
@@ -317,6 +328,8 @@ code;
     }
 
     /**
+     * Get map for given file.
+     *
      * @param string $fileId
      * @param array $params
      * @return array

--- a/lib/internal/Magento/Framework/RequireJs/Test/Unit/ConfigTest.php
+++ b/lib/internal/Magento/Framework/RequireJs/Test/Unit/ConfigTest.php
@@ -101,9 +101,13 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     {
         $this->fileReader->expects($this->any())
             ->method('readAll')
-            ->will($this->returnCallback(function ($file) {
-                return $file . ' content';
-            }));
+            ->will(
+                $this->returnCallback(
+                    function ($file) {
+                        return $file . ' content';
+                    }
+                )
+            );
         $fileOne = $this->createMock(\Magento\Framework\View\File::class);
         $fileOne->expects($this->once())
             ->method('getFilename')
@@ -180,11 +184,12 @@ expected;
 
         $expected = <<<code
     var ctx = require.s.contexts._,
-        origNameToUrl = ctx.nameToUrl;
+        origNameToUrl = ctx.nameToUrl,
+        baseUrl = ctx.config.baseUrl;
 
     ctx.nameToUrl = function() {
         var url = origNameToUrl.apply(ctx, arguments);
-        if (!url.match(/\.min\./)) {
+        if (url.indexOf(baseUrl) === 0&&!url.match(/\.min\./)) {
             url = url.replace(/(\.min)?\.js$/, '.min.js');
         }
         return url;


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This commit adds and additional check if file belongs to current base URL before setting `min.js` suffix.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25690: RequireJs is not resolving CDN path for some js files

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Enable JavaScript minification in admin panel.
2. In developer console execute `require(['https://magento.com/test.js'], console.log);`.
3. In network tab verify that the request was made for `test.js` and not for `test.min.js`.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
