### PR TITLE
{ASI} :- Error message to be cached for grid data storage component

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/data-storage.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/data-storage.js
@@ -188,7 +188,8 @@ define([
 
             result = {
                 items: this.getByIds(request.ids),
-                totalRecords: request.totalRecords
+                totalRecords: request.totalRecords,
+                errorMessage: request.errorMessage
             };
 
             delay ?
@@ -216,7 +217,8 @@ define([
             this._requests.push({
                 ids: this.getIds(data.items),
                 params: params,
-                totalRecords: data.totalRecords
+                totalRecords: data.totalRecords,
+                errorMessage: data.errorMessage
             });
 
             return this;

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
@@ -62,13 +62,13 @@ define([
             });
         });
 
-        describe('"getByIds"', function() {
+        describe('"getByIds" method', function () {
 
             var model = new DataStorage({
                 dataScope: 'magento'
             });
 
-            it('check for defined', function() {
+            it('check for defined', function () {
                 expect(model.hasOwnProperty('getByIds')).toBeDefined();
             });
 
@@ -78,23 +78,198 @@ define([
 
             it('Check returned value if method called with argument', function () {
                 var ids = [1,2,3];
+
                 expect(model.getByIds(ids)).toBeDefined();
             });
 
-            it('check returned false if method called with argument', function() {
-                var ids = [1,2,3];
-                var type = typeof model.getByIds(ids);
+            it('check returned type if method called with argument', function () {
+                var ids = [1,2,3],
+                    type = typeof model.getByIds(ids);
+
                 expect(type).toEqual('boolean');
             });
 
-            it('Return false', function() {
+            it('Return false if "getByIds" has been called', function () {
                 var ids = [1,2,3];
-                expect(model.getByIds(ids)).toEqual('false');
+
+                expect(model.getByIds(ids)).toEqual(false);
+            });
+
+            it('Return array if "getByIds" has been called', function () {
+                var ids = [1];
+
+                model = new DataStorage({
+                    dataScope: 'magento',
+                    data: {
+                        1: {
+                            id_field_name: 'entity_id',
+                            entity_id: '1'
+                        }
+                    }
+                });
+
+                expect(typeof model.getByIds(ids)).toEqual('object');
             });
 
         });
 
-        describe('hasScopeChanged', function () {
+        describe('"getIds" method', function () {
+
+            var model = new DataStorage({
+                dataScope: 'magento'
+            });
+
+            it('check for defined', function () {
+                expect(model.hasOwnProperty('getIds')).toBeDefined();
+            });
+
+            it('check method type', function () {
+                expect(typeof model.getIds).toEqual('function');
+            });
+
+            it('check returned value if method called with argument', function () {
+                var ids = [1,2,3];
+
+                expect(model.getIds(ids)).toBeDefined();
+            });
+
+            it('check returned type if method called with argument', function () {
+                var ids = [1,2,3],
+                    type = typeof model.getIds(ids);
+
+                expect(type).toEqual('object');
+            });
+
+        });
+
+        describe('"getData" method', function () {
+
+            var model = new DataStorage({
+                dataScope: 'magento'
+            });
+
+            it('check for defined', function () {
+                expect(model.hasOwnProperty('getData')).toBeDefined();
+            });
+
+            it('check method type', function () {
+                expect(typeof model.getData).toEqual('function');
+            });
+
+            it('check returned value if method called with argument', function () {
+                var params = {
+                    namespace: 'magento',
+                    search: '',
+                    filters: {
+                        store_id: 0
+                    },
+                    sorting: {},
+                    paging: {}
+                };
+
+                expect(model.getData(params)).toBeDefined();
+            });
+
+            it('check returned type if method called with argument', function () {
+                var params = {
+                    namespace: 'magento',
+                    search: '',
+                    filters: {
+                        store_id: 0
+                    },
+                    sorting: {},
+                    paging: {}
+                },
+                    type = typeof model.getData(params);
+
+                expect(type).toEqual('object');
+            });
+
+            it('check "clearRequests" has been called', function () {
+                var params = {
+                    namespace: 'magento',
+                    search: '',
+                    filters: {
+                        store_id: 0
+                    },
+                    sorting: {},
+                    paging: {}
+                };
+
+                spyOn(model, 'clearRequests');
+                spyOn(model, 'hasScopeChanged').and.callFake(function () {
+                    return true;
+                });
+                model.getData(params);
+                expect(model.clearRequests).toHaveBeenCalled();
+            });
+
+            it('check "getRequest" has been called', function () {
+                var params = {
+                    namespace: 'magento',
+                    search: '',
+                    filters: {
+                        store_id: 0
+                    },
+                    sorting: {},
+                    paging: {}
+                };
+
+                spyOn(model, 'getRequest');
+                spyOn(model, 'hasScopeChanged').and.callFake(function () {
+                    return false;
+                });
+                model.getData(params);
+                expect(model.getRequest).toHaveBeenCalled();
+            });
+
+            it('Return "getRequestData" method', function () {
+                var params = {
+                    namespace: 'magento',
+                    search: '',
+                    filters: {
+                        store_id: 0
+                    },
+                    sorting: {},
+                    paging: {}
+                },
+                    options = {
+                        refresh: false
+                    };
+
+                spyOn(model, 'getRequestData');
+                spyOn(model, 'getRequest').and.callFake(function () {
+                    return true;
+                });
+                model.getData(params, options);
+                expect(model.getRequestData).toHaveBeenCalled();
+            });
+
+            it('Return "requestData" method', function () {
+                var params = {
+                        namespace: 'magento',
+                        search: '',
+                        filters: {
+                            store_id: 0
+                        },
+                        sorting: {},
+                        paging: {}
+                    },
+                    options = {
+                        refresh: true
+                    };
+
+                spyOn(model, 'requestData');
+                spyOn(model, 'getRequest').and.callFake(function () {
+                    return false;
+                });
+                model.getData(params, options);
+                expect(model.requestData).toHaveBeenCalled();
+            });
+
+        });
+
+        describe('"hasScopeChanged" method', function () {
             it('is function', function () {
                 var model = new DataStorage({
                     dataScope: ''
@@ -144,10 +319,37 @@ define([
                 expect(model.hasScopeChanged(newParams)).toBeTruthy();
             });
         });
+
+        describe('"updateData" method', function () {
+            var model = new DataStorage({
+                dataScope: 'magento'
+            });
+
+            it('Check for defined ', function () {
+                expect(model.hasOwnProperty('updateData')).toBeDefined();
+            });
+
+            it('Check method type', function () {
+                var type = typeof model.updateData;
+
+                expect(type).toEqual('function');
+            });
+
+            it('Check updateData has been called', function () {
+                var data = [{
+                    id_field_name: 'entity_id',
+                    entity_id: '1'
+                }];
+
+                expect(model.updateData(data)).toBeTruthy();
+            });
+        });
+
         describe('"getRequestData" method', function () {
             var model = new DataStorage({
                 dataScope: 'magento'
             });
+
             it('Check for defined ', function () {
                 expect(model.hasOwnProperty('getRequestData')).toBeDefined();
             });
@@ -162,6 +364,7 @@ define([
                 var request = {
                     ids: [1,2,3]
                 };
+
                 expect(model.getRequestData(request)).toBeTruthy();
             });
         });
@@ -170,6 +373,7 @@ define([
             var model = new DataStorage({
                 dataScope: 'magento'
             });
+
             it('Check for defined ', function () {
                 expect(model.hasOwnProperty('cacheRequest')).toBeDefined();
             });
@@ -180,19 +384,217 @@ define([
                 expect(type).toEqual('function');
             });
 
-            it('check "cacheRequest" has been executed', function () {
-                var data = {
-                        items: [1,2,3],
-                        totalRecords: 3,
-                        errorMessage: ''
-                    },
-                    params = {
+            it('check "model._requests"', function () {
+                var params = {
+                    namespace: 'magento',
+                    search: '',
+                    sorting: {},
+                    paging: {}
+                },
+                data = {
+                    items: ['1','2','3'],
+                    totalRecords: 3
+                };
+
+                spyOn(model, 'removeRequest');
+                spyOn(model, 'getIds').and.callFake(function () {
+                    return ['1','2','3'];
+                });
+                model.cacheRequest(data, params);
+                expect(typeof model._requests).toEqual('object');
+                expect(model.getIds).toHaveBeenCalled();
+                expect(model.removeRequest).not.toHaveBeenCalled();
+            });
+
+            it('check "removeRequest" is executed', function () {
+                var params = {
                         namespace: 'magento',
                         search: '',
                         sorting: {},
                         paging: {}
+                    },
+                    data = {
+                        items: ['1','2','3'],
+                        totalRecords: 3
                     };
-                expect(model.cacheRequest(data, params)).toBeTruthy();
+
+                spyOn(model, 'removeRequest');
+                spyOn(model, 'getRequest').and.callFake(function () {
+                    return true;
+                });
+                spyOn(model, 'getIds').and.callFake(function () {
+                    return ['1','2','3'];
+                });
+                model.cacheRequest(data, params);
+                expect(typeof model._requests).toEqual('object');
+                expect(model.getIds).toHaveBeenCalled();
+                expect(model.removeRequest).toHaveBeenCalled();
+            });
+        });
+
+        describe('"clearRequests" method', function () {
+
+            var model = new DataStorage({
+                dataScope: 'magento'
+            });
+
+            it('Check for defined ', function () {
+                expect(model.hasOwnProperty('clearRequests')).toBeDefined();
+            });
+
+            it('Check method type', function () {
+                var type = typeof model.clearRequests;
+
+                expect(type).toEqual('function');
+            });
+
+            it('check "clearRequests" will empty _requests array', function () {
+                var params = {
+                    namespace: 'magento',
+                    search: 'magento',
+                    filters: {
+                        store_id: 1
+                    }
+                };
+
+                model = new DataStorage({
+                    dataScope: 'magento',
+                    _requests: []
+                });
+
+                model._requests.push({
+                    ids: ['1','2','3','4'],
+                    params: params,
+                    totalRecords: 4,
+                    errorMessage: 'errorMessage'
+                });
+                model.clearRequests();
+                expect(model._requests).toEqual([]);
+            });
+        });
+
+        describe('"removeRequest" method', function () {
+
+            var model = new DataStorage({
+                dataScope: 'magento'
+            });
+
+            it('Check for defined ', function () {
+                expect(model.hasOwnProperty('removeRequest')).toBeDefined();
+            });
+
+            it('Check method type', function () {
+                var type = typeof model.removeRequest;
+
+                expect(type).toEqual('function');
+            });
+
+            it('check "removeRequest" is defined', function () {
+                var params = {
+                    namespace: 'magento',
+                    search: 'magento',
+                    filters: {
+                        store_id: 1
+                    }
+                },
+                request = [{
+                    ids: [1,2,3],
+                    params: params,
+                    totalRecords: 3,
+                    errorMessage: 'errorMessage'
+                }];
+
+                expect(model.removeRequest(request)).toBeDefined();
+            });
+        });
+
+        describe('"wasRequested" method', function () {
+            var model = new DataStorage({
+                dataScope: 'magento'
+            });
+
+            it('Check for defined ', function () {
+                expect(model.hasOwnProperty('wasRequested')).toBeDefined();
+            });
+
+            it('Check method type', function () {
+                var type = typeof model.wasRequested;
+
+                expect(type).toEqual('function');
+            });
+
+            it('Return false if getRequest method returns false', function () {
+                var params = {
+                    namespace: 'magento',
+                    search: '',
+                    sorting: {},
+                    paging: {}
+                };
+
+                model.wasRequested(params);
+                expect(model.wasRequested(params)).toBeFalsy();
+            });
+        });
+
+        describe('"onRequestComplete" method', function () {
+            var model = new DataStorage({
+                dataScope: 'magento'
+            });
+
+            it('Check for defined ', function () {
+                expect(model.hasOwnProperty('onRequestComplete')).toBeDefined();
+            });
+
+            it('Check method type', function () {
+                var type = typeof model.onRequestComplete;
+
+                expect(type).toEqual('function');
+            });
+
+            it('Check "updateData" method has been called', function () {
+                var data = {
+                    items: [{
+                        id_field_name: 'entity_id',
+                        entity_id: '1'
+                    }]
+                },
+params = {
+                    namespace: 'magento',
+                    search: '',
+                    sorting: {},
+                    paging: {}
+                };
+
+                spyOn(model, 'updateData').and.callFake(function () {
+                    return data;
+                });
+                model.onRequestComplete(params, data);
+                expect(model.updateData).toHaveBeenCalled();
+            });
+
+            it('Check "cacheRequest" method has been called', function () {
+                var data = {
+                    items: [{
+                        id_field_name: 'entity_id',
+                        entity_id: '1'
+                    }]
+                },
+                params = {
+                    namespace: 'magento',
+                    search: '',
+                    sorting: {},
+                    paging: {}
+                };
+
+                model = new DataStorage({
+                    dataScope: 'magento',
+                    cacheRequests: true
+                });
+                spyOn(model, 'cacheRequest').and.callFake(function () {
+                    return data;
+                });
+                model.onRequestComplete(params, data);
+                expect(model.cacheRequest).toHaveBeenCalled();
             });
         });
     });

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
@@ -480,12 +480,10 @@ define([
                         totalRecords: 3,
                         errorMessage: ''
                     };
-
-                    model = new DataStorage({
-                        dataScope: 'magento',
-                        cachedRequestDelay: 0
-                    });
-
+                model = new DataStorage({
+                    dataScope: 'magento',
+                    cachedRequestDelay: 0
+                });
                 spyOn(_, 'delay');
                 model.getRequestData(request);
                 expect(_.delay).not.toHaveBeenCalled();

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
@@ -12,7 +12,8 @@ define([
     'use strict';
 
     describe('Magento_Ui/js/grid/data-storage', function () {
-        describe('costructor', function () {
+
+        describe('constructor', function () {
             it('converts dataScope property to array', function () {
                 var model = new DataStorage({
                     dataScope: 'magento'
@@ -20,6 +21,77 @@ define([
 
                 expect(model.dataScope).toEqual(['magento']);
             });
+        });
+
+        describe('"initConfig" method', function () {
+
+            var model = new DataStorage({
+                dataScope: 'magento'
+            });
+
+            it('Check for defined ', function () {
+                expect(model.hasOwnProperty('initConfig')).toBeDefined();
+            });
+
+            it('Check method type', function () {
+                var type = typeof model.initConfig;
+
+                expect(type).toEqual('function');
+            });
+
+            it('Check returned value if method called without arguments', function () {
+                expect(model.initConfig()).toBeDefined();
+            });
+
+            it('Check returned value type if method called without arguments', function () {
+                var type = typeof model.initConfig();
+
+                expect(type).toEqual('object');
+            });
+
+            it('Check this.dataScope property (is modify in initConfig method)', function () {
+                model.dataScope = null;
+                model.initConfig();
+                expect(typeof model.dataScope).toEqual('object');
+            });
+
+            it('Check this._requests property (is modify in initConfig method)', function () {
+                model._requests = null;
+                model.initConfig();
+                expect(typeof model._requests).toEqual('object');
+            });
+        });
+
+        describe('"getByIds"', function() {
+
+            var model = new DataStorage({
+                dataScope: 'magento'
+            });
+
+            it('check for defined', function() {
+                expect(model.hasOwnProperty('getByIds')).toBeDefined();
+            });
+
+            it('check method type', function () {
+                expect(typeof model.getByIds).toEqual('function');
+            });
+
+            it('Check returned value if method called with argument', function () {
+                var ids = [1,2,3];
+                expect(model.getByIds(ids)).toBeDefined();
+            });
+
+            it('check returned false if method called with argument', function() {
+                var ids = [1,2,3];
+                var type = typeof model.getByIds(ids);
+                expect(type).toEqual('boolean');
+            });
+
+            it('Return false', function() {
+                var ids = [1,2,3];
+                expect(model.getByIds(ids)).toEqual('false');
+            });
+
         });
 
         describe('hasScopeChanged', function () {
@@ -70,6 +142,57 @@ define([
 
                 expect(model.hasScopeChanged(params)).toBeFalsy();
                 expect(model.hasScopeChanged(newParams)).toBeTruthy();
+            });
+        });
+        describe('"getRequestData" method', function () {
+            var model = new DataStorage({
+                dataScope: 'magento'
+            });
+            it('Check for defined ', function () {
+                expect(model.hasOwnProperty('getRequestData')).toBeDefined();
+            });
+
+            it('Check method type', function () {
+                var type = typeof model.getRequestData;
+
+                expect(type).toEqual('function');
+            });
+
+            it('check "getRequestData" has been executed', function () {
+                var request = {
+                    ids: [1,2,3]
+                };
+                expect(model.getRequestData(request)).toBeTruthy();
+            });
+        });
+
+        describe('"cacheRequest" method', function () {
+            var model = new DataStorage({
+                dataScope: 'magento'
+            });
+            it('Check for defined ', function () {
+                expect(model.hasOwnProperty('cacheRequest')).toBeDefined();
+            });
+
+            it('Check method type', function () {
+                var type = typeof model.cacheRequest;
+
+                expect(type).toEqual('function');
+            });
+
+            it('check "cacheRequest" has been executed', function () {
+                var data = {
+                        items: [1,2,3],
+                        totalRecords: 3,
+                        errorMessage: ''
+                    },
+                    params = {
+                        namespace: 'magento',
+                        search: '',
+                        sorting: {},
+                        paging: {}
+                    };
+                expect(model.cacheRequest(data, params)).toBeTruthy();
             });
         });
     });

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
@@ -5,6 +5,8 @@
 
 /*eslint max-nested-callbacks: 0*/
 /*jscs:disable requireCamelCaseOrUpperCaseIdentifiers*/
+/*eslint newline-after-var: ["error", "always"]*/
+/*eslint-env es6*/
 define([
     'jquery',
     'Magento_Ui/js/grid/data-storage'
@@ -52,6 +54,7 @@ define([
 
             it('initializes _requests property as an empty array', function () {
                 var model = new DataStorage();
+
                 model._requests = null;
                 model.initConfig();
                 expect(model._requests).toEqual([]);
@@ -110,7 +113,7 @@ define([
                             2: {
                                 id_field_name: 'entity_id',
                                 entity_id: '42'
-                            },
+                            }
                         }
                     });
 
@@ -129,8 +132,10 @@ define([
                 spyOn(model, 'clearRequests');
                 spyOn(model, 'hasScopeChanged').and.returnValue(true);
                 spyOn(model, 'requestData').and.returnValue(requestDataResult);
+                spyOn(model, 'getRequest');
                 expect(model.getData()).toEqual(requestDataResult);
                 expect(model.clearRequests).toHaveBeenCalled();
+                expect(model.getRequest).not.toHaveBeenCalled();
             });
 
             it('returns the cached result if scope have not been changed', function () {
@@ -210,7 +215,7 @@ define([
                         id_field_name: 'entity_id',
                         entity_id: '1',
                         field: 'value'
-                    },
+                    }
                 }
             });
 
@@ -237,7 +242,7 @@ define([
                     /**
                      * Success result for ajax request
                      *
-                     * @param handler
+                     * @param {Function} handler
                      * @returns {*}
                      */
                     done: function (handler) {
@@ -297,10 +302,11 @@ define([
                     model = new DataStorage({
                         cachedRequestDelay: 0
                     });
+
                 spyOn(model, 'getByIds').and.returnValue(items);
                 model.getRequestData(request).then(function (promiseResult) {
-                    expect(promiseResult).toEqual(result)
-                })
+                    expect(promiseResult).toEqual(result);
+                });
             });
         });
 

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
@@ -225,7 +225,7 @@ define([
                 expect(model.getRequest).toHaveBeenCalled();
             });
 
-            it('Return "getRequestData" method', function () {
+            it('it returns cached request data if a cached request exists and no refresh option is provided', function () {
                 var params = {
                     namespace: 'magento',
                     search: '',
@@ -247,7 +247,7 @@ define([
                 expect(model.getRequestData).toHaveBeenCalled();
             });
 
-            it('Return "requestData" method', function () {
+            it('if refresh option is true so it will ignore cache and execute the requestData function', function () {
                 var params = {
                         namespace: 'magento',
                         search: '',

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
@@ -5,8 +5,6 @@
 
 /*eslint max-nested-callbacks: 0*/
 /*jscs:disable requireCamelCaseOrUpperCaseIdentifiers*/
-/*eslint newline-after-var: ["error", "always"]*/
-/*eslint-env es6*/
 define([
     'jquery',
     'Magento_Ui/js/grid/data-storage'

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/data-storage.test.js
@@ -31,20 +31,6 @@ define([
                 dataScope: 'magento'
             });
 
-            it('Check for defined ', function () {
-                expect(model.hasOwnProperty('initConfig')).toBeDefined();
-            });
-
-            it('Check method type', function () {
-                var type = typeof model.initConfig;
-
-                expect(type).toEqual('function');
-            });
-
-            it('Check returned value if method called without arguments', function () {
-                expect(model.initConfig()).toBeDefined();
-            });
-
             it('Check returned value type if method called without arguments', function () {
                 var type = typeof model.initConfig();
 
@@ -70,20 +56,6 @@ define([
                 dataScope: 'magento'
             });
 
-            it('check for defined', function () {
-                expect(model.hasOwnProperty('getByIds')).toBeDefined();
-            });
-
-            it('check method type', function () {
-                expect(typeof model.getByIds).toEqual('function');
-            });
-
-            it('Check returned value if method called with argument', function () {
-                var ids = [1,2,3];
-
-                expect(model.getByIds(ids)).toBeDefined();
-            });
-
             it('check returned type if method called with argument', function () {
                 var ids = [1,2,3],
                     type = typeof model.getByIds(ids);
@@ -98,7 +70,13 @@ define([
             });
 
             it('Return array if "getByIds" has been called', function () {
-                var ids = [1];
+                var ids = [1],
+                    expectedValue = [
+                        {
+                            id_field_name: 'entity_id',
+                            entity_id: '1'
+                        }
+                    ];
 
                 model = new DataStorage({
                     dataScope: 'magento',
@@ -110,7 +88,7 @@ define([
                     }
                 });
 
-                expect(typeof model.getByIds(ids)).toEqual('object');
+                expect(model.getByIds(ids)).toEqual(expectedValue);
             });
 
         });
@@ -121,25 +99,15 @@ define([
                 dataScope: 'magento'
             });
 
-            it('check for defined', function () {
-                expect(model.hasOwnProperty('getIds')).toBeDefined();
-            });
-
-            it('check method type', function () {
-                expect(typeof model.getIds).toEqual('function');
-            });
-
-            it('check returned value if method called with argument', function () {
-                var ids = [1,2,3];
-
-                expect(model.getIds(ids)).toBeDefined();
-            });
-
-            it('check returned type if method called with argument', function () {
-                var ids = [1,2,3],
-                    type = typeof model.getIds(ids);
-
-                expect(type).toEqual('object');
+            it('check array of entity_id will return', function () {
+                var ids = [
+                    {
+                        id_field_name: 'entity_id',
+                        entity_id: '1'
+                    }
+                ],
+                expectedValue = ['1'];
+                expect(model.getIds(ids)).toEqual(expectedValue);
             });
 
         });
@@ -148,28 +116,6 @@ define([
 
             var model = new DataStorage({
                 dataScope: 'magento'
-            });
-
-            it('check for defined', function () {
-                expect(model.hasOwnProperty('getData')).toBeDefined();
-            });
-
-            it('check method type', function () {
-                expect(typeof model.getData).toEqual('function');
-            });
-
-            it('check returned value if method called with argument', function () {
-                var params = {
-                    namespace: 'magento',
-                    search: '',
-                    filters: {
-                        store_id: 0
-                    },
-                    sorting: {},
-                    paging: {}
-                };
-
-                expect(model.getData(params)).toBeDefined();
             });
 
             it('check returned type if method called with argument', function () {
@@ -332,16 +278,6 @@ define([
                 }
             });
 
-            it('Check for defined ', function () {
-                expect(model.hasOwnProperty('updateData')).toBeDefined();
-            });
-
-            it('Check method type', function () {
-                var type = typeof model.updateData;
-
-                expect(type).toEqual('function');
-            });
-
             it('Check updateData has been called', function () {
                 var data = [{
                     id_field_name: 'entity_id',
@@ -355,16 +291,6 @@ define([
         describe('"requestData" method', function () {
             var model = new DataStorage({
                 dataScope: 'magento'
-            });
-
-            it('Check for defined', function () {
-                expect(model.hasOwnProperty('requestData')).toBeDefined();
-            });
-
-            it('Check method type', function () {
-                var type = typeof model.requestData;
-
-                expect(type).toEqual('function');
             });
 
             it('Check Ajax request', function () {
@@ -401,16 +327,6 @@ define([
                 dataScope: 'magento'
             });
 
-            it('Check for defined', function () {
-                expect(model.hasOwnProperty('getRequest')).toBeDefined();
-            });
-
-            it('Check method', function () {
-                var type = typeof model.getRequest;
-
-                expect(type).toEqual('function');
-            });
-
             it('check "getRequest" has been executed', function () {
                 var params = {
                     namespace: 'magento',
@@ -432,16 +348,6 @@ define([
         describe('"getRequestData" method', function () {
             var model = new DataStorage({
                 dataScope: 'magento'
-            });
-
-            it('Check for defined ', function () {
-                expect(model.hasOwnProperty('getRequestData')).toBeDefined();
-            });
-
-            it('Check method type', function () {
-                var type = typeof model.getRequestData;
-
-                expect(type).toEqual('function');
             });
 
             it('check "getRequestData" has been executed', function () {
@@ -493,16 +399,6 @@ define([
         describe('"cacheRequest" method', function () {
             var model = new DataStorage({
                 dataScope: 'magento'
-            });
-
-            it('Check for defined ', function () {
-                expect(model.hasOwnProperty('cacheRequest')).toBeDefined();
-            });
-
-            it('Check method type', function () {
-                var type = typeof model.cacheRequest;
-
-                expect(type).toEqual('function');
             });
 
             it('check "model._requests"', function () {
@@ -559,16 +455,6 @@ define([
                 dataScope: 'magento'
             });
 
-            it('Check for defined ', function () {
-                expect(model.hasOwnProperty('clearRequests')).toBeDefined();
-            });
-
-            it('Check method type', function () {
-                var type = typeof model.clearRequests;
-
-                expect(type).toEqual('function');
-            });
-
             it('check "clearRequests" will empty _requests array', function () {
                 var params = {
                     namespace: 'magento',
@@ -600,16 +486,6 @@ define([
                 dataScope: 'magento'
             });
 
-            it('Check for defined ', function () {
-                expect(model.hasOwnProperty('removeRequest')).toBeDefined();
-            });
-
-            it('Check method type', function () {
-                var type = typeof model.removeRequest;
-
-                expect(type).toEqual('function');
-            });
-
             it('check "removeRequest" is defined', function () {
                 var params = {
                     namespace: 'magento',
@@ -634,16 +510,6 @@ define([
                 dataScope: 'magento'
             });
 
-            it('Check for defined ', function () {
-                expect(model.hasOwnProperty('wasRequested')).toBeDefined();
-            });
-
-            it('Check method type', function () {
-                var type = typeof model.wasRequested;
-
-                expect(type).toEqual('function');
-            });
-
             it('Return false if getRequest method returns false', function () {
                 var params = {
                     namespace: 'magento',
@@ -662,16 +528,6 @@ define([
         describe('"onRequestComplete" method', function () {
             var model = new DataStorage({
                 dataScope: 'magento'
-            });
-
-            it('Check for defined ', function () {
-                expect(model.hasOwnProperty('onRequestComplete')).toBeDefined();
-            });
-
-            it('Check method type', function () {
-                var type = typeof model.onRequestComplete;
-
-                expect(type).toEqual('function');
             });
 
             it('Check "updateData" method has been called', function () {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR is part of the ASI issue in which error message is not cached when user try to apply filter
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#863: Message disappear when the request with broken credentials is sent second time

### Manual testing scenarios (*)
Please check https://github.com/magento/adobe-stock-integration/pull/884

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
