### PR TITLE
Resolve issue 25896: Cannot create folder using only letters #25896

### DIFF
--- a/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
@@ -416,7 +416,7 @@ class Storage extends \Magento\Framework\DataObject
     {
         if (!preg_match(self::DIRECTORY_NAME_REGEXP, $name)) {
             throw new \Magento\Framework\Exception\LocalizedException(
-                __('Please rename the folder using only letters, numbers, underscores and dashes.')
+                __('Please rename the folder using only Latin letters, numbers, underscores and dashes.')
             );
         }
 

--- a/app/code/Magento/Cms/i18n/en_US.csv
+++ b/app/code/Magento/Cms/i18n/en_US.csv
@@ -75,7 +75,7 @@ Pages,Pages
 "A block identifier with the same properties already exists in the selected store.","A block identifier with the same properties already exists in the selected store."
 "The page URL key contains capital letters or disallowed symbols.","The page URL key contains capital letters or disallowed symbols."
 "The page URL key cannot be made of only numbers.","The page URL key cannot be made of only numbers."
-"Please rename the folder using only letters, numbers, underscores and dashes.","Please rename the folder using only letters, numbers, underscores and dashes."
+"Please rename the folder using only Latin letters, numbers, underscores and dashes.","Please rename the folder using only Latin letters, numbers, underscores and dashes."
 "We found a directory with the same name. Please try another folder name.","We found a directory with the same name. Please try another folder name."
 "We cannot create a new directory.","We cannot create a new directory."
 "We cannot delete directory %1.","We cannot delete directory %1."


### PR DESCRIPTION

**Description (*)**

1. Consistency between message and behavior when creating folder without latin letters while adding folder from CMS page.
Changed message to => Please rename the folder using only Latin letters, numbers, underscores and dashes.

Fixed Issues (if relevant)

1. magento/magento2#25896: Cannot create folder using only letters

**Manual testing scenarios (*)**

1. On CMS edit page open media gallery
2. Click "Create Folder"
3. Type in "папка"
4. Click "OK"

**Expected result**

1. Consistency between message and behavior. => Change message to: Please rename the folder using only Latin letters, numbers, underscores and dash

**Questions or comments**

**Contribution checklist (*)**
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
