### PR TITLE
fix for the issue #26135

### DIFF
--- a/app/design/frontend/Magento/blank/web/css/source/_layout.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_layout.less
@@ -62,7 +62,7 @@
     .page-header {
         background-color: @page__background-color;
         .lib-sticky-nav();
-	}
+    }
     
     .page-main {
         .account &,

--- a/app/design/frontend/Magento/blank/web/css/source/_layout.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_layout.less
@@ -59,6 +59,11 @@
         padding-right: @layout__width-xs-indent;
     }
 
+    .page-header {
+	    background-color: @page__background-color;
+	    .lib-sticky-nav();
+	}
+	
     .page-main {
         .account &,
         .cms-privacy-policy & {

--- a/app/design/frontend/Magento/blank/web/css/source/_layout.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_layout.less
@@ -58,12 +58,12 @@
         padding-left: @layout__width-xs-indent;
         padding-right: @layout__width-xs-indent;
     }
-
+    
     .page-header {
-	    background-color: @page__background-color;
-	    .lib-sticky-nav();
+        background-color: @page__background-color;
+        .lib-sticky-nav();
 	}
-	
+    
     .page-main {
         .account &,
         .cms-privacy-policy & {

--- a/app/design/frontend/Magento/blank/web/css/source/_navigation.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_navigation.less
@@ -284,7 +284,7 @@
     }
 
     .nav-sections {
-	    .lib-sticky-nav();
+        .lib-sticky-nav();
         .lib-vendor-prefix-flex-shrink(0);
         .lib-vendor-prefix-flex-basis(auto);
         margin-bottom: @indent__m;

--- a/app/design/frontend/Magento/blank/web/css/source/_navigation.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_navigation.less
@@ -284,6 +284,7 @@
     }
 
     .nav-sections {
+	    .lib-sticky-nav();
         .lib-vendor-prefix-flex-shrink(0);
         .lib-vendor-prefix-flex-basis(auto);
         margin-bottom: @indent__m;

--- a/lib/web/css/source/lib/_utilities.less
+++ b/lib/web/css/source/lib/_utilities.less
@@ -22,6 +22,12 @@
     @fontValue: @_value;
 }
 
+.lib-sticky-nav() {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
 .lib-visibility-hidden() {
     height: 0;
     visibility: hidden;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#26135 : Sticky header for navigation in mobile, desktop 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to any page in magento instance
2. Scroll the page to the footer
3. you can observe that the header is not sticky for both mobile and desktop.
4. With this fix the user is abled to access the header links directly from the footer section.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
