### PR TITLE
Hardcode usage of AddressInterface when merging address objects

### DIFF
--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -1859,7 +1859,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
             $existingAddressDataObject = $this->addressRepository->getById($quoteAddressId);
             /** Update customer address data */
             $this->dataObjectHelper->mergeDataObjects(
-                get_class($existingAddressDataObject),
+                \Magento\Customer\Api\Data\AddressInterface::class,
                 $existingAddressDataObject,
                 $customerAddress
             );


### PR DESCRIPTION
### Description (*)
Hardcode usage of AddressInterface when merging address objects. Extension attributes might cause the `get_class($existingAddressDataObject)` return an interceptor class.

### Fixed Issues (if relevant)
1. Relates to magento/magento2#10583: Checkout place order exception when using a new address.

### Manual testing scenarios (*)
1. Create extension attribute on `\Magento\Customer\Api\Data\AddressInterface`.
2. Create customer account.
3. Create order in adminhtml area.

### Questions or comments
Given error:
> Order saving error: Method's return type must be specified using @return annotation. See Magento\Customer\Model\Data\Address\Interceptor::setData()

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
