### PR TITLE
Making message lock release possible

### DIFF
--- a/app/code/Magento/MessageQueue/Model/ResourceModel/Lock.php
+++ b/app/code/Magento/MessageQueue/Model/ResourceModel/Lock.php
@@ -1,29 +1,42 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\MessageQueue\Model\ResourceModel;
 
-use \Magento\Framework\MessageQueue\Lock\ReaderInterface;
-use \Magento\Framework\MessageQueue\Lock\WriterInterface;
+use DateInterval;
+use DateTime;
+use Exception;
+use Magento\Framework\MessageQueue\Lock\ReaderInterface;
+use Magento\Framework\MessageQueue\Lock\WriterInterface;
+use Magento\Framework\MessageQueue\LockInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use Magento\Framework\Model\ResourceModel\Db\Context;
+use Magento\Framework\Stdlib\DateTime\DateTime as MagentoDateTime;
+use Magento\MessageQueue\Model\Lock as LockModel;
+use Magento\MessageQueue\Model\LockFactory;
 
 /**
  * Class Lock to handle database lock table db transactions.
  */
-class Lock extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implements ReaderInterface, WriterInterface
+class Lock extends AbstractDb implements ReaderInterface, WriterInterface
 {
-    /**#@+
-     * Constants
+    /**
+     * @var string
      */
-    const QUEUE_LOCK_TABLE = 'queue_lock';
-    /**#@-*/
+    private const QUEUE_LOCK_TABLE = 'queue_lock';
 
-    /**#@-*/
+    /**
+     * @var MagentoDateTime
+     */
     private $dateTime;
 
     /**
-     * @var \Magento\MessageQueue\Model\LockFactory
+     * @var LockFactory
      */
     private $lockFactory;
 
@@ -35,18 +48,18 @@ class Lock extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implemen
     /**
      * Initialize dependencies.
      *
-     * @param \Magento\Framework\Model\ResourceModel\Db\Context $context
-     * @param \Magento\Framework\Stdlib\DateTime\DateTime $dateTime
-     * @param \Magento\MessageQueue\Model\LockFactory $lockFactory
-     * @param null $connectionName
+     * @param Context $context
+     * @param MagentoDateTime $dateTime
+     * @param LockFactory $lockFactory
+     * @param string|null $connectionName
      * @param integer $interval
      */
     public function __construct(
-        \Magento\Framework\Model\ResourceModel\Db\Context $context,
-        \Magento\Framework\Stdlib\DateTime\DateTime $dateTime,
-        \Magento\MessageQueue\Model\LockFactory $lockFactory,
-        $connectionName = null,
-        $interval = 86400
+        Context $context,
+        MagentoDateTime $dateTime,
+        LockFactory $lockFactory,
+        ?string $connectionName = null,
+        int $interval = 86400
     ) {
         $this->lockFactory = $lockFactory;
         $this->interval = $interval;
@@ -55,43 +68,63 @@ class Lock extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implemen
     }
 
     /**
-     * {@inheritDoc}
+     * Init.
+     *
+     * @return void
+     *
+     * @codeCoverageIgnore
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
      */
-    protected function _construct()
+    protected function _construct(): void
     {
         $this->_init(self::QUEUE_LOCK_TABLE, 'id');
     }
 
     /**
-     * {@inheritDoc}
+     * Read lock
+     *
+     * @param LockInterface $lock
+     * @param string $code
+     * @return void
      */
-    public function read(\Magento\Framework\MessageQueue\LockInterface $lock, $code)
+    public function read(LockInterface $lock, string $code): void
     {
+        /** @var $object LockModel */
         $object = $this->lockFactory->create();
-        $object->load($code, 'message_code');
+        $this->load($object, $code, 'message_code');
         $lock->setId($object->getId());
         $lock->setMessageCode($object->getMessageCode() ?: $code);
         $lock->setCreatedAt($object->getCreatedAt());
     }
 
     /**
-     * {@inheritDoc}
+     * Save lock
+     *
+     * @param LockInterface $lock
+     *
+     * @return void
+     * @throws Exception
      */
-    public function saveLock(\Magento\Framework\MessageQueue\LockInterface $lock)
+    public function saveLock(LockInterface $lock): void
     {
+        /** @var $object LockModel */
         $object = $this->lockFactory->create();
         $object->setMessageCode($lock->getMessageCode());
         $object->setCreatedAt($this->dateTime->gmtTimestamp());
-        $object->save();
+        $this->save($object);
+        $lock->setId($object->getId());
     }
 
     /**
-     * {@inheritDoc}
+     * Remove outdated locks
+     *
+     * @return void
+     * @throws Exception
      */
-    public function releaseOutdatedLocks()
+    public function releaseOutdatedLocks(): void
     {
-        $date = (new \DateTime())->setTimestamp($this->dateTime->gmtTimestamp());
-        $date->add(new \DateInterval('PT' . $this->interval . 'S'));
+        $date = (new DateTime())->setTimestamp($this->dateTime->gmtTimestamp());
+        $date->add(new DateInterval('PT' . $this->interval . 'S'));
         $this->getConnection()->delete($this->getTable(self::QUEUE_LOCK_TABLE), ['created_at <= ?' => $date]);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/MessageQueue/Model/Plugin/ResourceModel/LockTest.php
+++ b/dev/tests/integration/testsuite/Magento/MessageQueue/Model/Plugin/ResourceModel/LockTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
@@ -6,37 +9,46 @@
 
 namespace Magento\MessageQueue\Model\Plugin\ResourceModel;
 
-use Magento\TestFramework\Event\Magento;
+use Magento\Framework\App\MaintenanceMode;
+use Magento\Framework\MessageQueue\Lock\ReaderInterface;
+use Magento\Framework\MessageQueue\Lock\WriterInterface;
+use Magento\Framework\MessageQueue\LockInterface;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
 
-class LockTest extends \PHPUnit\Framework\TestCase
+class LockTest extends TestCase
 {
     /**
-     * @var \Magento\Framework\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
     protected $objectManager;
 
     /**
-     * @var \Magento\Framework\MessageQueue\LockInterface
+     * @var LockInterface
      */
     protected $lock;
 
     /**
-     * @var \Magento\Framework\MessageQueue\Lock\WriterInterface
+     * @var WriterInterface
      */
     protected $writer;
 
     /**
-     * @var \Magento\Framework\MessageQueue\Lock\ReaderInterface
+     * @var ReaderInterface
      */
     protected $reader;
 
-    protected function setUp()
+    /**
+     * @return void
+     */
+    protected function setUp(): void
     {
-        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->objectManager = Bootstrap::getObjectManager();
 
-        $this->lock = $this->objectManager->get(\Magento\Framework\MessageQueue\LockInterface::class);
-        $this->writer = $this->objectManager->get(\Magento\Framework\MessageQueue\Lock\WriterInterface::class);
-        $this->reader = $this->objectManager->get(\Magento\Framework\MessageQueue\Lock\ReaderInterface::class);
+        $this->lock = $this->objectManager->get(LockInterface::class);
+        $this->writer = $this->objectManager->get(WriterInterface::class);
+        $this->reader = $this->objectManager->get(ReaderInterface::class);
     }
 
     /**
@@ -44,11 +56,13 @@ class LockTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testLockClearedByMaintenanceModeOff()
+    public function testLockClearedByMaintenanceModeOff(): void
     {
-        /** @var $maintenanceMode \Magento\Framework\App\MaintenanceMode */
-        $maintenanceMode = $this->objectManager->get(\Magento\Framework\App\MaintenanceMode::class);
+        /** @var $maintenanceMode MaintenanceMode */
+        $maintenanceMode = $this->objectManager->get(MaintenanceMode::class);
+        // phpcs:disable
         $code = md5('consumer.name-1');
+        // phpcs:enable
         $this->lock->setMessageCode($code);
         $this->writer->saveLock($this->lock);
         $this->reader->read($this->lock, $code);

--- a/lib/internal/Magento/Framework/MessageQueue/Lock/ReaderInterface.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Lock/ReaderInterface.php
@@ -1,9 +1,14 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Framework\MessageQueue\Lock;
+
+use Magento\Framework\MessageQueue\LockInterface;
 
 /**
  * Message lock reader interface
@@ -13,9 +18,9 @@ interface ReaderInterface
     /**
      * Get lock from storage
      *
-     * @param \Magento\Framework\MessageQueue\LockInterface $lock
+     * @param LockInterface $lock
      * @param string $code
      * @return void
      */
-    public function read(\Magento\Framework\MessageQueue\LockInterface $lock, $code);
+    public function read(LockInterface $lock, string $code): void;
 }

--- a/lib/internal/Magento/Framework/MessageQueue/Lock/WriterInterface.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Lock/WriterInterface.php
@@ -1,9 +1,14 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Framework\MessageQueue\Lock;
+
+use Magento\Framework\MessageQueue\LockInterface;
 
 /**
  * Message lock writer
@@ -13,15 +18,15 @@ interface WriterInterface
     /**
      * Save lock
      *
-     * @param \Magento\Framework\MessageQueue\LockInterface $lock
+     * @param LockInterface $lock
      * @return void
      */
-    public function saveLock(\Magento\Framework\MessageQueue\LockInterface $lock);
+    public function saveLock(LockInterface $lock): void;
 
     /**
      * Remove outdated locks
      *
      * @return void
      */
-    public function releaseOutdatedLocks();
+    public function releaseOutdatedLocks(): void;
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Message can't be processed by the same consumer if it was rejected previuosly, beacause message lock is not released.
Example:
If we create dead-letter exchange (so far not possible using xml-s - see related PRs) we want our consumer to process the same message again later. It is not possible, because message is locked in db and we get exception [here](https://github.com/magento/magento2/blob/04b376d799498a950e32bcea6b9cbbccd7d2aff5/lib/internal/Magento/Framework/MessageQueue/Consumer.php#L219). It should be released [here](https://github.com/magento/magento2/blob/04b376d799498a950e32bcea6b9cbbccd7d2aff5/lib/internal/Magento/Framework/MessageQueue/Consumer.php#L231) when message was rejected but it's not, because saving lock process create separate lock object, and one we pass as argument doesn't get populated with id.

I will fix test, as soon as solution will be accepted.

If PR will be accepted, please port to 2.3 as well.

### Related Pull Requests
<!-- related pull request placeholder -->
https://github.com/magento/magento2/pull/26966
https://github.com/magento/magento2/pull/26967

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Publish message on queue
2. Make consumer reject it
3. Make consumer somehow consume it again (for example dead letter exchange)
4. Message should be consumer and acked or rejected again, but not because of lock.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29616: Making message lock release possible