### PR TITLE
Fixed Issue 26389

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
@@ -130,14 +130,22 @@ class ParamsBuilder
         );
 
         if ($file) {
-            $size = explode(
-                'x',
-                (string) $this->scopeConfig->getValue(
+            $watermarkSize = (string) $this->scopeConfig->getValue(
                     "design/watermark/{$type}_size",
                     ScopeInterface::SCOPE_STORE,
                     $scopeId
-                )
-            );
+                );
+            $size = [];
+            if(!$watermarkSize){
+                $size = explode(
+                            'x',
+                            (string) $this->scopeConfig->getValue(
+                                "design/watermark/{$type}_size",
+                                ScopeInterface::SCOPE_STORE,
+                                $scopeId
+                            )
+                        );
+            }
             $opacity = $this->scopeConfig->getValue(
                 "design/watermark/{$type}_imageOpacity",
                 ScopeInterface::SCOPE_STORE,

--- a/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
@@ -136,7 +136,7 @@ class ParamsBuilder
                     $scopeId
                 );
             $size = [];
-            if(!$watermarkSize){
+            if($watermarkSize != ''){
                 $size = explode(
                             'x',
                             (string) $this->scopeConfig->getValue(


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Watermark is breaking product page when size is not set the issue fixed
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#26389: Watermark is breaking product page when size is not set

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1.     Navigate to theme configuration in Content -> Design -> Configuration -> <some theme> -> Product Image Watermarks
2.     Upload a new watermark. Specify opacity and DO NOT specify Image size

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
