### PR TITLE
Fix issue #27355 with too many cookies in admin

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/layout/default.xml
+++ b/app/code/Magento/Backend/view/adminhtml/layout/default.xml
@@ -70,7 +70,6 @@
                             <argument name="bugreport_url" xsi:type="string">https://github.com/magento/magento2/issues</argument>
                         </arguments>
                     </block>
-                    
                 </container>
             </container>
         </referenceContainer>

--- a/app/code/Magento/Translation/Block/Js.php
+++ b/app/code/Magento/Translation/Block/Js.php
@@ -14,6 +14,10 @@ use Magento\Translation\Model\Js\Config;
  *
  * @api
  * @since 100.0.2
+ * @deprecated logic was refactored in order to not use localstorage at all.
+ *
+ * You can see details in app/code/Magento/Translation/view/base/web/js/mage-translation-dictionary.js
+ * These block and view file were left in order to keep backward compatibility
  */
 class Js extends Template
 {

--- a/app/code/Magento/Translation/view/base/requirejs-config.js
+++ b/app/code/Magento/Translation/view/base/requirejs-config.js
@@ -6,7 +6,10 @@
 var config = {
     map: {
         '*': {
-            'mediaUploader':  'Magento_Backend/js/media-uploader'
+            mageTranslationDictionary: 'Magento_Translation/js/mage-translation-dictionary'
         }
-    }
+    },
+    deps: [
+        'mageTranslationDictionary'
+    ]
 };

--- a/app/code/Magento/Translation/view/base/templates/translate.phtml
+++ b/app/code/Magento/Translation/view/base/templates/translate.phtml
@@ -7,61 +7,8 @@
 /**
  * @var \Magento\Translation\Block\Js $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @deprecated logic was refactored in order to not use localstorage at all.
+ *
+ * You can see details in app/code/Magento/Translation/view/base/web/js/mage-translation-dictionary.js
+ * These block and view file were left in order to keep backward compatibility
  */
-?>
-<!--
-For frontend area dictionary file is inserted into html head in Magento/Translation/view/base/templates/dictionary.phtml
-Same translation mechanism should be introduced for admin area in 2.4 version.
--->
-<?php
-if ($block->dictionaryEnabled()) {
-    $version = $block->getTranslationFileVersion();
-    $escapedVersion = $block->escapeJs($version);
-    $dictionaryFileName = /* @noEscape */ Magento\Translation\Model\Js\Config::DICTIONARY_FILE_NAME;
-
-    $scriptString = <<<script
-        require.config({
-            deps: [
-                'jquery',
-                'mage/translate',
-                'jquery/jquery-storageapi'
-            ],
-            callback: function ($) {
-                'use strict';
-
-                var dependencies = [],
-                    versionObj;
-
-                $.initNamespaceStorage('mage-translation-storage');
-                $.initNamespaceStorage('mage-translation-file-version');
-                versionObj = $.localStorage.get('mage-translation-file-version');
-
-                if (versionObj.version !== '{$escapedVersion}') {
-                    dependencies.push(
-                        'text!{$dictionaryFileName}'
-                    );
-
-                }
-
-                require.config({
-                    deps: dependencies,
-                    callback: function (string) {
-                        if (typeof string === 'string') {
-                            $.mage.translate.add(JSON.parse(string));
-                            $.localStorage.set('mage-translation-storage', string);
-                            $.localStorage.set(
-                                'mage-translation-file-version',
-                                {
-                                    version: '{$escapedVersion}'
-                                }
-                            );
-                        } else {
-                            $.mage.translate.add($.localStorage.get('mage-translation-storage'));
-                        }
-                    }
-                });
-            }
-        });
-script;
-    echo /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false);
-}

--- a/app/code/Magento/Translation/view/frontend/requirejs-config.js
+++ b/app/code/Magento/Translation/view/frontend/requirejs-config.js
@@ -8,12 +8,10 @@ var config = {
         '*': {
             editTrigger: 'mage/edit-trigger',
             addClass: 'Magento_Translation/js/add-class',
-            'Magento_Translation/add-class': 'Magento_Translation/js/add-class',
-            mageTranslationDictionary: 'Magento_Translation/js/mage-translation-dictionary'
+            'Magento_Translation/add-class': 'Magento_Translation/js/add-class'
         }
     },
     deps: [
-        'mage/translate-inline',
-        'mageTranslationDictionary'
+        'mage/translate-inline'
     ]
 };


### PR DESCRIPTION
Port MC-19247 for adminhtml in order to not use jQuery.localStorage plugin


<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
As part of https://github.com/magento/magento2/commit/71c781df5536a2ec79c9cf42ade0c262396767a3 there were significantly changed translation module for frontend, but for backend was left old implementation that caused https://github.com/magento/magento2/issues/27355

Before my changes js translation file was loaded via 
https://github.com/magento/magento2/blob/71c781df5536a2ec79c9cf42ade0c262396767a3/app/code/Magento/Translation/view/base/templates/translate.phtml

After - via https://github.com/magento/magento2/blob/71c781df5536a2ec79c9cf42ade0c262396767a3/app/code/Magento/Translation/view/base/web/js/mage-translation-dictionary.js
so it not creating any cookies anymore.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/magento2/issues/27355 : Adminhtml - Too many mage-translation-file-version cookies
2. Reduces time of reproducing https://github.com/magento/magento2/issues/17195

### Manual testing scenarios (*)
1. See https://github.com/magento/magento2/issues/27355

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
