### PR TITLE
magento/magento2#26112: mutation createEmptyCart doesn't throw exception when authorization header is set and token has expired

### DIFF
--- a/app/code/Magento/CustomerGraphQl/Model/Context/AddUserInfoToContext.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Context/AddUserInfoToContext.php
@@ -60,6 +60,7 @@ class AddUserInfoToContext implements ContextParametersProcessorInterface
      */
     private function isCustomer(?int $customerId, ?int $customerType): bool
     {
-        return !empty($customerId) && !empty($customerType) && $customerType !== UserContextInterface::USER_TYPE_GUEST;
+        return $customerId !== null && $customerType !== null
+            && $customerType !== UserContextInterface::USER_TYPE_GUEST;
     }
 }

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/CustomerCart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/CustomerCart.php
@@ -3,21 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 declare(strict_types=1);
 
 namespace Magento\QuoteGraphQl\Model\Resolver;
 
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
-use Magento\QuoteGraphQl\Model\Cart\CreateEmptyCartForCustomer;
 use Magento\GraphQl\Model\Query\ContextInterface;
-use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
 use Magento\Quote\Api\CartManagementInterface;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
+use Magento\Authorization\Model\UserContextInterface;
 use Magento\Quote\Model\ResourceModel\Quote\QuoteIdMask as QuoteIdMaskResourceModel;
+use Magento\QuoteGraphQl\Model\Cart\CreateEmptyCartForCustomer;
 
 /**
  * Get cart for the customer
@@ -43,6 +45,7 @@ class CustomerCart implements ResolverInterface
      * @var QuoteIdMaskResourceModel
      */
     private $quoteIdMaskResourceModel;
+
     /**
      * @var QuoteIdToMaskedQuoteIdInterface
      */
@@ -66,7 +69,7 @@ class CustomerCart implements ResolverInterface
         $this->cartManagement = $cartManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->quoteIdMaskResourceModel = $quoteIdMaskResourceModel;
