### PR TITLE
[Fedex] covered Model/Source/Generic.php by unit test

### DIFF
--- a/app/code/Magento/Fedex/Model/Source/Generic.php
+++ b/app/code/Magento/Fedex/Model/Source/Generic.php
@@ -1,16 +1,17 @@
 <?php
+
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 
- /**
-  * Fedex generic source implementation
-  *
-  * @author Magento Core Team <core@magentocommerce.com>
-  */
 namespace Magento\Fedex\Model\Source;
 
+/**
+ * Fedex generic source implementation
+ *
+ * @author Magento Core Team <core@magentocommerce.com>
+ */
 class Generic implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**

--- a/app/code/Magento/Fedex/Model/Source/Generic.php
+++ b/app/code/Magento/Fedex/Model/Source/Generic.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Fedex\Model\Source;
 
-class Generic implements \Magento\Framework\Option\ArrayInterface
+class Generic implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var \Magento\Fedex\Model\Carrier
@@ -36,9 +36,12 @@ class Generic implements \Magento\Framework\Option\ArrayInterface
     {
         $configData = $this->_shippingFedex->getCode($this->_code);
         $arr = [];
-        foreach ($configData as $code => $title) {
-            $arr[] = ['value' => $code, 'label' => $title];
+        if($configData) {
+            foreach ($configData as $code => $title) {
+                $arr[] = ['value' => $code, 'label' => $title];
+            }
         }
+
         return $arr;
     }
 }

--- a/app/code/Magento/Fedex/Model/Source/Generic.php
+++ b/app/code/Magento/Fedex/Model/Source/Generic.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
@@ -9,8 +8,6 @@ namespace Magento\Fedex\Model\Source;
 
 /**
  * Fedex generic source implementation
- *
- * @author Magento Core Team <core@magentocommerce.com>
  */
 class Generic implements \Magento\Framework\Data\OptionSourceInterface
 {
@@ -44,9 +41,14 @@ class Generic implements \Magento\Framework\Data\OptionSourceInterface
         $configData = $this->_shippingFedex->getCode($this->_code);
         $arr = [];
         if ($configData) {
-            foreach ($configData as $code => $title) {
-                $arr[] = ['value' => $code, 'label' => $title];
-            }
+            $arr = array_map(
+                function ($code, $title) {
+                    return [
+                        'value' => $code,
+                        'label' => $title
+                    ];
+                }, array_keys($configData), $configData
+            );
         }
 
         return $arr;

--- a/app/code/Magento/Fedex/Model/Source/Generic.php
+++ b/app/code/Magento/Fedex/Model/Source/Generic.php
@@ -47,7 +47,9 @@ class Generic implements \Magento\Framework\Data\OptionSourceInterface
                         'value' => $code,
                         'label' => $title
                     ];
-                }, array_keys($configData), $configData
+                },
+                array_keys($configData),
+                $configData
             );
         }
 

--- a/app/code/Magento/Fedex/Model/Source/Generic.php
+++ b/app/code/Magento/Fedex/Model/Source/Generic.php
@@ -3,6 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+ /**
+  * Fedex generic source implementation
+  *
+  * @author Magento Core Team <core@magentocommerce.com>
+  */
 namespace Magento\Fedex\Model\Source;
 
 class Generic implements \Magento\Framework\Data\OptionSourceInterface
@@ -36,7 +42,7 @@ class Generic implements \Magento\Framework\Data\OptionSourceInterface
     {
         $configData = $this->_shippingFedex->getCode($this->_code);
         $arr = [];
-        if($configData) {
+        if ($configData) {
             foreach ($configData as $code => $title) {
                 $arr[] = ['value' => $code, 'label' => $title];
             }

--- a/app/code/Magento/Fedex/Test/Unit/Model/Source/GenericTest.php
+++ b/app/code/Magento/Fedex/Test/Unit/Model/Source/GenericTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Fedex\Test\Unit\Model\Source;
+
+use Magento\Fedex\Model\Source\Generic;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Magento\Fedex\Model\Carrier;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+
+/**
+ * Unit test for Magento\Fedex\Test\Unit\Model\Source\Generic
+ */
+class GenericTest extends TestCase
+{
+    /**
+     * @var Generic
+     */
+    private $model;
+
+    /**
+     * @var Carrier|MockObject
+     */
+    private $shippingFedexMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->shippingFedexMock = $this->createMock(Carrier::class);
+
+        $objectManager = new ObjectManagerHelper($this);
+        $this->model = $objectManager->getObject(
+            Generic::class,
+            [
+                'shippingFedex' => $this->shippingFedexMock
+            ]
+        );
+    }
+
+    /**
+     * Test toOptionArray
+     *
+     * @param string $code
+     * @param array|false $methods
+     * @param array $result
+     * @return void
+     * @dataProvider toOptionArrayDataProvider
+     */
+    public function testToOptionArray($code, $methods, $result): void
+    {
+        $this->model->code = $code;
+        $this->shippingFedexMock->expects($this->once())
+            ->method('getCode')
+            ->willReturn($methods);
+
+        $this->assertEquals($result, $this->model->toOptionArray());
+    }
+    
+    /**
+     * Data provider for testToOptionArray()
+     *
+     * @return array
+     */
+    public function toOptionArrayDataProvider(): array
+    {
+        return [
+            [
+                'method',
+                [
+                    'FEDEX_GROUND' => __('Ground'),
+                    'FIRST_OVERNIGHT' => __('First Overnight')
+                ],
+                [
+                    ['value' => 'FEDEX_GROUND', 'label' => __('Ground')],
+                    ['value' => 'FIRST_OVERNIGHT', 'label' => __('First Overnight')]
+                ]
+            ],
+            [
+                '',
+                false,
+                []
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
### Description (*)
[Fedex] covered Generic.php by unit test & changed the deprecated class `Option\ArrayInterface` into `Data\OptionSourceInterface`
Path: app/code/Magento/Fedex/Model/Source/Generic.php

### Manual testing scenarios (*)
`vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/Fedex/Test/Unit/Model/Source/GenericTest.php`

### Questions or comments
If any please let me know your feedback

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
