### PR TITLE
MFTF: Refactor `amOnPage` for Admin product edit page

### DIFF
--- a/app/code/Magento/Braintree/Test/Mftf/Test/CretateAdminOrderWithOnlinePaymentIncludingTaxAndDiscountTest.xml
+++ b/app/code/Magento/Braintree/Test/Mftf/Test/CretateAdminOrderWithOnlinePaymentIncludingTaxAndDiscountTest.xml
@@ -74,7 +74,7 @@
         </after>
 
         <!-- Create a cart price rule with 10% discount for whole cart -->
-        <click selector="{{AdminMenuSection.marketing}}" stepKey="clickOnMarketing" />
+        <click selector="{{AdminMenuSection.marketing}}" stepKey="clickOnMarketing"/>
         <waitForPageLoad stepKey="waitForMarketing"/>
         <click selector="{{CartPriceRulesSubmenuSection.cartPriceRules}}" stepKey="clickOnCartPriceRules"/>
         <waitForPageLoad stepKey="waitForCartPriceRules"/>
@@ -93,7 +93,9 @@
         <actionGroup ref="ChangeShippingTaxClassActionGroup" stepKey="changeShippingTaxClass"/>
 
         <!--Adding Special price to product-->
-        <amOnPage url="{{AdminProductEditPage.url($$simpleProduct.id$$)}}" stepKey="openAdminProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openAdminProductEditPage">
+            <argument name="productId" value="$$simpleProduct.id$$"/>
+        </actionGroup>
         <actionGroup ref="AddSpecialPriceToProductActionGroup" stepKey="addSpecialPrice"/>
         <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProductForm"/>
 

--- a/app/code/Magento/Bundle/Test/Mftf/Test/AdminAddBundleProductToCartFromWishListPageTest.xml
+++ b/app/code/Magento/Bundle/Test/Mftf/Test/AdminAddBundleProductToCartFromWishListPageTest.xml
@@ -50,14 +50,16 @@
                 <requiredEntity createDataKey="bundleOption"/>
                 <requiredEntity createDataKey="createSimpleProduct2"/>
             </createData>
-            <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="goToProductEditPage"/>
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage">
+                <argument name="productId" value="$$createProduct.id$$"/>
+            </actionGroup>
             <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProduct"/>
         </before>
         <after>
             <!-- Delete created data -->
             <comment userInput="Delete created data" stepKey="commentDeleteCreatedData"/>
             <deleteData createDataKey="createCustomerViaTheStorefront" stepKey="deleteCustomerViaTheStorefront"/>
-            <deleteData createDataKey="createProduct" stepKey="deleteProduct" />
+            <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
             <!-- Log out -->
             <comment userInput="Log out" stepKey="commentLogOut"/>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
@@ -74,8 +76,8 @@
         <actionGroup ref="StorefrontCustomerAddProductToWishlistActionGroup" stepKey="addToWishlistProduct">
             <argument name="productVar" value="$$createProduct$$"/>
         </actionGroup>
-        <moveMouseOver selector="{{StorefrontCategoryProductSection.ProductInfoByName($$createProduct.name$$)}}" stepKey="moveMouseOverProduct" />
-        <click selector="{{StorefrontCategoryProductSection.ProductAddToCartByName($$createProduct.name$$)}}" stepKey="clickAddToCart" />
+        <moveMouseOver selector="{{StorefrontCategoryProductSection.ProductInfoByName($$createProduct.name$$)}}" stepKey="moveMouseOverProduct"/>
+        <click selector="{{StorefrontCategoryProductSection.ProductAddToCartByName($$createProduct.name$$)}}" stepKey="clickAddToCart"/>
         <waitForPageLoad stepKey="waitForProductBundlePage"/>
         <!-- See error message -->
         <comment userInput="See error message" stepKey="commentSeeErrorMessage"/>

--- a/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontCheckBundleProductOptionTierPricesTest.xml
+++ b/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontCheckBundleProductOptionTierPricesTest.xml
@@ -27,7 +27,9 @@
             <!-- Add tier prices to simple products -->
             <!-- Simple product 1 -->
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
-            <amOnPage url="{{AdminProductEditPage.url($$simpleProduct1CreateBundleProduct.id$$)}}" stepKey="openAdminEditPageProduct1"/>
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openAdminEditPageProduct1">
+                <argument name="productId" value="$$simpleProduct1CreateBundleProduct.id$$"/>
+            </actionGroup>
             <actionGroup ref="ProductSetAdvancedPricingActionGroup" stepKey="addTierPriceProduct1">
                 <argument name="group" value="ALL GROUPS"/>
                 <argument name="quantity" value="5"/>
@@ -35,7 +37,9 @@
                 <argument name="amount" value="50"/>
             </actionGroup>
             <!-- Simple product 2 -->
-            <amOnPage url="{{AdminProductEditPage.url($$simpleProduct2CreateBundleProduct.id$$)}}" stepKey="openAdminEditPageProduct2"/>
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openAdminEditPageProduct2">
+                <argument name="productId" value="$$simpleProduct2CreateBundleProduct.id$$"/>
+            </actionGroup>
             <actionGroup ref="ProductSetAdvancedPricingActionGroup" stepKey="addTierPriceProduct2">
                 <argument name="group" value="ALL GROUPS"/>
                 <argument name="quantity" value="7"/>

--- a/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontVerifyDynamicBundleProductPricesForCombinationOfOptionsTest.xml
+++ b/app/code/Magento/Bundle/Test/Mftf/Test/StorefrontVerifyDynamicBundleProductPricesForCombinationOfOptionsTest.xml
@@ -40,7 +40,9 @@
 
             <!--Add special price to simple product-->
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
-            <amOnPage url="{{AdminProductEditPage.url($$simpleProduct5.id$$)}}" stepKey="openAdminEditPage"/>
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openAdminEditPage">
+                <argument name="productId" value="$$simpleProduct5.id$$"/>
+            </actionGroup>
             <actionGroup ref="AddSpecialPriceToProductActionGroup" stepKey="addSpecialPrice"/>
             <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProductForm"/>
 

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductPageOpenByIdActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductPageOpenByIdActionGroup.xml
@@ -14,6 +14,5 @@
         </arguments>
 
         <amOnPage url="{{AdminProductEditPage.url(productId)}}" stepKey="goToProduct"/>
-        <waitForPageLoad stepKey="waitForProductPage"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductPageOpenByIdActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductPageOpenByIdActionGroup.xml
@@ -1,21 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- /**
-  * Copyright © Magento, Inc. All rights reserved.
-  * See COPYING.txt for license details.
-  */
--->
 
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
-    <actionGroup name="GoToProductPageViaIDActionGroup">
-        <annotations>
-            <description>Goes to the Product edit page for the provided Product ID.</description>
-        </annotations>
+    <actionGroup name="AdminProductPageOpenByIdActionGroup">
         <arguments>
             <argument name="productId" type="string"/>
         </arguments>
 
         <amOnPage url="{{AdminProductEditPage.url(productId)}}" stepKey="goToProduct"/>
+        <waitForPageLoad stepKey="waitForProductPage"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductPageOpenByIdActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminProductPageOpenByIdActionGroup.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
 
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/_Deprecated_ActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/_Deprecated_ActionGroup.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="GoToProductPageViaIDActionGroup" extends="AdminProductPageOpenByIdActionGroup" deprecated="Use AdminProductPageOpenByIdActionGroup instead"/>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/_Deprecated_ActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/_Deprecated_ActionGroup.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
 
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AddToCartCrossSellTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AddToCartCrossSellTest.xml
@@ -7,7 +7,7 @@
 -->
 
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="AddToCartCrossSellTest">
         <annotations>
             <features value="Catalog"/>
