### PR TITLE
MC-29726 Wrong grand_total in Magento\Quote\Model\Quote\Address\Total\Grand

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Address/Total/Grand.php
+++ b/app/code/Magento/Quote/Model/Quote/Address/Total/Grand.php
@@ -42,8 +42,14 @@ class Grand extends AbstractTotal
      */
     public function collect(Quote $quote, ShippingAssignment $shippingAssignment, Total $total): Grand
     {
-        $totals = array_sum($total->getAllTotalAmounts());
-        $baseTotals = array_sum($total->getAllBaseTotalAmounts());
+        $totals = 0;
+        $baseTotals = 0;
+        foreach ($total->getAllTotalAmounts() as $itemTotal) {
+            $totals = $totals + $this->priceRounder->roundPrice($itemTotal, 4);
+        }
+        foreach ($total->getAllBaseTotalAmounts() as $baseTotal) {
+            $baseTotals = $baseTotals + $this->priceRounder->roundPrice($baseTotal, 4);
+        }
         $grandTotal = $this->priceRounder->roundPrice($total->getGrandTotal() + $totals, 4);
         $baseGrandTotal = $this->priceRounder->roundPrice($total->getBaseGrandTotal() + $baseTotals, 4);
 


### PR DESCRIPTION
https://github.com/magento/magento2/issues/26012

The same issue is https://github.com/magento/magento2/issues/6734 but you closed it.
### Preconditions (*)
Magento ver. 2.2.10, 2.4-develop / PHP Version 7.2.25

php function array_sum calculate wrong amount in 
vendor/magento/module-quote/Model/Quote/Address/Total/Grand.php
Line 26 $totals = array_sum($total->getAllTotalAmounts());
Line 27 $baseTotals = array_sum($total->getAllBaseTotalAmounts());

### Steps to reproduce (*)
For replicate it you can run this php script which return output 2.8421709430404E-14 but must be 0.

```
<?php 
$getAllTotalAmounts = [ 
"subtotal" => 108.29, "tax" => 0, 
"discount_tax_compensation" => 21.66, 
"weee" => 0, "shipping" => 0, 
"shipping_discount_tax_compensation" => 0, 
"discount" => -129.95, 
"extra_tax" => 0, 
"weee_tax" => 0 ]; 
echo array_sum($getAllTotalAmounts);
```
### Expected result (*)
for this code 
$totals = array_sum($total->getAllTotalAmounts());
$baseTotals = array_sum($total->getAllBaseTotalAmounts());

$totals and $baseTotals must be 0

### Actual result (*)
$totals and $baseTotals = 2.8421709430404E-14 

For fix it I replaced in vendor/magento/module-quote/Model/Quote/Address/Total/Grand.php

```
Line 26 $totals = array_sum($total->getAllTotalAmounts());
Line 27 $baseTotals = array_sum($total->getAllBaseTotalAmounts());
```

on 
```
        foreach ($total->getAllTotalAmounts() as $itemTotal) {
            $totals = round($totals, 2) + round($itemTotal, 2);
        }
        foreach ($total->getAllBaseTotalAmounts() as $baseTotal) {
            $baseTotals = round($baseTotals, 2) + round($baseTotal, 2);
        }
```