### PR TITLE
[GoogleAdWords] Conversion ID client validation

### DIFF
--- a/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminCheckUseSystemValueActionGroup.xml
+++ b/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminCheckUseSystemValueActionGroup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminCheckUseSystemValueActionGroup">
+        <arguments>
+            <argument name="rowId" type="string"/>
+        </arguments>
+
+        <checkOption selector="{{AdminConfigSection.useSystemValue(rowId)}}" stepKey="checkUseSystemValue"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminToggleEnabledActionGroup.xml
+++ b/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminToggleEnabledActionGroup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminToggleEnabledActionGroup">
+        <arguments>
+            <argument name="element" type="string"/>
+            <argument name="state" type="string" defaultValue="Yes"/>
+        </arguments>
+        <selectOption selector="{{element}}" userInput="{{state}}" stepKey="switchActiveState"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminUncheckUseSystemValueActionGroup.xml
+++ b/app/code/Magento/Config/Test/Mftf/ActionGroup/AdminUncheckUseSystemValueActionGroup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminUncheckUseSystemValueActionGroup">
+        <arguments>
+            <argument name="rowId" type="string"/>
+        </arguments>
+
+        <uncheckOption selector="{{AdminConfigSection.useSystemValue(rowId)}}" stepKey="uncheckUseSystemValue"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Config/Test/Mftf/ActionGroup/AssertAdminValidationErrorActionGroup.xml
+++ b/app/code/Magento/Config/Test/Mftf/ActionGroup/AssertAdminValidationErrorActionGroup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertAdminValidationErrorActionGroup">
+        <arguments>
+            <argument name="inputId" type="string"/>
+            <argument name="errorMessage" type="string" defaultValue="This is a required field."/>
+        </arguments>
+
+        <see selector="{{AdminConfigSection.errorElement(inputId)}}" userInput="{{errorMessage}}"
+             stepKey="seeElementValidationError"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Config/Test/Mftf/Section/AdminConfigSection.xml
+++ b/app/code/Magento/Config/Test/Mftf/Section/AdminConfigSection.xml
@@ -22,5 +22,6 @@
         <element name="useSystemValue" type="checkbox" selector="#{{configRowId}} > .use-default > input" parameterized="true"/>
         <element name="collapsibleSectionByTitle" type="text" selector="//form[@id='config-edit-form']//div[@class='section-config'][contains(.,'{{sectionTitle}}')]" parameterized="true" />
         <element name="expandedSectionByTitle" type="text" selector="//form[@id='config-edit-form']//div[@class='section-config active'][contains(.,'{{sectionTitle}}')]" parameterized="true" />
+        <element name="errorElement" type="text" selector="#{{inputId}}-error" parameterized="true" />
     </section>
 </sections>

--- a/app/code/Magento/GoogleAdwords/Test/Mftf/ActionGroup/AdminNavigateToGoogleAdwordsConfigurationActionGroup.xml
+++ b/app/code/Magento/GoogleAdwords/Test/Mftf/ActionGroup/AdminNavigateToGoogleAdwordsConfigurationActionGroup.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminNavigateToGoogleAdwordsConfigurationActionGroup">
+        <amOnPage url="{{AdminGoogleAdwordsConfigPage.url}}" stepKey="navigateToConfigurationPage"/>
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/GoogleAdwords/Test/Mftf/Page/AdminGoogleAdwordsConfigPage.xml
+++ b/app/code/Magento/GoogleAdwords/Test/Mftf/Page/AdminGoogleAdwordsConfigPage.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/PageObject.xsd">
+    <page name="AdminGoogleAdwordsConfigPage" url="admin/system_config/edit/section/google/" area="admin"
+          module="Magento_Config">
+        <section name="AdminGoogleAdwordsConfigSection"/>
+    </page>
+</pages>

--- a/app/code/Magento/GoogleAdwords/Test/Mftf/Section/AdminGoogleAdwordsConfigSection.xml
+++ b/app/code/Magento/GoogleAdwords/Test/Mftf/Section/AdminGoogleAdwordsConfigSection.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminGoogleAdwordsConfigSection">
+        <element name="active" type="text" selector="#google_adwords #google_adwords_active"/>
+    </section>
+</sections>