@@ -42,7 +42,9 @@
         </after>
 
         <!-- Go to simpleProduct1, add simpleProduct2 and simpleProduct3 as cross-sell-->
-        <amOnPage url="{{AdminProductEditPage.url($simpleProduct1.id$)}}" stepKey="goToProduct1"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct1">
+            <argument name="productId" value="$simpleProduct1.id$"/>
+        </actionGroup>
         <click stepKey="openHeader1" selector="{{AdminProductFormRelatedUpSellCrossSellSection.sectionHeader}}"/>
 
         <actionGroup ref="AddCrossSellProductBySkuActionGroup" stepKey="addProduct2ToSimp1">
@@ -55,7 +57,9 @@
         <waitForPageLoad stepKey="waitForPageLoad1"/>
 
         <!-- Go to simpleProduct3, add simpleProduct1 and simpleProduct2 as cross-sell-->
-        <amOnPage url="{{AdminProductEditPage.url($simpleProduct3.id$)}}" stepKey="goToProduct3"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct3">
+            <argument name="productId" value="$simpleProduct3.id$"/>
+        </actionGroup>
         <click stepKey="openHeader2" selector="{{AdminProductFormRelatedUpSellCrossSellSection.sectionHeader}}"/>
 
         <actionGroup ref="AddCrossSellProductBySkuActionGroup" stepKey="addProduct1ToSimp3">

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckCustomAttributeValuesAfterProductSaveTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckCustomAttributeValuesAfterProductSaveTest.xml
@@ -49,7 +49,9 @@
         </after>
 
         <!-- Open created product for edit -->
-        <amOnPage url="{{AdminProductEditPage.url($createSimpleProduct.id$)}}" stepKey="goToProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage">
+            <argument name="productId" value="$createSimpleProduct.id$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPageLoad"/>
 
         <!-- Add created attribute to the product -->

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckMediaRolesForFirstAddedImageViaApiTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminCheckMediaRolesForFirstAddedImageViaApiTest.xml
@@ -30,7 +30,7 @@
             <actionGroup ref="CliRunReindexUsingCronJobsActionGroup" stepKey="reindexInvalidatedIndices"/>
         </after>
 
-        <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="goToSimpleProduct">
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToSimpleProduct">
             <argument name="productId" value="$$createSimpleProduct.id$$"/>
         </actionGroup>
         <actionGroup ref="AdminOpenProductImagesSectionActionGroup" stepKey="openProductImagesSection"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminCloneProductWithDuplicateUrlTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminCloneProductWithDuplicateUrlTest.xml
@@ -34,7 +34,9 @@
             <actionGroup ref="ResetProductGridToDefaultViewActionGroup" stepKey="resetFiltersIfExist"/>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logoutOfAdmin"/>
         </after>
-        <amOnPage url="{{AdminProductEditPage.url($$createSimpleProduct.id$$)}}" stepKey="goToProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage">
+            <argument name="productId" value="$$createSimpleProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForSimpleProductPageLoad"/>
         <!--Save and duplicated the product once-->
         <comment userInput="Save and duplicated the product once" stepKey="commentSaveAndDuplicateProduct"/>
@@ -45,7 +47,9 @@
         <assertContains expectedType="string" expected="-1" actual="$grabDuplicatedProductUrlKey" stepKey="assertDuplicatedProductUrlKey1"/>
         <!--Add duplicated product to the simple product-->
         <comment userInput="Add duplicated product to the simple product" stepKey="commentAddProduct"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createSimpleProduct.id$$)}}" stepKey="goToSimpleProductPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToSimpleProductPage">
+            <argument name="productId" value="$$createSimpleProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForSimpleProductPageLoad1"/>
         <actionGroup ref="AddCrossSellProductBySkuActionGroup" stepKey="addCrossSellProduct">
             <argument name="sku" value="$$createSimpleProduct.sku$$"/>
@@ -63,7 +67,9 @@
         <see selector="{{AdminProductFormRelatedUpSellCrossSellSection.selectedProductSku('crosssell')}}" userInput="$$createSimpleProduct.sku$$-1" stepKey="seeCrossSellProduct"/>
         <!--Save and duplicated the product second time-->
         <comment userInput="Save and duplicated the product second time" stepKey="commentSaveAndDuplicateProduct1"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createSimpleProduct.id$$)}}" stepKey="goToProductEditPage1"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage1">
+            <argument name="productId" value="$$createSimpleProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForSimpleProductPageLoad2"/>
         <actionGroup ref="AdminFormSaveAndDuplicateActionGroup" stepKey="saveAndDuplicateProductFormSecondTime"/>
         <conditionalClick selector="{{AdminProductSEOSection.sectionHeader}}" dependentSelector="{{AdminProductSEOSection.urlKeyInput}}" visible="false" stepKey="openProductSEOSection"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateNewAttributeFromProductTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateNewAttributeFromProductTest.xml
@@ -54,7 +54,9 @@
         </actionGroup>
 
         <!--Go to created product page and create new attribute-->
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="openAdminEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openAdminEditPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <actionGroup ref="AdminCreateAttributeWithValueWithTwoStoreViesFromProductPageActionGroup" stepKey="createAttribute">
             <argument name="attributeName" value="{{productDropDownAttribute.attribute_code}}"/>
             <argument name="attributeType" value="Dropdown"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteProductsImageInCaseOfMultipleStoresTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminDeleteProductsImageInCaseOfMultipleStoresTest.xml
@@ -40,12 +40,16 @@
             <createData entity="SimpleProduct2" stepKey="createProduct"/>
             <createData entity="SubCategory" stepKey="createSubCategory"/>
             <createData entity="NewRootCategory" stepKey="createRootCategory"/>
-            <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="visitAdminProductPage"/>
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="visitAdminProductPage">
+                <argument name="productId" value="$$createProduct.id$$"/>
+            </actionGroup>
             <waitForPageLoad stepKey="waitForProductPageLoad0"/>
             <searchAndMultiSelectOption selector="{{AdminProductFormSection.categoriesDropdown}}" parameterArray="['Default Category', $$createRootCategory.name$$, $$createSubCategory.name$$]" stepKey="fillCategory"/>
             <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProduct"/>
             <!--Add images to the product-->
-            <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="visitAdminProductPage2"/>
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="visitAdminProductPage2">
+                <argument name="productId" value="$$createProduct.id$$"/>
+            </actionGroup>
             <waitForPageLoad stepKey="waitForProductPageLoad1"/>
             <actionGroup ref="AddProductImageActionGroup" stepKey="addImageToProduct">
                 <argument name="image" value="ProductImage"/>
@@ -80,7 +84,9 @@
         <click selector="{{AdminStoresGridSection.resetButton}}" stepKey="clickResetButton"/>
         <waitForPageLoad stepKey="waitForStorePageLoad"/>
         <!--Open product page on admin-->
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="openProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openProductEditPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPageLoad2"/>
         <!--Enable the newly created website and save the product-->
         <actionGroup ref="SelectProductInWebsitesActionGroup" stepKey="selectWebsiteInProduct2">

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminFilterByNameByStoreViewOnProductGridTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminFilterByNameByStoreViewOnProductGridTest.xml
@@ -28,7 +28,9 @@
             <actionGroup ref="ClearProductsFilterActionGroup" stepKey="clearProductsFilter"/>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
