### PR TITLE
Create helloWorld modules, add plugins, add tests

### DIFF
--- a/app/code/HelloWorld/HelloWorld/Model/HelloWorldManagement.php
+++ b/app/code/HelloWorld/HelloWorld/Model/HelloWorldManagement.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelloWorld\HelloWorld\Model;
+
+use HelloWorld\HelloWorldApi\Api\Data\HelloWorldManagementInterface;
+
+/**
+ * HelloWorldManagement Class for Rest Api result
+ */
+class HelloWorldManagement implements HelloWorldManagementInterface
+{
+    /**
+     * @var string
+     */
+    public $prefix = '';
+
+    /**
+     * @inheritDoc
+     */
+    public function getHelloWorld(): string
+    {
+        return 'Hello World';
+    }
+}

--- a/app/code/HelloWorld/HelloWorld/etc/di.xml
+++ b/app/code/HelloWorld/HelloWorld/etc/di.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="HelloWorld\HelloWorld\Model\HelloWorldManagement">
+        <plugin name="addPrefix" type="HelloWorld\HelloWorldPlugins\Plugin\HelloWorldPlugin"/>
+    </type>
+</config>

--- a/app/code/HelloWorld/HelloWorld/etc/module.xml
+++ b/app/code/HelloWorld/HelloWorld/etc/module.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="HelloWorld_HelloWorld" setup_version="1.0.0"/>
+</config>

--- a/app/code/HelloWorld/HelloWorld/registration.php
+++ b/app/code/HelloWorld/HelloWorld/registration.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'HelloWorld_HelloWorld',
+    __DIR__
+);

--- a/app/code/HelloWorld/HelloWorldApi/Api/Data/HelloWorldManagementInterface.php
+++ b/app/code/HelloWorld/HelloWorldApi/Api/Data/HelloWorldManagementInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelloWorld\HelloWorldApi\Api\Data;
+
+/**
+ * RestAPI Hello World interface.
+ */
+interface HelloWorldManagementInterface
+{
+    /**
+     * Get Hello world action.
+     *
+     * @return string
+     */
+    public function getHelloWorld() : string;
+}

--- a/app/code/HelloWorld/HelloWorldApi/etc/module.xml
+++ b/app/code/HelloWorld/HelloWorldApi/etc/module.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="HelloWorld_HelloWorldApi" setup_version="1.0.0"/>
+</config>

--- a/app/code/HelloWorld/HelloWorldApi/registration.php
+++ b/app/code/HelloWorld/HelloWorldApi/registration.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'HelloWorld_HelloWorldApi',
+    __DIR__
+);

--- a/app/code/HelloWorld/HelloWorldPlugins/Plugin/HelloWorldPlugin.php
+++ b/app/code/HelloWorld/HelloWorldPlugins/Plugin/HelloWorldPlugin.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelloWorld\HelloWorldPlugins\Plugin;
+
+use HelloWorld\HelloWorld\Model\HelloWorldManagement;
+
+/**
+ * Plugin to make rest api result as 'prefix<h1>Hello World</h1>suffix'
+ */
+class HelloWorldPlugin
+{
+    /**
+     * Add prefix to 'Hello World' string
+     *
+     * @param HelloWorldManagement $subject
+     */
+    public function beforeGetHelloWorld(HelloWorldManagement $subject)
+    {
+        $subject->prefix = "prefix";
+    }
+
+    /**
+     * Wraps 'Hello World' string with H1 tag.
+     *
+     * @param HelloWorldManagement $subject
+     * @param callable $proceed
+     * @return string
+     */
+    public function aroundGetHelloWorld(HelloWorldManagement $subject, callable $proceed) : string
+    {
+        $result = $proceed();
+        return $subject->prefix . '<h1>' . $result . '</h1>';
+    }
+
+    /**
+     * Add suffix to 'prefix<h1>Hello World</h1>' string.
+     *
+     * @param HelloWorldManagement $subject
+     * @param string $result
+     * @return string
+     */
+    public function afterGetHelloWorld(HelloWorldManagement $subject, string $result) : string
+    {
+        return $result . "suffix";
+    }
+}

