### PR TITLE
#26800 Fixed Undefined variable  in ProductLink/Management

### DIFF
--- a/app/code/Magento/Catalog/Api/ProductLinkManagementInterface.php
+++ b/app/code/Magento/Catalog/Api/ProductLinkManagementInterface.php
@@ -6,11 +6,6 @@
 
 namespace Magento\Catalog\Api;
 
-use Magento\Catalog\Api\Data\ProductLinkInterface;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Framework\Exception\CouldNotSaveException;
-use Magento\Framework\Exception\InputException;
-
 /**
  * @api
  * @since 100.0.2
@@ -22,8 +17,8 @@ interface ProductLinkManagementInterface
      *
      * @param string $sku
      * @param string $type
-     * @throws NoSuchEntityException
-     * @return ProductLinkInterface[]
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @return \Magento\Catalog\Api\Data\ProductLinkInterface[]
      */
     public function getLinkedItemsByType($sku, $type);
 
@@ -31,10 +26,10 @@ interface ProductLinkManagementInterface
      * Assign a product link to another product
      *
      * @param string $sku
-     * @param ProductLinkInterface[] $items
-     * @throws NoSuchEntityException
-     * @throws CouldNotSaveException
-     * @throws InputException
+     * @param \Magento\Catalog\Api\Data\ProductLinkInterface[] $items
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     * @throws \Magento\Framework\Exception\InputException
      * @return bool
      */
     public function setProductLinks($sku, array $items);

--- a/app/code/Magento/Catalog/Api/ProductLinkManagementInterface.php
+++ b/app/code/Magento/Catalog/Api/ProductLinkManagementInterface.php
@@ -6,6 +6,11 @@
 
 namespace Magento\Catalog\Api;
 
+use Magento\Catalog\Api\Data\ProductLinkInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\InputException;
+
 /**
  * @api
  * @since 100.0.2
@@ -17,7 +22,8 @@ interface ProductLinkManagementInterface
      *
      * @param string $sku
      * @param string $type
-     * @return \Magento\Catalog\Api\Data\ProductLinkInterface[]
+     * @throws NoSuchEntityException
+     * @return ProductLinkInterface[]
      */
     public function getLinkedItemsByType($sku, $type);
 
@@ -25,9 +31,10 @@ interface ProductLinkManagementInterface
      * Assign a product link to another product
      *
      * @param string $sku
-     * @param \Magento\Catalog\Api\Data\ProductLinkInterface[] $items
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     * @throws \Magento\Framework\Exception\CouldNotSaveException
+     * @param ProductLinkInterface[] $items
+     * @throws NoSuchEntityException
+     * @throws CouldNotSaveException
+     * @throws InputException
      * @return bool
      */
     public function setProductLinks($sku, array $items);

--- a/app/code/Magento/Catalog/Model/ProductLink/Management.php
+++ b/app/code/Magento/Catalog/Model/ProductLink/Management.php
@@ -13,6 +13,9 @@ use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product\LinkTypeProvider;
 use Magento\Catalog\Api\ProductLinkManagementInterface;
 
