### PR TITLE
Add plugin for SalesOrderItemRepository gift message (#19093)

### DIFF
--- a/app/code/Magento/GiftMessage/Model/Plugin/OrderItemGet.php
+++ b/app/code/Magento/GiftMessage/Model/Plugin/OrderItemGet.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GiftMessage\Model\Plugin;
+
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\GiftMessage\Api\OrderItemRepositoryInterface as GiftMessageItemRepositoryInterface;
+use Magento\Sales\Api\Data\OrderItemExtensionFactory;
+use Magento\Sales\Api\Data\OrderItemInterface;
+use Magento\Sales\Api\OrderItemRepositoryInterface;
+
+/**
+ * Plugin for adding gift message to order item
+ */
+class OrderItemGet
+{
+
+    /**
+     * @var OrderItemExtensionFactory
+     */
+    private $orderItemExtensionFactory;
+
+    /**
+     * @var GiftMessageItemRepositoryInterface
+     */
+    private $giftMessageItemRepository;
+
+    /**
+     * OrderItemGet constructor.
+     *
+     * @param GiftMessageItemRepositoryInterface $giftMessageItemRepository
+     * @param OrderItemExtensionFactory $orderItemExtensionFactory
+     */
+    public function __construct(
+        GiftMessageItemRepositoryInterface $giftMessageItemRepository,
+        OrderItemExtensionFactory $orderItemExtensionFactory
+    ) {
+        $this->giftMessageItemRepository = $giftMessageItemRepository;
+        $this->orderItemExtensionFactory = $orderItemExtensionFactory;
+    }
+
+    /**
+     * Add gift message for order item
+     *
+     * @param OrderItemRepositoryInterface $subject
+     * @param OrderItemInterface $orderItem
+     * @return OrderItemInterface
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function afterGet(OrderItemRepositoryInterface $subject, OrderItemInterface $orderItem)
+    {
+        $extensionAttributes = $orderItem->getExtensionAttributes();
+        if ($extensionAttributes && $extensionAttributes->getGiftMessage()) {
+            return $orderItem;
+        }
+        try {
+            /* @var \Magento\GiftMessage\Api\Data\MessageInterface $giftMessage */
+            $giftMessage = $this->giftMessageItemRepository->get(
+                $orderItem->getOrderId(),
+                $orderItem->getItemId()
+            );
+        } catch (NoSuchEntityException $e) {
+            return $orderItem;
+        }
+        /** @var \Magento\Sales\Api\Data\OrderItemExtension $orderItemExtension */
+        $orderItemExtension = $extensionAttributes ?: $this->orderItemExtensionFactory->create();
+        $orderItemExtension->setGiftMessage($giftMessage);
+        $orderItem->setExtensionAttributes($orderItemExtension);
+
+        return $orderItem;
+    }
+}

--- a/app/code/Magento/GiftMessage/etc/di.xml
+++ b/app/code/Magento/GiftMessage/etc/di.xml
@@ -37,4 +37,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Sales\Api\OrderItemRepositoryInterface">
+        <plugin name="get_gift_message" type="Magento\GiftMessage\Model\Plugin\OrderItemGet"/>
+    </type>
 </config>