-        <amOnPage url="{{AdminProductEditPage.url($$createSimpleProduct.id$$)}}" stepKey="goToEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToEditPage">
+            <argument name="productId" value="$$createSimpleProduct.id$$"/>
+        </actionGroup>
         <actionGroup ref="AdminSwitchStoreViewActionGroup" stepKey="switchToDefaultStoreView">
             <argument name="storeView" value="_defaultStore.name"/>
         </actionGroup>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminImportCustomizableOptionToProductWithSKUTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminImportCustomizableOptionToProductWithSKUTest.xml
@@ -49,7 +49,9 @@
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logoutOfAdmin"/>
         </after>
         <!--Change second product sku to first product sku-->
-        <amOnPage url="{{AdminProductEditPage.url($$createSecondProduct.id$$)}}" stepKey="goToProductEditPage1"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage1">
+            <argument name="productId" value="$$createSecondProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductEditPageLoad1"/>
         <fillField selector="{{AdminProductFormSection.productSku}}" userInput="$$createFirstProduct.sku$$" stepKey="fillProductSku1"/>
         <!--Import customizable options and check-->

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveProductBetweenCategoriesTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveProductBetweenCategoriesTest.xml
@@ -68,7 +68,9 @@
         <seeElement selector="{{AdminCategoryMessagesSection.SuccessMessage}}" stepKey="seeSaveSuccessMessage"/>
 
         <!-- Assign <product1> to the <Sub1> -->
-        <amOnPage url="{{AdminProductEditPage.url($$simpleProduct.id$$)}}" stepKey="goToProduct"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct">
+            <argument name="productId" value="$$simpleProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPageLoad"/>
         <click selector="{{AdminProductFormSection.categoriesDropdown}}" stepKey="activateDropDownCategory"/>
         <fillField userInput="{{SimpleSubCategory.name}}" selector="{{AdminProductFormSection.searchCategory}}" stepKey="fillSearch"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductCategoryIndexerInUpdateOnScheduleModeTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductCategoryIndexerInUpdateOnScheduleModeTest.xml
@@ -74,7 +74,9 @@
 
         <!-- Case: change product category from product page -->
         <!-- 1. Open Admin > Catalog > Products > Product A1 -->
-        <amOnPage url="{{AdminProductEditPage.url($$createProductA1.id$$)}}" stepKey="goToProductA1"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductA1">
+            <argument name="productId" value="$$createProductA1.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPageLoad"/>
 
         <!-- 2. Assign category A to product A1. Save product -->
@@ -104,7 +106,9 @@
         <see userInput="$$createProductA1.name$$" selector="{{StorefrontCategoryMainSection.productName}}" stepKey="seeProductA1"/>
 
         <!--6.  Open Admin > Catalog > Products > Product A1. Unassign category A from product A1 -->
-        <amOnPage url="{{AdminProductEditPage.url($$createProductA1.id$$)}}" stepKey="OnPageProductA1"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="OnPageProductA1">
+            <argument name="productId" value="$$createProductA1.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductA1PageLoad"/>
         <actionGroup ref="AdminUnassignCategoryOnProductAndSaveActionGroup" stepKey="unassignCategoryA">
             <argument name="categoryName" value="$$createCategoryA.name$$"/>
@@ -144,7 +148,9 @@
         <see userInput="$$createProductC2.name$$" selector="{{StorefrontCategoryMainSection.productName}}" stepKey="seeNameProductC2"/>
 
         <!-- 11. Open product C1 in Admin. Make it disabled (Enable Product = No)-->
-        <amOnPage url="{{AdminProductEditPage.url($$createProductC1.id$$)}}" stepKey="goToProductC1"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductC1">
+            <argument name="productId" value="$$createProductC1.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductC1PageLoad"/>
         <click selector="{{AdminProductFormSection.enableProductLabel}}" stepKey="clickOffEnableToggleAgain"/>
         <!-- Saved successfully -->
@@ -200,7 +206,9 @@
 
         <!-- 17. Repeat steps 10-16, but enable products instead. -->
         <!-- 17.11 Open product C1 in Admin. Make it enabled -->
-        <amOnPage url="{{AdminProductEditPage.url($$createProductC1.id$$)}}" stepKey="goToEditProductC1"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToEditProductC1">
+            <argument name="productId" value="$$createProductC1.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductC1Page"/>
         <click selector="{{AdminProductFormSection.enableProductLabel}}" stepKey="clickOnEnableToggleAgain"/>
 
@@ -258,7 +266,9 @@
         <!-- Case: change product visibility -->
         <!-- 18. Repeat steps 10-17 but change product Visibility instead of product status -->
         <!-- 18.11 Open product C1 in Admin. Make it enabled -->
-        <amOnPage url="{{AdminProductEditPage.url($$createProductC1.id$$)}}" stepKey="editProductC1"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="editProductC1">
+            <argument name="productId" value="$$createProductC1.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitProductC1Page"/>
         <selectOption selector="{{AdminProductFormBundleSection.visibilityDropDown}}" userInput="Search"
                       stepKey="changeVisibility"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductCustomURLKeyPreservedWhenAssignedToCategoryWithoutCustomURLKeyTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductCustomURLKeyPreservedWhenAssignedToCategoryWithoutCustomURLKeyTest.xml
@@ -51,7 +51,9 @@
         </after>
 
         <!-- Open product -->
-        <amOnPage url="{{AdminProductEditPage.url($createSimpleProductSecond.id$)}}" stepKey="openProductSecondEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openProductSecondEditPage">
+            <argument name="productId" value="$createSimpleProductSecond.id$"/>
+        </actionGroup>
         <!-- switch store view -->
         <actionGroup ref="AdminSwitchStoreViewActionGroup" stepKey="switchToStoreView">
             <argument name="storeView" value="storeViewData.name"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductTypeSwitchingOnEditingTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminProductTypeSwitchingOnEditingTest.xml
@@ -38,7 +38,9 @@
         </after>
         <!--Change product type to Downloadable-->
         <comment userInput="Change product type to Downloadable" stepKey="commentCreateDownloadable"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="gotToDownloadableProductPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="gotToDownloadableProductPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForDownloadableProductPageLoad"/>
         <actionGroup ref="AdminAddDownloadableLinkInformationActionGroup" stepKey="addDownloadableLinkInformation"/>
         <checkOption selector="{{AdminProductDownloadableSection.isLinksPurchasedSeparately}}" stepKey="checkOptionPurchaseSeparately"/>
@@ -76,7 +78,9 @@
         </annotations>
         <!--Change product type to Simple-->
         <comment userInput="Change product type to Simple Product" stepKey="commentCreateSimple"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="gotToProductPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="gotToProductPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPageLoad"/>
         <actionGroup ref="AdminAddDownloadableLinkInformationActionGroup" stepKey="addDownloadableLinkInformation"/>
         <selectOption selector="{{AdminProductFormSection.productWeightSelect}}" userInput="This item has weight" stepKey="selectWeightForProduct"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveCustomOptionsFromProductTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminRemoveCustomOptionsFromProductTest.xml
