### PR TITLE
Fixed #26302 Product grid has quantity in decimals

### DIFF
--- a/app/code/Magento/CatalogInventory/etc/db_schema.xml
+++ b/app/code/Magento/CatalogInventory/etc/db_schema.xml
@@ -27,8 +27,8 @@
                 default="0" comment="Product ID"/>
         <column xsi:type="smallint" name="stock_id" padding="5" unsigned="true" nullable="false" identity="false"
                 default="0" comment="Stock ID"/>
-        <column xsi:type="decimal" name="qty" scale="4" precision="12" unsigned="false" nullable="true" comment="Qty"/>
-        <column xsi:type="decimal" name="min_qty" scale="4" precision="12" unsigned="false" nullable="false"
+        <column xsi:type="float" name="qty" unsigned="false" nullable="true" comment="Qty"/>
+        <column xsi:type="float" name="min_qty" unsigned="false" nullable="false"
                 default="0" comment="Min Qty"/>
         <column xsi:type="smallint" name="use_config_min_qty" padding="5" unsigned="true" nullable="false"
                 identity="false" default="1" comment="Use Config Min Qty"/>


### PR DESCRIPTION
Fixed issue #26302

### Preconditions (*)

1. Magento 2.3.3, 2.4-develop

### Steps to reproduce (*)

1. Install
2. Add product
3. Go to products grid

### Expected result (*)

Don't know about you, but we don't sell goods in fractions.

Show product quantity without decimals.

### Actual result (*)

Product quantity with decimals.

![image](https://user-images.githubusercontent.com/1741593/71955802-9a0e7080-31e9-11ea-8362-2f70c7b0789f.png)
