### PR TITLE
Exception in getMediaGalleryImages()

### DIFF
--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -1528,7 +1528,7 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
         if (!$this->hasData('media_gallery_images')) {
             $this->setData('media_gallery_images', $this->_collectionFactory->create());
         }
-        if (!$this->getData('media_gallery_images')->count() && is_array($this->getMediaGallery('images'))) {
+        if (!is_array($this->getData('media_gallery_images')) && is_array($this->getMediaGallery('images'))) {
             $images = $this->getData('media_gallery_images');
             foreach ($this->getMediaGallery('images') as $image) {
                 if (!empty($image['disabled'])


### PR DESCRIPTION
Trying to access a member function count() on array result in this error:
PHP Fatal error: Uncaught Error: Call to a member function count() on array in /vendor/magento/module-catalog/Model/Product.php:1533
Stack trace:
#0 /vendor/magento/module-configurable-product/Block/Plugin/Product/Media/Gallery.php(62): Magento\Catalog\Model\Product->getMediaGalleryImages()
#1 /vendor/magento/module-configurable-product/Block/Plugin/Product/Media/Gallery.php(49): Magento\ConfigurableProduct\Block\Plugin\Product\Media\Gallery->getProductGallery(Object(Magento\Catalog\Model\Product\Interceptor))
#2 /vendor/magento/framework/Interception/Interceptor.php(146): Magento\ConfigurableProduct\Block\Plugin\Product\Media\Gallery->afterGetOptionsMediaGalleryDataJson(Object(Magento\ProductVideo\Block\Product\View\Gallery\Interceptor), Array)