### PR TITLE
magento/magento2#: Remove a redundant PHP5 directives from .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -37,29 +37,6 @@
 
     DirectoryIndex index.php
 
-<IfModule mod_php5.c>
-############################################
-## adjust memory limit
-
-    php_value memory_limit 756M
-    php_value max_execution_time 18000
-
-############################################
-## disable automatic session start
-## before autoload was initialized
-
-    php_flag session.auto_start off
-
-############################################
-## enable resulting html compression
-
-    #php_flag zlib.output_compression on
-
-###########################################
-## disable user agent verification to not break multiple image upload
-
-    php_flag suhosin.session.cryptua off
-</IfModule>
 <IfModule mod_php7.c>
 ############################################
 ## adjust memory limit


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

PR removes directives for `mod_php5.c` from `.htaccess` file since Magento 2 supports > PHP 7.x.x

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
