### PR TITLE
magento/magento2#22196

### DIFF
--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -109,9 +109,9 @@ class Bootstrap
     private $factory;
 
     /**
-     * Application Object
+     * HTTP web application
      *
-     * @var ObjectManagerFactory
+     * @var \Magento\Framework\AppInterface
      */
     private $app;
 

--- a/lib/internal/Magento/Framework/App/Bootstrap.php
+++ b/lib/internal/Magento/Framework/App/Bootstrap.php
@@ -109,6 +109,13 @@ class Bootstrap
     private $factory;
 
     /**
+     * Application Object
+     *
+     * @var ObjectManagerFactory
+     */
+    private $app;
+
+    /**
      * Static method so that client code does not have to create Object Manager Factory every time Bootstrap is called
      *
      * @param string $rootDir
@@ -235,6 +242,7 @@ class Bootstrap
             if (!($application instanceof AppInterface)) {
                 throw new \InvalidArgumentException("The provided class doesn't implement AppInterface: {$type}");
             }
+            $this->app = $application;
             return $application;
         } catch (\Exception $e) {
             $this->terminate($e);
@@ -383,7 +391,7 @@ class Bootstrap
         $handler = new ErrorHandler();
         set_error_handler([$handler, 'handler']);
     }
-    
+
     /**
      * Getter for error code
      *
@@ -440,6 +448,7 @@ class Bootstrap
             }
             echo $message;
         }
+        $this->app->handleTerminateError();
         exit(1);
     }
     // phpcs:enable

--- a/lib/internal/Magento/Framework/App/Http.php
+++ b/lib/internal/Magento/Framework/App/Http.php
@@ -155,4 +155,17 @@ class Http implements \Magento\Framework\AppInterface
     {
         return $this->exceptionHandler->handle($bootstrap, $exception, $this->_response, $this->_request);
     }
+
+    /**
+     * Error Handler for Application Termination
+     *
+     * @return bool
+     */
+    public function handleTerminateError()
+    {
+        $this->_response->setHttpResponseCode(500);
+        $this->_response->setHeader('Content-Type', 'text/html; charset=UTF-8');
+        $this->_response->sendResponse();
+        return true;
+    }
 }

--- a/lib/internal/Magento/Framework/App/Http.php
+++ b/lib/internal/Magento/Framework/App/Http.php
@@ -161,11 +161,12 @@ class Http implements \Magento\Framework\AppInterface
      *
      * @return bool
      */
-    public function handleTerminateError()
+    public function handleTerminateError(): bool
     {
         $this->_response->setHttpResponseCode(500);
         $this->_response->setHeader('Content-Type', 'text/html; charset=UTF-8');
         $this->_response->sendResponse();
+
         return true;
     }
 }

--- a/lib/internal/Magento/Framework/App/Test/Unit/HttpTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/HttpTest.php
@@ -173,6 +173,17 @@ class HttpTest extends \PHPUnit\Framework\TestCase
             ->willReturn($this->responseMock);
     }
 
+    public function testHandleTerminateError()
+    {
+        $this->responseMock->expects($this->once())
+            ->method('setHttpResponseCode')->with('500');
+        $this->responseMock->expects($this->once())
+            ->method('setHeader')->with('Content-Type', 'text/html; charset=UTF-8');
+        $this->responseMock->expects($this->once())->method('sendResponse');
+
+        $this->assertTrue($this->http->handleTerminateError());
+    }
+
     public function testLaunchSuccess()
     {
         $this->setUpLaunch();


### PR DESCRIPTION
### Description (*)
Fixed 200 Response Code When Exception is Thrown During Bootstrap Issue

### Fixed Issues
1. magento/magento2#22196: 200 Response Code When Exception is Thrown During Bootstrap

### Manual testing scenarios (*)
1. Force any exception to be thrown during the bootstrapping process so that Magento\Framework\App\Bootstrap calls its terminate() function.

For example:
In `\Magento\Catalog\Controller\Category\View::__construct`
add new line:
`throw new \Throwable('New exception');`

2. Send GET request to http://{base_url}/catalog/category/view/id/1

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. An error message is displayed and 500 response code is returned.

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. An error message is displayed and the http response code is 200 OK.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