--- a/app/code/HelloWorld/HelloWorldPlugins/Test/Api/HelloWorldManagementTest.php
+++ b/app/code/HelloWorld/HelloWorldPlugins/Test/Api/HelloWorldManagementTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelloWorld\HelloWorldPlugins\Test\Api;
+
+use Magento\Framework\Webapi\Rest\Request;
+use Magento\TestFramework\TestCase\WebapiAbstract;
+
+class HelloWorldManagementTest extends WebapiAbstract
+{
+    /**#@+
+     * Service constants
+     */
+    const RESOURCE_PATH = '/V1/helloworld';
+    private $_actualResult;
+    /**
+     * @var string
+     */
+    private $_desiredResult;
+
+    public function testGetList()
+    {
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => self::RESOURCE_PATH,
+                'httpMethod' => Request::HTTP_METHOD_GET,
+            ]
+        ];
+
+        $response = $this->_webApiCall($serviceInfo);
+        $this->_actualResult = $response;
+        $this->_desiredResult = "prefix<h1>Hello World</h1>suffix";
+        $this->assertEquals($this->_desiredResult, $this->_actualResult);
+    }
+}

--- a/app/code/HelloWorld/HelloWorldPlugins/Test/Integration/DisplayHelloWorldPlugins.php
+++ b/app/code/HelloWorld/HelloWorldPlugins/Test/Integration/DisplayHelloWorldPlugins.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelloWorld\HelloWorldPlugins\Test\Integration;
+
+use HelloWorld\HelloWorldApi\Api\Data\HelloWorldManagementInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+class DisplayHelloWorldPlugins extends TestCase
+{
+    private $getMessage;
+
+    protected function setUp()
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->getMessage = $objectManager->get(HelloWorldManagementInterface::class);
+    }
+
+    public function testExecute()
+    {
+        $response = $this->getMessage->getHelloWorld();
+        $actualResult = $response;
+        $desiredResult = "prefix<h1>Hello World</h1>suffix";
+        $this->assertEquals($desiredResult, $actualResult);
+    }
+}

--- a/app/code/HelloWorld/HelloWorldPlugins/Test/Mftf/ActionGroup/HelloWorldStorefrontActionGroup.xml
+++ b/app/code/HelloWorld/HelloWorldPlugins/Test/Mftf/ActionGroup/HelloWorldStorefrontActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="HelloWorldStorefrontActionGroup">
+        <annotations>
+            <description>Check message on hello world page.</description>
+        </annotations>
+        <arguments>
+            <argument name="prefix" defaultValue="prefix" type="string"/>
+            <argument name="helloworld" defaultValue="Hello World" type="string"/>
+            <argument name="suffix" defaultValue="suffix" type="string"/>
+        </arguments>
+        <amOnPage stepKey="signupPage" url="helloworld/"/>
+        <waitForElementVisible selector="{{HelloWorldStorefrontSection.message}}" stepKey="waitWhenMessageBeVisible"/>
+        <see selector="{{HelloWorldStorefrontSection.message}}" userInput="{{prefix}}" stepKey="seePrefix"/>
+        <see selector="{{HelloWorldStorefrontSection.helloWorldMessage}}" userInput="{{helloworld}}" stepKey="seeHelloWorld"/>
+        <see selector="{{HelloWorldStorefrontSection.message}}" userInput="{{suffix}}" stepKey="seeSuffix"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/HelloWorld/HelloWorldPlugins/Test/Mftf/Page/HelloWorldStorefrontPage.xml
+++ b/app/code/HelloWorld/HelloWorldPlugins/Test/Mftf/Page/HelloWorldStorefrontPage.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/PageObject.xsd">
+    <page name="HelloWorldStorefrontPage" url="/helloworld" module="Magento_Cms" area="storefront">
+        <section name="StorefrontCheckHelloMessageSection"/>
+    </page>
+</pages>

