### PR TITLE
Refactor / Cleanup: `use` section does not need leading backslash

### DIFF
--- a/app/code/Magento/AdminAnalytics/registration.php
+++ b/app/code/Magento/AdminAnalytics/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_AdminAnalytics', __DIR__);

--- a/app/code/Magento/AdminNotification/registration.php
+++ b/app/code/Magento/AdminNotification/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_AdminNotification', __DIR__);

--- a/app/code/Magento/AdvancedPricingImportExport/registration.php
+++ b/app/code/Magento/AdvancedPricingImportExport/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_AdvancedPricingImportExport', __DIR__);

--- a/app/code/Magento/AdvancedSearch/registration.php
+++ b/app/code/Magento/AdvancedSearch/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_AdvancedSearch', __DIR__);

--- a/app/code/Magento/Amqp/registration.php
+++ b/app/code/Magento/Amqp/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Amqp', __DIR__);

--- a/app/code/Magento/AmqpStore/registration.php
+++ b/app/code/Magento/AmqpStore/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_AmqpStore', __DIR__);

--- a/app/code/Magento/AsynchronousOperations/registration.php
+++ b/app/code/Magento/AsynchronousOperations/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_AsynchronousOperations', __DIR__);

--- a/app/code/Magento/Authorization/registration.php
+++ b/app/code/Magento/Authorization/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Authorization', __DIR__);

--- a/app/code/Magento/Authorizenet/registration.php
+++ b/app/code/Magento/Authorizenet/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Authorizenet', __DIR__);

--- a/app/code/Magento/AuthorizenetAcceptjs/registration.php
+++ b/app/code/Magento/AuthorizenetAcceptjs/registration.php
@@ -6,6 +6,6 @@
 
 declare(strict_types=1);
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_AuthorizenetAcceptjs', __DIR__);

--- a/app/code/Magento/AuthorizenetCardinal/registration.php
+++ b/app/code/Magento/AuthorizenetCardinal/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_AuthorizenetCardinal', __DIR__);

--- a/app/code/Magento/Backend/registration.php
+++ b/app/code/Magento/Backend/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Backend', __DIR__);

--- a/app/code/Magento/Backup/registration.php
+++ b/app/code/Magento/Backup/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Backup', __DIR__);

--- a/app/code/Magento/Braintree/registration.php
+++ b/app/code/Magento/Braintree/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Braintree', __DIR__);

--- a/app/code/Magento/Bundle/registration.php
+++ b/app/code/Magento/Bundle/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Bundle', __DIR__);

--- a/app/code/Magento/BundleImportExport/registration.php
+++ b/app/code/Magento/BundleImportExport/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_BundleImportExport', __DIR__);

--- a/app/code/Magento/CacheInvalidate/registration.php
+++ b/app/code/Magento/CacheInvalidate/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_CacheInvalidate', __DIR__);

--- a/app/code/Magento/Captcha/registration.php
+++ b/app/code/Magento/Captcha/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Captcha', __DIR__);

--- a/app/code/Magento/CardinalCommerce/registration.php
+++ b/app/code/Magento/CardinalCommerce/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_CardinalCommerce', __DIR__);

--- a/app/code/Magento/Catalog/registration.php
+++ b/app/code/Magento/Catalog/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Catalog', __DIR__);

--- a/app/code/Magento/CatalogImportExport/registration.php
+++ b/app/code/Magento/CatalogImportExport/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_CatalogImportExport', __DIR__);

--- a/app/code/Magento/CatalogInventory/registration.php
+++ b/app/code/Magento/CatalogInventory/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_CatalogInventory', __DIR__);

--- a/app/code/Magento/CatalogRule/registration.php
+++ b/app/code/Magento/CatalogRule/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_CatalogRule', __DIR__);

--- a/app/code/Magento/CatalogRuleConfigurable/registration.php
+++ b/app/code/Magento/CatalogRuleConfigurable/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_CatalogRuleConfigurable', __DIR__);

