### PR TITLE
MFTF: Create Account tests (Success & Failure) with `extend`

### DIFF
--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/SignUpNewUserFromStorefrontActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/SignUpNewUserFromStorefrontActionGroup.xml
@@ -8,7 +8,7 @@
 
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
-    <actionGroup name="SignUpNewUserFromStorefrontActionGroup">
+    <actionGroup name="SignUpNewUserFromStorefrontActionGroup" deprecated="Avoid using super-ActionGroups. See StorefrontCreateCustomerTest for replacement.">
         <annotations>
             <description>Goes to the Storefront. Clicks on 'Create Account'. Fills in the provided Customer details, excluding Newsletter Sign-Up. Clicks on 'Create Account' button. Validate that the Customer details are present and correct.</description>
         </annotations>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerTest.xml
@@ -12,19 +12,22 @@
         <annotations>
             <features value="Customer"/>
             <stories value="Create a Customer via the Storefront"/>
-            <title value="Admin should be able to create a customer via the storefront"/>
-            <description value="Admin should be able to create a customer via the storefront"/>
+            <title value="As a Customer I should be able to register an account on Storefront"/>
+            <description value="As a Customer I should be able to register an account on Storefront"/>
             <severity value="CRITICAL"/>
             <testCaseId value="MAGETWO-23546"/>
             <group value="customer"/>
             <group value="create"/>
         </annotations>
-        <after>
-            <actionGroup ref="AdminLogoutActionGroup" stepKey="adminLogout"/>
-        </after>
 
-        <actionGroup ref="SignUpNewUserFromStorefrontActionGroup" stepKey="SignUpNewUser">
-            <argument name="Customer" value="CustomerEntityOne"/>
+        <actionGroup ref="StorefrontOpenCustomerAccountCreatePageActionGroup" stepKey="openCreateAccountPage"/>
+        <actionGroup ref="StorefrontFillCustomerAccountCreationFormActionGroup" stepKey="fillCreateAccountForm">
+            <argument name="customer" value="Simple_US_Customer"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontClickCreateAnAccountCustomerAccountCreationFormActionGroup" stepKey="submitCreateAccountForm"/>
+        <actionGroup ref="AssertMessageCustomerCreateAccountActionGroup" stepKey="seeSuccessMessage">
+            <argument name="messageType" value="success"/>
+            <argument name="message" value="Thank you for registering with Main Website Store."/>
         </actionGroup>
     </test>
 </tests>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateExistingCustomerTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateExistingCustomerTest.xml
@@ -8,29 +8,28 @@
 
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
-    <test name="StorefrontCreateExistingCustomerTest">
+    <test name="StorefrontCreateExistingCustomerTest" extends="StorefrontCreateCustomerTest">
         <annotations>
             <features value="Customer"/>
             <stories value="Customer Registration"/>
-            <title value="Attempt to register customer on storefront with existing email"/>
-            <description value="Attempt to register customer on storefront with existing email"/>
+            <title value="As a Customer I should not be able to register an account using already registered e-mail"/>
+            <description value="As a Customer I should not be able to register an account using already registered e-mail"/>
             <testCaseId value="MC-10907"/>
             <severity value="MAJOR"/>
             <group value="customers"/>
             <group value="mtf_migrated"/>
         </annotations>
         <before>
-            <createData entity="Simple_US_Customer" stepKey="customer"/>
+            <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
         </before>
         <after>
-            <deleteData createDataKey="customer" stepKey="deleteCustomer"/>
+            <deleteData createDataKey="createCustomer" stepKey="deleteCustomer"/>
         </after>
 
-        <actionGroup ref="StorefrontOpenCustomerAccountCreatePageActionGroup" stepKey="openCreateAccountPage"/>
         <actionGroup ref="StorefrontFillCustomerAccountCreationFormActionGroup" stepKey="fillCreateAccountForm">
-            <argument name="customer" value="$$customer$$"/>
+            <argument name="customer" value="$$createCustomer$$"/>
         </actionGroup>
-        <actionGroup ref="StorefrontClickCreateAnAccountCustomerAccountCreationFormActionGroup" stepKey="submitCreateAccountForm"/>
+        <remove keyForRemoval="seeSuccessMessage"/>
         <actionGroup ref="AssertMessageCustomerCreateAccountActionGroup" stepKey="seeErrorMessage">
             <argument name="messageType" value="error"/>
             <argument name="message" value="There is already an account with this email address."/>


### PR DESCRIPTION
### Description (*)
The previous test for Create Customer account was based on single ActionGroup that does everything at once. As ActionGroups should have singular responsibility, I used different set.

By the way, I've changed the Failure example to show the best practices when it comes to extending existing tests, to slightly change their behaviour.

Replaced `customer` that was unclear where it comes from to `createCustomer` to show up, that everytime when `createCustomer` is being used, it means that we refer to stepKey

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Run MFTF tests `vendor/bin/mftf run:test -r StorefrontCreateCustomerTest StorefrontCreateExistingCustomerTest`

### Questions or comments
CC: @okolesnyk 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
