### PR TITLE
feat(framework): pull HeaderManager beforeSendResponse back to HttpInterface

### DIFF
--- a/lib/internal/Magento/Framework/App/Response/HeaderManager.php
+++ b/lib/internal/Magento/Framework/App/Response/HeaderManager.php
@@ -32,11 +32,11 @@ class HeaderManager
     }
 
     /**
-     * @param \Magento\Framework\App\Response\Http $subject
+     * @param \Magento\Framework\App\Response\HttpInterface $subject
      * @return void
      * @codeCoverageIgnore
      */
-    public function beforeSendResponse(\Magento\Framework\App\Response\Http $subject)
+    public function beforeSendResponse(\Magento\Framework\App\Response\HttpInterface $subject)
     {
         foreach ($this->headerProviders as $provider) {
             if ($provider->canApply()) {

--- a/lib/internal/Magento/Framework/App/Response/HeaderManager.php
+++ b/lib/internal/Magento/Framework/App/Response/HeaderManager.php
@@ -32,11 +32,12 @@ class HeaderManager
     }
 
     /**
+     * Applies provided headers before sending responce
+     *
      * @param \Magento\Framework\App\Response\HttpInterface $subject
      * @return void
-     * @codeCoverageIgnore
      */
-    public function beforeSendResponse(\Magento\Framework\App\Response\HttpInterface $subject)
+    public function beforeSendResponse(\Magento\Framework\App\Response\HttpInterface $subject): void
     {
         foreach ($this->headerProviders as $provider) {
             if ($provider->canApply()) {


### PR DESCRIPTION
### Description (*)
The [HeaderManager](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/App/Response/HeaderManager.php) depends on a concrete type for the `beforeSendResponse` method, this causes the `Magento\Framework\Webapi\Rest\Response` not to be interceptable with the [HeaderManager](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/App/Response/HeaderManager.php). Both the `Magento\Framework\Webapi\Rest\Response` and the `Magento\Framework\App\Response\Http` implement the `\Magento\Framework\App\Response\HttpInterface` and the dependent methods of the `HeaderManager` only depend on `setHeader`  (defined in the interface) so there should be no need for the concrete typing.

This allows further plugin configuration like:

```xml
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
<type name="Magento\Framework\Webapi\Rest\Response">
        <plugin name="genericHeaderPlugin" type="Magento\Framework\App\Response\HeaderManager"/>
    </type>
</xml>
```

### Questions or comments
I don't know why the interface is strict, it may be by intention. If it isn't, this shouldn't be a breaking change. No framework code depends on the concretion, but it is possible that a 3rd-party extension is improperly depending on the concrete class.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29622: feat(framework): pull HeaderManager beforeSendResponse back to HttpInterface