### PR TITLE
Issue #26332 BeforeOrderPaymentSaveObserver override payment instructions

### DIFF
--- a/app/code/Magento/OfflinePayments/Observer/BeforeOrderPaymentSaveObserver.php
+++ b/app/code/Magento/OfflinePayments/Observer/BeforeOrderPaymentSaveObserver.php
@@ -30,7 +30,8 @@ class BeforeOrderPaymentSaveObserver implements ObserverInterface
             Banktransfer::PAYMENT_METHOD_BANKTRANSFER_CODE,
             Cashondelivery::PAYMENT_METHOD_CASHONDELIVERY_CODE
         ];
-        if (in_array($payment->getMethod(), $instructionMethods)) {
+        if (in_array($payment->getMethod(), $instructionMethods)
+            && empty($payment->getAdditionalInformation('instructions'))) {
             $payment->setAdditionalInformation(
                 'instructions',
                 $payment->getMethodInstance()->getInstructions()

--- a/app/code/Magento/OfflinePayments/Test/Unit/Observer/BeforeOrderPaymentSaveObserverTest.php
+++ b/app/code/Magento/OfflinePayments/Test/Unit/Observer/BeforeOrderPaymentSaveObserverTest.php
@@ -172,4 +172,24 @@ class BeforeOrderPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
 
         $this->_model->execute($this->observer);
     }
+
+    /**
+     * @param string $methodCode
+     * @dataProvider dataProviderBeforeOrderPaymentSaveWithInstructions
+     */
+    public function testBeforeOrderPaymentSaveWithInstructionsAlreadySet($methodCode)
+    {
+        $this->payment
+            ->method('getMethod')
+            ->willReturn($methodCode);
+
+        $this->payment->expects(self::once())
+            ->method('getAdditionalInformation')
+            ->willReturn('Test');
+
+        $this->payment->expects(self::never())
+            ->method('setAdditionalInformation');
+
+        $this->_model->execute($this->observer);
+    }
 }


### PR DESCRIPTION
### Description (*)
Fix for the problem with BeforeOrderPaymentSaveObserver, which overrides payment instructions.

### Fixed Issues (if relevant)
1. magento/magento2#26332: BeforeOrderPaymentSaveObserver override payment insructions with wrong store view config

### Manual testing scenarios (*)
Testing scenario is described in the ticket magento/magento2#26332 .

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
