### PR TITLE
[Removed spacing in submenu on hover desktop]

### DIFF
--- a/lib/web/css/source/lib/_navigation.less
+++ b/lib/web/css/source/lib/_navigation.less
@@ -459,7 +459,7 @@
                 }
 
                 .submenu {
-                    top: 0 !important;
+                    top: -1px !important;
                     left: 100% !important;
                 }
 

--- a/lib/web/css/source/lib/variables/_navigation.less
+++ b/lib/web/css/source/lib/variables/_navigation.less
@@ -91,7 +91,7 @@
 @submenu-desktop__font-size: '';
 @submenu-desktop__font-weight: @font-weight__bold;
 @submenu-desktop__min-width: 230px;
-@submenu-desktop__padding: 15px 0;
+@submenu-desktop__padding: 0;
 
 @submenu-desktop-arrow: true; // [true|false]
 @submenu-desktop-arrow__size: 10px;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
No space required in sub-menu top and bottom.

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25972: Removed spacing in submenu on hover desktop


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Go to the Home page and hover menu.



### Expected result
<!--- Tell us what should happen -->
1. No space required in sub menu top and bottom .
![expected](https://user-images.githubusercontent.com/23443991/70523884-f5f1c500-1b69-11ea-83fb-c025e96a8aea.png)

### Actual result
<!--- Tell us what happens instead -->
1. Space in sub menu top and bottom .
![actual](https://user-images.githubusercontent.com/23443991/70524086-731d3a00-1b6a-11ea-93e9-572c44a216cf.png)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
