### PR TITLE
Fixed problems in the ResourceModel for the Inbox.

### DIFF
--- a/app/code/Magento/AdminNotification/Model/ResourceModel/Inbox.php
+++ b/app/code/Magento/AdminNotification/Model/ResourceModel/Inbox.php
@@ -98,16 +98,17 @@ class Inbox extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 
             if (empty($item['url'])) {
                 $select->where('url IS NULL');
+                unset($item['url']);
             } else {
                 $select->where('url = ?', $item['url']);
             }
 
             if (isset($item['internal'])) {
                 $row = false;
-                unset($item['internal']);
             } else {
                 $row = $connection->fetchRow($select);
             }
+            unset($item['internal']);
 
             if (!$row) {
                 $connection->insert($this->getMainTable(), $item);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When inserting a notification through `Magento\AdminNotification\Model\Inbox::add` 
with the URL empty(as it by default is), would result in the empty string being inserted into the database and therefore the `IS NULL` where condition would never match the next time around, so calling it twice with the same values and the `$isInternal` parameters set to `NULL` would result in 2 of the same notifications being inserted.
Setting the `$isInternal` parameter to `NULL` is the only way of hitting the duplication check, becuase of `isset($item['internal'])`, but hitting that would error before because `internal` is not a valid column in the `adminnotification_inbox` table.
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Calling `Magento\AdminNotification\Model\Inbox::add` with `$isInternal` set to `NULL` to hit the duplication check(should crash before fix).
2. Check `adminnotification_inbox` table after inserting a notification with the `$url` parameter empty(should show empty string before fix and `NULL` after fix).

### Questions or comments
This changes the value that will be inputet in the `adminnotification_inbox.url` column when there is not provided any URL, the value will change from an empty string to `NULL`.
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)

### Resolved issues:
1. [x] resolves magento/magento2#29617: Fixed problems in the ResourceModel for the Inbox.