### PR TITLE
In System/Export controlers use MessageManager instead of throwing exceptions

### DIFF
--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Delete.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Delete.php
@@ -63,7 +63,7 @@ class Delete extends ExportController implements HttpPostActionInterface
         $resultRedirect->setPath('adminhtml/export/index');
         $fileName = $this->getRequest()->getParam('filename');
         if (empty($fileName)) {
-            $this->messageManager->addErrorMessage(\__('Please provide valid export file name'));
+            $this->messageManager->addErrorMessage(__('Please provide valid export file name'));
 
             return $resultRedirect;
         }
@@ -73,9 +73,9 @@ class Delete extends ExportController implements HttpPostActionInterface
 
             if ($directory->isFile($path)) {
                 $this->file->deleteFile($path);
-                $this->messageManager->addSuccessMessage(\__('File %1 deleted', $fileName));
+                $this->messageManager->addSuccessMessage(__('File %1 deleted', $fileName));
             } else {
-                $this->messageManager->addErrorMessage(\__('%1 is not a valid file', $fileName));
+                $this->messageManager->addErrorMessage(__('%1 is not a valid file', $fileName));
             }
         } catch (FileSystemException $exception) {
             $this->messageManager->addErrorMessage($exception->getMessage());

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Delete.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Delete.php
@@ -62,7 +62,7 @@ class Delete extends ExportController implements HttpPostActionInterface
         $resultRedirect = $this->resultRedirectFactory->create();
         $resultRedirect->setPath('adminhtml/export/index');
         $fileName = $this->getRequest()->getParam('filename');
-        if (empty($fileName)) {
+        if (empty($fileName) || preg_match('/\.\.(\\\|\/)/', $fileName) !== 0) {
             $this->messageManager->addErrorMessage(__('Please provide valid export file name'));
 
             return $resultRedirect;

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Delete.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Delete.php
@@ -9,9 +9,7 @@ namespace Magento\ImportExport\Controller\Adminhtml\Export\File;
 
 use Magento\Backend\App\Action;
 use Magento\Framework\App\Action\HttpPostActionInterface;
-use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\FileSystemException;
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\ImportExport\Controller\Adminhtml\Export as ExportController;
 use Magento\Framework\Filesystem;
@@ -56,29 +54,33 @@ class Delete extends ExportController implements HttpPostActionInterface
     /**
      * Controller basic method implementation.
      *
-     * @return \Magento\Framework\App\ResponseInterface|\Magento\Framework\Controller\ResultInterface
-     * @throws LocalizedException
+     * @return \Magento\Framework\Controller\ResultInterface
      */
     public function execute()
     {
+        /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */
+        $resultRedirect = $this->resultRedirectFactory->create();
+        $resultRedirect->setPath('adminhtml/export/index');
+        $fileName = $this->getRequest()->getParam('filename');
+        if (empty($fileName)) {
+            $this->messageManager->addErrorMessage(\__('Please provide valid export file name'));
+
+            return $resultRedirect;
+        }
         try {
-            if (empty($fileName = $this->getRequest()->getParam('filename'))) {
-                throw new LocalizedException(__('Please provide export file name'));
-            }
             $directory = $this->filesystem->getDirectoryRead(DirectoryList::VAR_DIR);
             $path = $directory->getAbsolutePath() . 'export/' . $fileName;
 
-            if (!$directory->isFile($path)) {
-                throw new LocalizedException(__('Sorry, but the data is invalid or the file is not uploaded.'));
+            if ($directory->isFile($path)) {
+                $this->file->deleteFile($path);
+                $this->messageManager->addSuccessMessage(\__('File %1 deleted', $fileName));
+            } else {
+                $this->messageManager->addErrorMessage(\__('%1 is not a valid file', $fileName));
             }
-
-            $this->file->deleteFile($path);
-            /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
-            $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
-            $resultRedirect->setPath('adminhtml/export/index');
-            return $resultRedirect;
         } catch (FileSystemException $exception) {
-            throw new LocalizedException(__('There are no export file with such name %1', $fileName));
+            $this->messageManager->addErrorMessage($exception->getMessage());
         }
+
+        return $resultRedirect;
     }
 }

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Download.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Download.php
@@ -61,8 +61,8 @@ class Download extends ExportController implements HttpGetActionInterface
         $resultRedirect = $this->resultRedirectFactory->create();
         $resultRedirect->setPath('adminhtml/export/index');
         $fileName = $this->getRequest()->getParam('filename');
-        if (empty($fileName) || \preg_match('/\.\.(\\\|\/)/', $fileName) !== 0) {
-            $this->messageManager->addErrorMessage(\__('Please provide valid export file name'));
+        if (empty($fileName) || preg_match('/\.\.(\\\|\/)/', $fileName) !== 0) {
+            $this->messageManager->addErrorMessage(__('Please provide valid export file name'));
 
             return $resultRedirect;
         }
@@ -76,7 +76,7 @@ class Download extends ExportController implements HttpGetActionInterface
                     DirectoryList::VAR_DIR
                 );
             }
-            $this->messageManager->addErrorMessage(\__('%1 is not a valid file', $fileName));
+            $this->messageManager->addErrorMessage(__('%1 is not a valid file', $fileName));
         } catch (\Exception $exception) {
             $this->messageManager->addErrorMessage($exception->getMessage());
         }

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Download.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Download.php
@@ -10,7 +10,6 @@ namespace Magento\ImportExport\Controller\Adminhtml\Export\File;
 use Magento\Backend\App\Action;
 use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Response\Http\FileFactory;
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\ImportExport\Controller\Adminhtml\Export as ExportController;
 use Magento\Framework\Filesystem;
@@ -55,12 +54,17 @@ class Download extends ExportController implements HttpGetActionInterface
      * Controller basic method implementation.
      *
      * @return \Magento\Framework\App\ResponseInterface
-     * @throws LocalizedException
      */
     public function execute()
     {
-        if (empty($fileName = $this->getRequest()->getParam('filename'))) {
-            throw new LocalizedException(__('Please provide export file name'));
+        /** @var \Magento\Framework\Controller\Result\Redirect $resultRedirect */
+        $resultRedirect = $this->resultRedirectFactory->create();
+        $resultRedirect->setPath('adminhtml/export/index');
+        $fileName = $this->getRequest()->getParam('filename');
+        if (empty($fileName) || \preg_match('/\.\.(\\\|\/)/', $fileName) !== 0) {
+            $this->messageManager->addErrorMessage(\__('Please provide valid export file name'));
+
+            return $resultRedirect;
         }
         try {
             $path = 'export/' . $fileName;
@@ -72,8 +76,11 @@ class Download extends ExportController implements HttpGetActionInterface
                     DirectoryList::VAR_DIR
                 );
             }
-        } catch (LocalizedException | \Exception $exception) {
-            throw new LocalizedException(__('There are no export file with such name %1', $fileName));
+            $this->messageManager->addErrorMessage(\__('%1 is not a valid file', $fileName));
+        } catch (\Exception $exception) {
+            $this->messageManager->addErrorMessage($exception->getMessage());
         }
+
+        return $resultRedirect;
     }
 }

