### PR TITLE
Issue Fixed #26726 Qty decimals allowed on configurable product even when setting set to 'no' .. 

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
+++ b/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurablePanel.php
@@ -490,7 +490,10 @@ class ConfigurablePanel extends AbstractModifier
                     'quantity_container' => $this->getColumn(
                         'quantity',
                         __('Quantity'),
-                        ['dataScope' => 'qty'],
+                        [
+                            'validation' => ['validate-number' => true],
+                            'imports' => ['handleChanges' => '${$.provider}:data.product.stock_data.is_qty_decimal']
+                        ],
                         ['dataScope' => 'qty']
                     ),
                     'price_weight' => $this->getColumn('weight', __('Weight')),


### PR DESCRIPTION
Issue Fixed #26726
<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.3.2) and any important information on the environment where bug is reproducible.
-->
1. Magento CE 2.2.10

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Add simple product having 'Qty Uses Decimals' = 'No' (default)
2. Add configurable product having 'Qty Uses Decimals' = 'No' (default)
3. Link simple to configurable
4. Go to PDP and add '1.x' (ie 1.5) to cart

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
1. Behaviour like simple products - floored qty is added to cart

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->
1. Decimal qty is added to cart
