### PR TITLE
Mark AbstractAccount as DEPRECATED for Magento_Customer controllers

### DIFF
--- a/app/code/Magento/Customer/Controller/AbstractAccount.php
+++ b/app/code/Magento/Customer/Controller/AbstractAccount.php
@@ -12,7 +12,7 @@ use Magento\Framework\App\Action\Action;
  * AbstractAccount class is deprecated, in favour of Composition approach to build Controllers
  *
  * @SuppressWarnings(PHPMD.NumberOfChildren)
- * @deprecated 2.4.0
+ * @deprecated
  * @see \Magento\Customer\Controller\AccountInterface
  */
 abstract class AbstractAccount extends Action implements AccountInterface

--- a/app/code/Magento/Customer/Controller/AbstractAccount.php
+++ b/app/code/Magento/Customer/Controller/AbstractAccount.php
@@ -9,6 +9,8 @@ namespace Magento\Customer\Controller;
 use Magento\Framework\App\Action\Action;
 
 /**
+ * AbstractAccount class is deprecated, in favour of Composition approach to build Controllers
+ *
  * @SuppressWarnings(PHPMD.NumberOfChildren)
  * @deprecated 2.4.0
  * @see \Magento\Customer\Controller\AccountInterface

--- a/app/code/Magento/Customer/Controller/AbstractAccount.php
+++ b/app/code/Magento/Customer/Controller/AbstractAccount.php
@@ -9,9 +9,9 @@ namespace Magento\Customer\Controller;
 use Magento\Framework\App\Action\Action;
 
 /**
- * Class AbstractAccount
- * @package Magento\Customer\Controller
  * @SuppressWarnings(PHPMD.NumberOfChildren)
+ * @deprecated 2.4.0
+ * @see \Magento\Customer\Controller\AccountInterface
  */
 abstract class AbstractAccount extends Action implements AccountInterface
 {

--- a/app/code/Magento/Customer/Controller/Plugin/Account.php
+++ b/app/code/Magento/Customer/Controller/Plugin/Account.php
@@ -10,8 +10,6 @@ namespace Magento\Customer\Controller\Plugin;
 use Closure;
 use Magento\Customer\Controller\AccountInterface;
 use Magento\Customer\Model\Session;
-use Magento\Framework\App\ActionFlag;
-use Magento\Framework\App\ActionInterface;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\ResultInterface;

--- a/app/code/Magento/Customer/Controller/Plugin/Account.php
+++ b/app/code/Magento/Customer/Controller/Plugin/Account.php
@@ -14,6 +14,9 @@ use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\ResultInterface;
 
+/**
+ * Plugin verifies permissions using Action Name against injected (`fontend/di.xml`) rules
+ */
 class Account
 {
     /**
@@ -22,13 +25,14 @@ class Account
     protected $session;
 
     /**
-     * @var array
-     */
-    private $allowedActions = [];
-    /**
      * @var RequestInterface
      */
     private $request;
+
+    /**
+     * @var array
+     */
+    private $allowedActions = [];
 
     /**
      * @param RequestInterface $request

--- a/app/code/Magento/Customer/Controller/Plugin/Account.php
+++ b/app/code/Magento/Customer/Controller/Plugin/Account.php
@@ -60,12 +60,10 @@ class Account
      */
     public function aroundExecute(AccountInterface $controllerAction, Closure $proceed)
     {
-        if ($this->isActionAllowed()) {
+        /** @FIXME Move Authentication and redirect out of Session model */
+        if ($this->isActionAllowed() || $this->session->authenticate()) {
             return $proceed();
         }
-
-        /** @FIXME Move Authentication and redirect out of Session model */
-        $this->session->authenticate();
     }
 
     /**

--- a/app/code/Magento/Customer/Controller/Plugin/Account.php
+++ b/app/code/Magento/Customer/Controller/Plugin/Account.php
@@ -35,27 +35,20 @@ class Account
      * @var array
      */
     private $allowedActions = [];
-    /**
-     * @var ActionFlag
-     */
-    private $actionFlag;
 
     /**
      * @param RequestInterface $request
      * @param Session $customerSession
-     * @param ActionFlag $actionFlag
      * @param array $allowedActions List of actions that are allowed for not authorized users
      */
     public function __construct(
         RequestInterface $request,
         Session $customerSession,
-        ActionFlag $actionFlag,
         array $allowedActions = []
     ) {
+        $this->request = $request;
         $this->session = $customerSession;
         $this->allowedActions = $allowedActions;
-        $this->request = $request;
-        $this->actionFlag = $actionFlag;
     }
 
     /**
@@ -68,16 +61,11 @@ class Account
     public function aroundExecute(AccountInterface $controllerAction, Closure $proceed)
     {
         if ($this->isActionAllowed()) {
-            $this->session->setNoReferer(true);
-            $response = $proceed();
-            $this->session->unsNoReferer(false);
-
-            return $response;
+            return $proceed();
         }
 
-        if (!$this->session->authenticate()) {
-            $this->actionFlag->set('', ActionInterface::FLAG_NO_DISPATCH, true);
-        }
+        /** @FIXME Move Authentication and redirect out of Session model */
+        $this->session->authenticate();
     }
 
     /**

--- a/app/code/Magento/Customer/Controller/Plugin/Account.php
+++ b/app/code/Magento/Customer/Controller/Plugin/Account.php
@@ -22,7 +22,7 @@ class Account
     /**
      * @var Session
      */
-    protected $session;
+    private $session;
 
     /**
      * @var RequestInterface
@@ -55,6 +55,7 @@ class Account
      * @param AccountInterface $controllerAction
      * @param Closure $proceed
      * @return ResultInterface|ResponseInterface|void
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function aroundExecute(AccountInterface $controllerAction, Closure $proceed)
     {

--- a/app/code/Magento/Customer/Test/Unit/Controller/Plugin/AccountTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Plugin/AccountTest.php
@@ -85,12 +85,14 @@ class AccountTest extends TestCase
      * @param string $action
      * @param array $allowedActions
      * @param boolean $isAllowed
-     * @param boolean $isAuthenticated
      *
      * @dataProvider beforeExecuteDataProvider
      */
-    public function testAroundExecuteInterruptsOriginalCallWhenNotAllowed(string $action, array $allowedActions, bool $isAllowed, bool $isAuthenticated)
-    {
+    public function testAroundExecuteInterruptsOriginalCallWhenNotAllowed(
+        string $action,
+        array $allowedActions,
+        bool $isAllowed
+    ) {
         /** @var callable|MockObject $proceedMock */
         $proceedMock = $this->getMockBuilder(\stdClass::class)
             ->setMethods(['__invoke'])

--- a/app/code/Magento/Customer/etc/frontend/di.xml
+++ b/app/code/Magento/Customer/etc/frontend/di.xml
@@ -51,7 +51,7 @@
             </argument>
         </arguments>
     </type>
-    <type name="Magento\Customer\Controller\AbstractAccount">
+    <type name="Magento\Customer\Controller\AccountInterface">
         <plugin name="customer_account" type="Magento\Customer\Controller\Plugin\Account" />
     </type>
     <type name="Magento\Checkout\Block\Cart\Sidebar">

--- a/dev/tests/integration/testsuite/Magento/Customer/Controller/AuthenticationTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Controller/AuthenticationTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Customer\Controller;
+
+use Magento\Customer\Controller\Plugin\Account as AccountPlugin;
+use Magento\TestFramework\TestCase\AbstractController;
+
+/**
+ * Set of Tests to verify that Authentication methods work properly
+ */
+class AuthenticationTest extends AbstractController
+{
+    /**
+     * Make sure that customized AccountPlugin was reverted.
+     */
+    protected function tearDown()
+    {
+        $this->resetAllowedActions();
+        parent::tearDown();
+    }
+
+    /**
+     * After changes to `di.xml` and overriding list of allowed actions, unallowed ones should cause redirect.
+     */
+    public function testExpectRedirectResponseWhenDispatchNotAllowedAction()
+    {
+        $this->overrideAllowedActions(['notExistingRoute']);
+
+        $this->dispatch('customer/account/create');
+        $this->assertRedirect($this->stringContains('customer/account/login'));
+    }
+
+    /**
+     * Allowed actions should be displayed
+     */
+    public function testExpectPageDispatchWhenAllowedAction()
+    {
+        $this->overrideAllowedActions(['create']);
+
+        $this->dispatch('customer/account/create');
+        $this->assertEquals(200, $this->getResponse()->getStatusCode());
+    }
+
+    /**
+     * Overrides list of `allowedActions` for Authorization Plugin
+     *
+     * @param string[] $allowedActions
+     * @see \Magento\Customer\Controller\Plugin\Account
+     */
+    private function overrideAllowedActions(array $allowedActions): void
+    {
+        $allowedActions = array_combine($allowedActions, $allowedActions);
+        $pluginMock = $this->_objectManager->create(AccountPlugin::class, ['allowedActions' => $allowedActions]);
+        $this->_objectManager->addSharedInstance($pluginMock, AccountPlugin::class);
+    }
+
+    /**
+     * Removes all the customizations applied to `allowedActions`
+     * @see \Magento\Customer\Controller\Plugin\Account
+     */
+    private function resetAllowedActions()
+    {
+        $this->_objectManager->removeSharedInstance(AccountPlugin::class);
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Customer/Controller/AuthenticationTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Controller/AuthenticationTest.php
@@ -36,9 +36,9 @@ class AuthenticationTest extends AbstractController
     }
 
     /**
-     * Allowed actions should be displayed
+     * Allowed actions should be rendered normally
      */
-    public function testExpectPageDispatchWhenAllowedAction()
+    public function testExpectPageResponseWhenAllowedAction()
     {
         $this->overrideAllowedActions(['create']);
 

--- a/dev/tests/integration/testsuite/Magento/Customer/Controller/AuthenticationTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Controller/AuthenticationTest.php
@@ -55,8 +55,8 @@ class AuthenticationTest extends AbstractController
     private function overrideAllowedActions(array $allowedActions): void
     {
         $allowedActions = array_combine($allowedActions, $allowedActions);
-        $pluginMock = $this->_objectManager->create(AccountPlugin::class, ['allowedActions' => $allowedActions]);
-        $this->_objectManager->addSharedInstance($pluginMock, AccountPlugin::class);
+        $pluginFake = $this->_objectManager->create(AccountPlugin::class, ['allowedActions' => $allowedActions]);
+        $this->_objectManager->addSharedInstance($pluginFake, AccountPlugin::class);
     }
 
     /**


### PR DESCRIPTION
### Description (*)
According to recent changes in favour of Composition over inheritance in Magento 2 Controller Structure - I've introduced changes to Account controllers. That is the first step - make `AbstractAccount` deprecated.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
Reattached the Authorization plugin to `AccountInterface` from `AbstractAccount`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
