### PR TITLE
make store switcher style more resistent

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
@@ -289,7 +289,7 @@
         text-align: center;
     }
 
-    .page-header,
+    .page-header .panel.wrapper,
     .page-footer {
         .switcher {
             .options {


### PR DESCRIPTION
make store switcher more resistent against moving of layout blocks
especially, moving the `navigation.sections` into the `header-wrapper`

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The issue I encountered was related to the duplicated store switcher block for the mobile navigation, which is part of the `navigation.sections`. 

The styling which is here added for the dropdown of the store switcher for the desktop variant, is currently also applied to the mobile variant when moved into the `header-wrapper` (to have the category navigation on Desktop between logo and other Header Parts)

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
1. have a layout xml which moves the `navigation.sections`into the `header-wrapper``
```
<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd" label="Customer My Account (All Pages)" design_abstraction="custom">
    <body>

        <move element="navigation.sections" destination="header-wrapper" after="logo"/>
    </body>
</page>
```
2. reduce the Website to "mobile size" and check the store switcher in the mobile navigation

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