--- a/app/code/HelloWorld/HelloWorldPlugins/Test/Mftf/Section/HelloWorldStorefrontSection.xml
+++ b/app/code/HelloWorld/HelloWorldPlugins/Test/Mftf/Section/HelloWorldStorefrontSection.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="HelloWorldStorefrontSection">
+        <element name="message" type="text" selector="p.display-message-from-api"/>
+        <element name="helloWorldMessage" type="text" selector="p.display-message-from-api h1"/>
+    </section>
+</sections>

--- a/app/code/HelloWorld/HelloWorldPlugins/Test/Mftf/Test/HelloWorldStorefrontTest.xml
+++ b/app/code/HelloWorld/HelloWorldPlugins/Test/Mftf/Test/HelloWorldStorefrontTest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="HelloWorldStorefrontTest">
+        <annotations>
+            <features value="HelloWorld"/>
+            <stories value="Hello World message"/>
+            <title value="Check message Hello World on storefront"/>
+            <description value="Check message Hello World on storefront"/>
+            <severity value="MINOR"/>
+            <testCaseId value="63370"/>
+            <useCaseId value="63370"/>
+            <group value="HelloWorld"/>
+        </annotations>
+        <actionGroup ref="HelloWorldStorefrontActionGroup" stepKey="HelloWorldStorefront"/>
+    </test>
+</tests>

--- a/app/code/HelloWorld/HelloWorldPlugins/etc/module.xml
+++ b/app/code/HelloWorld/HelloWorldPlugins/etc/module.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="HelloWorld_HelloWorldPlugins" setup_version="1.0.0"/>
+</config>

--- a/app/code/HelloWorld/HelloWorldPlugins/registration.php
+++ b/app/code/HelloWorld/HelloWorldPlugins/registration.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'HelloWorld_HelloWorldPlugins',
+    __DIR__
+);

--- a/app/code/HelloWorld/HelloWorldStorefrontUi/Block/Display.php
+++ b/app/code/HelloWorld/HelloWorldStorefrontUi/Block/Display.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelloWorld\HelloWorldStorefrontUi\Block;
+
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Element\Template\Context;
+
+/**
+ * Display page to display result from RestApi.
+ */
+class Display extends Template
+{
+}

--- a/app/code/HelloWorld/HelloWorldStorefrontUi/Controller/Index/Index.php
+++ b/app/code/HelloWorld/HelloWorldStorefrontUi/Controller/Index/Index.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HelloWorld\HelloWorldStorefrontUi\Controller\Index;
+
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\Action\HttpGetActionInterface as HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+
+/**
+ * All posts list page.
+ */
+class Index extends Action implements HttpGetActionInterface
+{
+    /**
+     * @var PageFactory
+     */
+    private $pageFactory;
+
+    /**
+     * @param Context $context
+     * @param PageFactory $pageFactory
+     */
+    public function __construct(
+        Context $context,
+        PageFactory $pageFactory
+    ) {
+        $this->pageFactory = $pageFactory;
+        parent::__construct($context);
+    }
+
+    /**
+     * @return Page
+     */
+    public function execute()
+    {
+        return $this->pageFactory->create();
+    }
+}

--- a/app/code/HelloWorld/HelloWorldStorefrontUi/etc/di.xml
+++ b/app/code/HelloWorld/HelloWorldStorefrontUi/etc/di.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="HelloWorld\HelloWorldApi\Api\Data\HelloWorldManagementInterface" type="HelloWorld\HelloWorld\Model\HelloWorldManagement"/>
+</config>

