### PR TITLE
[DownloadableImportExport] Cover Helper Data by Unit Test

### DIFF
--- a/app/code/Magento/DownloadableImportExport/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/DownloadableImportExport/Test/Unit/Helper/DataTest.php
@@ -10,6 +10,7 @@ namespace Magento\DownloadableImportExport\Test\Unit\Helper;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\DownloadableImportExport\Helper\Data as HelperData;
+use Magento\DownloadableImportExport\Model\Import\Product\Type\Downloadable;
 use PHPUnit\Framework\TestCase;
 
 class DataTest extends TestCase
@@ -50,15 +51,15 @@ class DataTest extends TestCase
         return [
             'Data set include downloadable link and sample' => [
                 [
-                    'downloadable_links' => 'https://magento2.com/download_link',
-                    'downloadable_samples' => 'https://magento2.com/sample_link'
+                    Downloadable::COL_DOWNLOADABLE_LINKS => 'https://magento2.com/download_link',
+                    Downloadable::COL_DOWNLOADABLE_SAMPLES => 'https://magento2.com/sample_link'
                 ],
                 false
             ],
             'Data set with empty' => [
                 [
-                    'downloadable_links' => '',
-                    'downloadable_samples' => ''
+                    Downloadable::COL_DOWNLOADABLE_LINKS => '',
+                    Downloadable::COL_DOWNLOADABLE_SAMPLES => ''
                 ],
                 true
             ]
@@ -87,15 +88,15 @@ class DataTest extends TestCase
         return [
             'Data set include downloadable link and sample' => [
                 [
-                    'downloadable_links' => 'https://magento2.com/download_link',
-                    'downloadable_samples' => 'https://magento2.com/sample_link'
+                    Downloadable::COL_DOWNLOADABLE_LINKS => 'https://magento2.com/download_link',
+                    Downloadable::COL_DOWNLOADABLE_SAMPLES => 'https://magento2.com/sample_link'
                 ],
                 true
             ],
             'Data set with empty' => [
                 [
-                    'downloadable_links' => '',
-                    'downloadable_samples' => ''
+                    Downloadable::COL_DOWNLOADABLE_LINKS => '',
+                    Downloadable::COL_DOWNLOADABLE_SAMPLES => ''
                 ],
                 false
             ]
@@ -267,11 +268,11 @@ class DataTest extends TestCase
         return [
             'Case File Option Value' => [
                 'file1',
-                'file'
+                Downloadable::FILE_OPTION_VALUE
             ],
             'Case url Option Value' => [
                 'https://example.com',
-                'url'
+                Downloadable::URL_OPTION_VALUE
             ]
         ];
     }

--- a/app/code/Magento/DownloadableImportExport/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/DownloadableImportExport/Test/Unit/Helper/DataTest.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\DownloadableImportExport\Test\Unit\Helper;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\DownloadableImportExport\Helper\Data as HelperData;
+use PHPUnit\Framework\TestCase;
+
+class DataTest extends TestCase
+{
+    /**
+     * @var HelperData
+     */
+    private $helper;
+
+    /**
+     * Setup environment for test
+     */
+    protected function setUp()
+    {
+        $objectManagerHelper = new ObjectManagerHelper($this);
+        $this->helper = $objectManagerHelper->getObject(HelperData::class);
+    }
+
+    /**
+     * Test isRowDownloadableEmptyOptions with dataProvider
+     *
+     * @param array $rowData
+     * @param bool $expected
+     * @dataProvider isRowDownloadableEmptyOptionsDataProvider
+     */
+    public function testIsRowDownloadableEmptyOptions($rowData, $expected)
+    {
+        $this->assertEquals($expected, $this->helper->isRowDownloadableEmptyOptions($rowData));
+    }
+
+    /**
+     * Data Provider to test isRowDownloadableEmptyOptions
+     *
+     * @return array
+     */
+    public function isRowDownloadableEmptyOptionsDataProvider()
+    {
+        return [
+            'Data set include downloadable link and sample' => [
+                [
+                    'downloadable_links' => 'https://magento2.com/download_link',
+                    'downloadable_samples' => 'https://magento2.com/sample_link'
+                ],
+                false
+            ],
+            'Data set with empty' => [
+                [
+                    'downloadable_links' => '',
+                    'downloadable_samples' => ''
+                ],
+                true
+            ]
+        ];
+    }
+
+    /**
+     * Test isRowDownloadableNoValid with dataProvider
+     *
+     * @param array $rowData
+     * @param bool $expected
+     * @dataProvider isRowDownloadableNoValidDataProvider
+     */
+    public function isRowDownloadableNoValid($rowData, $expected)
+    {
+        $this->assertEquals($expected, $this->helper->isRowDownloadableNoValid($rowData));
+    }
+
+    /**
+     * Data Provider to test isRowDownloadableEmptyOptions
+     *
+     * @return array
+     */
+    public function isRowDownloadableNoValidDataProvider()
+    {
+        return [
+            'Data set include downloadable link and sample' => [
+                [
+                    'downloadable_links' => 'https://magento2.com/download_link',
+                    'downloadable_samples' => 'https://magento2.com/sample_link'
+                ],
+                true
+            ],
+            'Data set with empty' => [
+                [
+                    'downloadable_links' => '',
+                    'downloadable_samples' => ''
+                ],
+                false
+            ]
+        ];
+    }
+
+    /**
+     * Test fillExistOptions with dataProvider
+     *
+     * @param array $base
+     * @param array $option
+     * @param array $existingOptions
+     * @param array $expected
+     * @dataProvider fillExistOptionsDataProvider
+     */
+    public function testFillExistOptions($base, $option, $existingOptions, $expected)
+    {
+        $this->assertEquals($expected, $this->helper->fillExistOptions($base, $option, $existingOptions));
+    }
+
+    /**
+     * Data Provider to test fillExistOptions
+     *
+     * @return array
+     */
+    public function fillExistOptionsDataProvider()
+    {
+        return [
+            'Data set 1' => [
+                [],
+                [
+                    'product_id' => 1,
+                    'sample_type' => 'sample_type1',
+                    'sample_url' => 'sample_url1',
+                    'sample_file' => 'sample_file1',
+                    'link_file' => 'link_file1',
+                    'link_type' => 'link_type1',
+                    'link_url' => 'link_url1'
+                ],
+                [
+                    [
+                        'product_id' => 1,
+                        'sample_type' => 'sample_type1',
+                        'sample_url' => 'sample_url1',
+                        'sample_file' => 'sample_file1',
+                        'link_file' => 'link_file1',
+                        'link_type' => 'link_type1',
+                        'link_url' => 'link_url1'
+                    ],
+                    [
+                        'product_id' => 2,
+                        'sample_type' => 'sample_type2',
+                        'sample_url' => 'sample_url2',
+                        'sample_file' => 'sample_file2',
+                        'link_file' => 'link_file2',
+                        'link_type' => 'link_type2',
+                        'link_url' => 'link_url2'
+                    ]
+                ],
+                [
+                    'product_id' => 1,
+                    'sample_type' => 'sample_type1',
+                    'sample_url' => 'sample_url1',
+                    'sample_file' => 'sample_file1',
+                    'link_file' => 'link_file1',
+                    'link_type' => 'link_type1',
+                    'link_url' => 'link_url1'
+                ]
+            ],
+            'Data set 2' => [
+                [],
+                [
+                    'product_id' => 1,
+                    'sample_type' => 'sample_type1',
+                    'sample_url' => 'sample_url1',
+                    'sample_file' => 'sample_file1',
+                    'link_file' => 'link_file1',
+                    'link_type' => 'link_type1',
+                    'link_url' => 'link_url1'
+                ],
+                [],
+                []
+            ]
+        ];
+    }
+
+    /**
+     * Test prepareDataForSave with dataProvider
+     *
+     * @param array $base
+     * @param array $replacement
+     * @param array $expected
+     * @dataProvider prepareDataForSaveDataProvider
+     */
+    public function testPrepareDataForSave($base, $replacement, $expected)
+    {
+        $this->assertEquals($expected, $this->helper->prepareDataForSave($base, $replacement));
+    }
+
+    /**
+     * Data Provider to test prepareDataForSave
+     *
+     * @return array
+     */
+    public function prepareDataForSaveDataProvider()
+    {
+        return [
+            'Data set 1' => [
+                [],
+                [],
+                []
+            ],
+
+            'Data set 2' => [
+                [
+                    'product_id' => 1,
+                    'sample_type' => 'sample_type1',
+                    'sample_url' => 'sample_url1',
+                    'sample_file' => 'sample_file1',
+                    'link_file' => 'link_file1',
+                    'link_type' => 'link_type1',
+                    'link_url' => 'link_url1'
+                ],
+                [
+                    [
+                        'product_id' => 2,
+                        'sample_type' => 'sample_type2',
+                        'sample_url' => 'sample_url2',
+                        'sample_file' => 'sample_file2',
+                        'link_file' => 'link_file2',
+                        'link_type' => 'link_type2',
+                        'link_url' => 'link_url2'
+                    ]
+                ],
+                [
+                    [
+                        'product_id' => 2,
+                        'sample_type' => 'sample_type2',
+                        'sample_url' => 'sample_url2',
+                        'sample_file' => 'sample_file2',
+                        'link_file' => 'link_file2',
+                        'link_type' => 'link_type2',
+                        'link_url' => 'link_url2'
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Test getTypeByValue with dataProvider
+     *
+     * @param string $option
+     * @param string $expected
+     * @dataProvider getTypeByValueDataProvider
+     */
+    public function testGetTypeByValue($option, $expected)
+    {
+        $this->assertEquals($expected, $this->helper->getTypeByValue($option));
+    }
+
+    /**
+     * Data Provider for getTypeByValue
+     *
+     * @return array
+     */
+    public function getTypeByValueDataProvider()
+    {
+        return [
+            'Case File Option Value' => [
+                'file1',
+                'file'
+            ],
+            'Case url Option Value' => [
+                'https://example.com',
+                'url'
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

**Increase Test Coverage** 

class Magento\DownloadableImportExport\Helper\Data

- Test isRowDownloadableEmptyOptions
- Test isRowDownloadableNoValid
- Test fillExistOptions
- Test prepareDataForSave
- Test getTypeByValue

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

vendor/bin/phpunit app/code/Magento/DownloadableImportExport/Test/Unit/Helper/DataTest.php

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
