### PR TITLE
Fix #17933 - Bank Transfer Payment Instructions switch back to default

### DIFF
--- a/app/code/Magento/OfflinePayments/Observer/BeforeOrderPaymentSaveObserver.php
+++ b/app/code/Magento/OfflinePayments/Observer/BeforeOrderPaymentSaveObserver.php
@@ -3,9 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\OfflinePayments\Observer;
 
+use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\OfflinePayments\Model\Banktransfer;
 use Magento\OfflinePayments\Model\Cashondelivery;
@@ -19,10 +21,10 @@ class BeforeOrderPaymentSaveObserver implements ObserverInterface
     /**
      * Sets current instructions for bank transfer account
      *
-     * @param \Magento\Framework\Event\Observer $observer
+     * @param Observer $observer
      * @return void
      */
-    public function execute(\Magento\Framework\Event\Observer $observer)
+    public function execute(Observer $observer)
     {
         /** @var \Magento\Sales\Model\Order\Payment $payment */
         $payment = $observer->getEvent()->getPayment();
@@ -34,15 +36,22 @@ class BeforeOrderPaymentSaveObserver implements ObserverInterface
             && empty($payment->getAdditionalInformation('instructions'))) {
             $payment->setAdditionalInformation(
                 'instructions',
-                $payment->getMethodInstance()->getInstructions()
+                $payment->getMethodInstance()->getConfigData(
+                    'instructions',
+                    $payment->getOrder()->getStoreId()
+                )
             );
         } elseif ($payment->getMethod() === Checkmo::PAYMENT_METHOD_CHECKMO_CODE) {
             $methodInstance = $payment->getMethodInstance();
-            if (!empty($methodInstance->getPayableTo())) {
-                $payment->setAdditionalInformation('payable_to', $methodInstance->getPayableTo());
+            $storeId = $payment->getOrder()->getStoreId();
+
+            $payableTo = $methodInstance->getConfigData('payable_to', $storeId);
+            if (!empty($payableTo)) {
+                $payment->setAdditionalInformation('payable_to', $payableTo);
             }
-            if (!empty($methodInstance->getMailingAddress())) {
-                $payment->setAdditionalInformation('mailing_address', $methodInstance->getMailingAddress());
+            $mailingAddress = $methodInstance->getConfigData('mailing_address', $storeId);
+            if (!empty($mailingAddress)) {
+                $payment->setAdditionalInformation('mailing_address', $mailingAddress);
             }
         }
     }

--- a/app/code/Magento/OfflinePayments/Test/Unit/Observer/BeforeOrderPaymentSaveObserverTest.php
+++ b/app/code/Magento/OfflinePayments/Test/Unit/Observer/BeforeOrderPaymentSaveObserverTest.php
@@ -10,32 +10,44 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\OfflinePayments\Model\Banktransfer;
 use Magento\OfflinePayments\Model\Cashondelivery;
-use Magento\OfflinePayments\Observer\BeforeOrderPaymentSaveObserver;
-use Magento\Sales\Model\Order\Payment;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Magento\OfflinePayments\Model\Checkmo;
+use Magento\OfflinePayments\Observer\BeforeOrderPaymentSaveObserver;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Payment;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class BeforeOrderPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
+/**
+ * Test class for \Magento\OfflinePayments\Observer\BeforeOrderPaymentSaveObserver
+ */
+class BeforeOrderPaymentSaveObserverTest extends TestCase
 {
+    private const STORE_ID = 1;
+
     /**
      * @var BeforeOrderPaymentSaveObserver
      */
-    protected $_model;
+    private $model;
 
     /**
      * @var Payment|MockObject
      */
-    private $payment;
+    private $paymentMock;
 
     /**
      * @var Event|MockObject
      */
-    private $event;
+    private $eventMock;
 
     /**
      * @var Observer|MockObject
      */
-    private $observer;
+    private $observerMock;
+
+    /**
+     * @var Order|MockObject
+     */
+    private $orderMock;
 
     /**
      * @inheritdoc
@@ -43,40 +55,50 @@ class BeforeOrderPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
     protected function setUp()
     {
         $objectManagerHelper = new ObjectManager($this);
-        $this->payment = $this->getMockBuilder(Payment::class)
+        $this->paymentMock = $this->getMockBuilder(Payment::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->event = $this->getMockBuilder(Event::class)
+        $this->eventMock = $this->getMockBuilder(Event::class)
             ->disableOriginalConstructor()
             ->setMethods(['getPayment'])
             ->getMock();
 
-        $this->event->expects(self::once())
+        $this->eventMock->expects(self::once())
             ->method('getPayment')
-            ->willReturn($this->payment);
+            ->willReturn($this->paymentMock);
 
-        $this->observer = $this->getMockBuilder(Observer::class)
+        $this->observerMock = $this->getMockBuilder(Observer::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->observer->expects(self::once())
+        $this->observerMock->expects(self::once())
             ->method('getEvent')
-            ->willReturn($this->event);
+            ->willReturn($this->eventMock);
 
-        $this->_model = $objectManagerHelper->getObject(BeforeOrderPaymentSaveObserver::class);
+        $this->orderMock = $this->getMockBuilder(Order::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->orderMock->method('getStoreId')
+            ->willReturn(static::STORE_ID);
+
+        $this->paymentMock->method('getOrder')
+            ->willReturn($this->orderMock);
+
+        $this->model = $objectManagerHelper->getObject(BeforeOrderPaymentSaveObserver::class);
     }
 
     /**
+     * Checks a case when payment method is either bank transfer or cash on delivery
      * @param string $methodCode
      * @dataProvider dataProviderBeforeOrderPaymentSaveWithInstructions
      */
     public function testBeforeOrderPaymentSaveWithInstructions($methodCode)
     {
-        $this->payment->expects(self::once())
+        $this->paymentMock->expects(self::once())
             ->method('getMethod')
             ->willReturn($methodCode);
-        $this->payment->expects(self::once())
+        $this->paymentMock->expects(self::once())
             ->method('setAdditionalInformation')
             ->with('instructions', 'payment configuration');
         $method = $this->getMockBuilder(Banktransfer::class)
@@ -84,13 +106,14 @@ class BeforeOrderPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
         $method->expects(self::once())
-            ->method('getInstructions')
+            ->method('getConfigData')
+            ->with('instructions', static::STORE_ID)
             ->willReturn('payment configuration');
-        $this->payment->expects(self::once())
+        $this->paymentMock->expects(self::once())
             ->method('getMethodInstance')
             ->willReturn($method);
 
-        $this->_model->execute($this->observer);
+        $this->model->execute($this->observerMock);
     }
 
     /**
@@ -106,33 +129,37 @@ class BeforeOrderPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    /**
+     * Checks a case when payment method is Check Money
+     */
     public function testBeforeOrderPaymentSaveWithCheckmo()
     {
-        $this->payment->expects(self::exactly(2))
+        $this->paymentMock->expects(self::exactly(2))
             ->method('getMethod')
             ->willReturn(Checkmo::PAYMENT_METHOD_CHECKMO_CODE);
-        $this->payment->expects(self::exactly(2))
+        $this->paymentMock->expects(self::exactly(2))
             ->method('setAdditionalInformation')
             ->willReturnMap(
                 [
-                    ['payable_to', 'payable to', $this->payment],
-                    ['mailing_address', 'mailing address', $this->payment],
+                    ['payable_to', 'payable to', $this->paymentMock],
+                    ['mailing_address', 'mailing address', $this->paymentMock],
                 ]
             );
 
         $method = $this->getMockBuilder(Checkmo::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $method->expects(self::exactly(2))
-            ->method('getPayableTo')
-            ->willReturn('payable to');
-        $method->expects(self::exactly(2))
-            ->method('getMailingAddress')
-            ->willReturn('mailing address');
-        $this->payment->expects(self::once())
+        $method->method('getConfigData')
+            ->willReturnMap(
+                [
+                    ['payable_to', static::STORE_ID, 'payable to'],
+                    ['mailing_address', static::STORE_ID, 'mailing address']
+                ]
+            );
+        $this->paymentMock->expects(self::once())
             ->method('getMethodInstance')
             ->willReturn($method);
-        $this->_model->execute($this->observer);
+        $this->model->execute($this->observerMock);
     }
 
     /**
@@ -141,36 +168,40 @@ class BeforeOrderPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
      */
     public function testBeforeOrderPaymentSaveWithCheckmoWithoutConfig()
     {
-        $this->payment->expects(self::exactly(2))
+        $this->paymentMock->expects(self::exactly(2))
             ->method('getMethod')
             ->willReturn(Checkmo::PAYMENT_METHOD_CHECKMO_CODE);
-        $this->payment->expects(self::never())
+        $this->paymentMock->expects(self::never())
             ->method('setAdditionalInformation');
 
         $method = $this->getMockBuilder(Checkmo::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $method->expects(self::once())
-            ->method('getPayableTo')
-            ->willReturn(null);
-        $method->expects(self::once())
-            ->method('getMailingAddress')
-            ->willReturn(null);
-        $this->payment->expects(self::once())
+        $method->method('getConfigData')
+            ->willReturnMap(
+                [
+                    ['payable_to', static::STORE_ID, null],
+                    ['mailing_address', static::STORE_ID, null]
+                ]
+            );
+        $this->paymentMock->expects(self::once())
             ->method('getMethodInstance')
             ->willReturn($method);
-        $this->_model->execute($this->observer);
+        $this->model->execute($this->observerMock);
     }
 
+    /**
+     * Checks a case with payment method not handled by observer
+     */
     public function testBeforeOrderPaymentSaveWithOthers()
     {
-        $this->payment->expects(self::exactly(2))
+        $this->paymentMock->expects(self::exactly(2))
             ->method('getMethod')
             ->willReturn('somepaymentmethod');
-        $this->payment->expects(self::never())
+        $this->paymentMock->expects(self::never())
             ->method('setAdditionalInformation');
 
-        $this->_model->execute($this->observer);
+        $this->model->execute($this->observerMock);
     }
 
     /**
@@ -179,17 +210,16 @@ class BeforeOrderPaymentSaveObserverTest extends \PHPUnit\Framework\TestCase
      */
     public function testBeforeOrderPaymentSaveWithInstructionsAlreadySet($methodCode)
     {
-        $this->payment
-            ->method('getMethod')
+        $this->paymentMock->method('getMethod')
             ->willReturn($methodCode);
 
-        $this->payment->expects(self::once())
+        $this->paymentMock->expects(self::once())
             ->method('getAdditionalInformation')
             ->willReturn('Test');
 
-        $this->payment->expects(self::never())
+        $this->paymentMock->expects(self::never())
             ->method('setAdditionalInformation');
 
-        $this->_model->execute($this->observer);
+        $this->model->execute($this->observerMock);
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This is fix for #17933 
The issue was caused because observer modified here did override `additional_information` column in `sales_order_payment` table with data for incorrect store view.
Also, exactly the same issue occurred for Cash On Delivery and very similar, just for other fields (`payable_to` and `mailing_address`), for Check Money Order - both also are resolved with this fix.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#17933: Bank Transer Payment Instuctions switch back to default

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Please check fixed issue for testing scenario

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
