### PR TITLE
Media Gallery component now receives allowable file types from File Uploader

### DIFF
--- a/app/code/Magento/Cms/Block/Adminhtml/Wysiwyg/Images/Content/Uploader.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Wysiwyg/Images/Content/Uploader.php
@@ -43,7 +43,7 @@ class Uploader extends \Magento\Backend\Block\Media\Uploader
     {
         parent::_construct();
         $type = $this->_getMediaType();
-        $allowed = $this->_imagesStorage->getAllowedExtensions($type);
+        $allowed = $this->_getAllowedFileExtensions();
         $labels = [];
         $files = [];
         foreach ($allowed as $ext) {
@@ -70,5 +70,19 @@ class Uploader extends \Magento\Backend\Block\Media\Uploader
             return $this->_getData('media_type');
         }
         return $this->getRequest()->getParam('type');
+    }
+
+    /**
+     * Return allowed file extensions based on request or config
+     *
+     * @return array
+     */
+    protected function _getAllowedFileExtensions()
+    {
+        if ($encodedExtensions = $this->getRequest()->getParam('allowed_extensions')) {
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
+            return(explode(" ", base64_decode($encodedExtensions)));
+        }
+        return $this->_imagesStorage->getAllowedExtensions($this->_getMediaType());
     }
 }

--- a/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/Thumbnail.php
+++ b/app/code/Magento/Cms/Controller/Adminhtml/Wysiwyg/Images/Thumbnail.php
@@ -1,14 +1,21 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\Cms\Controller\Adminhtml\Wysiwyg\Images;
 
 use Magento\Backend\App\Action;
+use Magento\Cms\Model\Wysiwyg\Images\Storage;
+use Psr\Log\LoggerInterface;
+use Magento\Framework\View\Asset\Repository;
+use Magento\Framework\Image\AdapterFactory;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 
-class Thumbnail extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images
+/**
+ * Thumbnail class returns raw image thumbnails for WYSIWYG Media Browser
+ */
+class Thumbnail extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images implements HttpGetActionInterface
 {
     /**
      * @var \Magento\Framework\Controller\Result\RawFactory
@@ -16,16 +23,40 @@ class Thumbnail extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images
     protected $resultRawFactory;
 
     /**
+     * @var Repository
+     */
+    protected $assetRepo;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var AdapterFactory
+     */
+    protected $adapterFactory;
+
+    /**
      * @param Action\Context $context
      * @param \Magento\Framework\Registry $coreRegistry
      * @param \Magento\Framework\Controller\Result\RawFactory $resultRawFactory
+     * @param Repository $assetRepo
+     * @param LoggerInterface|null $logger
+     * @param AdapterFactory $adapterFactory
      */
     public function __construct(
         Action\Context $context,
         \Magento\Framework\Registry $coreRegistry,
-        \Magento\Framework\Controller\Result\RawFactory $resultRawFactory
+        \Magento\Framework\Controller\Result\RawFactory $resultRawFactory,
+        Repository $assetRepo,
+        LoggerInterface $logger,
+        AdapterFactory $adapterFactory
     ) {
         $this->resultRawFactory = $resultRawFactory;
+        $this->assetRepo = $assetRepo;
+        $this->logger = $logger;
+        $this->adapterFactory = $adapterFactory;
         parent::__construct($context, $coreRegistry);
     }
 
@@ -38,18 +69,28 @@ class Thumbnail extends \Magento\Cms\Controller\Adminhtml\Wysiwyg\Images
     {
         $file = $this->getRequest()->getParam('file');
         $file = $this->_objectManager->get(\Magento\Cms\Helper\Wysiwyg\Images::class)->idDecode($file);
-        $thumb = $this->getStorage()->resizeOnTheFly($file);
         /** @var \Magento\Framework\Controller\Result\Raw $resultRaw */
         $resultRaw = $this->resultRawFactory->create();
-        if ($thumb !== false) {
-            /** @var \Magento\Framework\Image\Adapter\AdapterInterface $image */
-            $image = $this->_objectManager->get(\Magento\Framework\Image\AdapterFactory::class)->create();
+        /** @var \Magento\Framework\Image\Adapter\AdapterInterface $image */
+        $image = $this->adapterFactory->create();
+        try {
+            $thumb = $this->getStorage()->resizeOnTheFly($file);
             $image->open($thumb);
             $resultRaw->setHeader('Content-Type', $image->getMimeType());
             $resultRaw->setContents($image->getImage());
             return $resultRaw;
-        } else {
-            // todo: generate some placeholder
+        } catch (\Exception $e) {
+            //The thumbnail could not be generated using the current Image Adapter. Use CMS Thumb placeholder instead.
+            try {
+                $thumb = $this->assetRepo->createAsset(Storage::THUMB_PLACEHOLDER_PATH_SUFFIX)->getSourceFile();
+                $image->open($thumb);
+                $resultRaw->setHeader('Content-Type', $image->getMimeType());
+                $resultRaw->setContents($image->getImage());
+                $this->logger->warning($e);
+            } catch (\Exception $e) {
+                $this->logger->warning($e);
+            }
         }
+        return $resultRaw;
     }
 }

--- a/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
@@ -552,9 +552,12 @@ class Storage extends \Magento\Framework\DataObject
             throw new \Magento\Framework\Exception\LocalizedException(__('We can\'t upload the file right now.'));
         }
 
