### PR TITLE
Fixed #26513

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Item.php
+++ b/app/code/Magento/Quote/Model/Quote/Item.php
@@ -609,7 +609,7 @@ class Item extends \Magento\Quote\Model\Quote\Item\AbstractItem implements \Mage
     /**
      * Add option to item
      *
-     * @param \Magento\Quote\Model\Quote\Item\Option|\Magento\Framework\DataObject $option
+     * @param \Magento\Quote\Model\Quote\Item\Option|\Magento\Framework\DataObject|array $option
      * @return $this
      * @throws \Magento\Framework\Exception\LocalizedException
      */


### PR DESCRIPTION
Preconditions (*)

    Magento 2.4-develop

The method addOption does indeed allow an array to be passed. The very first piece of logic is

> if (is_array($option)) {
>     $option = $this->_itemOptionFactory->create()->setData($option)->setItem($this);
> }

 Steps to reproduce (*)

    Check addOptionmethod in Magento\Quote\Model\Quote\Item class

Expected result (*)

Array is allowed

> @param \Magento\Quote\Model\Quote\Item\Option|\Magento\Framework\DataObject|array $option

Actual result (*)

However, the @param docblock only states

> @param \Magento\Quote\Model\Quote\Item\Option|\Magento\Framework\DataObject $option


An array type needs to be added at the end in the comment section.