### PR TITLE
Escape dollar sign for saving content into crontab

### DIFF
--- a/lib/internal/Magento/Framework/Crontab/CrontabManager.php
+++ b/lib/internal/Magento/Framework/Crontab/CrontabManager.php
@@ -203,7 +203,7 @@ class CrontabManager implements CrontabManagerInterface
      */
     private function save($content)
     {
-        $content = str_replace(['%', '"'], ['%%', '\"'], $content);
+        $content = str_replace(['%', '"', '$'], ['%%', '\"', '\$'], $content);
 
         try {
             $this->shell->execute('echo "' . $content . '" | crontab -');

--- a/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
+++ b/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
@@ -3,32 +3,34 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
+declare(strict_types=1);
 
 namespace Magento\Framework\Crontab\Test\Unit;
 
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Crontab\CrontabManager;
 use Magento\Framework\Crontab\CrontabManagerInterface;
-use Magento\Framework\ShellInterface;
-use Magento\Framework\Phrase;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
-use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem\Directory\ReadInterface;
 use Magento\Framework\Filesystem\DriverPool;
+use Magento\Framework\Phrase;
+use Magento\Framework\ShellInterface;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * Tests crontab manager functionality.
  */
-class CrontabManagerTest extends \PHPUnit\Framework\TestCase
+class CrontabManagerTest extends TestCase
 {
     /**
-     * @var ShellInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ShellInterface|MockObject
      */
     private $shellMock;
 
     /**
-     * @var Filesystem|\PHPUnit_Framework_MockObject_MockObject
+     * @var Filesystem|MockObject
      */
     private $filesystemMock;
 
@@ -38,7 +40,7 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
     private $crontabManager;
 
     /**
-     * @return void
+     * @inheritDoc
      */
     protected function setUp()
     {
@@ -53,9 +55,11 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Verify get tasks without cronetab.
+     *
      * @return void
      */
-    public function testGetTasksNoCrontab()
+    public function testGetTasksNoCrontab(): void
     {
         $exception = new \Exception('crontab: no crontab for user');
         $localizedException = new LocalizedException(new Phrase('Some error'), $exception);
@@ -69,12 +73,14 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Verify get tasks.
+     *
      * @param string $content
      * @param array $tasks
      * @return void
      * @dataProvider getTasksDataProvider
      */
-    public function testGetTasks($content, $tasks)
+    public function testGetTasks($content, $tasks): void
     {
         $this->shellMock->expects($this->once())
             ->method('execute')
@@ -85,9 +91,11 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Data provider to get tasks.
+     *
      * @return array
      */
-    public function getTasksDataProvider()
+    public function getTasksDataProvider(): array
     {
         return [
             [
@@ -120,11 +128,13 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Verify remove tasks with exception.
+     *
      * @return void
      * @expectedException \Magento\Framework\Exception\LocalizedException
      * @expectedExceptionMessage Shell error
      */
-    public function testRemoveTasksWithException()
+    public function testRemoveTasksWithException(): void
     {
         $exception = new \Exception('Shell error');
         $localizedException = new LocalizedException(new Phrase('Some error'), $exception);
@@ -143,12 +153,14 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Verify remove tasks.
+     *
      * @param string $contentBefore
      * @param string $contentAfter
      * @return void
      * @dataProvider removeTasksDataProvider
      */
-    public function testRemoveTasks($contentBefore, $contentAfter)
+    public function testRemoveTasks($contentBefore, $contentAfter): void
     {
         $this->shellMock->expects($this->at(0))
             ->method('execute')
@@ -163,9 +175,11 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Data provider to remove tasks.
+     *
      * @return array
      */
-    public function removeTasksDataProvider()
+    public function removeTasksDataProvider(): array
     {
         return [
             [
@@ -195,11 +209,13 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Verify save tasks with empty tasks list.
+     *
      * @return void
      * @expectedException \Magento\Framework\Exception\LocalizedException
      * @expectedExceptionMessage The list of tasks is empty. Add tasks and try again.
      */
-    public function testSaveTasksWithEmptyTasksList()
+    public function testSaveTasksWithEmptyTasksList(): void
     {
         $baseDirMock = $this->getMockBuilder(ReadInterface::class)
             ->getMockForAbstractClass();
@@ -222,11 +238,13 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Verify save tasks with out command.
+     *
      * @return void
      * @expectedException \Magento\Framework\Exception\LocalizedException
      * @expectedExceptionMessage The command shouldn't be empty. Enter and try again.
      */
-    public function testSaveTasksWithoutCommand()
+    public function testSaveTasksWithoutCommand(): void
     {
         $baseDirMock = $this->getMockBuilder(ReadInterface::class)
             ->getMockForAbstractClass();
@@ -252,13 +270,15 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Verify sava task.
+     *
      * @param array $tasks
      * @param string $content
      * @param string $contentToSave
      * @return void
      * @dataProvider saveTasksDataProvider
      */
-    public function testSaveTasks($tasks, $content, $contentToSave)
+    public function testSaveTasks($tasks, $content, $contentToSave): void
     {
         $baseDirMock = $this->getMockBuilder(ReadInterface::class)
             ->getMockForAbstractClass();
@@ -291,9 +311,11 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Data provider to save tasks.
+     *
      * @return array
      */
-    public function saveTasksDataProvider()
+    public function saveTasksDataProvider(): array
     {
         $content = '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
             . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . hash("sha256", BP) . PHP_EOL
@@ -352,6 +374,17 @@ class CrontabManagerTest extends \PHPUnit\Framework\TestCase
                     . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . hash("sha256", BP) . PHP_EOL
                     . '* * * * * ' . PHP_BINARY . ' /var/www/magento2/run.php'
                     . ' %% cron:run | grep -v \"Ran \'jobs\' by schedule\"' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL,
+            ],
+            [
+                'tasks' => [
+                    ['command' => '{magentoRoot}run.php % cron:run | grep -v "Ran \'jobs\' by schedule"$']
+                ],
+                'content' => '* * * * * /bin/php /var/www/cron.php',
+                'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
+                    . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . hash("sha256", BP) . PHP_EOL
+                    . '* * * * * ' . PHP_BINARY . ' /var/www/magento2/run.php'
+                    . ' %% cron:run | grep -v \"Ran \'jobs\' by schedule\"\$' . PHP_EOL
                     . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL,
             ],
         ];

--- a/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
+++ b/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
@@ -378,13 +378,13 @@ class CrontabManagerTest extends TestCase
             ],
             [
                 'tasks' => [
-                    ['command' => '{magentoRoot}run.php % cron:run | grep -v "Ran \'jobs\' by schedule"$']
+                    ['command' => '{magentoRoot}run.php mysqldump db > db-$(date +%F).sql']
                 ],
                 'content' => '* * * * * /bin/php /var/www/cron.php',
                 'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
                     . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . hash("sha256", BP) . PHP_EOL
                     . '* * * * * ' . PHP_BINARY . ' /var/www/magento2/run.php'
-                    . ' %% cron:run | grep -v \"Ran \'jobs\' by schedule\"\$' . PHP_EOL
+                    . ' mysqldump db > db-\$(date +%%F).sql' . PHP_EOL
                     . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL,
             ],
         ];


### PR DESCRIPTION
The crontab contents can contain dollar sign (e.g. $(date)).
The current code does not escape it which transform it to actual values.
In this commit a replacement to escape dollar sign is added to the previous replacements.

an example in crontab could be
`mysqldump db > db-$(date +%F).sql`

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Class `lib/internal/Magento/Framework/Crontab/CrontabManager.php` function `save` already replace couple of special characters '%' and '"'. I added a new entry into the replacement to escape dollar sign as well. i.e. convert `$` to `\$`.

<!---
### Fixed Issues (if relevant)

    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.

1. magento/magento2#<issue_number>: Issue title
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add a new entry to crontab with dollar sign, e.g: `mysqldump -uroot  DB >/home/backups/$(date +%F)_db.sql`
1. Run the cron install command in the magento root directory: `bin\magento cron:install`
1. check the content of the crontab. The  `$(date +%F)` is transformed to actual date string. `bin\magento cron:remove` has the same effect as well. 

This pull request should fix the conversion, i.e. after `bin\magento cron:install` the content of the other parts with dollar sign should stay intact. 

<!---
### Questions or comments

	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
