### PR TITLE
[CurrencySymbol] Fixing the redirect after saving the currency symbols

### DIFF
--- a/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currencysymbol/Save.php
+++ b/app/code/Magento/CurrencySymbol/Controller/Adminhtml/System/Currencysymbol/Save.php
@@ -67,6 +67,6 @@ class Save extends CurrencysymbolController implements HttpPostActionInterface
             $this->messageManager->addErrorMessage($e->getMessage());
         }
 
-        return $resultRedirect->setPath('*');
+        return $resultRedirect->setPath('adminhtml/*/');
     }
 }

--- a/app/code/Magento/CurrencySymbol/Test/Unit/Controller/Adminhtml/System/Currencysymbol/SaveTest.php
+++ b/app/code/Magento/CurrencySymbol/Test/Unit/Controller/Adminhtml/System/Currencysymbol/SaveTest.php
@@ -132,7 +132,7 @@ class SaveTest extends TestCase
             ->with(__('You applied the custom currency symbols.'));
 
         $redirect = $this->createMock(Redirect::class);
-        $redirect->expects($this->once())->method('setPath')->with('*')->willReturnSelf();
+        $redirect->expects($this->once())->method('setPath')->with('adminhtml/*/')->willReturnSelf();
         $this->resultRedirectFactory->method('create')->willReturn($redirect);
 
         $this->assertEquals($redirect, $this->action->execute());


### PR DESCRIPTION

### Description (*)
This PR fixes the redirect path after saving the currency rates.

### Fixed Issues (if relevant)

1. Navigate to `Stores / Currency Symbols`
2. Save symbols
3. You're redirected to Dashboard with the Success message ❌ 

### Manual testing scenarios (*)

1. Navigate to `Stores / Currency Symbols`
2. Save symbols
3. You should stay on the same submitted page ✅ 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
