### PR TITLE
Remove Filename Normalization in Delete Controller

### DIFF
--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFiles.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFiles.php
@@ -79,7 +79,7 @@ class DeleteFiles extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images imple
                 /** @var \Magento\Framework\Filesystem $filesystem */
                 $filesystem = $this->_objectManager->get(\Magento\Framework\Filesystem::class);
                 $dir = $filesystem->getDirectoryRead(DirectoryList::MEDIA);
-                $filePath = $path . '/' . \Magento\Framework\File\Uploader::getCorrectFileName($file);
+                $filePath = $path . '/' . $file;
                 if ($dir->isFile($dir->getRelativePath($filePath)) && !preg_match('#.htaccess#', $file)) {
                     $this->getStorage()->deleteFile($filePath);
                 }

--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFiles.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFiles.php
@@ -5,8 +5,8 @@
  */
 namespace Magento\Cms\Controller\Adminhtml\Wysiwyg\Images;
 
-use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\Filesystem\DirectoryList;
 
 /**
  * Delete image files.
@@ -62,6 +62,7 @@ class DeleteFiles extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images imple
     {
         try {
             if (!$this->getRequest()->isPost()) {
+                //phpcs:ignore Magento2.Exceptions.DirectThrow
                 throw new \Exception('Wrong request.');
             }
             $files = $this->getRequest()->getParam('files');
@@ -84,8 +85,9 @@ class DeleteFiles extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images imple
                     $this->getStorage()->deleteFile($filePath);
                 }
             }
-            
+
             return $this->resultRawFactory->create();
+            // phpcs:ignore Magento2.Exceptions.ThrowCatch
         } catch (\Exception $e) {
             $result = ['error' => true, 'message' => $e->getMessage()];
             /** @var \Magento\Framework\Controller\Result\Json $resultJson */

--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFiles.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFiles.php
@@ -60,11 +60,15 @@ class DeleteFiles extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images imple
      */
     public function execute()
     {
+        $resultJson = $this->resultJsonFactory->create();
+
+        if (!$this->getRequest()->isPost()) {
+            $result = ['error' => true, 'message' => __('Wrong request.')];
+            /** @var \Magento\Framework\Controller\Result\Json $resultJson */
+            return $resultJson->setData($result);
+        }
+
         try {
-            if (!$this->getRequest()->isPost()) {
-                //phpcs:ignore Magento2.Exceptions.DirectThrow
-                throw new \Exception('Wrong request.');
-            }
             $files = $this->getRequest()->getParam('files');
 
             /** @var $helper \Magento\Cms\Helper\Wysiwyg\Images */
@@ -90,8 +94,6 @@ class DeleteFiles extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images imple
             // phpcs:ignore Magento2.Exceptions.ThrowCatch
         } catch (\Exception $e) {
             $result = ['error' => true, 'message' => $e->getMessage()];
-            /** @var \Magento\Framework\Controller\Result\Json $resultJson */
-            $resultJson = $this->resultJsonFactory->create();
 
             return $resultJson->setData($result);
         }

--- a/dev/tests/integration/testsuite/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFilesTest.php
@@ -105,6 +105,10 @@ class DeleteFilesTest extends \PHPUnit\Framework\TestCase
     public function executeDataProvider(): array
     {
         return [
+            ['name with spaces.jpg'],
+            ['name with, comma.jpg'],
+            ['name with* asterisk.jpg'],
+            ['name with[ bracket.jpg'],
             ['magento_small_image.jpg'],
             ['_.jpg'],
             [' - .jpg'],

--- a/dev/tests/integration/testsuite/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/DeleteFilesTest.php
@@ -75,20 +75,41 @@ class DeleteFilesTest extends \PHPUnit\Framework\TestCase
      * Execute method with correct directory path and file name to check that files under WYSIWYG media directory
      * can be removed.
      *
+     * @param string $filename
      * @return void
+     * @dataProvider executeDataProvider
      */
-    public function testExecute()
+    public function testExecute(string $filename)
     {
+        $filePath =  $this->fullDirectoryPath . DIRECTORY_SEPARATOR . $filename;
+        $fixtureDir = realpath(__DIR__ . '/../../../../../Catalog/_files');
+        copy($fixtureDir . '/' . $this->fileName, $filePath);
+
         $this->model->getRequest()->setMethod('POST')
-            ->setPostValue('files', [$this->imagesHelper->idEncode($this->fileName)]);
+            ->setPostValue('files', [$this->imagesHelper->idEncode($filename)]);
         $this->model->getStorage()->getSession()->setCurrentPath($this->fullDirectoryPath);
         $this->model->execute();
 
         $this->assertFalse(
             $this->mediaDirectory->isExist(
-                $this->mediaDirectory->getRelativePath($this->fullDirectoryPath . '/' . $this->fileName)
+                $this->mediaDirectory->getRelativePath($this->fullDirectoryPath . '/' . $filename)
             )
         );
+    }
+
+    /**
+     * DataProvider for testExecute
+     *
+     * @return array
+     */
+    public function executeDataProvider(): array
+    {
+        return [
+            ['magento_small_image.jpg'],
+            ['_.jpg'],
+            [' - .jpg'],
+            ['-.jpg'],
+        ];
     }
 
     /**


### PR DESCRIPTION
### Description (*)

Filenames are normalized when saving to the server via the uploader.

https://github.com/magento/magento2/blob/241271e8417c4264d44682169aa2032e955d6942/lib/internal/Magento/Framework/File/Uploader.php#L391-L407

This normalization was added to the admin delete controller in 2.2.0

https://github.com/magento/magento2/commit/09d662e2a163049d7d09c8e23e60a547a4b0400a#diff-7c65d1bd4c41efed1d26ddf72f15aa91R62

This change prevents admin users from deleting CMS images not conforming to the
uploader normalization. For instance an image on the server named ` - .jpg`
would have it's name normalized to ` _ .jpg` in the delete controller which
causes the deletion to fail.

### Fixed Issues (if relevant)
1. magento/adobe-stock-integration#889 : The image named with underscore symbol " _ " can not be deleted from Gallery 

### Manual testing scenarios (*)
1. Upload file named ` - .jpg` or `_.jpg` to `{mage-root}/pub/media/` (Must be done manually, as the uploader will alter the name if saved through the admin panel.)
1. Login to admin panel
1. Navigate to edit CMS Page or Block content
1. Click insert image icon to open the media gallery
1. Locate and select file created in step one
1. Click `Delete Selected` button

Expect the file to be successfully deleted after this PR is applied. Prior to this PR the file would remain on the server and visible in the media gallery.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
