### PR TITLE
#11209 Wishlist Add grouped product Error

### DIFF
--- a/app/code/Magento/GroupedProduct/Model/Wishlist/Product/Item.php
+++ b/app/code/Magento/GroupedProduct/Model/Wishlist/Product/Item.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\GroupedProduct\Model\Wishlist\Product;
 
 use Magento\Wishlist\Model\Item as WishlistItem;
@@ -25,7 +27,7 @@ class Item
     public function beforeRepresentProduct(
         WishlistItem $subject,
         Product $product
-    ) {
+    ): array {
         if ($product->getTypeId() === TypeGrouped::TYPE_CODE
             && $product->getId() === $subject->getProduct()->getId()
         ) {
@@ -72,9 +74,9 @@ class Item
      */
     public function beforeCompareOptions(
         WishlistItem $subject,
-        $options1,
-        $options2
-    ) {
+        array $options1,
+        array $options2
+    ): array {
         $diff = array_diff_key($options1, $options2);
 
         if (!$diff) {

--- a/app/code/Magento/GroupedProduct/Model/Wishlist/Product/Item.php
+++ b/app/code/Magento/GroupedProduct/Model/Wishlist/Product/Item.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\GroupedProduct\Model\Wishlist\Product;
+
+use Magento\Wishlist\Model\Item as WishlistItem;
+use Magento\GroupedProduct\Model\Product\Type\Grouped as TypeGrouped;
+use Magento\Catalog\Model\Product;
+
+/**
+ * Wishlist logic for grouped product
+ */
+class Item
+{
+    /**
+     * Modify Wishlist item based on associated product qty
+     *
+     * @param WishlistItem $subject
+     * @param Product $product
+     * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function beforeRepresentProduct(
+        WishlistItem $subject,
+        Product $product
+    ) {
+        if ($product->getTypeId() === TypeGrouped::TYPE_CODE
+            && $product->getId() === $subject->getProduct()->getId()
+        ) {
+            $itemOptions = $subject->getOptionsByCode();
+            $productOptions = $product->getCustomOptions();
+
+            $diff = array_diff_key($itemOptions, $productOptions);
+
+            if (!$diff) {
+                $buyRequest = $subject->getBuyRequest();
+                $superGroupInfo = $buyRequest->getData('super_group');
+
+                foreach ($itemOptions as $key => $itemOption) {
+                    if (preg_match('/associated_product_\d+/', $key)) {
+                        $simpleId = str_replace('associated_product_', '', $key);
+                        $prodQty = $productOptions[$key]->getValue();
+
+                        $itemOption->setValue($itemOption->getValue() + $prodQty);
+
+                        if (isset($superGroupInfo[$simpleId])) {
+                            $superGroupInfo[$simpleId] = $itemOptions[$key]->getValue();
+                        }
+                    }
+                }
+
+                $buyRequest->setData('super_group', $superGroupInfo);
+
+                $subject->setOptions($itemOptions);
+                $subject->mergeBuyRequest($buyRequest);
+            }
+        }
+
+        return [$product];
+    }
+
+    /**
+     * Remove associated_product_id key. associated_product_id contains qty
+     *
+     * @param WishlistItem $subject
+     * @param array $options1
+     * @param array $options2
+     * @return array
+     */
+    public function beforeCompareOptions(
+        WishlistItem $subject,
+        $options1,
+        $options2
+    ) {
+        $diff = array_diff_key($options1, $options2);
+
+        if (!$diff) {
+            foreach ($options1 as $key => $val) {
+                if (preg_match('/associated_product_\d+/', $key)) {
+                    unset($options1[$key]);
+                    unset($options2[$key]);
+                }
+            }
+        }
+
+        return [$options1, $options2];
+    }
+}

--- a/app/code/Magento/GroupedProduct/Model/Wishlist/Product/Item.php
+++ b/app/code/Magento/GroupedProduct/Model/Wishlist/Product/Item.php
@@ -68,6 +68,7 @@ class Item
      * @param array $options1
      * @param array $options2
      * @return array
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function beforeCompareOptions(
         WishlistItem $subject,
@@ -77,7 +78,7 @@ class Item
         $diff = array_diff_key($options1, $options2);
 
         if (!$diff) {
-            foreach ($options1 as $key => $val) {
+            foreach (array_keys($options1) as $key) {
                 if (preg_match('/associated_product_\d+/', $key)) {
                     unset($options1[$key]);
                     unset($options2[$key]);

--- a/app/code/Magento/GroupedProduct/Test/Unit/Model/Wishlist/Product/ItemTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Model/Wishlist/Product/ItemTest.php
@@ -61,6 +61,10 @@ class ItemTest extends \PHPUnit\Framework\TestCase
      */
     public function testBeforeRepresentProduct()
     {
+        $testSimpleProdId = 34;
+        $prodInitQty = 2;
+        $prodQtyInWishlist = 3;
+        $resWishlistQty = $prodInitQty + $prodQtyInWishlist;
         $superGroup = [
             'super_group' => [
                 33 => "0",
@@ -71,12 +75,12 @@ class ItemTest extends \PHPUnit\Framework\TestCase
 
         $superGroupObj = new \Magento\Framework\DataObject($superGroup);
 
-        $this->productMock->expects($this->once())->method('getId')->willReturn(34);
+        $this->productMock->expects($this->once())->method('getId')->willReturn($testSimpleProdId);
         $this->productMock->expects($this->once())->method('getTypeId')
             ->willReturn(TypeGrouped::TYPE_CODE);
         $this->productMock->expects($this->once())->method('getCustomOptions')
             ->willReturn(
-                $this->getProductAssocOption(2, 34)
+                $this->getProductAssocOption($prodInitQty, $testSimpleProdId)
             );
 
         $wishlistItemProductMock = $this->createPartialMock(
@@ -85,13 +89,13 @@ class ItemTest extends \PHPUnit\Framework\TestCase
                 'getId',
             ]
         );
-        $wishlistItemProductMock->expects($this->once())->method('getId')->willReturn(34);
+        $wishlistItemProductMock->expects($this->once())->method('getId')->willReturn($testSimpleProdId);
 
         $this->subjectMock->expects($this->once())->method('getProduct')
             ->willReturn($wishlistItemProductMock);
         $this->subjectMock->expects($this->once())->method('getOptionsByCode')
             ->willReturn(
-                $this->getWishlistAssocOption(3, 5, 34)
+                $this->getWishlistAssocOption($prodQtyInWishlist, $resWishlistQty, $testSimpleProdId)
             );
         $this->subjectMock->expects($this->once())->method('getBuyRequest')->willReturn($superGroupObj);
 

--- a/app/code/Magento/GroupedProduct/Test/Unit/Model/Wishlist/Product/ItemTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Model/Wishlist/Product/ItemTest.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\GroupedProduct\Test\Unit\Model\Wishlist\Product;
+
+use Magento\GroupedProduct\Model\Product\Type\Grouped as TypeGrouped;
+
+/**
+ * Unit test for Wishlist Item Plugin.
+ */
+class ItemTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\GroupedProduct\Model\Wishlist\Product\Item
+     */
+    protected $model;
+
+    /**
+     * @var \Magento\Catalog\Model\Product|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $productMock;
+
+    /**
+     * @var \Magento\Wishlist\Model\Item|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $subjectMock;
+
+    /**
+     * Init Mock Objects
+     */
+    protected function setUp()
+    {
+        $this->subjectMock = $this->createPartialMock(
+            \Magento\Wishlist\Model\Item::class,
+            [
+                'getOptionsByCode',
+                'getBuyRequest',
+                'setOptions',
+                'mergeBuyRequest',
+                'getProduct'
+            ]
+        );
+
+        $this->productMock = $this->createPartialMock(
+            \Magento\Catalog\Model\Product::class,
+            [
+                'getId',
+                'getTypeId',
+                'getCustomOptions'
+            ]
+        );
+
+        $this->model = new \Magento\GroupedProduct\Model\Wishlist\Product\Item();
+    }
+
+    /**
+     * Test Before Represent Product method
+     */
+    public function testBeforeRepresentProduct()
+    {
+        $superGroup = [
+            'super_group' => [
+                33 => "0",
+                34 => 3,
+                35 => "0"
+            ]
+        ];
+
+        $superGroupObj = new \Magento\Framework\DataObject($superGroup);
+
+        $this->productMock->expects($this->once())->method('getId')->willReturn(34);
+        $this->productMock->expects($this->once())->method('getTypeId')
+            ->willReturn(TypeGrouped::TYPE_CODE);
+        $this->productMock->expects($this->once())->method('getCustomOptions')
+            ->willReturn(
+                $this->getProductAssocOption(2, 34)
+            );
+
+        $wishlistItemProductMock = $this->createPartialMock(
+            \Magento\Catalog\Model\Product::class,
+            [
+                'getId',
+            ]
+        );
+        $wishlistItemProductMock->expects($this->once())->method('getId')->willReturn(34);
+
+        $this->subjectMock->expects($this->once())->method('getProduct')
+            ->willReturn($wishlistItemProductMock);
+        $this->subjectMock->expects($this->once())->method('getOptionsByCode')
+            ->willReturn(
+                $this->getWishlistAssocOption(3, 5, 34)
+            );
+        $this->subjectMock->expects($this->once())->method('getBuyRequest')->willReturn($superGroupObj);
+
+        $this->model->beforeRepresentProduct($this->subjectMock, $this->productMock);
+    }
+
+    /**
+     * Test Before Compare Options method with same keys
+     */
+    public function testBeforeCompareOptionsSameKeys()
+    {
+        $options1 = ['associated_product_34' => 3];
+        $options2 = ['associated_product_34' => 2];
+
+        $res = $this->model->beforeCompareOptions($this->subjectMock, $options1, $options2);
+
+        $this->assertEquals([], $res[0]);
+        $this->assertEquals([], $res[1]);
+    }
+
+    /**
+     * Test Before Compare Options method with diff keys
+     */
+    public function testBeforeCompareOptionsDiffKeys()
+    {
+        $options1 = ['associated_product_1' => 3];
+        $options2 = ['associated_product_34' => 2];
+
+        $res = $this->model->beforeCompareOptions($this->subjectMock, $options1, $options2);
+
+        $this->assertEquals($options1, $res[0]);
+        $this->assertEquals($options2, $res[1]);
+    }
+
+    /**
+     * Return mock array with wishlist options
+     *
+     * @param int $initVal
+     * @param int $resVal
+     * @param int $prodId
+     * @return array
+     */
+    private function getWishlistAssocOption($initVal, $resVal, $prodId)
+    {
+        $items = [];
+
+        $optionMock = $this->createPartialMock(
+            \Magento\Wishlist\Model\Item\Option::class,
+            [
+                'getValue',
+            ]
+        );
+        $optionMock->expects($this->at(0))->method('getValue')->willReturn($initVal);
+        $optionMock->expects($this->at(1))->method('getValue')->willReturn($resVal);
+
+        $items['associated_product_' . $prodId] = $optionMock;
+
+        return $items;
+    }
+
+    /**
+     * Return mock array with product options
+     *
+     * @param int $initVal
+     * @param int $prodId
+     * @return array
+     */
+    private function getProductAssocOption($initVal, $prodId)
+    {
+        $items = [];
+
+        $optionMock = $this->createPartialMock(
+            \Magento\Catalog\Model\Product\Configuration\Item\Option::class,
+            [
+                'getValue',
+            ]
+        );
+
+        $optionMock->expects($this->once())->method('getValue')->willReturn($initVal);
+
+        $items['associated_product_' . $prodId] = $optionMock;
+
+        return $items;
+    }
+}

--- a/app/code/Magento/GroupedProduct/composer.json
+++ b/app/code/Magento/GroupedProduct/composer.json
@@ -18,7 +18,8 @@
         "magento/module-quote": "*",
         "magento/module-sales": "*",
         "magento/module-store": "*",
-        "magento/module-ui": "*"
+        "magento/module-ui": "*",
+        "magento/module-wishlist": "*"
     },
     "suggest": {
         "magento/module-grouped-product-sample-data": "*"

--- a/app/code/Magento/GroupedProduct/etc/frontend/di.xml
+++ b/app/code/Magento/GroupedProduct/etc/frontend/di.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Wishlist\Model\Item">
+        <plugin name="groupedProductWishlistProcessor" type="Magento\GroupedProduct\Model\Wishlist\Product\Item" />
+    </type>
+</config>


### PR DESCRIPTION
### Description (*)
Fixed Wishlist logic for grouped products when add same simple product

### Fixed Issues (if relevant)
1. magento/magento2#11209: Wishlist Add grouped product Error

### Manual testing scenarios (*)
1. Go to the grouped product page.
2. Set qty for one of the simple products
3. click add to wishlist
4. Go to grouped product page and add same simple product with different qty to the wishlist
5. check number of grouped products in the wishlist and check Option Details in grouped product

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
