### PR TITLE
Issue/26843: Fix es_US Spanish (United States ) Locale is not support…

### DIFF
--- a/lib/internal/Magento/Framework/Locale/Config.php
+++ b/lib/internal/Magento/Framework/Locale/Config.php
@@ -108,6 +108,7 @@ class Config implements \Magento\Framework\Locale\ConfigInterface
         'es_VE', /*Spanish (Venezuela)*/
         'en_IE', /*English (Ireland)*/
         'es_BO', /*Spanish (Bolivia)*/
+        'es_US', /*Spanish (United States)*/
     ];
 
     /**


### PR DESCRIPTION
…ed in Magento 2.3.4 #26843

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

Fix missing code es_US in the list of  available locales

### Description (*)
Fix missing code in the list of  available locales

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#26843: es_US Spanish (United States ) Locale is not supported in Magento 2.3.4

### Manual testing scenarios (*)
1. Create a store view and set locale as "es_US"
2. Run command: php bin/magento setup:static-content:deploy -f --theme="Magento/blank" es_US

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
