### PR TITLE
Disabled the sorting option in status column on cache grid

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_cache_block.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/adminhtml_cache_block.xml
@@ -80,6 +80,7 @@
                             <argument name="type" xsi:type="string">options</argument>
                             <argument name="width" xsi:type="string">120</argument>
                             <argument name="align" xsi:type="string">left</argument>
+                            <argument name="sortable" xsi:type="string">0</argument>
                             <argument name="options" xsi:type="array">
                                 <item name="disabled" xsi:type="array">
                                     <item name="value" xsi:type="string">0</item>


### PR DESCRIPTION
### Description (*)
This PR to disable the sorting option in status column at cache grid.

### Fixed Issues (if relevant)
1. magento/magento2#26208

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
Actually rest of the column has no sorting options & no pagination in cache grid, so My thought is sorting option of status column is not required. please share you feedback I am happy to update this PR itself.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
