### PR TITLE
Remove blank space at the end of label

### DIFF
--- a/app/code/Magento/Cron/etc/adminhtml/system.xml
+++ b/app/code/Magento/Cron/etc/adminhtml/system.xml
@@ -12,7 +12,7 @@
                 <label>Cron (Scheduled Tasks)</label>
                 <comment>For correct URLs generated during cron runs please make sure that Web &gt; Secure and Unsecure Base URLs are explicitly set. All the times are in minutes.</comment>
                 <group id="template" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
-                    <label>Cron configuration options for group: </label>
+                    <label>Cron configuration options for group:</label>
                     <field id="schedule_generate_every" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                         <label>Generate Schedules Every</label>
                         <validate>validate-zero-or-greater validate-digits</validate>

--- a/app/code/Magento/Cron/i18n/en_US.csv
+++ b/app/code/Magento/Cron/i18n/en_US.csv
@@ -11,7 +11,7 @@ Monthly,Monthly
 "Test exception","Test exception"
 "Cron (Scheduled Tasks)","Cron (Scheduled Tasks)"
 "For correct URLs generated during cron runs please make sure that Web > Secure and Unsecure Base URLs are explicitly set. All the times are in minutes.","For correct URLs generated during cron runs please make sure that Web > Secure and Unsecure Base URLs are explicitly set. All the times are in minutes."
-"Cron configuration options for group: ","Cron configuration options for group: "
+"Cron configuration options for group:","Cron configuration options for group:"
 "Generate Schedules Every","Generate Schedules Every"
 "Schedule Ahead for","Schedule Ahead for"
 "Missed if Not Run Within","Missed if Not Run Within"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Removed white space because in crowdin translation there is no space at end of text

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. go to https://crowdin.com/translate/magento-2/14908/enus-ptbr#496746
2. put text with space at end of text
3. site's give feedback "The source text does not end with a space, please remove 1 space at the end of your translation."

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
