### PR TITLE
TierPriceBox toHtml method should be return with string

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Pricing/Render/TierPriceBox.php
+++ b/app/code/Magento/ConfigurableProduct/Pricing/Render/TierPriceBox.php
@@ -9,8 +9,6 @@ use Magento\Catalog\Pricing\Price\TierPrice;
 
 /**
  * Responsible for displaying tier price box on configurable product page.
- *
- * @package Magento\ConfigurableProduct\Pricing\Render
  */
 class TierPriceBox extends FinalPriceBox
 {

--- a/app/code/Magento/ConfigurableProduct/Pricing/Render/TierPriceBox.php
+++ b/app/code/Magento/ConfigurableProduct/Pricing/Render/TierPriceBox.php
@@ -23,6 +23,7 @@ class TierPriceBox extends FinalPriceBox
         if (!$this->isMsrpPriceApplicable() && $this->isTierPriceApplicable()) {
             return parent::toHtml();
         }
+        return '';
     }
 
     /**

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Pricing/Render/TierPriceBoxTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Pricing/Render/TierPriceBoxTest.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\ConfigurableProduct\Test\Unit\Pricing\Render;
+
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Pricing\Renderer\SalableResolverInterface;
+use Magento\Catalog\Pricing\Price\MinimalPriceCalculatorInterface;
+use Magento\ConfigurableProduct\Pricing\Price\ConfigurableOptionsProviderInterface;
+use Magento\ConfigurableProduct\Pricing\Render\TierPriceBox;
+use Magento\Framework\Pricing\Price\PriceInterface;
+use Magento\Framework\Pricing\PriceInfoInterface;
+use Magento\Framework\Pricing\Render\RendererPool;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\View\Element\Template\Context;
+use Magento\Msrp\Pricing\Price\MsrpPrice;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class TierPriceBoxTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var Context|MockObject
+     */
+    private $context;
+
+    /**
+     * @var Product|MockObject
+     */
+    private $saleableItem;
+
+    /**
+     * @var PriceInterface|MockObject
+     */
+    private $price;
+
+    /**
+     * @var RendererPool|MockObject
+     */
+    private $rendererPool;
+
+    /**
+     * @var SalableResolverInterface|MockObject
+     */
+    private $salableResolver;
+
+    /**
+     * @var MinimalPriceCalculatorInterface|MockObject
+     */
+    private $minimalPriceCalculator;
+
+    /**
+     * @var ConfigurableOptionsProviderInterface|MockObject
+     */
+    private $configurableOptionsProvider;
+
+    /**
+     * @var TierPriceBox
+     */
+    private $model;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        $this->context = $this->createPartialMock(Context::class, []);
+        $this->saleableItem = $this->createPartialMock(Product::class, ['getPriceInfo']);
+        $this->price = $this->createMock(PriceInterface::class);
+        $this->rendererPool = $this->createPartialMock(RendererPool::class, []);
+        $this->salableResolver = $this->createPartialMock(SalableResolverInterface::class, ['isSalable']);
+        $this->minimalPriceCalculator = $this->createMock(MinimalPriceCalculatorInterface::class);
+        $this->configurableOptionsProvider = $this->createMock(ConfigurableOptionsProviderInterface::class);
+
+        $this->model = (new ObjectManager($this))->getObject(
+            TierPriceBox::class,
+            [
+                'context'                     => $this->context,
+                'saleableItem'                => $this->saleableItem,
+                'price'                       => $this->price,
+                'rendererPool'                => $this->rendererPool,
+                'salableResolver'             => $this->salableResolver,
+                'minimalPriceCalculator'      => $this->minimalPriceCalculator,
+                'configurableOptionsProvider' => $this->configurableOptionsProvider,
+            ]
+        );
+    }
+
+    public function testToHtmlEmptyWhenMsrpPriceIsApplicable()
+    {
+        $msrpPriceMock = $this->createPartialMock(
+            MsrpPrice::class,
+            ['canApplyMsrp', 'isMinimalPriceLessMsrp']
+        );
+        $msrpPriceMock->expects($this->once())
+            ->method('canApplyMsrp')
+            ->willReturn(true);
+        $msrpPriceMock->expects($this->once())
+            ->method('isMinimalPriceLessMsrp')
+            ->willReturn(true);
+
+        $priceInfoMock = $this->createMock(PriceInfoInterface::class);
+        $priceInfoMock->expects($this->once())
+            ->method('getPrice')
+            ->willReturn($msrpPriceMock);
+
+        $this->saleableItem->expects($this->once())
+            ->method('getPriceInfo')
+            ->willReturn($priceInfoMock);
+
+        $result = $this->model->toHtml();
+        $this->assertSame('', $result);
+    }
+}

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Pricing/Render/TierPriceBoxTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Pricing/Render/TierPriceBoxTest.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 declare(strict_types=1);
 
 namespace Magento\ConfigurableProduct\Test\Unit\Pricing\Render;
@@ -61,7 +65,7 @@ class TierPriceBoxTest extends \PHPUnit\Framework\TestCase
     /**
      * @inheritDoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->context = $this->createPartialMock(Context::class, []);
         $this->saleableItem = $this->createPartialMock(Product::class, ['getPriceInfo']);
@@ -85,7 +89,7 @@ class TierPriceBoxTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testToHtmlEmptyWhenMsrpPriceIsApplicable()
+    public function testToHtmlEmptyWhenMsrpPriceIsApplicable(): void
     {
         $msrpPriceMock = $this->createPartialMock(
             MsrpPrice::class,


### PR DESCRIPTION
### Description

`\Magento\ConfigurableProduct\Pricing\Render\TierPriceBox::toHtml` method can return with null (nothing) at missing return statement

```
public function toHtml()
{
        // Hide tier price block in case of MSRP or in case when no options with tier price.
        if (!$this->isMsrpPriceApplicable() && $this->isTierPriceApplicable()) {
            return parent::toHtml();
        }
}

```
It brakes the implemented interface `\Magento\Framework\View\Element\BlockInterface`

```
interface BlockInterface
{
    /**
     * Produce and return block's html output
     *
     * @return string
     */
    public function toHtml();
}

```