+/**
+ * Manage product links from api
+ */
 class Management implements ProductLinkManagementInterface
 {
     /**
@@ -38,7 +41,7 @@ class Management implements ProductLinkManagementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getLinkedItemsByType($sku, $type)
     {
@@ -65,7 +68,7 @@ class Management implements ProductLinkManagementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setProductLinks($sku, array $items)
     {

--- a/app/code/Magento/Catalog/Model/ProductLink/Management.php
+++ b/app/code/Magento/Catalog/Model/ProductLink/Management.php
@@ -6,30 +6,32 @@
 
 namespace Magento\Catalog\Model\ProductLink;
 
-use Magento\Catalog\Api\Data;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\InputException;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product\LinkTypeProvider;
+use Magento\Catalog\Api\ProductLinkManagementInterface;
 
-class Management implements \Magento\Catalog\Api\ProductLinkManagementInterface
+class Management implements ProductLinkManagementInterface
 {
     /**
-     * @var \Magento\Catalog\Api\ProductRepositoryInterface
+     * @var ProductRepositoryInterface
      */
     protected $productRepository;
 
     /**
-     * @var \Magento\Catalog\Model\Product\LinkTypeProvider
+     * @var LinkTypeProvider
      */
     protected $linkTypeProvider;
 
     /**
-     * @param \Magento\Catalog\Api\ProductRepositoryInterface $productRepository
-     * @param \Magento\Catalog\Model\Product\LinkTypeProvider $linkTypeProvider
+     * @param ProductRepositoryInterface $productRepository
+     * @param LinkTypeProvider $linkTypeProvider
      */
     public function __construct(
-        \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
-        \Magento\Catalog\Model\Product\LinkTypeProvider $linkTypeProvider
+        ProductRepositoryInterface $productRepository,
+        LinkTypeProvider $linkTypeProvider
     ) {
         $this->productRepository = $productRepository;
         $this->linkTypeProvider = $linkTypeProvider;
@@ -67,43 +69,38 @@ class Management implements \Magento\Catalog\Api\ProductLinkManagementInterface
      */
     public function setProductLinks($sku, array $items)
     {
+
+        if (empty($items)) {
+            throw InputException::invalidFieldValue('items', 'empty array');
+        }
+
         $linkTypes = $this->linkTypeProvider->getLinkTypes();
 
         // Check if product link type is set and correct
-        if (!empty($items)) {
-            foreach ($items as $newLink) {
-                $type = $newLink->getLinkType();
-                if ($type == null) {
-                    throw InputException::requiredField("linkType");
-                }
-                if (!isset($linkTypes[$type])) {
-                    throw new NoSuchEntityException(
-                        __('The "%1" link type wasn\'t found. Verify the type and try again.', $type)
-                    );
-                }
+        foreach ($items as $newLink) {
+            $type = $newLink->getLinkType();
+            if ($type == null) {
+                throw InputException::requiredField("linkType");
+            }
+            if (!isset($linkTypes[$type])) {
+                throw new NoSuchEntityException(
+                    __('The "%1" link type wasn\'t found. Verify the type and try again.', $type)
+                );
             }
         }
 
         $product = $this->productRepository->get($sku);
 
-        // Replace only links of the specified type
         $existingLinks = $product->getProductLinks();
-        $newLinks = [];
-        if (!empty($existingLinks)) {
-            foreach ($existingLinks as $link) {
-                if ($link->getLinkType() != $type) {
-                    $newLinks[] = $link;
-                }
-            }
-            $newLinks = array_merge($newLinks, $items);
-        } else {
-            $newLinks = $items;
-        }
+        $newLinks = array_merge($existingLinks, $items);
+
         $product->setProductLinks($newLinks);
         try {
             $this->productRepository->save($product);
         } catch (\Exception $exception) {
-            throw new CouldNotSaveException(__('The linked products data is invalid. Verify the data and try again.'));
+            throw new CouldNotSaveException(
+                __('The linked products data is invalid. Verify the data and try again.')
+            );
         }
 
         return true;

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductLink/ManagementTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductLink/ManagementTest.php
@@ -7,45 +7,66 @@
 namespace Magento\Catalog\Test\Unit\Model\ProductLink;
 
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Catalog\Model\ProductLink\Management;
+use Magento\Catalog\Model\ProductRepository;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\LinkTypeProvider;
+use Magento\Catalog\Model\ProductLink\Link;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class ManagementTest extends \PHPUnit\Framework\TestCase
+/**
+ * Unit Test for Magento\Catalog\Model\ProductLink\Management
+ */
+class ManagementTest extends TestCase
 {
+
+    const STUB_PRODUCT_SKU_1 = 'Simple Product 1';
+    const STUB_PRODUCT_SKU_2 = 'Simple Product 2';
+    const STUB_PRODUCT_TYPE = 'simple';
+    const STUB_LINK_TYPE = 'related';
+    const STUB_BAD_TYPE = 'bad type';
+
     /**
-     * @var \Magento\Catalog\Model\ProductLink\Management
+     * @var Management
      */
     protected $model;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var ProductRepository|MockObject
      */
-
     protected $productRepositoryMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var Product|MockObject
      */
     protected $productMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var LinkTypeProvider|MockObject
      */
     protected $linkTypeProviderMock;
 
     /**
-     * @var \Magento\Framework\ObjectManagerInterface
+     * @var ObjectManagerHelper
      */
     protected $objectManager;
 
-    protected function setUp()
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
     {
-        $this->productRepositoryMock = $this->createMock(\Magento\Catalog\Model\ProductRepository::class);
-        $this->productMock = $this->createMock(\Magento\Catalog\Model\Product::class);
+        $this->productRepositoryMock = $this->createMock(ProductRepository::class);
+        $this->productMock = $this->createMock(Product::class);
+        $this->linkTypeProviderMock = $this->createMock(LinkTypeProvider::class);
 
-        $this->linkTypeProviderMock = $this->createMock(\Magento\Catalog\Model\Product\LinkTypeProvider::class);
-
-        $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $this->objectManager = new ObjectManagerHelper($this);
         $this->model = $this->objectManager->getObject(
-            \Magento\Catalog\Model\ProductLink\Management::class,
+            Management::class,
             [
                 'productRepository' => $this->productRepositoryMock,
                 'linkTypeProvider' => $this->linkTypeProviderMock
@@ -53,193 +74,321 @@ class ManagementTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetLinkedItemsByType()
+    /**
+     * Test getLinkedItemsByType()
+     *
+     * @return void
+     */
+    public function testGetLinkedItemsByType(): void
     {
-        $productSku = 'Simple Product 1';
-        $linkType = 'related';
-        $this->productRepositoryMock->expects($this->once())->method('get')->with($productSku)
+        $productSku = self::STUB_PRODUCT_SKU_1;
+        $linkType = self::STUB_LINK_TYPE;
+
+        $this->productRepositoryMock->expects($this->once())
+            ->method('get')
+            ->with($productSku)
             ->willReturn($this->productMock);
 
-        $inputRelatedLink = $this->objectManager->getObject(\Magento\Catalog\Model\ProductLink\Link::class);
-        $inputRelatedLink->setProductSku($productSku);
-        $inputRelatedLink->setLinkType($linkType);
-        $inputRelatedLink->setData("sku", "Simple Product 2");
-        $inputRelatedLink->setData("type_id", "simple");
-        $inputRelatedLink->setPosition(0);
-        $links = [$inputRelatedLink];
+        $links = $this->getInputRelatedLinkMock(
+            $productSku,
+            $linkType,
+            self::STUB_PRODUCT_SKU_2,
+            self::STUB_PRODUCT_TYPE
+        );
 
-        $linkTypes = ['related' => 1, 'upsell' => 4, 'crosssell' => 5, 'associated' => 3];
-        $this->linkTypeProviderMock->expects($this->once())
-            ->method('getLinkTypes')
-            ->willReturn($linkTypes);
+        $this->getLinkTypesMock();
 
-        $this->productMock->expects($this->once())->method('getProductLinks')->willReturn($links);
-        $this->assertEquals($links, $this->model->getLinkedItemsByType($productSku, $linkType));
+        $this->productMock->expects($this->once())
+            ->method('getProductLinks')
+            ->willReturn($links);
+
+        $this->assertEquals(
+            $links,
+            $this->model->getLinkedItemsByType($productSku, $linkType)
+        );
     }
 
     /**
-     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     * @expectedExceptionMessage The "bad type" link type is unknown. Verify the type and try again.
+     * Test for GetLinkedItemsByType() with wrong type
+     *
+     * @return void
+     * @throws NoSuchEntityException
      */
-    public function testGetLinkedItemsByTypeWithWrongType()
+    public function testGetLinkedItemsByTypeWithWrongType(): void
     {
-        $productSku = 'Simple Product 1';
-        $linkType = 'bad type';
-        $this->productRepositoryMock->expects($this->never())->method('get')->with($productSku)
+        $productSku = self::STUB_PRODUCT_SKU_1;
+        $linkType = self::STUB_BAD_TYPE;
+
+        $this->productRepositoryMock->expects($this->never())
+            ->method('get')
+            ->with($productSku)
             ->willReturn($this->productMock);
 
-        $inputRelatedLink = $this->objectManager->getObject(\Magento\Catalog\Model\ProductLink\Link::class);
-        $inputRelatedLink->setProductSku($productSku);
-        $inputRelatedLink->setLinkType($linkType);
-        $inputRelatedLink->setData("sku", "Simple Product 2");
-        $inputRelatedLink->setData("type_id", "simple");
-        $inputRelatedLink->setPosition(0);
-        $links = [$inputRelatedLink];
+        $links = $this->getInputRelatedLinkMock(
+            $productSku,
+            $linkType,
+            self::STUB_PRODUCT_SKU_2,
+            self::STUB_PRODUCT_TYPE
+        );
 
-        $linkTypes = ['related' => 1, 'upsell' => 4, 'crosssell' => 5, 'associated' => 3];
-        $this->linkTypeProviderMock->expects($this->once())
-            ->method('getLinkTypes')
-            ->willReturn($linkTypes);
+        $this->getLinkTypesMock();
 
-        $this->productMock->expects($this->never())->method('getProductLinks')->willReturn($links);
+        $this->productMock->expects($this->never())
+            ->method('getProductLinks')
+            ->willReturn($links);
+
+        $this->expectException(NoSuchEntityException::class);
+        $this->expectExceptionMessage(
+            'The "bad type" link type is unknown. Verify the type and try again.'
+        );
+
         $this->model->getLinkedItemsByType($productSku, $linkType);
     }
 
-    public function testSetProductLinks()
+    /**
+     * Test for setProductLinks()
+     *
+     * @return void
+     */
+    public function testSetProductLinks(): void
     {
-        $productSku = 'Simple Product 1';
-        $linkType = 'related';
-        $this->productRepositoryMock->expects($this->once())->method('get')->with($productSku)
+        $productSku = self::STUB_PRODUCT_SKU_1;
+        $linkType = self::STUB_LINK_TYPE;
+
+        $this->productRepositoryMock->expects($this->once())
+            ->method('get')
+            ->with($productSku)
             ->willReturn($this->productMock);
 
-        $inputRelatedLink = $this->objectManager->getObject(\Magento\Catalog\Model\ProductLink\Link::class);
-        $inputRelatedLink->setProductSku($productSku);
-        $inputRelatedLink->setLinkType($linkType);
-        $inputRelatedLink->setData("sku", "Simple Product 1");
-        $inputRelatedLink->setData("type_id", "related");
-        $inputRelatedLink->setPosition(0);
-        $links = [$inputRelatedLink];
+        $links = $this->getInputRelatedLinkMock(
+            $productSku,
+            $linkType,
+            self::STUB_PRODUCT_SKU_2,
+            self::STUB_PRODUCT_TYPE
+        );
 
-        $linkTypes = ['related' => 1, 'upsell' => 4, 'crosssell' => 5, 'associated' => 3];
-        $this->linkTypeProviderMock->expects($this->once())
-            ->method('getLinkTypes')
-            ->willReturn($linkTypes);
+        $this->getLinkTypesMock();
 
-        $this->productMock->expects($this->once())->method('getProductLinks')->willReturn([]);
-        $this->productMock->expects($this->once())->method('setProductLinks')->with($links);
+        $this->productMock->expects($this->once())
+            ->method('getProductLinks')
+            ->willReturn([]);
+        $this->productMock->expects($this->once())
+            ->method('setProductLinks')
+            ->with($links);
+
         $this->assertTrue($this->model->setProductLinks($productSku, $links));
     }
 
     /**
-     * @expectedException \Magento\Framework\Exception\InputException
-     * @expectedExceptionMessage "linkType" is required. Enter and try again.
+     * Test for SetProductLinks without link type in link object
+     *
+     * @return void
+     * @throws InputException
      */
-    public function testSetProductLinksWithoutLinkTypeInLink()
+    public function testSetProductLinksWithoutLinkTypeInLink(): void
     {
-        $productSku = 'Simple Product 1';
+        $productSku = self::STUB_PRODUCT_SKU_1;
 
-        $inputRelatedLink = $this->objectManager->getObject(\Magento\Catalog\Model\ProductLink\Link::class);
+        $inputRelatedLink = $this->objectManager->getObject(Link::class);
         $inputRelatedLink->setProductSku($productSku);
-        $inputRelatedLink->setData("sku", "Simple Product 1");
+        $inputRelatedLink->setData("sku", self::STUB_PRODUCT_SKU_2);
         $inputRelatedLink->setPosition(0);
         $links = [$inputRelatedLink];
 
-        $linkTypes = ['related' => 1, 'upsell' => 4, 'crosssell' => 5, 'associated' => 3];
-        $this->linkTypeProviderMock->expects($this->once())
-            ->method('getLinkTypes')
-            ->willReturn($linkTypes);
+        $this->getLinkTypesMock();
+
+        $this->expectException(InputException::class);
+        $this->expectExceptionMessage(
+            '"linkType" is required. Enter and try again.'
+        );
 
         $this->assertTrue($this->model->setProductLinks($productSku, $links));
     }
 
+
     /**
-     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     * @expectedExceptionMessage The "bad type" link type wasn't found. Verify the type and try again.
+     * Test for SetProductLinks with empty array of items
+     *
+     * @return void
+     * @throws InputException
+     */
+    public function testSetProductLinksWithEmptyArrayItems(): void
+    {
+        $productSku = self::STUB_PRODUCT_SKU_1;
+
+        $this->productRepositoryMock->expects($this->never())
+            ->method('get')
+            ->with($productSku)
+            ->willReturn($this->productMock);
+
+        $this->linkTypeProviderMock->expects($this->never())
+            ->method('getLinkTypes')
+            ->willReturn([]);
+
+        $this->expectException(InputException::class);
+        $this->expectExceptionMessage(
+            'Invalid value of "empty array" provided for the items field.'
+        );
+
+        $this->assertTrue($this->model->setProductLinks($productSku, []));
+    }
+
+    /**
+     * Test setProductLinks() throw exception if product link type not exist
+     *
+     * @return void
+     * @throws NoSuchEntityException
      */
     public function testSetProductLinksThrowExceptionIfProductLinkTypeDoesNotExist()
     {
-        $productSku = 'Simple Product 1';
-        $linkType = 'bad type';
-        $this->productRepositoryMock->expects($this->never())->method('get')->with($productSku)
+        $productSku = self::STUB_PRODUCT_SKU_1;
+        $linkType = self::STUB_BAD_TYPE;
+
+        $this->productRepositoryMock->expects($this->never())
+            ->method('get')
+            ->with($productSku)
             ->willReturn($this->productMock);
 
-        $inputRelatedLink = $this->objectManager->getObject(\Magento\Catalog\Model\ProductLink\Link::class);
-        $inputRelatedLink->setProductSku($productSku);
-        $inputRelatedLink->setLinkType($linkType);
-        $inputRelatedLink->setData("sku", "Simple Product 2");
-        $inputRelatedLink->setData("type_id", "simple");
-        $inputRelatedLink->setPosition(0);
-        $links = [$inputRelatedLink];
+        $links = $this->getInputRelatedLinkMock(
+            $productSku,
+            $linkType,
+            self::STUB_PRODUCT_SKU_2,
+            self::STUB_PRODUCT_TYPE
+        );
 
-        $linkTypes = ['related' => 1, 'upsell' => 4, 'crosssell' => 5, 'associated' => 3];
-        $this->linkTypeProviderMock->expects($this->once())
-            ->method('getLinkTypes')
-            ->willReturn($linkTypes);
+        $this->getLinkTypesMock();
+
+        $this->expectException(NoSuchEntityException::class);
+        $this->expectExceptionMessage(
+            'The "bad type" link type wasn\'t found. Verify the type and try again.'
+        );
 
         $this->assertTrue($this->model->setProductLinks('', $links));
     }
 
     /**
-     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     * @expectedExceptionMessage The product that was requested doesn't exist. Verify the product and try again.
+     * Test for setProductLinks() with no product exception
+     *
+     * @return void
+     * @throws NoSuchEntityException
      */
     public function testSetProductLinksNoProductException()
     {
-        $productSku = 'Simple Product 1';
-        $linkType = 'related';
+        $productSku = self::STUB_PRODUCT_SKU_1;
+        $linkType = self::STUB_LINK_TYPE;
 
-        $inputRelatedLink = $this->objectManager->getObject(\Magento\Catalog\Model\ProductLink\Link::class);
-        $inputRelatedLink->setProductSku($productSku);
-        $inputRelatedLink->setLinkType($linkType);
-        $inputRelatedLink->setData("sku", "Simple Product 2");
-        $inputRelatedLink->setData("type_id", "simple");
-        $inputRelatedLink->setPosition(0);
-        $links = [$inputRelatedLink];
+        $links = $this->getInputRelatedLinkMock(
+            $productSku,
+            $linkType,
+            self::STUB_PRODUCT_SKU_2,
+            self::STUB_PRODUCT_TYPE
+        );
 
-        $linkTypes = ['related' => 1, 'upsell' => 4, 'crosssell' => 5, 'associated' => 3];
-        $this->linkTypeProviderMock->expects($this->once())
-            ->method('getLinkTypes')
-            ->willReturn($linkTypes);
+        $this->getLinkTypesMock();
 
         $this->productRepositoryMock->expects($this->once())
             ->method('get')
-            ->will(
-                $this->throwException(
-                    new \Magento\Framework\Exception\NoSuchEntityException(
-                        __("The product that was requested doesn't exist. Verify the product and try again.")
-                    )
+            ->willThrowException(
+                new NoSuchEntityException(
+                    __("The product that was requested doesn't exist. Verify the product and try again.")
                 )
             );
+
+        $this->expectException(NoSuchEntityException::class);
+        $this->expectExceptionMessage(
+            "The product that was requested doesn't exist. Verify the product and try again."
+        );
+
         $this->model->setProductLinks($productSku, $links);
     }
 
     /**
-     * @expectedException \Magento\Framework\Exception\CouldNotSaveException
-     * @expectedExceptionMessage The linked products data is invalid. Verify the data and try again.
+     * Test setProductLnks() with invliad data exception
+     *
+     * @return void
+     * @throws CouldNotSaveException
      */
-    public function testSetProductLinksInvalidDataException()
+    public function testSetProductLinksInvalidDataException(): void
     {
-        $productSku = 'Simple Product 1';
-        $linkType = 'related';
-        $this->productRepositoryMock->expects($this->once())->method('get')->with($productSku)
+        $productSku = self::STUB_PRODUCT_SKU_1;
+        $linkType = self::STUB_LINK_TYPE;
+
+        $this->productRepositoryMock->expects($this->once())
+            ->method('get')
+            ->with($productSku)
             ->willReturn($this->productMock);
 
-        $inputRelatedLink = $this->objectManager->getObject(\Magento\Catalog\Model\ProductLink\Link::class);
-        $inputRelatedLink->setProductSku($productSku);
-        $inputRelatedLink->setLinkType($linkType);
-        $inputRelatedLink->setData("sku", "bad sku");
-        $inputRelatedLink->setData("type_id", "bad type");
-        $inputRelatedLink->setPosition(0);
-        $links = [$inputRelatedLink];
+        $links = $this->getInputRelatedLinkMock(
+            $productSku,
+            $linkType,
+            self::STUB_PRODUCT_SKU_2,
+            self::STUB_PRODUCT_TYPE
+        );
 
-        $linkTypes = ['related' => 1, 'upsell' => 4, 'crosssell' => 5, 'associated' => 3];
+        $this->getLinkTypesMock();
+
+        $this->productMock->expects($this->once())
+            ->method('getProductLinks')
+            ->willReturn([]);
+
+        $this->productRepositoryMock->expects($this->once())
+            ->method('save')
+            ->willThrowException(
+                new CouldNotSaveException(
+                    __("The linked products data is invalid. Verify the data and try again.")
+                )
+            );
+
+        $this->expectException(CouldNotSaveException::class);
+        $this->expectExceptionMessage(
+            "The linked products data is invalid. Verify the data and try again."
+        );
+
+        $this->model->setProductLinks($productSku, $links);
+    }
+
+    /**
+     * Mock for getLinkTypesMock
+     *
+     * @return void
+     */
+    private function getLinkTypesMock(): void
+    {
+        $linkTypes = [
+            'related' => 1,
+            'upsell' => 4,
+            'crosssell' => 5,
+            'associated' => 3
+        ];
+
         $this->linkTypeProviderMock->expects($this->once())
             ->method('getLinkTypes')
             ->willReturn($linkTypes);
+    }
 
-        $this->productMock->expects($this->once())->method('getProductLinks')->willReturn([]);
+    /**
+     * get inputRelatedLinkMock
+     *
+     * @param string $productSku1
+     * @param string $linkType
+     * @param string $productSku2
+     * @param string $typeId
+     * @return array
+     */
+    private function getInputRelatedLinkMock(
+        string $productSku1,
+        string $linkType,
+        string $productSku2,
+        string $typeId
+    ) {
 
-        $this->productRepositoryMock->expects($this->once())->method('save')->willThrowException(new \Exception());
-        $this->model->setProductLinks($productSku, $links);
+        $inputRelatedLinkMock = $this->objectManager->getObject(Link::class);
+        $inputRelatedLinkMock->setProductSku($productSku1);
+        $inputRelatedLinkMock->setLinkType($linkType);
+        $inputRelatedLinkMock->setData("sku", $productSku2);
+        $inputRelatedLinkMock->setData("type_id", $typeId);
+        $inputRelatedLinkMock->setPosition(0);
+
+        return [$inputRelatedLinkMock];
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductLink/ManagementTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductLink/ManagementTest.php
@@ -205,7 +205,6 @@ class ManagementTest extends TestCase
         $this->assertTrue($this->model->setProductLinks($productSku, $links));
     }
 
-
     /**
      * Test for SetProductLinks with empty array of items
      *


### PR DESCRIPTION
### Description (*)
This PR fixed the issue #26800.
Set product links through API with with empty array of items its throws 'undefined variable' if the product has existing links, So I added the additional condition to check array is empty If yes throws the `InputException`.
Covered the unit test case with that scenario.
Updated doc blocks in `ProductLinkManagementInterface.php` with exception class.

### Fixed Issues (if relevant)
magento/magento2#26800 

### Manual testing scenarios (*)
**Unit Test:** `vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/Catalog/Test/Unit/Model/ProductLink/ManagementTest.php`

**From API:** 
URL: `/rest/V1/products/1234/links`
Method: POST
Data: 
`{
	"items": []
}`

_(eariler its throws `undefined variable` if the product has atleast one product link & now its should show valid error message from `InputException`)_

### Questions or comments
If any please let me know the feedback's

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
