### PR TITLE
Fix the wrong behavior of validation scroll on the iPhone X

### DIFF
--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -1970,7 +1970,7 @@ define([
             }
 
             if (firstActive.length) {
-                $('body').stop().animate({
+                $('html, body').stop().animate({
                     scrollTop: firstActive.offset().top - windowHeight / 2
                 });
                 firstActive.focus();


### PR DESCRIPTION
### Description (*)
Changes from PR: #23035 added regression for validation scroll.
On the iPhone X, if try to run validation programmatically (without tap to screen), Magento doesn't scroll to the failed field.
This pull request fixes this issue.

### Preconditions
1. Magento 2.3.3
2. iPhone X (iOS 13.3)

### Manual testing scenarios
1. Add following script to the Store view in the Admin -> Content -> Design -> Configuration -> HTML Head -> Scripts and Style Sheets
```
<script>
setTimeout(function () {
    jQuery('.input-text.qty:last').val('');
    jQuery('.action.update').click();
}, 5000);
</script>
```
2. Add minimum 3 product to the cart
3. Go to the Cart page and wait 5 second

### Expected result
1. Should be scrolled to the field with an error

### Actual result
1. Don't scroll to the field with an error

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
