### PR TITLE
Cleanup ObjectManager usage - Magento_Catalog ViewModel,Plugin

### DIFF
--- a/app/code/Magento/Catalog/Plugin/Model/ResourceModel/Config.php
+++ b/app/code/Magento/Catalog/Plugin/Model/ResourceModel/Config.php
@@ -3,9 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Catalog\Plugin\Model\ResourceModel;
 
-use Magento\Framework\App\ObjectManager;
+use Magento\Eav\Model\Cache\Type;
+use Magento\Eav\Model\Entity\Attribute;
+use Magento\Framework\App\Cache\StateInterface;
+use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 
 /**
@@ -21,12 +26,12 @@ class Config
     /**#@-*/
 
     /**#@-*/
-    protected $cache;
+    private $cache;
 
     /**
-     * @var bool|null
+     * @var bool
      */
-    protected $isCacheEnabled = null;
+    private $isCacheEnabled;
 
     /**
      * @var SerializerInterface
@@ -34,30 +39,30 @@ class Config
     private $serializer;
 
     /**
-     * @param \Magento\Framework\App\CacheInterface $cache
-     * @param \Magento\Framework\App\Cache\StateInterface $cacheState
+     * @param CacheInterface $cache
+     * @param StateInterface $cacheState
      * @param SerializerInterface $serializer
      */
     public function __construct(
-        \Magento\Framework\App\CacheInterface $cache,
-        \Magento\Framework\App\Cache\StateInterface $cacheState,
-        SerializerInterface $serializer = null
+        CacheInterface $cache,
+        StateInterface $cacheState,
+        SerializerInterface $serializer
     ) {
         $this->cache = $cache;
-        $this->isCacheEnabled = $cacheState->isEnabled(\Magento\Eav\Model\Cache\Type::TYPE_IDENTIFIER);
-        $this->serializer = $serializer ?: ObjectManager::getInstance()->get(SerializerInterface::class);
+        $this->isCacheEnabled = $cacheState->isEnabled(Type::TYPE_IDENTIFIER);
+        $this->serializer = $serializer;
     }
 
     /**
      * Cache attribute used in listing.
      *
      * @param \Magento\Catalog\Model\ResourceModel\Config $config
-     * @param \Closure $proceed
+     * @param callable $proceed
      * @return array
      */
     public function aroundGetAttributesUsedInListing(
         \Magento\Catalog\Model\ResourceModel\Config $config,
-        \Closure $proceed
+        callable $proceed
     ) {
         $cacheId = self::PRODUCT_LISTING_ATTRIBUTES_CACHE_ID . $config->getEntityTypeId() . '_' . $config->getStoreId();
         if ($this->isCacheEnabled && ($attributes = $this->cache->load($cacheId))) {
@@ -69,8 +74,8 @@ class Config
                 $this->serializer->serialize($attributes),
                 $cacheId,
                 [
-                    \Magento\Eav\Model\Cache\Type::CACHE_TAG,
-                    \Magento\Eav\Model\Entity\Attribute::CACHE_TAG
+                    Type::CACHE_TAG,
+                    Attribute::CACHE_TAG
                 ]
             );
         }
@@ -81,12 +86,12 @@ class Config
      * Cache attributes used for sorting.
      *
      * @param \Magento\Catalog\Model\ResourceModel\Config $config
-     * @param \Closure $proceed
+     * @param callable $proceed
      * @return array
      */
     public function aroundGetAttributesUsedForSortBy(
         \Magento\Catalog\Model\ResourceModel\Config $config,
-        \Closure $proceed
+        callable $proceed
     ) {
         $cacheId = self::PRODUCT_LISTING_SORT_BY_ATTRIBUTES_CACHE_ID . $config->getEntityTypeId() . '_'
             . $config->getStoreId();
@@ -99,8 +104,8 @@ class Config
                 $this->serializer->serialize($attributes),
                 $cacheId,
                 [
-                    \Magento\Eav\Model\Cache\Type::CACHE_TAG,
-                    \Magento\Eav\Model\Entity\Attribute::CACHE_TAG
+                    Type::CACHE_TAG,
+                    Attribute::CACHE_TAG
                 ]
             );
         }

