### PR TITLE
[Downloadable] Cover the Observer SetHasDownloadableProductsObserver by Unit Test

### DIFF
--- a/app/code/Magento/Downloadable/Test/Unit/Observer/SetHasDownloadableProductsObserverTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Observer/SetHasDownloadableProductsObserverTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Downloadable\Test\Unit\Observer;
+
+use Magento\Catalog\Model\Product\Type as ProductType;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Downloadable\Model\Product\Type as DownloadableProductType;
+use Magento\Downloadable\Observer\SetHasDownloadableProductsObserver;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Item;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SetHasDownloadableProductsObserverTest extends TestCase
+{
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var CheckoutSession|MockObject
+     */
+    private $checkoutSessionMock;
+
+    /**
+     * @var SetHasDownloadableProductsObserver
+     */
+    private $setHasDownloadableProductsObserver;
+
+    /**
+     * @var Order|MockObject
+     */
+    private $orderMock;
+
+    /**
+     * Setup environment for test
+     */
+    protected function setUp()
+    {
+        $this->objectManager = new ObjectManager($this);
+
+        $this->orderMock = $this->createPartialMock(Order::class, ['getAllItems']);
+
+        $this->checkoutSessionMock = $this->createPartialMock(
+            CheckoutSession::class,
+            [
+                'getHasDownloadableProducts',
+                'setHasDownloadableProducts'
+            ]
+        );
+
+
+        $this->setHasDownloadableProductsObserver = $this->objectManager->getObject(
+            SetHasDownloadableProductsObserver::class,
+            [
+                'checkoutSession' => $this->checkoutSessionMock
+            ]
+        );
+    }
+
+    /**
+     * Test execute with session has downloadable products
+     */
+    public function testExecuteWithSessionHasDownloadableProducts()
+    {
+        $event = new DataObject(['item' => $this->orderMock]);
+        $observer = new Observer(['event' => $event]);
+
+        $this->checkoutSessionMock->method('getHasDownloadableProducts')->willReturn(true);
+        $this->orderMock->method('getAllItems')->willReturn([]);
+
+        $this->checkoutSessionMock->expects($this->never())
+            ->method('setHasDownloadableProducts')->with(true);
+
+        $this->setHasDownloadableProductsObserver->execute($observer);
+    }
+
+    /**
+     * Test execute with session has no downloadable products with the data provider
+     *
+     * @dataProvider executeWithSessionNoDownloadableProductsDataProvider
+     */
+    public function testExecuteWithSessionNoDownloadableProducts($allItems, $expectedCall)
+    {
+        $event = new DataObject(['order' => $this->orderMock]);
+        $observer = new Observer(['event' => $event]);
+
+        $allOrderItemsMock = [];
+        foreach ($allItems as $item) {
+            $allOrderItemsMock[] = $this->createOrderItem(...$item);
+        }
+
+        $this->checkoutSessionMock->method('getHasDownloadableProducts')->willReturn(false);
+
+        $this->orderMock->method('getAllItems')->willReturn($allOrderItemsMock);
+
+        $this->checkoutSessionMock->expects($expectedCall)
+            ->method('setHasDownloadableProducts')->with(true);
+
+        $this->setHasDownloadableProductsObserver->execute($observer);
+    }
+
+    /**
+     * Create Order Item Mock
+     *
+     * @param string $productType
+     * @param string $realProductType
+     * @param string $isDownloadable
+     * @return Item|MockObject
+     */
+    private function createOrderItem(
+        $productType = DownloadableProductType::TYPE_DOWNLOADABLE,
+        $realProductType = DownloadableProductType::TYPE_DOWNLOADABLE,
+        $isDownloadable = '1'
+    ) {
+        $item = $this->createPartialMock(
+            Item::class,
+            ['getProductType', 'getRealProductType', 'getProductOptionByCode']
+        );
+
+        $item->expects($this->any())
+            ->method('getProductType')
+            ->willReturn($productType);
+        $item->expects($this->any())
+            ->method('getRealProductType')
+            ->willReturn($realProductType);
+        $item->expects($this->any())
+            ->method('getProductOptionByCode')
+            ->with('is_downloadable')
+            ->willReturn($isDownloadable);
+
+        return $item;
+    }
+
+    /**
+     * Data Provider for test execute with session has no downloadable product
+     *
+     * @return array
+     */
+    public function executeWithSessionNoDownloadableProductsDataProvider()
+    {
+        return [
+            'Order has once item is downloadable product' => [
+                [
+                    [
+                        DownloadableProductType::TYPE_DOWNLOADABLE,
+                        DownloadableProductType::TYPE_DOWNLOADABLE,
+                        '1'
+                    ],
+                    [
+                        ProductType::TYPE_SIMPLE,
+                        ProductType::TYPE_SIMPLE,
+                        '1'
+                    ]
+                ],
+                $this->once()
+            ],
+            'Order has all items are simple product' => [
+                [
+                    [
+                        ProductType::TYPE_SIMPLE,
+                        ProductType::TYPE_SIMPLE,
+                        '0'
+                    ],
+                    [
+                        ProductType::TYPE_SIMPLE,
+                        ProductType::TYPE_SIMPLE,
+                        '0'
+                    ]
+                ],
+                $this->never()
+            ],
+        ];
+    }
+}

--- a/app/code/Magento/Downloadable/Test/Unit/Observer/SetHasDownloadableProductsObserverTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Observer/SetHasDownloadableProductsObserverTest.php
@@ -59,7 +59,6 @@ class SetHasDownloadableProductsObserverTest extends TestCase
             ]
         );
 
-
         $this->setHasDownloadableProductsObserver = $this->objectManager->getObject(
             SetHasDownloadableProductsObserver::class,
             [
@@ -150,7 +149,7 @@ class SetHasDownloadableProductsObserverTest extends TestCase
     public function executeWithSessionNoDownloadableProductsDataProvider()
     {
         return [
-            'Order has once item is downloadable product' => [
+            'Order has one item is downloadable product' => [
                 [
                     [
                         DownloadableProductType::TYPE_DOWNLOADABLE,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Cover the Observer SetHasDownloadableProductsObserver by Unit Test

Session has downloadable products

Session has no downloadable product
- Order has once item is downloadable product
- Order has all items are simple product


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
vendor/bin/phpunit app/code/Magento/Downloadable/Test/Unit/Observer/SetHasDownloadableProductsObserverTest.php
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
