### PR TITLE
Catalog image lazy load

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/image.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image.phtml
@@ -4,11 +4,14 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Catalog\Block\Product\Image */ ?>
+<?php
+/** @var $block \Magento\Catalog\Block\Product\Image */
+/** @var $escaper \Magento\Framework\Escaper */
+?>
 
-<img class="photo image <?= $block->escapeHtmlAttr($block->getClass()) ?>"
-    <?= $block->escapeHtml($block->getCustomAttributes()) ?>
-    src="<?= $block->escapeUrl($block->getImageUrl()) ?>"
-    width="<?= $block->escapeHtmlAttr($block->getWidth()) ?>"
-    height="<?= $block->escapeHtmlAttr($block->getHeight()) ?>"
-    alt="<?= /* @noEscape */ $block->stripTags($block->getLabel(), null, true) ?>" />
+<img class="photo image <?= $escaper->escapeHtmlAttr($block->getClass()) ?>"
+     <?= $escaper->escapeHtml($block->getCustomAttributes()) ?>
+     src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
+     width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"
+     height="<?= $escaper->escapeHtmlAttr($block->getHeight()) ?>"
+     alt="<?= /* @noEscape */ $block->stripTags($block->getLabel(), null, true) ?>" />

--- a/app/code/Magento/Catalog/view/frontend/templates/product/image.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image.phtml
@@ -10,9 +10,9 @@
 ?>
 
 <img class="photo image <?= $escaper->escapeHtmlAttr($block->getClass()) ?>"
-     <?= $escaper->escapeHtml($block->getCustomAttributes()) ?>
-     src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
-     loading="lazy"
-     width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"
-     height="<?= $escaper->escapeHtmlAttr($block->getHeight()) ?>"
-     alt="<?= /* @noEscape */ $block->stripTags($block->getLabel(), null, true) ?>" />
+    <?= $escaper->escapeHtml($block->getCustomAttributes()) ?>
+    src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
+    loading="lazy"
+    width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"
+    height="<?= $escaper->escapeHtmlAttr($block->getHeight()) ?>"
+    alt="<?= $escaper->escapeHtmlAttr($block->getLabel()) ?>" />

--- a/app/code/Magento/Catalog/view/frontend/templates/product/image.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image.phtml
@@ -12,6 +12,7 @@
 <img class="photo image <?= $escaper->escapeHtmlAttr($block->getClass()) ?>"
      <?= $escaper->escapeHtml($block->getCustomAttributes()) ?>
      src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
+     loading="lazy"
      width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"
      height="<?= $escaper->escapeHtmlAttr($block->getHeight()) ?>"
      alt="<?= /* @noEscape */ $block->stripTags($block->getLabel(), null, true) ?>" />

--- a/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
@@ -17,7 +17,7 @@
              <?= $escaper->escapeHtmlAttr($block->getCustomAttributes()) ?>
              src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
              loading="lazy"
-             max-width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"
-             max-height="<?= $escaper->escapeHtmlAttr($block->getHeight()) ?>"
+             width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"
+             height="<?= $escaper->escapeHtmlAttr($block->getHeight()) ?>"
              alt="<?= /* @noEscape */ $block->stripTags($block->getLabel(), null, true) ?>"/></span>
 </span>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
@@ -4,16 +4,19 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Catalog\Block\Product\Image */ ?>
+<?php
+/** @var $block \Magento\Catalog\Block\Product\Image */
+/** @var $escaper \Magento\Framework\Escaper */
+?>
 
 <span class="product-image-container"
-      style="width:<?= $block->escapeHtmlAttr($block->getWidth()) ?>px;">
+      style="width:<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>px;">
     <span class="product-image-wrapper"
           style="padding-bottom: <?= ($block->getRatio() * 100) ?>%;">
-        <img class="<?= $block->escapeHtmlAttr($block->getClass()) ?>"
-            <?= $block->escapeHtmlAttr($block->getCustomAttributes()) ?>
-            src="<?= $block->escapeUrl($block->getImageUrl()) ?>"
-            max-width="<?= $block->escapeHtmlAttr($block->getWidth()) ?>"
-            max-height="<?= $block->escapeHtmlAttr($block->getHeight()) ?>"
-            alt="<?= /* @noEscape */ $block->stripTags($block->getLabel(), null, true) ?>"/></span>
+        <img class="<?= $escaper->escapeHtmlAttr($block->getClass()) ?>"
+             <?= $escaper->escapeHtmlAttr($block->getCustomAttributes()) ?>
+             src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
+             max-width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"
+             max-height="<?= $escaper->escapeHtmlAttr($block->getHeight()) ?>"
+             alt="<?= /* @noEscape */ $block->stripTags($block->getLabel(), null, true) ?>"/></span>
 </span>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
@@ -14,10 +14,10 @@
     <span class="product-image-wrapper"
           style="padding-bottom: <?= ($block->getRatio() * 100) ?>%;">
         <img class="<?= $escaper->escapeHtmlAttr($block->getClass()) ?>"
-             <?= $escaper->escapeHtmlAttr($block->getCustomAttributes()) ?>
-             src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
-             loading="lazy"
-             width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"
-             height="<?= $escaper->escapeHtmlAttr($block->getHeight()) ?>"
-             alt="<?= /* @noEscape */ $block->stripTags($block->getLabel(), null, true) ?>"/></span>
+            <?= $escaper->escapeHtmlAttr($block->getCustomAttributes()) ?>
+            src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
+            loading="lazy"
+            width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"
+            height="<?= $escaper->escapeHtmlAttr($block->getHeight()) ?>"
+            alt="<?= $escaper->escapeHtmlAttr($block->getLabel()) ?>"/></span>
 </span>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
@@ -16,6 +16,7 @@
         <img class="<?= $escaper->escapeHtmlAttr($block->getClass()) ?>"
              <?= $escaper->escapeHtmlAttr($block->getCustomAttributes()) ?>
              src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
+             loading="lazy"
              max-width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"
              max-height="<?= $escaper->escapeHtmlAttr($block->getHeight()) ?>"
              alt="<?= /* @noEscape */ $block->stripTags($block->getLabel(), null, true) ?>"/></span>


### PR DESCRIPTION
### Description (*)
This changeset adds lazy loading to the catalog product list.

### Fixed Issues (if relevant)
1. magento/magento2#27032: Add image lazy loading

### Manual testing scenarios (*)
1. Have a product list with more than 16 products, all having unique products.
2. Check inspector if images are loaded through scrolling.

### Related pull requests
- #27034: FIX: wrong img size attributes (this PR includes those changes)

### Questions or comments
I think discussions on the topic 'image lazy loading' should be held on #27032. 

Any code reviewing comments can be placed in this PR.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
