### PR TITLE
Add bundle qty and selection qty for calculation tier price

### DIFF
--- a/app/code/Magento/Bundle/Model/Product/Type.php
+++ b/app/code/Magento/Bundle/Model/Product/Type.php
@@ -746,7 +746,7 @@ class Type extends \Magento\Catalog\Model\Product\Type\AbstractType
                      * for selection (not for all bundle)
                      */
                     $price = $product->getPriceModel()
-                        ->getSelectionFinalTotalPrice($product, $selection, 0, 1);
+                        ->getSelectionFinalTotalPrice($product, $selection, $buyRequest->getQty(), $qty);
                     $attributes = [
                         'price' => $price,
                         'qty' => $qty,


### PR DESCRIPTION
### Description (*)
Selection qty was hardcoded and passed to `getSelectionFinalTotalPrice` also bundle qty was hardcoded to 0. It caused wrong data type passed in `getTierPrce` method.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. fixes magento/magento2#22807: Bundles and tier price give unexpected results

### Manual testing scenarios (*)
1. ...
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
