### PR TITLE
Issue 26382 strict comparison to prevent adminhtml area being selected

### DIFF
--- a/lib/internal/Magento/Framework/App/AreaList.php
+++ b/lib/internal/Magento/Framework/App/AreaList.php
@@ -72,7 +72,7 @@ class AreaList
                 $resolver = $this->_resolverFactory->create($areaInfo['frontNameResolver']);
                 $areaInfo['frontName'] = $resolver->getFrontName(true);
             }
-            if ($areaInfo['frontName'] == $frontName) {
+            if ($areaInfo['frontName'] === $frontName) {
                 return $areaCode;
             }
         }


### PR DESCRIPTION
### Description (*)
Fix issue #26382 

### Fixed Issues (if relevant)
1. magento/magento2#< 26382 >: Security issue: exposed admin url by going to {{base_url}}/0

### Manual testing scenarios (*)
1. On any version of Magento, configure the following
2. admin/url/use_custom_path = 1
3. admin/url/custom_path to any value (valid url)
4. Navigate to site url /0
5. Admin url should not be exposed

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
