### PR TITLE
Add the ability for plugin overrides.

### DIFF
--- a/app/code/Magento/Checkout/Block/Cart/LayoutProcessor.php
+++ b/app/code/Magento/Checkout/Block/Cart/LayoutProcessor.php
@@ -59,7 +59,7 @@ class LayoutProcessor implements \Magento\Checkout\Block\Checkout\LayoutProcesso
      * @return bool
      * @codeCoverageIgnore
      */
-    protected function isCityActive()
+    public function isCityActive()
     {
         return false;
     }
@@ -70,7 +70,7 @@ class LayoutProcessor implements \Magento\Checkout\Block\Checkout\LayoutProcesso
      * @return bool
      * @codeCoverageIgnore
      */
-    protected function isStateActive()
+    public function isStateActive()
     {
         return false;
     }


### PR DESCRIPTION
### Description (*)

Adds the ability for plugin overrides on two shipping address fieldsets. This is important as if you'd like to display a city in the shipping address fieldset on checkout/cart, you're unable to do so easily without creating a preference. This isn't ideal and there is no reason these methods shouldn't be public.