### PR TITLE
Unit test for \Magento\Captcha\Observer\ResetAttemptForBackendObserver and ResetAttemptForFrontendObserver

### DIFF
--- a/app/code/Magento/Captcha/Test/Unit/Observer/ResetAttemptForBackendObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/ResetAttemptForBackendObserverTest.php
@@ -28,7 +28,7 @@ class ResetAttemptForBackendObserverTest extends TestCase
     public function testExecuteExpectsDeleteUserAttemptsCalled()
     {
         $logMock = $this->createMock(Log::class);
-        $logMock->expects($this->once())->method('deleteUserAttempts');
+        $logMock->expects($this->once())->method('deleteUserAttempts')->willReturnSelf();
 
         $resLogFactoryMock = $this->createMock(LogFactory::class);
         $resLogFactoryMock->expects($this->once())
@@ -48,6 +48,6 @@ class ResetAttemptForBackendObserverTest extends TestCase
             ResetAttemptForBackendObserver::class,
             ['resLogFactory' => $resLogFactoryMock]
         );
-        $observer->execute($eventObserverMock);
+        $this->assertInstanceOf(Log::class, $observer->execute($eventObserverMock));
     }
 }

--- a/app/code/Magento/Captcha/Test/Unit/Observer/ResetAttemptForBackendObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/ResetAttemptForBackendObserverTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Captcha\Test\Unit\Observer;
+
+use Magento\Captcha\Model\ResourceModel\Log;
+use Magento\Captcha\Model\ResourceModel\LogFactory;
+use Magento\Captcha\Observer\ResetAttemptForBackendObserver;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit test for \Magento\Captcha\Observer\ResetAttemptForBackendObserver
+ */
+class ResetAttemptForBackendObserverTest extends TestCase
+{
+    /**
+     * Test that the method resets attempts for Backend
+     */
+    public function testExecuteExpectsDeleteUserAttemptsCalled()
+    {
+        $logMock = $this->createMock(Log::class);
+        $logMock->expects($this->once())->method('deleteUserAttempts');
+
+        $resLogFactoryMock = $this->createMock(LogFactory::class);
+        $resLogFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($logMock);
+
+        /** @var MockObject|Observer $eventObserverMock */
+        $eventObserverMock = $this->createPartialMock(Observer::class, ['getUser']);
+        $eventMock = $this->createMock(Event::class);
+        $eventObserverMock->expects($this->once())
+            ->method('getUser')
+            ->willReturn($eventMock);
+
+        $objectManager = new ObjectManagerHelper($this);
+        /** @var ResetAttemptForBackendObserver $observer */
+        $observer = $objectManager->getObject(
+            ResetAttemptForBackendObserver::class,
+            ['resLogFactory' => $resLogFactoryMock]
+        );
+        $observer->execute($eventObserverMock);
+    }
+}

--- a/app/code/Magento/Captcha/Test/Unit/Observer/ResetAttemptForFrontendObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/ResetAttemptForFrontendObserverTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Captcha\Test\Unit\Observer;
+
+use Magento\Captcha\Model\ResourceModel\Log;
+use Magento\Captcha\Model\ResourceModel\LogFactory;
+use Magento\Captcha\Observer\ResetAttemptForFrontendObserver;
+use Magento\Customer\Model\Customer;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit test for \Magento\Captcha\Observer\ResetAttemptForFrontendObserver
+ */
+class ResetAttemptForFrontendObserverTest extends TestCase
+{
+    /**
+     * Test that the method resets attempts for Frontend
+     */
+    public function testExecuteExpectsDeleteUserAttemptsCalled()
+    {
+        $logMock = $this->createMock(Log::class);
+        $logMock->expects($this->once())->method('deleteUserAttempts');
+
+        $resLogFactoryMock = $this->createMock(LogFactory::class);
+        $resLogFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($logMock);
+
+        /** @var MockObject|Observer $eventObserverMock */
+        $eventObserverMock = $this->createPartialMock(Observer::class, ['getModel']);
+        $eventObserverMock->expects($this->once())
+            ->method('getModel')
+            ->willReturn($this->createMock(Customer::class));
+
+        $objectManager = new ObjectManagerHelper($this);
+        /** @var ResetAttemptForFrontendObserver $observer */
+        $observer = $objectManager->getObject(
+            ResetAttemptForFrontendObserver::class,
+            ['resLogFactory' => $resLogFactoryMock]
+        );
+        $observer->execute($eventObserverMock);
+    }
+}

--- a/app/code/Magento/Captcha/Test/Unit/Observer/ResetAttemptForFrontendObserverTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Observer/ResetAttemptForFrontendObserverTest.php
@@ -28,7 +28,7 @@ class ResetAttemptForFrontendObserverTest extends TestCase
     public function testExecuteExpectsDeleteUserAttemptsCalled()
     {
         $logMock = $this->createMock(Log::class);
-        $logMock->expects($this->once())->method('deleteUserAttempts');
+        $logMock->expects($this->once())->method('deleteUserAttempts')->willReturnSelf();
 
         $resLogFactoryMock = $this->createMock(LogFactory::class);
         $resLogFactoryMock->expects($this->once())
@@ -47,6 +47,6 @@ class ResetAttemptForFrontendObserverTest extends TestCase
             ResetAttemptForFrontendObserver::class,
             ['resLogFactory' => $resLogFactoryMock]
         );
-        $observer->execute($eventObserverMock);
+        $this->assertInstanceOf(Log::class, $observer->execute($eventObserverMock));
     }
 }


### PR DESCRIPTION
### Description (*)
Covers \Magento\Captcha\Observer\ResetAttemptForBackendObserver and \Magento\Captcha\Observer\ResetAttemptForFrontendObserver with Unit tests.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
