### PR TITLE
Allow wishlist share when all items are out of stock

### DIFF
--- a/app/code/Magento/Wishlist/Controller/Index/Update.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Update.php
@@ -70,7 +70,12 @@ class Update extends \Magento\Wishlist\Controller\AbstractIndex implements HttpP
         }
 
         $post = $this->getRequest()->getPostValue();
-        if ($post && isset($post['description']) && is_array($post['description'])) {
+        $resultRedirect->setPath('*', ['wishlist_id' => $wishlist->getId()]);
+        if (!$post) {
+            return $resultRedirect;
+        }
+
+        if (isset($post['description']) && is_array($post['description'])) {
             $updatedItems = 0;
 
             foreach ($post['description'] as $itemId => $description) {
@@ -136,13 +141,12 @@ class Update extends \Magento\Wishlist\Controller\AbstractIndex implements HttpP
                     $this->messageManager->addErrorMessage(__('Can\'t update wish list'));
                 }
             }
-
-            if (isset($post['save_and_share'])) {
-                $resultRedirect->setPath('*/*/share', ['wishlist_id' => $wishlist->getId()]);
-                return $resultRedirect;
-            }
         }
-        $resultRedirect->setPath('*', ['wishlist_id' => $wishlist->getId()]);
+
+        if (isset($post['save_and_share'])) {
+            $resultRedirect->setPath('*/*/share', ['wishlist_id' => $wishlist->getId()]);
+        }
+
         return $resultRedirect;
     }
 }

--- a/app/code/Magento/Wishlist/Controller/Index/Update.php
+++ b/app/code/Magento/Wishlist/Controller/Index/Update.php
@@ -11,7 +11,7 @@ use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\Controller\ResultFactory;
 
 /**
- * Class Update
+ * Controller for updating wishlists
  */
 class Update extends \Magento\Wishlist\Controller\AbstractIndex implements HttpPostActionInterface
 {

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/UpdateTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/UpdateTest.php
@@ -29,19 +29,9 @@ use PHPUnit_Framework_MockObject_MockObject as MockObject;
  */
 class UpdateTest extends TestCase
 {
-    /**
-     * Wishlist item id
-     *
-     * @var int
-     */
-    private const ITEM_ID = 1;
+    private const STUB_ITEM_ID = 1;
 
-    /**
-     * Product qty for wishlist
-     *
-     * @var int
-     */
-    private const WISHLIST_PRODUCT_QTY = 21;
+    private const STUB_WISHLIST_PRODUCT_QTY = 21;
 
     /**
      * @var MockObject|Validator $formKeyValidatorMock
@@ -126,7 +116,9 @@ class UpdateTest extends TestCase
             ->method('getMessageManager')
            ->willReturn($this->messageManagerMock);
 
-        $this->updateController = (new ObjectManagerHelper($this))->getObject(
+        $objectManager = new ObjectManagerHelper($this);
+
+        $this->updateController = $objectManager->getObject(
             Update::class,
             [
                 'context' => $this->contextMock,
@@ -286,11 +278,11 @@ class UpdateTest extends TestCase
             [
                 [
                     [
-                        'id' => self::ITEM_ID
+                        'id' => self::STUB_ITEM_ID
                     ],
                     [
-                        'qty' => [self::ITEM_ID => self::WISHLIST_PRODUCT_QTY],
-                        'description' => [self::ITEM_ID => 'Description for item_id 1']
+                        'qty' => [self::STUB_ITEM_ID => self::STUB_WISHLIST_PRODUCT_QTY],
+                        'description' => [self::STUB_ITEM_ID => 'Description for item_id 1']
                     ]
                 ]
             ];

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/UpdateTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/UpdateTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Wishlist\Test\Unit\Controller\Index;
+
+use Magento\Backend\Model\View\Result\Redirect;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Data\Form\FormKey\Validator;
+use Magento\Wishlist\Controller\Index\Update;
+use Magento\Wishlist\Controller\WishlistProviderInterface;
+use Magento\Wishlist\Model\LocaleQuantityProcessor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test for upate controller wishlist
+ */
+class UpdateTest extends TestCase
+{
+    /**
+     * @var Validator $formKeyValidator
+     */
+    private $formKeyValidator;
+
+    /**
+     * @var WishlistProviderInterface $wishlistProvider
+     */
+    private $wishlistProvider;
+
+    /**
+     * @var LocaleQuantityProcessor $quantityProcessor
+     */
+    private $quantityProcessor;
+
+    /**
+     * @var Update $updateController
+     */
+    private $updateController;
+
+    /**
+     * @var $context
+     */
+    private $context;
+
+    /**
+     * @var Redirect $resultRedirect
+     */
+    private $resultRedirect;
+
+    /**
+     * @var ResultFactory $resultFatory
+     */
+    private $resultFactory;
+
+    /**
+     * @var RequestInterface $requestMock
+     */
+    private $requestMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->formKeyValidator = $this->createMock(Validator::class);
+        $this->wishlistProvider = $this->createMock(WishlistProviderInterface::class);
+        $this->quantityProcessor = $this->createMock(LocaleQuantityProcessor::class);
+        $this->context = $this->createMock(Context::class);
+        $this->resultRedirect = $this->createMock(Redirect::class);
+        $this->resultFactory = $this->createPartialMock(ResultFactory::class, ['create']);
+        $this->requestMock = $this->getMockBuilder(RequestInterface::class)
+            ->setMethods(['getPostValue'])
+            ->getMockForAbstractClass();
+
+        $this->context->expects($this->once())
+                      ->method('getResultFactory')
+                      ->willReturn($this->resultFactory);
+
+        $this->resultFactory->expects($this->any())
+                              ->method('create')
+                              ->willReturn($this->resultRedirect);
+        $this->context->expects($this->any())
+            ->method('getRequest')
+            ->willReturn($this->requestMock);
+
+        $this->updateController = new Update(
+            $this->context,
+            $this->formKeyValidator,
+            $this->wishlistProvider,
+            $this->quantityProcessor
+        );
+    }
+
+    /**
+     * Test for update method Wishlist controller.
+     *
+     * Check if there is not post value result redirect returned.
+     *
+     * @return void
+     */
+    public function testUpdate(): void
+    {
+        $this->formKeyValidator->expects($this->once())
+                               ->method('validate')
+                               ->willReturn(true);
+
+        $wishlist = $this->createMock(\Magento\Wishlist\Model\Wishlist::class);
+        $this->wishlistProvider->expects($this->once())
+            ->method('getWishlist')
+            ->willReturn($wishlist);
+        $this->requestMock->expects($this->once())
+            ->method('getPostValue')
+            ->willReturn(null);
+        $this->assertEquals($this->resultRedirect, $this->updateController->execute());
+    }
+}


### PR DESCRIPTION
### Description (*)
Clicking `Share` on the wishlist view page updates and saves the wishlist
before redirecting to the share page. The redirection to the share page only
happens when the post body includes wishlist descriptions. Because qty and
comment are disabled for out of stock wishlist items these properties are not
sent with the post resulting in the share redirect being unreachable when all
items are out of stock.

This commit updates the controller flow separating the logic conditions for
saving and sharing. This allows sharing wishlist where all items are out of
stock.

### Manual testing scenarios (*)
1. Create simple product
2. Make simple product out of stock
3. Add product to wishlist
4. Confirm wishlist only contains the out of stock product
5. Click share

**Expected Result With PR**
You should be redirected to the share page for inputting email addresses and messages.

**Current Behavior**
You are redirected back to the wishlist view without any messaging.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
