### PR TITLE
Add Visual Code catalog generator

### DIFF
--- a/app/code/Magento/Developer/Model/XmlCatalog/Format/VsCode.php
+++ b/app/code/Magento/Developer/Model/XmlCatalog/Format/VsCode.php
@@ -117,7 +117,7 @@ class VsCode implements FormatInterface
      */
     private function initEmptyFile(\DOMDocument $dom): \DOMElement
     {
-        $copyrigthComment = $dom->createComment('
+        $copyrightComment = $dom->createComment('
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.

--- a/app/code/Magento/Developer/Model/XmlCatalog/Format/VsCode.php
+++ b/app/code/Magento/Developer/Model/XmlCatalog/Format/VsCode.php
@@ -123,7 +123,7 @@ class VsCode implements FormatInterface
  * See COPYING.txt for license details.
  */
 ');
-        $dom->appendChild($copyrigthComment);
+        $dom->appendChild($copyrightComment);
 
         $catalogNode = $dom->createElement('catalog');
         $catalogNode->setAttribute('xmlns', self::XMLNS);


### PR DESCRIPTION
### Description (*)
Add urn-catalog model generate for visual code

### Manual testing scenarios (*)
1. Run `bin/magento dev:urn-catalog:generate --ide=vscode  .vscode/catalog.xml`
2. Open project on visual code with redhat.vscode-xml extension

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
