### PR TITLE
LoadCssAsync html format fixed for critical css 

### DIFF
--- a/app/code/Magento/Theme/Controller/Result/AsyncCssPlugin.php
+++ b/app/code/Magento/Theme/Controller/Result/AsyncCssPlugin.php
@@ -16,7 +16,7 @@ use Magento\Framework\App\Response\Http;
  */
 class AsyncCssPlugin
 {
-    private const XML_PATH_USE_CSS_CRITICAL_PATH = 'dev/css/use_css_critical_path';
+    const XML_PATH_USE_CSS_CRITICAL_PATH = 'dev/css/use_css_critical_path';
 
     /**
      * @var ScopeConfigInterface
@@ -60,7 +60,7 @@ class AsyncCssPlugin
                     $loadCssAsync = sprintf(
                         '<link rel="preload" as="style" media="%s"' .
                          ' onload="this.onload=null;this.rel=\'stylesheet\'"' .
-                        ' href="%s">',
+                        ' href="%s" />',
                         $media,
                         $href
                     );

--- a/app/code/Magento/Theme/Controller/Result/AsyncCssPlugin.php
+++ b/app/code/Magento/Theme/Controller/Result/AsyncCssPlugin.php
@@ -58,9 +58,9 @@ class AsyncCssPlugin
                     }
                     $media = $media ?? 'all';
                     $loadCssAsync = sprintf(
-                        '<link rel="preload" as="style" media="%s" .
-                         onload="this.onload=null;this.rel=\'stylesheet\'"' .
-                        'href="%s">',
+                        '<link rel="preload" as="style" media="%s"' .
+                         ' onload="this.onload=null;this.rel=\'stylesheet\'"' .
+                        ' href="%s">',
                         $media,
                         $href
                     );

--- a/app/code/Magento/Theme/Controller/Result/AsyncCssPlugin.php
+++ b/app/code/Magento/Theme/Controller/Result/AsyncCssPlugin.php
@@ -16,7 +16,7 @@ use Magento\Framework\App\Response\Http;
  */
 class AsyncCssPlugin
 {
-    const XML_PATH_USE_CSS_CRITICAL_PATH = 'dev/css/use_css_critical_path';
+    private const XML_PATH_USE_CSS_CRITICAL_PATH = 'dev/css/use_css_critical_path';
 
     /**
      * @var ScopeConfigInterface

--- a/app/code/Magento/Theme/Test/Unit/Controller/Result/AsyncCssPluginTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Result/AsyncCssPluginTest.php
@@ -59,9 +59,9 @@ class AsyncCssPluginTest extends TestCase
     /**
      * Data Provider for before send response
      *
-     * @return void
+     * @return array
      */
-    public function sendResponseDataProvider()
+    public function sendResponseDataProvider(): array
     {
         return [
             [

--- a/app/code/Magento/Theme/Test/Unit/Controller/Result/AsyncCssPluginTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Result/AsyncCssPluginTest.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Theme\Test\Unit\Controller\Result;
+
+use Magento\Theme\Controller\Result\AsyncCssPlugin;
+use Magento\Framework\App\Response\Http;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+
+/**
+ * Unit test for Magento\Theme\Test\Unit\Controller\Result\AsyncCssPlugin.
+ */
+class AsyncCssPluginTest extends TestCase
+{
+    /**
+     * @var AsyncCssPlugin
+     */
+    private $plugin;
+
+    /**
+     * @var ScopeConfigInterface|MockObject
+     */
+    private $scopeConfigMock;
+
+    /**
+     * @var Http|MockObject
+     */
+    private $httpMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)
+            ->setMethods(['isSetFlag'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $this->httpMock = $this->createMock(Http::class);
+
+        $objectManager = new ObjectManagerHelper($this);
+        $this->plugin = $objectManager->getObject(
+            AsyncCssPlugin::class,
+            [
+                'scopeConfig' => $this->scopeConfigMock
+            ]
+        );
+    }
+
+    /**
+     * Data Provider for before send response
+     *
+     * @return void
+     */
+    public function sendResponseDataProvider()
+    {
+        return [
+            [
+                "content" => "<body><h1>Test Title</h1>" .
+                    "<link rel=\"stylesheet\" href=\"css/critical.css\" />" .
+                    "<p>Test Content</p></body>",
+                "flag" => true,
+                "result" => "<body><h1>Test Title</h1>" .
+                    "<link rel=\"preload\" as=\"style\" media=\"all\"" .
+                    " onload=\"this.onload=null;this.rel='stylesheet'\" href=\"css/critical.css\" />" .
+                    "<p>Test Content</p>" .
+                    "<link rel=\"stylesheet\" href=\"css/critical.css\" />" .
+                    "\n</body>"
+            ],
+            [
+                "content" => "<body><p>Test Content</p></body>",
+                "flag" => false,
+                "result" => "<body><p>Test Content</p></body>"
+            ],
+            [
+                "content" => "<body><p>Test Content</p></body>",
+                "flag" => true,
+                "result" => "<body><p>Test Content</p></body>"
+            ]
+        ];
+    }
+
+    /**
+     * Test beforeSendResponse
+     *
+     * @param string $content
+     * @param bool $isSetFlag
+     * @param string $result
+     * @return void
+     * @dataProvider sendResponseDataProvider
+     */
+    public function testBeforeSendResponse($content, $isSetFlag, $result): void
+    {
+        $this->httpMock->expects($this->once())
+            ->method('getContent')
+            ->willReturn($content);
+
+        $this->scopeConfigMock->expects($this->once())
+            ->method('isSetFlag')
+            ->with(
+                AsyncCssPlugin::XML_PATH_USE_CSS_CRITICAL_PATH,
+                ScopeInterface::SCOPE_STORE
+            )
+            ->willReturn($isSetFlag);
+
+        $this->httpMock->expects($this->any())
+            ->method('setContent')
+            ->with($result);
+
+        $this->plugin->beforeSendResponse($this->httpMock);
+    }
+
+    /**
+     * Test BeforeSendResponse if content is not a string
+     *
+     * @return void
+     */
+    public function testIfGetContentIsNotAString(): void
+    {
+        $this->httpMock->expects($this->once())
+            ->method('getContent')
+            ->willReturn([]);
+
+        $this->scopeConfigMock->expects($this->any())
+            ->method('isSetFlag')
+            ->with(
+                AsyncCssPlugin::XML_PATH_USE_CSS_CRITICAL_PATH,
+                ScopeInterface::SCOPE_STORE
+            )
+            ->willReturn(false);
+
+        $this->plugin->beforeSendResponse($this->httpMock);
+    }
+}

--- a/app/code/Magento/Theme/Test/Unit/Controller/Result/AsyncCssPluginTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Result/AsyncCssPluginTest.php
@@ -20,6 +20,8 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHe
  */
 class AsyncCssPluginTest extends TestCase
 {
+    const STUB_XML_PATH_USE_CSS_CRITICAL_PATH = 'dev/css/use_css_critical_path';
+
     /**
      * @var AsyncCssPlugin
      */
@@ -107,7 +109,7 @@ class AsyncCssPluginTest extends TestCase
         $this->scopeConfigMock->expects($this->once())
             ->method('isSetFlag')
             ->with(
-                AsyncCssPlugin::XML_PATH_USE_CSS_CRITICAL_PATH,
+                self::STUB_XML_PATH_USE_CSS_CRITICAL_PATH,
                 ScopeInterface::SCOPE_STORE
             )
             ->willReturn($isSetFlag);
@@ -133,7 +135,7 @@ class AsyncCssPluginTest extends TestCase
         $this->scopeConfigMock->expects($this->any())
             ->method('isSetFlag')
             ->with(
-                AsyncCssPlugin::XML_PATH_USE_CSS_CRITICAL_PATH,
+                self::STUB_XML_PATH_USE_CSS_CRITICAL_PATH,
                 ScopeInterface::SCOPE_STORE
             )
             ->willReturn(false);


### PR DESCRIPTION
### Description (*)
LoadCssAsync html format fixed

### Fixed Issues (if relevant)
1. magento/magento2#26760: Validate html error when enable critical css

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
