### PR TITLE
Cannot create catagory's name with thai langauge  #13689

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Observer/CategoryUrlPathAutogeneratorObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/CategoryUrlPathAutogeneratorObserver.php
@@ -92,6 +92,11 @@ class CategoryUrlPathAutogeneratorObserver implements ObserverInterface
         $useDefaultAttribute = !empty($category->getData('use_default')['url_key']);
         if ($category->getUrlKey() !== false && !$useDefaultAttribute) {
             $resultUrlKey = $this->categoryUrlPathGenerator->getUrlKey($category);
+            if(empty($resultUrlKey)) {
+                //NOTE: If resultUrlKey not found due to entering category name in other language then use category name
+                $resultUrlKey = $category->getName();
+            }
+            
             $this->updateUrlKey($category, $resultUrlKey);
         } elseif ($useDefaultAttribute) {
             if (!$category->isObjectNew() && $category->getStoreId() === Store::DEFAULT_STORE_ID) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Cannot create catagory's name with thai langauge issue Fixed.
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<13689>: Cannot create catagory's name with thai langauge

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create New Category and save name with Thai language or other languages.
2. Check the newly created category in the frontend menu and thai link show clickable.
3. Check that category URL is created in the url_rewrite table or not with the actual scenario.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
