### PR TITLE
Fix sales_email_order_items rendering

### DIFF
--- a/app/code/Magento/Sales/Block/Order/Email/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items.php
@@ -9,7 +9,12 @@
  *
  * @author     Magento Core Team <core@magentocommerce.com>
  */
+
 namespace Magento\Sales\Block\Order\Email;
+
+use Magento\Framework\View\Element\Template;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
 
 /**
  * @api
@@ -17,4 +22,26 @@ namespace Magento\Sales\Block\Order\Email;
  */
 class Items extends \Magento\Sales\Block\Items\AbstractItems
 {
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    public function __construct(
+        Template\Context $context,
+        OrderRepositoryInterface $orderRepository,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->orderRepository = $orderRepository;
+    }
+
+    public function getOrder(): ?OrderInterface
+    {
+        if ($order = $this->getData('order')) {
+            return $order;
+        }
+
+        return $this->orderRepository->get($this->getOrderId());
+    }
 }

--- a/app/code/Magento/Sales/Block/Order/Email/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items.php
@@ -17,6 +17,8 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 
 /**
+ * Block which renders order items in emails
+ *
  * @api
  * @since 100.0.2
  */

--- a/app/code/Magento/Sales/Block/Order/Email/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items.php
@@ -23,10 +23,19 @@ use Magento\Sales\Api\OrderRepositoryInterface;
 class Items extends \Magento\Sales\Block\Items\AbstractItems
 {
     /**
+     * OrderRepository
+     *
      * @var OrderRepositoryInterface
      */
     private $orderRepository;
 
+    /**
+     * Constructor
+     *
+     * @param Template\Context $context
+     * @param OrderRepositoryInterface $orderRepository
+     * @param array $data
+     */
     public function __construct(
         Template\Context $context,
         OrderRepositoryInterface $orderRepository,
@@ -36,6 +45,11 @@ class Items extends \Magento\Sales\Block\Items\AbstractItems
         $this->orderRepository = $orderRepository;
     }
 
+    /**
+     * Retrieve order
+     *
+     * @return OrderInterface|null
+     */
     public function getOrder(): ?OrderInterface
     {
         if ($order = $this->getData('order')) {

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
@@ -135,7 +135,8 @@ class OrderSender extends Sender
                 'customer_name' => $order->getCustomerName(),
                 'is_not_virtual' => $order->getIsNotVirtual(),
                 'email_customer_note' => $order->getEmailCustomerNote(),
-                'frontend_status_label' => $order->getFrontendStatusLabel()
+                'frontend_status_label' => $order->getFrontendStatusLabel(),
+                'id' => $order->getId(),
             ]
         ];
         $transportObject = new DataObject($transport);

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
@@ -16,7 +16,8 @@ use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\DataObject;
 
 /**
- * Class OrderSender
+ * Email notification sender for Orders.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class OrderSender extends Sender

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/OrderSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/OrderSenderTest.php
@@ -296,9 +296,7 @@ class OrderSenderTest extends AbstractSenderTest
             ->method('getFrontendStatusLabel')
             ->willReturn($frontendStatusLabel);
 
-        $this->orderMock->expects($this->once())
-            ->method('getId')
-            ->willReturn($orderId);
+        $this->orderMock->expects($this->once())->method('getId')->willReturn($orderId);
 
         $this->templateContainerMock->expects($this->once())
             ->method('setTemplateVars')

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/OrderSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/OrderSenderTest.php
@@ -66,6 +66,7 @@ class OrderSenderTest extends AbstractSenderTest
         $customerName = 'test customer';
         $frontendStatusLabel = 'Processing';
         $isNotVirtual = true;
+        $orderId = 20501;
 
         $this->orderMock->expects($this->once())
             ->method('setSendEmail')
@@ -122,6 +123,10 @@ class OrderSenderTest extends AbstractSenderTest
                     ->method('getFrontendStatusLabel')
                     ->willReturn($frontendStatusLabel);
 
+                $this->orderMock->expects($this->once())
+                    ->method('getId')
+                    ->willReturn($orderId);
+
                 $this->templateContainerMock->expects($this->once())
                     ->method('setTemplateVars')
                     ->with(
@@ -137,9 +142,9 @@ class OrderSenderTest extends AbstractSenderTest
                                 'customer_name' => $customerName,
                                 'is_not_virtual' => $isNotVirtual,
                                 'email_customer_note' => '',
-                                'frontend_status_label' => $frontendStatusLabel
+                                'frontend_status_label' => $frontendStatusLabel,
+                                'id' => $orderId
                             ]
-
                         ]
                     );
 
@@ -242,6 +247,7 @@ class OrderSenderTest extends AbstractSenderTest
         $customerName = 'test customer';
         $frontendStatusLabel = 'Complete';
         $isNotVirtual = false;
+        $orderId = 20500;
 
         $this->orderMock->expects($this->once())
             ->method('setSendEmail')
@@ -290,6 +296,10 @@ class OrderSenderTest extends AbstractSenderTest
             ->method('getFrontendStatusLabel')
             ->willReturn($frontendStatusLabel);
 
+        $this->orderMock->expects($this->once())
+            ->method('getId')
+            ->willReturn($orderId);
+
         $this->templateContainerMock->expects($this->once())
             ->method('setTemplateVars')
             ->with(
@@ -305,7 +315,8 @@ class OrderSenderTest extends AbstractSenderTest
                         'customer_name' => $customerName,
                         'is_not_virtual' => $isNotVirtual,
                         'email_customer_note' => '',
-                        'frontend_status_label' => $frontendStatusLabel
+                        'frontend_status_label' => $frontendStatusLabel,
+                        'id' => $orderId
                     ]
                 ]
             );

--- a/app/code/Magento/Sales/view/frontend/email/order_new.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_new.html
@@ -23,6 +23,7 @@
 "var order_data.is_not_virtual":"Order Type",
 "var order":"Order",
 "var order_data.customer_name":"Customer Name"
+"var order_data.id":"Order Entity Id"
 } @-->
 
 {{template config_path="design/email/header_template"}}

--- a/app/code/Magento/Sales/view/frontend/email/order_new.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_new.html
@@ -22,7 +22,7 @@
 "var this.getUrl($store,'customer/account/',[_nosid:1])":"Customer Account URL",
 "var order_data.is_not_virtual":"Order Type",
 "var order":"Order",
-"var order_data.customer_name":"Customer Name"
+"var order_data.customer_name":"Customer Name",
 "var order_data.id":"Order Entity Id"
 } @-->
 

--- a/app/code/Magento/Sales/view/frontend/email/order_new.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_new.html
@@ -90,7 +90,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_items" order=$order area="frontend"}}
+            {{layout handle="sales_email_order_items" order_id=$order_data.id area="frontend"}}
         </td>
     </tr>
 </table>

--- a/app/code/Magento/Sales/view/frontend/email/order_new_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_new_guest.html
@@ -85,7 +85,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_items" order=$order}}
+            {{layout handle="sales_email_order_items" order_id=$order_data.id}}
         </td>
     </tr>
 </table>

--- a/app/code/Magento/Sales/view/frontend/email/order_new_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_new_guest.html
@@ -21,7 +21,7 @@
 "var store_email":"Store Email",
 "var store_hours":"Store Hours",
 "var order_data.is_not_virtual":"Order Type",
-"var order":"Order"
+"var order":"Order",
 "var order_data.id":"Order Entity Id"
 } @-->
 {{template config_path="design/email/header_template"}}

--- a/app/code/Magento/Sales/view/frontend/email/order_new_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_new_guest.html
@@ -22,6 +22,7 @@
 "var store_hours":"Store Hours",
 "var order_data.is_not_virtual":"Order Type",
 "var order":"Order"
+"var order_data.id":"Order Entity Id"
 } @-->
 {{template config_path="design/email/header_template"}}
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This pull request fixes the rendering of the sales order items in emails. Due to strict mode the order variable gets stripped and is not available anymore.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#26882: 2.3.4 Email Template New Pickup Order or add New Template order items are missing in Mail

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Test with the default new order email.
2. Test with a new default template created in the backend.
3. Both scenario's should now render the order items.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
