### PR TITLE
Filter out Dynamic SKU fragments for multi-select Options

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
@@ -315,7 +315,7 @@ class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
                     }
                 }
             }
-            $result = implode($skuDelimiter, $skus);
+            $result = implode($skuDelimiter, array_filter($skus));
         } elseif ($this->_isSingleSelection()) {
             $result = $option->getValueById($optionValue);
             if ($result) {


### PR DESCRIPTION
### Description (*)
When using Product Options, Magento builds a Dynamic SKU based on the options selected. When you omit the SKU fragment for single-value types, Magento does not append a value to the Dynamic SKU. However, multi-select values are built in an array, which is then imploded. 

Magento does not currently evaluate whether any of those values are empty, which can result in extraneous delimiters appearing at the end of the SKU. By using `array_filter` to toss out any blank SKU fragments, we can enact consistent behavior through all types.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#26297 Inconsistent Dynamic SKU behavior with multi-select Customizable options

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create any simple product
2. Add a Checkbox or Multi-Select Customizable Option
3. Configure at least two options (of any Title and Price), leaving the SKU fragments empty.
4. On the frontend, add this product to your cart, selecting both custom options.
5. In the quote_item table (or within the order after checkout), observe the SKU.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
