### PR TITLE
issue-#25675 Added fix for #25675 issue to the 2.4 Magento version

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator/QuoteItemQtyList.php
+++ b/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator/QuoteItemQtyList.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\CatalogInventory\Model\Quote\Item\QuantityValidator;
 
+/**
+ * Class QuoteItemQtyList collects qty of quote items
+ */
 class QuoteItemQtyList
 {
     /**
@@ -17,6 +20,7 @@ class QuoteItemQtyList
 
     /**
      * Get product qty includes information from all quote items
+     *
      * Need be used only in singleton mode
      *
      * @param int   $productId
@@ -29,9 +33,7 @@ class QuoteItemQtyList
     public function getQty($productId, $quoteItemId, $quoteId, $itemQty)
     {
         $qty = $itemQty;
-        if (isset(
-            $this->_checkedQuoteItems[$quoteId][$productId]['qty']
-        ) && !in_array(
+        if (isset($this->_checkedQuoteItems[$quoteId][$productId]['qty']) && !in_array(
             $quoteItemId,
             $this->_checkedQuoteItems[$quoteId][$productId]['items']
         )
@@ -39,8 +41,10 @@ class QuoteItemQtyList
             $qty += $this->_checkedQuoteItems[$quoteId][$productId]['qty'];
         }
 
-        $this->_checkedQuoteItems[$quoteId][$productId]['qty'] = $qty;
-        $this->_checkedQuoteItems[$quoteId][$productId]['items'][] = $quoteItemId;
+        if ($quoteItemId !== null) {
+            $this->_checkedQuoteItems[$quoteId][$productId]['qty'] = $qty;
+            $this->_checkedQuoteItems[$quoteId][$productId]['items'][] = $quoteItemId;
+        }
 
         return $qty;
     }

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/Quote/Item/QuantityValidator/QuoteItemQtyListTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/Quote/Item/QuantityValidator/QuoteItemQtyListTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\CatalogInventory\Test\Unit\Model\Quote\Item\QuantityValidator;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use Magento\CatalogInventory\Model\Quote\Item\QuantityValidator\QuoteItemQtyList;
+
+/**
+ * Class QuoteItemQtyListTest
+ */
+class QuoteItemQtyListTest extends TestCase
+{
+    /**
+     * @var QuoteItemQtyList
+     */
+    private $quoteItemQtyList;
+
+    /**
+     * @var int
+     */
+    private $itemQtyTestValue;
+
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $objectManagerHelper = new ObjectManager($this);
+        $this->quoteItemQtyList = $objectManagerHelper->getObject(QuoteItemQtyList::class);
+    }
+
+    /**
+     * This tests the scenario when item has not quote_item_id and after save gets a value.
+     *
+     * @return void
+     */
+    public function testSingleQuoteItemQty()
+    {
+        $this->itemQtyTestValue = 1;
+        $qty = $this->quoteItemQtyList->getQty(125, null, 11232, 1);
+        $this->assertEquals($this->itemQtyTestValue, $qty);
+
+        $qty = $this->quoteItemQtyList->getQty(125, 1, 11232, 1);
+        $this->assertEquals($this->itemQtyTestValue, $qty);
+    }
+
+    /**
+     * This tests the scenario when item has been added twice to the cart.
+     *
+     * @return void
+     */
+    public function testMultipleQuoteItemQty()
+    {
+        $this->itemQtyTestValue = 1;
+        $qty = $this->quoteItemQtyList->getQty(127, 1, 112, 1);
+        $this->assertEquals($this->itemQtyTestValue, $qty);
+
+        $this->itemQtyTestValue = 2;
+        $qty = $this->quoteItemQtyList->getQty(127, 2, 112, 1);
+        $this->assertEquals($this->itemQtyTestValue, $qty);
+    }
+}


### PR DESCRIPTION
Description
This pull request should fix issue #25675 in Magento 2.4

Fixed Issues
#25675: Unable add product to cart in Magento 2.3.3 backend when stock quantity is 1 - "The requested qty is not available"
Manual testing scenarios
Described here #25675