### PR TITLE
Issue #26113 GraphQL wrong placeholder for a product image

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/Image/Placeholder.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/Image/Placeholder.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Image;
 
 use Magento\Catalog\Model\View\Asset\PlaceholderFactory;
+use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Image\Placeholder\Theme;
 use Magento\Framework\View\Asset\Repository as AssetRepository;
 
 /**
@@ -26,15 +27,23 @@ class Placeholder
     private $assetRepository;
 
     /**
+     * @var Theme
+     */
+    private $theme;
+
+    /**
      * @param PlaceholderFactory $placeholderFactory
      * @param AssetRepository $assetRepository
+     * @param Theme $theme
      */
     public function __construct(
         PlaceholderFactory $placeholderFactory,
-        AssetRepository $assetRepository
+        AssetRepository $assetRepository,
+        Theme $theme
     ) {
         $this->placeholderFactory = $placeholderFactory;
         $this->assetRepository = $assetRepository;
+        $this->theme = $theme;
     }
 
     /**
@@ -52,8 +61,9 @@ class Placeholder
             return $imageAsset->getUrl();
         }
 
-        return $this->assetRepository->getUrl(
-            "Magento_Catalog::images/product/placeholder/{$imageType}.jpg"
+        return $this->assetRepository->getUrlWithParams(
+            "Magento_Catalog::images/product/placeholder/{$imageType}.jpg",
+            $this->theme->getThemeData()
         );
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductImageTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductImageTest.php
@@ -36,7 +36,7 @@ class ProductImageTest extends GraphQlAbstract
             label
         }
     }
-  }    
+  }
 }
 QUERY;
         $response = $this->graphQlQuery($query);
@@ -65,18 +65,20 @@ QUERY;
             label
         }
     }
-  }    
+  }
 }
 QUERY;
         $response = $this->graphQlQuery($query);
+
         self::assertEquals('Simple Product', $response['products']['items'][0]['image']['label']);
-        self::assertStringEndsWith(
-            'images/product/placeholder/image.jpg',
+        self::assertStringMatchesFormat(
+            '%s/frontend/%s/images/product/placeholder/image.jpg',
             $response['products']['items'][0]['image']['url']
         );
+
         self::assertEquals('Simple Product', $response['products']['items'][0]['small_image']['label']);
-        self::assertStringEndsWith(
-            'images/product/placeholder/small_image.jpg',
+        self::assertStringMatchesFormat(
+            '%s/frontend/%s/images/product/placeholder/small_image.jpg',
             $response['products']['items'][0]['small_image']['url']
         );
     }
@@ -96,7 +98,7 @@ QUERY;
             label
         }
     }
-  }    
+  }
 }
 QUERY;
         $response = $this->graphQlQuery($query);
@@ -121,7 +123,7 @@ QUERY;
             label
         }
     }
-  }    
+  }
 }
 QUERY;
         $response = $this->graphQlQuery($query);


### PR DESCRIPTION
### Description (*)
As mentioned in the issue, the placeholder link returned by graphql endpoint is broken.
There is a possible solution.

### Fixed Issues
1. magento/magento2#26113: GraphQL Cart endpoint returns incorrect or different product images

### Manual testing scenarios (*)

1) A product without images created.
2) Create a guest cart via GraphQL
3) Add a product from p.1) to your cart via GraphQL
4) Query the cart via GraphQL

```
query {
  cart(
    cart_id: "{cart_id}"
  ) {
    items {
      product {
        name
        image {
          url
        }
      }
    }
  }
}
```
Expected result - returned url should be valid (url for a product placeholder image).

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
