### PR TITLE
Set of fixes introduced during #CoreReview 31.01.2020

### DIFF
--- a/app/code/Magento/CatalogWidget/Block/Product/ProductsList.php
+++ b/app/code/Magento/CatalogWidget/Block/Product/ProductsList.php
@@ -8,6 +8,7 @@ namespace Magento\CatalogWidget\Block\Product;
 
 use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Catalog\Block\Product\AbstractProduct;
+use Magento\Catalog\Block\Product\Context;
 use Magento\Catalog\Block\Product\Widget\Html\Pager;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Visibility;
@@ -16,7 +17,7 @@ use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Catalog\Pricing\Price\FinalPrice;
 use Magento\CatalogWidget\Model\Rule;
 use Magento\Framework\App\ActionInterface;
-use Magento\Framework\App\Http\Context;
+use Magento\Framework\App\Http\Context as HttpContext;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Exception\LocalizedException;
@@ -27,7 +28,7 @@ use Magento\Framework\Url\EncoderInterface;
 use Magento\Framework\View\LayoutFactory;
 use Magento\Framework\View\LayoutInterface;
 use Magento\Rule\Model\Condition\Combine;
-use Magento\Rule\Model\Condition\Sql\Builder;
+use Magento\Rule\Model\Condition\Sql\Builder as SqlBuilder;
 use Magento\Widget\Block\BlockInterface;
 use Magento\Widget\Helper\Conditions;
 
@@ -69,7 +70,7 @@ class ProductsList extends AbstractProduct implements BlockInterface, IdentityIn
     protected $pager;
 
     /**
-     * @var Context
+     * @var HttpContext
      */
     protected $httpContext;
 
@@ -88,7 +89,7 @@ class ProductsList extends AbstractProduct implements BlockInterface, IdentityIn
     protected $productCollectionFactory;
 
     /**
-     * @var Builder
+     * @var SqlBuilder
      */
     protected $sqlBuilder;
 
@@ -135,34 +136,34 @@ class ProductsList extends AbstractProduct implements BlockInterface, IdentityIn
     private $categoryRepository;
 
     /**
-     * @param \Magento\Catalog\Block\Product\Context $context
+     * @param Context $context
      * @param CollectionFactory $productCollectionFactory
      * @param Visibility $catalogProductVisibility
-     * @param Context $httpContext
-     * @param Builder $sqlBuilder
+     * @param HttpContext $httpContext
+     * @param SqlBuilder $sqlBuilder
      * @param Rule $rule
      * @param Conditions $conditionsHelper
-     * @param CategoryRepositoryInterface $categoryRepository
      * @param array $data
      * @param Json|null $json
      * @param LayoutFactory|null $layoutFactory
      * @param EncoderInterface|null $urlEncoder
+     * @param CategoryRepositoryInterface|null $categoryRepository
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
-        \Magento\Catalog\Block\Product\Context $context,
+        Context $context,
         CollectionFactory $productCollectionFactory,
         Visibility $catalogProductVisibility,
-        Context $httpContext,
-        Builder $sqlBuilder,
+        HttpContext $httpContext,
+        SqlBuilder $sqlBuilder,
         Rule $rule,
         Conditions $conditionsHelper,
-        CategoryRepositoryInterface $categoryRepository,
         array $data = [],
         Json $json = null,
         LayoutFactory $layoutFactory = null,
-        EncoderInterface $urlEncoder = null
+        EncoderInterface $urlEncoder = null,
+        CategoryRepositoryInterface $categoryRepository = null
     ) {
         $this->productCollectionFactory = $productCollectionFactory;
         $this->catalogProductVisibility = $catalogProductVisibility;
@@ -173,7 +174,8 @@ class ProductsList extends AbstractProduct implements BlockInterface, IdentityIn
         $this->json = $json ?: ObjectManager::getInstance()->get(Json::class);
         $this->layoutFactory = $layoutFactory ?: ObjectManager::getInstance()->get(LayoutFactory::class);
         $this->urlEncoder = $urlEncoder ?: ObjectManager::getInstance()->get(EncoderInterface::class);
-        $this->categoryRepository = $categoryRepository;
+        $this->categoryRepository = $categoryRepository ?? ObjectManager::getInstance()
+                ->get(CategoryRepositoryInterface::class);
         parent::__construct(
             $context,
             $data

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Category/Delete/DeleteCategoryWithEnabledFlatTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Category/Delete/DeleteCategoryWithEnabledFlatTest.php
@@ -24,6 +24,8 @@ use Magento\TestFramework\TestCase\AbstractBackendController;
  */
 class DeleteCategoryWithEnabledFlatTest extends AbstractBackendController
 {
+    const STUB_CATEGORY_ID = 333;
+
     /**
      * @var IndexerRegistry
      */
@@ -79,13 +81,16 @@ class DeleteCategoryWithEnabledFlatTest extends AbstractBackendController
      */
     public function testDeleteCategory(): void
     {
-        $this->assertEquals(1, $this->getFlatCategoryCollectionSizeByCategoryId(333));
-        $this->getRequest()->setMethod(HttpRequest::METHOD_POST);
-        $this->getRequest()->setPostValue(['id' => 333]);
-        $this->dispatch('backend/catalog/category/delete');
+        // Given
+        $this->assertEquals(1, $this->getFlatCategoryCollectionSizeByCategoryId(self::STUB_CATEGORY_ID));
+
+        // When
+        $this->sendDeleteCategoryRequest(self::STUB_CATEGORY_ID);
+
+        // Then
         $this->assertSessionMessages($this->equalTo([(string)__('You deleted the category.')]));
-        $this->assertEquals(0, $this->getFlatCategoryCollectionSizeByCategoryId(333));
-        $this->checkCategoryIsDeleted(333);
+        $this->assertEquals(0, $this->getFlatCategoryCollectionSizeByCategoryId(self::STUB_CATEGORY_ID));
+        $this->checkCategoryIsDeleted(self::STUB_CATEGORY_ID);
     }
 
     /**
@@ -106,10 +111,26 @@ class DeleteCategoryWithEnabledFlatTest extends AbstractBackendController
      * Assert that category is deleted.
      *
      * @param int $categoryId
+     * @return void
      */
     private function checkCategoryIsDeleted(int $categoryId): void
     {
-        $this->expectExceptionObject(new NoSuchEntityException(__("No such entity with id = {$categoryId}")));
+        $this->expectExceptionObject(
+            new NoSuchEntityException(__("No such entity with id = %entityId", ['entityId' => $categoryId]))
+        );
         $this->categoryRepository->get($categoryId);
+    }
+
+    /**
+     * Method passes the request to Backend to remove given category.
+     *
+     * @param int $categoryId
+     * @return void
+     */
+    private function sendDeleteCategoryRequest(int $categoryId): void
+    {
+        $this->getRequest()->setMethod(HttpRequest::METHOD_POST);
+        $this->getRequest()->setPostValue(['id' => $categoryId]);
+        $this->dispatch('backend/catalog/category/delete');
     }
 }


### PR DESCRIPTION
### Description (*)
This PR fixes introduced backward incompatible changes in following commit (`CategoryRepositoryInterface` dependency was added in the middle of constructor arguments):
https://github.com/magento/magento2/commit/5e12e57e99a8adf2c042d5cc81e85dca3a29757a#diff-28c7c49b28292e55b8349293d02f8499R145


Changes covered and explained during #CoreReview 
https://youtu.be/076Y_EAVD8c


### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