--- a/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DeleteTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DeleteTest.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-namespace Magento\ImportExport\Controller\Adminhtml\Export\File;
+namespace Magento\ImportExport\Test\Unit\Controller\Adminhtml\Export\File;
 
 use Magento\Backend\App\Action\Context;
 use Magento\Backend\Model\View\Result\Redirect;
@@ -17,6 +17,7 @@ use Magento\Framework\Filesystem\Directory\ReadInterface;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\ImportExport\Controller\Adminhtml\Export\File\Delete;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 

--- a/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DeleteTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DeleteTest.php
@@ -122,7 +122,6 @@ class DeleteTest extends TestCase
             ->method('getMessageManager')
             ->willReturn($this->messageManagerMock);
 
-
         $this->objectManagerHelper = new ObjectManagerHelper($this);
         $this->deleteControllerMock = $this->objectManagerHelper->getObject(
             Delete::class,
@@ -143,7 +142,9 @@ class DeleteTest extends TestCase
             ->with('filename')
             ->willReturn('sampleFile');
 
-        $this->fileSystemMock->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directoryMock));
+        $this->fileSystemMock->expects($this->once())
+            ->method('getDirectoryRead')
+            ->will($this->returnValue($this->directoryMock));
         $this->directoryMock->expects($this->once())->method('isFile')->willReturn(true);
         $this->fileMock->expects($this->once())->method('deleteFile')->willReturn(true);
         $this->messageManagerMock->expects($this->once())->method('addSuccessMessage');
@@ -160,7 +161,9 @@ class DeleteTest extends TestCase
             ->with('filename')
             ->willReturn('sampleFile');
 
-        $this->fileSystemMock->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directoryMock));
+        $this->fileSystemMock->expects($this->once())
+            ->method('getDirectoryRead')
+            ->will($this->returnValue($this->directoryMock));
         $this->directoryMock->expects($this->once())->method('isFile')->willReturn(false);
         $this->messageManagerMock->expects($this->once())->method('addErrorMessage');
 

--- a/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DeleteTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DeleteTest.php
@@ -3,119 +3,132 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\ImportExport\Controller\Adminhtml\Export\File;
 
