### PR TITLE
Fixed keyboard arrow keys behavior for number fields in AdobeStock grid

### DIFF
--- a/dev/tests/js/jasmine/tests/lib/jquery/jstree/jquery.hotkeys.test.js
+++ b/dev/tests/js/jasmine/tests/lib/jquery/jstree/jquery.hotkeys.test.js
@@ -15,15 +15,15 @@ define([
             inputNumberElement = $('<input type="number">');
 
         beforeAll(function () {
-            $(document).bind('keyup', 'right', function () {
-                // Change element body to track a trigger action
+            /**
+             * Insert text to the divElement
+             */
+            var addHtmlToDivElement = function () {
                 divElement.html(divBodyAfterTrigger);
-            });
+            };
 
-            $(document).bind('keyup', 'left', function () {
-                // Change element body to track a trigger action
-                divElement.html(divBodyAfterTrigger);
-            });
+            $(document).bind('keyup', 'right', addHtmlToDivElement);
+            $(document).bind('keyup', 'left', addHtmlToDivElement);
 
         });
 
@@ -38,7 +38,8 @@ define([
         });
 
         it('Check "left key" hotkey is not being processed when number input is focused', function () {
-            var keypress = $.Event("keyup");
+            var keypress = $.Event('keyup');
+
             keypress.which = 37; // "left arrow" key
             inputNumberElement.trigger(keypress);
 
@@ -46,7 +47,8 @@ define([
         });
 
         it('Check "right key" hotkey is not being processed when number input is focused', function () {
-            var keypress = $.Event("keyup");
+            var keypress = $.Event('keyup');
+
             keypress.which = 39; // "right arrow" key
             inputNumberElement.trigger(keypress);
 
@@ -54,7 +56,8 @@ define([
         });
 
         it('Check "left key" hotkey is being processed when registered on the page', function () {
-            var keypress = $.Event("keyup");
+            var keypress = $.Event('keyup');
+
             keypress.which = 37; // "left arrow" key
             divElement.trigger(keypress);
 
@@ -62,7 +65,8 @@ define([
         });
 
         it('Check "right key" hotkey is being processed when registered on the page', function () {
-            var keypress = $.Event("keyup");
+            var keypress = $.Event('keyup');
+
             keypress.which = 39; // "right arrow" key
             $('body').trigger(keypress);
 

--- a/dev/tests/js/jasmine/tests/lib/jquery/jstree/jquery.hotkeys.test.js
+++ b/dev/tests/js/jasmine/tests/lib/jquery/jstree/jquery.hotkeys.test.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define([
+    'jquery',
+    'jquery/jstree/jquery.hotkeys'
+], function ($) {
+    'use strict';
+
+    describe('Test for jquery/jstree/jquery.hotkeys', function () {
+        var divElement = $('<div></div>'),
+            divBodyAfterTrigger = 'pressed',
+            inputNumberElement = $('<input type="number">');
+
+        beforeAll(function () {
+            $(document).bind('keyup', 'right', function () {
+                // Change element body to track a trigger action
+                divElement.html(divBodyAfterTrigger);
+            });
+
+            $(document).bind('keyup', 'left', function () {
+                // Change element body to track a trigger action
+                divElement.html(divBodyAfterTrigger);
+            });
+
+        });
+
+        beforeEach(function () {
+            inputNumberElement.appendTo(document.body);
+            divElement.appendTo(document.body);
+        });
+
+        afterEach(function () {
+            divElement.remove();
+            inputNumberElement.remove();
+        });
+
+        it('Check "left key" hotkey is not being processed when number input is focused', function () {
+            var keypress = $.Event("keyup");
+            keypress.which = 37; // "left arrow" key
+            inputNumberElement.trigger(keypress);
+
+            expect(divElement.html()).toEqual('');
+        });
+
+        it('Check "right key" hotkey is not being processed when number input is focused', function () {
+            var keypress = $.Event("keyup");
+            keypress.which = 39; // "right arrow" key
+            inputNumberElement.trigger(keypress);
+
+            expect(divElement.html()).toEqual('');
+        });
+
+        it('Check "left key" hotkey is being processed when registered on the page', function () {
+            var keypress = $.Event("keyup");
+            keypress.which = 37; // "left arrow" key
+            divElement.trigger(keypress);
+
+            expect(divElement.html()).toEqual(divBodyAfterTrigger);
+        });
+
+        it('Check "right key" hotkey is being processed when registered on the page', function () {
+            var keypress = $.Event("keyup");
+            keypress.which = 39; // "right arrow" key
+            $('body').trigger(keypress);
+
+            expect(divElement.html()).toEqual(divBodyAfterTrigger);
+        });
+
+    });
+});

--- a/lib/web/jquery/jstree/jquery.hotkeys.js
+++ b/lib/web/jquery/jstree/jquery.hotkeys.js
@@ -53,7 +53,8 @@
              * longer maintained by its author however we require content editable to behave as expected.
              */
 			if ( this !== event.target && (/textarea|select/i.test( event.target.nodeName ) ||
-				 event.target.type === "text" || jQuery(event.target).attr('contenteditable')) ) {
+                event.target.type === "text" || event.target.type === "number" ||
+                jQuery(event.target).attr('contenteditable')) ) {
 				return;
 			}
 			


### PR DESCRIPTION
### Description (*)
This PR introduces a fix for keyboard arrow keys in `<input type="number"/>` of AdobeStock grid. 

#### Technical background
The jsTree (that is used for media gallery directory tree) hotkeys plugin conflicts with `<input type="number"/>`. The plugin works well with most input types but overtakes keyboard cursors control from the number type. Basically, if we have jsTree with hotkeys plugin enabled and `<input type="number"/>` on the same page, the keyboard cursor buttons will be handled by jsTree when any of the `<input type="number"/>` is focused.
If you take a look at the modified file, there were similar "hotfixes" previously but the "number" type has not been taken into consideration. 

### Fixed Issues (if relevant)
1. https://github.com/magento/adobe-stock-integration/issues/846 : The cursor is not moved in Page Number field with keyboard arrow keys

### Manual testing scenarios (*)
The AdobeStock plugin needs to be installed and configured.

1. From Magento Admin go to **Content** - **Pages**, click **Add New Page**
2. Expand **Content**, click **Show / Hide Editor**, select **Insert Image...**
3. Click **Search Adobe Stock**
4. Try to edit the pages field, move the cursor on it and click
![pages field1](https://user-images.githubusercontent.com/45624059/70228598-4974a500-175d-11ea-96f5-7d64107793d2.png)
5. Try to move the cursor with left and right arrow keys on the keyboard 

The cursor should be moved in order to edit the page number. Please, refer to the original issue to see the "bugged" behavior.

Please note, there's one more issue with arrow keys behavior for input fields that is not connected to the current one somehow. It's fixed in https://github.com/magento/magento2/pull/25991
