### PR TITLE
magento#26745 add method setAdditionalInformation to OrderPaymentInte…

### DIFF
--- a/app/code/Magento/Sales/Api/Data/OrderPaymentInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderPaymentInterface.php
@@ -1043,6 +1043,14 @@ interface OrderPaymentInterface extends \Magento\Framework\Api\ExtensibleDataInt
     public function setCcTransId($id);
 
     /**
+     * Set the additional information for the order payment.
+     *
+     * @param string[] $additionalInformation
+     * @return $this
+     */
+    public function setAdditionalInformation($additionalInformation);
+
+    /**
      * Sets the address status for the order payment.
      *
      * @param string $addressStatus


### PR DESCRIPTION

### Description (*)
No setter for additional_information in OrderPaymentInterface is defined: this is an inconsistency between its schema declaration and the real properties accepted.

### Fixed Issues (if relevant)
 magento/magento2#26745: OrderPaymentInterface is missing setAdditionalInformation() 

### Manual testing scenarios (*)
- create an API interface accepting OrderPaymentInterface
- try to set an object with a property additional_information with a value

### Questions or comments
IMO this looks like an elephant in the room since this definition is missing from a long time in the definition of this interface

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
