### PR TITLE
25038 Only set collection to toolbar once in ListProduct block

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ListProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/ListProduct.php
@@ -516,7 +516,9 @@ class ListProduct extends AbstractProduct implements IdentityInterface
             $toolbar->setModes($modes);
         }
         // set collection to toolbar and apply sort
-        $toolbar->setCollection($collection);
+        if (!$toolbar->getCollection()) {
+            $toolbar->setCollection($collection);
+        }
         $this->setChild('toolbar', $toolbar);
     }
 }

--- a/app/code/Magento/Catalog/Block/Product/ListProduct.php
+++ b/app/code/Magento/Catalog/Block/Product/ListProduct.php
@@ -355,6 +355,7 @@ class ListProduct extends AbstractProduct implements IdentityInterface
         }
 
         foreach ($this->_getProductCollection() as $item) {
+            // phpcs:ignore Magento2.Performance.ForeachArrayMerge
             $identities = array_merge($identities, $item->getIdentities());
         }
 


### PR DESCRIPTION
Fix for: https://github.com/magento/magento2/issues/25038

When using ElasticSearch, pagination does not work in some cases if pagination is set multiple times (in the toolbar).
The catalog does not show results when clicking past the first page of results in catalog.

Only setting the $collection once fixes the issue.