### PR TITLE
Prevent resizing an image if it was already resized before

### DIFF
--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -15,17 +15,18 @@ use Magento\Framework\App\Area;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Framework\Image;
 use Magento\Framework\Image\Factory as ImageFactory;
 use Magento\Catalog\Model\Product\Media\ConfigInterface as MediaConfig;
 use Magento\Framework\App\State;
 use Magento\Framework\View\ConfigInterface as ViewConfig;
-use \Magento\Catalog\Model\ResourceModel\Product\Image as ProductImage;
+use Magento\Catalog\Model\ResourceModel\Product\Image as ProductImage;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Theme\Model\Config\Customization as ThemeCustomizationConfig;
-use Magento\Theme\Model\ResourceModel\Theme\Collection;
+use Magento\Theme\Model\ResourceModel\Theme\Collection as ThemeCollection;
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\MediaStorage\Helper\File\Storage\Database;
+use Magento\MediaStorage\Helper\File\Storage\Database as FileStorageDatabase;
 use Magento\Theme\Model\Theme;
 
 /**
@@ -76,24 +77,20 @@ class ImageResize
     private $themeCustomizationConfig;
 
     /**
-     * @var Collection
+     * @var ThemeCollection
      */
     private $themeCollection;
 
     /**
-     * @var Filesystem
+     * @var WriteInterface
      */
     private $mediaDirectory;
 
     /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    /**
-     * @var Database
+     * @var FileStorageDatabase
      */
     private $fileStorageDatabase;
+
     /**
      * @var StoreManagerInterface
      */
@@ -108,9 +105,9 @@ class ImageResize
      * @param ViewConfig $viewConfig
      * @param AssertImageFactory $assertImageFactory
      * @param ThemeCustomizationConfig $themeCustomizationConfig
-     * @param Collection $themeCollection
+     * @param ThemeCollection $themeCollection
      * @param Filesystem $filesystem
-     * @param Database $fileStorageDatabase
+     * @param FileStorageDatabase $fileStorageDatabase
      * @param StoreManagerInterface $storeManager
      * @throws \Magento\Framework\Exception\FileSystemException
      * @internal param ProductImage $gallery
@@ -125,9 +122,9 @@ class ImageResize
         ViewConfig $viewConfig,
         AssertImageFactory $assertImageFactory,
         ThemeCustomizationConfig $themeCustomizationConfig,
-        Collection $themeCollection,
+        ThemeCollection $themeCollection,
         Filesystem $filesystem,
-        Database $fileStorageDatabase = null,
+        FileStorageDatabase $fileStorageDatabase = null,
         StoreManagerInterface $storeManager = null
     ) {
         $this->appState = $appState;
@@ -140,9 +137,8 @@ class ImageResize
         $this->themeCustomizationConfig = $themeCustomizationConfig;
         $this->themeCollection = $themeCollection;
         $this->mediaDirectory = $filesystem->getDirectoryWrite(DirectoryList::MEDIA);
-        $this->filesystem = $filesystem;
         $this->fileStorageDatabase = $fileStorageDatabase ?:
-            ObjectManager::getInstance()->get(Database::class);
+            ObjectManager::getInstance()->get(FileStorageDatabase::class);
         $this->storeManager = $storeManager ?? ObjectManager::getInstance()->get(StoreManagerInterface::class);
     }
 

--- a/app/code/Magento/MediaStorage/Test/Unit/Service/ImageResizeTest.php
+++ b/app/code/Magento/MediaStorage/Test/Unit/Service/ImageResizeTest.php
@@ -24,8 +24,6 @@ use Magento\MediaStorage\Helper\File\Storage\Database;
 use Magento\Framework\App\Filesystem\DirectoryList;
 
 /**
- * Class ImageResizeTest
- *
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */

--- a/app/code/Magento/MediaStorage/Test/Unit/Service/ImageResizeTest.php
+++ b/app/code/Magento/MediaStorage/Test/Unit/Service/ImageResizeTest.php
@@ -247,6 +247,9 @@ class ImageResizeTest extends \PHPUnit\Framework\TestCase
         $this->databaseMock->expects($this->any())
             ->method('checkDbUsage')
             ->will($this->returnValue(true));
