### PR TITLE
Set empty value to color picker when input is reset to update preview

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/color-picker.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/knockout/bindings/color-picker.js
@@ -71,6 +71,11 @@ define([
         update: function (element, valueAccessor, allBindings, viewModel) {
             var config = valueAccessor();
 
+            /** Initialise value as empty if it is undefined when color picker input is reset **/
+            if (config.value() === undefined) {
+                config.value('');
+            }
+
             if (tinycolor(config.value()).isValid() || config.value() === '') {
                 $(element).spectrum('set', config.value());
 

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/lib/ko/bind/color-picker.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/lib/ko/bind/color-picker.test.js
@@ -85,5 +85,28 @@ define([
 
             expect($.fn.init).toHaveBeenCalledWith($input, undefined);
         });
+
+        it('Verify config value is empty when reset colorpicker intput', function () {
+            var value = {
+                    configStuffInHere: true,
+                    value: jasmine.createSpy().and.returnValue(undefined)
+                },
+                valueAccessor = jasmine.createSpy().and.returnValue(value),
+                viewModel = {
+                    disabled: jasmine.createSpy().and.returnValue(false)
+                };
+
+            $.fn.spectrum = jasmine.createSpy();
+            $input = jasmine.createSpy();
+
+            ko.bindingHandlers.colorPicker.update($input, valueAccessor, null, viewModel);
+            expect($.fn.spectrum).toHaveBeenCalledTimes(1);
+            expect(valueAccessor().value).toHaveBeenCalledTimes(4);
+
+            value.value = jasmine.createSpy().and.returnValue('');
+            ko.bindingHandlers.colorPicker.update($input, valueAccessor, null, viewModel);
+            expect($.fn.spectrum).toHaveBeenCalledTimes(3);
+            expect(valueAccessor().value).toHaveBeenCalledTimes(5);
+        });
     });
 });


### PR DESCRIPTION
### Description (*)
When the color picker input is reset by an event, the preview doesn't update accordingly as the value is undefined and the logic to update it gets skipped. With this change, if the value is undefined, we set it to an empty value.

### Fixed Issues (if relevant)
1. magento/adobe-stock-integration#822: The Color picker is not reset on switching bookmarks

### Manual testing scenarios (*)
I couldn't find any areas in the core where the color picker is being used as part of the grid filters in the backend.

- From Magento Admin go to Content - Pages, click Add New Page
- Expand Content Click Show / Hide Editor, select Insert Image...
- Click Search Adobe Stock
- Create a new Filter view
- Click Filters and Apply any filter, Price - Standard for example (this step is done to enable Save View As button)
- Click Default View dropdown and select Save View As...
- Type in "New View", for example, and click Enter key
- Click on the Color square and select any color, Black for example
- Do not Apply it, switch to Default View and observe the Color square

### Questions or comments
It would be nice to get some feedback on the fix and if there is a better way to deal with the issue.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
