### PR TITLE
Cleanup ObjectManager usage - Magento_CacheInvalidate

### DIFF
--- a/app/code/Magento/CacheInvalidate/Observer/InvalidateVarnishObserver.php
+++ b/app/code/Magento/CacheInvalidate/Observer/InvalidateVarnishObserver.php
@@ -3,61 +3,76 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\CacheInvalidate\Observer;
 
+use Magento\CacheInvalidate\Model\PurgeCache;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\App\Cache\Tag\Resolver;
+use Magento\PageCache\Model\Config;
 
+/**
+ * Observer used to invalidate varnish cache once Magento cache was cleaned
+ */
 class InvalidateVarnishObserver implements ObserverInterface
 {
     /**
      * Application config object
      *
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     * @var ScopeConfigInterface
      */
-    protected $config;
+    private $config;
 
     /**
-     * @var \Magento\CacheInvalidate\Model\PurgeCache
+     * @var PurgeCache
      */
-    protected $purgeCache;
+    private $purgeCache;
 
     /**
      * Invalidation tags resolver
      *
-     * @var \Magento\Framework\App\Cache\Tag\Resolver
+     * @var Resolver
      */
     private $tagResolver;
 
     /**
-     * @param \Magento\PageCache\Model\Config $config
-     * @param \Magento\CacheInvalidate\Model\PurgeCache $purgeCache
+     * @param Config $config
+     * @param PurgeCache $purgeCache
+     * @param Resolver $tagResolver
      */
     public function __construct(
-        \Magento\PageCache\Model\Config $config,
-        \Magento\CacheInvalidate\Model\PurgeCache $purgeCache
+        Config $config,
+        PurgeCache $purgeCache,
+        Resolver $tagResolver
     ) {
         $this->config = $config;
         $this->purgeCache = $purgeCache;
+        $this->tagResolver = $tagResolver;
     }
 
     /**
-     * If Varnish caching is enabled it collects array of tags
-     * of incoming object and asks to clean cache.
+     * If Varnish caching is enabled it collects array of tags of incoming object and asks to clean cache.
      *
-     * @param \Magento\Framework\Event\Observer $observer
+     * @param Observer $observer
+     *
      * @return void
      */
-    public function execute(\Magento\Framework\Event\Observer $observer)
+    public function execute(Observer $observer)
     {
         $object = $observer->getEvent()->getObject();
+
         if (!is_object($object)) {
             return;
         }
-        if ($this->config->getType() == \Magento\PageCache\Model\Config::VARNISH && $this->config->isEnabled()) {
-            $bareTags = $this->getTagResolver()->getTags($object);
+
+        if ((int)$this->config->getType() === Config::VARNISH && $this->config->isEnabled()) {
+            $bareTags = $this->tagResolver->getTags($object);
 
             $tags = [];
-            $pattern = "((^|,)%s(,|$))";
+            $pattern = '((^|,)%s(,|$))';
             foreach ($bareTags as $tag) {
                 $tags[] = sprintf($pattern, $tag);
             }
@@ -65,18 +80,5 @@ class InvalidateVarnishObserver implements ObserverInterface
                 $this->purgeCache->sendPurgeRequest(implode('|', array_unique($tags)));
             }
         }
-    }
-
-    /**
-     * @deprecated 100.1.2
-     * @return \Magento\Framework\App\Cache\Tag\Resolver
-     */
-    private function getTagResolver()
-    {
-        if ($this->tagResolver === null) {
-            $this->tagResolver = \Magento\Framework\App\ObjectManager::getInstance()
-                ->get(\Magento\Framework\App\Cache\Tag\Resolver::class);
-        }
-        return $this->tagResolver;
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR cleanups ObjectManager usage in Magento_CacheInvalidate, by removing object manager instantiation from non-api classes

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
N/A

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
