### PR TITLE
Advance the order state to processing when a capture notification is received

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Payment/State/RegisterCaptureNotificationCommand.php
+++ b/app/code/Magento/Sales/Model/Order/Payment/State/RegisterCaptureNotificationCommand.php
@@ -11,6 +11,11 @@ use Magento\Sales\Api\Data\OrderPaymentInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\StatusResolver;
 
+/**
+ * Class RegisterCaptureNotificationCommand
+ *
+ * @package Magento\Sales\Model\Order\Payment\State
+ */
 class RegisterCaptureNotificationCommand implements CommandInterface
 {
     /**
@@ -23,11 +28,12 @@ class RegisterCaptureNotificationCommand implements CommandInterface
      */
     public function __construct(StatusResolver $statusResolver = null)
     {
-        $this->statusResolver = $statusResolver
-            ? : ObjectManager::getInstance()->get(StatusResolver::class);
+        $this->statusResolver = $statusResolver ?: ObjectManager::getInstance()->get(StatusResolver::class);
     }
 
     /**
+     * Registers a capture event for this payment
+     *
      * @param OrderPaymentInterface $payment
      * @param string|float|int $amount
      * @param OrderInterface $order
@@ -35,7 +41,11 @@ class RegisterCaptureNotificationCommand implements CommandInterface
      */
     public function execute(OrderPaymentInterface $payment, $amount, OrderInterface $order)
     {
-        $state = $order->getState() ?: Order::STATE_PROCESSING;
+        $state = $order->getState();
+        if (!$state || $state === Order::STATE_NEW || $state === Order::STATE_PENDING_PAYMENT) {
+            $state = Order::STATE_PROCESSING;
+        }
+
         $status = null;
         $message = 'Registered notification about captured amount of %1.';
 
@@ -61,6 +71,8 @@ class RegisterCaptureNotificationCommand implements CommandInterface
     }
 
     /**
+     * Sets the state and status of the order
+     *
      * @deprecated 100.2.0 Replaced by a StatusResolver class call.
      *
      * @param Order $order

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/State/RegisterCaptureNotificationCommandTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/State/RegisterCaptureNotificationCommandTest.php
@@ -81,6 +81,22 @@ class RegisterCaptureNotificationCommandTest extends \PHPUnit\Framework\TestCase
                 'Registered notification about captured amount of %1.',
             ],
             [
+                false,
+                false,
+                Order::STATE_NEW,
+                Order::STATE_PROCESSING,
+                $this->newOrderStatus,
+                'Registered notification about captured amount of %1.',
+            ],
+            [
+                false,
+                false,
+                Order::STATE_PENDING_PAYMENT,
+                Order::STATE_PROCESSING,
+                $this->newOrderStatus,
+                'Registered notification about captured amount of %1.',
+            ],
+            [
                 true,
                 false,
                 Order::STATE_PROCESSING,


### PR DESCRIPTION
### Description (*)
When the registerCaptureNotificationCommand is executed, if the order is in state "new" or "pending payment", then its state is advanced to "processing", as it was up to Magento 2.2.5.
This should fix issues with orders remaining in "pending payment" state even though they were correctly paid. See issue #25659
Previously this command would set the state to "processing" only if the order did not already have a state set. This PR changes that check to do the same for "new" and "pending payment" orders too.
The unit test covering the command has been updated to include the new test cases.

### Fixed Issues (if relevant)
magento/magento2#25659: Paypal Payments Pro IPN keeping payments marked as Pending Payment

### Manual testing scenarios (*)
Prerequisite: a payment method must be installed and enabled that initially creates orders in state "new" or "pending payment" and then uses the "registerCaptureNotification" command to indicate when the payment is captured.

1. Place an order with the aforementioned payment method
2. When the payment is complete and the payment method has issued the registerCaptureNotification command, check the state of the generated order. Without this PR the state will still be "new" or "pending payment". With this PR the state becomes "processing"
