### PR TITLE
Fix typo in sitemap product collection docblock

### DIFF
--- a/app/code/Magento/Sitemap/Model/ResourceModel/Catalog/Product.php
+++ b/app/code/Magento/Sitemap/Model/ResourceModel/Catalog/Product.php
@@ -291,7 +291,7 @@ class Product extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     }
 
     /**
-     * Get category collection array
+     * Get product collection array
      *
      * @param null|string|bool|int|Store $storeId
      *


### PR DESCRIPTION
## Description (*)
This method returns a product collection, not a category collection as the current docblock suggests. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
