### PR TITLE
Resolve Duplicate Records when sorting column in Content->Themes Grid issue25925

### DIFF
--- a/app/code/Magento/Theme/Test/Mftf/Section/AdminThemeSection.xml
+++ b/app/code/Magento/Theme/Test/Mftf/Section/AdminThemeSection.xml
@@ -15,7 +15,8 @@
         <element name="rowsInThemeTitleColumn" type="text" selector="//tbody/tr/td[contains(@class, 'parent_theme')]/preceding-sibling::td"/>
         <element name="rowsInColumn" type="text" selector="//tbody/tr/td[contains(@class, '{{column}}')]" parameterized="true"/>
         <!--Specific cell e.g. {{Section.gridCell('Name')}}-->
-        <element name="gridCell" type="text" selector="//table[@id='theme_grid_table']//td[contains(text(), '{{gridCellText}}')]" parameterized="true"/>
+        <element name="gridCell" type="text" selector="//table//div[contains(text(), '{{gridCellText}}')]" parameterized="true"/>
+        <element name="gridCellUpdated" type="text" selector="//tbody//tr//div[contains(text(), '{{gridCellText}}')]" parameterized="true"/>
         <element name="columnHeader" type="text" selector="//thead/tr/th[contains(@class, 'data-grid-th')]/span[text() = '{{label}}']" parameterized="true" timeout="30"/>
     </section>
 </sections>

--- a/app/code/Magento/Theme/Test/Mftf/Test/AdminContentThemeSortTest.xml
+++ b/app/code/Magento/Theme/Test/Mftf/Test/AdminContentThemeSortTest.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminContentThemesSortTest">
+        <annotations>
+            <features value="Theme"/>
+            <stories value="Menu Navigation"/>
+            <title value="Admin content themes sort themes test"/>
+            <description value="Admin should be able to sort Themes"/>
+            <severity value="CRITICAL"/>
+            <testCaseId value="https://github.com/magento/magento2/pull/25926"/>
+            <group value="menu"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="LoginAsAdmin"/>
+        </before>
+        <after>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+        <actionGroup ref="AdminNavigateMenuActionGroup" stepKey="navigateToContentThemesPage">
+            <argument name="menuUiId" value="{{AdminMenuContent.dataUiId}}"/>
+            <argument name="submenuUiId" value="{{AdminMenuContentDesignThemes.dataUiId}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminAssertPageTitleActionGroup" stepKey="seePageTitle">
+            <argument name="title" value="{{AdminMenuContentDesignThemes.pageTitle}}"/>
+        </actionGroup>
+	<click selector="{{AdminThemeSection.columnHeader('Theme Title')}}" stepKey="clickSortByTitle"/>
+	<click selector="{{AdminThemeSection.columnHeader('Theme Title')}}" stepKey="clickSortByTitleSecondTime"/>
+        <seeNumberOfElements selector="{{AdminThemeSection.rowsInColumn('theme_path')}}" userInput="2" stepKey="see2RowsOnTheGrid"/>
+        <seeElement selector="{{AdminThemeSection.gridCellUpdated('Magento Luma')}}" stepKey="seeLumaThemeInTitleColumn"/>
+        <seeElement selector="{{AdminThemeSection.gridCellUpdated('Magento Blank')}}" stepKey="seeBlankThemeInTitleColumn"/>
+    </test>
+</tests>

--- a/app/code/Magento/Theme/Test/Mftf/Test/AdminContentThemeSortTest.xml
+++ b/app/code/Magento/Theme/Test/Mftf/Test/AdminContentThemeSortTest.xml
@@ -34,7 +34,6 @@
         <click selector="{{AdminThemeSection.columnHeader('Theme Title')}}" stepKey="clickSortByTitle"/>
         <click selector="{{AdminThemeSection.columnHeader('Theme Title')}}" stepKey="clickSortByTitleSecondTime"/>
         <seeNumberOfElements selector="{{AdminThemeSection.rowsInColumn('theme_path')}}" userInput="2" stepKey="see2RowsOnTheGrid"/>
-        <seeElement selector="{{AdminThemeSection.gridCellUpdated('Magento Luma')}}" stepKey="seeLumaThemeInTitleColumn"/>
-        <seeElement selector="{{AdminThemeSection.gridCellUpdated('Magento Blank')}}" stepKey="seeBlankThemeInTitleColumn"/>
+        <seeNumberOfElements selector="{{AdminThemeSection.gridCellUpdated('Magento Luma')}}" userInput="1" stepKey="seeLumaThemeInTitleColumn"/>
     </test>
 </tests>

--- a/app/code/Magento/Theme/Test/Mftf/Test/AdminContentThemeSortTest.xml
+++ b/app/code/Magento/Theme/Test/Mftf/Test/AdminContentThemeSortTest.xml
@@ -31,8 +31,8 @@
         <actionGroup ref="AdminAssertPageTitleActionGroup" stepKey="seePageTitle">
             <argument name="title" value="{{AdminMenuContentDesignThemes.pageTitle}}"/>
         </actionGroup>
-	<click selector="{{AdminThemeSection.columnHeader('Theme Title')}}" stepKey="clickSortByTitle"/>
-	<click selector="{{AdminThemeSection.columnHeader('Theme Title')}}" stepKey="clickSortByTitleSecondTime"/>
+        <click selector="{{AdminThemeSection.columnHeader('Theme Title')}}" stepKey="clickSortByTitle"/>
+        <click selector="{{AdminThemeSection.columnHeader('Theme Title')}}" stepKey="clickSortByTitleSecondTime"/>
         <seeNumberOfElements selector="{{AdminThemeSection.rowsInColumn('theme_path')}}" userInput="2" stepKey="see2RowsOnTheGrid"/>
         <seeElement selector="{{AdminThemeSection.gridCellUpdated('Magento Luma')}}" stepKey="seeLumaThemeInTitleColumn"/>
         <seeElement selector="{{AdminThemeSection.gridCellUpdated('Magento Blank')}}" stepKey="seeBlankThemeInTitleColumn"/>

--- a/app/code/Magento/Theme/view/adminhtml/ui_component/design_theme_listing.xml
+++ b/app/code/Magento/Theme/view/adminhtml/ui_component/design_theme_listing.xml
@@ -20,6 +20,9 @@
     <dataSource name="design_theme_listing_data_source" component="Magento_Ui/js/grid/provider">
         <settings>
             <updateUrl path="mui/index/render"/>
+            <storageConfig>
+                <param name="indexField" xsi:type="string">theme_id</param>
+            </storageConfig>
         </settings>
         <aclResource>Magento_Theme::theme</aclResource>
         <dataProvider class="Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider" name="design_theme_listing_data_source">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. Resolve magento/magento2#25925: Duplicate Records when sorting column in Content->Themes Grid

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25925: Duplicate Records when sorting column in Content->Themes Grid

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to backend
2. Content->Themes
3. Click Theme Title to sort
4. Click Theme title to sort again
=> Doesn't duplicate records

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
