### PR TITLE
Fix confusing phpdoc in curl client

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/Client/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Curl.php
@@ -423,7 +423,7 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
      */
     public function doError($string)
     {
-        //  hpcs:ignore Magento2.Exceptions.DirectThrow
+        //  phpcs:ignore Magento2.Exceptions.DirectThrow
         throw new \Exception($string);
     }
 

--- a/lib/internal/Magento/Framework/HTTP/Client/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Curl.php
@@ -107,9 +107,9 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
     protected $_headerCount = 0;
 
     /**
-     * Set request timeout, msec
+     * Set request timeout
      *
-     * @param int $value
+     * @param int $value value in seconds
      * @return void
      */
     public function setTimeout($value)

--- a/lib/internal/Magento/Framework/HTTP/Client/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Curl.php
@@ -423,6 +423,7 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
      */
     public function doError($string)
     {
+        //  hpcs:ignore Magento2.Exceptions.DirectThrow
         throw new \Exception($string);
     }
 


### PR DESCRIPTION
### Description (*)
According to [php documentation](https://www.php.net/manual/en/function.curl-setopt.php):
> CURLOPT_TIMEOUT - The maximum number of seconds to allow cURL functions to execute.

### Fixed Issues (if relevant)
None that I know of.

### Manual testing scenarios (*)
Not relevant.

### Questions or comments
None.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
