### PR TITLE
[CatalogInventory] Covering the InvalidatePriceIndexUponConfigChangeObserver for Catalog…

### DIFF
--- a/app/code/Magento/CatalogInventory/Test/Unit/Observer/InvalidatePriceIndexUponConfigChangeObserverTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Observer/InvalidatePriceIndexUponConfigChangeObserverTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogInventory\Test\Unit\Observer;
+
+use Magento\Catalog\Model\Indexer\Product\Price\Processor;
+use Magento\CatalogInventory\Model\Configuration;
+use Magento\CatalogInventory\Observer\InvalidatePriceIndexUponConfigChangeObserver;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Indexer\IndexerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class InvalidatePriceIndexUponConfigChangeObserverTest
+ *
+ * Testing invalidating product price index onn config changing
+ */
+class InvalidatePriceIndexUponConfigChangeObserverTest extends TestCase
+{
+    /**
+     * @var InvalidatePriceIndexUponConfigChangeObserver
+     */
+    private $observer;
+
+    /**
+     * @var Processor|MockObject
+     */
+    private $priceIndexProcessorMock;
+
+    /**
+     * @var Observer|MockObject
+     */
+    private $observerMock;
+
+    /**
+     * @var Event|MockObject
+     */
+    private $eventMock;
+
+    /**
+     * @var IndexerInterface|MockObject
+     */
+    private $indexerMock;
+
+    /**
+     * Set Up
+     */
+    public function setUp()
+    {
+        $this->priceIndexProcessorMock = $this->createMock(Processor::class);
+        $this->indexerMock = $this->getMockBuilder(IndexerInterface::class)
+            ->getMockForAbstractClass();
+        $this->observerMock = $this->createMock(Observer::class);
+        $this->eventMock = $this->getMockBuilder(Event::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getChangedPaths'])
+            ->getMock();
+
+        $this->observer = new InvalidatePriceIndexUponConfigChangeObserver(
+            $this->priceIndexProcessorMock
+        );
+    }
+
+    /**
+     * Testing invalidating product price index on catalog inventory config changes
+     */
+    public function testInvalidatingPriceOnChangingOutOfStockConfig()
+    {
+        $changedPaths = [Configuration::XML_PATH_SHOW_OUT_OF_STOCK];
+
+        $this->eventMock->expects($this->once())
+            ->method('getChangedPaths')
+            ->willReturn($changedPaths);
+        $this->observerMock->expects($this->once())
+            ->method('getEvent')
+            ->willReturn($this->eventMock);
+        $this->indexerMock->expects($this->once())
+            ->method('invalidate');
+        $this->priceIndexProcessorMock->expects($this->once())
+            ->method('getIndexer')
+            ->willReturn($this->indexerMock);
+
+        $this->observer->execute($this->observerMock);
+    }
+
+    /**
+     * Testing invalidating product price index on changing any other config
+     */
+    public function testInvalidatingPriceOnChangingAnyOtherConfig()
+    {
+        $changedPaths = [Configuration::XML_PATH_ITEM_AUTO_RETURN];
+
+        $this->eventMock->expects($this->once())
+            ->method('getChangedPaths')
+            ->willReturn($changedPaths);
+        $this->observerMock->expects($this->once())
+            ->method('getEvent')
+            ->willReturn($this->eventMock);
+        $this->indexerMock->expects($this->never())
+            ->method('invalidate');
+        $this->priceIndexProcessorMock->expects($this->never())
+            ->method('getIndexer')
+            ->willReturn($this->indexerMock);
+
+        $this->observer->execute($this->observerMock);
+    }
+}

--- a/app/code/Magento/CatalogInventory/Test/Unit/Observer/InvalidatePriceIndexUponConfigChangeObserverTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Observer/InvalidatePriceIndexUponConfigChangeObserverTest.php
@@ -13,6 +13,7 @@ use Magento\CatalogInventory\Observer\InvalidatePriceIndexUponConfigChangeObserv
 use Magento\Framework\Event;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Indexer\IndexerInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -53,6 +54,7 @@ class InvalidatePriceIndexUponConfigChangeObserverTest extends TestCase
      */
     public function setUp()
     {
+        $objectManager = new ObjectManager($this);
         $this->priceIndexProcessorMock = $this->createMock(Processor::class);
         $this->indexerMock = $this->getMockBuilder(IndexerInterface::class)
             ->getMockForAbstractClass();
@@ -62,8 +64,11 @@ class InvalidatePriceIndexUponConfigChangeObserverTest extends TestCase
             ->setMethods(['getChangedPaths'])
             ->getMock();
 
-        $this->observer = new InvalidatePriceIndexUponConfigChangeObserver(
-            $this->priceIndexProcessorMock
+        $this->observer = $objectManager->getObject(
+            InvalidatePriceIndexUponConfigChangeObserver::class,
+            [
+                'priceIndexProcessor' => $this->priceIndexProcessorMock
+            ]
         );
     }
 


### PR DESCRIPTION
…Inventory by Unit Test

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR adds missing unit tests for the following class:
- `\Magento\CatalogInventory\Observer\InvalidatePriceIndexUponConfigChangeObserver`

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
