### PR TITLE
Issue-25968 - Added additional checking for returning needed variable…

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Item.php
@@ -385,6 +385,8 @@ class Item extends AbstractModel implements OrderItemInterface
      *
      * @param string $statusId
      * @return \Magento\Framework\Phrase
+     *
+     * phpcs:disable Magento2.Functions.StaticFunction
      */
     public static function getStatusName($statusId)
     {
@@ -422,6 +424,8 @@ class Item extends AbstractModel implements OrderItemInterface
      * Retrieve order item statuses array
      *
      * @return array
+     *
+     * phpcs:disable Magento2.Functions.StaticFunction
      */
     public static function getStatuses()
     {

--- a/app/code/Magento/Sales/Model/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Item.php
@@ -1319,7 +1319,13 @@ class Item extends AbstractModel implements OrderItemInterface
      */
     public function getPrice()
     {
-        return $this->getData(OrderItemInterface::PRICE);
+        $price = $this->getData(OrderItemInterface::PRICE);
+
+        if ($price === null) {
+            return $price;
+        }
+
+        return (float) $price;
     }
 
     /**

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
@@ -348,4 +348,22 @@ class ItemTest extends \PHPUnit\Framework\TestCase
             ]
         ];
     }
+
+    /**
+     * Test getPrice() method
+     */
+    public function testGetPrice()
+    {
+        $price = 9.99;
+        $this->model->setPrice($price);
+        $this->assertEquals($price, $this->model->getPrice());
+
+        $newPrice = 5.53;
+        $this->model->setData(\Magento\Sales\Api\Data\OrderItemInterface::PRICE, $newPrice);
+        $this->assertEquals($newPrice, $this->model->getPrice());
+
+        $nullablePrice = null;
+        $this->model->setPrice($nullablePrice);
+        $this->assertEquals($nullablePrice, $this->model->getPrice());
+    }
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
@@ -7,9 +7,8 @@
 namespace Magento\Sales\Test\Unit\Model\Order;
 
 use Magento\Framework\Serialize\Serializer\Json;
-use Magento\Sales\Model\ResourceModel\OrderFactory;
-use \Magento\Sales\Model\Order;
 use Magento\Sales\Api\Data\OrderItemInterface;
+use Magento\Sales\Model\ResourceModel\OrderFactory;
 
 /**
  * Unit test for order item class.
@@ -349,7 +348,7 @@ class ItemTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test getPrice() method should returns float
+     * Test getPrice() method returns float
      */
     public function testGetPriceReturnsFloat()
     {
@@ -359,7 +358,7 @@ class ItemTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test getPrice() method should returns null
+     * Test getPrice() method returns null
      */
     public function testGetPriceReturnsNull()
     {
@@ -367,5 +366,4 @@ class ItemTest extends \PHPUnit\Framework\TestCase
         $this->model->setData(OrderItemInterface::PRICE, $nullablePrice);
         $this->assertEquals($nullablePrice, $this->model->getPrice());
     }
-
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
@@ -9,11 +9,10 @@ namespace Magento\Sales\Test\Unit\Model\Order;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Sales\Model\ResourceModel\OrderFactory;
 use \Magento\Sales\Model\Order;
+use Magento\Sales\Api\Data\OrderItemInterface;
 
 /**
- * Class ItemTest
- *
- * @package Magento\Sales\Model\Order
+ * Unit test for order item class.
  */
 class ItemTest extends \PHPUnit\Framework\TestCase
 {
@@ -72,7 +71,7 @@ class ItemTest extends \PHPUnit\Framework\TestCase
     public function testGetPatentItem()
     {
         $item = $this->objectManager->getObject(\Magento\Sales\Model\Order\Item::class, []);
-        $this->model->setData(\Magento\Sales\Api\Data\OrderItemInterface::PARENT_ITEM, $item);
+        $this->model->setData(OrderItemInterface::PARENT_ITEM, $item);
         $this->assertEquals($item, $this->model->getParentItem());
     }
 
@@ -184,7 +183,7 @@ class ItemTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($price, $this->model->getOriginalPrice());
 
         $originalPrice = 5.55;
-        $this->model->setData(\Magento\Sales\Api\Data\OrderItemInterface::ORIGINAL_PRICE, $originalPrice);
+        $this->model->setData(OrderItemInterface::ORIGINAL_PRICE, $originalPrice);
         $this->assertEquals($originalPrice, $this->model->getOriginalPrice());
     }
 
@@ -350,20 +349,23 @@ class ItemTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test getPrice() method
+     * Test getPrice() method should returns float
      */
-    public function testGetPrice()
+    public function testGetPriceReturnsFloat()
     {
         $price = 9.99;
         $this->model->setPrice($price);
         $this->assertEquals($price, $this->model->getPrice());
+    }
 
-        $newPrice = 5.53;
-        $this->model->setData(\Magento\Sales\Api\Data\OrderItemInterface::PRICE, $newPrice);
-        $this->assertEquals($newPrice, $this->model->getPrice());
-
+    /**
+     * Test getPrice() method should returns null
+     */
+    public function testGetPriceReturnsNull()
+    {
         $nullablePrice = null;
-        $this->model->setPrice($nullablePrice);
+        $this->model->setData(OrderItemInterface::PRICE, $nullablePrice);
         $this->assertEquals($nullablePrice, $this->model->getPrice());
     }
+
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR add fix for returned type for  getPrice() method. Also added unit tests coverage for method getPrice.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25968: `getPrice()` returns a string when setting custom price in admin order

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
We have not easy steps to manual test these changes. 
I can recommend use [sandboxes](https://www.atwix.com/magento/sandboxes/) to get test it more easily 
