### PR TITLE
Unit test for ProductProcessUrlRewriteRemovingObserver

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/ProductProcessUrlRewriteRemovingObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/ProductProcessUrlRewriteRemovingObserverTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogUrlRewrite\Test\Unit\Observer;
+
+use Magento\Catalog\Model\Product;
+use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
+use Magento\CatalogUrlRewrite\Observer\ProductProcessUrlRewriteRemovingObserver;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+use Magento\UrlRewrite\Model\UrlPersistInterface;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Unit test for Magento\CatalogUrlRewrite\Observer\ProductProcessUrlRewriteRemovingObserver
+ */
+class ProductProcessUrlRewriteRemovingObserverTest extends TestCase
+{
+    /**
+     * Testable Object
+     *
+     * @var ProductProcessUrlRewriteRemovingObserver
+     */
+    private $observer;
+
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var Observer|MockObject
+     */
+    private $observerMock;
+
+    /**
+     * @var Event|MockObject
+     */
+    private $eventMock;
+
+    /**
+     * @var Product|MockObject
+     */
+    private $productMock;
+
+    /**
+     * @var UrlPersistInterface|MockObject
+     */
+    private $urlPersist;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->objectManager = new ObjectManager($this);
+        $this->observerMock = $this->createMock(Observer::class);
+
+        $this->eventMock = $this->getMockBuilder(Event::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getProduct'])
+            ->getMock();
+
+        $this->productMock = $this->getMockBuilder(Product::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getId'])
+            ->getMock();
+
+        $this->urlPersist = $this->getMockBuilder(UrlPersistInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->observer = $this->objectManager->getObject(
+            ProductProcessUrlRewriteRemovingObserver::class,
+            [
+                'urlPersist' => $this->urlPersist
+            ]
+        );
+    }
+
+    /**
+     * Test for execute()
+     */
+    public function testRemoveProductUrlsFromStorage()
+    {
+        $productId = 333;
+
+        $this->observerMock
+            ->expects($this->once())
+            ->method('getEvent')
+            ->willReturn($this->eventMock);
+
+        $this->eventMock
+            ->expects($this->once())
+            ->method('getProduct')
+            ->willReturn($this->productMock);
+
+        $this->productMock
+            ->expects($this->exactly(2))
+            ->method('getId')
+            ->willReturn($productId);
+
+        $this->urlPersist->expects($this->once())
+            ->method('deleteByData')
+            ->with([
+                UrlRewrite::ENTITY_ID => $productId,
+                UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
+            ]);
+
+        $this->observer->execute($this->observerMock);
+    }
+}

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/ProductProcessUrlRewriteRemovingObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/ProductProcessUrlRewriteRemovingObserverTest.php
@@ -11,19 +11,24 @@ namespace Magento\CatalogUrlRewrite\Test\Unit\Observer;
 use Magento\Catalog\Model\Product;
 use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
 use Magento\CatalogUrlRewrite\Observer\ProductProcessUrlRewriteRemovingObserver;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\Event;
 use Magento\Framework\Event\Observer;
-use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
-use PHPUnit\Framework\TestCase;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit test for Magento\CatalogUrlRewrite\Observer\ProductProcessUrlRewriteRemovingObserver
  */
 class ProductProcessUrlRewriteRemovingObserverTest extends TestCase
 {
+    /*
+     * Stub product ID
+     */
+    private const STUB_PRODUCT_ID = 333;
+
     /**
      * Testable Object
      *
@@ -54,7 +59,7 @@ class ProductProcessUrlRewriteRemovingObserverTest extends TestCase
     /**
      * @var UrlPersistInterface|MockObject
      */
-    private $urlPersist;
+    private $urlPersistMock;
 
     /**
      * @inheritdoc
@@ -74,25 +79,23 @@ class ProductProcessUrlRewriteRemovingObserverTest extends TestCase
             ->setMethods(['getId'])
             ->getMock();
 
-        $this->urlPersist = $this->getMockBuilder(UrlPersistInterface::class)
+        $this->urlPersistMock = $this->getMockBuilder(UrlPersistInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->observer = $this->objectManager->getObject(
             ProductProcessUrlRewriteRemovingObserver::class,
             [
-                'urlPersist' => $this->urlPersist
+                'urlPersist' => $this->urlPersistMock
             ]
         );
     }
 
     /**
-     * Test for execute()
+     * Test for execute(), covers test case for removing product URLs from storage
      */
-    public function testRemoveProductUrlsFromStorage()
+    public function testRemoveProductUrlsFromStorage(): void
     {
-        $productId = 333;
-
         $this->observerMock
             ->expects($this->once())
             ->method('getEvent')
@@ -106,14 +109,39 @@ class ProductProcessUrlRewriteRemovingObserverTest extends TestCase
         $this->productMock
             ->expects($this->exactly(2))
             ->method('getId')
-            ->willReturn($productId);
+            ->willReturn(self::STUB_PRODUCT_ID);
 
-        $this->urlPersist->expects($this->once())
+        $this->urlPersistMock->expects($this->once())
             ->method('deleteByData')
             ->with([
-                UrlRewrite::ENTITY_ID => $productId,
+                UrlRewrite::ENTITY_ID => self::STUB_PRODUCT_ID,
                 UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
             ]);
+
+        $this->observer->execute($this->observerMock);
+    }
+
+    /**
+     * Test for execute(), covers test case for removing product URLs when the product doesn't have an ID
+     */
+    public function testRemoveProductUrlsWithEmptyProductId()
+    {
+        $this->observerMock
+            ->expects($this->once())
+            ->method('getEvent')
+            ->willReturn($this->eventMock);
+
+        $this->eventMock
+            ->expects($this->once())
+            ->method('getProduct')
+            ->willReturn($this->productMock);
+
+        $this->productMock
+            ->expects($this->once())
+            ->method('getId')
+            ->willReturn(null);
+
+        $this->urlPersistMock->expects($this->never())->method('deleteByData');
 
         $this->observer->execute($this->observerMock);
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR adds unit test that covers Magento\CatalogUrlRewrite\Observer\ProductProcessUrlRewriteRemovingObserver

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
