### PR TITLE
magento/magento2#: GraphQl. DeletePaymentToken. Remove redundant validation logic. Test coverage.

### DIFF
--- a/app/code/Magento/VaultGraphQl/Model/Resolver/DeletePaymentToken.php
+++ b/app/code/Magento/VaultGraphQl/Model/Resolver/DeletePaymentToken.php
@@ -9,7 +9,6 @@ namespace Magento\VaultGraphQl\Model\Resolver;
 
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
-use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
@@ -57,10 +56,6 @@ class DeletePaymentToken implements ResolverInterface
         /** @var ContextInterface $context */
         if (false === $context->getExtensionAttributes()->getIsCustomer()) {
             throw new GraphQlAuthorizationException(__('The current customer isn\'t authorized.'));
-        }
-
-        if (!isset($args['public_hash'])) {
-            throw new GraphQlInputException(__('Specify the "public_hash" value.'));
         }
 
         $token = $this->paymentTokenManagement->getByPublicHash($args['public_hash'], $context->getUserId());

--- a/app/code/Magento/VaultGraphQl/Test/Unit/Model/Resolver/DeletePaymentTokenTest.php
+++ b/app/code/Magento/VaultGraphQl/Test/Unit/Model/Resolver/DeletePaymentTokenTest.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\VaultGraphQl\Test\Unit\Model\Resolver;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\GraphQl\Model\Query\ContextInterface;
+use Magento\GraphQl\Model\Query\ContextExtensionInterface;
+use Magento\Vault\Api\PaymentTokenManagementInterface;
+use Magento\Vault\Api\PaymentTokenRepositoryInterface;
+use Magento\Vault\Api\Data\PaymentTokenInterface;
+use Magento\VaultGraphQl\Model\Resolver\DeletePaymentToken;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for \Magento\VaultGraphQl\Model\Resolver\DeletePaymentToken
+ */
+class DeletePaymentTokenTest extends TestCase
+{
+    /**
+     * Object Manager Instance
+     *
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * Testable Object
+     *
+     * @var DeletePaymentToken
+     */
+    private $resolver;
+
+    /**
+     * @var ContextInterface|MockObject
+     */
+    private $contextMock;
+
+    /**
+     * @var ContextExtensionInterface|MockObject
+     */
+    private $contextExtensionMock;
+
+    /**
+     * @var Field|MockObject
+     */
+    private $fieldMock;
+
+    /**
+     * @var PaymentTokenManagementInterface|MockObject
+     */
+    private $paymentTokenManagementMock;
+
+    /**
+     * @var PaymentTokenRepositoryInterface|MockObject
+     */
+    private $paymentTokenRepositoryMock;
+
+    /**
+     * @var PaymentTokenInterface|MockObject
+     */
+    private $paymentTokenMock;
+
+    /**
+     * @var ResolveInfo|MockObject
+     */
+    private $resolveInfoMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp() : void
+    {
+        $this->objectManager = new ObjectManager($this);
+
+        $this->contextMock = $this->getMockBuilder(ContextInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(
+                [
+                    'getExtensionAttributes',
+                    'getUserId',
+                    'getUserType',
+                ]
+            )
+            ->getMock();
+
+        $this->contextExtensionMock = $this->getMockBuilder(ContextExtensionInterface::class)
+            ->setMethods(
+                [
+                    'getIsCustomer',
+                    'getStore',
+                    'setStore',
+                    'setIsCustomer',
+                ]
+            )
+            ->getMock();
+
+        $this->fieldMock = $this->getMockBuilder(Field::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->paymentTokenManagementMock = $this->getMockBuilder(PaymentTokenManagementInterface::class)
+            ->getMockForAbstractClass();
+
+        $this->paymentTokenRepositoryMock = $this->getMockBuilder(PaymentTokenRepositoryInterface::class)
+            ->getMockForAbstractClass();
+
+        $this->paymentTokenMock = $this->getMockBuilder(PaymentTokenInterface::class)
+            ->getMockForAbstractClass();
+
+        $this->resolveInfoMock = $this->getMockBuilder(ResolveInfo::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->resolver = $this->objectManager->getObject(
+            DeletePaymentToken::class,
+            [
+                'paymentTokenManagement' => $this->paymentTokenManagementMock,
+                'paymentTokenRepository' => $this->paymentTokenRepositoryMock,
+            ]
+        );
+    }
+
+    /**
+     * Test delete customer payment token
+     */
+    public function testDeleteCustomerPaymentToken()
+    {
+        $isCustomer = true;
+        $paymentTokenResult = true;
+
+        $this->contextMock
+            ->expects($this->once())
+            ->method('getExtensionAttributes')
+            ->willReturn($this->contextExtensionMock);
+
+        $this->contextExtensionMock
+            ->expects($this->once())
+            ->method('getIsCustomer')
+            ->willReturn($isCustomer);
+
+        $this->paymentTokenManagementMock
+            ->expects($this->once())
+            ->method('getByPublicHash')
+            ->willReturn($this->paymentTokenMock);
+
+        $this->paymentTokenRepositoryMock
+            ->expects($this->once())
+            ->method('delete')
+            ->with($this->paymentTokenMock)
+            ->willReturn($paymentTokenResult);
+
+        $this->assertEquals(
+            [
+                'result' => true
+            ],
+            $this->resolver->resolve(
+                $this->fieldMock,
+                $this->contextMock,
+                $this->resolveInfoMock
+            )
+        );
+    }
+
+    /**
+     * Test mutation when customer isn't authorized.
+     *
+     * @expectedException \Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException
+     * @expectedExceptionMessage The current customer isn't authorized.
+     */
+    public function testCustomerNotAuthorized()
+    {
+        $isCustomer = false;
+
+        $this->contextMock
+            ->expects($this->once())
+            ->method('getExtensionAttributes')
+            ->willReturn($this->contextExtensionMock);
+
+        $this->contextExtensionMock
+            ->expects($this->once())
+            ->method('getIsCustomer')
+            ->willReturn($isCustomer);
+
+        $this->resolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->resolveInfoMock
+        );
+    }
+
+    /**
+     * Test mutation when provided token ID does not exist
+     */
+    public function testCustomerPaymentTokenNotExists()
+    {
+        $isCustomer = true;
+        $token = false;
+
+        $this->contextMock
+            ->expects($this->once())
+            ->method('getExtensionAttributes')
+            ->willReturn($this->contextExtensionMock);
+
+        $this->contextExtensionMock
+            ->expects($this->once())
+            ->method('getIsCustomer')
+            ->willReturn($isCustomer);
+
+        $this->paymentTokenManagementMock
+            ->expects($this->once())
+            ->method('getByPublicHash')
+            ->willReturn($token);
+
+        $this->expectException(GraphQlNoSuchEntityException::class);
+
+        $this->resolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->resolveInfoMock
+        );
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Pull request:
- removes a redundant validation logic from `\Magento\VaultGraphQl\Model\Resolver\DeletePaymentToken` because `Webonix` will cover a removed validation logic.
- adds a unit test for mentioned class

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)

Thank you!