### PR TITLE
Unit test for Magento\Config\Observer\Config\Backend\Admin\AfterCusto…

### DIFF
--- a/app/code/Magento/Config/Observer/Config/Backend/Admin/AfterCustomUrlChangedObserver.php
+++ b/app/code/Magento/Config/Observer/Config/Backend/Admin/AfterCustomUrlChangedObserver.php
@@ -7,7 +7,12 @@ declare(strict_types=1);
 
 namespace Magento\Config\Observer\Config\Backend\Admin;
 
+use Magento\Backend\Helper\Data;
+use Magento\Backend\Model\Auth\Session;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Registry;
 
 /**
  * Class AfterCustomUrlChangedObserver redirects to new custom admin URL.
@@ -19,38 +24,38 @@ class AfterCustomUrlChangedObserver implements ObserverInterface
     /**
      * Backend data
      *
-     * @var \Magento\Backend\Helper\Data
+     * @var Data
      */
     protected $_backendData;
 
     /**
      * Core registry
      *
-     * @var \Magento\Framework\Registry
+     * @var Registry
      */
     protected $_coreRegistry;
 
     /**
-     * @var \Magento\Backend\Model\Auth\Session
+     * @var Session
      */
     protected $_authSession;
 
     /**
-     * @var \Magento\Framework\App\ResponseInterface
+     * @var ResponseInterface
      */
     protected $_response;
 
     /**
-     * @param \Magento\Backend\Helper\Data $backendData
-     * @param \Magento\Framework\Registry $coreRegistry
-     * @param \Magento\Backend\Model\Auth\Session $authSession
-     * @param \Magento\Framework\App\ResponseInterface $response
+     * @param Data $backendData
+     * @param Registry $coreRegistry
+     * @param Session $authSession
+     * @param ResponseInterface $response
      */
     public function __construct(
-        \Magento\Backend\Helper\Data $backendData,
-        \Magento\Framework\Registry $coreRegistry,
-        \Magento\Backend\Model\Auth\Session $authSession,
-        \Magento\Framework\App\ResponseInterface $response
+        Data $backendData,
+        Registry $coreRegistry,
+        Session $authSession,
+        ResponseInterface $response
     ) {
         $this->_backendData = $backendData;
         $this->_coreRegistry = $coreRegistry;
@@ -61,11 +66,11 @@ class AfterCustomUrlChangedObserver implements ObserverInterface
     /**
      * Log out user and redirect to new admin custom url
      *
-     * @param \Magento\Framework\Event\Observer $observer
-     * @return void
+     * @param Observer $observer
+     * @return $this|void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function execute(\Magento\Framework\Event\Observer $observer)
+    public function execute(Observer $observer)
     {
         if ($this->_coreRegistry->registry('custom_admin_path_redirect') === null) {
             return;
@@ -74,7 +79,7 @@ class AfterCustomUrlChangedObserver implements ObserverInterface
         $this->_authSession->destroy();
         $adminUrl = $this->_backendData->getHomePageUrl();
         $this->_response->setRedirect($adminUrl)->sendResponse();
-        // phpcs:ignore Magento2.Security.LanguageConstruct.ExitUsage
-        exit(0);
+
+        return $this;
     }
 }

--- a/app/code/Magento/Config/Test/Unit/Observer/Config/Backend/Admin/AfterCustomUrlChangedObserverTest.php
+++ b/app/code/Magento/Config/Test/Unit/Observer/Config/Backend/Admin/AfterCustomUrlChangedObserverTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Config\Test\Unit\Observer\Config\Backend\Admin;
+
+use Magento\Backend\Helper\Data;
+use Magento\Backend\Model\Auth\Session;
+use Magento\Config\Observer\Config\Backend\Admin\AfterCustomUrlChangedObserver;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Registry;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit test for Magento\Config\Observer\Config\Backend\Admin\AfterCustomUrlChangedObserver
+ */
+class AfterCustomUrlChangedObserverTest extends TestCase
+{
+    /*
+     * Stub backend start page URL
+     */
+    private const STUB_ADMIN_URL = 'https://localhost/admin/';
+
+    /**
+     * Testable Object
+     *
+     * @var AfterCustomUrlChangedObserver
+     */
+    private $observer;
+
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var Observer|MockObject
+     */
+    private $observerMock;
+
+    /**
+     * @var Data|MockObject
+     */
+    private $backendDataMock;
+
+    /**
+     * @var Registry|MockObject
+     */
+    private $coreRegistryMock;
+
+    /**
+     * @var Session|MockObject
+     */
+    private $authSessionMock;
+
+    /**
+     * @var ResponseInterface|MockObject
+     */
+    private $responseMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->objectManager = new ObjectManager($this);
+        $this->observerMock = $this->createMock(Observer::class);
+
+        $this->coreRegistryMock = $this->getMockBuilder(Registry::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['registry'])
+            ->getMock();
+
+        $this->authSessionMock = $this->getMockBuilder(Session::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['destroy'])
+            ->getMock();
+
+        $this->backendDataMock = $this->getMockBuilder(Data::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getHomePageUrl'])
+            ->getMock();
+
+        $this->responseMock = $this->getMockBuilder(ResponseInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setRedirect', 'sendResponse'])
+            ->getMockForAbstractClass();
+
+        $this->observer = $this->objectManager->getObject(
+            AfterCustomUrlChangedObserver::class,
+            [
+                'backendData' => $this->backendDataMock,
+                'coreRegistry' => $this->coreRegistryMock,
+                'authSession' => $this->authSessionMock,
+                'response' => $this->responseMock,
+            ]
+        );
+    }
+
+    /**
+     * Test for execute(), covers test case to log out user and redirect to new admin custom url
+     */
+    public function testExecuteLogOutUserWithRedirect(): void
+    {
+        $this->coreRegistryMock
+            ->expects($this->once())
+            ->method('registry')
+            ->with('custom_admin_path_redirect')
+            ->willReturn(true);
+
+        $this->authSessionMock
+            ->expects($this->once())
+            ->method('destroy');
+
+        $this->backendDataMock
+            ->expects($this->once())
+            ->method('getHomePageUrl')
+            ->willReturn(self::STUB_ADMIN_URL);
+
+        $this->responseMock
+            ->expects($this->once())
+            ->method('setRedirect')
+            ->with(self::STUB_ADMIN_URL)
+            ->willReturnSelf();
+
+        $this->responseMock
+            ->expects($this->once())
+            ->method('sendResponse');
+
+        $this->observer->execute($this->observerMock);
+    }
+
+    /**
+     * Test for execute(), covers test case to log out user and no redirect
+     */
+    public function testExecuteLogOutUserWithNoRedirect(): void
+    {
+        $this->coreRegistryMock
+            ->expects($this->once())
+            ->method('registry')
+            ->with('custom_admin_path_redirect')
+            ->willReturn(null);
+
+        $this->authSessionMock
+            ->expects($this->never())
+            ->method('destroy');
+
+        $this->backendDataMock
+            ->expects($this->never())
+            ->method('getHomePageUrl');
+
+        $this->responseMock
+            ->expects($this->never())
+            ->method('setRedirect');
+
+        $this->responseMock
+            ->expects($this->never())
+            ->method('sendResponse');
+
+        $this->observer->execute($this->observerMock);
+    }
+}


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR adds unit test that covers Magento\Config\Observer\Config\Backend\Admin\AfterCustomUrlChangedObserver.

Also in the Magento\Config\Server\Config\Backend\Admin\AfterCustomUrlChanged class, `exit(0)` was replaced with `return $this`.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