@@ -32,7 +32,9 @@
         </after>
         <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
         <!-- Edit Simple Product -->
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="goToProduct"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <!-- See 3 options are present -->
         <actionGroup ref="AdminAssertProductCustomOptionVisibleActionGroup" stepKey="assertCustomOptionsField">
             <argument name="option" value="ProductOptionField"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminSimpleProductEditUiTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminSimpleProductEditUiTest.xml
@@ -34,7 +34,9 @@
 
         <!--check admin for valid Enable Status label-->
         <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createSimpleProduct.id$$)}}" stepKey="goToEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToEditPage">
+            <argument name="productId" value="$$createSimpleProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="wait1"/>
         <seeCheckboxIsChecked selector="{{AdminProductFormSection.productStatus}}" stepKey="seeCheckboxEnableProductIsChecked"/>
 

--- a/app/code/Magento/Catalog/Test/Mftf/Test/StoreFrontSimpleProductWithSpecialAndTierDiscountPriceTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/StoreFrontSimpleProductWithSpecialAndTierDiscountPriceTest.xml
@@ -34,7 +34,7 @@
 
         <actionGroup ref="LoginAsAdmin" stepKey="LoginAsAdmin"/>
 
-        <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="openAdminProductEditPage">
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openAdminProductEditPage">
             <argument name="productId" value="$createProduct.id$"/>
         </actionGroup>
 

--- a/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontConfigurableOptionsThumbImagesTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontConfigurableOptionsThumbImagesTest.xml
@@ -87,7 +87,7 @@
 
             <!-- ConfigProduct -->
             <!-- Go to Product Page (ConfigProduct) -->
-            <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="goToConfigProduct">
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToConfigProduct">
                 <argument name="productId" value="$$createConfigProduct.id$$"/>
             </actionGroup>
 
@@ -113,7 +113,7 @@
 
             <!-- ChildProduct1 -->
             <!-- Go to Product Page (ChildProduct1) -->
-            <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="goToChildProduct1">
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToChildProduct1">
                 <argument name="productId" value="$$createConfigChildProduct1.id$$"/>
             </actionGroup>
 
@@ -138,7 +138,7 @@
 
             <!-- ChildProduct2 -->
             <!-- Go to Product Page (ChildProduct2) -->
-            <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="goToChildProduct2">
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToChildProduct2">
                 <argument name="productId" value="$$createConfigChildProduct2.id$$"/>
             </actionGroup>
 

--- a/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontSpecialPriceForDifferentTimezonesForWebsitesTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontSpecialPriceForDifferentTimezonesForWebsitesTest.xml
@@ -57,7 +57,9 @@
         <click selector="{{AdminMainActionsSection.save}}" stepKey="saveConfig1"/>
 
         <!--Set special price to created product-->
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="openAdminEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openAdminEditPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <actionGroup ref="AddSpecialPriceToProductActionGroup" stepKey="setSpecialPriceToCreatedProduct">
             <argument name="price" value="15"/>
         </actionGroup>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/VerifyCategoryProductAndProductCategoryPartialReindexTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/VerifyCategoryProductAndProductCategoryPartialReindexTest.xml
@@ -104,7 +104,9 @@
         </actionGroup>
 
         <!--  Unassign category M from Product B -->
-        <amOnPage url="{{AdminProductEditPage.url($$productB.id$$)}}" stepKey="amOnEditCategoryPageB"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="amOnEditCategoryPageB">
+            <argument name="productId" value="$$productB.id$$"/>
+        </actionGroup>
         <actionGroup ref="AdminUnassignCategoryOnProductAndSaveActionGroup" stepKey="unassignCategoryM">
             <argument name="categoryName" value="$$categoryM.name$$"/>
         </actionGroup>
@@ -166,13 +168,17 @@
         <!-- Open categories K, L, N to edit. Assign/unassign Products to/from them. Save changes -->
 
         <!-- Remove Product A assignment for category K -->
-        <amOnPage url="{{AdminProductEditPage.url($$productA.id$$)}}" stepKey="amOnEditProductPageA"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="amOnEditProductPageA">
+            <argument name="productId" value="$$productA.id$$"/>
+        </actionGroup>
         <actionGroup ref="AdminUnassignCategoryOnProductAndSaveActionGroup" stepKey="unassignCategoryK">
             <argument name="categoryName" value="$$categoryK.name$$"/>
         </actionGroup>
 
         <!-- Remove Product C assignment for category L -->
-        <amOnPage url="{{AdminProductEditPage.url($$productC.id$$)}}" stepKey="amOnEditProductPageC"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="amOnEditProductPageC">
+            <argument name="productId" value="$$productC.id$$"/>
+        </actionGroup>
         <actionGroup ref="AdminUnassignCategoryOnProductAndSaveActionGroup" stepKey="unassignCategoryL">
             <argument name="categoryName" value="$$categoryL.name$$"/>
         </actionGroup>

--- a/app/code/Magento/CatalogInventory/Test/Mftf/Test/AdminCreateProductWithZeroMaximumQtyAllowedInShoppingCartTest.xml
+++ b/app/code/Magento/CatalogInventory/Test/Mftf/Test/AdminCreateProductWithZeroMaximumQtyAllowedInShoppingCartTest.xml
@@ -54,7 +54,9 @@
         <actionGroup ref="AdminSaveConfigActionGroup" stepKey="saveConfigWithCorrectNumber"/>
 
         <!-- Go to product page -->
-        <amOnPage url="{{AdminProductEditPage.url($$createdProduct.id$$)}}" stepKey="openAdminProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openAdminProductEditPage">
+            <argument name="productId" value="$$createdProduct.id$$"/>
+        </actionGroup>
         <!-- Validate zero value -->
         <actionGroup ref="AdminProductMaxQtyAllowedInShoppingCartValidationActionGroup" stepKey="productValidateZeroValue">
             <argument name="qty" value="0"/>

--- a/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminApplyCatalogRuleForConfigurableProductWithSpecialPricesTest.xml
+++ b/app/code/Magento/CatalogRule/Test/Mftf/Test/AdminApplyCatalogRuleForConfigurableProductWithSpecialPricesTest.xml
@@ -98,7 +98,7 @@
         </after>
 
         <!-- Add special prices for products -->
-        <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="goToFirstChildProduct">
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToFirstChildProduct">
             <argument name="productId" value="$$createFirstConfigChildProduct.id$$"/>
         </actionGroup>
         <actionGroup ref="AddSpecialPriceToProductActionGroup" stepKey="addSpecialPriceForFirstProduct">
@@ -106,7 +106,7 @@
         </actionGroup>
         <actionGroup ref="SaveProductFormActionGroup" stepKey="saveFirstProduct"/>
 
-        <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="goToSecondChildProduct">
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToSecondChildProduct">
             <argument name="productId" value="$$createSecondConfigChildProduct.id$$"/>
         </actionGroup>
         <actionGroup ref="AddSpecialPriceToProductActionGroup" stepKey="addSpecialPriceForSecondProduct">

--- a/app/code/Magento/CatalogSearch/Test/Mftf/Test/SearchEntityResultsTest.xml
+++ b/app/code/Magento/CatalogSearch/Test/Mftf/Test/SearchEntityResultsTest.xml
@@ -506,7 +506,9 @@
             </createData>
             <!--Finish bundle creation-->
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
-            <amOnPage url="{{AdminProductEditPage.url($$createBundleProduct.id$$)}}" stepKey="goToProductEditPage"/>
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage">
+                <argument name="productId" value="$$createBundleProduct.id$$"/>
+            </actionGroup>
             <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProduct"/>
 
             <!-- Perform reindex and flush cache -->
