### PR TITLE
#26624 Color swatch tooltip arrow position is not proper on the Produ…

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
@@ -258,14 +258,14 @@
                             border-color: @color-gray68 transparent transparent transparent;
                             border-width: 8px 8.5px 0 8.5px;
                             left: 0;
-                            top: 2px;
+                            top: 3px;
                         }
 
                         &:after {
                             border-color: @color-white transparent transparent transparent;
                             border-width: 7px 7.5px 0 7.5px;
                             left: -15px;
-                            top: 1px;
+                            top: 2px;
                         }
                     }
 


### PR DESCRIPTION
Color swatch tooltip arrow position is not proper on the Product detail page

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#26624: Color swatch tooltip arrow position is not proper on the Product detail page

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
