### PR TITLE
Fixed issue 22409

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Associated/AssociatedDataProvider.php
+++ b/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Associated/AssociatedDataProvider.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\ConfigurableProduct\Ui\DataProvider\Product\Associated;
+
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Ui\DataProvider\Modifier\PoolInterface;
+use Magento\Framework\App\RequestInterface;
+use Magento\Store\Api\StoreRepositoryInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Locator\LocatorInterface;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Catalog\Model\ProductFactory;
+use Magento\Store\Api\Data\StoreInterface;
+
+/**
+ * Class AssociatedDataProvider
+ *
+ */
+class AssociatedDataProvider extends \Magento\Catalog\Ui\DataProvider\Product\ProductDataProvider
+{
+
+    /**
+     * @var ProductFactory
+     */
+    private $productFactory;
+
+    /**
+     * @var \Magento\Ui\DataProvider\AddFieldToCollectionInterface[]
+     */
+    protected $addFieldStrategies;
+
+    /**
+     * @var \Magento\Ui\DataProvider\AddFilterToCollectionInterface[]
+     */
+    protected $addFilterStrategies;
+
+    /**
+     * @var StoreInterface
+     */
+    private $store;
+
+    /**
+     * @var Configurable
+     */
+    protected $configurableType;
+
+    /**
+     * @var LocatorInterface
+     */
+    protected $locator;
+
+    /**
+     * @var RequestInterface
+     */
+    protected $request;
+
+    /**
+     * @var StoreRepositoryInterface
+     */
+    private $storeRepository;
+
+
+    /**
+     * AssociatedDataProvider constructor.
+     * @param Configurable $configurableType
+     * @param ProductFactory $productFactory
+     * @param string $name
+     * @param string $primaryFieldName
+     * @param string $requestFieldName
+     * @param CollectionFactory $collectionFactory
+     * @param array $addFieldStrategies
+     * @param array $addFilterStrategies
+     * @param array $meta
+     * @param array $data
+     * @param LocatorInterface $locator
+     * @param PoolInterface|null $modifiersPool
+     * @param StoreRepositoryInterface $storeRepository
+     * @param ProductRepositoryInterface $productRepository
+     * @param RequestInterface $request
+     */
+    public function __construct(
+        Configurable $configurableType,
+        ProductFactory $productFactory,
+        $name,
+        $primaryFieldName,
+        $requestFieldName,
+        CollectionFactory $collectionFactory,
+        array $addFieldStrategies = [],
+        array $addFilterStrategies = [],
+        array $meta = [],
+        array $data = [],
+        LocatorInterface $locator,
+        PoolInterface $modifiersPool = null,
+        StoreRepositoryInterface $storeRepository,
+        ProductRepositoryInterface $productRepository,
+        RequestInterface $request
+    ) {
+        $this->_configurableType = $configurableType;
+        $this->productFactory= $productFactory;
+        $this->locator = $locator;
+        $this->request = $request;
+        $this->storeRepository = $storeRepository;
+        $this->productRepository = $productRepository;
+        parent::__construct($name, $primaryFieldName, $requestFieldName, $collectionFactory, $addFieldStrategies, $addFilterStrategies, $meta, $data);
+    }
+
+    /**
+     * @return Collection|\Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
+     */
+    public function getCollection()
+    {
+        /** @var Collection $collection */
+        $collection = parent::getCollection();
+        $collection->addAttributeToSelect('status');
+
+
+        if ($this->getStore()) {
+            $collection->setStore($this->getStore());
+        }
+
+        $collection->addFieldToFilter(
+            'type_id',
+            ['in' => [
+                \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE,
+                \Magento\Catalog\Model\Product\Type::TYPE_VIRTUAL,
+                \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE
+            ]]
+        );
+
+        $product = $this->_getProduct();
+        foreach ((array)$this->_configurableType->getConfigurableAttributesAsArray($product) as $attribute) {
+            $collection->addAttributeToSelect($attribute['attribute_code']);
+            $collection->addAttributeToFilter($attribute['attribute_code'], array('notnull' => 1));
+        }
+
+        return $collection;
+    }
+
+    /**
+     * Get product
+     *
+     * @return \Magento\Catalog\Model\Product
+     */
+    private function _getProduct()
+    {
+        $product_id = (int) $this->request->getParam('id');
+        return $this->productFactory->create()->load($product_id);
+    }
+
+    /**
+     * Retrieve store
+     *
+     * @return StoreInterface|null
+     * @since 101.0.0
+     */
+    private function getStore()
+    {
+        if (null !== $this->store) {
+            return $this->store;
+        }
+
+        if (!($storeId = $this->request->getParam('current_store_id'))) {
+            return null;
+        }
+
+        return $this->store = $this->storeRepository->getById($storeId);
+    }
+
+}

