### PR TITLE
Fix #22964

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
@@ -362,7 +362,7 @@ class Timezone implements TimezoneInterface
 
             $formatterWithoutHour = new \IntlDateFormatter(
                 $locale,
-                \IntlDateFormatter::SHORT,
+                \IntlDateFormatter::MEDIUM,
                 \IntlDateFormatter::NONE,
                 new \DateTimeZone($timezone)
             );
@@ -379,7 +379,7 @@ class Timezone implements TimezoneInterface
 
             $formatterWithHour = new \IntlDateFormatter(
                 $locale,
-                \IntlDateFormatter::SHORT,
+                \IntlDateFormatter::MEDIUM,
                 \IntlDateFormatter::SHORT,
                 new \DateTimeZone($timezone)
             );

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
@@ -182,7 +182,7 @@ class Timezone implements TimezoneInterface
                     new \DateTimeZone($timezone)
                 );
 
-                $date = $this->appendTimeIfNeeded($date, $includeTime);
+                $date = $this->appendTimeIfNeeded($date, $includeTime, $timezone, $locale);
                 $date = $formatter->parse($date) ?: (new \DateTime($date))->getTimestamp();
                 break;
         }
@@ -347,16 +347,31 @@ class Timezone implements TimezoneInterface
     }
 
     /**
-     * Retrieve date with time
-     *
      * @param string $date
-     * @param bool $includeTime
+     * @param boolean $includeTime
+     * @param string $timezone
+     * @param string $locale
      * @return string
      */
-    private function appendTimeIfNeeded($date, $includeTime)
+    private function appendTimeIfNeeded($date, $includeTime, $timezone, $locale)
     {
         if ($includeTime && !preg_match('/\d{1}:\d{2}/', $date)) {
-            $date .= " 0:00am";
+
+            $formatterWithoutHour = new \IntlDateFormatter(
+                $locale,
+                \IntlDateFormatter::SHORT,
+                \IntlDateFormatter::NONE,
+                new \DateTimeZone($timezone)
+            );
+            $convertedDate = $formatterWithoutHour->parse($date);
+            $formatterWithHour = new \IntlDateFormatter(
+                $locale,
+                \IntlDateFormatter::SHORT,
+                \IntlDateFormatter::SHORT,
+                new \DateTimeZone($timezone)
+            );
+
+            $date = $formatterWithHour->format($convertedDate);
         }
         return $date;
     }

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
@@ -354,6 +354,7 @@ class Timezone implements TimezoneInterface
      * @param string $timezone
      * @param string $locale
      * @return string
+     * @throws LocalizedException
      */
     private function appendTimeIfNeeded($date, $includeTime, $timezone, $locale)
     {
@@ -366,6 +367,16 @@ class Timezone implements TimezoneInterface
                 new \DateTimeZone($timezone)
             );
             $convertedDate = $formatterWithoutHour->parse($date);
+
+            if (!$convertedDate) {
+                throw new LocalizedException(
+                    new Phrase(
+                        'Could not append time to DateTime'
+                    )
+                );
+
+            }
+
             $formatterWithHour = new \IntlDateFormatter(
                 $locale,
                 \IntlDateFormatter::SHORT,

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
@@ -177,7 +177,7 @@ class Timezone implements TimezoneInterface
                 $timeType = $includeTime ? \IntlDateFormatter::SHORT : \IntlDateFormatter::NONE;
                 $formatter = new \IntlDateFormatter(
                     $locale,
-                    \IntlDateFormatter::SHORT,
+                    \IntlDateFormatter::MEDIUM,
                     $timeType,
                     new \DateTimeZone($timezone)
                 );

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
@@ -347,6 +347,8 @@ class Timezone implements TimezoneInterface
     }
 
     /**
+     * Append time to DateTime
+     *
      * @param string $date
      * @param boolean $includeTime
      * @param string $timezone

--- a/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/TimezoneTest.php
+++ b/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/TimezoneTest.php
@@ -132,13 +132,13 @@ class TimezoneTest extends \PHPUnit\Framework\TestCase
                 '30/10/2021', // datetime
                 'el_GR', // locale
                 false, // include time
-                1635552000 // expected timestamp
+                1635570000 // expected timestamp
             ],
             'Parse greek d/m/y date with time' => [
-                '30/10/21, 12:00 π.μ.', // datetime
+                '30/10/2021, 12:00 π.μ.', // datetime
                 'el_GR', // locale
                 true, // include time
-                1635552000 // expected timestamp
+                1635570000 // expected timestamp
             ],
         ];
     }

--- a/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/TimezoneTest.php
+++ b/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/TimezoneTest.php
@@ -135,10 +135,10 @@ class TimezoneTest extends \PHPUnit\Framework\TestCase
                 1635570000 // expected timestamp
             ],
             'Parse greek d/m/y date with time' => [
-                '30/10/2021, 12:00 π.μ.', // datetime
+                '30/10/2021, 12:01 π.μ.', // datetime
                 'el_GR', // locale
                 true, // include time
-                1635570000 // expected timestamp
+                1635570060 // expected timestamp
             ],
         ];
     }

--- a/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/TimezoneTest.php
+++ b/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/TimezoneTest.php
@@ -128,6 +128,18 @@ class TimezoneTest extends \PHPUnit\Framework\TestCase
                 true, // include time
                 1495170060 // expected timestamp
             ],
+            'Parse greek d/m/y date without time' => [
+                '30/10/2021', // datetime
+                'el_GR', // locale
+                false, // include time
+                1635552000 // expected timestamp
+            ],
+            'Parse greek d/m/y date with time' => [
+                '30/10/21, 12:00 π.μ.', // datetime
+                'el_GR', // locale
+                true, // include time
+                1635552000 // expected timestamp
+            ],
         ];
     }
 


### PR DESCRIPTION
### Description (*)
It was need to change the appendTimeIfNeeded, because isn't a good practice to transform DateTime without hour into DateTime with hour just appending a string in the end of other string.

### Fixed Issues (if relevant)
1. magento/magento2#22964: Unable to save any dates if the user interface locale is not english (US) in 2.3.1

### Manual testing scenarios (*)
1. Change interface to Greek locale
2. Go to product (create or edit one)
3. Try to save one date attribute

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
