### PR TITLE
Add Event Prefix And Object To The Catalog Product Option Value Collection

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Option/Value/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Option/Value/Collection.php
@@ -15,6 +15,20 @@ namespace Magento\Catalog\Model\ResourceModel\Product\Option\Value;
 class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
 {
     /**
+     * Name prefix of events that are dispatched by model
+     *
+     * @var string
+     */
+    protected $_eventPrefix = 'catalog_product_option_value_collection';
+
+    /**
+     * Name of event parameter
+     *
+     * @var string
+     */
+    protected $_eventObject = 'product_option_value_collection';
+
+    /**
      * Resource initialization
      *
      * @return void


### PR DESCRIPTION
### Description (*)
This pull request adds an event prefix and event object to the catalog product option value collection, so that it can be customized in a better way.

### Fixed Issues (if relevant)
n/a

### Manual testing scenarios (*)
1. Try to customize the collection loading of \Magento\Catalog\Model\ResourceModel\Product\Option\Value\Collection.
2. Currently, one can only use the generic events like `core_collection_abstract_load_before`.
3. With this pull request, one can also use specific events like `catalog_product_option_value_collection_load_before`.

### Questions or comments
Would it make sense to check more relevant Magento core models / collections and add event prefixes / objects there as well?

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29621: Add Event Prefix And Object To The Catalog Product Option Value Collection