### PR TITLE
Fix #26917 Tax rate zip/post range check box alignment issue

### DIFF
--- a/app/code/Magento/Tax/Block/Adminhtml/Rate/Form.php
+++ b/app/code/Magento/Tax/Block/Adminhtml/Rate/Form.php
@@ -211,7 +211,12 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         $fieldset->addField(
             'zip_is_range',
             'checkbox',
-            ['name' => 'zip_is_range', 'label' => __('Zip/Post is Range'), 'value' => '1']
+            [
+                'name' => 'zip_is_range',
+                'label' => __('Zip/Post is Range'),
+                'value' => '1',
+                'class' => 'zip-is-range-checkbox'
+            ]
         );
 
         if (!isset($formData['tax_postcode'])) {

--- a/app/code/Magento/Tax/view/adminhtml/templates/rate/form.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/rate/form.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<div class="entry-edit form-inline tax-rate-form">
+<div class="entry-edit form-inline">
     <?= $block->getFormHtml() ?>
 </div>
 <?= $block->getChildHtml('form_after') ?>

--- a/app/code/Magento/Tax/view/adminhtml/templates/rate/form.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/rate/form.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<div class="entry-edit form-inline">
+<div class="entry-edit form-inline tax-rate-form">
     <?= $block->getFormHtml() ?>
 </div>
 <?= $block->getChildHtml('form_after') ?>

--- a/app/design/adminhtml/Magento/backend/Magento_Tax/web/css/source/_module.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Tax/web/css/source/_module.less
@@ -14,7 +14,7 @@
 
 .block.mselect-list.paginated {
     .admin__action-multiselect-search-wrap {
-        border:1px solid @color-gray80;
+        border: 1px solid @color-gray80;
         border-bottom: none;
         border-radius: 3px;
         margin: 0;

--- a/app/design/adminhtml/Magento/backend/Magento_Tax/web/css/source/_module.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Tax/web/css/source/_module.less
@@ -26,10 +26,8 @@
     }
 }
 
-.tax-rate-form {
-    .admin__fieldset > .admin__field > .admin__field-control {
-        input[type='checkbox'] {
-            margin: 8px 0 0 0;
-        }
+.admin__fieldset > .admin__field > .admin__field-control {
+    input.zip-is-range-checkbox {
+        margin: 8px 0 0 0;
     }
 }

--- a/app/design/adminhtml/Magento/backend/Magento_Tax/web/css/source/_module.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Tax/web/css/source/_module.less
@@ -25,3 +25,11 @@
         font-size: 1.3rem;
     }
 }
+
+.tax-rate-form {
+    .admin__fieldset > .admin__field > .admin__field-control {
+        input[type='checkbox'] {
+            margin: 8px 0 0 0;
+        }
+    }
+}


### PR DESCRIPTION
### Description (*)
This PR fixed the issue #26917. I added new class in template because I can't able to find any specific field set for that section. Same type of style applied in Customer Module itself which I get a reference from `app/design/adminhtml/Magento/backend/Magento_Customer/web/css/source/_module.less
Line No: 105 to 109`.

### Fixed Issues (if relevant)
1. magento/magento2#26917

### Manual testing scenarios (*)
- GOTO Admin -> Store -> Taxes -> Tax Zones and Rates -> Add new -> Tax rate Zip/Post range
- Checkbox alignment should be in same line

### Questions or comments
If any please let me know the feedback

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
