### PR TITLE
Fixed DHL shipping #25192

### DIFF
--- a/app/code/Magento/Dhl/Model/Carrier.php
+++ b/app/code/Magento/Dhl/Model/Carrier.php
@@ -676,6 +676,7 @@ class Carrier extends \Magento\Dhl\Model\AbstractDhl implements \Magento\Shippin
             'H' => __('Economy select'),
             'J' => __('Jumbo box'),
             'M' => __('Express 10:30'),
+            'N' => __('Domestic express'),
             'V' => __('Europack'),
             'Y' => __('Express 12:00'),
         ];

--- a/app/code/Magento/Dhl/Test/Unit/Model/CarrierTest.php
+++ b/app/code/Magento/Dhl/Test/Unit/Model/CarrierTest.php
@@ -332,6 +332,7 @@ class CarrierTest extends \PHPUnit\Framework\TestCase
                     'H' => 'Economy select',
                     'J' => 'Jumbo box',
                     'M' => 'Express 10:30',
+                    'N' => 'Domestic express',
                     'V' => 'Europack',
                     'Y' => 'Express 12:00',
                 ],

--- a/app/code/Magento/Dhl/etc/config.xml
+++ b/app/code/Magento/Dhl/etc/config.xml
@@ -21,7 +21,7 @@
                 <active>0</active>
                 <title>DHL</title>
                 <sallowspecific>0</sallowspecific>
-                <nondoc_methods>1,3,4,8,P,Q,E,F,H,J,M,V,Y</nondoc_methods>
+                <nondoc_methods>1,3,4,8,P,Q,E,F,H,J,M,N,V,Y</nondoc_methods>
                 <doc_methods>2,5,6,7,9,B,C,D,U,K,L,G,W,I,N,O,R,S,T,X</doc_methods>
                 <free_method>G</free_method>
                 <gateway_url>https://xmlpi-ea.dhl.com/XMLShippingServlet</gateway_url>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

In Non-Document, we don't get the desired Allowed Methods:

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25192: DHL Shipping

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Content-type in the setting of DHL have two options

Document
Non-Document
But while we make a selection of Document we get the desired Allowed methods: