### PR TITLE
Improve performance of Mysql::isTableExists()

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -2614,7 +2614,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      */
     public function isTableExists($tableName, $schemaName = null)
     {
-        return $this->showTableStatus($tableName, $schemaName) !== false;
+        return $this->getCreateTable($tableName, $schemaName) !== false;
     }
 
     /**

--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -2614,7 +2614,11 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      */
     public function isTableExists($tableName, $schemaName = null)
     {
-        return $this->getCreateTable($tableName, $schemaName) !== false;
+        $isDdlCacheAllowed = $this->_isDdlCacheAllowed;
+        $this->_isDdlCacheAllowed = false;
+        $tableExists = $this->getCreateTable($tableName, $schemaName) !== false;
+        $this->_isDdlCacheAllowed = $isDdlCacheAllowed;
+        return $tableExists;
     }
 
     /**


### PR DESCRIPTION
### Description (*)

Replaces `showTableStatus()` with `getCreateTable()`, which is functionally equivalent for the desired case (return false if table does not exist).

This is especially relevant for `Magento\Indexer\Setup\Recurring`, where lots of repeated calls to `isTableExists()` happen during unsubscribing and subscribing the mviews.

- SHOW TABLE STATUS can take significantly longer than SHOW CREATE TABLE and we are not interested in status information
- getCreateTable() uses DDL cache

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
