### PR TITLE
[Framework] Fixing the caches that don't have no instance configured

### DIFF
--- a/lib/internal/Magento/Framework/App/Cache/TypeList.php
+++ b/lib/internal/Magento/Framework/App/Cache/TypeList.php
@@ -8,6 +8,11 @@ namespace Magento\Framework\App\Cache;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Serialize\SerializerInterface;
 
+/**
+ * Class TypeList
+ *
+ * Caching types list
+ */
 class TypeList implements TypeListInterface
 {
     const INVALIDATED_TYPES = 'core_cache_invalidate';
@@ -132,7 +137,7 @@ class TypeList implements TypeListInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getTypeLabels()
     {

--- a/lib/internal/Magento/Framework/App/Cache/TypeList.php
+++ b/lib/internal/Magento/Framework/App/Cache/TypeList.php
@@ -191,7 +191,12 @@ class TypeList implements TypeListInterface
      */
     public function cleanType($typeCode)
     {
-        $this->_getTypeInstance($typeCode)->clean();
+        $typeInstance = $this->_getTypeInstance($typeCode);
+
+        if ($typeInstance) {
+            $typeInstance->clean();
+        }
+
         $types = $this->_getInvalidatedTypes();
         unset($types[$typeCode]);
         $this->_saveInvalidatedTypes($types);

--- a/lib/internal/Magento/Framework/App/Test/Unit/Cache/TypeListTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Cache/TypeListTest.php
@@ -163,7 +163,12 @@ class TypeListTest extends \PHPUnit\Framework\TestCase
         $this->_typeList->invalidate([self::TYPE_KEY]);
     }
 
-    public function testCleanType()
+    /**
+     * @dataProvider cacheTypeConfigDataProvider
+     *
+     * @param array $cacheConfig
+     */
+    public function testCleanType(array $cacheConfig)
     {
         $this->serializerMock->expects($this->once())
             ->method('unserialize')
@@ -173,7 +178,7 @@ class TypeListTest extends \PHPUnit\Framework\TestCase
             $this->returnValue('serializedData')
         );
         $this->_config->expects($this->once())->method('getType')->with(self::TYPE_KEY)->will(
-            $this->returnValue(['instance' => self::CACHE_TYPE])
+            $this->returnValue($cacheConfig)
         );
         unset($this->_typesArray[self::TYPE_KEY]);
         $this->serializerMock->expects($this->once())
@@ -185,6 +190,25 @@ class TypeListTest extends \PHPUnit\Framework\TestCase
             TypeList::INVALIDATED_TYPES
         );
         $this->_typeList->cleanType(self::TYPE_KEY);
+    }
+
+    /**
+     * Cache config provider
+     *
+     * @return array
+     */
+    public function cacheTypeConfigDataProvider(): array
+    {
+        return [
+            [
+                [
+                    'instance' => self::CACHE_TYPE
+                ],
+            ],
+            [
+                []
+            ]
+        ];
     }
 
     /**


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes the caches that don't no instance configured, as it's an optional argument.

### Fixed Issues (if relevant)
1. magento/magento2#26224: Cache type without "instance" causes exception

### Manual testing scenarios (*)

1. Create a cache type using "cache.xml" without the "instance" argument
```xml
<config .../>
    <type name="exceptional_cache_type">
        <label>Exceptional Cache Type</label>
        <description>An exceptional cache type using a quantum computer</description>
    </type>
</config>
```
2. Go to "System > Cache Management" in the backend
3. Check the checkbox of the cache type "Exceptional Cache Type"
4. Select "Disable" and click "Submit"

### Questions or comments


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