+use Magento\Backend\App\Action\Context;
+use Magento\Backend\Model\View\Result\Redirect;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\Controller\Result\Raw;
+use Magento\Framework\Controller\Result\RedirectFactory;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\ReadInterface;
+use Magento\Framework\Filesystem\DriverInterface;
+use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class DeleteTest extends \PHPUnit\Framework\TestCase
+class DeleteTest extends TestCase
 {
     /**
-     * @var \Magento\Backend\App\Action\Context|\PHPUnit_Framework_MockObject_MockObject
+     * @var Context|MockObject
      */
-    protected $context;
+    private $contextMock;
 
     /**
-     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     * @var ObjectManagerHelper
      */
-    protected $objectManagerHelper;
+    private $objectManagerHelper;
 
     /**
-     * @var \Magento\Framework\App\Request\Http|\PHPUnit_Framework_MockObject_MockObject
+     * @var Http|MockObject
      */
-    protected $request;
+    private $requestMock;
 
     /**
-     * @var \Magento\Framework\Controller\Result\Raw|\PHPUnit_Framework_MockObject_MockObject
+     * @var Raw|MockObject
      */
-    protected $redirect;
+    private $redirectMock;
 
     /**
-     * @var \Magento\Framework\Controller\Result\RedirectFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var RedirectFactory|MockObject
      */
-    protected $resultRedirectFactory;
+    private $resultRedirectFactoryMock;
 
     /**
-     * @var \Magento\Framework\Filesystem|\PHPUnit_Framework_MockObject_MockObject
+     * @var Filesystem|MockObject
      */
-    protected $fileSystem;
+    private $fileSystemMock;
 
     /**
-     * @var \Magento\Framework\Filesystem\DriverInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var DriverInterface|MockObject
      */
-    protected $file;
+    private $fileMock;
 
     /**
-     * @var \Magento\ImportExport\Controller\Adminhtml\Export\File\Delete|\PHPUnit_Framework_MockObject_MockObject
+     * @var Delete|MockObject
      */
-    protected $deleteController;
+    private $deleteControllerMock;
 
     /**
-     * @var \Magento\Framework\Message\ManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ManagerInterface|MockObject
      */
-    protected $messageManager;
+    private $messageManagerMock;
 
     /**
-     * @var \Magento\Framework\Filesystem\Directory\ReadInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ReadInterface|MockObject
      */
-    protected $directory;
+    private $directoryMock;
 
     /**
      * Set up
      */
     protected function setUp()
     {
-        $this->request = $this->getMockBuilder(\Magento\Framework\App\Request\Http::class)
+        $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->fileSystem = $this->getMockBuilder(\Magento\Framework\Filesystem::class)
+        $this->fileSystemMock = $this->getMockBuilder(Filesystem::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->directory = $this->getMockBuilder(\Magento\Framework\Filesystem\Directory\ReadInterface::class)
+        $this->directoryMock = $this->getMockBuilder(ReadInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->file = $this->getMockBuilder(\Magento\Framework\Filesystem\DriverInterface::class)
+        $this->fileMock = $this->getMockBuilder(DriverInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->messageManager = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
+        $this->messageManagerMock = $this->getMockBuilder(ManagerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->context = $this->createPartialMock(
-            \Magento\Backend\App\Action\Context::class,
+        $this->contextMock = $this->createPartialMock(
+            Context::class,
             ['getRequest', 'getResultRedirectFactory', 'getMessageManager']
         );
 
-        $this->redirect = $this->createPartialMock(\Magento\Backend\Model\View\Result\Redirect::class, ['setPath']);
+        $this->redirectMock = $this->createPartialMock(Redirect::class, ['setPath']);
 
-        $this->resultRedirectFactory = $this->createPartialMock(
-            \Magento\Framework\Controller\Result\RedirectFactory::class,
+        $this->resultRedirectFactoryMock = $this->createPartialMock(
+            RedirectFactory::class,
             ['create']
         );
-        $this->resultRedirectFactory->expects($this->any())->method('create')->willReturn($this->redirect);
-        $this->context->expects($this->any())->method('getRequest')->willReturn($this->request);
-        $this->context->expects($this->any())
+        $this->resultRedirectFactoryMock->expects($this->any())->method('create')->willReturn($this->redirectMock);
+        $this->contextMock->expects($this->any())->method('getRequest')->willReturn($this->requestMock);
+        $this->contextMock->expects($this->any())
             ->method('getResultRedirectFactory')
-            ->willReturn($this->resultRedirectFactory);
+            ->willReturn($this->resultRedirectFactoryMock);
 
-        $this->context->expects($this->any())
+        $this->contextMock->expects($this->any())
             ->method('getMessageManager')
-            ->willReturn($this->messageManager);
+            ->willReturn($this->messageManagerMock);
 
 
         $this->objectManagerHelper = new ObjectManagerHelper($this);
-        $this->deleteController = $this->objectManagerHelper->getObject(
+        $this->deleteControllerMock = $this->objectManagerHelper->getObject(
             Delete::class,
             [
-                'context' => $this->context,
-                'filesystem' => $this->fileSystem,
-                'file' => $this->file
+                'context' => $this->contextMock,
+                'filesystem' => $this->fileSystemMock,
+                'file' => $this->fileMock
             ]
         );
     }
@@ -125,52 +138,52 @@ class DeleteTest extends \PHPUnit\Framework\TestCase
      */
     public function testExecuteSuccess()
     {
-        $this->request->method('getParam')
+        $this->requestMock->method('getParam')
             ->with('filename')
             ->willReturn('sampleFile');
 
-        $this->fileSystem->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directory));
-        $this->directory->expects($this->once())->method('isFile')->willReturn(true);
-        $this->file->expects($this->once())->method('deleteFile')->willReturn(true);
-        $this->messageManager->expects($this->once())->method('addSuccessMessage');
+        $this->fileSystemMock->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directoryMock));
+        $this->directoryMock->expects($this->once())->method('isFile')->willReturn(true);
+        $this->fileMock->expects($this->once())->method('deleteFile')->willReturn(true);
+        $this->messageManagerMock->expects($this->once())->method('addSuccessMessage');
 
-        $this->deleteController->execute();
+        $this->deleteControllerMock->execute();
     }
 
     /**
      * Tests download controller with different file names in request.
-
      */
     public function testExecuteFileDoesntExists()
     {
-        $this->request->method('getParam')
+        $this->requestMock->method('getParam')
             ->with('filename')
             ->willReturn('sampleFile');
 
-        $this->fileSystem->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directory));
-        $this->directory->expects($this->once())->method('isFile')->willReturn(false);
-        $this->messageManager->expects($this->once())->method('addErrorMessage');
+        $this->fileSystemMock->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directoryMock));
+        $this->directoryMock->expects($this->once())->method('isFile')->willReturn(false);
+        $this->messageManagerMock->expects($this->once())->method('addErrorMessage');
 
-        $this->deleteController->execute();
+        $this->deleteControllerMock->execute();
     }
 
     /**
      * Test execute() with invalid file name
      * @param string $requestFilename
-     * @dataProvider executeDataProvider
+     * @dataProvider invalidFileDataProvider
      */
     public function testExecuteInvalidFileName($requestFilename)
     {
-        $this->request->method('getParam')->with('filename')->willReturn($requestFilename);
-        $this->messageManager->expects($this->once())->method('addErrorMessage');
+        $this->requestMock->method('getParam')->with('filename')->willReturn($requestFilename);
+        $this->messageManagerMock->expects($this->once())->method('addErrorMessage');
 
-        $this->deleteController->execute();
+        $this->deleteControllerMock->execute();
     }
 
     /**
+     * Data provider to test possible invalid filenames
      * @return array
      */