--- a/app/code/Magento/CatalogSearch/registration.php
+++ b/app/code/Magento/CatalogSearch/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_CatalogSearch', __DIR__);

--- a/app/code/Magento/CatalogUrlRewrite/registration.php
+++ b/app/code/Magento/CatalogUrlRewrite/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_CatalogUrlRewrite', __DIR__);

--- a/app/code/Magento/CatalogWidget/registration.php
+++ b/app/code/Magento/CatalogWidget/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_CatalogWidget', __DIR__);

--- a/app/code/Magento/Checkout/registration.php
+++ b/app/code/Magento/Checkout/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Checkout', __DIR__);

--- a/app/code/Magento/CheckoutAgreements/registration.php
+++ b/app/code/Magento/CheckoutAgreements/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_CheckoutAgreements', __DIR__);

--- a/app/code/Magento/Cms/registration.php
+++ b/app/code/Magento/Cms/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Cms', __DIR__);

--- a/app/code/Magento/CmsUrlRewrite/registration.php
+++ b/app/code/Magento/CmsUrlRewrite/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_CmsUrlRewrite', __DIR__);

--- a/app/code/Magento/Config/registration.php
+++ b/app/code/Magento/Config/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Config', __DIR__);

--- a/app/code/Magento/ConfigurableImportExport/registration.php
+++ b/app/code/Magento/ConfigurableImportExport/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_ConfigurableImportExport', __DIR__);

--- a/app/code/Magento/ConfigurableProduct/registration.php
+++ b/app/code/Magento/ConfigurableProduct/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_ConfigurableProduct', __DIR__);

--- a/app/code/Magento/ConfigurableProductSales/registration.php
+++ b/app/code/Magento/ConfigurableProductSales/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_ConfigurableProductSales', __DIR__);

--- a/app/code/Magento/Contact/registration.php
+++ b/app/code/Magento/Contact/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Contact', __DIR__);

--- a/app/code/Magento/Cookie/registration.php
+++ b/app/code/Magento/Cookie/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Cookie', __DIR__);

--- a/app/code/Magento/Cron/registration.php
+++ b/app/code/Magento/Cron/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Cron', __DIR__);

--- a/app/code/Magento/Csp/registration.php
+++ b/app/code/Magento/Csp/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Csp', __DIR__);

--- a/app/code/Magento/CurrencySymbol/registration.php
+++ b/app/code/Magento/CurrencySymbol/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_CurrencySymbol', __DIR__);

--- a/app/code/Magento/Customer/registration.php
+++ b/app/code/Magento/Customer/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Customer', __DIR__);

--- a/app/code/Magento/CustomerImportExport/registration.php
+++ b/app/code/Magento/CustomerImportExport/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_CustomerImportExport', __DIR__);

--- a/app/code/Magento/Deploy/registration.php
+++ b/app/code/Magento/Deploy/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Deploy', __DIR__);

--- a/app/code/Magento/Developer/registration.php
+++ b/app/code/Magento/Developer/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Developer', __DIR__);

--- a/app/code/Magento/Dhl/registration.php
+++ b/app/code/Magento/Dhl/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Dhl', __DIR__);

--- a/app/code/Magento/Directory/registration.php
+++ b/app/code/Magento/Directory/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Directory', __DIR__);

--- a/app/code/Magento/Downloadable/registration.php
+++ b/app/code/Magento/Downloadable/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Downloadable', __DIR__);

--- a/app/code/Magento/DownloadableImportExport/registration.php
+++ b/app/code/Magento/DownloadableImportExport/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_DownloadableImportExport', __DIR__);

--- a/app/code/Magento/Eav/registration.php
+++ b/app/code/Magento/Eav/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Eav', __DIR__);

--- a/app/code/Magento/Email/registration.php
+++ b/app/code/Magento/Email/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Email', __DIR__);

--- a/app/code/Magento/EncryptionKey/registration.php
+++ b/app/code/Magento/EncryptionKey/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_EncryptionKey', __DIR__);

