### PR TITLE
Disabled flat: cast $attributeId as (int) in selects

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -24,7 +24,7 @@ use Magento\Framework\Exception\LocalizedException;
 abstract class AbstractCollection extends AbstractDb implements SourceProviderInterface
 {
     /**
-     * Attribute table alias prefix
+     * Define default prefix for attribute table alias
      */
     const ATTRIBUTE_TABLE_ALIAS_PREFIX = 'at_';
 
@@ -495,7 +495,7 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
             $entity = clone $this->getEntity();
             $attributes = $entity->loadAllAttributes()->getAttributesByCode();
             foreach ($attributes as $attrCode => $attr) {
-                $this->_selectAttributes[$attrCode] = $attr->getId();
+                $this->_selectAttributes[$attrCode] = (int) $attr->getId();
             }
         } else {
             if (isset($this->_joinAttributes[$attribute])) {
@@ -511,7 +511,7 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
                     )
                 );
             }
-            $this->_selectAttributes[$attrInstance->getAttributeCode()] = $attrInstance->getId();
+            $this->_selectAttributes[$attrInstance->getAttributeCode()] = (int) $attrInstance->getId();
         }
         return $this;
     }

--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -1173,7 +1173,7 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
             }
             $attribute = $this->_eavConfig->getAttribute($entity->getType(), $attributeCode);
             if ($attribute && !$attribute->isStatic()) {
-                $tableAttributes[$attribute->getBackendTable()][] = $attributeId;
+                $tableAttributes[$attribute->getBackendTable()][] = (int) $attributeId;
                 if (!isset($attributeTypes[$attribute->getBackendTable()])) {
                     $attributeTypes[$attribute->getBackendTable()] = $attribute->getBackendType();
                 }

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Collection/AbstractCollectionStub.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Collection/AbstractCollectionStub.php
@@ -30,4 +30,14 @@ class AbstractCollectionStub extends \Magento\Eav\Model\Entity\Collection\Abstra
     {
         return $this->_init(\Magento\Framework\DataObject::class, 'test_entity_model');
     }
+
+    /**
+     * Retrieve collection empty item
+     *
+     * @return \Magento\Framework\DataObject
+     */
+    public function getNewEmptyItem()
+    {
+        return new \Magento\Framework\DataObject();
+    }
 }

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Collection/AbstractCollectionTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Collection/AbstractCollectionTest.php
@@ -12,6 +12,10 @@ namespace Magento\Eav\Test\Unit\Model\Entity\Collection;
  */
 class AbstractCollectionTest extends \PHPUnit\Framework\TestCase
 {
+    const ATTRIBUTE_CODE = 'any_attribute';
+    const ATTRIBUTE_ID_STRING = '15';
+    const ATTRIBUTE_ID_INT = 15;
+
     /**
      * @var AbstractCollectionStub|\PHPUnit_Framework_MockObject_MockObject
      */
@@ -105,6 +109,26 @@ class AbstractCollectionTest extends \PHPUnit\Framework\TestCase
         $entityMock = $this->createMock(\Magento\Eav\Model\Entity\AbstractEntity::class);
         $entityMock->expects($this->any())->method('getConnection')->will($this->returnValue($connectionMock));
         $entityMock->expects($this->any())->method('getDefaultAttributes')->will($this->returnValue([]));
+        $entityMock->expects($this->any())->method('getLinkField')->willReturn('entity_id');
+
+        $attributeMock = $this->createMock(\Magento\Eav\Model\Attribute::class);
+        $attributeMock->expects($this->any())->method('isStatic')->willReturn(false);
+        $attributeMock->expects($this->any())->method('getAttributeCode')->willReturn(self::ATTRIBUTE_CODE);
+        $attributeMock->expects($this->any())->method('getBackendTable')->willReturn('eav_entity_int');
+        $attributeMock->expects($this->any())->method('getBackendType')->willReturn('int');
+        $attributeMock->expects($this->any())->method('getId')->willReturn(self::ATTRIBUTE_ID_STRING);
+
+        $entityMock
+            ->expects($this->any())
+            ->method('getAttribute')
+            ->with(self::ATTRIBUTE_CODE)
+            ->willReturn($attributeMock);
+
+        $this->configMock
+            ->expects($this->any())
+            ->method('getAttribute')
+            ->with(null, self::ATTRIBUTE_CODE)
+            ->willReturn($attributeMock);
 
         $this->validatorFactoryMock->expects(
             $this->any()
@@ -191,6 +215,30 @@ class AbstractCollectionTest extends \PHPUnit\Framework\TestCase
         $this->model->removeItemByKey($testId);
         $this->assertCount($count - 1, $this->model->getItems());
         $this->assertNull($this->model->getItemById($testId));
+    }
+
+    /**
+     * @dataProvider getItemsDataProvider
+     */
+    public function testAttributeIdIsInt($values)
+    {
+        $this->resourceHelperMock->expects($this->any())->method('getLoadAttributesSelectGroups')->willReturn([]);
+        $this->fetchStrategyMock->expects($this->any())->method('fetchAll')->will($this->returnValue($values));
+        $selectMock = $this->coreResourceMock->getConnection()->select();
+        $selectMock->expects($this->any())->method('from')->willReturn($selectMock);
+        $selectMock->expects($this->any())->method('join')->willReturn($selectMock);
+        $selectMock->expects($this->any())->method('where')->willReturn($selectMock);
+        $selectMock->expects($this->any())->method('columns')->willReturn($selectMock);
+
+        $this->model
+            ->addAttributeToSelect(self::ATTRIBUTE_CODE)
+            ->_loadEntities()
+            ->_loadAttributes();
+
+        $_selectAttributesActualValue = $this->readAttribute($this->model, '_selectAttributes');
+
+        $this->assertAttributeEquals([self::ATTRIBUTE_CODE => self::ATTRIBUTE_ID_STRING], '_selectAttributes', $this->model);
+        $this->assertSame($_selectAttributesActualValue[self::ATTRIBUTE_CODE], self::ATTRIBUTE_ID_INT);
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When we disabled flat we noticed that ids are cast as string
```
SELECT `t_d`.`attribute_id`, `e`.`entity_id`
FROM `catalog_product_entity_varchar` AS `t_d`
         INNER JOIN `catalog_product_entity` AS `e` ON e.entity_id = t_d.entity_id
         LEFT JOIN `catalog_product_entity_varchar` AS `t_s`
                   ON t_s.attribute_id = t_d.attribute_id AND t_s.entity_id = t_d.entity_id AND t_s.store_id = 8
WHERE (e.entity_id IN
       (209884, 213420, 212364, 212009, 211989, 211710, 210914, 210588, 212316, 212239, 210456, 210453, 213157, 212556,
        212380, 211186, 210984, 210157, 209443, 208989, 169036, 168488, 158426, 211496, 209688, 210951, 203816, 206125,
        203077, 158390, 158397, 158402, 206534, 143843, 149488, 149470, 200116, 193494, 193134, 208259, 151009, 213770,
        213759, 213751, 213735, 213731, 213721, 213270, 212975, 212948, 212917, 212865, 212753, 212729, 212655, 212541))
  AND (t_d.attribute_id IN
       ('73', '87', '88', '89', '109', '110', '111', '119', '122', '133', '148', '177', '180', '184', '210', '220',
        '222'))
  AND (t_d.store_id = IFNULL(t_s.store_id, 0));
```
this fix will change it to be cast like numbers
```
SELECT `t_d`.`attribute_id`, `e`.`entity_id`
FROM `catalog_product_entity_varchar` AS `t_d`
         INNER JOIN `catalog_product_entity` AS `e` ON e.entity_id = t_d.entity_id
         LEFT JOIN `catalog_product_entity_varchar` AS `t_s`
                   ON t_s.attribute_id = t_d.attribute_id AND t_s.entity_id = t_d.entity_id AND t_s.store_id = 8
WHERE (e.entity_id IN
       (209884, 213420, 212364, 212009, 211989, 211710, 210914, 210588, 212316, 212239, 210456, 210453, 213157, 212556,
        212380, 211186, 210984, 210157, 209443, 208989, 169036, 168488, 158426, 211496, 209688, 210951, 203816, 206125,
        203077, 158390, 158397, 158402, 206534, 143843, 149488, 149470, 200116, 193494, 193134, 208259, 151009, 213770,
        213759, 213751, 213735, 213731, 213721, 213270, 212975, 212948, 212917, 212865, 212753, 212729, 212655, 212541))
  AND (t_d.attribute_id IN (73, 87, 88, 89, 109, 110, 111, 119, 122, 133, 148, 177, 180, 184, 210, 220, 222))
  AND (t_d.store_id = IFNULL(t_s.store_id, 0));
```

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See selects generated in `\Magento\Eav\Model\Entity\Collection\AbstractCollection::_loadAttributes` method
2. 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
