### PR TITLE
Improvement: Add DB index on attribute_id and sort_order to eav_attribute_option 

### DIFF
--- a/app/code/Magento/Eav/etc/db_schema.xml
+++ b/app/code/Magento/Eav/etc/db_schema.xml
@@ -440,6 +440,10 @@
         <index referenceId="EAV_ATTRIBUTE_OPTION_ATTRIBUTE_ID" indexType="btree">
             <column name="attribute_id"/>
         </index>
+        <index referenceId="EAV_ATTRIBUTE_OPTION_ATTRIBUTE_ID_SORT_ORDER" indexType="btree">
+            <column name="attribute_id"/>
+            <column name="sort_order"/>
+        </index>
     </table>
     <table name="eav_attribute_option_value" resource="default" engine="innodb" comment="Eav Attribute Option Value">
         <column xsi:type="int" name="value_id" padding="10" unsigned="true" nullable="false" identity="true"

--- a/app/code/Magento/Eav/etc/db_schema_whitelist.json
+++ b/app/code/Magento/Eav/etc/db_schema_whitelist.json
@@ -266,7 +266,8 @@
             "sort_order": true
         },
         "index": {
-            "EAV_ATTRIBUTE_OPTION_ATTRIBUTE_ID": true
+            "EAV_ATTRIBUTE_OPTION_ATTRIBUTE_ID": true,
+            "EAV_ATTRIBUTE_OPTION_ATTRIBUTE_ID_SORT_ORDER": true
         },
         "constraint": {
             "PRIMARY": true,


### PR DESCRIPTION
### Description (*)
This adds a composite index on (`attribute_id`, `sort_order`) to the eav_attribute_option table, which speeds up many queries done by Magento internally.
Currently there are no indexes on `sort_order` at all, which is quite a problem for a row which is primarily used for sorting. This makes any queries that `ORDER BY` it quite slow, e.g. any Option Collections which use `\Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\Collection::setPositionOrder` which is used internally in many places. 

Using `sort_order` generally only makes sense along with the `attribute_id`, hence it being a composite index.

### Manual testing scenarios (*)
1. Install magento using `setup:install` and note the `eav_attribute_option` table has no indexes at all on `sort_order`
2. Reinstall magento after applying the changes and note that `sort_order` now has a composite index (`attribute_id`, `sort_order`)

### Questions or comments
EAV Option queries are still relatively slow due to `\Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\Collection::setStoreFilter` often being used to get default values for options. `setStoreFilter(..., true)` causes MySQL to use a temp table to sort by `value` because value is determined by an `IF()` function. So, there's room for more optimization here if this could be avoided.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)

### Resolved issues:
1. [x] resolves magento/magento2#29620: Improvement: Add DB index on attribute_id and sort_order to eav_attribute_option 