### PR TITLE
Issue 23521

### DIFF
--- a/app/code/Magento/Downloadable/Test/Unit/Helper/DownloadTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Helper/DownloadTest.php
@@ -17,7 +17,10 @@ use Magento\Framework\Filesystem\File\ReadInterface as FileReadInterface;
  */
 class DownloadTest extends \PHPUnit\Framework\TestCase
 {
-    /** @var DownloadHelper */
+	/** @var array Result of get_headers() function */
+	public static $headers;
+
+	/** @var DownloadHelper */
     protected $_helper;
 
     /** @var Filesystem|\PHPUnit_Framework_MockObject_MockObject */
@@ -230,6 +233,7 @@ class DownloadTest extends \PHPUnit\Framework\TestCase
             $this->returnValue($this->_handleMock)
         );
 
+		self::$headers = ['200 OK'];
         $this->_helper->setResource($url, DownloadHelper::LINK_TYPE_URL);
     }
 

--- a/app/code/Magento/Downloadable/Test/Unit/Helper/DownloadTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Helper/DownloadTest.php
@@ -17,10 +17,10 @@ use Magento\Framework\Filesystem\File\ReadInterface as FileReadInterface;
  */
 class DownloadTest extends \PHPUnit\Framework\TestCase
 {
-	/** @var array Result of get_headers() function */
-	public static $headers;
+    /** @var array Result of get_headers() function */
+    public static $headers;
 
-	/** @var DownloadHelper */
+    /** @var DownloadHelper */
     protected $_helper;
 
     /** @var Filesystem|\PHPUnit_Framework_MockObject_MockObject */
@@ -233,7 +233,7 @@ class DownloadTest extends \PHPUnit\Framework\TestCase
             $this->returnValue($this->_handleMock)
         );
 
-		self::$headers = ['200 OK'];
+        self::$headers = ['200 OK'];
         $this->_helper->setResource($url, DownloadHelper::LINK_TYPE_URL);
     }
 

--- a/app/code/Magento/Downloadable/Test/Unit/_files/download_mock.php
+++ b/app/code/Magento/Downloadable/Test/Unit/_files/download_mock.php
@@ -22,3 +22,13 @@ function mime_content_type()
 {
     return DownloadTest::$mimeContentType;
 }
+
+/**
+ * Override standard function
+ *
+ * @return array
+ */
+function get_headers()
+{
+	return DownloadTest::$headers;
+}

--- a/app/code/Magento/Downloadable/Test/Unit/_files/download_mock.php
+++ b/app/code/Magento/Downloadable/Test/Unit/_files/download_mock.php
@@ -30,5 +30,5 @@ function mime_content_type()
  */
 function get_headers()
 {
-	return DownloadTest::$headers;
+    return DownloadTest::$headers;
 }


### PR DESCRIPTION
### Description (*)
Using a mock function for get_headers() as the existing mock used for HttpTest class.

### Fixed Issues (if relevant)
1. magento/magento2#23521: Unable to run \Magento\Downloadable\Test\Unit\Helper\DownloadTest without internet connection / dns resolution

### Manual testing scenarios (*)
1. Simply try to run the involved unit tests. 


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
