### PR TITLE
Removes setting domain when domain for cookies empty

### DIFF
--- a/lib/internal/Magento/Framework/Session/Config.php
+++ b/lib/internal/Magento/Framework/Session/Config.php
@@ -160,8 +160,7 @@ class Config implements ConfigInterface
         $this->setCookiePath($path, $this->_httpRequest->getBasePath());
 
         $domain = $this->_scopeConfig->getValue(self::XML_PATH_COOKIE_DOMAIN, $this->_scopeType);
-        $domain = empty($domain) ? $this->_httpRequest->getHttpHost() : $domain;
-        $this->setCookieDomain((string)$domain, $this->_httpRequest->getHttpHost());
+        $this->setCookieDomain((string)$domain);
 
         $this->setCookieHttpOnly(
             $this->_scopeConfig->getValue(self::XML_PATH_COOKIE_HTTPONLY, $this->_scopeType)

--- a/lib/internal/Magento/Framework/Session/SaveHandler/Redis/Config.php
+++ b/lib/internal/Magento/Framework/Session/SaveHandler/Redis/Config.php
@@ -131,7 +131,7 @@ class Config implements \Cm\RedisSession\Handler\ConfigInterface
     const XML_PATH_ADMIN_SESSION_LIFETIME = 'admin/security/session_lifetime';
 
     /**
-     * Session max lifetime
+     * Max lifetime for session
      */
     const SESSION_MAX_LIFETIME = 31536000;
 

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -10,7 +10,7 @@ namespace Magento\Framework\Session;
 use Magento\Framework\Session\Config\ConfigInterface;
 
 /**
- * Session Manager
+ * Basic Session Manager implementation
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  */

--- a/lib/internal/Magento/Framework/Session/SessionManagerInterface.php
+++ b/lib/internal/Magento/Framework/Session/SessionManagerInterface.php
@@ -8,7 +8,7 @@
 namespace Magento\Framework\Session;
 
 /**
- * Session Manager Interface
+ * Session Manager - Manages php session
  *
  * @api
  */

--- a/lib/internal/Magento/Framework/Session/SidResolver.php
+++ b/lib/internal/Magento/Framework/Session/SidResolver.php
@@ -10,7 +10,7 @@ namespace Magento\Framework\Session;
 use Magento\Framework\App\State;
 
 /**
- * Class SidResolver
+ * Handle SID in urls
  * @deprecated 2.3.3 SIDs in URLs are no longer used
  */
 class SidResolver implements SidResolverInterface

--- a/lib/internal/Magento/Framework/Session/Test/Unit/ConfigTest.php
+++ b/lib/internal/Magento/Framework/Session/Test/Unit/ConfigTest.php
@@ -402,9 +402,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
             ['getBasePath', 'isSecure', 'getHttpHost']
         );
         $this->requestMock->expects($this->atLeastOnce())->method('getBasePath')->will($this->returnValue('/'));
-        $this->requestMock->expects(
-            $this->atLeastOnce()
-        )->method(
+        $this->requestMock->method(
             'getHttpHost'
         )->will(
             $this->returnValue('init.host')


### PR DESCRIPTION
The previous implementation set the domain for cookies to the current
domain provided in the Request object.
As per RFC - https://tools.ietf.org/html/rfc6265#section-4.1.2.3,
this is the default behavior to use the current domain (and only
current domain) when the domain is not set in setcookie call.
Setting the domain explicitly during setcookie has a side effect
- the cookie is also visible for subdomains.
This visibility is probably not intended.  Current implementation
(before my change) is based on old  RFC (https://tools.ietf.org/html/rfc2109)
when domain shall be prepended with dot to make it visible for subdomains.
If a user wants to include cookie for subdomains - shall provide
the domain in cookie settings.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

I just removed the setting of the default domain when it is not explicitly provided. That will default to RFC so functionally everything shall work the same but without side effects.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. fixes magento/magento2#17323 : form_key cookie contain leading dot
1. fixes magento/magento2#13505 : Cookie collision with multiple magento instances

### Manual testing scenarios (*)

#### Steps to reproduce

Change the configuration to set the cookie for specific domain
Login in the backend with valid details
Store > Configuration > General
Change the website view to save the configuration for only website wise
Web Default Cookie Settings > Cookie Domain set your website domain (i.e magento.loc)
Set the cookie path to /
Save the configuration
clear cacher and clear browser cookies(for the current domain) and restart the browser

#### Expected result
All Magento cookie should set the only domain without any leading dot but in the form_key cookie I can see it is adding a leading dot (and I don't want to set the cookie for subdomain as well)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
