### PR TITLE
Correct wrong use of html size attributes on img in image_with_borders

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
@@ -13,7 +13,7 @@
         <img class="<?= $block->escapeHtmlAttr($block->getClass()) ?>"
             <?= $block->escapeHtmlAttr($block->getCustomAttributes()) ?>
             src="<?= $block->escapeUrl($block->getImageUrl()) ?>"
-            max-width="<?= $block->escapeHtmlAttr($block->getWidth()) ?>"
-            max-height="<?= $block->escapeHtmlAttr($block->getHeight()) ?>"
+            width="<?= $block->escapeHtmlAttr($block->getWidth()) ?>"
+            height="<?= $block->escapeHtmlAttr($block->getHeight()) ?>"
             alt="<?= /* @noEscape */ $block->stripTags($block->getLabel(), null, true) ?>"/></span>
 </span>


### PR DESCRIPTION
### Description (*)

Since commit https://github.com/magento/magento2/commit/da7a64f2585ac534762235821db727f7af59f808#diff-eed94ca7983b385a07b8fb5ee2dbc20d the html attributes on the `image_with_borders.phtml` have changed from width to max-width and height to max-heigth.
This is off course not valid html.

### Manual testing scenarios (*)

No testing required.
It is a html bug.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