--- a/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
+++ b/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
@@ -207,7 +207,7 @@ class ConfigurablePanel extends AbstractModifier
                                             . $this->associatedListingPrefix
                                             . static::ASSOCIATED_PRODUCT_LISTING . '.product_columns.ids',
                                         'ns' => $this->associatedListingPrefix . static::ASSOCIATED_PRODUCT_LISTING,
-                                        'render_url' => $this->urlBuilder->getUrl('mui/index/render'),
+                                        'render_url' => $this->urlBuilder->getUrl('mui/index/render', ['id' => $this->locator->getProduct()->getId()]),
                                         'realTimeLink' => true,
                                         'behaviourType' => 'simple',
                                         'externalFilterMode' => false,

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/ui_component/configurable_associated_product_listing.xml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/ui_component/configurable_associated_product_listing.xml
@@ -25,7 +25,7 @@
             <updateUrl path="mui/index/render"/>
         </settings>
         <aclResource>Magento_Catalog::products</aclResource>
-        <dataProvider class="Magento\Catalog\Ui\DataProvider\Product\ProductDataProvider" name="data_source">
+        <dataProvider class="Magento\ConfigurableProduct\Ui\DataProvider\Product\Associated\AssociatedDataProvider" name="data_source">
             <settings>
                 <requestFieldName>id</requestFieldName>
                 <primaryFieldName>entity_id</primaryFieldName>

--- a/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
+++ b/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
@@ -218,6 +218,13 @@ class Grouped extends \Magento\Catalog\Model\Product\Type\AbstractType
                 ['in' => $this->getStatusFilters($product)]
             );
 
+            $collection->getSelect()
+                ->joinInner(
+                    'cataloginventory_stock_item',
+                    'e.entity_id=cataloginventory_stock_item.product_id AND cataloginventory_stock_item.is_in_stock ="1"',
+                    ['is_in_stock']
+                );
+                
             foreach ($collection as $item) {
                 $associatedProducts[] = $item;
             }

--- a/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
+++ b/app/code/Magento/GroupedProduct/Model/Product/Type/Grouped.php
@@ -218,13 +218,6 @@ class Grouped extends \Magento\Catalog\Model\Product\Type\AbstractType
                 ['in' => $this->getStatusFilters($product)]
             );
 
-            $collection->getSelect()
-                ->joinInner(
-                    'cataloginventory_stock_item',
-                    'e.entity_id=cataloginventory_stock_item.product_id AND cataloginventory_stock_item.is_in_stock ="1"',
-                    ['is_in_stock']
-                );
-                
             foreach ($collection as $item) {
                 $associatedProducts[] = $item;
             }


### PR DESCRIPTION
### Description (*)
Configurable products are shown on Select Associated Product modal

### Fixed Issues (if relevant)
Configurable products are shown on Select Associated Product modal

1. magento/magento2#22409: Issue title

### Manual testing scenarios (*)
1.Create a configurable product Test 1 with 2 child products (color = red and color = black for the example)
2. Create a new simple product Test 2 with color = red
3. Open the last created product Test 2 in admin panel and convert it to configurable by adding child products (color = green, color = grey), do not change the value for color attribute while you edit product
4. Open the first configurable product Test 1, remove the child product with color = red, click on 'Add products manually' link in Configurations section


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
