### PR TITLE
#25768 fixed authorize.net config migration patch

### DIFF
--- a/app/code/Magento/AuthorizenetAcceptjs/Test/Unit/Setup/Patch/Data/CopyCurrentConfigTest.php
+++ b/app/code/Magento/AuthorizenetAcceptjs/Test/Unit/Setup/Patch/Data/CopyCurrentConfigTest.php
@@ -21,6 +21,9 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\Website;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class CopyCurrentConfigTest extends TestCase
 {
     /**
@@ -87,7 +90,7 @@ class CopyCurrentConfigTest extends TestCase
         $this->storeManager = $this->createMock(StoreManagerInterface::class);
         $this->website = $this->createMock(Website::class);
         $this->connection = $this->createMock(AdapterInterface::class);
-        $this->select = $this->createMock(Select::class);//@todo check if we really need it
+        $this->select = $this->createMock(Select::class);
     }
 
     public function testMigrateData(): void


### PR DESCRIPTION

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
In a app/code/Magento/AuthorizenetAcceptjs/Setup/Patch/Data/CopyCurrentConfig.php patch config values from Authorize.net DirectPost are being migrated to the new Authorize.net Accept.js module. There is no check if DirectPost values exist in core_config_data table, so in fact values are being read from DirectPost config.xml and saved to database to Authorize,net Accept.js. The main problem is that it saves values to website config scope, so store owner has no clue why selected payment action is "authorise and capture" and payments are not being captured.



### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25768: Authorize.net Auth & Capture not Capturing

### Manual testing scenarios (*)
1. On fresh 2.3-2.4 instance setup Autorize.net payment method
2. Select Authorize And Capture payment action
3. Please order using Authorize.net method
Expected behaviour:
Invoice is created 
Actual behaviour:
Invoice is not created 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
