### PR TITLE
magento/magento2#14086: Guest cart API ignoring cartId in url for some methods

### DIFF
--- a/app/code/Magento/Quote/Plugin/UpdateCartId.php
+++ b/app/code/Magento/Quote/Plugin/UpdateCartId.php
@@ -42,7 +42,9 @@ class UpdateCartId
         GuestCartItemRepositoryInterface $guestCartItemRepository,
         CartItemInterface $cartItem
     ): void {
-        if ($cartId = $this->request->getParam('cartId')) {
+        $cartId = $this->request->getParam('cartId');
+
+        if ($cartId) {
             $cartItem->setQuoteId($cartId);
         }
     }

--- a/app/code/Magento/Quote/Plugin/UpdateCartId.php
+++ b/app/code/Magento/Quote/Plugin/UpdateCartId.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Quote\Plugin;
+
+use Magento\Framework\Webapi\Rest\Request as RestRequest;
+use Magento\Quote\Api\Data\CartItemInterface;
+use Magento\Quote\Api\GuestCartItemRepositoryInterface;
+
+/**
+ * Update cart id from request param
+ */
+class UpdateCartId
+{
+    /**
+     * @var RestRequest $request
+     */
+    private $request;
+
+    /**
+     * @param RestRequest $request
+     */
+    public function __construct(RestRequest $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * Update id from request if param cartId exist
+     *
+     * @param GuestCartItemRepositoryInterface $guestCartItemRepository
+     * @param CartItemInterface $cartItem
+     * @return void
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function beforeSave(
+        GuestCartItemRepositoryInterface $guestCartItemRepository,
+        CartItemInterface $cartItem
+    ): void {
+        if ($cartId = $this->request->getParam('cartId')) {
+            $cartItem->setQuoteId($cartId);
+        }
+    }
+}

--- a/app/code/Magento/Quote/etc/webapi_rest/di.xml
+++ b/app/code/Magento/Quote/etc/webapi_rest/di.xml
@@ -13,4 +13,7 @@
         <plugin name="accessControl" type="Magento\Quote\Model\QuoteRepository\Plugin\AccessChangeQuoteControl" />
         <plugin name="authorization" type="Magento\Quote\Model\QuoteRepository\Plugin\Authorization" />
     </type>
+    <type name="Magento\Quote\Api\GuestCartItemRepositoryInterface">
+        <plugin name="updateCartIdFromRequest" type="Magento\Quote\Plugin\UpdateCartId" />
+    </type>
 </config>

--- a/app/code/Magento/Swatches/Test/Mftf/Section/AdminManageSwatchSection.xml
+++ b/app/code/Magento/Swatches/Test/Mftf/Section/AdminManageSwatchSection.xml
@@ -21,6 +21,7 @@
         <element name="chooserBlock" type="block" selector="#swatch-visual-options-panel table tbody tr:nth-of-type({{var}}) .swatches-visual-col .swatch_sub-menu_container" parameterized="true"/>
         <!-- Selector for Admin Description input where the index is zero-based -->
         <element name="swatchAdminDescriptionByIndex" type="input" selector="input[name='optiontext[value][option_{{index}}][0]']" parameterized="true"/>
+        <element name="swatchWindow" type="button" selector="#swatch_window_option_option_{{var}}" parameterized="true"/>
         <element name="nthChooseColor" type="button" selector="#swatch-visual-options-panel table tbody tr:nth-of-type({{var}}) .swatch_row_name.colorpicker_handler" parameterized="true"/>
         <element name="nthUploadFile" type="button" selector="#swatch-visual-options-panel table tbody tr:nth-of-type({{var}}) .swatch_row_name.btn_choose_file_upload" parameterized="true"/>
         <element name="nthDelete" type="button" selector="#swatch-visual-options-panel table tbody tr:nth-of-type({{var}}) button.delete-option" parameterized="true"/>

--- a/app/code/Magento/Swatches/Test/Mftf/Test/AdminCreateImageSwatchTest.xml
+++ b/app/code/Magento/Swatches/Test/Mftf/Test/AdminCreateImageSwatchTest.xml
@@ -53,6 +53,7 @@
         <click selector="{{AdminManageSwatchSection.nthUploadFile('1')}}" stepKey="clickUploadFile1"/>
         <attachFile selector="input[name='datafile']" userInput="adobe-thumb.jpg" stepKey="attachFile1"/>
         <fillField selector="{{AdminManageSwatchSection.adminInputByIndex('0')}}" userInput="adobe-thumb" stepKey="fillAdmin1"/>
+        <click selector="{{AdminManageSwatchSection.swatchWindow('0')}}" stepKey="clicksWatchWindow1"/>
 
         <!-- Set swatch image #2 -->
         <click selector="{{AdminManageSwatchSection.addSwatch}}" stepKey="clickAddSwatch2"/>
@@ -62,6 +63,7 @@
         <click selector="{{AdminManageSwatchSection.nthUploadFile('2')}}" stepKey="clickUploadFile2"/>
         <attachFile selector="input[name='datafile']" userInput="adobe-small.jpg" stepKey="attachFile2"/>
         <fillField selector="{{AdminManageSwatchSection.adminInputByIndex('1')}}" userInput="adobe-small" stepKey="fillAdmin2"/>
+        <click selector="{{AdminManageSwatchSection.swatchWindow('1')}}" stepKey="clicksWatchWindow2"/>
 
         <!-- Set swatch image #3 -->
         <click selector="{{AdminManageSwatchSection.addSwatch}}" stepKey="clickAddSwatch3"/>

--- a/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontFilterByImageSwatchTest.xml
+++ b/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontFilterByImageSwatchTest.xml
@@ -55,6 +55,7 @@
         <click selector="{{AdminManageSwatchSection.nthUploadFile('1')}}" stepKey="clickUploadFile1"/>
         <attachFile selector="input[name='datafile']" userInput="adobe-thumb.jpg" stepKey="attachFile1"/>
         <fillField selector="{{AdminManageSwatchSection.adminInputByIndex('0')}}" userInput="adobe-thumb" stepKey="fillAdmin1"/>
+        <click selector="{{AdminManageSwatchSection.swatchWindow('0')}}" stepKey="clicksWatchWindow1"/>
 
         <!-- Set swatch #2 image using the file upload -->
         <click selector="{{AdminManageSwatchSection.addSwatch}}" stepKey="clickAddSwatch2"/>

--- a/dev/tests/api-functional/testsuite/Magento/Quote/Api/GuestCartItemRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Quote/Api/GuestCartItemRepositoryTest.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -8,25 +7,35 @@ namespace Magento\Quote\Api;
 
 use Magento\CatalogInventory\Api\StockRegistryInterface;
 use Magento\CatalogInventory\Model\Stock;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\ObjectManager;
 use Magento\TestFramework\TestCase\WebapiAbstract;
 
+/**
+ * Test for Magento\Quote\Api\GuestCartItemRepositoryInterface.
+ */
 class GuestCartItemRepositoryTest extends WebapiAbstract
 {
-    const SERVICE_VERSION = 'V1';
-    const SERVICE_NAME = 'quoteGuestCartItemRepositoryV1';
-    const RESOURCE_PATH = '/V1/guest-carts/';
+    public const SERVICE_NAME = 'quoteGuestCartItemRepositoryV1';
+    private const SERVICE_VERSION = 'V1';
+    private const RESOURCE_PATH = '/V1/guest-carts/';
 
     /**
-     * @var \Magento\TestFramework\ObjectManager
+     * @var ObjectManager
      */
-    protected $objectManager;
+    private $objectManager;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp()
     {
-        $this->objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        $this->objectManager = Bootstrap::getObjectManager();
     }
 
     /**
+     * Test quote items
+     *
      * @magentoApiDataFixture Magento/Checkout/_files/quote_with_items_saved.php
      */
     public function testGetList()
@@ -112,12 +121,16 @@ class GuestCartItemRepositoryTest extends WebapiAbstract
         ];
 
         $requestData = [
-            "cartItem" => [
-                "sku" => $productSku,
-                "qty" => 7,
-                "quote_id" => $cartId,
+            'cartItem' => [
+                'sku' => $productSku,
+                'qty' => 7,
             ],
         ];
+
+        if (TESTS_WEB_API_ADAPTER === self::ADAPTER_SOAP) {
+            $requestData['cartItem']['quote_id'] = $cartId;
+        }
+
         $this->_webApiCall($serviceInfo, $requestData);
         $this->assertTrue($quote->hasProductId(2));
         $this->assertEquals(7, $quote->getItemByProduct($product)->getQty());
@@ -205,20 +218,11 @@ class GuestCartItemRepositoryTest extends WebapiAbstract
             ],
         ];
 
-        if (TESTS_WEB_API_ADAPTER == self::ADAPTER_SOAP) {
-            $requestData = [
-                "cartItem" => [
-                    "qty" => 5,
-                    "quote_id" => $cartId,
-                    "itemId" => $itemId,
-                ],
-            ];
-        } else {
-            $requestData = [
-                "cartItem" => [
-                    "qty" => 5,
-                    "quote_id" => $cartId,
-                ],
+        $requestData['cartItem']['qty'] = 5;
+        if (TESTS_WEB_API_ADAPTER === self::ADAPTER_SOAP) {
+            $requestData['cartItem'] += [
+                'quote_id' => $cartId,
+                'itemId' => $itemId,
             ];
         }
         if ($errorMessage) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Now guest cart API doesn't ignore card from URL. Covered by test.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#14086: Guest cart API ignoring cartId in url for some methods

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Please see https://github.com/magento/magento2/issues/14086

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
