### PR TITLE
#27044 Integration Test to cover `$storeId` on Category Repository `get()`

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryRepositoryTest.php
@@ -9,10 +9,10 @@ namespace Magento\Catalog\Model;
 
 use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Catalog\Api\CategoryRepositoryInterfaceFactory;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\TestFramework\Catalog\Model\CategoryLayoutUpdateManager;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\TestFramework\Catalog\Model\CategoryLayoutUpdateManager;
 use Magento\TestFramework\Helper\Bootstrap;
 use PHPUnit\Framework\TestCase;
 
@@ -21,6 +21,11 @@ use PHPUnit\Framework\TestCase;
  */
 class CategoryRepositoryTest extends TestCase
 {
+    private const FIXTURE_CATEGORY_ID = 333;
+    private const FIXTURE_TWO_STORES_CATEGORY_ID = 555;
+    private const FIXTURE_SECOND_STORE_CODE = 'fixturestore';
+    private const FIXTURE_FIRST_STORE_CODE = 'default';
+
     /**
      * @var CategoryLayoutUpdateManager
      */
@@ -77,13 +82,13 @@ class CategoryRepositoryTest extends TestCase
     {
         //New valid value
         $repo = $this->createRepo();
-        $category = $repo->get(333);
+        $category = $repo->get(self::FIXTURE_CATEGORY_ID);
         $newFile = 'test';
-        $this->layoutManager->setCategoryFakeFiles(333, [$newFile]);
+        $this->layoutManager->setCategoryFakeFiles(self::FIXTURE_CATEGORY_ID, [$newFile]);
         $category->setCustomAttribute('custom_layout_update_file', $newFile);
         $repo->save($category);
         $repo = $this->createRepo();
-        $category = $repo->get(333);
+        $category = $repo->get(self::FIXTURE_CATEGORY_ID);
         $this->assertEquals($newFile, $category->getCustomAttribute('custom_layout_update_file')->getValue());
 
         //Setting non-existent value
@@ -125,5 +130,31 @@ class CategoryRepositoryTest extends TestCase
             $difference,
             'Wrong categories was deleted'
         );
+    }
+
+    /**
+     * Verifies whether `get()` method `$storeId` attribute works as expected.
+     *
+     * @magentoDbIsolation enabled
+     * @magentoDataFixture Magento/Store/_files/core_fixturestore.php
+     * @magentoDataFixture Magento/Catalog/_files/category_with_two_stores.php
+     */
+    public function testGetCategoryForProvidedStore()
+    {
+        $categoryRepository = $this->repositoryFactory->create();
+
+        $categoryFirstStore = $categoryRepository->get(
+            self::FIXTURE_TWO_STORES_CATEGORY_ID,
+            self::FIXTURE_FIRST_STORE_CODE
+        );
+
+        $this->assertSame('category-defaultstore', $categoryFirstStore->getUrlKey());
+
+        $categorySecondStore = $categoryRepository->get(
+            self::FIXTURE_TWO_STORES_CATEGORY_ID,
+            self::FIXTURE_SECOND_STORE_CODE
+        );
+
+        $this->assertSame('category-fixturestore', $categorySecondStore->getUrlKey());
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryRepositoryTest.php
@@ -143,6 +143,12 @@ class CategoryRepositoryTest extends TestCase
     {
         $categoryRepository = $this->repositoryFactory->create();
 
+        $categoryDefault = $categoryRepository->get(
+            self::FIXTURE_TWO_STORES_CATEGORY_ID
+        );
+
+        $this->assertSame('category-defaultstore', $categoryDefault->getUrlKey());
+
         $categoryFirstStore = $categoryRepository->get(
             self::FIXTURE_TWO_STORES_CATEGORY_ID,
             self::FIXTURE_FIRST_STORE_CODE


### PR DESCRIPTION
### Description (*)
During other bug fixing process I've noticed that there is some unexpected behaviour of `get()` method that ignores the `$storeId` and returns unexpected data.

Unfortunately - isolating the issue - this seems to work.
As it seems to be useful - I don't remove the Integration Test I've used.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. magento/magento2##27044

### Manual testing scenarios (*)
N/A

### Questions or comments
I still have that problem with `$storeId` on un-isolated Integration Test.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
