### PR TITLE
Issue 27009: Fix error fire on catch when create new theme

### DIFF
--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -414,6 +414,7 @@ class Renderer implements RendererInterface
         $attributes = $this->getGroupAttributes($group);
 
         $result = '';
+        $template= '';
         try {
             /** @var $asset \Magento\Framework\View\Asset\AssetInterface */
             foreach ($assets as $asset) {

--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -414,7 +414,7 @@ class Renderer implements RendererInterface
         $attributes = $this->getGroupAttributes($group);
 
         $result = '';
-        $template= '';
+        $template = '';
         try {
             /** @var $asset \Magento\Framework\View\Asset\AssetInterface */
             foreach ($assets as $asset) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

Missing variable outside CATCH causing a double-fault in Renderer.php
Issue: https://github.com/magento/magento2/issues/27009
### Description (*)
Declare a variable to avoid firing on an exception

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#27009: Missing variable outside CATCH causing a double-fault in Renderer.php

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a new Theme, with web/css folder empty inside.

2. Create your default.xml and catalog_product_view.xml
3. Access to pages and see if there are any exceptions

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
