### PR TITLE
Prevent initializing of QuickSearch if search suggestions is disabled

### DIFF
--- a/app/code/Magento/Search/Helper/Data.php
+++ b/app/code/Magento/Search/Helper/Data.php
@@ -102,7 +102,9 @@ class Data extends AbstractHelper
     }
 
     /**
-     * Retrieve result page url and set "secure" param to avoid confirm
+     * Retrieve result page url
+     *
+     * Also, set "secure" param to avoid confirm
      * message when we submit form from secure page to unsecure
      *
      * @param   string $query
@@ -225,6 +227,8 @@ class Data extends AbstractHelper
     }
 
     /**
+     * Get query param name
+     *
      * @return string
      */
     public function getQueryParamName()
@@ -233,6 +237,8 @@ class Data extends AbstractHelper
     }
 
     /**
+     * Check if query exceeds maximum query length
+     *
      * @param string $queryText
      * @param int|string $maxQueryLength
      * @return bool
@@ -256,6 +262,8 @@ class Data extends AbstractHelper
     }
 
     /**
+     * Get shortened query text if it is too long
+     *
      * @param string $queryText
      * @param int|string $maxQueryLength
      * @return string

--- a/app/code/Magento/Search/Helper/Data.php
+++ b/app/code/Magento/Search/Helper/Data.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Search\Helper;
 
+use Magento\AdvancedSearch\Model\SuggestedQueriesInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
@@ -265,5 +266,20 @@ class Data extends AbstractHelper
             $queryText = $this->string->substr($queryText, 0, $maxQueryLength);
         }
         return $queryText;
+    }
+
+    /**
+     * Check if search suggestions is enabled
+     *
+     * @param mixed $store
+     * @return int|string
+     */
+    public function isSuggestionsEnabled($store = null)
+    {
+        return $this->scopeConfig->getValue(
+            SuggestedQueriesInterface::SEARCH_SUGGESTION_ENABLED,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
     }
 }

--- a/app/code/Magento/Search/composer.json
+++ b/app/code/Magento/Search/composer.json
@@ -11,7 +11,8 @@
         "magento/module-catalog-search": "*",
         "magento/module-reports": "*",
         "magento/module-store": "*",
-        "magento/module-ui": "*"
+        "magento/module-ui": "*",
+        "magento/module-advanced-search": "*"
     },
     "type": "magento2-module",
     "license": [

--- a/app/code/Magento/Search/view/frontend/templates/form.mini.phtml
+++ b/app/code/Magento/Search/view/frontend/templates/form.mini.phtml
@@ -21,12 +21,15 @@ $helper = $this->helper(\Magento\Search\Helper\Data::class);
                 </label>
                 <div class="control">
                     <input id="search"
-                           data-mage-init='{"quickSearch":{
-                                "formSelector":"#search_mini_form",
-                                "url":"<?= $block->escapeUrl($helper->getSuggestUrl())?>",
-                                "destinationSelector":"#search_autocomplete",
-                                "minSearchLength":"<?= $block->escapeHtml($helper->getMinQueryLength()) ?>"}
-                           }'
+                           <?php if ($helper->isSuggestionsEnabled()): ?>
+                               data-mage-init='{"quickSearch":{
+                                    "formSelector":"#search_mini_form",
+                                    "url":"<?= $block->escapeUrl($helper->getSuggestUrl())?>",
+                                    "destinationSelector":"#search_autocomplete",
+                                    "minSearchLength":"<?= $block->escapeHtml($helper->getMinQueryLength()) ?>",
+                                    "isEnabled":"<?= $block->escapeJs($helper->isSuggestionsEnabled()) ?>"}
+                               }'
+                           <?php endif; ?>
                            type="text"
                            name="<?= $block->escapeHtmlAttr($helper->getQueryParamName()) ?>"
                            value="<?= $block->escapeHtmlAttr($helper->getEscapedQueryText()) ?>"

--- a/app/code/Magento/Search/view/frontend/templates/form.mini.phtml
+++ b/app/code/Magento/Search/view/frontend/templates/form.mini.phtml
@@ -14,22 +14,23 @@ $helper = $this->helper(\Magento\Search\Helper\Data::class);
 <div class="block block-search">
     <div class="block block-title"><strong><?= $block->escapeHtml(__('Search')) ?></strong></div>
     <div class="block block-content">
-        <form class="form minisearch" id="search_mini_form" action="<?= $block->escapeUrl($helper->getResultUrl()) ?>" method="get">
+        <form class="form minisearch" id="search_mini_form"
+              action="<?= $block->escapeUrl($helper->getResultUrl()) ?>" method="get">
             <div class="field search">
                 <label class="label" for="search" data-role="minisearch-label">
                     <span><?= $block->escapeHtml(__('Search')) ?></span>
                 </label>
                 <div class="control">
                     <input id="search"
-                           <?php if ($helper->isSuggestionsEnabled()): ?>
-                               data-mage-init='{"quickSearch":{
+                            <?php if ($helper->isSuggestionsEnabled()): ?>
+                                data-mage-init='{"quickSearch":{
                                     "formSelector":"#search_mini_form",
                                     "url":"<?= $block->escapeUrl($helper->getSuggestUrl())?>",
                                     "destinationSelector":"#search_autocomplete",
                                     "minSearchLength":"<?= $block->escapeHtml($helper->getMinQueryLength()) ?>",
                                     "isEnabled":"<?= $block->escapeJs($helper->isSuggestionsEnabled()) ?>"}
-                               }'
-                           <?php endif; ?>
+                                }'
+                            <?php endif; ?>
                            type="text"
                            name="<?= $block->escapeHtmlAttr($helper->getQueryParamName()) ?>"
                            value="<?= $block->escapeHtmlAttr($helper->getEscapedQueryText()) ?>"


### PR DESCRIPTION
### Description

If Search Suggestions is disabled in Admin, [QuickSearch jQuery widget](https://devdocs.magento.com/guides/v2.3/javascript-dev-guide/widgets/widget_quickSearch.html#result) is not initialized for the mini search box on the top right so that no unnecessary call is made to retrieve the suggestions

### Fixed Issues
magento/magento2#21372: Admin Search Suggestions Toggle Not Working

### Manual testing scenarios
1. Navigate to the storefront
2. Open network tab
3. Type something in the search field on the top right
4. Verify no call is made to backend to get search suggestions as described in the linked issue

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
