### PR TITLE
Resolve queue_consumer.xml doesn't allow numbers in handler class issue25731

### DIFF
--- a/lib/internal/Magento/Framework/MessageQueue/Test/Unit/Consumer/Config/XsdTest.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Test/Unit/Consumer/Config/XsdTest.php
@@ -84,17 +84,17 @@ class XsdTest extends \PHPUnit\Framework\TestCase
             ],
             'invalid handler format' => [
                 '<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/consumer.xsd">
-                    <consumer name="consumer1" queue="queue1" handler="handlerClass1::handlerMethodOne" consumerInstance="consumerClass1" connection="amqp" maxMessages="100"/>
-                    <consumer name="consumer2" queue="queue2" handler="handlerClassTwo::handlerMethod2" consumerInstance="consumerClass2" connection="db"/>
+                    <consumer name="consumer1" queue="queue1" handler="handlerClass_One1::handlerMethod1" consumerInstance="consumerClass1" connection="amqp" maxMessages="100"/>
+                    <consumer name="consumer2" queue="queue2" handler="handlerClassOne2::handler_Method2" consumerInstance="consumerClass2" connection="db"/>
                     <consumer name="consumer3" queue="queue3" handler="handlerClassThree::handlerMethodThree" consumerInstance="consumerClass3"/>
                     <consumer name="consumer4" queue="queue4" handler="handlerClassFour::handlerMethodFour"/>
                     <consumer name="consumer5" queue="queue4"/>
                 </config>',
                 [
-                    "Element 'consumer', attribute 'handler': [facet 'pattern'] The value 'handlerClass1::handlerMethodOne' is not accepted by the pattern '[a-zA-Z\\\\]+::[a-zA-Z]+'.",
-                    "Element 'consumer', attribute 'handler': 'handlerClass1::handlerMethodOne' is not a valid value of the atomic type 'handlerType'.",
-                    "Element 'consumer', attribute 'handler': [facet 'pattern'] The value 'handlerClassTwo::handlerMethod2' is not accepted by the pattern '[a-zA-Z\\\\]+::[a-zA-Z]+'.",
-                    "Element 'consumer', attribute 'handler': 'handlerClassTwo::handlerMethod2' is not a valid value of the atomic type 'handlerType'.",
+                    "Element 'consumer', attribute 'handler': [facet 'pattern'] The value 'handlerClass_One1::handlerMethod1' is not accepted by the pattern '[a-zA-Z0-9\\\\]+::[a-zA-Z0-9]+'.",
+                    "Element 'consumer', attribute 'handler': 'handlerClass_One1::handlerMethod1' is not a valid value of the atomic type 'handlerType'.",
+                    "Element 'consumer', attribute 'handler': [facet 'pattern'] The value 'handlerClassOne2::handler_Method2' is not accepted by the pattern '[a-zA-Z0-9\\\\]+::[a-zA-Z0-9]+'.",
+                    "Element 'consumer', attribute 'handler': 'handlerClassOne2::handler_Method2' is not a valid value of the atomic type 'handlerType'.",
                 ],
             ],
             'invalid maxMessages format' => [

--- a/lib/internal/Magento/Framework/MessageQueue/etc/consumer.xsd
+++ b/lib/internal/Magento/Framework/MessageQueue/etc/consumer.xsd
@@ -32,7 +32,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z\\]+::[a-zA-Z]+" />
+            <xs:pattern value="[a-zA-Z0-9\\]+::[a-zA-Z0-9]+" />
             <xs:minLength value="5" />
         </xs:restriction>
     </xs:simpleType>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

1. Resolve magento/magento2#25731: queue_consumer.xml doesn't allow numbers in handler class

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25731: queue_consumer.xml doesn't allow numbers in handler class

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.  Create a `queue_consumer.xml`
2. Specify a *handler* with a number in the path

#### Expected result
<!--- Tell us what do you expect to happen. -->
1. XML validation passes

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