-        // create thumbnail
-        $this->resizeFile($targetPath . '/' . $uploader->getUploadedFileName(), true);
-
+        // Skip resize if we are in GD2 Image Adapter mode and the file extension is ico as they
+        // are not supported in GD2.
+        if ($uploader->getFileExtension() !== "ico" ||
+            !($this->_imageFactory->create() instanceof \Magento\Framework\Image\Adapter\Gd2)) {
+            $this->resizeFile($targetPath . '/' . $uploader->getUploadedFileName(), true);
+        }
         return $result;
     }
 

--- a/app/code/Magento/Cms/Test/Mftf/Section/TinyMCESection.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Section/TinyMCESection.xml
@@ -61,6 +61,7 @@
         <element name="checkIfWysiwygArrowExpand" type="button" selector="//li[@id='d3lzaXd5Zw--' and contains(@class,'jstree-closed')]" />
         <element name="confirmDelete" type="button" selector=".action-primary.action-accept" />
         <element name="imageBlockByName" type="block" selector="//div[@data-row='file'][contains(., '{{imageName}}')]" parameterized="true"/>
+        <element name="messages" type="block" selector=".message.message-warning.warning"/>
     </section>
     <section name="VariableSection">
         <element name="InsertWidget" type="button" selector="#insert_variable"/>

--- a/app/code/Magento/Cms/etc/di.xml
+++ b/app/code/Magento/Cms/etc/di.xml
@@ -44,6 +44,8 @@
                     <item name="jpeg" xsi:type="string">image/jpeg</item>
                     <item name="png" xsi:type="string">image/png</item>
                     <item name="gif" xsi:type="string">image/gif</item>
+                    <item name="ico" xsi:type="string">image/x-icon</item>
+                    <item name="apng" xsi:type="string">image/png</item>
                 </item>
                 <item name="media_allowed" xsi:type="array">
                     <item name="flv" xsi:type="string">video/x-flv</item>

--- a/app/code/Magento/Theme/Test/Mftf/Data/DesignData.xml
+++ b/app/code/Magento/Theme/Test/Mftf/Data/DesignData.xml
@@ -17,4 +17,9 @@
     <entity name="MagentoLumaTheme" type="theme">
         <data key="name">Magento Luma</data>
     </entity>
+    <entity name="ImageIcon1" type="uploadImage">
+        <data key="value">ico.ico</data>
+        <data key="fileName">ico</data>
+        <data key="extension">ico</data>
+    </entity>
 </entities>

