### PR TITLE
#26610 Fix failing CI due to invalid variable handler

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminAddingNewOptionsWithImagesAndPricesToConfigurableProductTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminAddingNewOptionsWithImagesAndPricesToConfigurableProductTest.xml
@@ -32,7 +32,7 @@
             <amOnPage url="{{AdminProductIndexPage.url}}" stepKey="navigateToProductIndex"/>
             <actionGroup ref="AdminClearFiltersActionGroup" stepKey="clearProductFilters"/>
             <actionGroup ref="DeleteProductActionGroup" stepKey="deleteProduct1">
-                <argument name="productName" value="$$createConfigProductAttributeCreateConfigurableProduct.name$$"/>
+                <argument name="productName" value="$$createConfigProductCreateConfigurableProduct.name$$"/>
             </actionGroup>
             <actionGroup ref="logout" stepKey="logout"/>
         </after>


### PR DESCRIPTION
### Description (*)
Filtering by Product Name was impossible due to the use of a non-existing variable that threw warning to console output during running test. Unfortunately - the warning was ignored and the whole test was passing by coincidence (no other test running simultaneously).

### Related Pull Requests
N/A
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. magento/magento2#26610

### Manual testing scenarios (*)
1. Modify README.md file
2. Submit PR to Github

### Questions or comments
:man_facepalming: 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
