### PR TITLE
magento/magento2#: Remove a redundant call to DB for guest session

### DIFF
--- a/app/code/Magento/Customer/Model/Session.php
+++ b/app/code/Magento/Customer/Model/Session.php
@@ -19,6 +19,7 @@ use Magento\Framework\App\ObjectManager;
  * @method string getNoReferer()
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
+ * @SuppressWarnings(PHPMD.TooManyFields)
  * @since 100.0.2
  */
 class Session extends \Magento\Framework\Session\SessionManager
@@ -97,6 +98,11 @@ class Session extends \Magento\Framework\Session\SessionManager
      * @var \Magento\Framework\App\Http\Context
      */
     protected $_httpContext;
+
+    /**
+     * @var AccountConfirmation
+     */
+    protected $accountConfirmation;
 
     /**
      * @var GroupManagementInterface
@@ -304,7 +310,11 @@ class Session extends \Magento\Framework\Session\SessionManager
     public function getCustomer()
     {
         if ($this->_customerModel === null) {
-            $this->_customerModel = $this->_customerFactory->create()->load($this->getCustomerId());
+            $this->_customerModel = $this->_customerFactory->create();
+
+            if ($this->getCustomerId()) {
+                $this->_customerResource->load($this->_customerModel, $this->getCustomerId());
+            }
         }
 
         return $this->_customerModel;

--- a/app/code/Magento/Customer/Test/Unit/Model/SessionTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/SessionTest.php
@@ -18,13 +18,15 @@ use Magento\Framework\App\Http\Context;
 use Magento\Framework\App\Response\Http;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\Framework\Url;
 use Magento\Framework\UrlFactory;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class SessionTest extends \PHPUnit\Framework\TestCase
+class SessionTest extends TestCase
 {
     /**
      * @var ResourceCustomer|MockObject
@@ -85,11 +87,11 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $this->urlFactoryMock = $this->createMock(UrlFactory::class);
         $this->customerFactoryMock = $this->getMockBuilder(CustomerFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->setMethods(['create', 'save'])
             ->getMock();
         $this->_customerResourceMock = $this->getMockBuilder(ResourceCustomer::class)
             ->disableOriginalConstructor()
-            ->setMethods(['load'])
+            ->setMethods(['load', 'save'])
             ->getMock();
         $this->customerRepositoryMock = $this->createMock(CustomerRepositoryInterface::class);
         $helper = new ObjectManagerHelper($this);
@@ -164,7 +166,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
      */
     public function testAuthenticate()
     {
-        $urlMock = $this->createMock(\Magento\Framework\Url::class);
+        $urlMock = $this->createMock(Url::class);
         $urlMock->expects($this->exactly(2))
             ->method('getUrl')
             ->willReturn('');
@@ -216,15 +218,12 @@ class SessionTest extends \PHPUnit\Framework\TestCase
 
         $customerMock = $this->createPartialMock(
             Customer::class,
-            ['getId', 'isConfirmationRequired', 'getConfirmation', 'updateData', 'getGroupId']
+            ['getId', 'getConfirmation', 'updateData', 'getGroupId']
         );
-        $customerMock->expects($this->once())
+        $customerMock->expects($this->exactly(3))
             ->method('getId')
             ->will($this->returnValue($customerId));
         $customerMock->expects($this->once())
-            ->method('isConfirmationRequired')
-            ->will($this->returnValue(true));
-        $customerMock->expects($this->never())
             ->method('getConfirmation')
             ->will($this->returnValue($customerId));
 
@@ -290,6 +289,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $this->_storageMock->expects($this->once())->method('unsIsCustomerEmulated');
         $this->_model->setCustomer($customerMock);
     }
+
     /**
      * Test "getCustomer()" for guest user
      *


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

When guest customer opens, for example, a home page then `Magento\Customer\Model\Session`::`getCustomer()` makes a redundant call to DB:

```
SELECT `customer_entity`.* FROM `customer_entity` WHERE (entity_id ='')
```

and as a result mentioned method returns an empty `\Magento\Customer\Model\Customer` object.

PR optimizes `Magento\Customer\Model\Session`::`getCustomer()` and allows a call to DB when customer ID is not null or greater than zero.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)

Thank you!