--- a/app/code/Magento/Theme/Test/Mftf/Test/AdminDesignConfigMediaGalleryFaviconICOUploadTest.xml
+++ b/app/code/Magento/Theme/Test/Mftf/Test/AdminDesignConfigMediaGalleryFaviconICOUploadTest.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminDesignConfigMediaGalleryFaviconICOUploadTest">
+
+        <annotations>
+            <features value="Theme"/>
+            <stories value="Themes"/>
+            <title value="Check that Admin is able to upload an ICO file to the Storage Root using the Media Gallery for the favicon design config element."/>
+            <description value="Use Media Gallery launched from favicon file uploader to upload .ico image file. Verify that warning message about unsupported image type is not displayed."/>
+            <severity value="MAJOR"/>
+            <group value="Theme"/>
+            <testCaseId value="magento/magento2#23881"/>
+        </annotations>
+
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginToAdminArea"/>
+        </before>
+
+        <after>
+            <actionGroup ref="logout" stepKey="logoutOfAdmin"/>
+        </after>
+
+        <!--Go to design config section for favicon-->
+        <comment userInput="Edit Store View" stepKey="editStoreViewComment"/>
+        <amOnPage url="{{DesignConfigPage.url}}" stepKey="navigateToDesignConfigPage" />
+        <waitForPageLoad stepKey="waitForPageload1"/>
+        <click selector="{{AdminDesignConfigSection.scopeRow('1')}}" stepKey="editStoreView"/>
+        <waitForPageLoad stepKey="waitForPageload2"/>
+        <scrollTo selector="{{AdminDesignConfigSection.htmlHeaderSection}}" stepKey="scrollToHtmlHeadSection"/>
+        <click selector="{{AdminDesignConfigSection.htmlHeaderSection}}" stepKey="openHtmlHeadSection"/>
+
+        <!--Open Media Gallery-->
+        <click selector="{{AdminDesignConfigSection.selectFromGalleryByFieldsetName('Head')}}" stepKey="openMediaGallery"/>
+        <actionGroup ref="VerifyMediaGalleryStorageActionsActionGroup" stepKey="verifyMediaGalleryStorageBtn"/>
+        <!--Upload Image-->
+        <actionGroup ref="AttachImageActionGroup" stepKey="attachImage">
+            <argument name="Image" value="ImageIcon1"/>
+        </actionGroup>
+        <!--We shouldn't see a warning about unsupported image format-->
+        <dontSee selector="{{MediaGallerySection.messages}}" userInput="Unsupported image format." stepKey="dontSeeIcoWarning"/>
+        <!--Unselect Image-->
+        <click selector="{{MediaGallerySection.lastImageOrImageCopy(ImageIcon1.fileName, ImageIcon1.extension)}}" stepKey="unselectImage"/>
+        <!--Delete it-->
+        <actionGroup ref="DeleteImageFromStorageActionGroup" stepKey="deleteImageFromStorage">
+            <argument name="Image" value="ImageIcon1"/>
+        </actionGroup>
+        <!--Close Media Gallery-->
+        <click selector="{{MediaGallerySection.CancelBtn}}" stepKey="closeModalIco"/>
+
+    </test>
+</tests>

--- a/app/code/Magento/Ui/view/base/web/js/form/element/image-uploader.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/image-uploader.js
@@ -81,6 +81,9 @@ define([
                 openDialogUrl += '&current_tree_path=' + Base64.mageEncode(this.mediaGallery.initialOpenSubpath);
             }
 
+            if (this.allowedExtensions) {
+                openDialogUrl += '&allowed_extensions=' + Base64.mageEncode(this.allowedExtensions);
+            }
             browser.openDialog(openDialogUrl, null, null, this.mediaGallery.openDialogTitle);
         },
 

--- a/app/design/adminhtml/Magento/backend/web/css/source/components/_messages.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/components/_messages.less
@@ -42,7 +42,8 @@
 //  Messages
 //  ---------------------------------------------
 
-.messages {
+.messages,
+.media-gallery-modal {
     .message {
         .lib-wrap-words();
         &:last-child {


### PR DESCRIPTION
### Description (*)
Extended allowable extensions for image type to include ico and apng (These are listed for the Favicon)

Magento Ui image uploader component now passes the list of allowable file types to the Media Gallery component. This will (optionally) override the default list of allowable file types obtained from di.xml. Previously the Media Gallery would just use the default set of allowable types as set in di.xml, even if the Image Uploader component was configured for a different set.

Implemented fallback thumbnail placeholder generation for Media Gallery when filetype is not supported by current Image Adapter. As no ico thumbnails can be generated by GD2, it shows the placeholder image instead when GD2 Image Adapter is selected.

Added a check to the uploader to skip resizing uploaded image for thumbnail generation if the image file extension is ico and the Image Adapter is GD2. 

Corrected error message style.

Added MFTF test.

### Related Pull Requests
Replaces the following PR
1. Closes #25007: ICO file not supported in media file uploader fixed, issue #23881

### Fixed Issues (if relevant)
1. Closes #23881: "Select from Gallery" option on media file uploader does not use correct allowable file types

### Manual testing scenarios (*)
As per original issue

### Questions or comments
Although ico is added to the list of allowable file types, and you are able to upload them, they are NOT supported by the GD2 Image Adapter which is the default. Therefore additional logic was required to skip thumbnail generation for the uploaded image, which although was handled gracefully on upload, caused an error message to be shown on the Media Gallery screen when ico files were uploaded. The error message is no longer shown.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