@@ -573,7 +575,9 @@
 
             <!--Finish bundle creation-->
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
-            <amOnPage url="{{AdminProductEditPage.url($$createBundleProduct.id$$)}}" stepKey="goToProductEditPage"/>
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage">
+                <argument name="productId" value="$$createBundleProduct.id$$"/>
+            </actionGroup>
             <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProduct"/>
 
             <!-- Perform reindex and flush cache -->

--- a/app/code/Magento/CatalogSearch/Test/Mftf/Test/SearchEntityResultsTest.xml
+++ b/app/code/Magento/CatalogSearch/Test/Mftf/Test/SearchEntityResultsTest.xml
@@ -203,7 +203,7 @@
 
 
             <!-- Create and Assign Attribute to product1-->
-            <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="goToProduct1">
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct1">
                 <argument name="productId" value="$product1.id$"/>
             </actionGroup>
             <actionGroup ref="AdminCreateAttributeWithSearchWeightActionGroup" stepKey="createProduct1Attribute">
@@ -224,7 +224,7 @@
             </actionGroup>
             <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProduct1b"/>
             <!-- Create and Assign Attribute to product2-->
-            <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="goToProduct2">
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct2">
                 <argument name="productId" value="$product2.id$"/>
             </actionGroup>
             <actionGroup ref="AdminCreateAttributeWithSearchWeightActionGroup" stepKey="createProduct2Attribute">

--- a/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontQuickSearchConfigurableChildrenTest.xml
+++ b/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontQuickSearchConfigurableChildrenTest.xml
@@ -92,7 +92,7 @@
         </actionGroup>
 
         <!-- Disable Child Product -->
-        <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="openSimpleProduct">
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openSimpleProduct">
             <argument name="productId" value="$createSimpleProduct.id$"/>
         </actionGroup>
         <actionGroup ref="ToggleProductEnabledActionGroup" stepKey="disableProduct"/>

--- a/app/code/Magento/CatalogUrlRewrite/Test/Mftf/Test/AdminUrlForProductRewrittenCorrectlyTest.xml
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Mftf/Test/AdminUrlForProductRewrittenCorrectlyTest.xml
@@ -37,7 +37,9 @@
         </after>
 
         <!--Open Created product-->
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="amOnEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="amOnEditPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForEditPage"/>
 
         <!--Switch to Default Store view-->

--- a/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontProductNameMinicartOnCheckoutPageDifferentStoreViewsTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontProductNameMinicartOnCheckoutPageDifferentStoreViewsTest.xml
@@ -41,7 +41,9 @@
         </actionGroup>
 
         <!--Go to created product page-->
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="goToEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToEditPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPage"/>
 
         <!--Switch to second store view and change the product name-->

--- a/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUpdatePriceInShoppingCartAfterProductSaveTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontUpdatePriceInShoppingCartAfterProductSaveTest.xml
@@ -52,7 +52,9 @@
 
         <!--Edit product price via admin panel-->
         <openNewTab stepKey="openNewTab"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createSimpleProduct.id$$)}}" stepKey="goToProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage">
+            <argument name="productId" value="$$createSimpleProduct.id$$"/>
+        </actionGroup>
         <fillField userInput="120" selector="{{AdminProductFormSection.productPrice}}"  stepKey="setNewPrice"/>
         <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProduct"/>
         <closeTab stepKey="closeTab"/>

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminAddingNewOptionsWithImagesAndPricesToConfigurableProductTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminAddingNewOptionsWithImagesAndPricesToConfigurableProductTest.xml
@@ -38,7 +38,9 @@
         </after>
 
         <!--Open edit product page-->
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigProductCreateConfigurableProduct.id$$)}}" stepKey="goToProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage">
+            <argument name="productId" value="$$createConfigProductCreateConfigurableProduct.id$$"/>
+        </actionGroup>
 
         <!--Open edit configuration wizard-->
         <click selector="{{AdminProductFormConfigurationsSection.createConfigurations}}" stepKey="clickEditConfigurations"/>

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductCreateTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductCreateTest.xml
@@ -95,7 +95,9 @@
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
 
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigProduct.id$$)}}" stepKey="goToEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToEditPage">
+            <argument name="productId" value="$$createConfigProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPage"/>
         <conditionalClick selector="{{AdminProductFormConfigurationsSection.sectionHeader}}" dependentSelector="{{AdminProductFormConfigurationsSection.createConfigurations}}" visible="false" stepKey="openConfigurationSection"/>
         <click selector="{{AdminProductFormConfigurationsSection.createConfigurations}}" stepKey="openConfigurationPane"/>

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductUpdateTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductUpdateTest.xml
@@ -158,7 +158,9 @@
 
         <!--check admin for both options-->
         <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigProduct.id$$)}}" stepKey="goToEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToEditPage">
+            <argument name="productId" value="$$createConfigProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="wait2"/>
         <see selector="{{AdminProductFormConfigurationsSection.currentVariationsNameCells}}" userInput="$$createConfigChildProduct1.name$$" stepKey="seeOption1Admin"/>
         <see selector="{{AdminProductFormConfigurationsSection.currentVariationsNameCells}}" userInput="$$createConfigChildProduct2.name$$" stepKey="seeOption2Admin"/>
@@ -254,7 +256,9 @@
 
         <!--go to admin and disable an option-->
         <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigProduct.id$$)}}" stepKey="goToEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToEditPage">
+            <argument name="productId" value="$$createConfigProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="wait2"/>
         <click selector="{{AdminProductFormConfigurationsSection.actionsBtn('1')}}" stepKey="clickToExpandActions"/>
         <click selector="{{AdminProductFormConfigurationsSection.disableProductBtn}}" stepKey="clickDisable"/>

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminProductTypeSwitchingOnEditingTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminProductTypeSwitchingOnEditingTest.xml
@@ -50,7 +50,9 @@
         </after>
         <!--Add configurations to product-->
         <comment userInput="Add configurations to product" stepKey="commentAddConfigs"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="gotToSimpleProductPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="gotToSimpleProductPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForSimpleProductPageLoad"/>
         <actionGroup ref="GenerateConfigurationsByAttributeCodeActionGroup" stepKey="setupConfigurations">
             <argument name="attributeCode" value="$$createConfigProductAttribute.attribute_code$$"/>
@@ -89,7 +91,9 @@
         </annotations>
         <!--Delete product configurations-->
         <comment userInput="Delete product configuration" stepKey="commentDeleteConfigs"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="gotToConfigProductPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="gotToConfigProductPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForConfigurableProductPageLoad"/>
         <conditionalClick selector="{{ AdminProductFormConfigurationsSection.sectionHeader}}" dependentSelector="{{AdminProductFormConfigurationsSection.createConfigurations}}" visible="false" stepKey="openConfigurationSection"/>
         <click selector="{{AdminProductFormConfigurationsSection.actionsBtn('1')}}" stepKey="clickToExpandOption1Actions"/>
