### PR TITLE
#26206 Add information about currently reindexed index.

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateDatetimeProductAttributeTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateDatetimeProductAttributeTest.xml
@@ -27,7 +27,7 @@
             <actionGroup ref="logout" stepKey="logout"/>
         </after>
         <!-- Generate the datetime default value -->
-        <generateDate date="now" format="m/j/y g:i A" stepKey="generateDefaultValue"/>
+        <generateDate date="now" format="n/j/y g:i A" stepKey="generateDefaultValue"/>
         <!-- Create new datetime product attribute -->
         <amOnPage url="{{AdminProductAttributeGridPage.url}}" stepKey="goToProductAttributes"/>
         <waitForPageLoad stepKey="waitForPageLoadAttributes"/>

--- a/app/code/Magento/Indexer/Console/Command/IndexerReindexCommand.php
+++ b/app/code/Magento/Indexer/Console/Command/IndexerReindexCommand.php
@@ -128,8 +128,8 @@ class IndexerReindexCommand extends AbstractIndexerManageCommand
         $dependentIndexers = [[]];
 
         foreach ($indexers as $indexer) {
-            array_push($relatedIndexers, $this->getRelatedIndexerIds($indexer->getId()));
-            array_push($dependentIndexers, $this->getDependentIndexerIds($indexer->getId()));
+            $relatedIndexers[] = $this->getRelatedIndexerIds($indexer->getId());
+            $dependentIndexers[] = $this->getDependentIndexerIds($indexer->getId());
         }
 
         $relatedIndexers = array_merge(...$relatedIndexers);
@@ -162,16 +162,15 @@ class IndexerReindexCommand extends AbstractIndexerManageCommand
      * @param string $indexerId
      * @return array
      */
-    private function getRelatedIndexerIds(string $indexerId)
+    private function getRelatedIndexerIds(string $indexerId): array
     {
         $relatedIndexerIds = [[]];
         foreach ($this->getDependencyInfoProvider()->getIndexerIdsToRunBefore($indexerId) as $relatedIndexerId) {
-            array_push($relatedIndexerIds, [$relatedIndexerId], $this->getRelatedIndexerIds($relatedIndexerId));
+            $relatedIndexerIds[] = [$relatedIndexerId];
+            $relatedIndexerIds[] = $this->getRelatedIndexerIds($relatedIndexerId);
         }
 
-        $relatedIndexerIds = array_merge(...$relatedIndexerIds);
-
-        return array_unique($relatedIndexerIds);
+        return array_unique(array_merge(...$relatedIndexerIds));
     }
 
     /**
@@ -180,13 +179,14 @@ class IndexerReindexCommand extends AbstractIndexerManageCommand
      * @param string $indexerId
      * @return array
      */
