### PR TITLE
#18012: added i18n wrapper to be used in underscore templates for translation

### DIFF
--- a/app/code/Magento/Translation/Test/Unit/Model/Js/DataProviderTest.php
+++ b/app/code/Magento/Translation/Test/Unit/Model/Js/DataProviderTest.php
@@ -105,24 +105,31 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
             'hello1' => 'hello1translated',
             'hello2' => 'hello2translated',
             'hello3' => 'hello3translated',
-            'hello4' => 'hello4translated'
+            'hello4' => 'hello4translated',
+            'ko i18' => 'ko i18 translated',
+            'underscore i18' => 'underscore i18 translated',
         ];
 
         $contentsMap = [
             'content1$.mage.__("hello1")content1',
             'content2$.mage.__("hello2")content2',
-            'content2$.mage.__("hello4")content4', // this value should be last after running data provider
-            'content2$.mage.__("hello3")content3',
+            'content2$.mage.__("hello4")content4 <!-- ko i18n: "ko i18" --><!-- /ko -->',
+            'content2$.mage.__("hello3")content3 <% _.i18n("underscore i18") %>',
         ];
 
         $translateMap = [
             [['hello1'], [], 'hello1translated'],
             [['hello2'], [], 'hello2translated'],
             [['hello3'], [], 'hello3translated'],
-            [['hello4'], [], 'hello4translated']
+            [['hello4'], [], 'hello4translated'],
+            [['ko i18'], [], 'ko i18 translated'],
+            [['underscore i18'], [], 'underscore i18 translated'],
         ];
 
-        $patterns = ['~\$\.mage\.__\(([\'"])(.+?)\1\)~'];
+        $patterns = [
+            '~\$\.mage\.__\(([\'"])(.+?)\1\)~',
+            '~(?:i18n\:|_\.i18n\()\s*(["\'])(.*?)(?<!\\\\)\1~',
+        ];
 
         $this->appStateMock->expects($this->once())
             ->method('getAreaCode')

--- a/app/code/Magento/Translation/Test/Unit/Model/Js/DataProviderTest.php
+++ b/app/code/Magento/Translation/Test/Unit/Model/Js/DataProviderTest.php
@@ -15,7 +15,7 @@ use Magento\Translation\Model\Js\Config;
 use Magento\Framework\Phrase\Renderer\Translate;
 
 /**
- * Class DataProviderTest
+ * Verify data provider translation
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */

--- a/app/code/Magento/Translation/etc/di.xml
+++ b/app/code/Magento/Translation/etc/di.xml
@@ -64,7 +64,7 @@
     <type name="Magento\Translation\Model\Js\Config">
         <arguments>
             <argument name="patterns" xsi:type="array">
-                <item name="i18n_translation" xsi:type="string"><![CDATA[~i18n\:\s*(["'])(.*?)(?<!\\)\1~]]></item>
+                <item name="i18n_translation" xsi:type="string"><![CDATA[~(?:i18n\:|_\.i18n\()\s*(["'])(.*?)(?<!\\)\1~]]></item>
                 <item name="translate_wrapping" xsi:type="string"><![CDATA[~translate\=("')([^\'].*?)\'\"~]]></item>
                 <item name="mage_translation_widget" xsi:type="string"><![CDATA[~(?s)(?:\$|jQuery)\.mage\.__\(\s*(['"])(?<translate>.+?)(?<!\\)\1\s*(*SKIP)\)\s*(?s)~]]></item>
                 <item name="mage_translation_static" xsi:type="string"><![CDATA[~(?s)\$t\(\s*(['"])(?<translate>.+?)(?<!\\)\1\s*(*SKIP)\)(?s)~]]></item>

--- a/lib/web/mage/translate.js
+++ b/lib/web/mage/translate.js
@@ -49,8 +49,14 @@ define([
 
     // Provide i18n wrapper to be used in underscore templates for translation
     _.extend(_, {
-        i18n: function (str) {
-            return $.mage.__(str);
+        /**
+         * Make a translation using $.mage.__
+         *
+         * @param {String} text
+         * @return {String}
+         */
+        i18n: function (text) {
+            return $.mage.__(text);
         }
     });
 

--- a/lib/web/mage/translate.js
+++ b/lib/web/mage/translate.js
@@ -6,8 +6,9 @@
 define([
     'jquery',
     'mage/mage',
-    'mageTranslationDictionary'
-], function ($, mage, dictionary) {
+    'mageTranslationDictionary',
+    'underscore'
+], function ($, mage, dictionary, _) {
     'use strict';
 
     $.extend(true, $, {
@@ -45,6 +46,13 @@ define([
         }
     });
     $.mage.__ = $.proxy($.mage.translate.translate, $.mage.translate);
+
+    // Provide i18n wrapper to be used in underscore templates for translation
+    _.extend(_, {
+        i18n: function (str) {
+            return $.mage.__(str);
+        }
+    });
 
     return $.mage.__;
 });


### PR DESCRIPTION
### Description
Introduced `i18n` method for underscore to provide an ability use translation in underscore templates.
`<%= _.i18n('Hello') %>`

### Fixed Issues
1. #18012

### Manual testing scenarios
See #18012 for the example.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