@@ -157,7 +161,9 @@
         </after>
         <!--Add configurations to product-->
         <comment userInput="Add configurations to product" stepKey="commentAddConfigurations"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="gotToConfigProductPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="gotToConfigProductPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForConfigurableProductPageLoad"/>
         <selectOption selector="{{AdminProductFormSection.productWeightSelect}}" userInput="This item has weight" stepKey="selectWeightForConfigurableProduct"/>
         <actionGroup ref="GenerateConfigurationsByAttributeCodeActionGroup" stepKey="setupConfigurationsForProduct">

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/ConfigurableProductPriceAdditionalStoreViewTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/ConfigurableProductPriceAdditionalStoreViewTest.xml
@@ -108,7 +108,9 @@
         <see userInput="You saved the store view." stepKey="seeSaveMessage" />
 
         <!--go to admin and open product edit page to disable product all store view -->
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigProduct.id$$)}}" stepKey="goToProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage">
+            <argument name="productId" value="$$createConfigProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitEditPage"/>
         <click selector="{{AdminProductFormSection.enableProductLabel}}" stepKey="disableProductForAllStoreView"/>
         <click selector="{{AdminProductFormActionSection.saveButton}}" stepKey="clickSaveButton2"/>
@@ -145,7 +147,9 @@
         <actionGroup ref="AdminFormSaveAndCloseActionGroup" stepKey="enabledConfigProductSecondStore"/>
 
         <!--go to admin and open product edit page to enable child product for second store view -->
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigProduct.id$$)}}" stepKey="goToProductEditPage2"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage2">
+            <argument name="productId" value="$$createConfigProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitEditPage2"/>
        <click selector="{{AdminProductFormActionSection.changeStoreButton}}" stepKey="clickStoreviewSwitcher1"/>
         <click selector="{{AdminProductFormActionSection.selectStoreView('Second Store View')}}" stepKey="chooseStoreView1"/>
@@ -166,14 +170,18 @@
         <see userInput="$$createConfigProduct.name$$" stepKey="assertProductPresent1"/>
 
         <!--go to admin and open child product1 and assign it to the second website -->
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigChildProduct1.id$$)}}" stepKey="goToProduct1EditPage1"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct1EditPage1">
+            <argument name="productId" value="$$createConfigChildProduct1.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitChild1EditPageToLoad"/>
         <click selector="{{ProductInWebsitesSection.sectionHeader}}" stepKey="openProduct1InWebsitesSection"/>
         <click selector="{{ProductInWebsitesSection.website('Second Website')}}" stepKey="selectSecondWebsite1"/>
         <actionGroup ref="AdminFormSaveAndCloseActionGroup" stepKey="saveUpdatedChild1Again"/>
 
         <!--go to admin again and open child product1 and enable for second store view-->
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigChildProduct1.id$$)}}" stepKey="goToProduct1EditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct1EditPage">
+            <argument name="productId" value="$$createConfigChildProduct1.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitChild1EditPageToLoad1"/>
         <click selector="{{AdminProductFormActionSection.changeStoreButton}}" stepKey="clickStoreviewSwitcherP1"/>
         <click selector="{{AdminProductFormActionSection.selectStoreView('Second Store View')}}" stepKey="chooseStoreView2P1"/>
@@ -185,14 +193,18 @@
         <actionGroup ref="AdminFormSaveAndCloseActionGroup" stepKey="save2UpdatedChild1"/>
 
         <!--go to admin and open child product2 edit page  and assign it to the second website -->
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigChildProduct2.id$$)}}" stepKey="goToProduct2EditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct2EditPage">
+            <argument name="productId" value="$$createConfigChildProduct2.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitChild2EditPageToLoad"/>
         <click selector="{{ProductInWebsitesSection.sectionHeader}}" stepKey="openProduct2InWebsitesSection"/>
         <click selector="{{ProductInWebsitesSection.website('Second Website')}}" stepKey="selectSecondWebsite2"/>
         <actionGroup ref="AdminFormSaveAndCloseActionGroup" stepKey="saveUpdatedChild2"/>
 
         <!--go to admin again and open child product2 and enable for second store view-->
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigChildProduct2.id$$)}}" stepKey="goToProduct2EditPage2"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct2EditPage2">
+            <argument name="productId" value="$$createConfigChildProduct2.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitChild2EditPageToLoad1"/>
         <click selector="{{AdminProductFormActionSection.changeStoreButton}}" stepKey="clickStoreviewSwitcherP2"/>
         <click selector="{{AdminProductFormActionSection.selectStoreView('Second Store View')}}" stepKey="chooseStoreView2P2"/>

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/NewProductsListWidgetConfigurableProductTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/NewProductsListWidgetConfigurableProductTest.xml
@@ -78,7 +78,9 @@
         <!-- A Cms page containing the New Products Widget gets created here via extends -->
 
         <!-- Modify the Configurable Product that we created in the before block -->
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigProduct.id$$)}}" stepKey="amOnEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="amOnEditPage">
+            <argument name="productId" value="$$createConfigProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForEditPage"/>
         <fillField selector="{{AdminProductFormSection.setProductAsNewFrom}}" userInput="01/1/2000" stepKey="fillProductNewFrom"/>
         <fillField selector="{{AdminProductFormSection.setProductAsNewTo}}" userInput="01/1/2099" stepKey="fillProductNewTo"/>

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/NoOptionAvailableToConfigureDisabledProductTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/NoOptionAvailableToConfigureDisabledProductTest.xml
@@ -109,13 +109,17 @@
         </after>
         <!-- Disable child product -->
         <comment userInput="Disable child product" stepKey="disableChildProduct"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigChildProduct1.id$$)}}" stepKey="goToEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToEditPage">
+            <argument name="productId" value="$$createConfigChildProduct1.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForChildProductPageLoad"/>
         <click selector="{{AdminProductFormSection.enableProductLabel}}" stepKey="disableProduct"/>
         <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProductForm"/>
         <!-- Set the second product out of stock -->
         <comment userInput="Set the second product out of stock" stepKey="outOfStockChildProduct"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigChildProduct2.id$$)}}" stepKey="goToSecondProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToSecondProductEditPage">
+            <argument name="productId" value="$$createConfigChildProduct2.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForSecondChildProductPageLoad"/>
         <selectOption selector="{{AdminProductFormSection.productStockStatus}}" userInput="Out of Stock" stepKey="outOfStockStatus"/>
         <actionGroup ref="SaveProductFormActionGroup" stepKey="saveSecondProductForm"/>

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontShouldSeeOnlyConfigurableProductChildAssignedToSeparateCategoryTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontShouldSeeOnlyConfigurableProductChildAssignedToSeparateCategoryTest.xml
@@ -101,7 +101,7 @@
         </after>
 
         <!-- Go to the product page for the first product -->
-        <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="openConfigChildProduct1Page">
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openConfigChildProduct1Page">
             <argument name="productId" value="$$createConfigChildProduct1.id$$"/>
         </actionGroup>
 

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontVisibilityOfDuplicateProductTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontVisibilityOfDuplicateProductTest.xml
@@ -49,7 +49,9 @@
         </after>
         <!--Create attribute and options for product-->
         <comment userInput="Create attribute and options for product" stepKey="commentCreateAttributesAndOptions"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigProduct.id$$)}}" stepKey="navigateToConfigProductPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="navigateToConfigProductPage">
+            <argument name="productId" value="$$createConfigProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPageLoad"/>
         <actionGroup ref="AddProductImageActionGroup" stepKey="addImageForProduct1">
             <argument name="image" value="MagentoLogo"/>

