### PR TITLE
Fix issue 24834: Display success message for Apply rules if haven't added rule

### DIFF
--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php
@@ -11,6 +11,8 @@ use Magento\Framework\Controller\ResultFactory;
 
 /**
  * Class ApplyRules: Apply rule
+ *
+ * @SuppressWarnings(PHPMD.AllPurposeAction)
  */
 class ApplyRules extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
 {

--- a/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php
+++ b/app/code/Magento/CatalogRule/Controller/Adminhtml/Promo/Catalog/ApplyRules.php
@@ -9,6 +9,9 @@ namespace Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog;
 use Magento\CatalogRule\Model\Rule\Job;
 use Magento\Framework\Controller\ResultFactory;
 
+/**
+ * Class ApplyRules: Apply rule
+ */
 class ApplyRules extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
 {
     /**
@@ -22,7 +25,8 @@ class ApplyRules extends \Magento\CatalogRule\Controller\Adminhtml\Promo\Catalog
         try {
             /** @var Job $ruleJob */
             $ruleJob = $this->_objectManager->get(\Magento\CatalogRule\Model\Rule\Job::class);
-            $ruleJob->applyAll();
+            $ruleId = $this->getRequest()->getParam('rule_id');
+            $ruleJob->applyRule($ruleId);
 
             if ($ruleJob->hasSuccess()) {
                 $this->messageManager->addSuccessMessage($ruleJob->getSuccess());

--- a/app/code/Magento/CatalogRule/Model/Rule/Job.php
+++ b/app/code/Magento/CatalogRule/Model/Rule/Job.php
@@ -64,4 +64,26 @@ class Job extends \Magento\Framework\DataObject
         }
         return $this;
     }
+
+    /**
+     * Apply & update catalog rule value
+     *
+     * @param int $ruleId
+     * @return \Magento\CatalogRule\Model\Rule\Job
+     * @api
+     */
+    public function applyRule($ruleId)
+    {
+        try {
+            if ($ruleId) {
+                $this->ruleProcessor->reindexRow($ruleId);
+            } else {
+                $this->ruleProcessor->reindexAll();
+            }
+            $this->setSuccess(__('Updated rules applied.'));
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            $this->setError($e->getMessage());
+        }
+        return $this;
+    }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fix issue 24834: Display success message for Apply rules if haven't added rule

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#24834: Display success message for Apply rules if haven't added rule

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Admin -> Marketing -> Promotions -> Catalog Price Rules
2. Click on Apply rules
3. It will display the message like "Updated rules applied."
4. Catalogrule will be applied for products

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
