### PR TITLE
#26622 - Check quote item for parentItem instead of parentItemId

### DIFF
--- a/app/code/Magento/SalesRule/Model/Validator.php
+++ b/app/code/Magento/SalesRule/Model/Validator.php
@@ -383,13 +383,7 @@ class Validator extends \Magento\Framework\Model\AbstractModel
 
                 foreach ($items as $item) {
                     //Skipping child items to avoid double calculations
-                    if ($item->getParentItemId() || $item->getParentItem()) {
-                        continue;
-                    }
-                    if (!$rule->getActions()->validate($item)) {
-                        continue;
-                    }
-                    if (!$this->canApplyDiscount($item)) {
+                    if (!$this->isValidItemForRule($item, $rule)) {
                         continue;
                     }
                     $qty = $this->validatorUtility->getItemQty($item, $rule);
@@ -407,6 +401,32 @@ class Validator extends \Magento\Framework\Model\AbstractModel
         }
 
         return $this;
+    }
+
+    /**
+     * Determine if quote item is valid for a given sales rule
+     * @param AbstractItem $item
+     * @param Rule $rule
+     * @return bool
+     */
+    protected function isValidItemForRule(
+        AbstractItem $item,
+        Rule $rule
+    ) {
+        /** @var AbstractItem $item */
+        if ($item->getParentItemId()) {
+            return false;
+        }
+        if ($item->getParentItem()) {
+            return false;
+        }
+        if (!$rule->getActions()->validate($item)) {
+            return false;
+        }
+        if (!$this->canApplyDiscount($item)) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/app/code/Magento/SalesRule/Model/Validator.php
+++ b/app/code/Magento/SalesRule/Model/Validator.php
@@ -405,6 +405,7 @@ class Validator extends \Magento\Framework\Model\AbstractModel
 
     /**
      * Determine if quote item is valid for a given sales rule
+     *
      * @param AbstractItem $item
      * @param Rule $rule
      * @return bool

--- a/app/code/Magento/SalesRule/Model/Validator.php
+++ b/app/code/Magento/SalesRule/Model/Validator.php
@@ -383,7 +383,7 @@ class Validator extends \Magento\Framework\Model\AbstractModel
 
                 foreach ($items as $item) {
                     //Skipping child items to avoid double calculations
-                    if ($item->getParentItem()) {
+                    if ($item->getParentItemId() || $item->getParentItem()) {
                         continue;
                     }
                     if (!$rule->getActions()->validate($item)) {

--- a/app/code/Magento/SalesRule/Model/Validator.php
+++ b/app/code/Magento/SalesRule/Model/Validator.php
@@ -383,7 +383,7 @@ class Validator extends \Magento\Framework\Model\AbstractModel
 
                 foreach ($items as $item) {
                     //Skipping child items to avoid double calculations
-                    if ($item->getParentItemId()) {
+                    if ($item->getParentItem()) {
                         continue;
                     }
                     if (!$rule->getActions()->validate($item)) {

--- a/app/code/Magento/SalesRule/Model/Validator.php
+++ b/app/code/Magento/SalesRule/Model/Validator.php
@@ -410,11 +410,8 @@ class Validator extends \Magento\Framework\Model\AbstractModel
      * @param Rule $rule
      * @return bool
      */
-    protected function isValidItemForRule(
-        AbstractItem $item,
-        Rule $rule
-    ) {
-        /** @var AbstractItem $item */
+    private function isValidItemForRule(AbstractItem $item, Rule $rule)
+    {
         if ($item->getParentItemId()) {
             return false;
         }

--- a/app/code/Magento/SalesRule/Test/Unit/Model/ValidatorTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/ValidatorTest.php
@@ -346,11 +346,14 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
                 'getDiscountCalculationPrice',
                 'getBaseDiscountCalculationPrice',
                 'getCalculationPrice',
-                'getParentItemId'
+                'getParentItemId',
+                'getParentItem'
             ]
         );
         $item2 = clone $item1;
-        $items = [$item1, $item2];
+        $item3 = clone $item1;
+        $item4 = clone $item1;
+        $items = [$item1, $item2, $item3, $item4];
 
         $rule->expects($this->any())
             ->method('getSimpleAction')
@@ -368,11 +371,21 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         $validator->expects($this->at(1))->method('isValid')->with($item2)->willReturn(true);
 
         $item1->expects($this->any())->method('getParentItemId')->willReturn(false);
+        $item1->expects($this->any())->method('getParentItem')->willReturn(false);
         $item1->expects($this->never())->method('getDiscountCalculationPrice');
         $item1->expects($this->never())->method('getBaseDiscountCalculationPrice');
         $item2->expects($this->any())->method('getParentItemId')->willReturn(false);
+        $item2->expects($this->any())->method('getParentItem')->willReturn(false);
         $item2->expects($this->any())->method('getDiscountCalculationPrice')->willReturn(50);
         $item2->expects($this->once())->method('getBaseDiscountCalculationPrice')->willReturn(50);
+        $item3->expects($this->any())->method('getParentItemId')->willReturn(false);
+        $item3->expects($this->any())->method('getParentItem')->willReturn(true);
+        $item3->expects($this->never())->method('getDiscountCalculationPrice');
+        $item3->expects($this->never())->method('getBaseDiscountCalculationPrice');
+        $item4->expects($this->any())->method('getParentItemId')->willReturn(true);
+        $item4->expects($this->any())->method('getParentItem')->willReturn(false);
+        $item4->expects($this->never())->method('getDiscountCalculationPrice');
+        $item4->expects($this->never())->method('getBaseDiscountCalculationPrice');
         $this->utility->expects($this->once())->method('getItemQty')->willReturn(1);
         $this->utility->expects($this->any())->method('canProcessRule')->willReturn(true);
 

--- a/app/code/Magento/SalesRule/Test/Unit/Model/ValidatorTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/ValidatorTest.php
@@ -13,7 +13,7 @@ use Magento\Store\Model\Store;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
- * Class ValidatorTest
+ * Tests for Magento\SalesRule\Model\Validator
  * @@SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ValidatorTest extends \PHPUnit\Framework\TestCase

--- a/app/code/Magento/SalesRule/Test/Unit/Model/ValidatorTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/ValidatorTest.php
@@ -370,20 +370,20 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
         $validator->expects($this->at(0))->method('isValid')->with($item1)->willReturn(false);
         $validator->expects($this->at(1))->method('isValid')->with($item2)->willReturn(true);
 
-        $item1->expects($this->any())->method('getParentItemId')->willReturn(false);
-        $item1->expects($this->any())->method('getParentItem')->willReturn(false);
+        $item1->expects($this->any())->method('getParentItemId')->willReturn(null);
+        $item1->expects($this->any())->method('getParentItem')->willReturn(null);
         $item1->expects($this->never())->method('getDiscountCalculationPrice');
         $item1->expects($this->never())->method('getBaseDiscountCalculationPrice');
-        $item2->expects($this->any())->method('getParentItemId')->willReturn(false);
-        $item2->expects($this->any())->method('getParentItem')->willReturn(false);
+        $item2->expects($this->any())->method('getParentItemId')->willReturn(null);
+        $item2->expects($this->any())->method('getParentItem')->willReturn(null);
         $item2->expects($this->any())->method('getDiscountCalculationPrice')->willReturn(50);
         $item2->expects($this->once())->method('getBaseDiscountCalculationPrice')->willReturn(50);
-        $item3->expects($this->any())->method('getParentItemId')->willReturn(false);
-        $item3->expects($this->any())->method('getParentItem')->willReturn(true);
+        $item3->expects($this->any())->method('getParentItemId')->willReturn(null);
+        $item3->expects($this->any())->method('getParentItem')->willReturn($item1);
         $item3->expects($this->never())->method('getDiscountCalculationPrice');
         $item3->expects($this->never())->method('getBaseDiscountCalculationPrice');
-        $item4->expects($this->any())->method('getParentItemId')->willReturn(true);
-        $item4->expects($this->any())->method('getParentItem')->willReturn(false);
+        $item4->expects($this->any())->method('getParentItemId')->willReturn(12345);
+        $item4->expects($this->any())->method('getParentItem')->willReturn(null);
         $item4->expects($this->never())->method('getDiscountCalculationPrice');
         $item4->expects($this->never())->method('getBaseDiscountCalculationPrice');
         $this->utility->expects($this->once())->method('getItemQty')->willReturn(1);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes issue #26622 - a "fixed amount for whole cart" discount is calculated incorrectly when a configurable product is first added to the cart. This change is to use `getParentItem` instead of `getParentItemId` from the quote item when determining if it should be skipped. This is because `parentItem` is set when the quote item is created, but `parentItemId` is only set in its `beforeSave` function.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#26622: Fixed cart discount calculated incorrectly when product first added to cart

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create fixed amount discount for whole cart of $1 with no conditions/restrictions
2. Navigate to PDP of configurable product
3. Choose configurable product options and add to cart
4. Confirm that discount is correct ($1) in minicart and/or database.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
