### PR TITLE
Bugfix: Changed saving sorting order in RefundOrder class

### DIFF
--- a/app/code/Magento/Sales/Model/RefundOrder.php
+++ b/app/code/Magento/Sales/Model/RefundOrder.php
@@ -160,8 +160,8 @@ class RefundOrder implements RefundOrderInterface
                 : $this->config->getStateDefaultStatus($orderState);
             $order->setStatus($status);
 
-            $order = $this->orderRepository->save($order);
             $creditmemo = $this->creditmemoRepository->save($creditmemo);
+            $order = $this->orderRepository->save($order);
             $connection->commit();
         } catch (\Exception $e) {
             $this->logger->critical($e);

--- a/app/code/Magento/Sales/Model/RefundOrder.php
+++ b/app/code/Magento/Sales/Model/RefundOrder.php
@@ -19,7 +19,8 @@ use Magento\Sales\Model\Order\Validation\RefundOrderInterface as RefundOrderVali
 use Psr\Log\LoggerInterface;
 
 /**
- * Class RefundOrder
+ * Class is used for creating a credit memo and refunding it.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class RefundOrder implements RefundOrderInterface


### PR DESCRIPTION
### Description

Bugfix: Changed saving sorting order. For Magento Commerce a comment is set on the order when refunding to store credit. This comment will not be saved and the store credit refund will not be shown on the order page, because it's not saved as the order was already saved before saving the credit note.

### Version
Magento Commerce 2.3.5
Fixes: https://github.com/magento/magento2/issues/26975
