### PR TITLE
Update MockObject class in Widget module

### DIFF
--- a/app/code/Magento/Widget/Test/Unit/Block/Adminhtml/Widget/Catalog/Category/ChooserTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Block/Adminhtml/Widget/Catalog/Category/ChooserTest.php
@@ -9,52 +9,52 @@ namespace Magento\Widget\Test\Unit\Block\Adminhtml\Widget\Catalog\Category;
 class ChooserTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Magento\Catalog\Model\ResourceModel\Category\Collection|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Catalog\Model\ResourceModel\Category\Collection|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $collection;
 
     /**
-     * @var \Magento\Framework\Data\Tree\Node|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Data\Tree\Node|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $childNode;
 
     /**
-     * @var \Magento\Framework\Data\Tree\Node|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Data\Tree\Node|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $rootNode;
 
     /**
-     * @var \Magento\Catalog\Model\ResourceModel\Category\Tree|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Catalog\Model\ResourceModel\Category\Tree|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $categoryTree;
 
     /**
-     * @var \Magento\Store\Model\Store|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Store\Model\Store|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $store;
 
     /**
-     * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $storeManager;
 
     /**
-     * @var \Magento\Framework\App\RequestInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\RequestInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $request;
 
     /**
-     * @var \Magento\Framework\Escaper|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Escaper|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $escaper;
 
     /**
-     * @var \Magento\Framework\Event\ManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Event\ManagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $eventManager;
 
     /**
-     * @var \Magento\Backend\Block\Template\Context|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Backend\Block\Template\Context|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $context;
 

--- a/app/code/Magento/Widget/Test/Unit/Block/Adminhtml/Widget/Instance/Edit/Chooser/AbstractContainerTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Block/Adminhtml/Widget/Instance/Edit/Chooser/AbstractContainerTest.php
@@ -10,47 +10,47 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHe
 abstract class AbstractContainerTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Magento\Framework\Event\Manager|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Event\Manager|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $eventManagerMock;
 
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $scopeConfigMock;
 
     /**
-     * @var \Magento\Backend\Block\Context|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Backend\Block\Context|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $contextMock;
 
     /**
-     * @var \Magento\Theme\Model\ResourceModel\Theme\Collection|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Theme\Model\ResourceModel\Theme\Collection|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $themeCollectionMock;
 
     /**
-     * @var \Magento\Theme\Model\ResourceModel\Theme\CollectionFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Theme\Model\ResourceModel\Theme\CollectionFactory|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $themeCollectionFactoryMock;
 
     /**
-     * @var \Magento\Theme\Model\Theme|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Theme\Model\Theme|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $themeMock;
 
     /**
-     * @var \Magento\Framework\View\Layout\ProcessorFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\View\Layout\ProcessorFactory|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $layoutProcessorFactoryMock;
 
     /**
-     * @var \Magento\Framework\View\Model\Layout\Merge|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\View\Model\Layout\Merge|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $layoutMergeMock;
 
     /**
-     * @var \Magento\Framework\Escaper|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Escaper|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $escaperMock;
 

--- a/app/code/Magento/Widget/Test/Unit/Block/Adminhtml/Widget/Instance/Edit/Tab/PropertiesTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Block/Adminhtml/Widget/Instance/Edit/Tab/PropertiesTest.php
@@ -8,12 +8,12 @@ namespace Magento\Widget\Test\Unit\Block\Adminhtml\Widget\Instance\Edit\Tab;
 class PropertiesTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit\Framework\MockObject\MockObject
      */
     protected $widget;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit\Framework\MockObject\MockObject
      */
     protected $registry;
 