--- a/app/code/HelloWorld/HelloWorldStorefrontUi/etc/frontend/routes.xml
+++ b/app/code/HelloWorld/HelloWorldStorefrontUi/etc/frontend/routes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="standard">
+        <route frontName="helloworld" id="helloworld">
+            <module name="HelloWorld_HelloWorldStorefrontUi"/>
+        </route>
+    </router>
+</config>

--- a/app/code/HelloWorld/HelloWorldStorefrontUi/etc/module.xml
+++ b/app/code/HelloWorld/HelloWorldStorefrontUi/etc/module.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="HelloWorld_HelloWorldStorefrontUi" setup_version="1.0.0"/>
+</config>

--- a/app/code/HelloWorld/HelloWorldStorefrontUi/etc/webapi.xml
+++ b/app/code/HelloWorld/HelloWorldStorefrontUi/etc/webapi.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+    <route method="GET" url="/V1/helloworld">
+        <service class="HelloWorld\HelloWorldApi\Api\Data\HelloWorldManagementInterface" method="getHelloWorld"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
+</routes>

--- a/app/code/HelloWorld/HelloWorldStorefrontUi/registration.php
+++ b/app/code/HelloWorld/HelloWorldStorefrontUi/registration.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'HelloWorld_HelloWorldStorefrontUi',
+    __DIR__
+);

--- a/app/code/HelloWorld/HelloWorldStorefrontUi/view/frontend/layout/helloworld_index_index.xml
+++ b/app/code/HelloWorld/HelloWorldStorefrontUi/view/frontend/layout/helloworld_index_index.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block class="HelloWorld\HelloWorldStorefrontUi\Block\Display" name="helloworldstorefrontui_index_index" template="HelloWorld_HelloWorldStorefrontUi::index.phtml"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/app/code/HelloWorld/HelloWorldStorefrontUi/view/frontend/templates/index.phtml
+++ b/app/code/HelloWorld/HelloWorldStorefrontUi/view/frontend/templates/index.phtml
@@ -1,0 +1,13 @@
+<?php
+use MyBlogModule\MyBlog\Block\PagedList;
+
+/** @var PagedList $block */
+?>
+    <p class="display-message-from-api"></p>
+    <script type="text/x-magento-init">
+    {
+        "*": {
+            "HelloWorld_HelloWorldStorefrontUi/js/getDataFromRestApi": {}
+        }
+    }
+    </script>

--- a/app/code/HelloWorld/HelloWorldStorefrontUi/view/frontend/web/js/getDataFromRestApi.js
+++ b/app/code/HelloWorld/HelloWorldStorefrontUi/view/frontend/web/js/getDataFromRestApi.js
@@ -1,0 +1,7 @@
+define(['jquery',], function($){
+    $(document).ready(function() {
+        $.get( "http://localhost/git/magento2/rest/V1/helloworld", function( data ) {
+            $( ".display-message-from-api" ).html( data );
+        });
+    });
+});

--- a/app/code/HelloWorld/HelloWorldStorefrontUi/view/frontend/web/requirejs-config.js
+++ b/app/code/HelloWorld/HelloWorldStorefrontUi/view/frontend/web/requirejs-config.js
@@ -1,0 +1,7 @@
+var config = {
+    map: {
+        '*': {
+            getDataFromRestApi: 'HelloWorld_HelloWorldStorefrontUi/js/getDataFromRestApi',
+        }
+    }
+};


### PR DESCRIPTION
1. Output "Hello World!" on storefront using service available via REST API.
Create module HelloWorldAPI with needed interfaces.
Create module HelloWorld with interface implementation.
Create module HelloWorldStorefrontUi with output logic.
Create REST API endpoint type "GET" to HelloWorld service.
2. Modify "Hello World!" with prefix, suffix and tags via plugins.
Create module with plugins.
Create before plugin, which will add prefix to HelloWorld service output
Create after plugin, which will add suffix to HelloWorld service output
Create around plugin, which will wrap HelloWorld service output with <h1> tags.
Cover all changes with integration, api-functional and MFTF tests.
