### PR TITLE
Fix: missing "null" and "false" return type hints in RouterInterface:…

### DIFF
--- a/lib/internal/Magento/Framework/App/RouterInterface.php
+++ b/lib/internal/Magento/Framework/App/RouterInterface.php
@@ -14,10 +14,18 @@ namespace Magento\Framework\App;
 interface RouterInterface
 {
     /**
-     * Match application action by request
+     * Match application action by request.
+     *
+     * For web requests, return null if the router doesn't match the request
+     * but other routers might still match. Or to cause a 404, throw a
+     * \Magento\Framework\Exception\NotFoundException.
+     * See \Magento\Framework\App\FrontController.
+     *
+     * For Webapi Rest requests, return FALSE instead of null.
+     * See \Magento\Webapi\Controller\Rest\Router.
      *
      * @param RequestInterface $request
-     * @return ActionInterface
+     * @return ActionInterface|null|false
      */
     public function match(RequestInterface $request);
 }

--- a/lib/internal/Magento/Framework/App/Test/Unit/FrontControllerTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/FrontControllerTest.php
@@ -175,6 +175,10 @@ class FrontControllerTest extends \PHPUnit\Framework\TestCase
         $this->router->expects($this->at(1))
             ->method('match')
             ->with($this->request)
+            ->will($this->returnValue(null));
+        $this->router->expects($this->at(2))
+            ->method('match')
+            ->with($this->request)
             ->will($this->returnValue($controllerInstance));
 
         $this->routerList->expects($this->any())


### PR DESCRIPTION
### Description (*)
The core code in FrontController expects a "falsy" value to be
returned from routers that don't match a request, but want to
delegate to the next router.

```
foreach ($this->_routerList as $router) {
    try {
        $actionInstance = $router->match($request);
        if ($actionInstance) { // <---- return type must evaluate to "false" for loop to continue
            $result = $this->processRequest();
            // ...
        }
    } catch (\Magento\Framework\Exception\NotFoundException $e) {
        // ...
    }
}
```

Similarly, the code in `Webapi\Rest\Router` expects
specifically a `false` for that same use-case.

However those concrete expectations are not reflected in the
RouterInterface::match return type hint (DocBlock) and are not
documented either. This creates problems with static code analysis like PHPStan.

This pull request:
* Adds the "null" and "false" return type hints to the RouterInterface::match()
DocBlock. This fixes issues with PHPStan and IDE's, and makes the behaviour more
explicit.
* Adds a unit test to FrontControllerTest to make sure specifically returning "null"
works as expected in FrontController.

### Manual testing scenarios (*)
Not necessary.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
