### PR TITLE
Fixed typo: "reviwGrid" to "reviewGrid"

### DIFF
--- a/app/code/Magento/Review/Block/Adminhtml/Grid.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Grid.php
@@ -90,7 +90,7 @@ class Grid extends \Magento\Backend\Block\Widget\Grid\Extended
     protected function _construct()
     {
         parent::_construct();
-        $this->setId('reviwGrid');
+        $this->setId('reviewGrid');
         $this->setDefaultSort('created_at');
     }
 

--- a/app/code/Magento/Review/Test/Mftf/Section/AdminReviewGridSection.xml
+++ b/app/code/Magento/Review/Test/Mftf/Section/AdminReviewGridSection.xml
@@ -9,11 +9,11 @@
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="AdminReviewGridSection">
-        <element name="nickname" type="input" selector="#reviwGrid_filter_nickname"/>
-        <element name="status" type="select" selector="#reviwGrid_filter_status"/>
+        <element name="nickname" type="input" selector="#reviewGrid_filter_nickname"/>
+        <element name="status" type="select" selector="#reviewGrid_filter_status"/>
         <element name="firstRow" type="block" selector=".data-grid tbody tr:nth-of-type(1)"/>
-        <element name="massActions" type="button" selector="#reviwGrid_massaction-mass-select"/>
-        <element name="massActionsSelect" type="button" selector="#reviwGrid_massaction-select"/>
+        <element name="massActions" type="button" selector="#reviewGrid_massaction-mass-select"/>
+        <element name="massActionsSelect" type="button" selector="#reviewGrid_massaction-select"/>
         <element name="submit" type="button" selector=".admin__grid-massaction-form .action-default.scalable"/>
         <element name="acceptModal" type="button" selector=".modal-popup.confirm button.action-accept"/>
     </section>

--- a/dev/tests/functional/tests/app/Magento/Review/Test/Block/Adminhtml/Customer/Edit/Tab/Reviews.php
+++ b/dev/tests/functional/tests/app/Magento/Review/Test/Block/Adminhtml/Customer/Edit/Tab/Reviews.php
@@ -18,7 +18,7 @@ class Reviews extends Tab
      *
      * @var string
      */
-    protected $reviews = '#reviwGrid';
+    protected $reviews = '#reviewGrid';
 
     /**
      * Returns product reviews grid.

--- a/dev/tests/functional/tests/app/Magento/Review/Test/Block/Adminhtml/Grid.php
+++ b/dev/tests/functional/tests/app/Magento/Review/Test/Block/Adminhtml/Grid.php
@@ -27,7 +27,7 @@ class Grid extends GridAbstract
             'selector' => 'input[name="title"]',
         ],
         'status' => [
-            'selector' => '#reviwGrid_filter_status',
+            'selector' => '#reviewGrid_filter_status',
             'input' => 'select',
         ],
         'nickname' => [

--- a/dev/tests/functional/tests/app/Magento/Review/Test/Page/Adminhtml/ReviewIndex.xml
+++ b/dev/tests/functional/tests/app/Magento/Review/Test/Page/Adminhtml/ReviewIndex.xml
@@ -8,7 +8,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../../vendor/magento/mtf/etc/pages.xsd">
     <page name="ReviewIndex" area="Adminhtml" mca="review/product/index" module="Magento_Review">
         <block name="messagesBlock" class="Magento\Backend\Test\Block\Messages" locator="#messages" strategy="css selector" />
-        <block name="reviewGrid" class="Magento\Review\Test\Block\Adminhtml\Grid" locator="#reviwGrid" strategy="css selector" />
+        <block name="reviewGrid" class="Magento\Review\Test\Block\Adminhtml\Grid" locator="#reviewGrid" strategy="css selector" />
         <block name="reviewActions" class="Magento\Backend\Test\Block\GridPageActions" locator=".page-main-actions" strategy="css selector" />
     </page>
 </config>

--- a/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/IndexTest.php
@@ -444,7 +444,7 @@ class IndexTest extends \Magento\TestFramework\TestCase\AbstractBackendControlle
         $this->getRequest()->setParam('id', 1);
         $this->dispatch('backend/customer/index/productReviews');
         $body = $this->getResponse()->getBody();
-        $this->assertContains('<div id="reviwGrid"', $body);
+        $this->assertContains('<div id="reviewGrid"', $body);
     }
 
     /**


### PR DESCRIPTION
Just fixing a typo:

From:
```reviwGrid```

To:
```reviewGrid```