-    public function executeDataProvider()
+    public function invalidFileDataProvider()
     {
         return [
             'Relative file name' => ['../.htaccess'],

--- a/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DeleteTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DeleteTest.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\ImportExport\Controller\Adminhtml\Export\File;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class DeleteTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Backend\App\Action\Context|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $context;
+
+    /**
+     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     */
+    protected $objectManagerHelper;
+
+    /**
+     * @var \Magento\Framework\App\Request\Http|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $request;
+
+    /**
+     * @var \Magento\Framework\Controller\Result\Raw|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $redirect;
+
+    /**
+     * @var \Magento\Framework\Controller\Result\RedirectFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $resultRedirectFactory;
+
+    /**
+     * @var \Magento\Framework\Filesystem|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $fileSystem;
+
+    /**
+     * @var \Magento\Framework\Filesystem\DriverInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $file;
+
+    /**
+     * @var \Magento\ImportExport\Controller\Adminhtml\Export\File\Delete|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $deleteController;
+
+    /**
+     * @var \Magento\Framework\Message\ManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $messageManager;
+
+    /**
+     * @var \Magento\Framework\Filesystem\Directory\ReadInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $directory;
+
+    /**
+     * Set up
+     */
+    protected function setUp()
+    {
+        $this->request = $this->getMockBuilder(\Magento\Framework\App\Request\Http::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->fileSystem = $this->getMockBuilder(\Magento\Framework\Filesystem::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->directory = $this->getMockBuilder(\Magento\Framework\Filesystem\Directory\ReadInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->file = $this->getMockBuilder(\Magento\Framework\Filesystem\DriverInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->messageManager = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->context = $this->createPartialMock(
+            \Magento\Backend\App\Action\Context::class,
+            ['getRequest', 'getResultRedirectFactory', 'getMessageManager']
+        );
+
+        $this->redirect = $this->createPartialMock(\Magento\Backend\Model\View\Result\Redirect::class, ['setPath']);
+
+        $this->resultRedirectFactory = $this->createPartialMock(
+            \Magento\Framework\Controller\Result\RedirectFactory::class,
+            ['create']
+        );
+        $this->resultRedirectFactory->expects($this->any())->method('create')->willReturn($this->redirect);
+        $this->context->expects($this->any())->method('getRequest')->willReturn($this->request);
+        $this->context->expects($this->any())
+            ->method('getResultRedirectFactory')
+            ->willReturn($this->resultRedirectFactory);
+
+        $this->context->expects($this->any())
+            ->method('getMessageManager')
+            ->willReturn($this->messageManager);
+
+
+        $this->objectManagerHelper = new ObjectManagerHelper($this);
+        $this->deleteController = $this->objectManagerHelper->getObject(
+            Delete::class,
+            [
+                'context' => $this->context,
+                'filesystem' => $this->fileSystem,
+                'file' => $this->file
+            ]
+        );
+    }
+
+    /**
+     * Tests download controller with different file names in request.
+     */
+    public function testExecuteSuccess()
+    {
+        $this->request->method('getParam')
+            ->with('filename')
+            ->willReturn('sampleFile');
+
+        $this->fileSystem->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directory));
+        $this->directory->expects($this->once())->method('isFile')->willReturn(true);
+        $this->file->expects($this->once())->method('deleteFile')->willReturn(true);
+        $this->messageManager->expects($this->once())->method('addSuccessMessage');
+
+        $this->deleteController->execute();
+    }
+
+    /**
+     * Tests download controller with different file names in request.
+
+     */
+    public function testExecuteFileDoesntExists()
+    {
+        $this->request->method('getParam')
+            ->with('filename')
+            ->willReturn('sampleFile');
+
+        $this->fileSystem->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directory));
+        $this->directory->expects($this->once())->method('isFile')->willReturn(false);
+        $this->messageManager->expects($this->once())->method('addErrorMessage');
+
+        $this->deleteController->execute();
+    }
+
+    /**
+     * Test execute() with invalid file name
+     * @param string $requestFilename
+     * @dataProvider executeDataProvider
+     */
+    public function testExecuteInvalidFileName($requestFilename)
+    {
+        $this->request->method('getParam')->with('filename')->willReturn($requestFilename);
+        $this->messageManager->expects($this->once())->method('addErrorMessage');
+
+        $this->deleteController->execute();
+    }
+
+    /**
+     * @return array
+     */
+    public function executeDataProvider()
+    {
+        return [
+            'Relative file name' => ['../.htaccess'],
+            'Empty file name' => [''],
+            'Null file name' => [null],
+        ];
+    }
+}

--- a/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DownloadTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DownloadTest.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-namespace Magento\ImportExport\Controller\Adminhtml\Export\File;
+namespace Magento\ImportExport\Test\Unit\Controller\Adminhtml\Export\File;
 
 use Magento\Backend\App\Action\Context;
 use Magento\Backend\Model\View\Result\Redirect;
@@ -17,6 +17,7 @@ use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\ReadInterface;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\ImportExport\Controller\Adminhtml\Export\File\Download;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 

--- a/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DownloadTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DownloadTest.php
@@ -3,127 +3,140 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\ImportExport\Controller\Adminhtml\Export\File;
 
+use Magento\Backend\App\Action\Context;
+use Magento\Backend\Model\View\Result\Redirect;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Framework\Controller\Result\Raw;
+use Magento\Framework\Controller\Result\RedirectFactory;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\ReadInterface;
+use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class DownloadTest extends \PHPUnit\Framework\TestCase
+class DownloadTest extends TestCase
 {
     /**
-     * @var \Magento\Backend\App\Action\Context|\PHPUnit_Framework_MockObject_MockObject
+     * @var Context|MockObject
      */
-    protected $context;
+    private $contextMock;
 
     /**
-     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     * @var ObjectManagerHelper
      */
-    protected $objectManagerHelper;
+    private $objectManagerHelper;
 
     /**
-     * @var \Magento\Framework\App\Request\Http|\PHPUnit_Framework_MockObject_MockObject
+     * @var Http|MockObject
      */
-    protected $request;
+    private $requestMock;
 
     /**
-     * @var \Magento\Framework\Controller\Result\Raw|\PHPUnit_Framework_MockObject_MockObject
+     * @var Raw|MockObject
      */
-    protected $redirect;
+    private $redirectMock;
 
     /**
-     * @var \Magento\Framework\Controller\Result\RedirectFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var RedirectFactory|MockObject
      */
-    protected $resultRedirectFactory;
+    private $resultRedirectFactoryMock;
 
     /**
-     * @var \Magento\Framework\Filesystem|\PHPUnit_Framework_MockObject_MockObject
+     * @var Filesystem|MockObject
      */
-    protected $fileSystem;
+    private $fileSystemMock;
 
     /**
-     * @var \Magento\Framework\App\Response\Http\FileFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var FileFactory|MockObject
      */
-    protected $fileFactory;
+    private $fileFactoryMock;
 
     /**
-     * @var \Magento\ImportExport\Controller\Adminhtml\Export\File\Download|\PHPUnit_Framework_MockObject_MockObject
+     * @var Download|MockObject
      */
-    protected $downloadController;
+    private $downloadControllerMock;
 
     /**
-     * @var \Magento\Framework\Message\ManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ManagerInterface|MockObject
      */
-    protected $messageManager;
+    private $messageManagerMock;
 
     /**
-     * @var \Magento\Framework\Filesystem\Directory\ReadInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ReadInterface|MockObject
      */
-    protected $directory;
+    private $directoryMock;
 
     /**
      * Set up
      */
     protected function setUp()
     {
-        $this->request = $this->getMockBuilder(\Magento\Framework\App\Request\Http::class)
+        $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->fileSystem = $this->getMockBuilder(\Magento\Framework\Filesystem::class)
+        $this->fileSystemMock = $this->getMockBuilder(Filesystem::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->directory = $this->getMockBuilder(\Magento\Framework\Filesystem\Directory\ReadInterface::class)
+        $this->directoryMock = $this->getMockBuilder(ReadInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->fileFactory = $this->getMockBuilder(\Magento\Framework\App\Response\Http\FileFactory::class)
+        $this->fileFactoryMock = $this->getMockBuilder(FileFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->messageManager = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
+        $this->messageManagerMock = $this->getMockBuilder(ManagerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->context = $this->createPartialMock(
-            \Magento\Backend\App\Action\Context::class,
+        $this->contextMock = $this->createPartialMock(
+            Context::class,
             ['getRequest', 'getResultRedirectFactory', 'getMessageManager']
         );
 
-        $this->redirect = $this->createPartialMock(
-            \Magento\Backend\Model\View\Result\Redirect::class,
+        $this->redirectMock = $this->createPartialMock(
+            Redirect::class,
             ['setPath']
         );
 
-        $this->resultRedirectFactory = $this->createPartialMock(
-            \Magento\Framework\Controller\Result\RedirectFactory::class,
+        $this->resultRedirectFactoryMock = $this->createPartialMock(
+            RedirectFactory::class,
             ['create']
         );
-        $this->resultRedirectFactory->expects($this->any())
+        $this->resultRedirectFactoryMock->expects($this->any())
             ->method('create')
-            ->willReturn($this->redirect);
+            ->willReturn($this->redirectMock);
 
-        $this->context->expects($this->any())
+        $this->contextMock->expects($this->any())
             ->method('getRequest')
-            ->willReturn($this->request);
+            ->willReturn($this->requestMock);
 
-        $this->context->expects($this->any())
+        $this->contextMock->expects($this->any())
             ->method('getResultRedirectFactory')
-            ->willReturn($this->resultRedirectFactory);
+            ->willReturn($this->resultRedirectFactoryMock);
 
-        $this->context->expects($this->any())
+        $this->contextMock->expects($this->any())
             ->method('getMessageManager')
-            ->willReturn($this->messageManager);
+            ->willReturn($this->messageManagerMock);
 
         $this->objectManagerHelper = new ObjectManagerHelper($this);
-        $this->downloadController = $this->objectManagerHelper->getObject(
+        $this->downloadControllerMock = $this->objectManagerHelper->getObject(
             Download::class,
             [
-                'context' => $this->context,
-                'filesystem' => $this->fileSystem,
-                'fileFactory' => $this->fileFactory
+                'context' => $this->contextMock,
+                'filesystem' => $this->fileSystemMock,
+                'fileFactory' => $this->fileFactoryMock
             ]
         );
     }
@@ -133,51 +146,51 @@ class DownloadTest extends \PHPUnit\Framework\TestCase
      */
     public function testExecuteSuccess()
     {
-        $this->request->method('getParam')
+        $this->requestMock->method('getParam')
             ->with('filename')
             ->willReturn('sampleFile.csv');
 
-        $this->fileSystem->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directory));
-        $this->directory->expects($this->once())->method('isFile')->willReturn(true);
-        $this->fileFactory->expects($this->once())->method('create');
+        $this->fileSystemMock->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directoryMock));
+        $this->directoryMock->expects($this->once())->method('isFile')->willReturn(true);
+        $this->fileFactoryMock->expects($this->once())->method('create');
 
-        $this->downloadController->execute();
+        $this->downloadControllerMock->execute();
     }
 
     /**
      * Tests download controller with file that doesn't exist
-
      */
     public function testExecuteFileDoesntExists()
     {
-        $this->request->method('getParam')
+        $this->requestMock->method('getParam')
             ->with('filename')
             ->willReturn('sampleFile');
 
-        $this->fileSystem->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directory));
-        $this->directory->expects($this->once())->method('isFile')->willReturn(false);
-        $this->messageManager->expects($this->once())->method('addErrorMessage');
+        $this->fileSystemMock->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directoryMock));
+        $this->directoryMock->expects($this->once())->method('isFile')->willReturn(false);
+        $this->messageManagerMock->expects($this->once())->method('addErrorMessage');
 
-        $this->downloadController->execute();
+        $this->downloadControllerMock->execute();
     }
 
     /**
      * Test execute() with invalid file name
-     * @param string $requestFilename
-     * @dataProvider executeDataProvider
+     * @param ?string $requestFilename
+     * @dataProvider invalidFileDataProvider
      */
     public function testExecuteInvalidFileName($requestFilename)
     {
-        $this->request->method('getParam')->with('filename')->willReturn($requestFilename);
-        $this->messageManager->expects($this->once())->method('addErrorMessage');
+        $this->requestMock->method('getParam')->with('filename')->willReturn($requestFilename);
+        $this->messageManagerMock->expects($this->once())->method('addErrorMessage');
 
-        $this->downloadController->execute();
+        $this->downloadControllerMock->execute();
     }
 
     /**
+     * Data provider to test possible invalid filenames
      * @return array
      */
-    public function executeDataProvider()
+    public function invalidFileDataProvider()
     {
         return [
             'Relative file name' => ['../.htaccess'],

--- a/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DownloadTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DownloadTest.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\ImportExport\Controller\Adminhtml\Export\File;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class DownloadTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Backend\App\Action\Context|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $context;
+
+    /**
+     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     */
+    protected $objectManagerHelper;
+
+    /**
+     * @var \Magento\Framework\App\Request\Http|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $request;
+
+    /**
+     * @var \Magento\Framework\Controller\Result\Raw|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $redirect;
+
+    /**
+     * @var \Magento\Framework\Controller\Result\RedirectFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $resultRedirectFactory;
+
+    /**
+     * @var \Magento\Framework\Filesystem|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $fileSystem;
+
+    /**
+     * @var \Magento\Framework\App\Response\Http\FileFactory|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $fileFactory;
+
+    /**
+     * @var \Magento\ImportExport\Controller\Adminhtml\Export\File\Download|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $downloadController;
+
+    /**
+     * @var \Magento\Framework\Message\ManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $messageManager;
+
+    /**
+     * @var \Magento\Framework\Filesystem\Directory\ReadInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $directory;
+
+    /**
+     * Set up
+     */
+    protected function setUp()
+    {
+        $this->request = $this->getMockBuilder(\Magento\Framework\App\Request\Http::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->fileSystem = $this->getMockBuilder(\Magento\Framework\Filesystem::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->directory = $this->getMockBuilder(\Magento\Framework\Filesystem\Directory\ReadInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->fileFactory = $this->getMockBuilder(\Magento\Framework\App\Response\Http\FileFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->messageManager = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->context = $this->createPartialMock(
+            \Magento\Backend\App\Action\Context::class,
+            ['getRequest', 'getResultRedirectFactory', 'getMessageManager']
+        );
+
+        $this->redirect = $this->createPartialMock(
+            \Magento\Backend\Model\View\Result\Redirect::class,
+            ['setPath']
+        );
+
+        $this->resultRedirectFactory = $this->createPartialMock(
+            \Magento\Framework\Controller\Result\RedirectFactory::class,
+            ['create']
+        );
+        $this->resultRedirectFactory->expects($this->any())
+            ->method('create')
+            ->willReturn($this->redirect);
+
+        $this->context->expects($this->any())
+            ->method('getRequest')
+            ->willReturn($this->request);
+
+        $this->context->expects($this->any())
+            ->method('getResultRedirectFactory')
+            ->willReturn($this->resultRedirectFactory);
+
+        $this->context->expects($this->any())
+            ->method('getMessageManager')
+            ->willReturn($this->messageManager);
+
+        $this->objectManagerHelper = new ObjectManagerHelper($this);
+        $this->downloadController = $this->objectManagerHelper->getObject(
+            Download::class,
+            [
+                'context' => $this->context,
+                'filesystem' => $this->fileSystem,
+                'fileFactory' => $this->fileFactory
+            ]
+        );
+    }
+
+    /**
+     * Tests download controller with successful file downloads
+     */
+    public function testExecuteSuccess()
+    {
+        $this->request->method('getParam')
+            ->with('filename')
+            ->willReturn('sampleFile.csv');
+
+        $this->fileSystem->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directory));
+        $this->directory->expects($this->once())->method('isFile')->willReturn(true);
+        $this->fileFactory->expects($this->once())->method('create');
+
+        $this->downloadController->execute();
+    }
+
+    /**
+     * Tests download controller with file that doesn't exist
+
+     */
+    public function testExecuteFileDoesntExists()
+    {
+        $this->request->method('getParam')
+            ->with('filename')
+            ->willReturn('sampleFile');
+
+        $this->fileSystem->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directory));
+        $this->directory->expects($this->once())->method('isFile')->willReturn(false);
+        $this->messageManager->expects($this->once())->method('addErrorMessage');
+
+        $this->downloadController->execute();
+    }
+
+    /**
+     * Test execute() with invalid file name
+     * @param string $requestFilename
+     * @dataProvider executeDataProvider
+     */
+    public function testExecuteInvalidFileName($requestFilename)
+    {
+        $this->request->method('getParam')->with('filename')->willReturn($requestFilename);
+        $this->messageManager->expects($this->once())->method('addErrorMessage');
+
+        $this->downloadController->execute();
+    }
+
+    /**
+     * @return array
+     */
+    public function executeDataProvider()
+    {
+        return [
+            'Relative file name' => ['../.htaccess'],
+            'Empty file name' => [''],
+            'Null file name' => [null],
+        ];
+    }
+}

--- a/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DownloadTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Controller/Adminhtml/Export/File/DownloadTest.php
@@ -151,7 +151,9 @@ class DownloadTest extends TestCase
             ->with('filename')
             ->willReturn('sampleFile.csv');
 
-        $this->fileSystemMock->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directoryMock));
+        $this->fileSystemMock->expects($this->once())
+            ->method('getDirectoryRead')
+            ->will($this->returnValue($this->directoryMock));
         $this->directoryMock->expects($this->once())->method('isFile')->willReturn(true);
         $this->fileFactoryMock->expects($this->once())->method('create');
 
@@ -167,7 +169,9 @@ class DownloadTest extends TestCase
             ->with('filename')
             ->willReturn('sampleFile');
 
-        $this->fileSystemMock->expects($this->once())->method('getDirectoryRead')->will($this->returnValue($this->directoryMock));
+        $this->fileSystemMock->expects($this->once())
+            ->method('getDirectoryRead')
+            ->will($this->returnValue($this->directoryMock));
         $this->directoryMock->expects($this->once())->method('isFile')->willReturn(false);
         $this->messageManagerMock->expects($this->once())->method('addErrorMessage');
 

--- a/app/code/Magento/ImportExport/i18n/en_US.csv
+++ b/app/code/Magento/ImportExport/i18n/en_US.csv
@@ -124,3 +124,6 @@ Summary,Summary
 "Message is added to queue, wait to get your file soon. Make sure your cron job is running to export the file","Message is added to queue, wait to get your file soon. Make sure your cron job is running to export the file"
 "Invalid data","Invalid data"
 "Invalid response","Invalid response"
+"File %1 deleted","File %1 deleted"
+"Please provide valid export file name","Please provide valid export file name"
+"%1 is not a valid file","%1 is not a valid file"


### PR DESCRIPTION
### Description (*)
Currently when you try to download or delete a file from Magento admin in System/Export section if the file is corrupted or was already deleted both controllers will throw exceptions that won't be caught. This will result in internal server error. I have refactor ImportExport\Controller\Adminhtml\Export\File\Delete and ImportExport\Controller\Adminhtml\Export\File\Download controllers. They will use messageManager instead of throwing errors. This means admin user will see proper success/error messages as in other admin areas.

### Related Pull Requests
NA

### Fixed Issues (if relevant)
NA

### Manual testing scenarios (*)
1. Go to Magento admin and navigate to System/Export
2. Export some entities
3. Keep the tab open and in a new tab go to the same page and delete one file
4. Try to delete/download the same file in the first tab (without refreshing before)
5. User friendly message will be visible

Testing can be done with SSH access to file system: File to download\delete can be made corrupted, ready only, no access to apache user, new folder can be created in var/export, etc.

### Questions or comments
The section with files to download shouldn't list folders. I'll try to fix this in a separate PR.

### Contribution checklist (*)
 - [x ] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
