### PR TITLE
Fix label not translating in www.example.com/catalog/product_compare/index

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
@@ -109,7 +109,7 @@
                                 <?php if ($index++ == 0) :?>
                                     <th scope="row" class="cell label">
                                         <span class="attribute label">
-                                            <?= $block->escapeHtml($attribute->getStoreLabel() ? $attribute->getStoreLabel() : __($attribute->getFrontendLabel())) ?>
+                                            <?= $block->escapeHtml($attribute->getStoreLabel() ? __($attribute->getStoreLabel()) : __($attribute->getFrontendLabel())) ?>
                                         </span>
                                     </th>
                                 <?php endif; ?>


### PR DESCRIPTION
### Description (*)
This pull request fixes a bug in **www.example.com/catalog/product_compare/index** (Compare products). The labels on the left side are not getting translated.
fixes #27006

### Fixed Issues (if relevant)
1. magento/magento2#27006:Label translation missing in product compare list

### Manual testing scenarios (*)
Check if the labels are getting translated properly on **www.example.com/catalog/product_compare/index**



### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
