### PR TITLE
fix based on issue #26693

### DIFF
--- a/app/code/Magento/Customer/Model/AccountManagement.php
+++ b/app/code/Magento/Customer/Model/AccountManagement.php
@@ -985,7 +985,9 @@ class AccountManagement implements AccountManagementInterface
                 $templateType = self::NEW_ACCOUNT_EMAIL_REGISTERED_NO_PASSWORD;
             }
             $this->getEmailNotification()->newAccount($customer, $templateType, $redirectUrl, $customer->getStoreId());
-            $customer->setConfirmation(null);
+            if($templateType != self::NEW_ACCOUNT_EMAIL_CONFIRMATION){
+                $customer->setConfirmation(null);
+            }
         } catch (MailException $e) {
             // If we are not able to send a new account email, this should be ignored
             $this->logger->critical($e);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Changes based on issue #26693 which stated problem when overriding Magento\Customer\Controller\Account\CreatePost. 
Just add after `$customer = $this->accountManagement ->createAccount($customer, $password, $redirectUrl);`
the following:
`$customer->save();` and the customer will be considered confirmed without actually confirming their account. This is caused by setting confirmation key to null without checking whether the email sent is a confirmation email or not in `sendEmailConfirmation` method in Magento\Customer\Model\AccountManagement.
This can be a problem when implementing custom create customer logic and you need to use the customer instance after using the `createAccount` method on `accountManagement`, especially if the customer is saved after. The workaround could be to get a new customer instance, but I think conditionally setting the confirmation key to null in `sendEmailConfirmation` method in account management would be better.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#26693: Overriding CreatePost can automatically confirm a customer

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. In Admin, turn on confirmation required through Stores - Configuration - Customers - Customer Configuration - Create New Account Options - Require Emails Confirmation
2. Override Magento\Customer\Controller\Account\CreatePost in a module. Copy everything in execute function as it is, but add after
`$customer = $this->accountManagement ->createAccount($customer, $password, $redirectUrl);`
the following:
`$customer->save()`
3.Open storefront as a guest and create account
4.Customer should not be confirmed until they access the confirmation link they received in their email.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
