### PR TITLE
[Search] Cover SynonymActions Column by Unit Test

### DIFF
--- a/app/code/Magento/Search/Test/Unit/Ui/Component/Listing/Column/SynonymActionsTest.php
+++ b/app/code/Magento/Search/Test/Unit/Ui/Component/Listing/Column/SynonymActionsTest.php
@@ -17,6 +17,21 @@ use PHPUnit\Framework\TestCase;
 class SynonymActionsTest extends TestCase
 {
     /**
+     * Stub synonym group id
+     */
+    private const STUB_SYNONYM_GROUP_ID = 1;
+
+    /**
+     * Synonym group delete url
+     */
+    private const SYNONYM_GROUP_DELETE_URL = 'http://localhost/magento2/admin/search/synonyms/delete/group_id/%d';
+
+    /**
+     * Synonym group edit url
+     */
+    private const SYNONYM_GROUP_EDIT_URL = 'http://localhost/magento2/admin/search/synonyms/edit/group_id/%d';
+
+    /**
      * @var SynonymActions
      */
     private $synonymActions;
@@ -72,31 +87,38 @@ class SynonymActionsTest extends TestCase
             'data' => [
                 'items' => [
                     [
-                        'group_id' => 1
+                        'group_id' => self::STUB_SYNONYM_GROUP_ID
                     ]
                 ]
             ]
         ];
+
         $expected = [
             'data' => [
                 'items' => [
                     [
-                        'group_id' => 1,
+                        'group_id' => self::STUB_SYNONYM_GROUP_ID,
                         'actions' => [
                             'delete' => [
-                                'href' => 'http://localhost/magento2/admin/search/synonyms/delete/group_id/1',
+                                'href' => sprintf(
+                                    self::SYNONYM_GROUP_DELETE_URL,
+                                    self::STUB_SYNONYM_GROUP_ID
+                                ),
                                 'label' => (string)__('Delete'),
                                 'confirm' => [
                                     'title' => (string)__('Delete'),
                                     'message' => (string)__(
                                         'Are you sure you want to delete synonym group with id: %1?',
-                                        1
+                                        self::STUB_SYNONYM_GROUP_ID
                                     )
                                 ],
                                 '__disableTmpl' => true
                             ],
                             'edit' => [
-                                'href' => 'http://localhost/magento2/admin/search/synonyms/edit/group_id/1',
+                                'href' => sprintf(
+                                    self::SYNONYM_GROUP_EDIT_URL,
+                                    self::STUB_SYNONYM_GROUP_ID
+                                ),
                                 'label' => (string)__('View/Edit'),
                                 '__disableTmpl' => true
                             ]
@@ -106,13 +128,18 @@ class SynonymActionsTest extends TestCase
             ]
         ];
 
-        $this->urlBuilderMock->expects($this->at(0))->method('getUrl')
-            ->with(SynonymActions::SYNONYM_URL_PATH_DELETE, ['group_id' => 1])
-            ->willReturn('http://localhost/magento2/admin/search/synonyms/delete/group_id/1');
-
-        $this->urlBuilderMock->expects($this->at(1))->method('getUrl')
-            ->with(SynonymActions::SYNONYM_URL_PATH_EDIT, ['group_id' => 1])
-            ->willReturn('http://localhost/magento2/admin/search/synonyms/edit/group_id/1');
+        $this->urlBuilderMock->method('getUrl')->will(
+            $this->returnValueMap([
+                [
+                    SynonymActions::SYNONYM_URL_PATH_DELETE, ['group_id' => self::STUB_SYNONYM_GROUP_ID],
+                    sprintf(self::SYNONYM_GROUP_DELETE_URL, self::STUB_SYNONYM_GROUP_ID)
+                ],
+                [
+                    SynonymActions::SYNONYM_URL_PATH_EDIT, ['group_id' => self::STUB_SYNONYM_GROUP_ID],
+                    sprintf(self::SYNONYM_GROUP_EDIT_URL, self::STUB_SYNONYM_GROUP_ID)
+                ]
+            ])
+        );
 
         /**
          * Assert Result

--- a/app/code/Magento/Search/Test/Unit/Ui/Component/Listing/Column/SynonymActionsTest.php
+++ b/app/code/Magento/Search/Test/Unit/Ui/Component/Listing/Column/SynonymActionsTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Search\Test\Unit\Ui\Component\Listing\Column;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\UrlInterface;
+use Magento\Search\Ui\Component\Listing\Column\SynonymActions;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SynonymActionsTest extends TestCase
+{
+    /**
+     * @var SynonymActions
+     */
+    private $synonymActions;
+
+    /**
+     * @var UrlInterface|MockObject
+     */
+    private $urlBuilderMock;
+
+    /**
+     * Setup environment to test
+     */
+    protected function setup()
+    {
+        $this->urlBuilderMock = $this->createMock(UrlInterface::class);
+
+        $objectManager = new ObjectManager($this);
+
+        $this->synonymActions = $objectManager->getObject(
+            SynonymActions::class,
+            [
+                'urlBuilder' => $this->urlBuilderMock,
+                'data' => [
+                    'name' => 'actions'
+                ]
+            ]
+        );
+    }
+
+    /**
+     * Test prepareDataSource() with data source has no item
+     */
+    public function testPrepareDataSourceWithNoItem()
+    {
+        $dataSource = [
+            'data' => []
+        ];
+        $expected = [
+            'data' => []
+        ];
+        /**
+         * Assert Result
+         */
+        $this->assertEquals($expected, $this->synonymActions->prepareDataSource($dataSource));
+    }
+
+    /**
+     * Test prepareDataSource() with data source has items
+     */
+    public function testPrepareDataSourceWithItems()
+    {
+        $dataSource = [
+            'data' => [
+                'items' => [
+                    [
+                        'group_id' => 1
+                    ]
+                ]
+            ]
+        ];
+        $expected = [
+            'data' => [
+                'items' => [
+                    [
+                        'group_id' => 1,
+                        'actions' => [
+                            'delete' => [
+                                'href' => 'http://localhost/magento2/admin/search/synonyms/delete/group_id/1',
+                                'label' => (string)__('Delete'),
+                                'confirm' => [
+                                    'title' => (string)__('Delete'),
+                                    'message' => (string)__(
+                                        'Are you sure you want to delete synonym group with id: %1?',
+                                        1
+                                    )
+                                ],
+                                '__disableTmpl' => true
+                            ],
+                            'edit' => [
+                                'href' => 'http://localhost/magento2/admin/search/synonyms/edit/group_id/1',
+                                'label' => (string)__('View/Edit'),
+                                '__disableTmpl' => true
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->urlBuilderMock->expects($this->at(0))->method('getUrl')
+            ->with(SynonymActions::SYNONYM_URL_PATH_DELETE, ['group_id' => 1])
+            ->willReturn('http://localhost/magento2/admin/search/synonyms/delete/group_id/1');
+
+        $this->urlBuilderMock->expects($this->at(1))->method('getUrl')
+            ->with(SynonymActions::SYNONYM_URL_PATH_EDIT, ['group_id' => 1])
+            ->willReturn('http://localhost/magento2/admin/search/synonyms/edit/group_id/1');
+
+        /**
+         * Assert Result
+         */
+        $this->assertEquals($expected, $this->synonymActions->prepareDataSource($dataSource));
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
**Increase Test Coverage**

[Search] Cover SynonymActions Column by Unit Test

- Test prepareDataSource() with data source has no item
- Test prepareDataSource() with data source has items

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

 vendor/bin/phpunit app/code/Magento/Search/Test/Unit/Ui/Component/Listing/Column/SynonymActionsTest.php

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
