### PR TITLE
Fix issue with incorrect images custom attributes output in catalog module

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/image.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image.phtml
@@ -10,7 +10,7 @@
 ?>
 
 <img class="photo image <?= $escaper->escapeHtmlAttr($block->getClass()) ?>"
-    <?= $escaper->escapeHtml($block->getCustomAttributes()) ?>
+    <?= /** @noEscape */ $block->getCustomAttributes() ?>
     src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
     loading="lazy"
     width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"

--- a/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
@@ -14,7 +14,7 @@
     <span class="product-image-wrapper"
           style="padding-bottom: <?= ($block->getRatio() * 100) ?>%;">
         <img class="<?= $escaper->escapeHtmlAttr($block->getClass()) ?>"
-            <?= $escaper->escapeHtmlAttr($block->getCustomAttributes()) ?>
+            <?= /** @noEscape */ $block->getCustomAttributes()  ?>
             src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
             loading="lazy"
             width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"


### PR DESCRIPTION
### Description (*)

Commit https://github.com/magento/magento2/commit/f40f24c3ff971fe49480a470868f443b6061d349 which was merged since `Magento 2.3.3-p1` caused a regression issue with custom attributes on category pages because method `getCustomAttributes` can contains content like `data-attr-value="some-attr-content" data-attr2-value="some-attr-content"` so it's a bad idea to escape it.

My changes reverts those escapes.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
