### PR TITLE
[issue-24045] Resolved auto-focus if the invalid field in the collaps…

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/form.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/form.js
@@ -277,7 +277,9 @@ define([
             var invalidField = _.find(this.delegate('checkInvalid'));
 
             if (!_.isUndefined(invalidField) && _.isFunction(invalidField.focused)) {
-                invalidField.focused(true);
+                setTimeout(function(){
+                    invalidField.focused(true);
+                }, 100);
             }
 
             return this;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
No auto-focus if the invalid field in the collapsed block (Catalog->Add New Product form)



### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24045: No auto-focus if the invalid field in the collapsed block (Catalog->Add New Product form) 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create Require Attribute 
- Go to Backend. Stores->Attributes->Product
- Add New Attribute "musthaveattr"
- Fill all information, "Values Required" is Yes.
2. Assign the Required Attribute to **collapsed group**
- Go to Backend. Stores->Attributes->Attribute Sets
- Edit "Default"
- Move "musthaveattr" to "Search Engine Optimization" Group
- Save
3. Go to Catalog-> Product-> Add Product
4. Fill " Product Name", "SKU", "Price"
5. Save

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
