### PR TITLE
Fixed  #26370 Add to cart (configurable)

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
@@ -223,14 +223,21 @@ switch ($type = $block->getType()) {
                                             <?php if ($showCart):?>
                                                 <div class="actions-primary">
                                                     <?php if ($_item->isSaleable()):?>
+                                                        <?php $postDataHelper =
+                                                            $this->helper
+                                                            (Magento\Framework\Data\Helper\PostHelper::class);
+                                                        $postData =
+                                                            $postDataHelper->getPostData($block->escapeUrl
+                                                            ($block->getAddToCartUrl($_item)),
+                                                                ['product' => $_item->getEntityId()])
+                                                        ?>
                                                         <?php if ($_item->getTypeInstance()->hasRequiredOptions($_item)):?>
-                                                            <button class="action tocart primary" data-mage-init='{"redirectUrl": {"url": "<?= $block->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}' type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                             <button class="action tocart primary"
+                                                                    data-post='<?= /* @noEscape */ $postData ?>'
+                                                                    type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
                                                                 <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
                                                             </button>
                                                         <?php else:?>
-                                                            <?php $postDataHelper = $this->helper(Magento\Framework\Data\Helper\PostHelper::class);
-                                                            $postData = $postDataHelper->getPostData($block->escapeUrl($block->getAddToCartUrl($_item)), ['product' => $_item->getEntityId()])
-                                                            ?>
                                                             <button class="action tocart primary"
                                                                     data-post='<?= /* @noEscape */ $postData ?>'
                                                                     type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">


### PR DESCRIPTION
Fixed  #26370 Add to cart (configurable)

### Preconditions (*)
1. Magento 2.3.3

### Steps to reproduce (*)
1. Set product attribute color to "Used in Product Listing: Yes"
2. Add an simple product
3. Add a configurable product with only color as option
4. Add some configurations to the configurable product
5. Add the configurable product as crossselling product to the simple product
6. Add the simple product to cart in frontend
7. Goto cart
8. Try to add the crossselling product (configurable) to add with the "Add to Cart" button

### Expected result (*)
1. The product detail page should be shown, because the product is a configurable product and needs a color to be choosen.

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. A 404 (Page not found) Exception is thrown because magento tries to add the product to the cart

Screenshots
![to-cart](https://user-images.githubusercontent.com/2369089/72255505-3334f100-3607-11ea-8f0e-9eb733efd044.jpg)


Reason:
In Magento\Catalog\Block\Product\AbstractProduct->getAddToCartUrl() the call $product->getTypeInstance()->isPossibleBuyFromList($product) for type configurable returns true if only attributes with flag "Used in Product Listing" are set as options.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
