### PR TITLE
Update getCustomer method in order class

### DIFF
--- a/app/code/Magento/Sales/Api/Data/OrderInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderInterface.php
@@ -5,8 +5,6 @@
  */
 namespace Magento\Sales\Api\Data;
 
-use Magento\Customer\Model\Customer;
-
 /**
  * Order interface.
  *
@@ -912,12 +910,6 @@ interface OrderInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      */
     public function setCreatedAt($createdAt);
 
-    /**
-     * Gets the customer from Order
-     * @return Customer
-     */
-    public function getCustomer();
-    
     /**
      * Gets the customer date-of-birth (DOB) for the order.
      *

--- a/app/code/Magento/Sales/Api/Data/OrderInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderInterface.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Sales\Api\Data;
 
+use Magento\Customer\Model\Customer;
+
 /**
  * Order interface.
  *
@@ -910,6 +912,12 @@ interface OrderInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      */
     public function setCreatedAt($createdAt);
 
+    /**
+     * Gets the customer from Order
+     * @return Customer
+     */
+    public function getCustomer();
+    
     /**
      * Gets the customer date-of-birth (DOB) for the order.
      *

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -6,6 +6,7 @@
 namespace Magento\Sales\Model;
 
 use Magento\Config\Model\Config\Source\Nooptreq;
+use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Directory\Model\Currency;
 use Magento\Framework\Api\AttributeValueFactory;
 use Magento\Framework\Api\SearchCriteriaBuilder;
@@ -51,7 +52,6 @@ use Magento\Store\Model\ScopeInterface;
  * @method bool hasCustomerNoteNotify()
  * @method bool hasForcedCanCreditmemo()
  * @method bool getIsInProcess()
- * @method \Magento\Customer\Model\Customer getCustomer()
  * @method \Magento\Sales\Model\Order setSendEmail(bool $value)
  * @SuppressWarnings(PHPMD.ExcessivePublicCount)
  * @SuppressWarnings(PHPMD.TooManyFields)
@@ -308,6 +308,11 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     private $scopeConfig;
 
     /**
+     * @var CustomerRepositoryInterface
+     */
+    private $_customerRepositoryInterface;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Api\ExtensionAttributesFactory $extensionFactory
@@ -340,6 +345,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * @param OrderItemRepositoryInterface $itemRepository
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
      * @param ScopeConfigInterface $scopeConfig
+     * @param CustomerRepositoryInterface $customerRepositoryInterface
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -366,6 +372,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         \Magento\Sales\Model\ResourceModel\Order\Shipment\Track\CollectionFactory $trackCollectionFactory,
         \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $salesOrderCollectionFactory,
         PriceCurrencyInterface $priceCurrency,
+        CustomerRepositoryInterface $customerRepositoryInterface,
         \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productListFactory,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
@@ -403,6 +410,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         $this->searchCriteriaBuilder = $searchCriteriaBuilder ?: ObjectManager::getInstance()
             ->get(SearchCriteriaBuilder::class);
         $this->scopeConfig = $scopeConfig ?: ObjectManager::getInstance()->get(ScopeConfigInterface::class);
+        $this->_customerRepositoryInterface = $customerRepositoryInterface;
 
         parent::__construct(
             $context,
@@ -560,6 +568,19 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
             return $this->_storeManager->getStore($storeId);
         }
         return $this->_storeManager->getStore();
+    }
+
+    /**
+     * Returns Customer
+     *
+     * @return \Magento\Customer\Api\Data\CustomerInterface
+     * @throws LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getCustomer()
+    {
+        $customerId = $this->getData(OrderInterface::CUSTOMER_ID);
+        return $this->_customerRepositoryInterface->getById($customerId);
     }
 
     /**

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -6,7 +6,6 @@
 namespace Magento\Sales\Model;
 
 use Magento\Config\Model\Config\Source\Nooptreq;
-use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Directory\Model\Currency;
 use Magento\Framework\Api\AttributeValueFactory;
 use Magento\Framework\Api\SearchCriteriaBuilder;
@@ -52,6 +51,7 @@ use Magento\Store\Model\ScopeInterface;
  * @method bool hasCustomerNoteNotify()
  * @method bool hasForcedCanCreditmemo()
  * @method bool getIsInProcess()
+ * @method \Magento\Customer\Model\Customer|null getCustomer()
  * @method \Magento\Sales\Model\Order setSendEmail(bool $value)
  * @SuppressWarnings(PHPMD.ExcessivePublicCount)
  * @SuppressWarnings(PHPMD.TooManyFields)
@@ -308,11 +308,6 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     private $scopeConfig;
 
     /**
-     * @var CustomerRepositoryInterface
-     */
-    private $_customerRepositoryInterface;
-
-    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Api\ExtensionAttributesFactory $extensionFactory
@@ -345,7 +340,6 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * @param OrderItemRepositoryInterface $itemRepository
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
      * @param ScopeConfigInterface $scopeConfig
-     * @param CustomerRepositoryInterface $customerRepositoryInterface
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -372,7 +366,6 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         \Magento\Sales\Model\ResourceModel\Order\Shipment\Track\CollectionFactory $trackCollectionFactory,
         \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $salesOrderCollectionFactory,
         PriceCurrencyInterface $priceCurrency,
-        CustomerRepositoryInterface $customerRepositoryInterface,
         \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productListFactory,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
@@ -410,7 +403,6 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         $this->searchCriteriaBuilder = $searchCriteriaBuilder ?: ObjectManager::getInstance()
             ->get(SearchCriteriaBuilder::class);
         $this->scopeConfig = $scopeConfig ?: ObjectManager::getInstance()->get(ScopeConfigInterface::class);
-        $this->_customerRepositoryInterface = $customerRepositoryInterface;
 
         parent::__construct(
             $context,
@@ -568,19 +560,6 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
             return $this->_storeManager->getStore($storeId);
         }
         return $this->_storeManager->getStore();
-    }
-
-    /**
-     * Returns Customer
-     *
-     * @return \Magento\Customer\Api\Data\CustomerInterface
-     * @throws LocalizedException
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     */
-    public function getCustomer()
-    {
-        $customerId = $this->getData(OrderInterface::CUSTOMER_ID);
-        return $this->_customerRepositoryInterface->getById($customerId);
     }
 
     /**

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1326,7 +1326,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      */
     public function getShippingMethod($asObject = false)
     {
-        $shippingMethod = $this->getData('shipping_method');
+        $shippingMethod = parent::getShippingMethod();
         if (!$asObject || !$shippingMethod) {
             return $shippingMethod;
         } else {

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1326,7 +1326,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      */
     public function getShippingMethod($asObject = false)
     {
-        $shippingMethod = parent::getShippingMethod();
+        $shippingMethod = $this->getData('shipping_method');
         if (!$asObject || !$shippingMethod) {
             return $shippingMethod;
         } else {


### PR DESCRIPTION
### Description (*)

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/25268 $order->getCustomer() returns NULL for registered customer

### Manual testing scenarios (*)
- Create an observer with `sales_order_save_after` event
- In execute method of the observer try to use getCustomer() method

**Expected Result**
A customer object should be returned

**Actual Result**
Null Returned


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)