### PR TITLE
Add missing translations JS escape calls on some modules

### DIFF
--- a/app/code/Magento/Backend/Block/Cache.php
+++ b/app/code/Magento/Backend/Block/Cache.php
@@ -35,7 +35,9 @@ class Cache extends \Magento\Backend\Block\Widget\Grid\Container
         }
 
         if ($this->_authorization->isAllowed('Magento_Backend::flush_cache_storage')) {
-            $message = __('The cache storage may contain additional data. Are you sure that you want to flush it?');
+            $message = $this->_escaper->escapeJs(
+                __('The cache storage may contain additional data. Are you sure that you want to flush it?')
+            );
             $this->buttonList->add(
                 'flush_system',
                 [

--- a/app/code/Magento/Paypal/Block/Adminhtml/Billing/Agreement/View.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/Billing/Agreement/View.php
@@ -67,7 +67,7 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
 
         $agreement = $this->_getBillingAgreement();
         if ($agreement && $agreement->canCancel() && $this->_isAllowed('Magento_Paypal::actions_manage')) {
-            $confirmText = __('Are you sure you want to do this?');
+            $confirmText = $this->_escaper->escapeJs(__('Are you sure you want to do this?'));
             $this->buttonList->add(
                 'cancel',
                 [

--- a/app/code/Magento/Paypal/Block/Adminhtml/Order/View.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/Order/View.php
@@ -68,7 +68,7 @@ class View extends OrderView
         if ($order === null) {
             return;
         }
-        $message = __('Are you sure you want to authorize full order amount?');
+        $message = $this->_escaper->escapeJs(__('Are you sure you want to authorize full order amount?'));
         if ($this->_isAllowedAction('Magento_Paypal::authorization') && $this->canAuthorize($order)) {
             $this->addButton(
                 'order_authorize',

--- a/app/code/Magento/Paypal/Block/Adminhtml/Settlement/Report.php
+++ b/app/code/Magento/Paypal/Block/Adminhtml/Settlement/Report.php
@@ -26,9 +26,9 @@ class Report extends \Magento\Backend\Block\Widget\Grid\Container
         $this->_headerText = __('PayPal Settlement Reports');
         parent::_construct();
         $this->buttonList->remove('add');
-        $message = __(
+        $message = $this->_escaper->escapeJs(__(
             'We are connecting to the PayPal SFTP server to retrieve new reports. Are you sure you want to continue?'
-        );
+        ));
         if (true == $this->_authorization->isAllowed('Magento_Paypal::fetch')) {
             $this->buttonList->add(
                 'fetch',

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Creditmemo/View.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Creditmemo/View.php
@@ -73,9 +73,9 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
                 [
                     'label' => __('Send Email'),
                     'class' => 'send-email',
-                    'onclick' => 'confirmSetLocation(\'' . __(
+                    'onclick' => 'confirmSetLocation(\'' . $this->_escaper->escapeJs(__(
                         'Are you sure you want to send a credit memo email to customer?'
-                    ) . '\', \'' . $this->getEmailUrl() . '\')'
+                    )) . '\', \'' . $this->getEmailUrl() . '\')'
                 ]
             );
         }

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Invoice/View.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Invoice/View.php
@@ -97,9 +97,9 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
                 [
                     'label' => __('Send Email'),
                     'class' => 'send-email',
-                    'onclick' => 'confirmSetLocation(\'' . __(
+                    'onclick' => 'confirmSetLocation(\'' . $this->_escaper->escapeJs(__(
                         'Are you sure you want to send an invoice email to customer?'
-                    ) . '\', \'' . $this->getEmailUrl() . '\')'
+                    )) . '\', \'' . $this->getEmailUrl() . '\')'
                 ]
             );
         }

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View.php
@@ -124,7 +124,7 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
         }
 
         if ($this->_isAllowedAction('Magento_Sales::emails') && !$order->isCanceled()) {
-            $message = __('Are you sure you want to send an order email to customer?');
+            $message = $this->_escaper->escapeJs(__('Are you sure you want to send an order email to customer?'));
             $this->addButton(
                 'send_notification',
                 [
@@ -136,10 +136,10 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
         }
 
         if ($this->_isAllowedAction('Magento_Sales::creditmemo') && $order->canCreditmemo()) {
-            $message = __(
+            $message = $this->_escaper->escapeJs(__(
                 'This will create an offline refund. ' .
                 'To create an online refund, open an invoice and create credit memo for it. Do you want to continue?'
-            );
+            ));
             $onClick = "setLocation('{$this->getCreditmemoUrl()}')";
             if ($order->getPayment()->getMethodInstance()->isGateway()) {
                 $onClick = "confirmSetLocation('{$message}', '{$this->getCreditmemoUrl()}')";
@@ -152,7 +152,7 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
 
         // invoice action intentionally
         if ($this->_isAllowedAction('Magento_Sales::invoice') && $order->canVoidPayment()) {
-            $message = __('Are you sure you want to void the payment?');
+            $message = $this->_escaper->escapeJs(__('Are you sure you want to void the payment?'));
             $this->addButton(
                 'void_payment',
                 [
@@ -192,7 +192,7 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
 
         if ($this->_isAllowedAction('Magento_Sales::review_payment')) {
             if ($order->canReviewPayment()) {
-                $message = __('Are you sure you want to accept this payment?');
+                $message = $this->_escaper->escapeJs(__('Are you sure you want to accept this payment?'));
                 $this->addButton(
                     'accept_payment',
                     [
@@ -200,7 +200,7 @@ class View extends \Magento\Backend\Block\Widget\Form\Container
                         'onclick' => "confirmSetLocation('{$message}', '{$this->getReviewPaymentUrl('accept')}')"
                     ]
                 );
-                $message = __('Are you sure you want to deny this payment?');
+                $message = $this->_escaper->escapeJs(__('Are you sure you want to deny this payment?'));
                 $this->addButton(
                     'deny_payment',
                     [


### PR DESCRIPTION
### Description (*)
Add missing translations JS escape calls on some modules, around `confirmSetLocation` JS method, on _adminhtml_ side, and prevent some JS errors with some languages (e.g. fr_FR).

### Manual testing scenarios (*)
1. Have a fresh install of Magento 2
2. Install `community-engineering/language-fr_fr` Composer package
3. Switch the back office to _fr_FR_ locale.
4. On the back office, Go to _System - Tools - Cache Management_
5. Click on _Flush Cache Storage_

**Expected Result With PR**
A confirmation dialog appears, no JS error on the browser console.

**Current Behavior**
No confirmation appears, nothing happens, and a JS error is present on the browser console.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)