### PR TITLE
FIX issue#26217 - Wrong fields selection while using fragments on GraphQL

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/Query/FieldSelection.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/Query/FieldSelection.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace Magento\CatalogGraphQl\Model\Resolver\Products\Query;
 
-use GraphQL\Language\AST\SelectionNode;
 use Magento\Framework\GraphQl\Query\FieldTranslator;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 
@@ -37,57 +36,18 @@ class FieldSelection
      */
     public function getProductsFieldSelection(ResolveInfo $resolveInfo): array
     {
-        return $this->getProductFields($resolveInfo);
-    }
+        $productFields = $resolveInfo->getFieldSelection(1);
+        $sectionNames = ['items', 'product'];
 
-    /**
-     * Return field names for all requested product fields.
-     *
-     * @param ResolveInfo $info
-     * @return string[]
-     */
-    private function getProductFields(ResolveInfo $info): array
-    {
         $fieldNames = [];
-        foreach ($info->fieldNodes as $node) {
-            if ($node->name->value !== 'products' && $node->name->value !== 'variants') {
-                continue;
-            }
-            foreach ($node->selectionSet->selections as $selection) {
-                if ($selection->name->value !== 'items' && $selection->name->value !== 'product') {
-                    continue;
+        foreach ($sectionNames as $sectionName) {
+            if (isset($productFields[$sectionName])) {
+                foreach (array_keys($productFields[$sectionName]) as $fieldName) {
+                    $fieldNames[] = $this->fieldTranslator->translate($fieldName);
                 }
-                $fieldNames[] = $this->collectProductFieldNames($selection, $fieldNames);
             }
-        }
-        if (!empty($fieldNames)) {
-            $fieldNames = array_merge(...$fieldNames);
-        }
-        return $fieldNames;
-    }
-
-    /**
-     * Collect field names for each node in selection
-     *
-     * @param SelectionNode $selection
-     * @param array $fieldNames
-     * @return array
-     */
-    private function collectProductFieldNames(SelectionNode $selection, array $fieldNames = []): array
-    {
-        foreach ($selection->selectionSet->selections as $itemSelection) {
-            if ($itemSelection->kind === 'InlineFragment') {
-                foreach ($itemSelection->selectionSet->selections as $inlineSelection) {
-                    if ($inlineSelection->kind === 'InlineFragment') {
-                        continue;
-                    }
-                    $fieldNames[] = $this->fieldTranslator->translate($inlineSelection->name->value);
-                }
-                continue;
-            }
-            $fieldNames[] = $this->fieldTranslator->translate($itemSelection->name->value);
         }
 
-        return $fieldNames;
+        return array_unique($fieldNames);
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductFragmentTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductFragmentTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Catalog;
+
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+/**
+ * Test for simple product fragment.
+ */
+class ProductFragmentTest extends GraphQlAbstract
+{
+    /**
+     * @magentoApiDataFixture Magento/Catalog/_files/product_simple.php
+     */
+    public function testSimpleProductFragment()
+    {
+        $sku = 'simple';
+        $name = 'Simple Product';
+        $price = 10;
+
+        $query = <<<QUERY
+query GetProduct {
+  products(filter: { sku: { eq: "$sku" } }) {
+    items {
+      sku
+      ...BasicProductInformation
+    }
+  }
+}
+
+fragment BasicProductInformation on ProductInterface {
+  sku
+  name
+  price {
+    regularPrice {
+      amount {
+        value
+      }
+    }
+  }
+}
+QUERY;
+        $result = $this->graphQlQuery($query);
+        $actualProductData = $result['products']['items'][0];
+        $this->assertNotEmpty($actualProductData);
+        $this->assertEquals($name, $actualProductData['name']);
+        $this->assertEquals($price, $actualProductData['price']['regularPrice']['amount']['value']);
+    }
+}


### PR DESCRIPTION
Wrong fields selection while using fragments on GraphQL products query

### Description (*)
The proposed solution is to use `\GraphQL\Type\Definition\ResolveInfo::getFieldSelection` to retrieve the fields list instead of the previsous implementation.

### Fixed Issues (if relevant)
1. magento/magento2#26217: Wrong fields selection while using fragments on GraphQL

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
