### PR TITLE
GH-26597: Also calculate tax discount compensation amount when prices are configured excl. tax

### DIFF
--- a/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
@@ -155,6 +155,7 @@ abstract class AbstractAggregateCalculator extends AbstractCalculator
         $rowTax = array_sum($rowTaxes);
         $rowTaxBeforeDiscount = array_sum($rowTaxesBeforeDiscount);
         $rowTotalInclTax = $rowTotal + $rowTaxBeforeDiscount;
+        $discountTaxCompensationAmount = $rowTaxBeforeDiscount - $rowTax;
         $priceInclTax = $rowTotalInclTax / $quantity;
 
         if ($round) {


### PR DESCRIPTION
This is a fix for the issue raised here: https://github.com/magento/magento2/issues/26597

See: \Magento\Tax\Model\Calculation\AbstractAggregateCalculator::calculateWithTaxInPrice and notice that in this scenario, the calculator does the correct thing for computing compensation value:
```$discountTaxCompensationAmount = $rowTax - $rowTaxAfterDiscount;```

Meanwhile in: \Magento\Tax\Model\Calculation\AbstractAggregateCalculator::calculateWithTaxNotInPrice the calculation is missing. Tax discount compensation should be calculated regardless of whether catalog prices were provided incl vs excl tax.