### PR TITLE
Hotfix for Invalid date format in Functional and hotfix for failing Integration Tests

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateDatetimeProductAttributeTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateDatetimeProductAttributeTest.xml
@@ -27,7 +27,7 @@
             <actionGroup ref="logout" stepKey="logout"/>
         </after>
         <!-- Generate the datetime default value -->
-        <generateDate date="now" format="m/j/y g:i A" stepKey="generateDefaultValue"/>
+        <generateDate date="now" format="n/j/y g:i A" stepKey="generateDefaultValue"/>
         <!-- Create new datetime product attribute -->
         <amOnPage url="{{AdminProductAttributeGridPage.url}}" stepKey="goToProductAttributes"/>
         <waitForPageLoad stepKey="waitForPageLoadAttributes"/>

--- a/dev/tests/integration/testsuite/Magento/Reports/Model/ResourceModel/Report/Product/Viewed/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Reports/Model/ResourceModel/Report/Product/Viewed/CollectionTest.php
@@ -72,20 +72,20 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
             $this->assertArrayHasKey('tableName', $from[$dbTableName]);
         } else {
             $union = $this->_collection->getSelect()->getPart('union');
+            $count = count($union);
             if ($period !== null && $dateFrom !== null && $dateTo !== null && $period != 'month') {
-                $count = count($union);
                 if ($period == 'year') {
                     if ($dbTableName == "report_viewed_product_aggregated_daily") {
-                        $this->assertEquals($count, 2);
+                        $this->assertEquals(2, $count);
                     }
                     if ($dbTableName == "report_viewed_product_aggregated_yearly") {
-                        $this->assertEquals($count, 3);
+                        $this->assertEquals(3, $count);
                     }
                 } else {
-                    $this->assertEquals($count, 3);
+                    $this->assertEquals(3, $count);
                 }
             } else {
-                $this->assertEquals(count($union), 2);
+                $this->assertEquals(2, $count);
             }
         }
     }
@@ -98,8 +98,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
      */
     public function tableForPeriodDataProvider()
     {
-        $dateNow = date('Y-m-d', time());
-        $dateYearAgo = date('Y-m-d', strtotime($dateNow . ' -1 year'));
+        $dateFrom = '2019-10-15';
+        $dateYearBefore = date('Y-m-d', strtotime($dateFrom . ' -1 year'));
         return [
             [
                 'period'    => 'year',
@@ -111,32 +111,32 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
             [
                 'period'    => 'year',
                 'table'     => 'report_viewed_product_aggregated_yearly',
-                'date_from' => $dateYearAgo,
-                'date_to'   => $dateNow,
+                'date_from' => $dateYearBefore,
+                'date_to'   => $dateFrom,
             ],
             [
                 'period'    => 'year',
                 'table'     => 'report_viewed_product_aggregated_yearly',
-                'date_from' => $dateYearAgo,
+                'date_from' => $dateYearBefore,
                 'date_to'   => null,
             ],
             [
                 'period'    => 'month',
                 'table'     => 'report_viewed_product_aggregated_monthly',
                 'date_from' => null,
-                'date_to'   => $dateNow,
+                'date_to'   => $dateFrom,
             ],
             [
                 'period'    => 'year',
                 'table'     => 'report_viewed_product_aggregated_yearly',
-                'date_from' => $dateYearAgo,
+                'date_from' => $dateYearBefore,
                 'date_to'   => null,
             ],
             [
                 'period'    => 'year',
                 'table'     => 'report_viewed_product_aggregated_yearly',
                 'date_from' => null,
-                'date_to'   => $dateNow,
+                'date_to'   => $dateFrom,
             ],
             [
                 'period'    => 'month',
@@ -147,19 +147,19 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
             [
                 'period'    => 'month',
                 'table'     => 'report_viewed_product_aggregated_monthly',
-                'date_from' => $dateYearAgo,
-                'date_to'   => $dateYearAgo,
+                'date_from' => $dateYearBefore,
+                'date_to'   => $dateYearBefore,
             ],
             [
                 'period'    => 'month',
                 'table'     => 'report_viewed_product_aggregated_monthly',
                 'date_from' => null,
-                'date_to'   => $dateYearAgo,
+                'date_to'   => $dateYearBefore,
             ],
             [
                 'period'    => 'month',
                 'table'     => 'report_viewed_product_aggregated_monthly',
-                'date_from' => $dateYearAgo,
+                'date_from' => $dateYearBefore,
                 'date_to'   => null,
             ],
             [
@@ -177,32 +177,32 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
             [
                 'period'    => null,
                 'table'     => 'report_viewed_product_aggregated_daily',
-                'date_from' => $dateYearAgo,
-                'date_to'   => $dateNow,
+                'date_from' => $dateYearBefore,
+                'date_to'   => $dateFrom,
             ],
             [
                 'period'    => null,
                 'table'     => 'report_viewed_product_aggregated_daily',
-                'date_from' => $dateNow,
-                'date_to'   => $dateNow,
+                'date_from' => $dateFrom,
+                'date_to'   => $dateFrom,
             ],
             [
                 'period'    => 'day',
                 'table'     => 'report_viewed_product_aggregated_daily',
-                'date_from' => $dateYearAgo,
-                'date_to'   => $dateYearAgo,
+                'date_from' => $dateYearBefore,
+                'date_to'   => $dateYearBefore,
             ],
             [
                 'period'    => 'year',
                 'table'     => 'report_viewed_product_aggregated_daily',
-                'date_from' => $dateYearAgo,
-                'date_to'   => $dateYearAgo,
+                'date_from' => $dateYearBefore,
+                'date_to'   => $dateYearBefore,
             ],
             [
                 'period'    => 'year',
                 'table'     => 'report_viewed_product_aggregated_daily',
                 'date_from' => null,
-                'date_to'   => $dateYearAgo,
+                'date_to'   => $dateYearBefore,
             ],
             [
                 'period'    => null,


### PR DESCRIPTION
### Description (*)
All the Continuous Integration for Magento fails with Functional Tests.
This is fix for invalid date format.

Also delivering fix for Integration Tests fail when there's assertion the number of UNIONs that are based on years that are analyzed.

... and placing `expected` in the right place :man_facepalming: 

### Fixed Issues (if relevant)
Functional Tests:
![image](https://user-images.githubusercontent.com/1639941/71647472-b72dd580-2cf7-11ea-9a54-319e66a898cc.png)

Integration Tests:
![image](https://user-images.githubusercontent.com/1639941/71647714-193c0a00-2cfb-11ea-8d4d-1df5954bbb46.png)


### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
