### PR TITLE
[Bundle] Covering the SetAttributeTabBlockObserver for Bundles by Unit Test

### DIFF
--- a/app/code/Magento/Bundle/Test/Unit/Observer/SetAttributeTabBlockObserverTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Observer/SetAttributeTabBlockObserverTest.php
@@ -14,6 +14,7 @@ use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Type;
 use Magento\Framework\Event;
 use Magento\Framework\Event\Observer;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -54,6 +55,7 @@ class SetAttributeTabBlockObserverTest extends TestCase
      */
     public function setUp()
     {
+        $objectManager = new ObjectManager($this);
         $this->helperCatalogMock = $this->createMock(Catalog::class);
         $this->observerMock = $this->createMock(Observer::class);
         $this->eventMock = $this->getMockBuilder(Event::class)
@@ -64,8 +66,11 @@ class SetAttributeTabBlockObserverTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->observer = new SetAttributeTabBlockObserver(
-            $this->helperCatalogMock
+        $this->observer = $objectManager->getObject(
+            SetAttributeTabBlockObserver::class,
+            [
+                'helperCatalog' => $this->helperCatalogMock
+            ]
         );
     }
 

--- a/app/code/Magento/Bundle/Test/Unit/Observer/SetAttributeTabBlockObserverTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Observer/SetAttributeTabBlockObserverTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Bundle\Test\Unit\Observer;
+
+use Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Attributes;
+use Magento\Bundle\Observer\SetAttributeTabBlockObserver;
+use Magento\Catalog\Helper\Catalog;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Type;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class SetAttributeTabBlockObserverTest
+ *
+ * Test setting attribute tab block for bundle products
+ */
+class SetAttributeTabBlockObserverTest extends TestCase
+{
+    /**
+     * @var SetAttributeTabBlockObserver
+     */
+    private $observer;
+
+    /**
+     * @var Catalog|MockObject
+     */
+    private $helperCatalogMock;
+
+    /**
+     * @var Observer|MockObject
+     */
+    private $observerMock;
+
+    /**
+     * @var Event|MockObject
+     */
+    private $eventMock;
+
+    /**
+     * @var Product|MockObject
+     */
+    private $productMock;
+
+    /**
+     * Set Up
+     */
+    public function setUp()
+    {
+        $this->helperCatalogMock = $this->createMock(Catalog::class);
+        $this->observerMock = $this->createMock(Observer::class);
+        $this->eventMock = $this->getMockBuilder(Event::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getProduct'])
+            ->getMock();
+        $this->productMock = $this->getMockBuilder(Product::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->observer = new SetAttributeTabBlockObserver(
+            $this->helperCatalogMock
+        );
+    }
+
+    /**
+     * Test setting attribute tab block for bundle product
+     */
+    public function testAddingAttributeTabForBundleProduct()
+    {
+        $this->productMock->expects($this->any())
+            ->method('getTypeId')
+            ->willReturn(Type::TYPE_BUNDLE);
+        $this->eventMock->expects($this->any())
+            ->method('getProduct')
+            ->willReturn($this->productMock);
+        $this->observerMock->expects($this->any())
+            ->method('getEvent')
+            ->willReturn($this->eventMock);
+        $this->helperCatalogMock->expects($this->once())
+            ->method('setAttributeTabBlock')
+            ->with(Attributes::class);
+
+        $this->observer->execute($this->observerMock);
+    }
+
+    /**
+     * Test setting attribute tab block for a non bundle product
+     */
+    public function testAddingAttributeTabForNonBundleProduct()
+    {
+        $this->productMock->expects($this->any())
+            ->method('getTypeId')
+            ->willReturn(Type::TYPE_VIRTUAL);
+        $this->eventMock->expects($this->any())
+            ->method('getProduct')
+            ->willReturn($this->productMock);
+        $this->observerMock->expects($this->any())
+            ->method('getEvent')
+            ->willReturn($this->eventMock);
+        $this->helperCatalogMock->expects($this->never())
+            ->method('setAttributeTabBlock');
+
+        $this->observer->execute($this->observerMock);
+    }
+}


### PR DESCRIPTION

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR adds missing unit tests for the following class:
 - `\Magento\Bundle\Observer\SetAttributeTabBlockObserver`

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