--- a/app/code/Magento/Fedex/registration.php
+++ b/app/code/Magento/Fedex/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Fedex', __DIR__);

--- a/app/code/Magento/GiftMessage/registration.php
+++ b/app/code/Magento/GiftMessage/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_GiftMessage', __DIR__);

--- a/app/code/Magento/GoogleAdwords/registration.php
+++ b/app/code/Magento/GoogleAdwords/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_GoogleAdwords', __DIR__);

--- a/app/code/Magento/GoogleAnalytics/registration.php
+++ b/app/code/Magento/GoogleAnalytics/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_GoogleAnalytics', __DIR__);

--- a/app/code/Magento/GoogleOptimizer/registration.php
+++ b/app/code/Magento/GoogleOptimizer/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_GoogleOptimizer', __DIR__);

--- a/app/code/Magento/GroupedCatalogInventory/registration.php
+++ b/app/code/Magento/GroupedCatalogInventory/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_GroupedCatalogInventory', __DIR__);

--- a/app/code/Magento/GroupedImportExport/registration.php
+++ b/app/code/Magento/GroupedImportExport/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_GroupedImportExport', __DIR__);

--- a/app/code/Magento/GroupedProduct/registration.php
+++ b/app/code/Magento/GroupedProduct/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_GroupedProduct', __DIR__);

--- a/app/code/Magento/ImportExport/registration.php
+++ b/app/code/Magento/ImportExport/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_ImportExport', __DIR__);

--- a/app/code/Magento/Indexer/registration.php
+++ b/app/code/Magento/Indexer/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Indexer', __DIR__);

--- a/app/code/Magento/InstantPurchase/registration.php
+++ b/app/code/Magento/InstantPurchase/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_InstantPurchase', __DIR__);

--- a/app/code/Magento/Integration/registration.php
+++ b/app/code/Magento/Integration/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Integration', __DIR__);

--- a/app/code/Magento/LayeredNavigation/registration.php
+++ b/app/code/Magento/LayeredNavigation/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_LayeredNavigation', __DIR__);

--- a/app/code/Magento/Marketplace/registration.php
+++ b/app/code/Magento/Marketplace/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Marketplace', __DIR__);

--- a/app/code/Magento/MediaStorage/registration.php
+++ b/app/code/Magento/MediaStorage/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_MediaStorage', __DIR__);

--- a/app/code/Magento/MessageQueue/registration.php
+++ b/app/code/Magento/MessageQueue/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_MessageQueue', __DIR__);

--- a/app/code/Magento/Msrp/registration.php
+++ b/app/code/Magento/Msrp/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Msrp', __DIR__);

--- a/app/code/Magento/MsrpConfigurableProduct/registration.php
+++ b/app/code/Magento/MsrpConfigurableProduct/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_MsrpConfigurableProduct', __DIR__);

--- a/app/code/Magento/MsrpGroupedProduct/registration.php
+++ b/app/code/Magento/MsrpGroupedProduct/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_MsrpGroupedProduct', __DIR__);

--- a/app/code/Magento/Multishipping/registration.php
+++ b/app/code/Magento/Multishipping/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Multishipping', __DIR__);

--- a/app/code/Magento/MysqlMq/registration.php
+++ b/app/code/Magento/MysqlMq/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_MysqlMq', __DIR__);

--- a/app/code/Magento/NewRelicReporting/registration.php
+++ b/app/code/Magento/NewRelicReporting/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_NewRelicReporting', __DIR__);

--- a/app/code/Magento/Newsletter/registration.php
+++ b/app/code/Magento/Newsletter/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Newsletter', __DIR__);

--- a/app/code/Magento/OfflinePayments/registration.php
+++ b/app/code/Magento/OfflinePayments/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_OfflinePayments', __DIR__);

--- a/app/code/Magento/OfflineShipping/registration.php
+++ b/app/code/Magento/OfflineShipping/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_OfflineShipping', __DIR__);

