### PR TITLE
Make totals compare subtotals with taxes before reloading customer data

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/totals.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/totals.js
@@ -15,7 +15,7 @@ define([
 
     var quoteItems = ko.observable(quote.totals().items),
         cartData = customerData.get('cart'),
-        quoteSubtotal = parseFloat(quote.totals().subtotal_incl_tax),
+        quoteSubtotal = parseFloat(quote.totals()['subtotal_incl_tax']),
         subtotalAmount = parseFloat(cartData().subtotalAmount);
 
     quote.totals.subscribe(function (newValue) {

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/totals.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/totals.js
@@ -15,7 +15,7 @@ define([
 
     var quoteItems = ko.observable(quote.totals().items),
         cartData = customerData.get('cart'),
-        quoteSubtotal = parseFloat(quote.totals().subtotal),
+        quoteSubtotal = parseFloat(quote.totals().subtotal_incl_tax),
         subtotalAmount = parseFloat(cartData().subtotalAmount);
 
     quote.totals.subscribe(function (newValue) {

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/totals.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/totals.test.js
@@ -4,6 +4,7 @@
  */
 
 /*jscs:disable jsDoc*/
+/* eslint-disable max-nested-callbacks */
 
 define([
     'squire',
@@ -17,7 +18,7 @@ define([
                 totals: ko.observable({
                     items: [],
                     subtotal: 0
-                }),
+                })
             },
             'Magento_Customer/js/customer-data': {
                 get: jasmine.createSpy().and.returnValue(
@@ -43,16 +44,19 @@ define([
 
     describe('Magento_Checkout/js/model/totals', function () {
 
-        it('does not reload cart in customer data when its subtotal is the same as the one in the quote', function (done) {
-            mocks['Magento_Checkout/js/model/quote'].totals({
-                items: [],
-                subtotal: 0
-            });
-            injector.require(['Magento_Checkout/js/model/totals'], function () {
-                expect(mocks['Magento_Customer/js/customer-data'].reload).not.toHaveBeenCalled();
-                done();
-            });
-        });
+        it(
+            'does not reload cart in customer data when its subtotal is the same as the one in the quote',
+            function (done) {
+                mocks['Magento_Checkout/js/model/quote'].totals({
+                    items: [],
+                    subtotal: 0
+                });
+                injector.require(['Magento_Checkout/js/model/totals'], function () {
+                    expect(mocks['Magento_Customer/js/customer-data'].reload).not.toHaveBeenCalled();
+                    done();
+                });
+            }
+        );
 
         it('reloads cart in customer data when its subtotal is different then the one in the quote', function (done) {
             mocks['Magento_Checkout/js/model/quote'].totals({
@@ -93,6 +97,7 @@ define([
 
             it('exposes quote items', function (done) {
                 var totalsItems, quoteItems = [];
+
                 mocks['Magento_Checkout/js/model/quote'].totals({
                     items: quoteItems,
                     subtotal: 0
@@ -106,6 +111,7 @@ define([
 
             it('exposes updated quote items when new values are pushed', function (done) {
                 var totalsItems, quoteItems = [];
+
                 mocks['Magento_Checkout/js/model/quote'].totals({});
                 injector.require(['Magento_Checkout/js/model/totals'], function (totals) {
                     mocks['Magento_Checkout/js/model/quote'].totals({
@@ -137,7 +143,7 @@ define([
 
             it('returns null when segment cannot be found', function (done) {
                 mocks['Magento_Checkout/js/model/quote'].totals({
-                    total_segments: []
+                    'total_segments': []
                 });
                 injector.require(['Magento_Checkout/js/model/totals'], function (totals) {
                     expect(totals.getSegment('test')).toBe(null);
@@ -149,8 +155,9 @@ define([
                 var segment = {
                     code: 'test'
                 };
+
                 mocks['Magento_Checkout/js/model/quote'].totals({
-                    total_segments: [
+                    'total_segments': [
                         segment
                     ]
                 });

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/totals.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Checkout/frontend/js/model/totals.test.js
@@ -1,0 +1,165 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/*jscs:disable jsDoc*/
+
+define([
+    'squire',
+    'ko'
+], function (Squire, ko) {
+    'use strict';
+
+    var injector,
+        mocks = {
+            'Magento_Checkout/js/model/quote': {
+                totals: ko.observable({
+                    items: [],
+                    subtotal: 0
+                }),
+            },
+            'Magento_Customer/js/customer-data': {
+                get: jasmine.createSpy().and.returnValue(
+                    ko.observable({
+                        subtotalAmount: 0
+                    })
+                ),
+                reload: jasmine.createSpy()
+            }
+        };
+
+    beforeEach(function () {
+        injector = new Squire();
+        injector.mock(mocks);
+    });
+
+    afterEach(function () {
+        try {
+            injector.clean();
+            injector.remove();
+        } catch (e) {}
+    });
+
+    describe('Magento_Checkout/js/model/totals', function () {
+
+        it('does not reload cart in customer data when its subtotal is the same as the one in the quote', function (done) {
+            mocks['Magento_Checkout/js/model/quote'].totals({
+                items: [],
+                subtotal: 0
+            });
+            injector.require(['Magento_Checkout/js/model/totals'], function () {
+                expect(mocks['Magento_Customer/js/customer-data'].reload).not.toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it('reloads cart in customer data when its subtotal is different then the one in the quote', function (done) {
+            mocks['Magento_Checkout/js/model/quote'].totals({
+                items: [],
+                subtotal: 1
+            });
+            injector.require(['Magento_Checkout/js/model/totals'], function () {
+                expect(mocks['Magento_Customer/js/customer-data'].reload).toHaveBeenCalled();
+                done();
+            });
+        });
+
+        describe('totals property', function () {
+            it('exposes quote totals observable', function (done) {
+                injector.require(['Magento_Checkout/js/model/totals'], function (totals) {
+                    expect(totals.totals).toBe(mocks['Magento_Checkout/js/model/quote'].totals);
+                    done();
+                });
+            });
+        });
+
+        describe('isLoading property', function () {
+            it('is an observable', function (done) {
+                injector.require(['Magento_Checkout/js/model/totals'], function (totals) {
+                    expect(typeof totals.isLoading.subscribe).toBe('function');
+                    done();
+                });
+            });
+        });
+
+        describe('getItems method', function () {
+            it('is a function', function (done) {
+                injector.require(['Magento_Checkout/js/model/totals'], function (totals) {
+                    expect(typeof totals.getItems).toBe('function');
+                    done();
+                });
+            });
+
+            it('exposes quote items', function (done) {
+                var totalsItems, quoteItems = [];
+                mocks['Magento_Checkout/js/model/quote'].totals({
+                    items: quoteItems,
+                    subtotal: 0
+                });
+                injector.require(['Magento_Checkout/js/model/totals'], function (totals) {
+                    totalsItems = totals.getItems();
+                    expect(totalsItems()).toBe(quoteItems);
+                    done();
+                });
+            });
+
+            it('exposes updated quote items when new values are pushed', function (done) {
+                var totalsItems, quoteItems = [];
+                mocks['Magento_Checkout/js/model/quote'].totals({});
+                injector.require(['Magento_Checkout/js/model/totals'], function (totals) {
+                    mocks['Magento_Checkout/js/model/quote'].totals({
+                        items: quoteItems,
+                        subtotal: 0
+                    });
+                    totalsItems = totals.getItems();
+                    expect(totalsItems()).toBe(quoteItems);
+                    done();
+                });
+            });
+        });
+
+        describe('getSegment method', function () {
+            it('is a function', function (done) {
+                injector.require(['Magento_Checkout/js/model/totals'], function (totals) {
+                    expect(typeof totals.getSegment).toBe('function');
+                    done();
+                });
+            });
+
+            it('returns null when there are no segments in quote', function (done) {
+                mocks['Magento_Checkout/js/model/quote'].totals({});
+                injector.require(['Magento_Checkout/js/model/totals'], function (totals) {
+                    expect(totals.getSegment('test')).toBe(null);
+                    done();
+                });
+            });
+
+            it('returns null when segment cannot be found', function (done) {
+                mocks['Magento_Checkout/js/model/quote'].totals({
+                    total_segments: []
+                });
+                injector.require(['Magento_Checkout/js/model/totals'], function (totals) {
+                    expect(totals.getSegment('test')).toBe(null);
+                    done();
+                });
+            });
+
+            it('returns segment when it is defined', function (done) {
+                var segment = {
+                    code: 'test'
+                };
+                mocks['Magento_Checkout/js/model/quote'].totals({
+                    total_segments: [
+                        segment
+                    ]
+                });
+                injector.require(['Magento_Checkout/js/model/totals'], function (totals) {
+                    expect(totals.getSegment('test')).toBe(segment);
+                    done();
+                });
+            });
+        });
+
+    });
+});


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Because of the fact that customer data cart's `subtotalAmount` contains a value that always includes a tax we need to use `subtotal_incl_tax` instead of `subtotal`, which contains the tax only if the setting to include them is enabled in admin panel.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#26294: Customer data AJAX request is executed on every cart page reload when subtotal is set to be displayed including tax.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Create tax zone and rule so products in shop are taxed
2. Set Stores -> Configuration -> Sales -> Tax -> Shopping Cart Display Settings -> Display subtotal to "Including Tax"
3. Refresh caches
4. Go to storefront
5. Add product to cart
6. Visit cart page
7.  Validate in devtools network tab that request for reloading customer data is not done on every refresh.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
