### PR TITLE
translate.js Not shows empty values 

### DIFF
--- a/dev/tests/js/jasmine/tests/lib/mage/translate.test.js
+++ b/dev/tests/js/jasmine/tests/lib/mage/translate.test.js
@@ -33,7 +33,8 @@ define([
 
             translation = {
                 'Hello World!': 'Hallo Welt!',
-                'Some text with symbols!-+"%#*': 'Ein Text mit Symbolen!-+"%#*'
+                'Some text with symbols!-+"%#*': 'Ein Text mit Symbolen!-+"%#*',
+                'Text with empty value': ''
             };
 
             $.mage.translate.add(translation);

--- a/lib/web/mage/translate.js
+++ b/lib/web/mage/translate.js
@@ -38,7 +38,7 @@ define([
                      * @return {String}
                      */
                     translate: function (text) {
-                        return _data.hasOwnProperty(text) ? _data[text] : text;
+                        return typeof _data[text] !== 'undefined' ? _data[text] : text;
                     }
                 };
             }())

--- a/lib/web/mage/translate.js
+++ b/lib/web/mage/translate.js
@@ -38,7 +38,7 @@ define([
                      * @return {String}
                      */
                     translate: function (text) {
-                        return _data[text] ? _data[text] : text;
+                        return _data.hasOwnProperty(text) ? _data[text] : text;
                     }
                 };
             }())


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
We wanted to hide translation for a specific key by removing a value for it;
e.g. `"Some text":""` //no value needed
We encountered an issue that `"Some text"` is still shown on fronted
We checked that value will be shown only if it's not an empty string

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create empty string translation in any `csv` 
2. e.g. en_US.csv
3. Add this translation `"Empty key",""`
4. Try to access this key (translate) with JS
5. See that no string shown instead of original key

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
