### PR TITLE
[ProductAlert] Cover Helper Data by Unit Test

### DIFF
--- a/app/code/Magento/ProductAlert/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/ProductAlert/Test/Unit/Helper/DataTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductAlert\Test\Unit\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Magento\ProductAlert\Helper\Data as HelperData;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\Framework\UrlInterface;
+use Magento\Framework\Url\EncoderInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\ProductAlert\Model\Observer;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Framework\View\LayoutInterface;
+use Magento\ProductAlert\Block\Email\Price;
+use Magento\Framework\Exception\LocalizedException;
+
+class DataTest extends TestCase
+{
+    /**
+     * @var HelperData
+     */
+    private $helper;
+
+    /**
+     * @var ObjectManagerHelper
+     */
+    private $objectManagerHelper;
+
+    /**
+     * @var Context|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $contextMock;
+
+    /**
+     * @var UrlInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $urlBuilderMock;
+
+    /**
+     * @var EncoderInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $encoderMock;
+
+    /**
+     * @var ScopeConfigInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $scopeConfigMock;
+
+    /**
+     * @var LayoutInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $layoutMock;
+
+    /**
+     * Setup environment for testing
+     */
+    protected function setUp()
+    {
+        $this->contextMock = $this->createMock(Context::class);
+        $this->urlBuilderMock = $this->createMock(UrlInterface::class);
+        $this->encoderMock = $this->createMock(EncoderInterface::class);
+        $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
+        $this->layoutMock = $this->createMock(LayoutInterface::class);
+        $this->contextMock->expects($this->once())->method('getUrlBuilder')->willReturn($this->urlBuilderMock);
+        $this->contextMock->expects($this->once())->method('getUrlEncoder')->willReturn($this->encoderMock);
+        $this->contextMock->expects($this->once())->method('getScopeConfig')->willReturn($this->scopeConfigMock);
+
+        $this->objectManagerHelper = new ObjectManagerHelper($this);
+
+        $productMock = $this->createMock(Product::class);
+        $productMock->expects($this->any())->method('getId')->willReturn(1);
+
+        $this->helper = $this->objectManagerHelper->getObject(
+            HelperData::class,
+            [
+                'context' => $this->contextMock,
+                'layout' => $this->layoutMock
+            ]
+        );
+        $this->helper->setProduct($productMock);
+    }
+
+    /**
+     * Test getSaveUrl() function
+     */
+    public function testGetSaveUrl()
+    {
+        $currentUrl = 'http://www.example.com/';
+        $type = 'stock';
+        $uenc = strtr(base64_encode($currentUrl), '+/=', '-_,');
+        $expected = 'http://www.example.com/roductalert/add/stock/product_id/1/uenc/' . $uenc;
+
+        $this->urlBuilderMock->expects($this->any())->method('getCurrentUrl')->willReturn($currentUrl);
+        $this->encoderMock->expects($this->any())->method('encode')
+            ->with($currentUrl)
+            ->willReturn($uenc);
+        $this->urlBuilderMock->expects($this->any())->method('getUrl')
+            ->with(
+                'productalert/add/' . $type,
+                [
+                    'product_id' => 1,
+                    'uenc' => $uenc
+                ]
+            )
+            ->willReturn($expected);
+
+        $this->assertEquals($expected, $this->helper->getSaveUrl($type));
+    }
+
+    /**
+     * Test createBlock() with no exception
+     */
+    public function testCreateBlockWithNoException()
+    {
+        $priceBlockMock = $this->createMock(Price::class);
+        $this->layoutMock->expects($this->once())->method('createBlock')->willReturn($priceBlockMock);
+
+        $this->assertEquals($priceBlockMock, $this->helper->createBlock(Price::class));
+    }
+
+    /**
+     * Test createBlock() with exception
+     */
+    public function testCreateBlockWithException()
+    {
+        $invalidBlock = $this->createMock(Product::class);
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage((string)__('Invalid block type: %1'));
+
+        $this->helper->createBlock($invalidBlock);
+    }
+
+    /**
+     * Test isStockAlertAllowed() function with Yes settings
+     */
+    public function testIsStockAlertAllowedWithYesSettings()
+    {
+        $this->scopeConfigMock->expects($this->any())->method('isSetFlag')
+            ->with(Observer::XML_PATH_STOCK_ALLOW, ScopeInterface::SCOPE_STORE)
+            ->willReturn('1');
+
+        $this->assertEquals('1', $this->helper->isStockAlertAllowed());
+    }
+
+    /**
+     * Test isPriceAlertAllowed() function with Yes settings
+     */
+    public function testIsPriceAlertAllowedWithYesSetting()
+    {
+        $this->scopeConfigMock->expects($this->any())->method('isSetFlag')
+            ->with(Observer::XML_PATH_PRICE_ALLOW, ScopeInterface::SCOPE_STORE)
+            ->willReturn('1');
+
+        $this->assertEquals('1', $this->helper->isPriceAlertAllowed());
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

**Increase Test Coverage by Unit Test**

Cover Helper Data: **Magento\ProductAlert\Helper\Data**
- getSaveUrl
- createBlock
- isStockAlertAllowed
- isPriceAlertAllowed

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Covered by Unit Test

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
