### PR TITLE
magento/magento2#26766: GraphQL. Query: categoryList. Returns wrong category image URL

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Image.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Image.php
@@ -56,7 +56,7 @@ class Image implements ResolverInterface
         $mediaPath = $this->directoryList->getUrlPath('media');
         $pos = strpos($imagePath, $mediaPath);
         if ($pos !== false) {
-            $imagePath = substr($imagePath, $pos + strlen($mediaPath), strlen($baseUrl));
+            $imagePath = substr($imagePath, $pos + strlen($mediaPath) + 1);
         }
         $imageUrl = rtrim($baseUrl, '/') . '/' . ltrim($imagePath, '/');
 


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

PR fixes https://github.com/magento/magento2/issues/26766.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#26766: GraphQL. Query: categoryList. Returns wrong category image URL

### Manual testing scenarios (*)

1. Open any GraphQl tool
2. Run the next query to retrieve a category image:

```
{
    categoryList(
      filters : {
        ids: {eq: "ENTITY_ID_OF_CATEGORY"}
      }
    )
    {
        image
    }
}

```


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