--- a/app/code/Magento/PageCache/registration.php
+++ b/app/code/Magento/PageCache/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_PageCache', __DIR__);

--- a/app/code/Magento/Payment/registration.php
+++ b/app/code/Magento/Payment/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Payment', __DIR__);

--- a/app/code/Magento/Paypal/registration.php
+++ b/app/code/Magento/Paypal/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Paypal', __DIR__);

--- a/app/code/Magento/PaypalCaptcha/registration.php
+++ b/app/code/Magento/PaypalCaptcha/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_PaypalCaptcha', __DIR__);

--- a/app/code/Magento/PaypalGraphQl/registration.php
+++ b/app/code/Magento/PaypalGraphQl/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_PaypalGraphQl', __DIR__);

--- a/app/code/Magento/Persistent/registration.php
+++ b/app/code/Magento/Persistent/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Persistent', __DIR__);

--- a/app/code/Magento/ProductAlert/registration.php
+++ b/app/code/Magento/ProductAlert/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_ProductAlert', __DIR__);

--- a/app/code/Magento/ProductVideo/registration.php
+++ b/app/code/Magento/ProductVideo/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_ProductVideo', __DIR__);

--- a/app/code/Magento/Quote/registration.php
+++ b/app/code/Magento/Quote/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Quote', __DIR__);

--- a/app/code/Magento/Reports/registration.php
+++ b/app/code/Magento/Reports/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Reports', __DIR__);

--- a/app/code/Magento/RequireJs/registration.php
+++ b/app/code/Magento/RequireJs/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_RequireJs', __DIR__);

--- a/app/code/Magento/Review/registration.php
+++ b/app/code/Magento/Review/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Review', __DIR__);

--- a/app/code/Magento/Robots/registration.php
+++ b/app/code/Magento/Robots/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Robots', __DIR__);

--- a/app/code/Magento/Rss/registration.php
+++ b/app/code/Magento/Rss/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Rss', __DIR__);

--- a/app/code/Magento/Rule/registration.php
+++ b/app/code/Magento/Rule/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Rule', __DIR__);

--- a/app/code/Magento/Sales/registration.php
+++ b/app/code/Magento/Sales/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Sales', __DIR__);

--- a/app/code/Magento/SalesInventory/registration.php
+++ b/app/code/Magento/SalesInventory/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_SalesInventory', __DIR__);

--- a/app/code/Magento/SalesRule/registration.php
+++ b/app/code/Magento/SalesRule/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_SalesRule', __DIR__);

--- a/app/code/Magento/SalesSequence/registration.php
+++ b/app/code/Magento/SalesSequence/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_SalesSequence', __DIR__);

--- a/app/code/Magento/SampleData/registration.php
+++ b/app/code/Magento/SampleData/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_SampleData', __DIR__);

--- a/app/code/Magento/Search/registration.php
+++ b/app/code/Magento/Search/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Search', __DIR__);

--- a/app/code/Magento/Security/registration.php
+++ b/app/code/Magento/Security/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Security', __DIR__);

--- a/app/code/Magento/SendFriend/registration.php
+++ b/app/code/Magento/SendFriend/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_SendFriend', __DIR__);

--- a/app/code/Magento/Shipping/registration.php
+++ b/app/code/Magento/Shipping/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Shipping', __DIR__);

--- a/app/code/Magento/Signifyd/registration.php
+++ b/app/code/Magento/Signifyd/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Signifyd', __DIR__);

--- a/app/code/Magento/Sitemap/registration.php
+++ b/app/code/Magento/Sitemap/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Sitemap', __DIR__);

--- a/app/code/Magento/Store/registration.php
+++ b/app/code/Magento/Store/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Store', __DIR__);

--- a/app/code/Magento/Swagger/registration.php
+++ b/app/code/Magento/Swagger/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Swagger', __DIR__);

--- a/app/code/Magento/SwaggerWebapi/registration.php
+++ b/app/code/Magento/SwaggerWebapi/registration.php
@@ -6,6 +6,6 @@
 
 declare(strict_types=1);
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_SwaggerWebapi', __DIR__);

