### PR TITLE
Fixed 'illegal offset type' warning, when scopeCode is an object.

### DIFF
--- a/lib/internal/Magento/Framework/App/Config.php
+++ b/lib/internal/Magento/Framework/App/Config.php
@@ -50,7 +50,7 @@ class Config implements ScopeConfigInterface
      *
      * @param string $path
      * @param string $scope
-     * @param null|int|string $scopeCode
+     * @param null|int|string|\Magento\Framework\App\ScopeInterface $scopeCode
      * @return mixed
      */
     public function getValue(
@@ -65,11 +65,7 @@ class Config implements ScopeConfigInterface
         }
         $configPath = $scope;
         if ($scope !== 'default') {
-            if (is_numeric($scopeCode) || $scopeCode === null) {
-                $scopeCode = $this->scopeCodeResolver->resolve($scope, $scopeCode);
-            } elseif ($scopeCode instanceof \Magento\Framework\App\ScopeInterface) {
-                $scopeCode = $scopeCode->getCode();
-            }
+            $scopeCode = $this->normalizeScopeCode($scope, $scopeCode);
             if ($scopeCode) {
                 $configPath .= '/' . $scopeCode;
             }
@@ -78,6 +74,26 @@ class Config implements ScopeConfigInterface
             $configPath .= '/' . $path;
         }
         return $this->get('system', $configPath);
+    }
+
+    /**
+     * @param string $scope
+     * @param null|int|string|\Magento\Framework\App\ScopeInterface $scopeCode
+     * @return string
+     */
+    protected function normalizeScopeCode($scope, $scopeCode)
+    {
+        if (is_string($scopeCode)) {
+            return $scopeCode;
+        }
+
+        if (is_numeric($scopeCode) || $scopeCode === null) {
+            $scopeCode = $this->scopeCodeResolver->resolve($scope, $scopeCode);
+        } elseif ($scopeCode instanceof \Magento\Framework\App\ScopeInterface) {
+            $scopeCode = $scopeCode->getCode();
+        }
+
+        return $scopeCode;
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/MutableScopeConfig.php
+++ b/lib/internal/Magento/Framework/App/MutableScopeConfig.php
@@ -29,6 +29,10 @@ class MutableScopeConfig extends Config implements MutableScopeConfigInterface
         $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
         $scopeCode = null
     ) {
+        if ($scopeCode !== null) {
+            $scopeCode = $this->normalizeScopeCode($scope, $scopeCode);
+        }
+
         if (isset($this->data[$scope][$scopeCode][$path])) {
             return $this->data[$scope][$scopeCode][$path];
         }
@@ -42,7 +46,7 @@ class MutableScopeConfig extends Config implements MutableScopeConfigInterface
      * @param string $path
      * @param mixed $value
      * @param string $scope
-     * @param null|string $scopeCode
+     * @param null|int|string|\Magento\Framework\App\ScopeInterface $scopeCode
      * @return void
      */
     public function setValue(
@@ -51,6 +55,10 @@ class MutableScopeConfig extends Config implements MutableScopeConfigInterface
         $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
         $scopeCode = null
     ) {
+        if ($scopeCode !== null) {
+            $scopeCode = $this->normalizeScopeCode($scope, $scopeCode);
+        }
+
         $this->data[$scope][$scopeCode][$path] = $value;
     }
 


### PR DESCRIPTION
# Description
[MutableScopeConfig::getValue](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/App/MutableScopeConfig.php#L32) may receive `\Magento\Framework\App\ScopeInterface` as a scopeCode. In this case php will generate a warning "Illegal offset type". 

See [Store::getFrontendName](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Store/Model/Store.php#L1351-L1352) - `$this` is used as a third argument.
See [Config::getValue](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/App/Config.php#L70) - `$scopeCode` is processed as `\Magento\Framework\App\ScopeInterface`.

### Manual testing scenarios (*)
Manual coding is required.
1. Open `Magento/Catalog/Controller/Adminhtml/Product/Index.php`
2. Add the following code at the top of the `execute` method:
 
 ```
        $result = \Magento\Framework\App\ObjectManager::getInstance()
            ->create(\Magento\Store\Model\Store::class)
            ->load(1)
            ->getFrontendName();
        echo $result;
        die;
```

3. Navigate to _Catalog > Products_ in backend panel.
4. Depending on your PHP settings you'll see a notice in the error log.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