--- a/dev/tests/api-functional/testsuite/Magento/GiftMessage/Api/OrderGetRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GiftMessage/Api/OrderGetRepositoryTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GiftMessage\Api;
+
+use Magento\TestFramework\TestCase\WebapiAbstract;
+
+class OrderGetRepositoryTest extends WebapiAbstract
+{
+    const SERVICE_VERSION = 'V1';
+
+    const SERVICE_NAME = 'giftMessageItemRepositoryV1';
+
+    const RESOURCE_PATH = '/V1/orders/';
+
+    /**
+     * @magentoDataFixture Magento/GiftMessage/_files/order_with_message.php
+     * @magentoConfigFixture default_store sales/gift_options/allow_order 1
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation disabled
+     */
+    public function testGet()
+    {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        /** @var \Magento\Sales\Model\Order $order */
+        $order = $objectManager->create(\Magento\Sales\Model\Order::class)->loadByIncrementId('100000001');
+        $orderId = $order->getId();
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => self::RESOURCE_PATH . $orderId,
+                'httpMethod' => \Magento\Framework\Webapi\Rest\Request::HTTP_METHOD_GET,
+            ],
+            'soap' => [
+                'service' => self::SERVICE_NAME,
+                'serviceVersion' => self::SERVICE_VERSION,
+                'operation' => self::SERVICE_NAME . 'Get',
+            ],
+        ];
+        $expectedMessage = [
+            'recipient' => 'Mercutio',
+            'sender' => 'Romeo',
+            'message' => 'I thought all for the best.',
+        ];
+        $requestData = ["orderId" => $orderId];
+        $result = $this->_webApiCall($serviceInfo, $requestData);
+        $resultMessage = $result['extension_attributes']['gift_message'];
+        static::assertCount(5, $resultMessage);
+        unset($resultMessage['gift_message_id']);
+        unset($resultMessage['customer_id']);
+        static::assertEquals($expectedMessage, $resultMessage);
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GiftMessage/Api/OrderGetRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GiftMessage/Api/OrderGetRepositoryTest.php
@@ -12,9 +12,7 @@ use Magento\TestFramework\TestCase\WebapiAbstract;
 class OrderGetRepositoryTest extends WebapiAbstract
 {
     const SERVICE_VERSION = 'V1';
-
-    const SERVICE_NAME = 'giftMessageItemRepositoryV1';
-
+    const SERVICE_NAME = 'salesOrderRepositoryV1';
     const RESOURCE_PATH = '/V1/orders/';
 
     /**
@@ -45,7 +43,7 @@ class OrderGetRepositoryTest extends WebapiAbstract
             'sender' => 'Romeo',
             'message' => 'I thought all for the best.',
         ];
-        $requestData = ["orderId" => $orderId];
+        $requestData = ['id' => $orderId];
         $result = $this->_webApiCall($serviceInfo, $requestData);
         $resultMessage = $result['extension_attributes']['gift_message'];
         static::assertCount(5, $resultMessage);

--- a/dev/tests/api-functional/testsuite/Magento/GiftMessage/Api/OrderItemGetRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GiftMessage/Api/OrderItemGetRepositoryTest.php
@@ -11,22 +11,9 @@ use Magento\TestFramework\TestCase\WebapiAbstract;
 
 class OrderItemGetRepositoryTest extends WebapiAbstract
 {
-
     const SERVICE_VERSION = 'V1';
-
-    const SERVICE_NAME = 'giftMessageItemRepositoryV1';
-
+    const SERVICE_NAME = 'salesOrderItemRepositoryV1';
     const RESOURCE_PATH = '/V1/orders/items/';
-
-    /**
-     * @var \Magento\TestFramework\ObjectManager
-     */
-    protected $objectManager;
-
-    protected function setUp()
-    {
-        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-    }
 
     /**
      * @magentoDataFixture Magento/GiftMessage/_files/order_with_message.php
@@ -36,8 +23,9 @@ class OrderItemGetRepositoryTest extends WebapiAbstract
      */
     public function testGet()
     {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
         /** @var \Magento\Sales\Model\Order $order */
-        $order = $this->objectManager->create(\Magento\Sales\Model\Order::class)->loadByIncrementId('100000001');
+        $order = $objectManager->create(\Magento\Sales\Model\Order::class)->loadByIncrementId('100000001');
         $items = $order->getItems();
         /** @var \Magento\Sales\Api\Data\OrderItemInterface $orderItem */
         $orderItem = array_shift($items);
@@ -58,7 +46,7 @@ class OrderItemGetRepositoryTest extends WebapiAbstract
             'sender' => 'Romeo',
             'message' => 'I thought all for the best.',
         ];
-        $requestData = ["orderItemId" => $itemId];
+        $requestData = ['id' => $itemId];
         $result = $this->_webApiCall($serviceInfo, $requestData);
         $resultMessage = $result['extension_attributes']['gift_message'];
         static::assertCount(5, $resultMessage);

--- a/dev/tests/api-functional/testsuite/Magento/GiftMessage/Api/OrderItemGetRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GiftMessage/Api/OrderItemGetRepositoryTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GiftMessage\Api;
+
+use Magento\TestFramework\TestCase\WebapiAbstract;
+
+class OrderItemGetRepositoryTest extends WebapiAbstract
+{
+
+    const SERVICE_VERSION = 'V1';
+
+    const SERVICE_NAME = 'giftMessageItemRepositoryV1';
+
+    const RESOURCE_PATH = '/V1/orders/items/';
+
+    /**
+     * @var \Magento\TestFramework\ObjectManager
+     */
+    protected $objectManager;
+
+    protected function setUp()
+    {
+        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+    }
+
+    /**
+     * @magentoDataFixture Magento/GiftMessage/_files/order_with_message.php
+     * @magentoConfigFixture default_store sales/gift_options/allow_items 1
+     * @magentoAppIsolation enabled
+     * @magentoDbIsolation disabled
+     */
+    public function testGet()
+    {
+        /** @var \Magento\Sales\Model\Order $order */
+        $order = $this->objectManager->create(\Magento\Sales\Model\Order::class)->loadByIncrementId('100000001');
+        $items = $order->getItems();
+        /** @var \Magento\Sales\Api\Data\OrderItemInterface $orderItem */
+        $orderItem = array_shift($items);
+        $itemId = $orderItem->getItemId();
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => self::RESOURCE_PATH . $itemId,
+                'httpMethod' => \Magento\Framework\Webapi\Rest\Request::HTTP_METHOD_GET,
+            ],
+            'soap' => [
+                'service' => self::SERVICE_NAME,
+                'serviceVersion' => self::SERVICE_VERSION,
+                'operation' => self::SERVICE_NAME . 'Get',
+            ],
+        ];
+        $expectedMessage = [
+            'recipient' => 'Mercutio',
+            'sender' => 'Romeo',
+            'message' => 'I thought all for the best.',
+        ];
+        $requestData = ["orderItemId" => $itemId];
+        $result = $this->_webApiCall($serviceInfo, $requestData);
+        $resultMessage = $result['extension_attributes']['gift_message'];
+        static::assertCount(5, $resultMessage);
+        unset($resultMessage['gift_message_id']);
+        unset($resultMessage['customer_id']);
+        static::assertEquals($expectedMessage, $resultMessage);
+    }
+}


### PR DESCRIPTION
### Description (*)
Include orderitem-level gift messages in REST API.

### Fixed Issues (if relevant)
1. magento/magento2#19093: API: salesOrderItemRepository does not include gift message

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create order with orderitem-level gift message
2. Call REST API `http://<base_url>/rest/V1/orders/items/<order_id>
2. Confirm gift message is included in extension attributes

### Questions or comments
This was already done in a previous pull request, but never finished.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
