### PR TITLE
Fixed php version issue in transalation

### DIFF
--- a/lib/internal/Magento/Framework/Serialize/Serializer/JsonHexTag.php
+++ b/lib/internal/Magento/Framework/Serialize/Serializer/JsonHexTag.php
@@ -26,7 +26,7 @@ class JsonHexTag extends Json implements SerializerInterface
      */
     public function serialize($data): string
     {
-        $result = json_encode($data, JSON_HEX_TAG);
+        $result = json_encode($data, JSON_INVALID_UTF8_IGNORE);
         if (false === $result) {
             throw new \InvalidArgumentException('Unable to serialize value.');
         }


### PR DESCRIPTION
Fixed php version issue in transalation

**Preconditions (*)**
magento 2.3.3 and above 

**Steps to reproduce (*)**
setup website with multiple language like English and spanish 
and edit product

**Expected result (*)**
product should be able to edit

**Actual result (*)**
error in translation 

**Additional Informations** 
 JSON_HEX_TAG (integer)
    All < and > are converted to \u003C and \u003E. Available as of PHP 5.3.0.
 JSON_INVALID_UTF8_IGNORE (integer)
    Ignore invalid UTF-8 characters. Available as of PHP 7.2.0.

we can refer https://www.php.net/manual/en/json.constants.php

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