--- a/app/code/Magento/SwaggerWebapiAsync/registration.php
+++ b/app/code/Magento/SwaggerWebapiAsync/registration.php
@@ -6,6 +6,6 @@
 
 declare(strict_types=1);
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_SwaggerWebapiAsync', __DIR__);

--- a/app/code/Magento/Swatches/registration.php
+++ b/app/code/Magento/Swatches/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Swatches', __DIR__);

--- a/app/code/Magento/SwatchesLayeredNavigation/registration.php
+++ b/app/code/Magento/SwatchesLayeredNavigation/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_SwatchesLayeredNavigation', __DIR__);

--- a/app/code/Magento/Tax/registration.php
+++ b/app/code/Magento/Tax/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Tax', __DIR__);

--- a/app/code/Magento/TaxImportExport/registration.php
+++ b/app/code/Magento/TaxImportExport/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_TaxImportExport', __DIR__);

--- a/app/code/Magento/Theme/registration.php
+++ b/app/code/Magento/Theme/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Theme', __DIR__);

--- a/app/code/Magento/Tinymce3/registration.php
+++ b/app/code/Magento/Tinymce3/registration.php
@@ -3,6 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Tinymce3', __DIR__);

--- a/app/code/Magento/Translation/registration.php
+++ b/app/code/Magento/Translation/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Translation', __DIR__);

--- a/app/code/Magento/Ui/registration.php
+++ b/app/code/Magento/Ui/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Ui', __DIR__);

--- a/app/code/Magento/Ups/registration.php
+++ b/app/code/Magento/Ups/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Ups', __DIR__);

--- a/app/code/Magento/UrlRewrite/registration.php
+++ b/app/code/Magento/UrlRewrite/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_UrlRewrite', __DIR__);

--- a/app/code/Magento/User/registration.php
+++ b/app/code/Magento/User/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_User', __DIR__);

--- a/app/code/Magento/Usps/registration.php
+++ b/app/code/Magento/Usps/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Usps', __DIR__);

--- a/app/code/Magento/Variable/registration.php
+++ b/app/code/Magento/Variable/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Variable', __DIR__);

--- a/app/code/Magento/Vault/registration.php
+++ b/app/code/Magento/Vault/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Vault', __DIR__);

--- a/app/code/Magento/Version/registration.php
+++ b/app/code/Magento/Version/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Version', __DIR__);

--- a/app/code/Magento/Webapi/registration.php
+++ b/app/code/Magento/Webapi/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Webapi', __DIR__);

--- a/app/code/Magento/WebapiSecurity/registration.php
+++ b/app/code/Magento/WebapiSecurity/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_WebapiSecurity', __DIR__);

--- a/app/code/Magento/Weee/registration.php
+++ b/app/code/Magento/Weee/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Weee', __DIR__);

--- a/app/code/Magento/Widget/registration.php
+++ b/app/code/Magento/Widget/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Widget', __DIR__);

--- a/app/code/Magento/Wishlist/registration.php
+++ b/app/code/Magento/Wishlist/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Wishlist', __DIR__);

--- a/app/design/adminhtml/Magento/backend/registration.php
+++ b/app/design/adminhtml/Magento/backend/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'adminhtml/Magento/backend', __DIR__);

--- a/app/design/frontend/Magento/blank/registration.php
+++ b/app/design/frontend/Magento/blank/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Magento/blank', __DIR__);

--- a/app/design/frontend/Magento/luma/registration.php
+++ b/app/design/frontend/Magento/luma/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Magento/luma', __DIR__);

--- a/app/i18n/Magento/de_DE/registration.php
+++ b/app/i18n/Magento/de_DE/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'magento_de_de', __DIR__);

--- a/app/i18n/Magento/en_US/registration.php
+++ b/app/i18n/Magento/en_US/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'magento_en_us', __DIR__);

