### PR TITLE
Missing "RESTRICT" value to declarative schema foreign constraint

### DIFF
--- a/app/code/Magento/Ui/view/base/web/templates/modal/modal-custom.html
+++ b/app/code/Magento/Ui/view/base/web/templates/modal/modal-custom.html
@@ -27,7 +27,7 @@
 
                 <% if(data.subTitle){ %>
                 <span class="modal-subtitle"
-                      data-role="subtitle">
+                      data-role="subTitle">
                     <%= data.subTitle %>
                 </span>
                 <% } %>

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/constraints/foreign.xsd
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/constraints/foreign.xsd
@@ -33,7 +33,6 @@
             <xs:enumeration value="CASCADE" />
             <xs:enumeration value="SET NULL" />
             <xs:enumeration value="NO ACTION" />
-            <xs:enumeration value="RESTRICT" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/constraints/foreign.xsd
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/constraints/foreign.xsd
@@ -33,6 +33,7 @@
             <xs:enumeration value="CASCADE" />
             <xs:enumeration value="SET NULL" />
             <xs:enumeration value="NO ACTION" />
+            <xs:enumeration value="RESTRICT" />
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
### Description (*)
Added missing "RESTRICT" value to declarative schema foreign constraint

### Fixed Issues (if relevant)
1. magento/magento2#27072: Missing "RESTRICT" value to declarative schema foreign constraint

### Manual testing scenarios (*)
1. Create a table with a customer_id column that references customer_entity.entity_id column, and you want that Customers cannot be deleted if there are associated records in your table.
2. In your db_schema.xml you cannot set a value "RESTRICT" in onDelete constraint attribute.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
