### PR TITLE
Fix return type in ResetAttemptForFrontendObserver and ResetAttemptForBackendObserver

### DIFF
--- a/app/code/Magento/Captcha/Observer/ResetAttemptForBackendObserver.php
+++ b/app/code/Magento/Captcha/Observer/ResetAttemptForBackendObserver.php
@@ -5,20 +5,27 @@
  */
 namespace Magento\Captcha\Observer;
 
+use Magento\Captcha\Model\ResourceModel\Log;
+use Magento\Captcha\Model\ResourceModel\LogFactory;
+use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\LocalizedException;
 
+/**
+ * Reset captcha attempts for Backend
+ */
 class ResetAttemptForBackendObserver implements ObserverInterface
 {
     /**
-     * @var \Magento\Captcha\Model\ResourceModel\LogFactory
+     * @var LogFactory
      */
     public $resLogFactory;
 
     /**
-     * @param \Magento\Captcha\Model\ResourceModel\LogFactory $resLogFactory
+     * @param LogFactory $resLogFactory
      */
     public function __construct(
-        \Magento\Captcha\Model\ResourceModel\LogFactory $resLogFactory
+        LogFactory $resLogFactory
     ) {
         $this->resLogFactory = $resLogFactory;
     }
@@ -26,10 +33,11 @@ class ResetAttemptForBackendObserver implements ObserverInterface
     /**
      * Reset Attempts For Backend
      *
-     * @param \Magento\Framework\Event\Observer $observer
-     * @return \Magento\Captcha\Observer\ResetAttemptForBackendObserver
+     * @param Observer $observer
+     * @return Log
+     * @throws LocalizedException
      */
-    public function execute(\Magento\Framework\Event\Observer $observer)
+    public function execute(Observer $observer)
     {
         return $this->resLogFactory->create()->deleteUserAttempts($observer->getUser()->getUsername());
     }

--- a/app/code/Magento/Captcha/Observer/ResetAttemptForFrontendObserver.php
+++ b/app/code/Magento/Captcha/Observer/ResetAttemptForFrontendObserver.php
@@ -5,20 +5,28 @@
  */
 namespace Magento\Captcha\Observer;
 
+use Magento\Captcha\Model\ResourceModel\Log;
+use Magento\Captcha\Model\ResourceModel\LogFactory;
+use Magento\Customer\Model\Customer;
+use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\LocalizedException;
 
+/**
+ * Reset captcha attempts for Frontend
+ */
 class ResetAttemptForFrontendObserver implements ObserverInterface
 {
     /**
-     * @var \Magento\Captcha\Model\ResourceModel\LogFactory
+     * @var LogFactory
      */
     public $resLogFactory;
 
     /**
-     * @param \Magento\Captcha\Model\ResourceModel\LogFactory $resLogFactory
+     * @param LogFactory $resLogFactory
      */
     public function __construct(
-        \Magento\Captcha\Model\ResourceModel\LogFactory $resLogFactory
+        LogFactory $resLogFactory
     ) {
         $this->resLogFactory = $resLogFactory;
     }
@@ -26,12 +34,13 @@ class ResetAttemptForFrontendObserver implements ObserverInterface
     /**
      * Reset Attempts For Frontend
      *
-     * @param \Magento\Framework\Event\Observer $observer
-     * @return \Magento\Captcha\Observer\ResetAttemptForFrontendObserver
+     * @param Observer $observer
+     * @return Log
+     * @throws LocalizedException
      */
-    public function execute(\Magento\Framework\Event\Observer $observer)
+    public function execute(Observer $observer)
     {
-        /** @var \Magento\Customer\Model\Customer $model */
+        /** @var Customer $model */
         $model = $observer->getModel();
 
         return $this->resLogFactory->create()->deleteUserAttempts($model->getEmail());


### PR DESCRIPTION
### Description (*)
Fixes return type in the docblock of execute() method , for \Magento\Captcha\Observer\ResetAttemptForFrontendObserver and \Magento\Captcha\Observer\ResetAttemptForBackendObserver; some code cleaning.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
