### PR TITLE
Removed unnecessary tabindex property

### DIFF
--- a/app/code/Magento/Ui/view/base/web/templates/grid/masonry.html
+++ b/app/code/Magento/Ui/view/base/web/templates/grid/masonry.html
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div data-role="grid-wrapper" class="masonry-image-grid" attr="'data-id': containerId" tabindex="0">
+<div data-role="grid-wrapper" class="masonry-image-grid" attr="'data-id': containerId">
     <div class="masonry-image-column" repeat="foreach: rows, item: '$row'">
         <div outerfasteach="data: getVisible(), as: '$col'" template="getBody()"/>
     </div>


### PR DESCRIPTION
### Description

Removed unnecessary `tabindex` property causing linked issue

### Related Pull Requests

- Fixed issue when the preview images navigation is triggered by moving the input filed cursor using arrow keys https://github.com/magento/magento2/pull/25991

### Fixed Issues
1. magento/adobe-stock-integration#973: Possible to switch to a whole div using TAB key 

### Manual testing scenarios
1. Disable Enhanced Media Gallery
2. Do not configure API key and client secret for Adobe Stock Integration
3. Open Adobe Stock Panel
4. Navigate through elements and assert entire div isn't focused as reported in issue
5. Also, ensure https://github.com/magento/adobe-stock-integration/issues/847 is not reproducible and linked PR added the tabindex, so we must ensure this issue is not reproducible as well

### Contribution checklist 
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
