### PR TITLE
26825 add all image roles for first product entity

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Gallery/GalleryManagement.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/GalleryManagement.php
@@ -61,6 +61,10 @@ class GalleryManagement implements \Magento\Catalog\Api\ProductAttributeMediaGal
         $existingMediaGalleryEntries = $product->getMediaGalleryEntries();
         $existingEntryIds = [];
         if ($existingMediaGalleryEntries == null) {
+            // set all media types if not specified
+            if ($entry->getTypes() == null) {
+                $entry->setTypes(array_keys($product->getMediaAttributes()));
+            }
             $existingMediaGalleryEntries = [$entry];
         } else {
             foreach ($existingMediaGalleryEntries as $existingEntries) {

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenProductImagesSectionActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenProductImagesSectionActionGroup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminOpenProductImagesSectionActionGroup">
+        <annotations>
+            <description>Requires the navigation to the Product page. Opens 'Image and Videos' section.</description>
+        </annotations>
+        <conditionalClick selector="{{AdminProductImagesSection.productImagesToggle}}" dependentSelector="{{AdminProductImagesSection.imageUploadButton}}" visible="false" stepKey="openProductImagesSection"/>
+        <waitForElementVisible selector="{{AdminProductImagesSection.imageUploadButton}}" stepKey="waitForImageUploadButton"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertAdminProductImageRolesSelectedActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AssertAdminProductImageRolesSelectedActionGroup.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertAdminProductImageRolesSelectedActionGroup">
+        <annotations>
+            <description>Requires the navigation to the Product page and opened 'Image and Videos' section.
+                Checks the Base, Small, Thumbnail and Swatch Roles are selected for provided image.</description>
+        </annotations>
+        <arguments>
+            <argument name="imageFileName" type="string" defaultValue="test_image"/>
+        </arguments>
+        <waitForElementVisible selector="{{AdminProductImagesSection.imageFile(imageFileName)}}" stepKey="seeProductImageName"/>
+        <click selector="{{AdminProductImagesSection.imageFile(imageFileName)}}" stepKey="clickProductImage"/>
+        <waitForElementVisible selector="{{AdminProductImagesSection.isBaseSelected}}" stepKey="checkRoleBaseSelected"/>
+        <waitForElementVisible selector="{{AdminProductImagesSection.isSmallSelected}}" stepKey="checkRoleSmallSelected"/>
+        <waitForElementVisible selector="{{AdminProductImagesSection.isThumbnailSelected}}" stepKey="checkRoleThumbnailSelected"/>
+        <waitForElementVisible selector="{{AdminProductImagesSection.isSwatchSelected}}" stepKey="checkRoleSwatchSelected"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/Data/ProductAttributeMediaGalleryEntryData.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Data/ProductAttributeMediaGalleryEntryData.xml
@@ -35,4 +35,11 @@
         <data key="label">Magento Logo</data>
         <requiredEntity type="ImageContent">MagentoLogoImageContentExportImport</requiredEntity>
     </entity>
+    <entity name="ApiProductAttributeMediaGalleryEntryWithoutTypesTestImage"  type="ProductAttributeMediaGalleryEntry">
+        <data key="media_type">image</data>
+        <data key="label" unique="suffix">Test Image</data>
+        <data key="position">0</data>
+        <data key="disabled">false</data>
+        <requiredEntity type="ImageContent">TestImageContent</requiredEntity>
+    </entity>
 </entities>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckMediaRolesForFirstAddedImageViaApiTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckMediaRolesForFirstAddedImageViaApiTest.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminCheckMediaRolesForFirstAddedImageViaApiTest">
+        <annotations>
+            <stories value="Add Simple Product with image via API"/>
+            <title value="Check that added image for created product has selected image roles."/>
+            <description value="Login as admin, create simple product, add image to created product (via API).Go to
+                Admin Product Edit page for created product to check that added image has selected image roles."/>
+            <group value="catalog"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginToAdminPanel"/>
+            <createData entity="SimpleOutOfStockProduct" stepKey="createSimpleProduct"/>
+            <createData entity="ApiProductAttributeMediaGalleryEntryWithoutTypesTestImage" stepKey="createSimpleProductImage">
+                <requiredEntity createDataKey="createSimpleProduct"/>
+            </createData>
+        </before>
+        <after>
+            <deleteData createDataKey="createSimpleProduct" stepKey="deleteSimpleProduct"/>
+            <actionGroup ref="logout" stepKey="logout"/>
+            <!-- Reindex invalidated indices after product attribute has been created/deleted -->
+            <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
+        </after>
+
+        <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="goToSimpleProduct">
+            <argument name="productId" value="$$createSimpleProduct.id$$"/>
+        </actionGroup>
+        <actionGroup ref="AdminOpenProductImagesSectionActionGroup" stepKey="openProductImagesSection"/>
+        <actionGroup ref="AssertAdminProductImageRolesSelectedActionGroup" stepKey="checkImageRolesSelected">
+            <argument name="imageFileName" value="$createSimpleProductImage.entry[content][name]$"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Gallery/GalleryManagementTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Gallery/GalleryManagementTest.php
@@ -59,6 +59,7 @@ class GalleryManagementTest extends \PHPUnit\Framework\TestCase
                 'getCustomAttribute',
                 'getMediaGalleryEntries',
                 'setMediaGalleryEntries',
+                'getMediaAttributes',
             ]
         );
         $this->mediaGalleryEntryMock =
@@ -99,6 +100,9 @@ class GalleryManagementTest extends \PHPUnit\Framework\TestCase
         $entryContentMock = $this->getMockBuilder(\Magento\Framework\Api\Data\ImageContentInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $attributeMock = $this->getMockBuilder(\Magento\Eav\Model\Entity\Attribute\AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->mediaGalleryEntryMock->expects($this->any())->method('getContent')->willReturn($entryContentMock);
         $this->productRepositoryMock->expects($this->once())
             ->method('get')
@@ -107,6 +111,10 @@ class GalleryManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->contentValidatorMock->expects($this->once())->method('isValid')->with($entryContentMock)
             ->willReturn(true);
+
+        $this->productMock->expects($this->any())
+            ->method('getMediaAttributes')
+            ->willReturn(['small_image' => $attributeMock]);
 
         $this->productRepositoryMock->expects($this->once())->method('save')->with($this->productMock)
             ->willThrowException(new \Exception());
@@ -132,6 +140,8 @@ class GalleryManagementTest extends \PHPUnit\Framework\TestCase
 
         $this->contentValidatorMock->expects($this->once())->method('isValid')->with($entryContentMock)
             ->willReturn(true);
+
+        $this->mediaGalleryEntryMock->expects($this->any())->method('getTypes')->willReturn(['small_image']);
 
         $newEntryMock = $this->createMock(\Magento\Catalog\Api\Data\ProductAttributeMediaGalleryEntryInterface::class);
         $newEntryMock->expects($this->exactly(2))->method('getId')->willReturn(42);


### PR DESCRIPTION
### Description
Added improvements to GalleryManagement 'create' method to set all image roles for first product entity.

### Fixed Issues (if relevant)
#26825

### Manual testing scenarios
See #26825 issue description for details.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