--- a/app/code/Magento/Downloadable/Test/Mftf/Test/AdminProductTypeSwitchingOnEditingTest.xml
+++ b/app/code/Magento/Downloadable/Test/Mftf/Test/AdminProductTypeSwitchingOnEditingTest.xml
@@ -54,7 +54,9 @@
         </after>
         <!--Change product type to Downloadable-->
         <comment userInput="Change product type to Downloadable" stepKey="commentCreateDownloadable"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="gotToDownloadableProductPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="gotToDownloadableProductPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForDownloadableProductPageLoad"/>
         <selectOption selector="{{AdminProductFormSection.productWeightSelect}}" userInput="This item has no weight" stepKey="selectNoWeightForProduct"/>
         <actionGroup ref="AdminAddDownloadableLinkInformationActionGroup" stepKey="addDownloadableLinkInformation"/>

--- a/app/code/Magento/Downloadable/Test/Mftf/Test/VerifyDisableDownloadableProductSamplesAreNotAccessibleTest.xml
+++ b/app/code/Magento/Downloadable/Test/Mftf/Test/VerifyDisableDownloadableProductSamplesAreNotAccessibleTest.xml
@@ -87,7 +87,7 @@
         <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
 
         <!-- Open Downloadable product from precondition -->
-        <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="openProductEditPage">
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openProductEditPage">
             <argument name="productId" value="$createProduct.id$"/>
         </actionGroup>
 

--- a/app/code/Magento/Fedex/Test/Mftf/Test/AdminCreatingShippingLabelTest.xml
+++ b/app/code/Magento/Fedex/Test/Mftf/Test/AdminCreatingShippingLabelTest.xml
@@ -78,7 +78,9 @@
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
         <!--Add country of manufacture to product-->
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="amOnEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="amOnEditPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForEditPage"/>
         <actionGroup ref="AdminFillProductCountryOfManufactureActionGroup" stepKey="fillCountryOfManufacture">
             <argument name="countryId" value="DE"/>

--- a/app/code/Magento/Indexer/Test/Mftf/Test/AdminSystemIndexManagementGridChangesTest.xml
+++ b/app/code/Magento/Indexer/Test/Mftf/Test/AdminSystemIndexManagementGridChangesTest.xml
@@ -44,7 +44,9 @@
         <seeElement selector="{{AdminIndexManagementSection.columnScheduleStatus}}" stepKey="seeScheduleStatusColumn"/>
 
         <!--Adding Special price to product-->
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="openAdminProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openAdminProductEditPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <actionGroup ref="AddSpecialPriceToProductActionGroup" stepKey="addSpecialPrice"/>
         <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProductForm"/>
 

--- a/app/code/Magento/LayeredNavigation/Test/Mftf/Test/ShopByButtonInMobileTest.xml
+++ b/app/code/Magento/LayeredNavigation/Test/Mftf/Test/ShopByButtonInMobileTest.xml
@@ -45,7 +45,9 @@
         <click selector="{{AdminProductAttributeSetSection.saveBtn}}" stepKey="clickAttributeSetSave"/>
         <!-- Go to simple product edit page and set the product attribute to a value -->
         <comment userInput="Go to simple product edit page and set the product attribute to a value" stepKey="commentProductAttributeEdit" />
-        <amOnPage url="{{AdminProductEditPage.url($$simpleProduct1.id$$)}}" stepKey="goToEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToEditPage">
+            <argument name="productId" value="$$simpleProduct1.id$$"/>
+        </actionGroup>
         <selectOption selector="{{AdminProductFormSection.customSelectField($$attribute.attribute[attribute_code]$$)}}" userInput="option1" stepKey="selectAttribute"/>
         <actionGroup ref="SaveProductFormActionGroup" stepKey="saveSimpleProduct"/>
         <!-- Check storefront mobile view for shop by button is functioning as expected -->

--- a/app/code/Magento/Msrp/Test/Mftf/Test/StorefrontProductWithMapAssignedConfigProductIsCorrectTest.xml
+++ b/app/code/Magento/Msrp/Test/Mftf/Test/StorefrontProductWithMapAssignedConfigProductIsCorrectTest.xml
@@ -111,7 +111,9 @@
         </after>
 
         <!-- Set Manufacturer's Suggested Retail Price to products-->
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigChildProduct1.id$$)}}" stepKey="goToFirstChildProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToFirstChildProductEditPage">
+            <argument name="productId" value="$$createConfigChildProduct1.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPageLoad"/>
         <click selector="{{AdminProductFormSection.advancedPricingLink}}" stepKey="clickOnAdvancedPricingButton"/>
         <waitForElement selector="{{AdminProductFormAdvancedPricingSection.msrp}}" stepKey="waitForMsrp"/>
@@ -119,7 +121,9 @@
         <click selector="{{AdminProductFormAdvancedPricingSection.doneButton}}" stepKey="clickDoneButton"/>
         <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProduct1"/>
 
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigChildProduct2.id$$)}}" stepKey="goToSecondChildProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToSecondChildProductEditPage">
+            <argument name="productId" value="$$createConfigChildProduct2.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPageLoad1"/>
         <click selector="{{AdminProductFormSection.advancedPricingLink}}" stepKey="clickOnAdvancedPricingButton1"/>
         <waitForElement selector="{{AdminProductFormAdvancedPricingSection.msrp}}" stepKey="waitForMsrp1"/>

--- a/app/code/Magento/Sales/Test/Mftf/Test/AdminCorrectnessInvoicedItemInBundleProductTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/AdminCorrectnessInvoicedItemInBundleProductTest.xml
@@ -52,7 +52,9 @@
         </after>
 
         <!--Complete Bundle product creation-->
-        <amOnPage url="{{AdminProductEditPage.url($$createBundleProduct.id$$)}}" stepKey="goToProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage">
+            <argument name="productId" value="$$createBundleProduct.id$$"/>
+        </actionGroup>
         <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProduct"/>
 
         <!--Run re-index task-->

--- a/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderWithSimpleProductCustomOptionFileTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderWithSimpleProductCustomOptionFileTest.xml
@@ -33,7 +33,9 @@
         </after>
 
         <!--Add option to product.-->
-        <amOnPage url="{{AdminProductEditPage.url($simpleProduct.id$)}}" stepKey="navigateToProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="navigateToProductEditPage">
+            <argument name="productId" value="$simpleProduct.id$"/>
+        </actionGroup>
         <actionGroup ref="AddProductCustomOptionFileActionGroup" stepKey="addOption">
             <argument name="option" value="ProductOptionFile"/>
         </actionGroup>

--- a/app/code/Magento/Sales/Test/Mftf/Test/AdminProductInTheShoppingCartCouldBeReachedByAdminDuringOrderCreationWithMultiWebsiteConfigTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/AdminProductInTheShoppingCartCouldBeReachedByAdminDuringOrderCreationWithMultiWebsiteConfigTest.xml
@@ -37,7 +37,7 @@
                 <argument name="StoreGroup" value="customStoreGroup"/>
                 <argument name="customStore" value="customStore"/>
             </actionGroup>
-            <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="goToProductEditPage">
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage">
                 <argument name="productId" value="$$createProduct.id$$"/>
             </actionGroup>
             <actionGroup ref="ProductSetWebsiteActionGroup" stepKey="assignProductToSecondWebsite">

--- a/app/code/Magento/Shipping/Test/Mftf/Test/AdminCreateOrderCustomStoreShippingMethodTableRatesTest.xml
+++ b/app/code/Magento/Shipping/Test/Mftf/Test/AdminCreateOrderCustomStoreShippingMethodTableRatesTest.xml
@@ -76,7 +76,9 @@
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
         <!--Assign product to custom website-->
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="goToProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPageLoad"/>
         <actionGroup ref="UnassignWebsiteFromProductActionGroup" stepKey="unassignWebsiteInProduct">
             <argument name="website" value="{{_defaultWebsite.name}}"/>

