### PR TITLE
[Ui] Adding admin class for password input type.

### DIFF
--- a/app/code/Magento/Backend/Block/System/Account/Edit/Form.php
+++ b/app/code/Magento/Backend/Block/System/Account/Edit/Form.php
@@ -114,7 +114,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'name' => 'password',
                 'label' => __('New Password'),
                 'title' => __('New Password'),
-                'class' => 'validate-admin-password admin__control-text'
+                'class' => 'validate-admin-password'
             ]
         );
 
@@ -124,7 +124,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             [
                 'name' => 'password_confirmation',
                 'label' => __('Password Confirmation'),
-                'class' => 'validate-cpassword admin__control-text'
+                'class' => 'validate-cpassword'
             ]
         );
 
@@ -152,7 +152,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'label' => __('Your Password'),
                 'id' => self::IDENTITY_VERIFICATION_PASSWORD_FIELD,
                 'title' => __('Your Password'),
-                'class' => 'validate-current-password required-entry admin__control-text',
+                'class' => 'validate-current-password required-entry',
                 'required' => true
             ]
         );

--- a/app/code/Magento/Backend/Block/System/Account/Edit/Form.php
+++ b/app/code/Magento/Backend/Block/System/Account/Edit/Form.php
@@ -68,7 +68,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function _prepareForm()
     {

--- a/app/code/Magento/Integration/Block/Adminhtml/Integration/Edit/Tab/Info.php
+++ b/app/code/Magento/Integration/Block/Adminhtml/Integration/Edit/Tab/Info.php
@@ -179,7 +179,7 @@ class Info extends \Magento\Backend\Block\Widget\Form\Generic implements \Magent
                 'label' => __('Your Password'),
                 'id' => self::DATA_CONSUMER_PASSWORD,
                 'title' => __('Your Password'),
-                'class' => 'input-text validate-current-password required-entry',
+                'class' => 'validate-current-password required-entry',
                 'required' => true
             ]
         );

--- a/app/code/Magento/User/Block/Role/Tab/Info.php
+++ b/app/code/Magento/User/Block/Role/Tab/Info.php
@@ -6,7 +6,7 @@
 namespace Magento\User\Block\Role\Tab;
 
 /**
- * implementing now
+ * Info
  *
  * @SuppressWarnings(PHPMD.DepthOfInheritance)
  */
@@ -18,6 +18,8 @@ class Info extends \Magento\Backend\Block\Widget\Form\Generic implements \Magent
     const IDENTITY_VERIFICATION_PASSWORD_FIELD = 'current_password';
 
     /**
+     * Get tab label
+     *
      * @return \Magento\Framework\Phrase
      */
     public function getTabLabel()
@@ -26,6 +28,8 @@ class Info extends \Magento\Backend\Block\Widget\Form\Generic implements \Magent
     }
 
     /**
+     * Get tab title
+     *
      * @return string
      */
     public function getTabTitle()
@@ -34,6 +38,8 @@ class Info extends \Magento\Backend\Block\Widget\Form\Generic implements \Magent
     }
 
     /**
+     * Can show tab
+     *
      * @return bool
      */
     public function canShowTab()
@@ -42,6 +48,8 @@ class Info extends \Magento\Backend\Block\Widget\Form\Generic implements \Magent
     }
 
     /**
+     * Is tab hidden
+     *
      * @return bool
      */
     public function isHidden()
@@ -50,6 +58,8 @@ class Info extends \Magento\Backend\Block\Widget\Form\Generic implements \Magent
     }
 
     /**
+     * Before html rendering
+     *
      * @return $this
      */
     public function _beforeToHtml()
@@ -60,6 +70,8 @@ class Info extends \Magento\Backend\Block\Widget\Form\Generic implements \Magent
     }
 
     /**
+     * Form initializatiion
+     *
      * @return void
      */
     protected function _initForm()

--- a/app/code/Magento/User/Block/Role/Tab/Info.php
+++ b/app/code/Magento/User/Block/Role/Tab/Info.php
@@ -99,7 +99,7 @@ class Info extends \Magento\Backend\Block\Widget\Form\Generic implements \Magent
                 'label' => __('Your Password'),
                 'id' => self::IDENTITY_VERIFICATION_PASSWORD_FIELD,
                 'title' => __('Your Password'),
-                'class' => 'input-text validate-current-password required-entry',
+                'class' => 'validate-current-password required-entry',
                 'required' => true
             ]
         );

--- a/app/code/Magento/User/Block/Role/Tab/Info.php
+++ b/app/code/Magento/User/Block/Role/Tab/Info.php
@@ -8,6 +8,8 @@ namespace Magento\User\Block\Role\Tab;
 /**
  * Info
  *
+ * User role tab info
+ *
  * @SuppressWarnings(PHPMD.DepthOfInheritance)
  */
 class Info extends \Magento\Backend\Block\Widget\Form\Generic implements \Magento\Backend\Block\Widget\Tab\TabInterface

--- a/app/code/Magento/User/Block/User/Edit/Tab/Main.php
+++ b/app/code/Magento/User/Block/User/Edit/Tab/Main.php
@@ -184,7 +184,7 @@ class Main extends \Magento\Backend\Block\Widget\Form\Generic
                 'label' => __('Your Password'),
                 'id' => self::CURRENT_USER_PASSWORD_FIELD,
                 'title' => __('Your Password'),
-                'class' => 'input-text validate-current-password required-entry',
+                'class' => 'validate-current-password required-entry',
                 'required' => true
             ]
         );

--- a/lib/internal/Magento/Framework/Data/Form/Element/Password.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Password.php
@@ -38,11 +38,14 @@ class Password extends AbstractElement
     }
 
     /**
+     * Get field html
+     *
      * @return mixed
      */
     public function getHtml()
     {
         $this->addClass('input-text admin__control-text');
+
         return parent::getHtml();
     }
 }

--- a/lib/internal/Magento/Framework/Data/Form/Element/Password.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/Password.php
@@ -13,6 +13,11 @@ namespace Magento\Framework\Data\Form\Element;
 
 use Magento\Framework\Escaper;
 
+/**
+ * Class Password
+ *
+ * Password input type
+ */
 class Password extends AbstractElement
 {
     /**
@@ -37,7 +42,7 @@ class Password extends AbstractElement
      */
     public function getHtml()
     {
-        $this->addClass('input-text');
+        $this->addClass('input-text admin__control-text');
         return parent::getHtml();
     }
 }

--- a/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/PasswordTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/PasswordTest.php
@@ -53,6 +53,6 @@ class PasswordTest extends \PHPUnit\Framework\TestCase
     {
         $html = $this->_model->getHtml();
         $this->assertContains('type="password"', $html);
-        $this->assertTrue(preg_match('/class=\".*input-text.*\"/i', $html) > 0);
+        $this->assertTrue(preg_match('/class=\"* input-text admin__control-text.*\"/i', $html) > 0);
     }
 }


### PR DESCRIPTION

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes the password type input, by applying the proper class name. It also removes the classes for existing inputs, to avoid duplicated class names.

### Fixed Issues (if relevant)
1. magento/magento2#25917: Admin confirm password input doesn't inherit needed styles

### Manual testing scenarios (*)

1. Navigate to `System / Integrations`
2. Click on `Add New Integration` button
3. Scroll down to `Current User Identity Verification` fieldset

### Questions or comments


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
