### PR TITLE
Fixed Issue with tier price 0 when saving product second time

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/TierPrice/UpdateHandler.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/TierPrice/UpdateHandler.php
@@ -129,7 +129,7 @@ class UpdateHandler extends AbstractHandler
     {
         $isChanged = false;
         foreach ($valuesToUpdate as $key => $value) {
-            if ((!empty($value['value'])
+            if ((($value['value'])!== null
                     && (float)$oldValues[$key]['price'] !== $this->localeFormat->getNumber($value['value'])
                 ) || $this->getPercentage($oldValues[$key]) !== $this->getPercentage($value)
             ) {

--- a/app/code/Magento/Catalog/Test/Unit/Model/Attribute/Backend/TierPrice/UpdateHandlerTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Attribute/Backend/TierPrice/UpdateHandlerTest.php
@@ -128,6 +128,12 @@ class UpdateHandlerTest extends \PHPUnit\Framework\TestCase
                     ['entity_id', $originalProductId]
                 ]
             );
+        $this->assertEquals($this->assertNotNull($newTierPrices[0]['price']), 
+        $this->tierPriceResource->expects($this->atLeastOnce())
+        ->method('updateValues')->with($newTierPrices, $originalTierPrices)->willReturn(true));
+        $this->assertEquals($this->assertNull($newTierPrices[0]['price']), 
+        $this->tierPriceResource->expects($this->atLeastOnce())
+        ->method('updateValues')->with($newTierPrices, $originalTierPrices)->willReturn(false));
         $product->expects($this->atLeastOnce())->method('getStoreId')->willReturn(0);
         $product->expects($this->atLeastOnce())->method('setData')->with('tier_price_changed', 1);
         $store = $this->getMockBuilder(\Magento\Store\Api\Data\StoreInterface::class)
@@ -163,7 +169,6 @@ class UpdateHandlerTest extends \PHPUnit\Framework\TestCase
         $this->tierPriceResource->expects($this->exactly(2))->method('savePriceData')->willReturnSelf();
         $this->tierPriceResource->expects($this->once())->method('deletePriceData')
             ->with($productId, null, $priceIdToDelete);
-
         $this->assertEquals($product, $this->updateHandler->execute($product));
     }
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/Attribute/Backend/TierPrice/UpdateHandlerTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Attribute/Backend/TierPrice/UpdateHandlerTest.php
@@ -128,12 +128,16 @@ class UpdateHandlerTest extends \PHPUnit\Framework\TestCase
                     ['entity_id', $originalProductId]
                 ]
             );
-        $this->assertEquals($this->assertNotNull($newTierPrices[0]['price']), 
-        $this->tierPriceResource->expects($this->atLeastOnce())
-        ->method('updateValues')->with($newTierPrices, $originalTierPrices)->willReturn(true));
-        $this->assertEquals($this->assertNull($newTierPrices[0]['price']), 
-        $this->tierPriceResource->expects($this->atLeastOnce())
-        ->method('updateValues')->with($newTierPrices, $originalTierPrices)->willReturn(false));
+        $this->assertEquals(
+            $this->assertNotNull($newTierPrices[0]['price']),
+                                 $this->tierPriceResource->expects($this->atLeastOnce())
+                ->method('updateValues')->with($newTierPrices, $originalTierPrices)->willReturn(true)
+        );
+        $this->assertEquals(
+            $this->assertNull($newTierPrices[0]['price']),
+                              $this->tierPriceResource->expects($this->atLeastOnce())
+                ->method('updateValues')->with($newTierPrices, $originalTierPrices)->willReturn(false)
+        );
         $product->expects($this->atLeastOnce())->method('getStoreId')->willReturn(0);
         $product->expects($this->atLeastOnce())->method('setData')->with('tier_price_changed', 1);
         $store = $this->getMockBuilder(\Magento\Store\Api\Data\StoreInterface::class)


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed Issue with tier price 0 when saving product second time
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25195: Issue with tier price 0 when saving product second time #25195

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
