### PR TITLE
Set STATE_PROCESSING when order is in STATE_PENDING_PAYMENT

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
@@ -24,7 +24,9 @@ class State
     public function check(Order $order)
     {
         $currentState = $order->getState();
-        if ($currentState == Order::STATE_NEW && $order->getIsInProcess()) {
+        if ($currentState == Order::STATE_NEW && $order->getIsInProcess() ||
+            $currentState == Order::STATE_PENDING_PAYMENT && $order->getIsInProcess()
+        ) {
             $order->setState(Order::STATE_PROCESSING)
                 ->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_PROCESSING));
             $currentState = Order::STATE_PROCESSING;

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
@@ -10,6 +10,8 @@ use Magento\Sales\Model\Order;
 
 /**
  * Class State
+ *
+ * @author      Magento Core Team <core@magentocommerce.com>
  */
 class State
 {

--- a/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/Handler/StateTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/Handler/StateTest.php
@@ -9,6 +9,8 @@ use Magento\Sales\Model\Order;
 
 /**
  * Class StateTest
+ *
+ * @author      Magento Core Team <core@magentocommerce.com>
  */
 class StateTest extends \PHPUnit\Framework\TestCase
 {
@@ -21,6 +23,16 @@ class StateTest extends \PHPUnit\Framework\TestCase
      * @var \Magento\Sales\Model\Order|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $orderMock;
+
+    /**
+     * @var \Magento\Sales\Model\Order\Address
+     */
+    protected $addressMock;
+
+    /**
+     * @var \Magento\Sales\Model\ResourceModel\Order\Address\Collection
+     */
+    protected $addressCollectionMock;
 
     protected function setUp()
     {

--- a/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/Handler/StateTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/Handler/StateTest.php
@@ -131,12 +131,16 @@ class StateTest extends \PHPUnit\Framework\TestCase
                 [true, 1, false, 1, Order::STATE_NEW, Order::STATE_COMPLETE, true, 1],
             'new - canCreditmemo, canShip, !IsInProcess -> new' =>
                 [true, 0, true, 0, Order::STATE_NEW, Order::STATE_NEW, false, 1],
+            'pending_payment - canCreditmemo, canShip, IsInProcess -> processing' =>
+                [true, 1, true, 1, Order::STATE_PENDING_PAYMENT, Order::STATE_PROCESSING, true, 1],
+            'pending_payment - canCreditmemo, !canShip, IsInProcess -> processing' =>
+                [true, 1, false, 1, Order::STATE_PENDING_PAYMENT, Order::STATE_COMPLETE, true, 1],
+            'pending_payment - canCreditmemo, canShip, !IsInProcess -> new' =>
+                [true, 0, true, 0, Order::STATE_PENDING_PAYMENT, Order::STATE_PENDING_PAYMENT, false, 1],
             'hold - canUnhold -> hold' =>
                 [true, 0, true, 0, Order::STATE_HOLDED, Order::STATE_HOLDED, false, 0, false, true],
             'payment_review - canUnhold -> payment_review' =>
                 [true, 0, true, 0, Order::STATE_PAYMENT_REVIEW, Order::STATE_PAYMENT_REVIEW, false, 0, false, true],
-            'pending_payment - canUnhold -> pending_payment' =>
-                [true, 0, true, 0, Order::STATE_PENDING_PAYMENT, Order::STATE_PENDING_PAYMENT, false, 0, false, true],
             'cancelled - isCanceled -> cancelled' =>
                 [true, 0, true, 0, Order::STATE_HOLDED, Order::STATE_HOLDED, false, 0, true],
         ];


### PR DESCRIPTION
### Description (*)

Added one more case when order is checked of status. It validates is status "pending_payment" then set "processing" status to order.

1. magento/magento2#26541: Order status pending payment not changing to processing after invoicing #26541

### Manual testing scenarios (*)

1. Cause I didn't reproduce moment when after Payment Getaway it lefts status "pending_payment'. I've only changed status in DB. Here is a screenshot where should be set (in item #26541). 
2. Create an invoice and submit.