--- a/app/code/Magento/GoogleAdwords/Test/Mftf/Section/AdminGoogleAdwordsConfigSection.xml
+++ b/app/code/Magento/GoogleAdwords/Test/Mftf/Section/AdminGoogleAdwordsConfigSection.xml
@@ -8,6 +8,7 @@
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="AdminGoogleAdwordsConfigSection">
-        <element name="active" type="text" selector="#google_adwords #google_adwords_active"/>
+        <element name="active" type="text" selector="#google_adwords_active"/>
+        <element name="conversionId" type="text" selector="#google_adwords_conversion_id"/>
     </section>
 </sections>

--- a/app/code/Magento/GoogleAdwords/Test/Mftf/Test/AdminValidateConversionIdConfigTest.xml
+++ b/app/code/Magento/GoogleAdwords/Test/Mftf/Test/AdminValidateConversionIdConfigTest.xml
@@ -31,14 +31,9 @@
         <actionGroup ref="AdminToggleEnabledActionGroup" stepKey="enableGoogleAdwordsConfig">
             <argument name="element" value="{{AdminGoogleAdwordsConfigSection.active}}"/>
         </actionGroup>
-
-
-
         <actionGroup ref="AdminClickFormActionButtonActionGroup" stepKey="clickSaveCustomVariable">
             <argument name="buttonSelector" value="{{AdminMainActionsSection.save}}"/>
         </actionGroup>
-
-
         <actionGroup ref="AssertAdminValidationErrorActionGroup" stepKey="seeRequiredValidationErrorForConversionId">
             <argument name="inputId" value="google_adwords_conversion_id"/>
         </actionGroup>

--- a/app/code/Magento/GoogleAdwords/Test/Mftf/Test/AdminValidateConversionIdConfigTest.xml
+++ b/app/code/Magento/GoogleAdwords/Test/Mftf/Test/AdminValidateConversionIdConfigTest.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminValidateConversionIdConfigTest">
+        <annotations>
+            <stories value="Admin validates the conversion ID when configuring the Google Adwords"/>
+            <title value="Admin validates the conversion ID when configuring the Google Adwords"/>
+            <description value="Testing for a required Conversion ID when configuring the Google Adwords"/>
+            <severity value="MINOR"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+        <actionGroup ref="AdminNavigateToGoogleAdwordsConfigurationActionGroup" stepKey="goToConfigPage"/>
+        <actionGroup ref="AdminExpandConfigSectionActionGroup" stepKey="expandingGoogleAdwordsSection">
+            <argument name="sectionName" value="Google AdWords"/>
+        </actionGroup>
+        <actionGroup ref="AdminUncheckUseSystemValueActionGroup" stepKey="uncheckUseSystemValue">
+            <argument name="rowId" value="row_google_adwords_active"/>
+        </actionGroup>
+        <actionGroup ref="AdminToggleEnabledActionGroup" stepKey="enableGoogleAdwordsConfig">
+            <argument name="element" value="{{AdminGoogleAdwordsConfigSection.active}}"/>
+        </actionGroup>
+
+
+
+        <actionGroup ref="AdminClickFormActionButtonActionGroup" stepKey="clickSaveCustomVariable">
+            <argument name="buttonSelector" value="{{AdminMainActionsSection.save}}"/>
+        </actionGroup>
+
+
+        <actionGroup ref="AssertAdminValidationErrorActionGroup" stepKey="seeRequiredValidationErrorForConversionId">
+            <argument name="inputId" value="google_adwords_conversion_id"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/GoogleAdwords/etc/adminhtml/system.xml
+++ b/app/code/Magento/GoogleAdwords/etc/adminhtml/system.xml
@@ -17,6 +17,7 @@
                 <field id="conversion_id" translate="label" type="text" sortOrder="11" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Conversion ID</label>
                     <backend_model>Magento\GoogleAdwords\Model\Config\Backend\ConversionId</backend_model>
+                    <validate>required-entry validate-number</validate>
                     <depends>
                         <field id="*/*/active">1</field>
                     </depends>


### PR DESCRIPTION
### Description (*)
This PR adds client validation for Conversion ID instead of validating the ID on the backend while configuring the Google AdWords.

### Fixed Issues (if relevant)
1. Navigate to `Stores / Configuration / Google API [Sales] / Google AdWords`
2. Enable `Google AdWords`
3. Save configs
4. You'll get `Conversion Id value is not valid "". Conversion Id should be an integer.` error message.

### Manual testing scenarios (*)
1. Navigate to `Stores / Configuration / Google API [Sales] / Google AdWords`
2. Enable `Google AdWords`
3. The Conversion ID should be validated before submitting the form.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
