### PR TITLE
[WeeeGraphQl] Covering the FixedProductTax

### DIFF
--- a/app/code/Magento/WeeeGraphQl/Test/Unit/FixedProductTaxTest.php
+++ b/app/code/Magento/WeeeGraphQl/Test/Unit/FixedProductTaxTest.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 declare(strict_types=1);
 
 namespace Magento\WeeeGraphQl\Test\Unit;

--- a/app/code/Magento/WeeeGraphQl/Test/Unit/FixedProductTaxTest.php
+++ b/app/code/Magento/WeeeGraphQl/Test/Unit/FixedProductTaxTest.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\WeeeGraphQl\Test\Unit;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\WeeeGraphQl\Model\Resolver\FixedProductTax;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+class FixedProductTaxTest extends TestCase
+{
+    /**
+     * @var FixedProductTax
+     */
+    private $resolver;
+
+    /**
+     * Build the Testing Environment
+     */
+    protected function setUp()
+    {
+        $objectManager = new ObjectManager($this);
+        $this->resolver = $objectManager->getObject(FixedProductTax::class);
+    }
+
+    public function testExceptionWhenNoModelSpecified(): void
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessageRegExp('/value should be specified/');
+
+        $this->resolver->resolve(
+            $this->getFieldStub(),
+            null,
+            $this->getResolveInfoStub()
+        );
+    }
+
+    /**
+     * Returns stub for Field
+     *
+     * @return MockObject|Field
+     */
+    private function getFieldStub(): Field
+    {
+        /** @var MockObject|Field $fieldMock */
+        $fieldMock = $this->getMockBuilder(Field::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        return $fieldMock;
+    }
+
+    /**
+     * Returns stub for ResolveInfo
+     *
+     * @return MockObject|ResolveInfo
+     */
+    private function getResolveInfoStub(): ResolveInfo
+    {
+        /** @var MockObject|ResolveInfo $resolveInfoMock */
+        $resolveInfoMock = $this->getMockBuilder(ResolveInfo::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        return $resolveInfoMock;
+    }
+}

--- a/app/code/Magento/WeeeGraphQl/Test/Unit/FixedProductTaxTest.php
+++ b/app/code/Magento/WeeeGraphQl/Test/Unit/FixedProductTaxTest.php
@@ -7,30 +7,81 @@ declare(strict_types=1);
 
 namespace Magento\WeeeGraphQl\Test\Unit;
 
+use Magento\Framework\DataObject;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\GraphQl\Model\Query\ContextExtensionInterface;
+use Magento\Weee\Helper\Data as WeeeHelper;
 use Magento\WeeeGraphQl\Model\Resolver\FixedProductTax;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 class FixedProductTaxTest extends TestCase
 {
+    const STUB_STORE_ID = 1;
+
+    /**
+     * @var MockObject|ContextInterface
+     */
+    private $contextMock;
+
+    /**
+     * @var MockObject|ContextExtensionInterface
+     */
+    private $extensionAttributesMock;
+
     /**
      * @var FixedProductTax
      */
     private $resolver;
 
     /**
+     * @var MockObject|WeeeHelper
+     */
+    private $weeeHelperMock;
+
+    /**
+     * @var MockObject|DataObject
+     */
+    private $productMock;
+
+    /**
      * Build the Testing Environment
      */
     protected function setUp()
     {
+        $this->contextMock = $this->getMockBuilder(ContextInterface::class)
+            ->setMethods(['getExtensionAttributes'])
+            ->getMock();
+
+        $this->extensionAttributesMock = $this->getMockBuilder(ContextExtensionInterface::class)
+            ->setMethods(['getStore'])
+            ->getMock();
+
+        $this->contextMock->method('getExtensionAttributes')
+            ->willReturn($this->extensionAttributesMock);
+
+        $this->productMock = $this->getMockBuilder(DataObject::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->weeeHelperMock = $this->getMockBuilder(WeeeHelper::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['isEnabled', 'getProductWeeeAttributesForDisplay'])
+            ->getMock();
+
         $objectManager = new ObjectManager($this);
-        $this->resolver = $objectManager->getObject(FixedProductTax::class);
+        $this->resolver = $objectManager->getObject(FixedProductTax::class, [
+            'weeeHelper' => $this->weeeHelperMock
+        ]);
     }
 
+    /**
+     * Verifies if the Exception is being thrown when no Product Model passed to resolver
+     */
     public function testExceptionWhenNoModelSpecified(): void
     {
         $this->expectException(LocalizedException::class);
@@ -40,6 +91,32 @@ class FixedProductTaxTest extends TestCase
             $this->getFieldStub(),
             null,
             $this->getResolveInfoStub()
+        );
+    }
+
+    /**
+     * Verifies that Attributes for display are not being fetched if feature not enabled in store
+     */
+    public function testNotGettingAttributesWhenWeeeDisabledForStore(): void
+    {
+        // Given
+        $this->extensionAttributesMock->method('getStore')
+            ->willreturn(self::STUB_STORE_ID);
+
+        // When
+        $this->weeeHelperMock->method('isEnabled')
+            ->with(self::STUB_STORE_ID)
+            ->willReturn(false);
+
+        // Then
+        $this->weeeHelperMock->expects($this->never())
+            ->method('getProductWeeeAttributesForDisplay');
+
+        $this->resolver->resolve(
+            $this->getFieldStub(),
+            $this->contextMock,
+            $this->getResolveInfoStub(),
+            ['model' => $this->productMock]
         );
     }
 


### PR DESCRIPTION
### Description (*)
Goal of this PR is improving test coverage for WeeeGraphQL module by covering the `\Magento\WeeeGraphQl\Model\Resolver\FixedProductTax` by Unit Tests

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Execute Unit Tests for WeeeGraphQl module

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
