### PR TITLE
Fix: #26973 Fatal error when Product Image size is not defined

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ImageFactory.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageFactory.php
@@ -123,7 +123,7 @@ class ImageFactory
         if (empty($label)) {
             $label = $product->getName();
         }
-        return (string) $label;
+        return (string)$label;
     }
 
     /**
@@ -161,7 +161,7 @@ class ImageFactory
         }
 
         $attributes = $attributes === null ? [] : $attributes;
-        
+
         $data = [
             'data' => [
                 'template' => 'Magento_Catalog::product/image_with_borders.phtml',
@@ -169,7 +169,7 @@ class ImageFactory
                 'width' => $imageMiscParams['image_width'],
                 'height' => $imageMiscParams['image_height'],
                 'label' => $this->getLabel($product, $imageMiscParams['image_type']),
-                'ratio' => $this->getRatio($imageMiscParams['image_width'], $imageMiscParams['image_height']),
+                'ratio' => $this->getRatio($imageMiscParams['image_width'] ?? 0, $imageMiscParams['image_height'] ?? 0),
                 'custom_attributes' => $this->getStringCustomAttributes($attributes),
                 'class' => $this->getClass($attributes),
                 'product_id' => $product->getId()

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageFactoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/ImageFactoryTest.php
@@ -95,6 +95,7 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
         return [
             $this->getTestDataWithoutAttributes(),
             $this->getTestDataWithAttributes(),
+            $this->getTestDataWithoutDimensions()
         ];
     }
 
@@ -208,5 +209,22 @@ class ImageFactoryTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
         ];
+    }
+
+    /**
+     * @return array
+     */
+    private function getTestDataWithoutDimensions(): array
+    {
+        $data = $this->getTestDataWithoutAttributes();
+
+        $data['data']['imageParamsBuilder']['image_width'] = null;
+        $data['data']['imageParamsBuilder']['image_height'] = null;
+
+        $data['expected']['data']['width'] = null;
+        $data['expected']['data']['height'] = null;
+        $data['expected']['data']['ratio'] = 1.0;
+
+        return $data;
     }
 }


### PR DESCRIPTION
### Description (*)
When product image parameters does not contain `image_width` and `image_height`, call to `getRatio` ends up with fatal error. Fixed by fallback to `0` for value not set.

### Related Pull Requests
N/A
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. magento/magento2#26973

### Manual testing scenarios (*)
N/A - Covered with Unit Test

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Support
![image](https://user-images.githubusercontent.com/1639941/75389169-62b56980-58e6-11ea-9c79-3079bffa2d40.png)
Solving this issue is supported by [Mediotype](mediotype.com)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
