### PR TITLE
[Customer] Removing the delete buttons for default customer groups

### DIFF
--- a/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/Column/GroupActionsTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/Column/GroupActionsTest.php
@@ -23,6 +23,36 @@ use PHPUnit\Framework\TestCase;
 class GroupActionsTest extends TestCase
 {
     /**
+     * @var int
+     */
+    private const STUB_NOT_LOGGED_IN_CUSTOMER_GROUP_ID = 0;
+
+    /**
+     * @var string
+     */
+    private const STUB_NOT_LOGGED_IN_CUSTOMER_GROUP_NAME = 'Not Logged In';
+
+    /**
+     * @var int
+     */
+    private const STUB_GENERAL_CUSTOMER_GROUP_ID = 1;
+
+    /**
+     * @var string
+     */
+    private const STUB_GENERAL_CUSTOMER_GROUP_NAME = 'General';
+
+    /**
+     * @var string
+     */
+    private const STUB_GROUP_EDIT_URL = 'http://magento.com/customer/group/edit';
+
+    /**
+     * @var string
+     */
+    private const STUB_GROUP_DELETE_URL = 'http://magento.com/customer/group/delete';
+
+    /**
      * @var GroupActions
      */
     private $component;
@@ -97,7 +127,6 @@ class GroupActionsTest extends TestCase
      */
     public function testPrepareDataSourceWithNonDefaultGroup(array $items, bool $isDefaultGroup, array $expected)
     {
-        $customerGroup = 'General';
         $dataSource = [
             'data' => [
                 'items' => $items
@@ -111,18 +140,29 @@ class GroupActionsTest extends TestCase
 
         $this->groupManagementMock->expects($this->any())
             ->method('isReadonly')
-            ->with(1)
+            ->with(static::STUB_GENERAL_CUSTOMER_GROUP_ID)
             ->willReturn($isDefaultGroup);
         $this->escaperMock->expects($this->any())
             ->method('escapeHtml')
-            ->with($customerGroup)
-            ->willReturn($customerGroup);
+            ->with(static::STUB_GENERAL_CUSTOMER_GROUP_NAME)
+            ->willReturn(static::STUB_GENERAL_CUSTOMER_GROUP_NAME);
         $this->urlBuilderMock->expects($this->any())
             ->method('getUrl')
             ->willReturnMap(
                 [
-                    ['customer/group/edit', ['id' => 1], 'http://magento.com/customer/group/edit'],
-                    ['customer/group/delete', ['id' => 1], 'http://magento.com/customer/group/delete']
+                    [
+                        'customer/group/edit',
+                        [
+                            'id' => static::STUB_GENERAL_CUSTOMER_GROUP_ID
+                        ],
+                        static::STUB_GROUP_EDIT_URL],
+                    [
+                        'customer/group/delete',
+                        [
+                            'id' => static::STUB_GENERAL_CUSTOMER_GROUP_ID
+                        ],
+                        static::STUB_GROUP_DELETE_URL
+                    ]
                 ]
             );
 
@@ -142,12 +182,12 @@ class GroupActionsTest extends TestCase
             'data' => [
                 'items' => [
                     [
-                        'customer_group_id' => 1,
-                        'customer_group_code' => 'General',
+                        'customer_group_id' => static::STUB_GENERAL_CUSTOMER_GROUP_ID,
+                        'customer_group_code' => static::STUB_GENERAL_CUSTOMER_GROUP_NAME,
                     ],
                     [
-                        'customer_group_id' => 0,
-                        'customer_group_code' => 'Not Logged In',
+                        'customer_group_id' => static::STUB_NOT_LOGGED_IN_CUSTOMER_GROUP_ID,
+                        'customer_group_code' => static::STUB_NOT_LOGGED_IN_CUSTOMER_GROUP_NAME,
                     ],
                 ]
             ]
@@ -156,22 +196,22 @@ class GroupActionsTest extends TestCase
             'data' => [
                 'items' => [
                     [
-                        'customer_group_id' => 1,
-                        'customer_group_code' => 'General',
+                        'customer_group_id' => static::STUB_GENERAL_CUSTOMER_GROUP_ID,
+                        'customer_group_code' => static::STUB_GENERAL_CUSTOMER_GROUP_NAME,
                         'name' => [
                             'edit' => [
-                                'href' => 'http://magento.com/customer/group/edit',
+                                'href' => static::STUB_GROUP_EDIT_URL,
                                 'label' => __('Edit'),
                                 '__disableTmpl' => true,
                             ]
                         ]
                     ],
                     [
-                        'customer_group_id' => 0,
-                        'customer_group_code' => 'Not Logged In',
+                        'customer_group_id' => static::STUB_NOT_LOGGED_IN_CUSTOMER_GROUP_ID,
+                        'customer_group_code' => static::STUB_NOT_LOGGED_IN_CUSTOMER_GROUP_NAME,
                         'name' => [
                             'edit' => [
-                                'href' => 'http://magento.com/customer/group/edit',
+                                'href' => static::STUB_GROUP_EDIT_URL,
                                 'label' => __('Edit'),
                                 '__disableTmpl' => true,
                             ]
@@ -188,16 +228,36 @@ class GroupActionsTest extends TestCase
             ->method('escapeHtml')
             ->willReturnMap(
                 [
-                    ['General', null, 'General'],
-                    ['Not Logged In', null, 'Not Logged In']
+                    [
+                        static::STUB_GENERAL_CUSTOMER_GROUP_NAME,
+                        null,
+                        static::STUB_GENERAL_CUSTOMER_GROUP_NAME
+                    ],
+                    [
+                        static::STUB_NOT_LOGGED_IN_CUSTOMER_GROUP_NAME,
+                        null,
+                        static::STUB_NOT_LOGGED_IN_CUSTOMER_GROUP_NAME
+                    ]
                 ]
             );
         $this->urlBuilderMock->expects($this->any())
             ->method('getUrl')
             ->willReturnMap(
                 [
-                    ['customer/group/edit', ['id' => 1], 'http://magento.com/customer/group/edit'],
-                    ['customer/group/edit', ['id' => 0], 'http://magento.com/customer/group/edit']
+                    [
+                        'customer/group/edit',
+                        [
+                            'id' => static::STUB_GENERAL_CUSTOMER_GROUP_ID
+                        ],
+                        static::STUB_GROUP_EDIT_URL
+                    ],
+                    [
+                        'customer/group/edit',
+                        [
+                            'id' => static::STUB_NOT_LOGGED_IN_CUSTOMER_GROUP_ID
+                        ],
+                        static::STUB_GROUP_EDIT_URL
+                    ]
                 ]
             );
 
@@ -216,23 +276,23 @@ class GroupActionsTest extends TestCase
             [
                 [
                     [
-                        'customer_group_id' => 1,
-                        'customer_group_code' => 'General',
+                        'customer_group_id' => static::STUB_GENERAL_CUSTOMER_GROUP_ID,
+                        'customer_group_code' => static::STUB_GENERAL_CUSTOMER_GROUP_NAME,
                     ],
                 ],
                 false,
                 [
                     [
-                        'customer_group_id' => 1,
-                        'customer_group_code' => 'General',
+                        'customer_group_id' => static::STUB_GENERAL_CUSTOMER_GROUP_ID,
+                        'customer_group_code' => static::STUB_GENERAL_CUSTOMER_GROUP_NAME,
                         'name' => [
                             'edit' => [
-                                'href' => 'http://magento.com/customer/group/edit',
+                                'href' => static::STUB_GROUP_EDIT_URL,
                                 'label' => __('Edit'),
                                 '__disableTmpl' => true,
                             ],
                             'delete' => [
-                                'href' => 'http://magento.com/customer/group/delete',
+                                'href' => static::STUB_GROUP_DELETE_URL,
                                 'label' => __('Delete'),
                                 'post' => true,
                                 '__disableTmpl' => true,

--- a/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/Column/GroupActionsTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/Column/GroupActionsTest.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Customer\Test\Unit\Ui\Component\Listing\Column;
+
+use Magento\Customer\Api\GroupManagementInterface;
+use Magento\Customer\Ui\Component\Listing\Column\GroupActions;
+use Magento\Framework\Escaper;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class GroupActionsTest
+ */
+class GroupActionsTest extends TestCase
+{
+    /**
+     * @var GroupActions
+     */
+    private $component;
+
+    /**
+     * @var ContextInterface|MockObject
+     */
+    private $contextMock;
+
+    /**
+     * @var UiComponentFactory|MockObject
+     */
+    private $uiComponentFactoryMock;
+
+    /**
+     * @var UrlInterface|MockObject
+     */
+    private $urlBuilderMock;
+
+    /**
+     * @var Escaper|MockObject
+     */
+    private $escaperMock;
+
+    /**
+     * @var GroupManagementInterface|MockObject
+     */
+    private $groupManagementMock;
+
+    /**
+     * Set Up
+     */
+    public function setUp()
+    {
+        $objectManager = new ObjectManager($this);
+
+        $this->contextMock = $this->getMockBuilder(ContextInterface::class)->getMockForAbstractClass();
+        $this->uiComponentFactoryMock = $this->createMock(UiComponentFactory::class);
+        $this->escaperMock = $this->createMock(Escaper::class);
+        $this->groupManagementMock = $this->createMock(GroupManagementInterface::class);
+        $this->urlBuilderMock = $this->getMockForAbstractClass(
+            UrlInterface::class,
+            [],
+            '',
+            false
+        );
+
+        $this->component = $objectManager->getObject(
+            GroupActions::class,
+            [
+                'context' => $this->contextMock,
+                'uiComponentFactory' => $this->uiComponentFactoryMock,
+                'urlBuilder' => $this->urlBuilderMock,
+                'escaper' => $this->escaperMock,
+                'components' => [],
+                'data' => [
+                    'name' => 'name'
+                ],
+                'groupManagement' => $this->groupManagementMock
+            ]
+        );
+    }
+
+    /**
+     * Test data source with a non default customer group
+     *
+     * @dataProvider customerGroupsDataProvider
+     *
+     * @param array $items
+     * @param bool $isDefaultGroup
+     * @param array $expected
+     */
+    public function testPrepareDataSourceWithNonDefaultGroup(array $items, bool $isDefaultGroup, array $expected)
+    {
+        $customerGroup = 'General';
+        $dataSource = [
+            'data' => [
+                'items' => $items
+            ]
+        ];
+        $expectedDataSource = [
+            'data' => [
+                'items' => $expected
+            ]
+        ];
+
+        $this->groupManagementMock->expects($this->any())
+            ->method('isReadonly')
+            ->with(1)
+            ->willReturn($isDefaultGroup);
+        $this->escaperMock->expects($this->any())
+            ->method('escapeHtml')
+            ->with($customerGroup)
+            ->willReturn($customerGroup);
+        $this->urlBuilderMock->expects($this->any())
+            ->method('getUrl')
+            ->willReturnMap(
+                [
+                    ['customer/group/edit', ['id' => 1], 'http://magento.com/customer/group/edit'],
+                    ['customer/group/delete', ['id' => 1], 'http://magento.com/customer/group/delete']
+                ]
+            );
+
+        $dataSource = $this->component->prepareDataSource($dataSource);
+        $this->assertEquals($expectedDataSource, $dataSource);
+    }
+
+    /**
+     * Test data source with a default customer group
+     *
+     * @dataProvider customerGroupsDataProvider
+     */
+    public function testPrepareDataSourceWithDefaultGroup()
+    {
+        $isDefaultGroup = true;
+        $dataSource = [
+            'data' => [
+                'items' => [
+                    [
+                        'customer_group_id' => 1,
+                        'customer_group_code' => 'General',
+                    ],
+                    [
+                        'customer_group_id' => 0,
+                        'customer_group_code' => 'Not Logged In',
+                    ],
+                ]
+            ]
+        ];
+        $expectedDataSource = [
+            'data' => [
+                'items' => [
+                    [
+                        'customer_group_id' => 1,
+                        'customer_group_code' => 'General',
+                        'name' => [
+                            'edit' => [
+                                'href' => 'http://magento.com/customer/group/edit',
+                                'label' => __('Edit'),
+                                '__disableTmpl' => true,
+                            ]
+                        ]
+                    ],
+                    [
+                        'customer_group_id' => 0,
+                        'customer_group_code' => 'Not Logged In',
+                        'name' => [
+                            'edit' => [
+                                'href' => 'http://magento.com/customer/group/edit',
+                                'label' => __('Edit'),
+                                '__disableTmpl' => true,
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->groupManagementMock->expects($this->any())
+            ->method('isReadonly')
+            ->willReturn($isDefaultGroup);
+        $this->escaperMock->expects($this->any())
+            ->method('escapeHtml')
+            ->willReturnMap(
+                [
+                    ['General', null, 'General'],
+                    ['Not Logged In', null, 'Not Logged In']
+                ]
+            );
+        $this->urlBuilderMock->expects($this->any())
+            ->method('getUrl')
+            ->willReturnMap(
+                [
+                    ['customer/group/edit', ['id' => 1], 'http://magento.com/customer/group/edit'],
+                    ['customer/group/edit', ['id' => 0], 'http://magento.com/customer/group/edit']
+                ]
+            );
+
+        $dataSource = $this->component->prepareDataSource($dataSource);
+        $this->assertEquals($expectedDataSource, $dataSource);
+    }
+
+    /**
+     * Providing customer group data
+     *
+     * @return array
+     */
+    public function customerGroupsDataProvider(): array
+    {
+        return [
+            [
+                [
+                    [
+                        'customer_group_id' => 1,
+                        'customer_group_code' => 'General',
+                    ],
+                ],
+                false,
+                [
+                    [
+                        'customer_group_id' => 1,
+                        'customer_group_code' => 'General',
+                        'name' => [
+                            'edit' => [
+                                'href' => 'http://magento.com/customer/group/edit',
+                                'label' => __('Edit'),
+                                '__disableTmpl' => true,
+                            ],
+                            'delete' => [
+                                'href' => 'http://magento.com/customer/group/delete',
+                                'label' => __('Delete'),
+                                'post' => true,
+                                '__disableTmpl' => true,
+                                'confirm' => [
+                                    'title' => __('Delete %1', 'General'),
+                                    'message' => __(
+                                        'Are you sure you want to delete a %1 record?',
+                                        'General'
+                                    )
+                                ],
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+}

--- a/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/Column/GroupActionsTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/Column/GroupActionsTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Class GroupActionsTest
+ *
+ * Testing GroupAction grid column
  */
 class GroupActionsTest extends TestCase
 {

--- a/app/code/Magento/Customer/Ui/Component/Listing/Column/GroupActions.php
+++ b/app/code/Magento/Customer/Ui/Component/Listing/Column/GroupActions.php
@@ -8,6 +8,10 @@ declare(strict_types=1);
 
 namespace Magento\Customer\Ui\Component\Listing\Column;
 
+use Magento\Customer\Api\GroupManagementInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponentFactory;
@@ -16,6 +20,8 @@ use Magento\Framework\Escaper;
 
 /**
  * Class GroupActions
+ *
+ * Customer Groups actions column
  */
 class GroupActions extends Column
 {
@@ -24,6 +30,11 @@ class GroupActions extends Column
      */
     const URL_PATH_EDIT = 'customer/group/edit';
     const URL_PATH_DELETE = 'customer/group/delete';
+
+    /**
+     * @var GroupManagementInterface
+     */
+    private $groupManagement;
 
     /**
      * @var UrlInterface
@@ -44,6 +55,7 @@ class GroupActions extends Column
      * @param Escaper $escaper
      * @param array $components
      * @param array $data
+     * @param GroupManagementInterface $groupManagement
      */
     public function __construct(
         ContextInterface $context,
@@ -51,10 +63,13 @@ class GroupActions extends Column
         UrlInterface $urlBuilder,
         Escaper $escaper,
         array $components = [],
-        array $data = []
+        array $data = [],
+        GroupManagementInterface $groupManagement = null
     ) {
         $this->urlBuilder = $urlBuilder;
         $this->escaper = $escaper;
+        $this->groupManagement = $groupManagement ?: ObjectManager::getInstance()->get(GroupManagementInterface::class);;
+
         parent::__construct($context, $uiComponentFactory, $components, $data);
     }
 
@@ -63,6 +78,8 @@ class GroupActions extends Column
      *
      * @param array $dataSource
      * @return array
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
      */
     public function prepareDataSource(array $dataSource)
     {
@@ -83,29 +100,26 @@ class GroupActions extends Column
                         ],
                     ];
 
-                    // hide delete action for 'NOT LOGGED IN' group
-                    if ($item['customer_group_id'] == 0 && $item['customer_group_code']) {
-                        continue;
+                    if (!$this->groupManagement->isReadonly($item['customer_group_id'])) {
+                        $item[$this->getData('name')]['delete'] = [
+                            'href' => $this->urlBuilder->getUrl(
+                                static::URL_PATH_DELETE,
+                                [
+                                    'id' => $item['customer_group_id']
+                                ]
+                            ),
+                            'label' => __('Delete'),
+                            'confirm' => [
+                                'title' => __('Delete %1', $this->escaper->escapeHtml($title)),
+                                'message' => __(
+                                    'Are you sure you want to delete a %1 record?',
+                                    $this->escaper->escapeHtml($title)
+                                )
+                            ],
+                            'post' => true,
+                            '__disableTmpl' => true
+                        ];
                     }
-
-                    $item[$this->getData('name')]['delete'] = [
-                        'href' => $this->urlBuilder->getUrl(
-                            static::URL_PATH_DELETE,
-                            [
-                                'id' => $item['customer_group_id']
-                            ]
-                        ),
-                        'label' => __('Delete'),
-                        'confirm' => [
-                            'title' => __('Delete %1', $this->escaper->escapeHtml($title)),
-                            'message' => __(
-                                'Are you sure you want to delete a %1 record?',
-                                $this->escaper->escapeHtml($title)
-                            )
-                        ],
-                        'post' => true,
-                        '__disableTmpl' => true
-                    ];
                 }
             }
         }

--- a/app/code/Magento/Customer/Ui/Component/Listing/Column/GroupActions.php
+++ b/app/code/Magento/Customer/Ui/Component/Listing/Column/GroupActions.php
@@ -68,7 +68,7 @@ class GroupActions extends Column
     ) {
         $this->urlBuilder = $urlBuilder;
         $this->escaper = $escaper;
-        $this->groupManagement = $groupManagement ?: ObjectManager::getInstance()->get(GroupManagementInterface::class);;
+        $this->groupManagement = $groupManagement ?: ObjectManager::getInstance()->get(GroupManagementInterface::class);
 
         parent::__construct($context, $uiComponentFactory, $components, $data);
     }


### PR DESCRIPTION
### Description (*)
This PR removes the listing `Delete` button for Default Customer Group, as far as we aren't able to remove it.

### Fixed Issues (if relevant)
1. Navigate to `Customers / Customer Groups`
2. Try to delete the default `General` group
3. You'll get `Cannot delete group` error message

### Manual testing scenarios (*)
1. Navigate to `Stores / Configuration / Customer Configuration / Create New Account Options`
2. Check what is the `Default Group` -> `General`
3. Navigate to `Customers / Customer Groups`
4. The `Delete` action shouldn't be available for `General` group.
![image](https://user-images.githubusercontent.com/15868188/71724784-375c5400-2e3a-11ea-9491-26917229e0f5.png)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