-         $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId;
+        $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId;
     }
 
     /**
@@ -74,9 +77,13 @@ class CustomerCart implements ResolverInterface
      */
     public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
     {
+        /** @var ContextInterface $context */
         $currentUserId = $context->getUserId();
 
-        /** @var ContextInterface $context */
+        if ($currentUserId === 0 && (int) $context->getUserType() === UserContextInterface::USER_TYPE_CUSTOMER) {
+            throw new GraphQlAuthorizationException(__('The authorization token is expired.'));
+        }
+
         if (false === $context->getExtensionAttributes()->getIsCustomer()) {
             throw new GraphQlAuthorizationException(__('The request is allowed for logged in customer'));
         }

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/CustomerCart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/CustomerCart.php
@@ -17,7 +17,6 @@ use Magento\GraphQl\Model\Query\ContextInterface;
 use Magento\Quote\Api\CartManagementInterface;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
-use Magento\Authorization\Model\UserContextInterface;
 use Magento\Quote\Model\ResourceModel\Quote\QuoteIdMask as QuoteIdMaskResourceModel;
 use Magento\QuoteGraphQl\Model\Cart\CreateEmptyCartForCustomer;
 
@@ -79,12 +78,10 @@ class CustomerCart implements ResolverInterface
     {
         /** @var ContextInterface $context */
         $currentUserId = $context->getUserId();
+        /** @var bool $isCustomer */
+        $isCustomer = (bool) $context->getExtensionAttributes()->getIsCustomer();
 
-        if ($currentUserId === 0 && (int) $context->getUserType() === UserContextInterface::USER_TYPE_CUSTOMER) {
-            throw new GraphQlAuthorizationException(__('The authorization token is expired.'));
-        }
-
-        if (false === $context->getExtensionAttributes()->getIsCustomer()) {
+        if (!$isCustomer || $isCustomer && $currentUserId === 0) {
             throw new GraphQlAuthorizationException(__('The request is allowed for logged in customer'));
         }
         try {

--- a/app/code/Magento/Webapi/Model/Authorization/TokenUserContext.php
+++ b/app/code/Magento/Webapi/Model/Authorization/TokenUserContext.php
@@ -191,7 +191,7 @@ class TokenUserContext implements UserContextInterface
     private function validateToken(Token $token): void
     {
         if ($token->getRevoked() || $this->isTokenExpired($token)) {
-            //userId 0 will mean that the token revoked or expired
+            //userId 0 will mean that the token is not valid
             $this->userId = 0;
             $this->userType = $token->getUserType();
 

--- a/app/code/Magento/Webapi/Model/Authorization/TokenUserContext.php
+++ b/app/code/Magento/Webapi/Model/Authorization/TokenUserContext.php
@@ -124,9 +124,11 @@ class TokenUserContext implements UserContextInterface
      */
     private function isTokenExpired(Token $token): bool
     {
-        if ($token->getUserType() == UserContextInterface::USER_TYPE_ADMIN) {
+        $userType = (int) $token->getUserType();
+
+        if ($userType === UserContextInterface::USER_TYPE_ADMIN) {
             $tokenTtl = $this->oauthHelper->getAdminTokenLifetime();
-        } elseif ($token->getUserType() == UserContextInterface::USER_TYPE_CUSTOMER) {
+        } elseif ($userType === UserContextInterface::USER_TYPE_CUSTOMER) {
             $tokenTtl = $this->oauthHelper->getCustomerTokenLifetime();
         } else {
             // other user-type tokens are considered always valid
@@ -149,41 +151,53 @@ class TokenUserContext implements UserContextInterface
      *
      * @return void
      */
-    protected function processRequest()
+    protected function processRequest(): void
     {
         if ($this->isRequestProcessed) {
             return;
         }
+        $this->isRequestProcessed = true;
 
         $authorizationHeaderValue = $this->request->getHeader('Authorization');
         if (!$authorizationHeaderValue) {
-            $this->isRequestProcessed = true;
             return;
         }
 
-        $headerPieces = explode(" ", $authorizationHeaderValue);
+        $headerPieces = explode(' ', $authorizationHeaderValue);
         if (count($headerPieces) !== 2) {
-            $this->isRequestProcessed = true;
             return;
         }
 
         $tokenType = strtolower($headerPieces[0]);
         if ($tokenType !== 'bearer') {
-            $this->isRequestProcessed = true;
             return;
         }
 
         $bearerToken = $headerPieces[1];
+        /** @var Token $token */
         $token = $this->tokenFactory->create()->loadByToken($bearerToken);
 
-        if (!$token->getId() || $token->getRevoked() || $this->isTokenExpired($token)) {
-            $this->isRequestProcessed = true;
+        if ($token->getId()) {
+            $this->validateToken($token);
+        }
+    }
+
+    /**
+     * Validate token
+     *
+     * @param Token $token
+     * @return void
+     */
+    private function validateToken(Token $token): void
+    {
+        if ($token->getRevoked() || $this->isTokenExpired($token)) {
+            //userId 0 will mean that the token revoked or expired
+            $this->userId = 0;
+            $this->userType = $token->getUserType();
 
             return;
         }
-
         $this->setUserDataViaToken($token);
-        $this->isRequestProcessed = true;
     }
 
     /**

--- a/app/code/Magento/Webapi/Test/Unit/Model/Authorization/TokenUserContextTest.php
+++ b/app/code/Magento/Webapi/Test/Unit/Model/Authorization/TokenUserContextTest.php
@@ -217,7 +217,7 @@ class TokenUserContextTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue(1));
 
         $this->assertNull($this->tokenUserContext->getUserType());
-        $this->assertNull($this->tokenUserContext->getUserId());
+        $this->assertEquals(0, $this->tokenUserContext->getUserId());
     }
 
     /**
@@ -451,8 +451,8 @@ class TokenUserContextTest extends \PHPUnit\Framework\TestCase
                 ],
                 'tokenTtl' => 1,
                 'currentTime' => $time,
-                'expectedUserType' => null,
-                'expectedUserId' => null,
+                'expectedUserType' => UserContextInterface::USER_TYPE_ADMIN,
+                'expectedUserId' => 0,
             ],
             'token_vigent_admin' => [
                 'tokenData' => [
@@ -473,8 +473,8 @@ class TokenUserContextTest extends \PHPUnit\Framework\TestCase
                 ],
                 'tokenTtl' => 1,
                 'currentTime' => $time,
-                'expectedUserType' => null,
-                'expectedUserId' => null,
+                'expectedUserType' => UserContextInterface::USER_TYPE_CUSTOMER,
+                'expectedUserId' => 0,
             ],
             'token_vigent_customer' => [
                 'tokenData' => [

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetCustomerCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetCustomerCartTest.php
@@ -179,7 +179,7 @@ class GetCustomerCartTest extends GraphQlAbstract
         $headers = $this->getHeaderMap();
         $bearerToken = $headers['Authorization'];
         $this->makeTokenExpired($bearerToken);
-        $this->expectExceptionMessage('The authorization token is expired.');
+        $this->expectExceptionMessage('The request is allowed for logged in customer');
         $this->expectException(ResponseContainsErrorsException::class);
 
         $this->graphQlMutation($customerCartQuery, [], '', $headers);

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetCustomerCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/GetCustomerCartTest.php
@@ -10,9 +10,13 @@ namespace Magento\GraphQl\Quote\Customer;
 use Exception;
 use Magento\GraphQl\Quote\GetMaskedQuoteIdByReservedOrderId;
 use Magento\Integration\Api\CustomerTokenServiceInterface;
+use Magento\Integration\Model\Oauth\Token;
+use Magento\Integration\Model\Oauth\TokenFactory;
+use Magento\Framework\Stdlib\DateTime;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\Quote\Model\ResourceModel\Quote\Collection;
 use Magento\Framework\ObjectManagerInterface;
+use Magento\TestFramework\TestCase\GraphQl\ResponseContainsErrorsException;
 use Magento\TestFramework\TestCase\GraphQlAbstract;
 
 /**
@@ -35,11 +39,20 @@ class GetCustomerCartTest extends GraphQlAbstract
      */
     private $objectManager;
 
+    /**
+     * @var TokenFactory
+     */
+    private $tokenFactory;
+
+    /**
+     * @inheritdoc
+     */
     protected function setUp()
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->getMaskedQuoteIdByReservedOrderId = $this->objectManager->get(GetMaskedQuoteIdByReservedOrderId::class);
         $this->customerTokenService = $this->objectManager->get(CustomerTokenServiceInterface::class);
+        $this->tokenFactory = $this->objectManager->get(TokenFactory::class);
     }
 
     /**
@@ -151,6 +164,41 @@ class GetCustomerCartTest extends GraphQlAbstract
         $this->revokeCustomerToken();
         $customerCartQuery = $this->getCustomerCartQuery();
         $this->graphQlQuery($customerCartQuery, [], '', $headers);
+    }
+
+    /**
+     * Create cart for customer after token is expired
+     *
+     * @magentoConfigFixture oauth/access_token_lifetime/customer 1
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @return void
+     */
+    public function testCreateCustomerCartAfterTokenExpired(): void
+    {
+        $customerCartQuery = $this->getCustomerCartQuery();
+        $headers = $this->getHeaderMap();
+        $bearerToken = $headers['Authorization'];
+        $this->makeTokenExpired($bearerToken);
+        $this->expectExceptionMessage('The authorization token is expired.');
+        $this->expectException(ResponseContainsErrorsException::class);
+
+        $this->graphQlMutation($customerCartQuery, [], '', $headers);
+    }
+
+    /**
+     * Set yesterday date to token created at
+     *
+     * @param string $bearerToken
+     * @return void
+     */
+    private function makeTokenExpired(string $bearerToken): void
+    {
+        $token = explode(' ', $bearerToken)[1];
+        $createdYesterday =  gmdate(DateTime::DATETIME_PHP_FORMAT, strtotime('-1 day'));
+        /** @var Token $tokenModel */
+        $tokenModel = $this->tokenFactory->create()->loadByToken($token);
+        $tokenModel->setCreatedAt($createdYesterday);
+        $tokenModel->save();
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Mutation createEmptyCart throws an exception when the authorization header is set and the token has expired and covered by a test.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#26112: mutation createEmptyCart doesn't throw exception when authorization header is set and token has expired

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Please see https://github.com/magento/magento2/issues/26112

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
