### PR TITLE
MFTF: Replace <amOnPage> with <actionGroup> for Admin log out

### DIFF
--- a/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminLogoutActionGroup.xml
+++ b/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminLogoutActionGroup.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminLogoutActionGroup">
+        <amOnPage url="{{AdminLogoutPage.url}}" stepKey="amOnLogoutPage"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/SalesRule/Test/Mftf/Test/PriceRuleCategoryNestingTest.xml
+++ b/app/code/Magento/SalesRule/Test/Mftf/Test/PriceRuleCategoryNestingTest.xml
@@ -32,7 +32,7 @@
         </before>
         <after>
             <deleteData createDataKey="subcategory1" stepKey="deleteCategory1"/>
-            <amOnPage url="{{_ENV.MAGENTO_BACKEND_NAME}}/admin/auth/logout/" stepKey="amOnLogoutPage"/>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="adminLogout"/>
         </after>
         <!-- Login as admin and open page for creation new Price Rule -->
         <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin1"/>

--- a/app/code/Magento/Wishlist/Test/Mftf/Test/AdminCustomerWishListShareOptionsInputValidationTest.xml
+++ b/app/code/Magento/Wishlist/Test/Mftf/Test/AdminCustomerWishListShareOptionsInputValidationTest.xml
@@ -26,7 +26,7 @@
                 <argument name="emailTextLengthLimit" value="{{Wishlist.default_email_text_length_limit}}"/>
             </actionGroup>
             <checkOption selector="{{WishListShareOptionsSection.useSystemValueForWishListEmailTextLimit}}" stepKey="checkUseSystemValueForWishListEmailTextLimit"/>
-            <amOnPage url="admin/admin/auth/logout/" stepKey="amOnLogoutPage"/>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="adminLogout"/>
         </after>
 
         <actionGroup ref="setEmailTextLengthLimitActionGroup" stepKey="setEmailTextLengthLimitToMin">


### PR DESCRIPTION
### Description (*)
I've replaced all incorrect uses of `<amOnPage>` used to log out with proper `<actionGroup>`.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
