### PR TITLE
Function getApiIdentifier can return null when config value is not set.

### DIFF
--- a/app/code/Magento/CardinalCommerce/Model/Config.php
+++ b/app/code/Magento/CardinalCommerce/Model/Config.php
@@ -54,9 +54,9 @@ class Config
      * GUID used to identify the specific API Key.
      *
      * @param int|null $storeId
-     * @return string
+     * @return string|null
      */
-    public function getApiIdentifier(?int $storeId = null): string
+    public function getApiIdentifier(?int $storeId = null): ?string
     {
         $apiIdentifier = $this->scopeConfig->getValue(
             'three_d_secure/cardinal/api_identifier',


### PR DESCRIPTION
### Description (*)
In this PR I changed the type definition for app/code/Magento/CardinalCommerce/Model/Config.php::getApiIdentifier to allow it to return null values. The returned value can be null when the `three_d_secure/cardinal/api_identifier` config setting is not set. This can cause an exception since, strict types is est to 1 for this file: https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/CardinalCommerce/Model/Config.php#L6

### Fixed Issues (if relevant)
1. None that I could find

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Make sure three_d_secure/cardinal/api_identifier is not set in the database (I believe it is not set by default).
2. Call app/code/Magento/CardinalCommerce/Model/Config.php::getApiIdentifier
3. You should see an exception.

Note: I encountered the exception when navigating to the onestepcheckout provided by https://www.mageplaza.com/magento-2-one-step-checkout-extension/
I am not sure when the function might be called in a vanilla instance of Magento, however since it will return null when the config value is not set, allowing null in the return type is required and will potentially fix some bugs.

### Questions or comments
Note that there are more functions in the class that also return config values but do not allow null as return type. I haven't checked these, but I suspect they should also be changed in the same way.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
