### PR TITLE
24938: Fix wrong shipping amount in totals for multiple address is used.

### DIFF
--- a/app/code/Magento/Tax/Model/Sales/Total/Quote/Shipping.php
+++ b/app/code/Magento/Tax/Model/Sales/Total/Quote/Shipping.php
@@ -48,10 +48,16 @@ class Shipping extends CommonTaxCollector
             ->calculateTax($baseQuoteDetails, $storeId);
         $baseTaxDetailsItems = $baseTaxDetails->getItems()[self::ITEM_CODE_SHIPPING];
 
-        $quote->getShippingAddress()
-            ->setShippingAmount($taxDetailsItems->getRowTotal());
-        $quote->getShippingAddress()
-            ->setBaseShippingAmount($baseTaxDetailsItems->getRowTotal());
+        if ($quote->getIsMultiShipping()) {
+            $address = $shippingAssignment->getShipping()->getAddress();
+            $address->setShippingAmount($taxDetailsItems->getRowTotal());
+            $address->setBaseShippingAmount($taxDetailsItems->getRowTotal());
+        } else {
+            $quote->getShippingAddress()
+                ->setShippingAmount($taxDetailsItems->getRowTotal());
+            $quote->getShippingAddress()
+                ->setBaseShippingAmount($baseTaxDetailsItems->getRowTotal());
+        }
 
         $this->processShippingTaxInfo(
             $shippingAssignment,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fix wrong shipping amount in totals when multiple address is selected with different shipping amount.


### Related Pull Requests
https://github.com/magento/magento2/commit/250180b7ee67d75c888dedc4ca99012148f66945

### Fixed Issues (if relevant)
1. magento/magento2#23631: Multishipping checkout, shipping amount is not applied correctly when different on different addresses/items
2. magento/magento2#24938: Wrong shipping amount calculation when checkout with multiple address is used.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

### Questions or comments
The commit shared in Related pull request  doesn't seems to be as per magento standard. But any how it was merged. Remove those commit, which will be reproduce issue.
Apply the changes for this PR, issue will work and will be as per standard.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
