### PR TITLE
Bugfix #26479 Exception when Autoloader was not registered properly

### DIFF
--- a/lib/internal/Magento/Framework/Autoload/AutoloaderRegistry.php
+++ b/lib/internal/Magento/Framework/Autoload/AutoloaderRegistry.php
@@ -34,12 +34,12 @@ class AutoloaderRegistry
      * @throws \Exception
      * @return AutoloaderInterface
      */
-    public static function getAutoloader()
+    public static function getAutoloader(): AutoloaderInterface
     {
-        if (self::$autoloader !== null) {
-            return self::$autoloader;
-        } else {
+        if (!self::$autoloader instanceof AutoloaderInterface) {
             throw new \Exception('Autoloader is not registered, cannot be retrieved.');
         }
+
+        return self::$autoloader;
     }
 }

--- a/lib/internal/Magento/Framework/Autoload/AutoloaderRegistry.php
+++ b/lib/internal/Magento/Framework/Autoload/AutoloaderRegistry.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Framework\Autoload;
 
+use InvalidArgumentException;
 use Magento\Framework\Autoload\AutoloaderInterface;
 
 /**
@@ -23,7 +24,7 @@ class AutoloaderRegistry
      * @param AutoloaderInterface $newAutoloader
      * @return void
      */
-    public static function registerAutoloader(AutoloaderInterface $newAutoloader)
+    public static function registerAutoloader(AutoloaderInterface $newAutoloader): void
     {
         self::$autoloader = $newAutoloader;
     }
@@ -31,13 +32,13 @@ class AutoloaderRegistry
     /**
      * Returns the registered autoloader
      *
-     * @throws \Exception
+     * @throws InvalidArgumentException
      * @return AutoloaderInterface
      */
     public static function getAutoloader(): AutoloaderInterface
     {
         if (!self::$autoloader instanceof AutoloaderInterface) {
-            throw new \Exception('Autoloader is not registered, cannot be retrieved.');
+            throw new InvalidArgumentException('Autoloader is not registered, cannot be retrieved.');
         }
 
         return self::$autoloader;


### PR DESCRIPTION
### Description (*)
Issue for problem occured randomly with Integration Tests.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/26479

### Manual testing scenarios (*)
1. Running Integration Tests, you should not get an error `Error: Call to a member function findFile() on array`

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