--- a/app/code/Magento/Widget/Test/Unit/Controller/Adminhtml/Widget/Instance/CategoriesTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Controller/Adminhtml/Widget/Instance/CategoriesTest.php
@@ -9,17 +9,17 @@ namespace Magento\Widget\Test\Unit\Controller\Adminhtml\Widget\Instance;
 class CategoriesTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Magento\Framework\App\RequestInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\RequestInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $request;
 
     /**
-     * @var \Magento\Framework\Math\Random|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Math\Random|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $mathRandom;
 
     /**
-     * @var \Magento\Framework\View\Layout|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\View\Layout|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $chooser;
 
@@ -29,22 +29,22 @@ class CategoriesTest extends \PHPUnit\Framework\TestCase
     protected $blockClass = \Magento\Widget\Block\Adminhtml\Widget\Catalog\Category\Chooser::class;
 
     /**
-     * @var \Magento\Framework\View\Layout|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\View\Layout|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $layout;
 
     /**
-     * @var \Magento\Framework\Controller\Result\Raw|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Controller\Result\Raw|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $resultRaw;
 
     /**
-     * @var \Magento\Framework\Controller\ResultFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Controller\ResultFactory|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $resultFactory;
 
     /**
-     * @var \Magento\Backend\App\Action\Context|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Backend\App\Action\Context|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $context;
 

--- a/app/code/Magento/Widget/Test/Unit/Controller/Adminhtml/Widget/LoadOptionsTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Controller/Adminhtml/Widget/LoadOptionsTest.php
@@ -26,32 +26,32 @@ class LoadOptionsTest extends \PHPUnit\Framework\TestCase
     private $objectManagerHelper;
 
     /**
-     * @var Context|\PHPUnit_Framework_MockObject_MockObject
+     * @var Context|\PHPUnit\Framework\MockObject\MockObject
      */
     private $contextMock;
 
     /**
-     * @var ViewInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ViewInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     private $viewMock;
 
     /**
-     * @var ConditionsHelper|\PHPUnit_Framework_MockObject_MockObject
+     * @var ConditionsHelper|\PHPUnit\Framework\MockObject\MockObject
      */
     private $conditionsHelperMock;
 
     /**
-     * @var ResponseInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ResponseInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     private $responseMock;
 
     /**
-     * @var ObjectManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ObjectManagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     private $objectManagerMock;
 
     /**
-     * @var RequestInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var RequestInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     private $requestMock;
 
@@ -110,7 +110,7 @@ class LoadOptionsTest extends \PHPUnit\Framework\TestCase
         $jsonResult = '{"error":true,"message":"Some error"}';
         $errorMessage = 'Some error';
 
-        /** @var \Magento\Framework\Json\Helper\Data|\PHPUnit_Framework_MockObject_MockObject $jsonDataHelperMock */
+        /** @var \Magento\Framework\Json\Helper\Data|\PHPUnit\Framework\MockObject\MockObject $jsonDataHelperMock */
         $jsonDataHelperMock = $this->getMockBuilder(\Magento\Framework\Json\Helper\Data::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -163,7 +163,7 @@ class LoadOptionsTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        /** @var \Magento\Framework\Json\Helper\Data|\PHPUnit_Framework_MockObject_MockObject $jsonDataHelperMock */
+        /** @var \Magento\Framework\Json\Helper\Data|\PHPUnit\Framework\MockObject\MockObject $jsonDataHelperMock */
         $jsonDataHelperMock = $this->getMockBuilder(\Magento\Framework\Json\Helper\Data::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -183,7 +183,7 @@ class LoadOptionsTest extends \PHPUnit\Framework\TestCase
             ->with(\Magento\Framework\Json\Helper\Data::class)
             ->willReturn($jsonDataHelperMock);
 
-        /** @var \Magento\Framework\View\Element\BlockInterface|\PHPUnit_Framework_MockObject_MockObject $blockMock */
+        /** @var \Magento\Framework\View\Element\BlockInterface|\PHPUnit\Framework\MockObject\MockObject $blockMock */
         $blockMock = $this->getMockBuilder(\Magento\Framework\View\Element\BlockInterface::class)
             ->setMethods(['setWidgetType', 'setWidgetValues'])
             ->getMockForAbstractClass();
@@ -196,7 +196,7 @@ class LoadOptionsTest extends \PHPUnit\Framework\TestCase
             ->with($resultWidgetArrayParams['values'])
             ->willReturnSelf();
 
-        /** @var \Magento\Framework\View\LayoutInterface|\PHPUnit_Framework_MockObject_MockObject $layoutMock */
+        /** @var \Magento\Framework\View\LayoutInterface|\PHPUnit\Framework\MockObject\MockObject $layoutMock */
         $layoutMock = $this->getMockForAbstractClass(\Magento\Framework\View\LayoutInterface::class);
         $layoutMock->expects($this->once())
             ->method('getBlock')

--- a/app/code/Magento/Widget/Test/Unit/Helper/ConditionsTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Helper/ConditionsTest.php
@@ -20,12 +20,12 @@ class ConditionsTest extends \PHPUnit\Framework\TestCase
     protected $conditions;
 
     /**
-     * @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit\Framework\MockObject\MockObject
      */
     private $serializer;
 
     /**
-     * @var Normalizer|\PHPUnit_Framework_MockObject_MockObject
+     * @var Normalizer|\PHPUnit\Framework\MockObject\MockObject
      */
     private $normalizer;
 

--- a/app/code/Magento/Widget/Test/Unit/Helper/ConditionsTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Helper/ConditionsTest.php
@@ -11,6 +11,8 @@ use Magento\Framework\Data\Wysiwyg\Normalizer;
 
 /**
  * Class ConditionsTest
+ *
+ * PHPUnit test case for \Magento\Widget\Helper\Conditions
  */
 class ConditionsTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/code/Magento/Widget/Test/Unit/Model/Config/FileResolverTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/Config/FileResolverTest.php
@@ -17,17 +17,17 @@ class FileResolverTest extends \PHPUnit\Framework\TestCase
     private $object;
 
     /**
-     * @var \Magento\Framework\Module\Dir\Reader|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Module\Dir\Reader|\PHPUnit\Framework\MockObject\MockObject
      */
     private $moduleReader;
 
     /**
-     * @var \Magento\Framework\Config\FileIteratorFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Config\FileIteratorFactory|\PHPUnit\Framework\MockObject\MockObject
      */
     private $factory;
 
     /**
-     * @var \Magento\Framework\Component\DirSearch|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Component\DirSearch|\PHPUnit\Framework\MockObject\MockObject
      */
     private $componentDirSearch;
 

--- a/app/code/Magento/Widget/Test/Unit/Model/NamespaceResolverTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/NamespaceResolverTest.php
@@ -13,7 +13,7 @@ class NamespaceResolverTest extends \PHPUnit\Framework\TestCase
     protected $namespaceResolver;
 
     /**
-     * @var \Magento\Framework\Module\ModuleListInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Module\ModuleListInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $moduleListMock;
 

--- a/app/code/Magento/Widget/Test/Unit/Model/ResourceModel/Layout/AbstractTestCase.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/ResourceModel/Layout/AbstractTestCase.php
@@ -51,7 +51,7 @@ abstract class AbstractTestCase extends \PHPUnit\Framework\TestCase
      * Retrieve resource model instance
      *
      * @param \Magento\Framework\DB\Select $select
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return \PHPUnit\Framework\MockObject\MockObject
      */
     protected function _getResource(\Magento\Framework\DB\Select $select)
     {
@@ -88,7 +88,7 @@ abstract class AbstractTestCase extends \PHPUnit\Framework\TestCase
 
         $collection = $this->_getCollection($select);
 
-        /** @var $connection \PHPUnit_Framework_MockObject_MockObject */
+        /** @var $connection \PHPUnit\Framework\MockObject\MockObject */
         $connection = $collection->getResource()->getConnection();
         $connection->expects(
             $this->any()

--- a/app/code/Magento/Widget/Test/Unit/Model/ResourceModel/Layout/Link/CollectionTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/ResourceModel/Layout/Link/CollectionTest.php
@@ -52,7 +52,7 @@ class CollectionTest extends \Magento\Widget\Test\Unit\Model\ResourceModel\Layou
 
         $collection = $this->_getCollection($select);
 
-        /** @var $connection \PHPUnit_Framework_MockObject_MockObject */
+        /** @var $connection \PHPUnit\Framework\MockObject\MockObject */
         $connection = $collection->getResource()->getConnection();
         $connection->expects(
             $this->any()
@@ -97,7 +97,7 @@ class CollectionTest extends \Magento\Widget\Test\Unit\Model\ResourceModel\Layou
 
         $collection = $this->_getCollection($select);
 
-        /** @var $resource \PHPUnit_Framework_MockObject_MockObject */
+        /** @var $resource \PHPUnit\Framework\MockObject\MockObject */
         $resource = $collection->getResource();
         $resource->expects(
             $this->once()

--- a/app/code/Magento/Widget/Test/Unit/Model/ResourceModel/Layout/Update/CollectionTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/ResourceModel/Layout/Update/CollectionTest.php
@@ -85,7 +85,7 @@ class CollectionTest extends \Magento\Widget\Test\Unit\Model\ResourceModel\Layou
 
         $collection = $this->_getCollection($select);
 
-        /** @var $connection \PHPUnit_Framework_MockObject_MockObject */
+        /** @var $connection \PHPUnit\Framework\MockObject\MockObject */
         $connection = $collection->getResource()->getConnection();
         $connection->expects(
             $this->once()

--- a/app/code/Magento/Widget/Test/Unit/Model/ResourceModel/Widget/Instance/Options/ThemesTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/ResourceModel/Widget/Instance/Options/ThemesTest.php
@@ -20,12 +20,12 @@ class ThemesTest extends \PHPUnit\Framework\TestCase
     private $model;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit\Framework\MockObject\MockObject
      */
     private $themeCollectionFactoryMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit\Framework\MockObject\MockObject
      */
     private $themeCollectionMock;
 

--- a/app/code/Magento/Widget/Test/Unit/Model/Template/FilterEmulateTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/Template/FilterEmulateTest.php
@@ -20,7 +20,7 @@ class FilterEmulateTest extends \PHPUnit\Framework\TestCase
     protected $filterEmulate;
 
     /**
-     * @var \Magento\Framework\App\State|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\State|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $appStateMock;
 

--- a/app/code/Magento/Widget/Test/Unit/Model/Template/FilterTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/Template/FilterTest.php
@@ -21,27 +21,27 @@ class FilterTest extends \PHPUnit\Framework\TestCase
     protected $objectManagerHelper;
 
     /**
-     * @var \Magento\Store\Model\Store|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Store\Model\Store|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $storeMock;
 
     /**
-     * @var StoreManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var StoreManagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $storeManagerMock;
 
     /**
-     * @var \Magento\Widget\Model\ResourceModel\Widget|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Widget\Model\ResourceModel\Widget|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $widgetResourceMock;
 
     /**
-     * @var \Magento\Widget\Model\Widget|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Widget\Model\Widget|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $widgetMock;
 
     /**
-     * @var \Magento\Framework\View\LayoutInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\View\LayoutInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $layoutMock;
 
@@ -235,11 +235,11 @@ class FilterTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @param string $returnedResult
-     * @return \Magento\Widget\Block\BlockInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @return \Magento\Widget\Block\BlockInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected function getBlockMock($returnedResult = '')
     {
-        /** @var \Magento\Widget\Block\BlockInterface|\PHPUnit_Framework_MockObject_MockObject $blockMock */
+        /** @var \Magento\Widget\Block\BlockInterface|\PHPUnit\Framework\MockObject\MockObject $blockMock */
         $blockMock = $this->getMockBuilder(\Magento\Widget\Block\BlockInterface::class)
             ->setMethods(['toHtml'])
             ->getMockForAbstractClass();

--- a/app/code/Magento/Widget/Test/Unit/Model/Widget/InstanceTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/Widget/InstanceTest.php
@@ -15,16 +15,16 @@ use Magento\Framework\Serialize\Serializer\Json;
 class InstanceTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Magento\Widget\Model\Config\Data|PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Widget\Model\Config\Data|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $_widgetModelMock;
 
     /**
-     * @var \Magento\Framework\View\FileSystem|PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\View\FileSystem|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $_viewFileSystemMock;
 
-    /** @var  \Magento\Widget\Model\NamespaceResolver |PHPUnit_Framework_MockObject_MockObject */
+    /** @var  \Magento\Widget\Model\NamespaceResolver|\PHPUnit\Framework\MockObject\MockObject */
     protected $_namespaceResolver;
 
     /**
@@ -36,16 +36,16 @@ class InstanceTest extends \PHPUnit\Framework\TestCase
     protected $_readerMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit\Framework\MockObject\MockObject
      */
     protected $_cacheTypesListMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit\Framework\MockObject\MockObject
      */
     protected $_directoryMock;
 
-    /** @var \Magento\Framework\Serialize\Serializer\Json | \PHPUnit_Framework_MockObject_MockObject */
+    /** @var \Magento\Framework\Serialize\Serializer\Json|\PHPUnit\Framework\MockObject\MockObject */
     private $serializer;
 
     protected function setUp()

--- a/app/code/Magento/Widget/Test/Unit/Model/WidgetTest.php
+++ b/app/code/Magento/Widget/Test/Unit/Model/WidgetTest.php
@@ -13,12 +13,12 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 class WidgetTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var \Magento\Widget\Model\Config\Data|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Widget\Model\Config\Data|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $dataStorageMock;
 
     /**
-     * @var \Magento\Framework\Escaper|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Escaper|\PHPUnit\Framework\MockObject\MockObject
      */
     private $escaperMock;
 


### PR DESCRIPTION
### Description (*)
Replace outdated PSR-0 `\PHPUnit_Framework_MockObject_MockObject` with current PSR-2 class name `\PHPUnit\Framework\MockObject\MockObject`


### Related Pull Requests
#26775 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
