### PR TITLE
Move JS module initialization to separate tasks

### DIFF
--- a/lib/web/mage/apply/main.js
+++ b/lib/web/mage/apply/main.js
@@ -32,6 +32,7 @@ define([
                 fn = fn.bind(null, config, el);
             } else {
                 $el = $(el);
+
                 if ($el[component]) {
                     fn = $el[component].bind($el, config);
                 }

--- a/lib/web/mage/apply/main.js
+++ b/lib/web/mage/apply/main.js
@@ -22,16 +22,22 @@ define([
      */
     function init(el, config, component) {
         require([component], function (fn) {
+            var $el;
 
             if (typeof fn === 'object') {
                 fn = fn[component].bind(fn);
             }
 
             if (_.isFunction(fn)) {
-                fn(config, el);
-            } else if ($(el)[component]) {
-                $(el)[component](config);
+                fn = fn.bind(null, config, el);
+            } else {
+                $el = $(el);
+                if ($el[component]) {
+                    fn = $el[component].bind($el, config);
+                }
             }
+            // Init module in separate task to prevent blocking main thread.
+            setTimeout(fn);
         }, function (error) {
             if ('console' in window && typeof window.console.error === 'function') {
                 console.error(error);

--- a/lib/web/mage/bootstrap.js
+++ b/lib/web/mage/bootstrap.js
@@ -16,6 +16,7 @@ define([
 
     /**
      * Init all components defined via data-mage-init attribute.
+     * Execute in a separate task to prevent main thread blocking.
      */
-    $(mage.apply);
+    setTimeout(mage.apply);
 });


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
I'm currently during a process of profilling and trying to improve Magento frontend performance as much as possible. This is one of the improvements that I found.

#### The Issue
As you can see on the below screenshot `First CPU idle` and `Max Potential First Input Delay` times are not great and it would be nice to improve them.
![mage-lighthouse](https://user-images.githubusercontent.com/829189/77074711-85bcd000-69f1-11ea-822f-0ad502e8d7ee.png)
And so I run a quick performance profile, with 4x CPU slowdown for easier spotting and here's what I found:
![mage-timeline](https://user-images.githubusercontent.com/829189/77074893-c9173e80-69f1-11ea-9433-05472dcfacb9.png)
Those two big long-running tasks are coming from Magento initializing all `data-mage-init` modules. The first one is responsible for collecting all the data needed for initialization which happens in the same task as initializing custom Knockout bindings, hence change in `lib/web/mage/bootstrap.js`. The second one is initialization of each of the modules themselves which can also be done in separate tasks like you see in changed `lib/web/mage/apply/main.js`.
#### The Fix
Here's the result after applying both changes:
![main improved lighthouse](https://user-images.githubusercontent.com/829189/77075320-6f634400-69f2-11ea-8c9d-18ca9f4abada.png)
![main improved timeline](https://user-images.githubusercontent.com/829189/77075329-71c59e00-69f2-11ea-93ed-f8f85a21c896.png)
As you can see both metrics improved dramatically. Next step would be to reduce this huge `TTI` but until it happens it would be great to make sure we are not blocking the main thread for too long preventing it from handling user interactions. 

### Manual testing scenarios (*)
This is not a functional change, everything should we working as before.

### Questions or comments
Since this is not a functional change, as long as all tests are still passing I would consider this change covered with tests.
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
