### PR TITLE
Fix caching Magento Metadata getVersion

### DIFF
--- a/lib/internal/Magento/Framework/App/ProductMetadata.php
+++ b/lib/internal/Magento/Framework/App/ProductMetadata.php
@@ -85,8 +85,8 @@ class ProductMetadata implements ProductMetadataInterface
                 } else {
                     $this->version = 'UNKNOWN';
                 }
-                $this->cache->save($this->version, self::VERSION_CACHE_KEY, [Config::CACHE_TAG]);
             }
+            $this->cache->save($this->version, self::VERSION_CACHE_KEY, [Config::CACHE_TAG]);
         }
         return $this->version;
     }

--- a/lib/internal/Magento/Framework/App/ProductMetadata.php
+++ b/lib/internal/Magento/Framework/App/ProductMetadata.php
@@ -13,9 +13,7 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Composer\ComposerInformation;
 
 /**
- * Class ProductMetadata
- *
- * @package Magento\Framework\App
+ * Magento application product metadata
  */
 class ProductMetadata implements ProductMetadataInterface
 {

--- a/lib/internal/Magento/Framework/App/Test/Unit/ProductMetadataTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/ProductMetadataTest.php
@@ -34,14 +34,10 @@ class ProductMetadataTest extends \PHPUnit\Framework\TestCase
         $this->cacheMock = $this->getMockBuilder(CacheInterface::class)->getMock();
 
         $objectManager = new ObjectManager($this);
-        $this->productMetadata = $objectManager->getObject(ProductMetadata::class);
+        $this->productMetadata = $objectManager->getObject(ProductMetadata::class, ['cache' => $this->cacheMock]);
         $reflectionProperty = new \ReflectionProperty($this->productMetadata, 'composerInformation');
         $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($this->productMetadata, $this->composerInformationMock);
-
-        $reflectionProperty = new \ReflectionProperty($this->productMetadata, 'cache');
-        $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue($this->productMetadata, $this->cacheMock);
     }
 
     /**
@@ -63,6 +59,7 @@ class ProductMetadataTest extends \PHPUnit\Framework\TestCase
         $expectedVersion = '1.2.3';
         $this->composerInformationMock->expects($this->never())->method('getSystemPackages');
         $this->cacheMock->expects($this->once())->method('load')->willReturn($expectedVersion);
+        $this->cacheMock->expects($this->never())->method('save');
         $productVersion = $this->productMetadata->getVersion();
         $this->assertEquals($expectedVersion, $productVersion);
     }


### PR DESCRIPTION
Fix caching result in ProductMetadata::getVersion.

### Description (*)
My change fixes issue that getVersion result never gets cached.

Original Pull Request: https://github.com/magento/magento2/pull/24030 
Caching was broken by this commit: https://github.com/magento/magento2/commit/37f6f6a6adc20fd2b72836116b48c8a5bfcd0cd8

In order to fix the issue, we should put that line where it was originally.

### Fixed Issues (if relevant)
1. magento/magento2#24025: Slow Performance of ProductMetadata::getVersion

### Manual testing scenarios (*)
1. have a module installed that relies on the product version to determine e.g. feature compatibility
2. profile uncached requests

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
