### PR TITLE
MC-26946: added fullScreenLoader.stopLoader method to validation

### DIFF
--- a/app/code/Magento/Braintree/view/frontend/web/js/view/payment/3d-secure.js
+++ b/app/code/Magento/Braintree/view/frontend/web/js/view/payment/3d-secure.js
@@ -157,9 +157,9 @@ define([
                             context.paymentPayload.nonce = payload.nonce;
                             self.state.resolve();
                         } else {
-                            fullScreenLoader.stopLoader();
                             self.state.reject($t('Please try again with another form of payment.'));
                         }
+                        fullScreenLoader.stopLoader();
                     });
                 })
                 .fail(function () {

--- a/app/code/Magento/Braintree/view/frontend/web/js/view/payment/3d-secure.js
+++ b/app/code/Magento/Braintree/view/frontend/web/js/view/payment/3d-secure.js
@@ -145,7 +145,6 @@ define([
                 .then(function () {
                     self.threeDSecureInstance.verifyCard(options, function (err, payload) {
                         if (err) {
-                            fullScreenLoader.stopLoader();
                             self.state.reject(err.message);
 
                             return;
@@ -159,12 +158,13 @@ define([
                         } else {
                             self.state.reject($t('Please try again with another form of payment.'));
                         }
-                        fullScreenLoader.stopLoader();
                     });
                 })
                 .fail(function () {
-                    fullScreenLoader.stopLoader();
                     self.state.reject($t('Please try again with another form of payment.'));
+                })
+                .always(function () {
+                    fullScreenLoader.stopLoader();
                 });
 
             return self.state.promise();


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
3d-secure.js **validate** method in one of the scenarios doesn't stopLoader and because of that it was impossible to make any further changes from the user perspective.

<!-- ### Related Pull Requests -->
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#26946: Declined Braintree 3DS enabled transactions result in stuck loader icon

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. well Described inside the ticket #26946

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
I'm not sure if we need any tests for that issue.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
