### PR TITLE
#27043 update directory path configuration for CLI when document_root…

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Console/CliTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Console/CliTest.php
@@ -86,7 +86,11 @@ class CliTest extends \PHPUnit\Framework\TestCase
     public function testDocumentRootIsPublic($isPub, $params)
     {
         $config = include __DIR__ . '/_files/env.php';
-        $config['directories']['document_root_is_pub'] = $isPub;
+        if ($isPub === null) {
+            unset($config['directories']['document_root_is_pub']);
+        } else {
+            $config['directories']['document_root_is_pub'] = $isPub;
+        }
         $this->writer->saveConfig([ConfigFilePool::APP_ENV => $config], true);
 
         $cli = new Cli();
@@ -123,7 +127,15 @@ class CliTest extends \PHPUnit\Framework\TestCase
                     'upload' => ['uri' => 'media/upload']
                 ]
             ]],
-            [false, []]
+            [false, []],
+            [null, [
+                'MAGE_DIRS' => [
+                    'pub' => ['uri' => ''],
+                    'media' => ['uri' => 'media'],
+                    'static' => ['uri' => 'static'],
+                    'upload' => ['uri' => 'media/upload']
+                ]
+            ]]
         ];
     }
 }

--- a/lib/internal/Magento/Framework/Console/Cli.php
+++ b/lib/internal/Magento/Framework/Console/Cli.php
@@ -245,7 +245,7 @@ class Cli extends Console\Application
     {
         $params = [];
         $deploymentConfig = $this->serviceManager->get(DeploymentConfig::class);
-        if ((bool)$deploymentConfig->get(ConfigOptionsListConstants::CONFIG_PATH_DOCUMENT_ROOT_IS_PUB)) {
+        if ((bool)$deploymentConfig->get(ConfigOptionsListConstants::CONFIG_PATH_DOCUMENT_ROOT_IS_PUB, true)) {
             $params[Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS] = [
                 DirectoryList::PUB => [DirectoryList::URL_PATH => ''],
                 DirectoryList::MEDIA => [DirectoryList::URL_PATH => 'media'],


### PR DESCRIPTION
…_is_pub is not set in env.php

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The following parameter in env.php determines if "pub" will be included in URLs when CLI is used:
```  
 'directories' => [
        'document_root_is_pub' => true
    ]
```
This parameter is not present in env.php by default. This PR adds necessary directory path configuration updates for CLI in case 'document_root_is_pub' is not in env.php.


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#27043: Logo url contains "/pub" in asynchronous command line generated emails

### Manual testing scenarios (*)
See https://github.com/magento/magento2/issues/27043 for steps

