### PR TITLE
Code refactor, updated Unit Test with JsonHexTag Serializer

### DIFF
--- a/app/code/Magento/Checkout/Block/Cart/Shipping.php
+++ b/app/code/Magento/Checkout/Block/Cart/Shipping.php
@@ -11,8 +11,8 @@ use Magento\Checkout\Block\Checkout\LayoutProcessorInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\Serialize\Serializer\JsonHexTag;
 use Magento\Framework\View\Element\Template\Context;
-use Magento\Customer\Model\Session as customerSession;
-use Magento\Checkout\Model\Session as checkoutSession;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Framework\App\ObjectManager;
 
 /**
@@ -45,8 +45,8 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
 
     /**
      * @param Context $context
-     * @param customerSession $customerSession
-     * @param checkoutSession $checkoutSession
+     * @param CustomerSession $customerSession
+     * @param CheckoutSession $checkoutSession
      * @param CompositeConfigProvider $configProvider
      * @param array $layoutProcessors
      * @param array $data
@@ -56,8 +56,8 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
      */
     public function __construct(
         Context $context,
-        customerSession $customerSession,
-        checkoutSession $checkoutSession,
+        CustomerSession $customerSession,
+        CheckoutSession $checkoutSession,
         CompositeConfigProvider $configProvider,
         array $layoutProcessors = [],
         array $data = [],

--- a/app/code/Magento/Checkout/Block/Cart/Shipping.php
+++ b/app/code/Magento/Checkout/Block/Cart/Shipping.php
@@ -3,7 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Checkout\Block\Cart;
+
+use Magento\Checkout\Model\CompositeConfigProvider;
+use Magento\Checkout\Block\Checkout\LayoutProcessorInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\Serialize\Serializer\JsonHexTag;
+use Magento\Framework\View\Element\Template\Context;
+use Magento\Customer\Model\Session as customerSession;
+use Magento\Checkout\Model\Session as checkoutSession;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * @api
@@ -12,45 +22,52 @@ namespace Magento\Checkout\Block\Cart;
 class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
 {
     /**
-     * @var \Magento\Checkout\Model\CompositeConfigProvider
+     * @var CompositeConfigProvider
      */
     protected $configProvider;
 
     /**
-     * @var array|\Magento\Checkout\Block\Checkout\LayoutProcessorInterface[]
+     * @var array|LayoutProcessorInterface[]
      */
     protected $layoutProcessors;
 
     /**
-     * @var \Magento\Framework\Serialize\Serializer\Json
+     * @var Json
      */
     private $serializer;
 
     /**
-     * @param \Magento\Framework\View\Element\Template\Context $context
-     * @param \Magento\Customer\Model\Session $customerSession
-     * @param \Magento\Checkout\Model\Session $checkoutSession
-     * @param \Magento\Checkout\Model\CompositeConfigProvider $configProvider
+     * @var JsonHexTag
+     */
+    private $jsonHexTagSerializer;
+
+    /**
+     * @param Context $context
+     * @param customerSession $customerSession
+     * @param checkoutSession $checkoutSession
+     * @param CompositeConfigProvider $configProvider
      * @param array $layoutProcessors
      * @param array $data
-     * @param \Magento\Framework\Serialize\Serializer\Json|null $serializer
+     * @param Json|null $serializer
+     * @param JsonHexTag|null $jsonHexTagSerializer
      * @throws \RuntimeException
      */
     public function __construct(
-        \Magento\Framework\View\Element\Template\Context $context,
-        \Magento\Customer\Model\Session $customerSession,
-        \Magento\Checkout\Model\Session $checkoutSession,
-        \Magento\Checkout\Model\CompositeConfigProvider $configProvider,
+        Context $context,
+        customerSession $customerSession,
+        checkoutSession $checkoutSession,
+        CompositeConfigProvider $configProvider,
         array $layoutProcessors = [],
         array $data = [],
-        \Magento\Framework\Serialize\Serializer\Json $serializer = null
+        Json $serializer = null,
+        JsonHexTag $jsonHexTagSerializer = null
     ) {
         $this->configProvider = $configProvider;
         $this->layoutProcessors = $layoutProcessors;
         parent::__construct($context, $customerSession, $checkoutSession, $data);
         $this->_isScopePrivate = true;
-        $this->serializer = $serializer ?: \Magento\Framework\App\ObjectManager::getInstance()
-            ->get(\Magento\Framework\Serialize\Serializer\Json::class);
+        $this->serializer = $serializer ?: ObjectManager::getInstance()->get(Json::class);
+        $this->jsonHexTagSerializer = $jsonHexTagSerializer ?: ObjectManager::getInstance()->get(JsonHexTag::class);
     }
 
     /**
@@ -75,7 +92,7 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
             $this->jsLayout = $processor->process($this->jsLayout);
         }
 
-        return json_encode($this->jsLayout, JSON_HEX_TAG);
+        return $this->jsonHexTagSerializer->serialize($this->jsLayout);
     }
 
     /**
@@ -95,6 +112,6 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
      */
     public function getSerializedCheckoutConfig()
     {
-        return json_encode($this->getCheckoutConfig(), JSON_HEX_TAG);
+        return $this->jsonHexTagSerializer->serialize($this->getCheckoutConfig());
     }
 }

--- a/app/code/Magento/Checkout/Block/Cart/Shipping.php
+++ b/app/code/Magento/Checkout/Block/Cart/Shipping.php
@@ -16,6 +16,8 @@ use Magento\Checkout\Model\Session as checkoutSession;
 use Magento\Framework\App\ObjectManager;
 
 /**
+ * Cart Shipping Block
+ *
  * @api
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
@@ -107,6 +109,8 @@ class Shipping extends \Magento\Checkout\Block\Cart\AbstractCart
     }
 
     /**
+     * Get Serialized Checkout Config
+     *
      * @return bool|string
      * @since 100.2.0
      */

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
@@ -14,16 +14,34 @@ use Magento\Checkout\Block\Checkout\LayoutProcessorInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\Serialize\Serializer\JsonHexTag;
 use Magento\Framework\View\Element\Template\Context;
-use Magento\Customer\Model\Session as customerSession;
-use Magento\Checkout\Model\Session as checkoutSession;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Model\Store;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  *  Unit Test for Magento\Checkout\Block\Cart\Shipping
  */
-class ShippingTest extends \PHPUnit\Framework\TestCase
+class ShippingTest extends TestCase
 {
+
+    /**
+     * Stub Preinitialized Componets
+     */
+    private const STUB_PREINITIALIZED_COMPONENTS = [
+        'components' => [
+            'firstComponent' => ['param' => 'value']
+        ]
+    ];
+
+    /**
+     * Stub Base URL
+     */
+    private const STUB_BASE_URL = 'baseurl';
+
     /**
      * @var Shipping
      */
@@ -35,12 +53,12 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
     protected $contextMock;
 
     /**
-     * @var customerSession|MockObject
+     * @var CustomerSession|MockObject
      */
     protected $customerSessionMock;
 
     /**
-     * @var checkoutSession|MockObject
+     * @var CheckoutSession|MockObject
      */
     protected $checkoutSessionMock;
 
@@ -57,7 +75,7 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
     /**
      * @var StoreManagerInterface|MockObject
      */
-    protected $storeManagerMock;
+    protected $storeManagerInterfaceMock;
 
     /**
      * @var array
@@ -80,32 +98,26 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $this->contextMock = $this->createMock(Context::class);
-        $this->customerSessionMock = $this->createMock(customerSession::class);
-        $this->checkoutSessionMock = $this->createMock(checkoutSession::class);
+        $this->customerSessionMock = $this->createMock(CustomerSession::class);
+        $this->checkoutSessionMock = $this->createMock(CheckoutSession::class);
         $this->configProviderMock = $this->createMock(CompositeConfigProvider::class);
         $this->layoutProcessorMock = $this->createMock(LayoutProcessorInterface::class);
         $this->serializerMock = $this->createMock(JsonHexTag::class);
         $this->jsonHexTagSerializerMock = $this->createMock(JsonHexTag::class);
-        $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
-        $this->layout = [
-            'components' => [
-                'firstComponent' => ['param' => 'value']
+        $this->storeManagerInterfaceMock = $this->createMock(StoreManagerInterface::class);
+        $this->layout = self::STUB_PREINITIALIZED_COMPONENTS;
+
+        $objectManager = new ObjectManager($this);
+        $this->block = $objectManager->getObject(
+            Shipping::class,
+            [
+                'configProvider' => $this->configProviderMock,
+                'layoutProcessors' => [$this->layoutProcessorMock],
+                'jsLayout' => $this->layout,
+                'serializer' => $this->serializerMock,
+                'jsonHexTagSerializer' => $this->jsonHexTagSerializerMock,
+                'storeManager' => $this->storeManagerInterfaceMock
             ]
-        ];
-
-        $this->contextMock->expects($this->once())
-            ->method('getStoreManager')
-            ->willReturn($this->storeManagerMock);
-
-        $this->block = new Shipping(
-            $this->contextMock,
-            $this->customerSessionMock,
-            $this->checkoutSessionMock,
-            $this->configProviderMock,
-            [$this->layoutProcessorMock],
-            ['jsLayout' => $this->layout],
-            $this->serializerMock,
-            $this->jsonHexTagSerializerMock
         );
     }
 
@@ -168,13 +180,13 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetBaseUrl(): void
     {
-        $baseUrl = 'baseUrl';
-        $storeMock = $this->createPartialMock(\Magento\Store\Model\Store::class, ['getBaseUrl']);
+        $baseUrl = self::STUB_BASE_URL;
+        $storeMock = $this->createPartialMock(Store::class, ['getBaseUrl']);
         $storeMock->expects($this->once())
             ->method('getBaseUrl')
             ->willReturn($baseUrl);
 
-        $this->storeManagerMock->expects($this->once())
+        $this->storeManagerInterfaceMock->expects($this->once())
             ->method('getStore')
             ->willReturn($storeMock);
 

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php
@@ -89,8 +89,7 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
         $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
         $this->layout = [
             'components' => [
-                'firstComponent' => ['param' => 'value'],
-                'secondComponent' => ['param' => 'value'],
+                'firstComponent' => ['param' => 'value']
             ]
         ];
 
@@ -153,11 +152,11 @@ class ShippingTest extends \PHPUnit\Framework\TestCase
     public function getJsLayoutDataProvider(): array
     {
         $layoutProcessed = $this->layout;
-        $layoutProcessed['components']['thirdComponent'] = ['param' => 'value'];
+        $layoutProcessed['components']['secondComponent'] = ['param' => 'value'];
         return [
             [
                 $layoutProcessed,
-                '{"components":{"firstComponent":{"param":"value"},"secondComponent":{"param":"value"},"thirdComponent":{"param":"value"}}}'
+                '{"components":{"firstComponent":{"param":"value"},"secondComponent":{"param":"value"}}}'
             ]
         ];
     }


### PR DESCRIPTION
### Description (*)
This PR helps to refactor the code of Block/Cart/Shipping in Checkout Module, utilised JsonHexTag class for replacing PHP json_encode with JsonHexTag option, Also covered the unit test case with JsonHexTag class & data provider.

Path: `app/code/Magento/Checkout/Block/Cart/Shipping.php`

### Manual testing scenarios (*)
`vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/Checkout/Test/Unit/Block/Cart/ShippingTest.php`

### Questions or comments
If any please let me know your feedback

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