--- a/app/i18n/Magento/es_ES/registration.php
+++ b/app/i18n/Magento/es_ES/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'magento_es_es', __DIR__);

--- a/app/i18n/Magento/fr_FR/registration.php
+++ b/app/i18n/Magento/fr_FR/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'magento_fr_fr', __DIR__);

--- a/app/i18n/Magento/nl_NL/registration.php
+++ b/app/i18n/Magento/nl_NL/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'magento_nl_nl', __DIR__);

--- a/app/i18n/Magento/pt_BR/registration.php
+++ b/app/i18n/Magento/pt_BR/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'magento_pt_br', __DIR__);

--- a/app/i18n/Magento/zh_Hans_CN/registration.php
+++ b/app/i18n/Magento/zh_Hans_CN/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'magento_zh_hans_cn', __DIR__);

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/_files/components/a/aa/aaa/registration.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/_files/components/a/aa/aaa/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Magento/theme', __DIR__);

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/_files/components/a/aa/registration.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/_files/components/a/aa/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'magento_language', __DIR__);

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/_files/components/b/registration.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/_files/components/b/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LIBRARY, 'magento/library', __DIR__);

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/_files/components/registration.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/_files/components/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_ModuleOne', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/_files/design/adminhtml/Magento/test_default/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/_files/design/adminhtml/Magento/test_default/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'adminhtml/BackendTest/test_default', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom1/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom1/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Magento/zoom1', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom2/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom2/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Magento/zoom2', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom3/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Deploy/_files/zoom3/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Magento/zoom3', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Email/Model/_files/design/adminhtml/Magento/default/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/_files/design/adminhtml/Magento/default/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'adminhtml/Magento_EmailTest/default', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Email/Model/_files/design/adminhtml/Vendor/custom_theme/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/_files/design/adminhtml/Vendor/custom_theme/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'adminhtml/Vendor_EmailTest/custom_theme', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Email/Model/_files/design/adminhtml/Vendor/default/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/_files/design/adminhtml/Vendor/default/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'adminhtml/Vendor_EmailTest/default', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Email/Model/_files/design/frontend/Magento/default/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/_files/design/frontend/Magento/default/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Magento_EmailTest/default', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Email/Model/_files/design/frontend/Vendor/custom_theme/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/_files/design/frontend/Vendor/custom_theme/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Vendor_EmailTest/custom_theme', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Email/Model/_files/design/frontend/Vendor/default/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Email/Model/_files/design/frontend/Vendor/default/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Vendor_EmailTest/default', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/bar/en_gb/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/bar/en_gb/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'bar_en_gb', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/bar/en_us/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/bar/en_us/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'bar_en_us', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/baz/en_gb/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/baz/en_gb/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'baz_en_gb', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/first/en_us/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/first/en_us/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'first_en_us', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/foo/en_au/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/foo/en_au/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'foo_en_au', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/my/ru_ru/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/my/ru_ru/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'my_ru_ru', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/second/en_gb/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/second/en_gb/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'second_en_gb', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/theirs/ru_ru/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Language/_files/theirs/ru_ru/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'theirs_ru_ru', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/App/Utility/_files/fixtures/language/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Utility/_files/fixtures/language/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LANGUAGE, 'magento_test_lang', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/App/Utility/_files/fixtures/library/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Utility/_files/fixtures/library/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LIBRARY, 'magento/test', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/App/Utility/_files/fixtures/module/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Utility/_files/fixtures/module/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_Module', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/App/Utility/_files/fixtures/theme/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Utility/_files/fixtures/theme/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Test/theme', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/Css/PreProcessor/_files/code/Magento/Other/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Css/PreProcessor/_files/code/Magento/Other/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'MagentoFrameworkCssTest_Other', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/Css/PreProcessor/_files/code/Magento/Third/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Css/PreProcessor/_files/code/Magento/Third/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'MagentoFrameworkCssTest_Third', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/Css/PreProcessor/_files/design/frontend/Test/default/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Css/PreProcessor/_files/design/frontend/Test/default/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/FrameworkCssTest/default', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/Css/PreProcessor/_files/design/frontend/Test/parent/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Css/PreProcessor/_files/design/frontend/Test/parent/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/FrameworkCssTest/parent', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/Fixture_Module/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/Fixture_Module/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Fixture_Module', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/UiComponent/theme/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/UiComponent/theme/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'adminhtml/FrameworkViewUiComponent/default', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/fallback/app/code/ViewTest_Module/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/fallback/app/code/ViewTest_Module/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'ViewTest_Module', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/fallback/design/frontend/Vendor/custom_theme/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/fallback/design/frontend/Vendor/custom_theme/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Vendor_ViewTest/custom_theme', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/fallback/design/frontend/Vendor/custom_theme2/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/fallback/design/frontend/Vendor/custom_theme2/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Vendor_ViewTest/custom_theme2', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/fallback/design/frontend/Vendor/default/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/fallback/design/frontend/Vendor/default/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Vendor_ViewTest/default', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/fallback/design/frontend/Vendor/standalone_theme/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/fallback/design/frontend/Vendor/standalone_theme/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Vendor_ViewTest/standalone_theme', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/static/theme/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/static/theme/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/FrameworkViewMinifier/default', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/root/app/code/Magento/A/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/root/app/code/Magento/A/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_A', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/root/app/code/Magento/B/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/root/app/code/Magento/B/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_B', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/root/app/code/Magento/C/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/root/app/code/Magento/C/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_C', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/root/app/code/Magento/D/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/root/app/code/Magento/D/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_D', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/adminhtml/Vendor/test/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/adminhtml/Vendor/test/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'adminhtml/FrameworkThemeTest/test', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/area_two/Vendor/theme_one/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/area_two/Vendor/theme_one/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'area_two/FrameworkThemeTest/theme_one', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/design_area/Vendor/theme_one/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/design_area/Vendor/theme_one/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'design_area/FrameworkThemeTest/theme_one', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Magento/default/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Magento/default/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Magento_FrameworkThemeTest/default', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Magento/default_iphone/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Magento/default_iphone/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Magento_FrameworkThemeTest/default_iphone', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Test/cache_test_theme/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Test/cache_test_theme/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Test_FrameworkThemeTest/cache_test_theme', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Test/default/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Test/default/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Test_FrameworkThemeTest/default', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Test/publication/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Test/publication/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Test_FrameworkThemeTest/publication', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Test/test_theme/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Test/test_theme/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Test_FrameworkThemeTest/test_theme', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Vendor/custom_theme/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Vendor/custom_theme/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Vendor_FrameworkThemeTest/custom_theme', __DIR__);

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Vendor/default/registration.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/_files/design/frontend/Vendor/default/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::THEME, 'frontend/Vendor_FrameworkThemeTest/default', __DIR__);

--- a/lib/internal/Magento/Framework/Amqp/registration.php
+++ b/lib/internal/Magento/Framework/Amqp/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LIBRARY, 'magento/framework-amqp', __DIR__);

--- a/lib/internal/Magento/Framework/Bulk/registration.php
+++ b/lib/internal/Magento/Framework/Bulk/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LIBRARY, 'magento/framework-bulk', __DIR__);

--- a/lib/internal/Magento/Framework/MessageQueue/registration.php
+++ b/lib/internal/Magento/Framework/MessageQueue/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LIBRARY, 'magento/framework-message-queue', __DIR__);

--- a/lib/internal/Magento/Framework/registration.php
+++ b/lib/internal/Magento/Framework/registration.php
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::LIBRARY, 'magento/framework', __DIR__);
 

--- a/setup/src/Magento/Setup/registration.php
+++ b/setup/src/Magento/Setup/registration.php
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-use \Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(ComponentRegistrar::SETUP, 'magento/setup', __DIR__);


### PR DESCRIPTION
### Description (*)
`use` section does not actually need `\` at the beginning of the classpath (leading backslash)

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