-    private function getDependentIndexerIds(string $indexerId)
+    private function getDependentIndexerIds(string $indexerId): array
     {
         $dependentIndexerIds = [[]];
         foreach (array_keys($this->getConfig()->getIndexers()) as $id) {
             $dependencies = $this->getDependencyInfoProvider()->getIndexerIdsToRunBefore($id);
             if (array_search($indexerId, $dependencies) !== false) {
-                array_push($dependentIndexerIds, [$id], $this->getDependentIndexerIds($id));
+                $dependentIndexerIds[] = [$id];
+                $dependentIndexerIds[] = $this->getDependentIndexerIds($id);
             }
         }
 

--- a/app/code/Magento/Indexer/Console/Command/IndexerReindexCommand.php
+++ b/app/code/Magento/Indexer/Console/Command/IndexerReindexCommand.php
@@ -76,6 +76,7 @@ class IndexerReindexCommand extends AbstractIndexerManageCommand
     {
         $returnValue = Cli::RETURN_FAILURE;
         foreach ($this->getIndexers($input) as $indexer) {
+            $output->write($indexer->getTitle() . ' ');
             try {
                 $this->validateIndexerStatus($indexer);
                 $startTime = microtime(true);
@@ -90,8 +91,9 @@ class IndexerReindexCommand extends AbstractIndexerManageCommand
                     }
                 }
                 $resultTime = microtime(true) - $startTime;
+
                 $output->writeln(
-                    $indexer->getTitle() . ' index has been rebuilt successfully in ' . gmdate('H:i:s', $resultTime)
+                    __('index has been rebuilt successfully in %time', ['time' => gmdate('H:i:s', $resultTime)])
                 );
                 $returnValue = Cli::RETURN_SUCCESS;
             } catch (LocalizedException $e) {
@@ -111,7 +113,7 @@ class IndexerReindexCommand extends AbstractIndexerManageCommand
      */
     protected function getIndexers(InputInterface $input)
     {
-        $indexers =  parent::getIndexers($input);
+        $indexers = parent::getIndexers($input);
         $allIndexers = $this->getAllIndexers();
         if (!array_diff_key($allIndexers, $indexers)) {
             return $indexers;

--- a/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerReindexCommandTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Console/Command/IndexerReindexCommandTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
 {
+    const STUB_INDEXER_NAME = 'Indexer Name';
     /**
      * Command being tested
      *
@@ -107,7 +108,7 @@ class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
             [
                 $this->getIndexerMock(
                     ['reindexAll', 'getStatus'],
-                    ['indexer_id' => 'id_indexerOne', 'title' => 'Title_indexerOne']
+                    ['indexer_id' => 'id_indexerOne', 'title' => self::STUB_INDEXER_NAME]
                 )
             ]
         );
@@ -117,7 +118,10 @@ class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
         $commandTester->execute([]);
         $actualValue = $commandTester->getDisplay();
         $this->assertSame(Cli::RETURN_SUCCESS, $commandTester->getStatusCode());
-        $this->assertStringStartsWith('Title_indexerOne index has been rebuilt successfully in', $actualValue);
+        $this->assertStringStartsWith(
+            self::STUB_INDEXER_NAME . ' index has been rebuilt successfully in',
+            $actualValue
+        );
     }
 
     /**
@@ -174,6 +178,7 @@ class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
             $this->objectManagerFactory,
             $this->indexerRegistryMock
         );
+
         $commandTester = new CommandTester($this->command);
         $commandTester->execute(['index' => $inputIndexers]);
         $this->assertSame(Cli::RETURN_SUCCESS, $commandTester->getStatusCode());
@@ -344,7 +349,8 @@ class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
             ],
             'With dependencies and multiple indexers in request' => [
                 'inputIndexers' => [
-                    'indexer_1', 'indexer_3'
+                    'indexer_1',
+                    'indexer_3'
                 ],
                 'indexers' => [
                     'indexer_2' => [
@@ -405,7 +411,10 @@ class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
     public function testExecuteWithLocalizedException()
     {
         $this->configureAdminArea();
-        $indexerOne = $this->getIndexerMock(['reindexAll', 'getStatus'], ['indexer_id' => 'indexer_1']);
+        $indexerOne = $this->getIndexerMock(
+            ['reindexAll', 'getStatus'],
+            ['indexer_id' => 'indexer_1', 'title' => self::STUB_INDEXER_NAME]
+        );
         $localizedException = new LocalizedException(new Phrase('Some Exception Message'));
         $indexerOne->expects($this->once())->method('reindexAll')->will($this->throwException($localizedException));
         $this->initIndexerCollectionByItems([$indexerOne]);
@@ -414,7 +423,10 @@ class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
         $commandTester->execute(['index' => ['indexer_1']]);
         $actualValue = $commandTester->getDisplay();
         $this->assertSame(Cli::RETURN_FAILURE, $commandTester->getStatusCode());
-        $this->assertStringStartsWith('Some Exception Message', $actualValue);
+        $this->assertStringStartsWith(
+            self::STUB_INDEXER_NAME . ' index exception: Some Exception Message',
+            $actualValue
+        );
     }
 
     public function testExecuteWithException()
@@ -433,7 +445,7 @@ class IndexerReindexCommandTest extends AbstractIndexerCommandCommonSetup
         $commandTester->execute(['index' => ['indexer_1']]);
         $actualValue = $commandTester->getDisplay();
         $this->assertSame(Cli::RETURN_FAILURE, $commandTester->getStatusCode());
-        $this->assertStringStartsWith('Title_indexer_1' . ' indexer process unknown error:', $actualValue);
+        $this->assertStringStartsWith('Title_indexer_1' . ' index process unknown error:', $actualValue);
     }
 
     public function testExecuteWithExceptionInGetIndexers()

--- a/dev/tests/integration/testsuite/Magento/Reports/Model/ResourceModel/Report/Product/Viewed/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Reports/Model/ResourceModel/Report/Product/Viewed/CollectionTest.php
@@ -72,20 +72,20 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
             $this->assertArrayHasKey('tableName', $from[$dbTableName]);
         } else {
             $union = $this->_collection->getSelect()->getPart('union');
+            $count = count($union);
             if ($period !== null && $dateFrom !== null && $dateTo !== null && $period != 'month') {
-                $count = count($union);
                 if ($period == 'year') {
                     if ($dbTableName == "report_viewed_product_aggregated_daily") {
-                        $this->assertEquals($count, 2);
+                        $this->assertEquals(2, $count);
                     }
                     if ($dbTableName == "report_viewed_product_aggregated_yearly") {
-                        $this->assertEquals($count, 3);
+                        $this->assertEquals(3, $count);
                     }
                 } else {
-                    $this->assertEquals($count, 3);
+                    $this->assertEquals(3, $count);
                 }
             } else {
-                $this->assertEquals(count($union), 2);
+                $this->assertEquals(2, $count);
             }
         }
     }
@@ -98,8 +98,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
      */
     public function tableForPeriodDataProvider()
     {
-        $dateNow = date('Y-m-d', time());
-        $dateYearAgo = date('Y-m-d', strtotime($dateNow . ' -1 year'));
+        $dateFrom = '2019-10-15';
+        $dateYearBefore = date('Y-m-d', strtotime($dateFrom . ' -1 year'));
         return [
             [
                 'period'    => 'year',
@@ -111,32 +111,32 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
             [
                 'period'    => 'year',
                 'table'     => 'report_viewed_product_aggregated_yearly',
-                'date_from' => $dateYearAgo,
-                'date_to'   => $dateNow,
+                'date_from' => $dateYearBefore,
+                'date_to'   => $dateFrom,
             ],
             [
                 'period'    => 'year',
                 'table'     => 'report_viewed_product_aggregated_yearly',
-                'date_from' => $dateYearAgo,
+                'date_from' => $dateYearBefore,
                 'date_to'   => null,
             ],
             [
                 'period'    => 'month',
                 'table'     => 'report_viewed_product_aggregated_monthly',
                 'date_from' => null,
-                'date_to'   => $dateNow,
+                'date_to'   => $dateFrom,
             ],
             [
                 'period'    => 'year',
                 'table'     => 'report_viewed_product_aggregated_yearly',
-                'date_from' => $dateYearAgo,
+                'date_from' => $dateYearBefore,
                 'date_to'   => null,
             ],
             [
                 'period'    => 'year',
                 'table'     => 'report_viewed_product_aggregated_yearly',
                 'date_from' => null,
-                'date_to'   => $dateNow,
+                'date_to'   => $dateFrom,
             ],
             [
                 'period'    => 'month',
@@ -147,19 +147,19 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
             [
                 'period'    => 'month',
                 'table'     => 'report_viewed_product_aggregated_monthly',
-                'date_from' => $dateYearAgo,
-                'date_to'   => $dateYearAgo,
+                'date_from' => $dateYearBefore,
+                'date_to'   => $dateYearBefore,
             ],
             [
                 'period'    => 'month',
                 'table'     => 'report_viewed_product_aggregated_monthly',
                 'date_from' => null,
-                'date_to'   => $dateYearAgo,
+                'date_to'   => $dateYearBefore,
             ],
             [
                 'period'    => 'month',
                 'table'     => 'report_viewed_product_aggregated_monthly',
-                'date_from' => $dateYearAgo,
+                'date_from' => $dateYearBefore,
                 'date_to'   => null,
             ],
             [
@@ -177,32 +177,32 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
             [
                 'period'    => null,
                 'table'     => 'report_viewed_product_aggregated_daily',
-                'date_from' => $dateYearAgo,
-                'date_to'   => $dateNow,
+                'date_from' => $dateYearBefore,
+                'date_to'   => $dateFrom,
             ],
             [
                 'period'    => null,
                 'table'     => 'report_viewed_product_aggregated_daily',
-                'date_from' => $dateNow,
-                'date_to'   => $dateNow,
+                'date_from' => $dateFrom,
+                'date_to'   => $dateFrom,
             ],
             [
                 'period'    => 'day',
                 'table'     => 'report_viewed_product_aggregated_daily',
-                'date_from' => $dateYearAgo,
-                'date_to'   => $dateYearAgo,
+                'date_from' => $dateYearBefore,
+                'date_to'   => $dateYearBefore,
             ],
             [
                 'period'    => 'year',
                 'table'     => 'report_viewed_product_aggregated_daily',
-                'date_from' => $dateYearAgo,
-                'date_to'   => $dateYearAgo,
+                'date_from' => $dateYearBefore,
+                'date_to'   => $dateYearBefore,
             ],
             [
                 'period'    => 'year',
                 'table'     => 'report_viewed_product_aggregated_daily',
                 'date_from' => null,
-                'date_to'   => $dateYearAgo,
+                'date_to'   => $dateYearBefore,
             ],
             [
                 'period'    => null,


### PR DESCRIPTION
### Description (*)
Answers the need for more information about failed reindex.

![ezgif-7-84cd063d47d7](https://user-images.githubusercontent.com/1639941/71579939-f1805280-2afe-11ea-9703-c539a02ccf27.gif)

Change additionally improves performance by replacing `foreach() { array_merge() }` with `array_merge(...$args)`. Additionally with `-v` debug information included about exception trace.

### Fixed Issues (if relevant)
1. magento/magento2#26206 Missing information about the currently reindexed index on failure

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run desired reindex. Expect the reindex name to be immediately visible

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