--- a/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontImageColorWhenFilterByColorFilterTest.xml
+++ b/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontImageColorWhenFilterByColorFilterTest.xml
@@ -41,7 +41,9 @@
             <actionGroup ref="DeleteProductsIfTheyExistActionGroup" stepKey="deleteAllProducts"/>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
-        <amOnPage url="{{AdminProductEditPage.url($$createConfigProduct.id$$)}}" stepKey="navigateToConfigProductPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="navigateToConfigProductPage">
+            <argument name="productId" value="$$createConfigProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPageLoad"/>
         <!--Create visual swatch attribute-->
         <actionGroup ref="AddVisualSwatchWithProductWithStorefrontPreviewImageConfigActionGroup" stepKey="addSwatchToProduct">

--- a/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontSeeProductImagesMatchingProductSwatchesTest.xml
+++ b/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontSeeProductImagesMatchingProductSwatchesTest.xml
@@ -63,7 +63,7 @@
         </actionGroup>
 
         <!-- Edit configurable product -->
-        <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="openProductEditPage">
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openProductEditPage">
             <argument name="productId" value="$$createSimpleProduct.id$$"/>
         </actionGroup>
 

--- a/app/code/Magento/Weee/Test/Mftf/Test/AdminFixedTaxValSavedForSpecificWebsiteTest.xml
+++ b/app/code/Magento/Weee/Test/Mftf/Test/AdminFixedTaxValSavedForSpecificWebsiteTest.xml
@@ -70,7 +70,9 @@
         </after>
         <!-- Go to product edit page and assign it to created website -->
         <comment userInput="Go to product edit page and assign it to created website" stepKey="assignProductToCreatedWebsite"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="navigateToProductPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="navigateToProductPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPageLoad"/>
         <actionGroup ref="SelectProductInWebsitesActionGroup" stepKey="selectWebsiteInProduct">
             <argument name="website" value="{{NewWebSiteData.name}}"/>
@@ -99,7 +101,9 @@
         <magentoCLI command="cache:flush" stepKey="flushCache"/>
         <!--See available websites only 'All Websites'-->
         <comment userInput="See available websites 'All Websites', 'Main Website' and Second website" stepKey="commentCheckWebsitesInProductPage"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="goToProductPageSecondTime"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductPageSecondTime">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <waitForPageLoad stepKey="waitForProductPageLoadSecondTime"/>
         <seeElement selector="{{AdminProductAddFPTValueSection.setWebSiteForFPTOption($$createProductFPTAttribute.attribute_code$$, 'All Websites')}}" stepKey="checkAllWebsitesInDropDown"/>
         <seeElement selector="{{AdminProductAddFPTValueSection.setWebSiteForFPTOption($$createProductFPTAttribute.attribute_code$$, 'Main Website')}}" stepKey="checkMainWebsiteInDropDown"/>

--- a/app/code/Magento/Weee/Test/Mftf/Test/StorefrontFPTTaxInformationInShoppingCartForCustomerPhysicalQuoteTest.xml
+++ b/app/code/Magento/Weee/Test/Mftf/Test/StorefrontFPTTaxInformationInShoppingCartForCustomerPhysicalQuoteTest.xml
@@ -42,7 +42,7 @@
             <!-- Customer is created with default addresses: -->
             <createData entity="Simple_US_Customer_CA" stepKey="createCustomer"/>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
-            <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="openProductEditPage">
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openProductEditPage">
                 <argument name="productId" value="$createSimpleProduct.id$"/>
             </actionGroup>
             <actionGroup ref="AdminProductAddFPTValueActionGroup" stepKey="addFPTValue1">

--- a/app/code/Magento/Weee/Test/Mftf/Test/StorefrontFPTTaxInformationInShoppingCartForGuestPhysicalQuoteTest.xml
+++ b/app/code/Magento/Weee/Test/Mftf/Test/StorefrontFPTTaxInformationInShoppingCartForGuestPhysicalQuoteTest.xml
@@ -40,7 +40,7 @@
                 <field key="price">10.00</field>
             </createData>
             <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
-            <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="openProductEditPage">
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openProductEditPage">
                 <argument name="productId" value="$createSimpleProduct.id$"/>
             </actionGroup>
             <actionGroup ref="AdminProductAddFPTValueActionGroup" stepKey="addFPTValue1">

--- a/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDeleteBundleDynamicProductFromWishlistTest.xml
+++ b/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDeleteBundleDynamicProductFromWishlistTest.xml
@@ -48,7 +48,7 @@
             </createData>
 
             <actionGroup ref="LoginAsAdmin" stepKey="LoginAsAdmin"/>
-            <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="goToProduct">
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct">
                 <argument name="productId" value="$$createBundleProduct.id$$"/>
             </actionGroup>
             <scrollTo selector="{{AdminProductFormBundleSection.contentDropDown}}" stepKey="scrollToBundleSection"/>

--- a/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontMoveDynamicBundleProductFromShoppingCartToWishlistTest.xml
+++ b/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontMoveDynamicBundleProductFromShoppingCartToWishlistTest.xml
@@ -46,7 +46,7 @@
                 <requiredEntity createDataKey="simpleProduct2"/>
             </createData>
             <actionGroup ref="LoginAsAdmin" stepKey="LoginAsAdmin"/>
-            <actionGroup ref="GoToProductPageViaIDActionGroup" stepKey="goToProduct">
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct">
                 <argument name="productId" value="$$createBundleProduct.id$$"/>
             </actionGroup>
             <scrollTo selector="{{AdminProductFormBundleSection.contentDropDown}}" stepKey="scrollToBundleSection"/>

--- a/app/code/Magento/Wishlist/Test/Mftf/Test/WishListWithDisabledProductTest.xml
+++ b/app/code/Magento/Wishlist/Test/Mftf/Test/WishListWithDisabledProductTest.xml
@@ -40,7 +40,9 @@
         </actionGroup>
         <openNewTab stepKey="openNewTab"/>
         <actionGroup ref="LoginAsAdmin" stepKey="loginToAdminArea"/>
-        <amOnPage url="{{AdminProductEditPage.url($$createProduct.id$$)}}" stepKey="goToProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
         <actionGroup ref="AdminSetProductDisabledActionGroup" stepKey="disableProduct"/>
         <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProduct"/>
         <closeTab stepKey="closeSecondTab"/>


### PR DESCRIPTION
### Description (*)
Renamed `GoToProductPageViaIDActionGroup` to the name that follows Magento best practices `AdminProductPageOpenByIdActionGroup`, replaced all `<amOnPage` calls to Action Groups

**Won't fix:**
Quite often problem of flaky tests in Magento CI is timeout on opening different pages. Most recent example is:
![image](https://user-images.githubusercontent.com/1639941/77214129-dc1f3100-6b0d-11ea-9847-38d2afc9d039.png)
![image](https://user-images.githubusercontent.com/1639941/77214138-e9d4b680-6b0d-11ea-8546-e8805bc45602.png)

You can see, that assertion (expectation) of loaded page failed, but the page is still loading. That's why I decided to add `waitForPageLoad`. But not only!

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
Magento CI failures

### Manual testing scenarios (*)
PR should pass.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
