### PR TITLE
Update MSRP price when dropdown attribute is changed

### DIFF
--- a/app/code/Magento/Swatches/view/base/web/js/swatch-renderer.js
+++ b/app/code/Magento/Swatches/view/base/web/js/swatch-renderer.js
@@ -823,7 +823,9 @@ define([
         _OnChange: function ($this, $widget) {
             var $parent = $this.parents('.' + $widget.options.classes.attributeClass),
                 attributeId = $parent.attr('attribute-id'),
-                $input = $parent.find('.' + $widget.options.classes.attributeInput);
+                $input = $parent.find('.' + $widget.options.classes.attributeInput),
+                $priceBox = $widget.element.parents($widget.options.selectorProduct)
+                    .find(this.options.selectorProductPrice);
 
             if ($widget.productForm.length > 0) {
                 $input = $widget.productForm.find(
@@ -842,6 +844,13 @@ define([
             $widget._Rebuild();
             $widget._UpdatePrice();
             $widget._loadMedia();
+            $(document).trigger('updateMsrpPriceBlock',
+                [
+                    this._getSelectedOptionPriceIndex(),
+                    $widget.options.jsonConfig.optionPrices,
+                    $priceBox
+                ]);
+
             $input.trigger('change');
         },
 


### PR DESCRIPTION
### Description 

The MSRP price is changed by triggering `updateMsrpPriceBlock`. This event is triggered in `mage.SwatchRenderer._OnClick` and in `mage.configurable._displayRegularPriceBlock`.

This pull request adds the trigger also to `mage.SwatchRenderer._OnChange`.

The _Onclick method is called when a visual swatch is clicked. The _OnChange method is called when a dropdown is changed.

### Fixed Issues

1. fixes magento/magento2#27166: MSRP price is not updated when using dropdown instead of swatch

### Manual testing scenarios
1. Enable MAP (Stores -> Configuration -> Sales -> Sales -> Minimum Advertised Price -> Enable MAP).
2. Create a configurable product
3. Create variations for two attributes. One of type "swatch", one of type "dropdown".
4. Assign different MSRP for the variations.
5. Go to product on the frontend click the swatches and change the dropdown.
6. Verify that the MSRP is changed when a swatch is clicked and when the dropdown is changed.

