### PR TITLE
Add functionality to show parent product

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Button/ShowParent.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Edit/Button/ShowParent.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Catalog\Block\Adminhtml\Product\Edit\Button;
+
+use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable;
+use Magento\Framework\Registry;
+use Magento\Framework\View\Element\UiComponent\Context;
+
+/**
+ * Class ShowParent
+ */
+class ShowParent extends Generic
+{
+    /**
+     * @var Configurable
+     */
+    private $configurableProductType;
+
+    /**
+     * ShowParent constructor.
+     * @param Context $context
+     * @param Registry $registry
+     * @param Configurable $configurableProductType
+     */
+    public function __construct(
+        Context $context,
+        Registry $registry,
+        Configurable $configurableProductType
+    ) {
+        parent::__construct($context, $registry);
+        $this->configurableProductType = $configurableProductType;
+    }
+
+    /**
+     * Get Button Data
+     *
+     * @return array
+     */
+    public function getButtonData()
+    {
+        $product = $this->getProduct();
+        $configurableProduct = $this->configurableProductType->getParentIdsByChild($product->getId());
+
+        if (isset($configurableProduct[0]) && !empty($configurableProduct[0])) {
+            return [
+                'label' => __('Show Parent'),
+                'sort_order' => 10,
+                'on_click' => sprintf("location.href = '%s';", $this->getParentUrl($configurableProduct[0]))
+            ];
+        }
+    }
+
+    /**
+     * Get URL for parent product
+     *
+     * @param $id
+     * @return string
+     */
+    public function getParentUrl($id)
+    {
+        return $this->getUrl(
+            'catalog/product/edit',
+            ['id' => $id]
+        );
+    }
+}

--- a/app/code/Magento/Catalog/i18n/en_US.csv
+++ b/app/code/Magento/Catalog/i18n/en_US.csv
@@ -815,4 +815,4 @@ Details,Details
 "Are you sure you want to delete this category?","Are you sure you want to delete this category?"
 "Attribute Set Information","Attribute Set Information"
 "Failed to retrieve product links for ""%1""","Failed to retrieve product links for ""%1"""
-
+"Show Parent","Show Parent"

--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/product_form.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/product_form.xml
@@ -19,6 +19,7 @@
         <buttons>
             <button name="save" class="Magento\Catalog\Block\Adminhtml\Product\Edit\Button\Save"/>
             <button name="addAttribute" class="Magento\Catalog\Block\Adminhtml\Product\Edit\Button\AddAttribute"/>
+            <button name="showParent" class="Magento\Catalog\Block\Adminhtml\Product\Edit\Button\ShowParent"/>
             <button name="back" class="Magento\Catalog\Block\Adminhtml\Product\Edit\Button\Back"/>
         </buttons>
         <deps>


### PR DESCRIPTION
### Description (*)
This Pull Request contains the code allowing the admin user to go back to the parent product after he opens a simple one.

<img width="1792" alt="Screenshot 2020-01-24 12 04 37" src="https://user-images.githubusercontent.com/24477165/73088658-add0fc80-3ea2-11ea-9517-3e789cca8b4b.png">


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [-] All new or changed code is covered with unit/integration tests (if applicable)
 - [-] All automated tests passed successfully (all builds are green)