+        $this->databaseMock->expects($this->any())
+            ->method('fileExists')
+            ->will($this->returnValue(false));
 
         $this->productImageMock->expects($this->any())
             ->method('getCountUsedProductImages')
@@ -287,6 +290,9 @@ class ImageResizeTest extends \PHPUnit\Framework\TestCase
         $this->databaseMock->expects($this->any())
             ->method('checkDbUsage')
             ->will($this->returnValue(true));
+        $this->databaseMock->expects($this->any())
+            ->method('fileExists')
+            ->will($this->returnValue(false));
 
         $this->mediaDirectoryMock->expects($this->any())
             ->method('isFile')
@@ -313,6 +319,67 @@ class ImageResizeTest extends \PHPUnit\Framework\TestCase
         $this->databaseMock->expects($this->once())
             ->method('saveFile')
             ->with($this->testfilepath);
+
+        $this->service->resizeFromImageName($this->testfilename);
+    }
+
+    public function testSkipResizingAlreadyResizedImageOnDisk()
+    {
+        $this->databaseMock->expects($this->any())
+            ->method('checkDbUsage')
+            ->will($this->returnValue(false));
+
+        $this->mediaDirectoryMock->expects($this->any())
+            ->method('isFile')
+            ->will($this->returnValue(true));
+
+        $this->themeCollectionMock->expects($this->any())
+            ->method('loadRegisteredThemes')
+            ->willReturn(
+                [ new DataObject(['id' => '0']) ]
+            );
+        $this->themeCustomizationConfigMock->expects($this->any())
+            ->method('getStoresByThemes')
+            ->willReturn(
+                ['0' => []]
+            );
+
+        $this->imageFactoryMock->expects($this->never())
+            ->method('create');
+
+        $this->service->resizeFromImageName($this->testfilename);
+    }
+
+    public function testSkipResizingAlreadyResizedImageInDatabase()
+    {
+        $this->databaseMock->expects($this->any())
+            ->method('checkDbUsage')
+            ->will($this->returnValue(true));
+        $this->databaseMock->expects($this->any())
+            ->method('fileExists')
+            ->will($this->returnValue(true));
+
+        $this->mediaDirectoryMock->expects($this->any())
+            ->method('isFile')
+            ->with($this->testfilepath)
+            ->willReturnOnConsecutiveCalls(
+                $this->returnValue(false),
+                $this->returnValue(true)
+            );
+
+        $this->themeCollectionMock->expects($this->any())
+            ->method('loadRegisteredThemes')
+            ->willReturn(
+                [ new DataObject(['id' => '0']) ]
+            );
+        $this->themeCustomizationConfigMock->expects($this->any())
+            ->method('getStoresByThemes')
+            ->willReturn(
+                ['0' => []]
+            );
+
+        $this->databaseMock->expects($this->never())
+            ->method('saveFile');
 
         $this->service->resizeFromImageName($this->testfilename);
     }


### PR DESCRIPTION
### Description (*)
Images shouldn't get resized again if they were already resized before when running `bin/magento catalog:images:resize`.
In Magento 2.1 they didn't get resized when they were already resized before. Somewhere between Magento 2.1.18 and 2.2.11 that got changed for some reason.

I also added some cleanup to that class in a second commit, because some use statements were missing meaningful aliases and some member variables weren't being used.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/26796: Running 'bin/magento catalog:images:resize' doesn't check if an image was already resized before, therefore it is superslow as it always resizes all images

### Manual testing scenarios (*)
1. Have a product with an image
2. Remove the directory `pub/media/catalog/product/cache/`
3. Run `bin/magento catalog:images:resize`
4. Look at the generated images in `pub/media/catalog/product/cache/` and check their modified timestamps
5. Wait a bit
6. Run `bin/magento catalog:images:resize` again
7. Look at the generated images in `pub/media/catalog/product/cache/` and check their modified timestamps

Please also test when using media storage in the database, I haven't tested that but the code should work I believe.

### Questions or comments
<del>I know the unit tests will fail, will take a look later, not that much time currently. Feel free to pick this up yourselves, I don't mind 🙂</del> - Update: Already Done

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
