### PR TITLE
Fix for footer newsletter input field length in IE/Edge

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
@@ -84,9 +84,9 @@
         
         .form.subscribe {
             > .field,
-		    > .actions {
-		        float: left;
-		    }
+            > .actions {
+                float: left;
+            }
         }
     }
 }

--- a/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
@@ -81,6 +81,13 @@
     .block.newsletter {
         max-width: 44%;
         width: max-content;
+        
+        .form.subscribe {
+            > .field,
+		    > .actions {
+		        float: left;
+		    }
+        }
     }
 }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#26176: Footer Newsletter input field width is not identical in Internet Explorer/EDGE browser compared with chrome

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Front-end footer section
2. With this fix the newsletter input field width is identical in Internet Explorer/Edge Browser as shown below
![search-expected](https://user-images.githubusercontent.com/54176640/71469257-9db7f580-27ee-11ea-975f-450f60aadcf1.png)



### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
