### PR TITLE
Make the wishlist item collection use the same store as the wishlist object

### DIFF
--- a/app/code/Magento/Wishlist/Model/Wishlist.php
+++ b/app/code/Magento/Wishlist/Model/Wishlist.php
@@ -377,11 +377,15 @@ class Wishlist extends AbstractModel implements IdentityInterface
         if ($this->_itemCollection === null) {
             $this->_itemCollection = $this->_wishlistCollectionFactory->create()->addWishlistFilter(
                 $this
-            )->setStore(
-                $this->getStore()
-            )->addStoreFilter(
-                $this->getSharedStoreIds()
             )->setVisibilityFilter();
+
+            if ($this->getStore()) {
+                $this->_itemCollection
+                    ->addStoreFilter($this->getStore()->getId())
+                    ->setStore($this->getStore());
+            } else {
+                 $this->_itemCollection->addStoreFilter($this->getSharedStoreIds());
+            }
         }
 
         return $this->_itemCollection;

--- a/app/code/Magento/Wishlist/Model/Wishlist.php
+++ b/app/code/Magento/Wishlist/Model/Wishlist.php
@@ -377,6 +377,8 @@ class Wishlist extends AbstractModel implements IdentityInterface
         if ($this->_itemCollection === null) {
             $this->_itemCollection = $this->_wishlistCollectionFactory->create()->addWishlistFilter(
                 $this
+            )->setStore(
+                $this->getStore()
             )->addStoreFilter(
                 $this->getSharedStoreIds()
             )->setVisibilityFilter();


### PR DESCRIPTION
### Summary
The method Magento\Wishlist\Model\ResourceModel\Item\Collection::_renderFiltersBefore attempts to create a join with an index table which doesn't exist if this is done in the adminhtml area.

### Description (*)
The _renderFiltersBefore method attempts to create a join to the catalog_category_product_index_storeN table to filter product visibility. This works fine, except if this is done in the Adminhtml area. Specifically when manually creating an order.

In this pull request the wishlist item collection is changed to first check if a store object has been set on it, and only if this has not been done to retrieve the current store from the StoreManager.

### Manual testing scenarios (*)
#### Before this pull request
1. In the adminhtml area go to Sales -> Orders
2. Start the order creation process by clicking on 'Create New Order'
3. Select or create a customer
4. Select a store (if necessary)
5. Add any product to the quote
6. Modify the amount and click on 'Update Items and Quantities'

At this point an AJAX call to sales/order_create/loadBlock will be performed.
- In developer mode the response will be an exception trace
- In default and production modes the exception will not be shown but will still be visible in var/log/system.log

The exception states that base table `catalog_category_product_index_store0` does not exist, which is true; that table does not exist and is never created.

#### After the changes in this pull request
Perform the same steps as before, there are no more errors as the wishlist item collection now joins the correct index table.

### Justification for this pull request
The product availability for which the join is performed should be done in the same store scope as in which the order is being created. The wishlist item returned by \Magento\Sales\Model\AdminOrder\Create::getCustomerWishlist however does contain a reference to the correct store object.

By passing this store object to the collection the join will be performed on the correct index table.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
