### PR TITLE
Resolve #25948, fixing the custom attribute filter when using configurable products

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Layer/Filter/Attribute.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Layer/Filter/Attribute.php
@@ -41,6 +41,7 @@ class Attribute extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $tableAlias = $attribute->getAttributeCode() . '_idx';
         $conditions = [
             "{$tableAlias}.entity_id = e.entity_id",
+            $connection->quoteInto("(e.type_id <> ? OR {$tableAlias}.entity_id = {$tableAlias}.source_id)", \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE),
             $connection->quoteInto("{$tableAlias}.attribute_id = ?", $attribute->getAttributeId()),
             $connection->quoteInto("{$tableAlias}.store_id = ?", $collection->getStoreId()),
             $connection->quoteInto("{$tableAlias}.value = ?", $value),
@@ -77,6 +78,7 @@ class Attribute extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $tableAlias = sprintf('%s_idx', $attribute->getAttributeCode());
         $conditions = [
             "{$tableAlias}.entity_id = e.entity_id",
+            $connection->quoteInto("(e.type_id <> ? OR {$tableAlias}.entity_id = {$tableAlias}.source_id)", \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE),
             $connection->quoteInto("{$tableAlias}.attribute_id = ?", $attribute->getAttributeId()),
             $connection->quoteInto("{$tableAlias}.store_id = ?", $filter->getStoreId()),
         ];


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This pull request fixes the error described in #25948 when custom attributes and layered navigation is used along with configurable products.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25948: Custom Attributes for Configurable Products in Layered Navigation lead to errors in Category View

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See related issue. Use the same procedure.
2. You can also print the generated SQL and try it yourself. You will see that the inner join for the custom attribute will multiply the product catalog by the number of available configurable products when the attribute is set.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
