### PR TITLE
Unit test for Magento\Fedex\Plugin\Block\Tracking\PopupDeliveryDate

### DIFF
--- a/app/code/Magento/Fedex/Test/Unit/Plugin/Block/Tracking/PopupDeliveryDateTest.php
+++ b/app/code/Magento/Fedex/Test/Unit/Plugin/Block/Tracking/PopupDeliveryDateTest.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Fedex\Test\Unit\Plugin\Block\Tracking;
 
+use Magento\Fedex\Model\Carrier;
 use Magento\Fedex\Plugin\Block\Tracking\PopupDeliveryDate;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Shipping\Block\Tracking\Popup;
@@ -44,7 +45,7 @@ class PopupDeliveryDateTest extends TestCase
             ->getMock();
         $trackingStatusMock->expects($this::once())
             ->method('getCarrier')
-            ->willReturn(\Magento\Fedex\Model\Carrier::CODE);
+            ->willReturn(Carrier::CODE);
 
         /** @var Popup|MockObject $subjectMock */
         $subjectMock = $this->getMockBuilder(Popup::class)

--- a/app/code/Magento/Fedex/Test/Unit/Plugin/Block/Tracking/PopupDeliveryDateTest.php
+++ b/app/code/Magento/Fedex/Test/Unit/Plugin/Block/Tracking/PopupDeliveryDateTest.php
@@ -4,6 +4,8 @@
  * See COPYING.txt for license details.
  */
 
+declare(strict_types=1);
+
 namespace Magento\Fedex\Test\Unit\Plugin\Block\Tracking;
 
 use Magento\Fedex\Model\Carrier;

--- a/app/code/Magento/Fedex/Test/Unit/Plugin/Block/Tracking/PopupDeliveryDateTest.php
+++ b/app/code/Magento/Fedex/Test/Unit/Plugin/Block/Tracking/PopupDeliveryDateTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Unit Test for @see \Magento\Fedex\Plugin\Block\Tracking\PopupDeliveryDate
+ * Unit Test for \Magento\Fedex\Plugin\Block\Tracking\PopupDeliveryDate
  */
 class PopupDeliveryDateTest extends TestCase
 {
@@ -63,9 +63,7 @@ class PopupDeliveryDateTest extends TestCase
         $this->trackingStatusMock->expects($this::once())
             ->method('getCarrier')
             ->willReturn(Carrier::CODE);
-
-        $this->subjectMock->expects($this->once())
-            ->method('formatDeliveryDate');
+        $this->subjectMock->expects($this->once())->method('formatDeliveryDate');
 
         $this->executeOriginalMethod();
     }
@@ -78,15 +76,13 @@ class PopupDeliveryDateTest extends TestCase
         $this->trackingStatusMock->expects($this::once())
             ->method('getCarrier')
             ->willReturn(self::STUB_CARRIER_CODE_NOT_FEDEX);
-
-        $this->subjectMock->expects($this->never())
-            ->method('formatDeliveryDate');
+        $this->subjectMock->expects($this->never())->method('formatDeliveryDate');
 
         $this->executeOriginalMethod();
     }
 
     /**
-     * Returns Mock for @see Status
+     * Returns Mock for \Magento\Shipping\Model\Tracking\Result\Status
      *
      * @return MockObject
      */
@@ -99,7 +95,7 @@ class PopupDeliveryDateTest extends TestCase
     }
 
     /**
-     * Returns Mock for @see Popup
+     * Returns Mock for \Magento\Shipping\Block\Tracking\Popup
      *
      * @return MockObject
      */

--- a/app/code/Magento/Fedex/Test/Unit/Plugin/Block/Tracking/PopupDeliveryDateTest.php
+++ b/app/code/Magento/Fedex/Test/Unit/Plugin/Block/Tracking/PopupDeliveryDateTest.php
@@ -112,7 +112,7 @@ class PopupDeliveryDateTest extends TestCase
     }
 
     /**
-     *
+     * Run plugin's original method
      */
     private function executeOriginalMethod()
     {

--- a/app/code/Magento/Fedex/Test/Unit/Plugin/Block/Tracking/PopupDeliveryDateTest.php
+++ b/app/code/Magento/Fedex/Test/Unit/Plugin/Block/Tracking/PopupDeliveryDateTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Fedex\Test\Unit\Plugin\Block\Tracking;
+
+use Magento\Fedex\Plugin\Block\Tracking\PopupDeliveryDate;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Shipping\Block\Tracking\Popup;
+use Magento\Shipping\Model\Tracking\Result\Status;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit Test for @see \Magento\Fedex\Plugin\Block\Tracking\PopupDeliveryDate
+ */
+class PopupDeliveryDateTest extends TestCase
+{
+    /**
+     * @var MockObject|PopupDeliveryDate
+     */
+    private $plugin;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        $objectManagerHelper = new ObjectManager($this);
+        $this->plugin = $objectManagerHelper->getObject(PopupDeliveryDate::class);
+    }
+
+    /**
+     * Test the method with Fedex carrier
+     */
+    public function testAfterFormatDeliveryDateTimeWithFedexCarrier()
+    {
+        /** @var Status|MockObject $trackingStatusMock */
+        $trackingStatusMock = $this->getMockBuilder(Status::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCarrier'])
+            ->getMock();
+        $trackingStatusMock->expects($this::once())
+            ->method('getCarrier')
+            ->willReturn(\Magento\Fedex\Model\Carrier::CODE);
+
+        /** @var Popup|MockObject $subjectMock */
+        $subjectMock = $this->getMockBuilder(Popup::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['formatDeliveryDate', 'getTrackingInfo'])
+            ->getMock();
+        $subjectMock->expects($this->once())
+            ->method('getTrackingInfo')
+            ->willReturn([[$trackingStatusMock]]);
+        $subjectMock->expects($this->once())
+            ->method('formatDeliveryDate');
+
+        $this->plugin->afterFormatDeliveryDateTime($subjectMock, 'Test Result', '2020-02-02', '12:00');
+    }
+
+    /**
+     * Test the method with a different carrier
+     */
+    public function testAfterFormatDeliveryDateTimeWithOtherCarrier()
+    {
+        /** @var Status|MockObject $trackingStatusMock */
+        $trackingStatusMock = $this->getMockBuilder(Status::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCarrier'])
+            ->getMock();
+        $trackingStatusMock->expects($this::once())
+            ->method('getCarrier')
+            ->willReturn('not-fedex');
+
+        /** @var Popup|MockObject $subjectMock */
+        $subjectMock = $this->getMockBuilder(Popup::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['formatDeliveryDate', 'getTrackingInfo'])
+            ->getMock();
+        $subjectMock->expects($this->once())
+            ->method('getTrackingInfo')
+            ->willReturn([[$trackingStatusMock]]);
+        $subjectMock->expects($this->never())
+            ->method('formatDeliveryDate');
+
+        $this->plugin->afterFormatDeliveryDateTime($subjectMock, 'Test Result', '2020-02-02', '12:00');
+    }
+}


### PR DESCRIPTION
### Description (*)
Covers Magento\Fedex\Plugin\Block\Tracking\PopupDeliveryDate class with a unit test.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
