### PR TITLE
invoice not found redirection issue resolved

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/View.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/View.php
@@ -44,9 +44,8 @@ class View extends \Magento\Sales\Controller\Adminhtml\Invoice\AbstractInvoice\V
     {
         $invoice = $this->getInvoice();
         if (!$invoice) {
-            /** @var \Magento\Framework\Controller\Result\Forward $resultForward */
-            $resultForward = $this->resultForwardFactory->create();
-            return $resultForward->forward('noroute');
+             $resultRedirect = $this->resultRedirectFactory->create();
+             return $resultRedirect->setPath('sales/invoice');
         }
 
         /** @var \Magento\Backend\Model\View\Result\Page $resultPage */


### PR DESCRIPTION
if passed wrong invoice id in url on invoice view it shows a 404 page instead of invoice grid->

### Description (*)
if passed wrong invoice id in url on invoice view it shows a 404 page instead of invoice grid

###Preconditions (*)

2.4 Develop

### Manual testing scenarios (*)


    1.Create An Order In Magento
    2.Create Invoice of that Order
   3. View the created invoice
    4.Now change the invoice id from url(use that id which does not exist) and run the url.

### Expected Result  (*)

A proper error message should come without any error

### Actual Result  (*)
A 404 page occurs with error message

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [] All automated tests passed successfully (all builds are green)