--- a/app/code/Magento/Catalog/Test/Unit/Plugin/Model/ResourceModel/ConfigTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Plugin/Model/ResourceModel/ConfigTest.php
@@ -3,43 +3,59 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Catalog\Test\Unit\Plugin\Model\ResourceModel;
 
+use Magento\Catalog\Model\ResourceModel\Config as ConfigResourceModel;
 use Magento\Catalog\Plugin\Model\ResourceModel\Config;
+use Magento\Eav\Model\Cache\Type;
+use Magento\Eav\Model\Entity\Attribute;
+use Magento\Framework\App\Cache\StateInterface;
+use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class ConfigTest extends \PHPUnit\Framework\TestCase
+class ConfigTest extends TestCase
 {
-    /** @var \Magento\Framework\App\CacheInterface|\PHPUnit_Framework_MockObject_MockObject */
-    private $cache;
+    /**
+     * @var CacheInterface|MockObject
+     */
+    private $cacheMock;
 
-    /** @var \Magento\Framework\App\Cache\StateInterface|\PHPUnit_Framework_MockObject_MockObject */
-    private $cacheState;
+    /**
+     * @var StateInterface|MockObject
+     */
+    private $cacheStateMock;
 
-    /** @var SerializerInterface|\PHPUnit_Framework_MockObject_MockObject */
-    private $serializer;
+    /**
+     * @var SerializerInterface|MockObject
+     */
+    private $serializerMock;
 
-    /** @var \Magento\Catalog\Model\ResourceModel\Config|\PHPUnit_Framework_MockObject_MockObject */
-    private $subject;
+    /**
+     * @var ConfigResourceModel|MockObject
+     */
+    private $configResourceModelMock;
 
     protected function setUp()
     {
-        $this->cache = $this->createMock(\Magento\Framework\App\CacheInterface::class);
-        $this->cacheState = $this->createMock(\Magento\Framework\App\Cache\StateInterface::class);
-        $this->serializer = $this->createMock(SerializerInterface::class);
-        $this->subject = $this->createMock(\Magento\Catalog\Model\ResourceModel\Config::class);
+        $this->cacheMock = $this->createMock(CacheInterface::class);
+        $this->cacheStateMock = $this->createMock(StateInterface::class);
+        $this->serializerMock = $this->createMock(SerializerInterface::class);
+        $this->configResourceModelMock = $this->createMock(ConfigResourceModel::class);
     }
 
     public function testGetAttributesUsedInListingOnCacheDisabled()
     {
-        $this->cache->expects($this->never())->method('load');
+        $this->cacheMock->expects($this->never())->method('load');
 
         $this->assertEquals(
             ['attributes'],
             $this->getConfig(false)->aroundGetAttributesUsedInListing(
-                $this->subject,
+                $this->configResourceModelMock,
                 $this->mockPluginProceed(['attributes'])
             )
         );
@@ -51,13 +67,13 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $storeId = 'store';
         $attributes = ['attributes'];
         $serializedAttributes = '["attributes"]';
-        $this->subject->expects($this->any())->method('getEntityTypeId')->willReturn($entityTypeId);
-        $this->subject->expects($this->any())->method('getStoreId')->willReturn($storeId);
-        $cacheId = \Magento\Catalog\Plugin\Model\ResourceModel\Config::PRODUCT_LISTING_ATTRIBUTES_CACHE_ID
+        $this->configResourceModelMock->method('getEntityTypeId')->willReturn($entityTypeId);
+        $this->configResourceModelMock->method('getStoreId')->willReturn($storeId);
+        $cacheId = Config::PRODUCT_LISTING_ATTRIBUTES_CACHE_ID
             . $entityTypeId
             . '_' . $storeId;
-        $this->cache->expects($this->any())->method('load')->with($cacheId)->willReturn($serializedAttributes);
-        $this->serializer->expects($this->once())
+        $this->cacheMock->method('load')->with($cacheId)->willReturn($serializedAttributes);
+        $this->serializerMock->expects($this->once())
             ->method('unserialize')
             ->with($serializedAttributes)
             ->willReturn($attributes);
@@ -65,7 +81,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             $attributes,
             $this->getConfig(true)->aroundGetAttributesUsedInListing(
-                $this->subject,
+                $this->configResourceModelMock,
                 $this->mockPluginProceed()
             )
         );
@@ -77,31 +93,31 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $storeId = 'store';
         $attributes = ['attributes'];
         $serializedAttributes = '["attributes"]';
-        $this->subject->expects($this->any())->method('getEntityTypeId')->willReturn($entityTypeId);
-        $this->subject->expects($this->any())->method('getStoreId')->willReturn($storeId);
-        $cacheId = \Magento\Catalog\Plugin\Model\ResourceModel\Config::PRODUCT_LISTING_ATTRIBUTES_CACHE_ID
+        $this->configResourceModelMock->method('getEntityTypeId')->willReturn($entityTypeId);
+        $this->configResourceModelMock->method('getStoreId')->willReturn($storeId);
+        $cacheId = Config::PRODUCT_LISTING_ATTRIBUTES_CACHE_ID
             . $entityTypeId
             . '_' . $storeId;
-        $this->cache->expects($this->any())->method('load')->with($cacheId)->willReturn(false);
-        $this->serializer->expects($this->never())
+        $this->cacheMock->method('load')->with($cacheId)->willReturn(false);
+        $this->serializerMock->expects($this->never())
             ->method('unserialize');
-        $this->serializer->expects($this->once())
+        $this->serializerMock->expects($this->once())
             ->method('serialize')
             ->with($attributes)
             ->willReturn($serializedAttributes);
-        $this->cache->expects($this->any())->method('save')->with(
+        $this->cacheMock->method('save')->with(
             $serializedAttributes,
             $cacheId,
             [
-                \Magento\Eav\Model\Cache\Type::CACHE_TAG,
-                \Magento\Eav\Model\Entity\Attribute::CACHE_TAG
+                Type::CACHE_TAG,
+                Attribute::CACHE_TAG
             ]
         );
 
         $this->assertEquals(
             $attributes,
             $this->getConfig(true)->aroundGetAttributesUsedInListing(
-                $this->subject,
+                $this->configResourceModelMock,
                 $this->mockPluginProceed($attributes)
             )
         );
@@ -109,12 +125,12 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
 
     public function testGetAttributesUsedForSortByOnCacheDisabled()
     {
-        $this->cache->expects($this->never())->method('load');
+        $this->cacheMock->expects($this->never())->method('load');
 
         $this->assertEquals(
             ['attributes'],
             $this->getConfig(false)->aroundGetAttributesUsedForSortBy(
-                $this->subject,
+                $this->configResourceModelMock,
                 $this->mockPluginProceed(['attributes'])
             )
         );
@@ -126,12 +142,12 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $storeId = 'store';
         $attributes = ['attributes'];
         $serializedAttributes = '["attributes"]';
-        $this->subject->expects($this->any())->method('getEntityTypeId')->willReturn($entityTypeId);
-        $this->subject->expects($this->any())->method('getStoreId')->willReturn($storeId);
-        $cacheId = \Magento\Catalog\Plugin\Model\ResourceModel\Config::PRODUCT_LISTING_SORT_BY_ATTRIBUTES_CACHE_ID
+        $this->configResourceModelMock->method('getEntityTypeId')->willReturn($entityTypeId);
+        $this->configResourceModelMock->method('getStoreId')->willReturn($storeId);
+        $cacheId = Config::PRODUCT_LISTING_SORT_BY_ATTRIBUTES_CACHE_ID
             . $entityTypeId . '_' . $storeId;
-        $this->cache->expects($this->any())->method('load')->with($cacheId)->willReturn($serializedAttributes);
-        $this->serializer->expects($this->once())
+        $this->cacheMock->method('load')->with($cacheId)->willReturn($serializedAttributes);
+        $this->serializerMock->expects($this->once())
             ->method('unserialize')
             ->with($serializedAttributes)
             ->willReturn($attributes);
@@ -139,7 +155,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(
             $attributes,
             $this->getConfig(true)->aroundGetAttributesUsedForSortBy(
-                $this->subject,
+                $this->configResourceModelMock,
                 $this->mockPluginProceed()
             )
         );
@@ -151,30 +167,30 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $storeId = 'store';
         $attributes = ['attributes'];
         $serializedAttributes = '["attributes"]';
-        $this->subject->expects($this->any())->method('getEntityTypeId')->willReturn($entityTypeId);
-        $this->subject->expects($this->any())->method('getStoreId')->willReturn($storeId);
-        $cacheId = \Magento\Catalog\Plugin\Model\ResourceModel\Config::PRODUCT_LISTING_SORT_BY_ATTRIBUTES_CACHE_ID
+        $this->configResourceModelMock->method('getEntityTypeId')->willReturn($entityTypeId);
+        $this->configResourceModelMock->method('getStoreId')->willReturn($storeId);
+        $cacheId = Config::PRODUCT_LISTING_SORT_BY_ATTRIBUTES_CACHE_ID
             . $entityTypeId . '_' . $storeId;
-        $this->cache->expects($this->any())->method('load')->with($cacheId)->willReturn(false);
-        $this->serializer->expects($this->never())
+        $this->cacheMock->method('load')->with($cacheId)->willReturn(false);
+        $this->serializerMock->expects($this->never())
             ->method('unserialize');
-        $this->serializer->expects($this->once())
+        $this->serializerMock->expects($this->once())
             ->method('serialize')
             ->with($attributes)
             ->willReturn($serializedAttributes);
-        $this->cache->expects($this->any())->method('save')->with(
+        $this->cacheMock->method('save')->with(
             $serializedAttributes,
             $cacheId,
             [
-                \Magento\Eav\Model\Cache\Type::CACHE_TAG,
-                \Magento\Eav\Model\Entity\Attribute::CACHE_TAG
+                Type::CACHE_TAG,
+                Attribute::CACHE_TAG
             ]
         );
 
         $this->assertEquals(
             $attributes,
             $this->getConfig(true)->aroundGetAttributesUsedForSortBy(
-                $this->subject,
+                $this->configResourceModelMock,
                 $this->mockPluginProceed($attributes)
             )
         );
@@ -182,29 +198,33 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @param bool $cacheEnabledFlag
-     * @return \Magento\Catalog\Plugin\Model\ResourceModel\Config
+     *
+     * @return Config
      */
     protected function getConfig($cacheEnabledFlag)
     {
-        $this->cacheState->expects($this->any())->method('isEnabled')
-            ->with(\Magento\Eav\Model\Cache\Type::TYPE_IDENTIFIER)->willReturn($cacheEnabledFlag);
+        $this->cacheStateMock->method('isEnabled')
+            ->with(Type::TYPE_IDENTIFIER)
+            ->willReturn($cacheEnabledFlag);
+
         return (new ObjectManager($this))->getObject(
-            \Magento\Catalog\Plugin\Model\ResourceModel\Config::class,
+            Config::class,
             [
-                'cache' => $this->cache,
-                'cacheState' => $this->cacheState,
-                'serializer' => $this->serializer,
+                'cache' => $this->cacheMock,
+                'cacheState' => $this->cacheStateMock,
+                'serializer' => $this->serializerMock,
             ]
         );
     }
 
     /**
      * @param mixed $returnValue
+     *
      * @return callable
      */
     protected function mockPluginProceed($returnValue = null)
     {
-        return function () use ($returnValue) {
+        return static function () use ($returnValue) {
             return $returnValue;
         };
     }

--- a/app/code/Magento/Catalog/Test/Unit/ViewModel/Product/BreadcrumbsTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/ViewModel/Product/BreadcrumbsTest.php
@@ -11,28 +11,25 @@ use Magento\Catalog\Helper\Data as CatalogHelper;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\ViewModel\Product\Breadcrumbs;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Escaper;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\Serialize\Serializer\JsonHexTag;
+use Magento\Store\Model\ScopeInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit test for Magento\Catalog\ViewModel\Product\Breadcrumbs.
  */
-class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
+class BreadcrumbsTest extends TestCase
 {
+    private const XML_PATH_CATEGORY_URL_SUFFIX = 'catalog/seo/category_url_suffix';
+    private const XML_PATH_PRODUCT_USE_CATEGORIES = 'catalog/seo/product_use_categories';
+
     /**
      * @var Breadcrumbs
      */
     private $viewModel;
-
-    /**
-     * @var CatalogHelper|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $catalogHelper;
-
-    /**
-     * @var ScopeConfigInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $scopeConfig;
 
     /**
      * @var ObjectManager
@@ -40,36 +37,46 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
     private $objectManager;
 
     /**
-     * @var JsonHexTag|\PHPUnit_Framework_MockObject_MockObject
+     * @var CatalogHelper|MockObject
      */
-    private $serializer;
+    private $catalogHelperMock;
+
+    /**
+     * @var ScopeConfigInterface|MockObject
+     */
+    private $scopeConfigMock;
+
+    /**
+     * @var JsonHexTag|MockObject
+     */
+    private $serializerMock;
 
     /**
      * @inheritdoc
      */
     protected function setUp() : void
     {
-        $this->catalogHelper = $this->getMockBuilder(CatalogHelper::class)
+        $this->catalogHelperMock = $this->getMockBuilder(CatalogHelper::class)
             ->setMethods(['getProduct'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->scopeConfig = $this->getMockBuilder(ScopeConfigInterface::class)
+        $this->scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)
             ->setMethods(['getValue', 'isSetFlag'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
-        $escaper = $this->getObjectManager()->getObject(\Magento\Framework\Escaper::class);
+        $escaper = $this->getObjectManager()->getObject(Escaper::class);
 
-        $this->serializer = $this->createMock(JsonHexTag::class);
+        $this->serializerMock = $this->createMock(JsonHexTag::class);
 
         $this->viewModel = $this->getObjectManager()->getObject(
             Breadcrumbs::class,
             [
-                'catalogData' => $this->catalogHelper,
-                'scopeConfig' => $this->scopeConfig,
+                'catalogData' => $this->catalogHelperMock,
+                'scopeConfig' => $this->scopeConfigMock,
                 'escaper' => $escaper,
-                'jsonSerializer' => $this->serializer
+                'jsonSerializer' => $this->serializerMock
             ]
         );
     }
@@ -79,9 +86,9 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetCategoryUrlSuffix() : void
     {
-        $this->scopeConfig->expects($this->once())
+        $this->scopeConfigMock->expects($this->once())
             ->method('getValue')
-            ->with('catalog/seo/category_url_suffix', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->with(static::XML_PATH_CATEGORY_URL_SUFFIX, ScopeInterface::SCOPE_STORE)
             ->willReturn('.html');
 
         $this->assertEquals('.html', $this->viewModel->getCategoryUrlSuffix());
@@ -92,9 +99,9 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
      */
     public function testIsCategoryUsedInProductUrl() : void
     {
-        $this->scopeConfig->expects($this->once())
+        $this->scopeConfigMock->expects($this->once())
             ->method('isSetFlag')
-            ->with('catalog/seo/product_use_categories', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->with(static::XML_PATH_PRODUCT_USE_CATEGORIES, ScopeInterface::SCOPE_STORE)
             ->willReturn(false);
 
         $this->assertFalse($this->viewModel->isCategoryUsedInProductUrl());
@@ -105,11 +112,12 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
      *
      * @param Product|null $product
      * @param string $expectedName
+     *
      * @return void
      */
     public function testGetProductName($product, string $expectedName) : void
     {
-        $this->catalogHelper->expects($this->atLeastOnce())
+        $this->catalogHelperMock->expects($this->atLeastOnce())
             ->method('getProduct')
             ->willReturn($product);
 
@@ -132,27 +140,26 @@ class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
      *
      * @param Product|null $product
      * @param string $expectedJson
+     *
      * @return void
      */
-    public function testGetJsonConfiguration($product, string $expectedJson) : void
+    public function testGetJsonConfigurationHtmlEscaped($product, string $expectedJson) : void
     {
-        $this->catalogHelper->expects($this->atLeastOnce())
+        $this->catalogHelperMock->expects($this->atLeastOnce())
             ->method('getProduct')
             ->willReturn($product);
 
-        $this->scopeConfig->expects($this->any())
-            ->method('isSetFlag')
-            ->with('catalog/seo/product_use_categories', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+        $this->scopeConfigMock->method('isSetFlag')
+            ->with(static::XML_PATH_PRODUCT_USE_CATEGORIES, ScopeInterface::SCOPE_STORE)
             ->willReturn(false);
 
-        $this->scopeConfig->expects($this->any())
-            ->method('getValue')
-            ->with('catalog/seo/category_url_suffix', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+        $this->scopeConfigMock->method('getValue')
+            ->with(static::XML_PATH_CATEGORY_URL_SUFFIX, ScopeInterface::SCOPE_STORE)
             ->willReturn('."html');
 
-        $this->serializer->expects($this->once())->method('serialize')->willReturn($expectedJson);
+        $this->serializerMock->expects($this->once())->method('serialize')->willReturn($expectedJson);
 
-        $this->assertEquals($expectedJson, $this->viewModel->getJsonConfiguration());
+        $this->assertEquals($expectedJson, $this->viewModel->getJsonConfigurationHtmlEscaped());
     }
 
     /**

--- a/app/code/Magento/Catalog/ViewModel/Product/Breadcrumbs.php
+++ b/app/code/Magento/Catalog/ViewModel/Product/Breadcrumbs.php
@@ -3,26 +3,27 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Catalog\ViewModel\Product;
 
 use Magento\Catalog\Helper\Data;
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\App\ObjectManager;
 use Magento\Framework\DataObject;
-use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\Serialize\Serializer\JsonHexTag;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Magento\Framework\Escaper;
+use Magento\Store\Model\ScopeInterface;
 
 /**
  * Product breadcrumbs view model.
  */
 class Breadcrumbs extends DataObject implements ArgumentInterface
 {
+    private const XML_PATH_CATEGORY_URL_SUFFIX = 'catalog/seo/category_url_suffix';
+    private const XML_PATH_PRODUCT_USE_CATEGORIES = 'catalog/seo/product_use_categories';
+
     /**
-     * Catalog data.
-     *
      * @var Data
      */
     private $catalogData;
@@ -45,24 +46,21 @@ class Breadcrumbs extends DataObject implements ArgumentInterface
     /**
      * @param Data $catalogData
      * @param ScopeConfigInterface $scopeConfig
-     * @param Json|null $json
-     * @param Escaper|null $escaper
-     * @param JsonHexTag|null $jsonSerializer
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @param Escaper $escaper
+     * @param JsonHexTag $jsonSerializer
      */
     public function __construct(
         Data $catalogData,
         ScopeConfigInterface $scopeConfig,
-        Json $json = null,
-        Escaper $escaper = null,
-        JsonHexTag $jsonSerializer = null
+        Escaper $escaper,
+        JsonHexTag $jsonSerializer
     ) {
         parent::__construct();
 
         $this->catalogData = $catalogData;
         $this->scopeConfig = $scopeConfig;
-        $this->escaper = $escaper ?: ObjectManager::getInstance()->get(Escaper::class);
-        $this->jsonSerializer = $jsonSerializer ?: ObjectManager::getInstance()->get(JsonHexTag::class);
+        $this->escaper = $escaper;
+        $this->jsonSerializer = $jsonSerializer;
     }
 
     /**
@@ -73,8 +71,8 @@ class Breadcrumbs extends DataObject implements ArgumentInterface
     public function getCategoryUrlSuffix()
     {
         return $this->scopeConfig->getValue(
-            'catalog/seo/category_url_suffix',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            static::XML_PATH_CATEGORY_URL_SUFFIX,
+            ScopeInterface::SCOPE_STORE
         );
     }
 
@@ -86,8 +84,8 @@ class Breadcrumbs extends DataObject implements ArgumentInterface
     public function isCategoryUsedInProductUrl(): bool
     {
         return $this->scopeConfig->isSetFlag(
-            'catalog/seo/product_use_categories',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            static::XML_PATH_PRODUCT_USE_CATEGORIES,
+            ScopeInterface::SCOPE_STORE
         );
     }
 
@@ -108,7 +106,7 @@ class Breadcrumbs extends DataObject implements ArgumentInterface
      *
      * @return string
      */
-    public function getJsonConfigurationHtmlEscaped() : string
+    public function getJsonConfigurationHtmlEscaped(): string
     {
         return $this->jsonSerializer->serialize(
             [
@@ -119,16 +117,5 @@ class Breadcrumbs extends DataObject implements ArgumentInterface
                 ]
             ]
         );
-    }
-
-    /**
-     * Returns breadcrumb json.
-     *
-     * @return string
-     * @deprecated in favor of new method with name {suffix}Html{postfix}()
-     */
-    public function getJsonConfiguration()
-    {
-        return $this->getJsonConfigurationHtmlEscaped();
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR cleanups ObjectManager usage in Magento_Catalog ViewModel and Plugin, by removing object manager instantiation from non-api classes. This is first part of https://github.com/magento/magento2/pull/27135 split into smaller chunks to proceed it easily.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
N/A

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
