### PR TITLE
Fix issue 27162 sort order link incorrect compare

### DIFF
--- a/app/code/Magento/Customer/Block/Account/Navigation.php
+++ b/app/code/Magento/Customer/Block/Account/Navigation.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 
 namespace Magento\Customer\Block\Account;
 
-use \Magento\Framework\View\Element\Html\Links;
-use \Magento\Customer\Block\Account\SortLinkInterface;
+use Magento\Framework\View\Element\Html\Links;
+use Magento\Customer\Block\Account\SortLinkInterface;
 
 /**
  * Class for sorting links in navigation panels.
@@ -19,7 +19,7 @@ use \Magento\Customer\Block\Account\SortLinkInterface;
 class Navigation extends Links
 {
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      * @since 100.2.0
      */
     public function getLinks()
@@ -47,6 +47,6 @@ class Navigation extends Links
      */
     private function compare(SortLinkInterface $firstLink, SortLinkInterface $secondLink): int
     {
-        return  $secondLink->getSortOrder() <=> $firstLink->getSortOrder();
+        return $firstLink->getSortOrder() <=> $secondLink->getSortOrder();
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Block/Account/NavigationTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Account/NavigationTest.php
@@ -19,6 +19,11 @@ use PHPUnit\Framework\TestCase;
 class NavigationTest extends TestCase
 {
     /**
+     * Stub name top links
+     */
+    private const STUB_TOP_LINKS_NAME_IN_LAYOUT = 'top.links';
+
+    /**
      * @var ObjectManagerHelper
      */
     private $objectManagerHelper;
@@ -62,7 +67,7 @@ class NavigationTest extends TestCase
      *
      * @return void
      */
-    public function testGetLinksWithCustomerAndWishList()
+    public function testGetLinksWithCustomerAndWishList(): void
     {
         $wishListLinkMock = $this->getMockBuilder(WishListLink::class)
             ->disableOriginalConstructor()
@@ -76,30 +81,30 @@ class NavigationTest extends TestCase
 
         $wishListLinkMock->expects($this->any())
             ->method('getSortOrder')
-            ->willReturn(100);
+            ->willReturn(30);
 
         $customerAccountLinkMock->expects($this->any())
             ->method('getSortOrder')
-            ->willReturn(20);
+            ->willReturn(0);
 
-        $nameInLayout = 'top.links';
+        $topLinksNameInLayout = self::STUB_TOP_LINKS_NAME_IN_LAYOUT;
 
         $blockChildren = [
-            'wishListLink' => $wishListLinkMock,
-            'customerAccountLink' => $customerAccountLinkMock
+            'customerAccountLink' => $customerAccountLinkMock,
+            'wishListLink' => $wishListLinkMock
         ];
 
-        $this->navigation->setNameInLayout($nameInLayout);
+        $this->navigation->setNameInLayout($topLinksNameInLayout);
         $this->layoutMock->expects($this->any())
             ->method('getChildBlocks')
-            ->with($nameInLayout)
+            ->with($topLinksNameInLayout)
             ->willReturn($blockChildren);
 
         /* Assertion */
         $this->assertEquals(
             [
-                0 => $wishListLinkMock,
-                1 => $customerAccountLinkMock
+                0 => $customerAccountLinkMock,
+                1 => $wishListLinkMock
             ],
             $this->navigation->getLinks()
         );

--- a/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/customer_account.xml
@@ -24,31 +24,31 @@
                         <arguments>
                             <argument name="label" xsi:type="string" translate="true">My Account</argument>
                             <argument name="path" xsi:type="string">customer/account</argument>
-                            <argument name="sortOrder" xsi:type="number">250</argument>
+                            <argument name="sortOrder" xsi:type="number">1</argument>
                         </arguments>
                     </block>
                     <block class="Magento\Customer\Block\Account\Delimiter" name="customer-account-navigation-delimiter-1" template="Magento_Customer::account/navigation-delimiter.phtml">
                         <arguments>
-                            <argument name="sortOrder" xsi:type="number">200</argument>
+                            <argument name="sortOrder" xsi:type="number">40</argument>
                         </arguments>
                     </block>
                     <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-address-link">
                         <arguments>
                             <argument name="label" xsi:type="string" translate="true">Address Book</argument>
                             <argument name="path" xsi:type="string">customer/address</argument>
-                            <argument name="sortOrder" xsi:type="number">190</argument>
+                            <argument name="sortOrder" xsi:type="number">50</argument>
                         </arguments>
                     </block>
                     <block class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-account-edit-link">
                         <arguments>
                             <argument name="label" xsi:type="string" translate="true">Account Information</argument>
                             <argument name="path" xsi:type="string">customer/account/edit</argument>
-                            <argument name="sortOrder" xsi:type="number">180</argument>
+                            <argument name="sortOrder" xsi:type="number">60</argument>
                         </arguments>
                     </block>
                     <block class="Magento\Customer\Block\Account\Delimiter" name="customer-account-navigation-delimiter-2" template="Magento_Customer::account/navigation-delimiter.phtml">
                         <arguments>
-                            <argument name="sortOrder" xsi:type="number">130</argument>
+                            <argument name="sortOrder" xsi:type="number">90</argument>
                         </arguments>
                     </block>
                 </block>

--- a/app/code/Magento/Customer/view/frontend/layout/default.xml
+++ b/app/code/Magento/Customer/view/frontend/layout/default.xml
@@ -8,10 +8,10 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="top.links">
-            <block class="Magento\Customer\Block\Account\Link" name="my-account-link">
+            <block class="Magento\Customer\Block\Account\Link" name="my-account-link" template="Magento_Customer::account/link/my-account.phtml">
                 <arguments>
                     <argument name="label" xsi:type="string" translate="true">My Account</argument>
-                    <argument name="sortOrder" xsi:type="number">110</argument>
+                    <argument name="sortOrder" xsi:type="number">1</argument>
                 </arguments>
             </block>
             <block class="Magento\Customer\Block\Account\RegisterLink" name="register-link">
@@ -20,7 +20,11 @@
                 </arguments>
             </block>
             <block class="Magento\Customer\Block\Account\AuthorizationLink" name="authorization-link"
-                   template="Magento_Customer::account/link/authorization.phtml"/>
+                   template="Magento_Customer::account/link/authorization.phtml">
+                <arguments>
+                    <argument name="sortOrder" xsi:type="number">30</argument>
+                </arguments>
+            </block>
         </referenceBlock>
         <referenceContainer name="content">
             <block class="Magento\Customer\Block\Account\AuthenticationPopup" name="authentication-popup" as="authentication-popup" template="Magento_Customer::account/authentication-popup.phtml">

--- a/app/code/Magento/Customer/view/frontend/templates/account/link/authorization.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/link/authorization.phtml
@@ -11,8 +11,7 @@ if ($block->isLoggedIn()) {
     $dataPostParam = sprintf(" data-post='%s'", $block->getPostParams());
 }
 ?>
-<li class="authorization-link" data-label="<?= $block->escapeHtml(__('or')) ?>">
-    <a <?= /* @noEscape */ $block->getLinkAttributes() ?><?= /* @noEscape */ $dataPostParam ?>>
-        <?= $block->escapeHtml($block->getLabel()) ?>
-    </a>
+<li class="link authorization-link" data-label="<?= $block->escapeHtml(__('or')) ?>">
+    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>
+        <?= /* @noEscape */ $dataPostParam ?>><?= $block->escapeHtml($block->getLabel()) ?></a>
 </li>

--- a/app/code/Magento/Customer/view/frontend/templates/account/link/authorization.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/link/authorization.phtml
@@ -4,14 +4,16 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Account\AuthorizationLink $block */
-
+/**
+ * @var \Magento\Customer\Block\Account\AuthorizationLink $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 $dataPostParam = '';
 if ($block->isLoggedIn()) {
     $dataPostParam = sprintf(" data-post='%s'", $block->getPostParams());
 }
 ?>
-<li class="link authorization-link" data-label="<?= $block->escapeHtml(__('or')) ?>">
+<li class="link authorization-link" data-label="<?= $escaper->escapeHtml(__('or')) ?>">
     <a <?= /* @noEscape */ $block->getLinkAttributes() ?>
-        <?= /* @noEscape */ $dataPostParam ?>><?= $block->escapeHtml($block->getLabel()) ?></a>
+        <?= /* @noEscape */ $dataPostParam ?>><?= $escaper->escapeHtml($block->getLabel()) ?></a>
 </li>

--- a/app/code/Magento/Customer/view/frontend/templates/account/link/my-account.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/link/my-account.phtml
@@ -4,9 +4,11 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Account\Link $block */
-
+/**
+ * @var \Magento\Customer\Block\Account\Link $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <li class="link my-account-link">
-    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>><?= $block->escapeHtml($block->getLabel()) ?></a>
+    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>><?= $escaper->escapeHtml($block->getLabel()) ?></a>
 </li>

--- a/app/code/Magento/Customer/view/frontend/templates/account/link/my-account.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/link/my-account.phtml
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/** @var \Magento\Customer\Block\Account\Link $block */
+
+?>
+<li class="link my-account-link">
+    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>><?= $block->escapeHtml($block->getLabel()) ?></a>
+</li>

--- a/app/code/Magento/Downloadable/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/customer_account.xml
@@ -12,7 +12,7 @@
                 <arguments>
                     <argument name="path" xsi:type="string">downloadable/customer/products</argument>
                     <argument name="label" xsi:type="string" translate="true">My Downloadable Products</argument>
-                    <argument name="sortOrder" xsi:type="number">217</argument>
+                    <argument name="sortOrder" xsi:type="number">20</argument>
                 </arguments>
             </block>
         </referenceBlock>

--- a/app/code/Magento/Newsletter/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Newsletter/view/frontend/layout/customer_account.xml
@@ -12,7 +12,7 @@
                 <arguments>
                     <argument name="path" xsi:type="string">newsletter/manage</argument>
                     <argument name="label" xsi:type="string" translate="true">Newsletter Subscriptions</argument>
-                    <argument name="sortOrder" xsi:type="number">40</argument>
+                    <argument name="sortOrder" xsi:type="number">110</argument>
                 </arguments>
             </block>
         </referenceBlock>

--- a/app/code/Magento/Paypal/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Paypal/view/frontend/layout/customer_account.xml
@@ -16,7 +16,7 @@
                 <arguments>
                     <argument name="path" xsi:type="string">paypal/billing_agreement</argument>
                     <argument name="label" xsi:type="string" translate="true">Billing Agreements</argument>
-                    <argument name="sortOrder" xsi:type="number">140</argument>
+                    <argument name="sortOrder" xsi:type="number">80</argument>
                 </arguments>
             </block>
         </referenceBlock>

--- a/app/code/Magento/Review/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Review/view/frontend/layout/customer_account.xml
@@ -12,7 +12,7 @@
                 <arguments>
                     <argument name="path" xsi:type="string">review/customer</argument>
                     <argument name="label" xsi:type="string" translate="true">My Product Reviews</argument>
-                    <argument name="sortOrder" xsi:type="number">50</argument>
+                    <argument name="sortOrder" xsi:type="number">100</argument>
                 </arguments>
             </block>
         </referenceBlock>

--- a/app/code/Magento/Sales/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/customer_account.xml
@@ -12,7 +12,7 @@
                 <arguments>
                     <argument name="path" xsi:type="string">sales/order/history</argument>
                     <argument name="label" xsi:type="string" translate="true">My Orders</argument>
-                    <argument name="sortOrder" xsi:type="number">230</argument>
+                    <argument name="sortOrder" xsi:type="number">10</argument>
                 </arguments>
             </block>
         </referenceBlock>

--- a/app/code/Magento/Vault/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Vault/view/frontend/layout/customer_account.xml
@@ -15,7 +15,7 @@
                 <arguments>
                     <argument name="path" xsi:type="string">vault/cards/listaction</argument>
                     <argument name="label" xsi:type="string" translate="true">Stored Payment Methods</argument>
-                    <argument name="sortOrder" xsi:type="number">160</argument>
+                    <argument name="sortOrder" xsi:type="number">70</argument>
                 </arguments>
             </block>
         </referenceBlock>

--- a/app/code/Magento/Wishlist/view/frontend/layout/customer_account.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/customer_account.xml
@@ -12,7 +12,7 @@
                 <arguments>
                     <argument name="path" xsi:type="string">wishlist</argument>
                     <argument name="label" xsi:type="string" translate="true">My Wish List</argument>
-                    <argument name="sortOrder" xsi:type="number">210</argument>
+                    <argument name="sortOrder" xsi:type="number">30</argument>
                 </arguments>
             </block>
         </referenceBlock>

--- a/app/code/Magento/Wishlist/view/frontend/layout/default.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/default.xml
@@ -13,7 +13,7 @@
         <referenceBlock name="top.links">
             <block class="Magento\Wishlist\Block\Link" name="wish-list-link" after="my-account-link">
                 <arguments>
-                    <argument name="sortOrder" xsi:type="number">60</argument>
+                    <argument name="sortOrder" xsi:type="number">30</argument>
                 </arguments>
             </block>
         </referenceBlock>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Previously sortOrder number of links not working as aspect. Lower number mean start first. Higher number will stay at last. Seem issue caused by previous changes. Just correct it again

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#27162: SortOrder is reversed in layout XML

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
After this changes can make order of some links in customer navigation account changed

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
