### PR TITLE
Fixes showing attributes that don't apply

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Attributes.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Attributes.php
@@ -115,7 +115,19 @@ class Attributes extends \Magento\Framework\View\Element\Template
         \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute,
         array $excludeAttr
     ) {
-        return ($attribute->getIsVisibleOnFront() && !in_array($attribute->getAttributeCode(), $excludeAttr) &&
-            (!empty($attribute->getApplyTo()) && in_array($this->getProduct()->getTypeId(), $attribute->getApplyTo())));
+        return ($this->isAppliesToProduct($attribute) && 
+                    $attribute->getIsVisibleOnFront() && !in_array($attribute->getAttributeCode(), $excludeAttr));
+    }
+
+    /**
+     * Determine if the attribute applies to the current product
+     *
+     * @param \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute
+     * @return bool
+     */
+    protected function isAppliesToProduct(
+        \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute
+    ) {
+        return (!empty($attribute->getApplyTo()) && in_array($this->getProduct()->getTypeId(), $attribute->getApplyTo()));
     }
 }

--- a/app/code/Magento/Catalog/Block/Product/View/Attributes.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Attributes.php
@@ -115,6 +115,7 @@ class Attributes extends \Magento\Framework\View\Element\Template
         \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute,
         array $excludeAttr
     ) {
-        return ($attribute->getIsVisibleOnFront() && !in_array($attribute->getAttributeCode(), $excludeAttr));
+        return ($attribute->getIsVisibleOnFront() && !in_array($attribute->getAttributeCode(), $excludeAttr) &&
+            (!empty($attribute->getApplyTo()) && in_array($this->getProduct()->getTypeId(), $attribute->getApplyTo())));
     }
 }


### PR DESCRIPTION
### Description (*)
This PR adds a fix for showing attributes that don't apply to the product by checking if the current product type exists in the apply_to array of th attribute

### Fixed Issues (if relevant)
1. magento/magento2 #26458:showing incorrect attributes on frontend

### Manual testing scenarios (*)
1. Create an attribute using code
2. Enter configurable in the 'apply_to' key
3. Enter \Magento\Eav\Model\Entity\Attribute\Source\Boolean::class in the source key
4. Visit a simple product on the front end
5. This attribute should not be listed under Specifications
6. Visit a configurable product on the front end
7. This attribute should be visible on the front end

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
