### PR TITLE
Fix wrong type of argument appendSummaryFieldsToCollection

### DIFF
--- a/app/code/Magento/Review/Model/ResourceModel/Review/Summary.php
+++ b/app/code/Magento/Review/Model/ResourceModel/Review/Summary.php
@@ -79,14 +79,14 @@ class Summary extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      * Append review summary fields to product collection
      *
      * @param \Magento\Catalog\Model\ResourceModel\Product\Collection $productCollection
-     * @param string $storeId
+     * @param int $storeId
      * @param string $entityCode
      * @return Summary
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function appendSummaryFieldsToCollection(
         \Magento\Catalog\Model\ResourceModel\Product\Collection $productCollection,
-        string $storeId,
+        int $storeId,
         string $entityCode
     ) {
         if (!$productCollection->isLoaded()) {

--- a/app/code/Magento/Review/Observer/CatalogProductListCollectionAppendSummaryFieldsObserver.php
+++ b/app/code/Magento/Review/Observer/CatalogProductListCollectionAppendSummaryFieldsObserver.php
@@ -53,7 +53,7 @@ class CatalogProductListCollectionAppendSummaryFieldsObserver implements Observe
         $productCollection = $observer->getEvent()->getCollection();
         $this->sumResourceFactory->create()->appendSummaryFieldsToCollection(
             $productCollection,
-            $this->storeManager->getStore()->getId(),
+            (int)$this->storeManager->getStore()->getId(),
             \Magento\Review\Model\Review::ENTITY_PRODUCT_CODE
         );
 

--- a/app/code/Magento/Review/Test/Unit/Observer/CatalogProductListCollectionAppendSummaryFieldsObserverTest.php
+++ b/app/code/Magento/Review/Test/Unit/Observer/CatalogProductListCollectionAppendSummaryFieldsObserverTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CatalogProductListCollectionAppendSummaryFieldsObserverTest extends TestCase
 {
-    private const STORE_ID = '1';
+    private const STORE_ID = 1;
 
     /**
      * @var Event|MockObject


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixed issue with wrong type of argument for appendSummaryFieldsToCollection
It will fix issue in `app/code/Magento/Review/Observer/CatalogProductListCollectionAppendSummaryFieldsObserver:execute()` where appendSummaryFieldsToCollection get `int`as `storeId`

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
