### PR TITLE
Fixed issue in composer install 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         "preferred-install": "dist",
         "sort-packages": true
     },
-    "repositories": {
-        "0": {
+    "repositories": [
+        {
             "type": "git",
             "url": "https://github.com/magento/composer"
         }
-    },
+    ],
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
         "ext-bcmath": "*",

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,12 @@
         "preferred-install": "dist",
         "sort-packages": true
     },
+    "repositories": {
+        "0": {
+            "type": "git",
+            "url": "https://github.com/magento/composer"
+        }
+    },
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
         "ext-bcmath": "*",


### PR DESCRIPTION
**Preconditions (*)**

Magento 2.3.4-develop

**Steps to reproduce (*)**
Clone code from magento 2.4-develop github repository 
https://github.com/magento/magento2
try to run composer install 

**Actual result (*)**
Error showing for PHP extensions are missing 

**Expected result (*)**
no error should be there 


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
