### PR TITLE
Visa expiration date fix functional test dataset

### DIFF
--- a/dev/tests/functional/tests/app/Magento/Payment/Test/Repository/CreditCard.xml
+++ b/dev/tests/functional/tests/app/Magento/Payment/Test/Repository/CreditCard.xml
@@ -10,7 +10,7 @@
         <dataset name="visa_default">
             <field name="cc_number" xsi:type="string">4111111111111111</field>
             <field name="cc_exp_month" xsi:type="string">01 - January</field>
-            <field name="cc_exp_year" xsi:type="string">2020</field>
+            <field name="cc_exp_year" xsi:type="string">2023</field>
             <field name="cc_cid" xsi:type="string">123</field>
         </dataset>
 


### PR DESCRIPTION
### Description (*)
There is a fluky functional test that uses an incorrect Visa card date. This PR introduces a fix for the test dataset. 

Example: https://public-results-storage-prod.magento-testing-service.engineering/reports/magento/magento2/pull/26662/33c5d3b08cbebd3b903348f583bb6d85/Functional/allure-report-ee/index.html#suites/1226604858f4649b0765942820003c99/bf78770da7d3775f/

![image](https://user-images.githubusercontent.com/2148959/73611587-8802d080-45e3-11ea-8202-10e4737d24b8.png)


### Related Pull Requests
1. https://github.com/magento/magento2/pull/26662
2. https://github.com/magento/magento2/pull/26660

### Fixed Issues (if relevant)
N/A
