### PR TITLE
Use Logger implementation based on deployment configuration

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -7,7 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="DateTimeInterface" type="DateTime" />
-    <preference for="Psr\Log\LoggerInterface" type="Magento\Framework\Logger\Monolog" />
+    <preference for="Psr\Log\LoggerInterface" type="Magento\Framework\Logger\LoggerProxy" />
     <preference for="Magento\Framework\EntityManager\EntityMetadataInterface" type="Magento\Framework\EntityManager\EntityMetadata" />
     <preference for="Magento\Framework\EntityManager\HydratorInterface" type="Magento\Framework\EntityManager\Hydrator" />
     <preference for="Magento\Framework\View\Template\Html\MinifierInterface" type="Magento\Framework\View\Template\Html\Minifier" />

--- a/dev/tests/integration/etc/di/preferences/ce.php
+++ b/dev/tests/integration/etc/di/preferences/ce.php
@@ -5,30 +5,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+use \Magento\Framework\App;
+use \Magento\Framework as MF;
+use \Magento\TestFramework as TF;
 
 return [
-    \Magento\Framework\Stdlib\CookieManagerInterface::class => \Magento\TestFramework\CookieManager::class,
-    \Magento\Framework\ObjectManager\DynamicConfigInterface::class =>
-        \Magento\TestFramework\ObjectManager\Configurator::class,
-    \Magento\Framework\App\RequestInterface::class => \Magento\TestFramework\Request::class,
-    \Magento\Framework\App\Request\Http::class => \Magento\TestFramework\Request::class,
-    \Magento\Framework\App\ResponseInterface::class => \Magento\TestFramework\Response::class,
-    \Magento\Framework\App\Response\Http::class => \Magento\TestFramework\Response::class,
-    \Magento\Framework\Interception\PluginListInterface::class =>
-        \Magento\TestFramework\Interception\PluginList::class,
-    \Magento\Framework\Interception\ObjectManager\ConfigInterface::class =>
-        \Magento\TestFramework\ObjectManager\Config::class,
-    \Magento\Framework\Interception\ObjectManager\Config\Developer::class =>
-        \Magento\TestFramework\ObjectManager\Config::class,
-    \Magento\Framework\View\LayoutInterface::class => \Magento\TestFramework\View\Layout::class,
-    \Magento\Framework\App\ResourceConnection\ConnectionAdapterInterface::class =>
-        \Magento\TestFramework\Db\ConnectionAdapter::class,
-    \Magento\Framework\Filesystem\DriverInterface::class => \Magento\Framework\Filesystem\Driver\File::class,
-    \Magento\Framework\App\Config\ScopeConfigInterface::class => \Magento\TestFramework\App\Config::class,
-    \Magento\Framework\App\ResourceConnection\ConfigInterface::class =>
-        \Magento\Framework\App\ResourceConnection\Config::class,
-    \Magento\Framework\Lock\Backend\Database::class =>
-        \Magento\TestFramework\Lock\Backend\DummyLocker::class,
-    \Magento\Framework\Session\SessionStartChecker::class => \Magento\TestFramework\Session\SessionStartChecker::class,
-    \Magento\Framework\HTTP\AsyncClientInterface::class => \Magento\TestFramework\HTTP\AsyncClientInterfaceMock::class
+    MF\Stdlib\CookieManagerInterface::class => TF\CookieManager::class,
+    MF\ObjectManager\DynamicConfigInterface::class => TF\ObjectManager\Configurator::class,
+    App\RequestInterface::class => TF\Request::class,
+    App\Request\Http::class => TF\Request::class,
+    App\ResponseInterface::class => TF\Response::class,
+    App\Response\Http::class => TF\Response::class,
+    MF\Interception\PluginListInterface::class => TF\Interception\PluginList::class,
+    MF\Interception\ObjectManager\ConfigInterface::class => TF\ObjectManager\Config::class,
+    MF\Interception\ObjectManager\Config\Developer::class => TF\ObjectManager\Config::class,
+    MF\View\LayoutInterface::class => TF\View\Layout::class,
+    App\ResourceConnection\ConnectionAdapterInterface::class => TF\Db\ConnectionAdapter::class,
+    MF\Filesystem\DriverInterface::class => MF\Filesystem\Driver\File::class,
+    App\Config\ScopeConfigInterface::class => TF\App\Config::class,
+    App\ResourceConnection\ConfigInterface::class => App\ResourceConnection\Config::class,
+    MF\Lock\Backend\Database::class => TF\Lock\Backend\DummyLocker::class,
+    MF\Session\SessionStartChecker::class => TF\Session\SessionStartChecker::class,
+    MF\HTTP\AsyncClientInterface::class => TF\HTTP\AsyncClientInterfaceMock::class
 ];

--- a/dev/tests/integration/framework/Magento/TestFramework/Application.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Application.php
@@ -5,12 +5,15 @@
  */
 namespace Magento\TestFramework;
 
-use Magento\Framework\Autoload\AutoloaderInterface;
-use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\DeploymentConfig;
-use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\App\DeploymentConfig\Reader;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Autoload\AutoloaderInterface;
+use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\Filesystem\Glob;
+use Magento\Framework\Mail;
+use Magento\TestFramework;
+use Psr\Log\LoggerInterface;
 
 /**
  * Encapsulates application installation, initialization and uninstall.
@@ -28,7 +31,7 @@ class Application
     /**
      * DB vendor adapter instance.
      *
-     * @var \Magento\TestFramework\Db\AbstractDb
+     * @var TestFramework\Db\AbstractDb
      */
     protected $_db;
 
@@ -105,14 +108,14 @@ class Application
     /**
      * Object manager factory.
      *
-     * @var \Magento\TestFramework\ObjectManagerFactory
+     * @var TestFramework\ObjectManagerFactory
      */
     protected $_factory;
 
     /**
      * Directory list.
      *
-     * @var \Magento\Framework\App\Filesystem\DirectoryList
+     * @var DirectoryList
      */
     protected $dirList;
 
@@ -180,7 +183,7 @@ class Application
         $this->loadTestExtensionAttributes = $loadTestExtensionAttributes;
 
         $customDirs = $this->getCustomDirs();
-        $this->dirList = new \Magento\Framework\App\Filesystem\DirectoryList(BP, $customDirs);
+        $this->dirList = new DirectoryList(BP, $customDirs);
         \Magento\Framework\Autoload\Populator::populateMappings(
             $autoloadWrapper,
             $this->dirList
@@ -189,9 +192,9 @@ class Application
             \Magento\Framework\App\Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS => $customDirs,
             \Magento\Framework\App\State::PARAM_MODE => $appMode
         ];
-        $driverPool = new \Magento\Framework\Filesystem\DriverPool;
-        $configFilePool = new \Magento\Framework\Config\File\ConfigFilePool;
-        $this->_factory = new \Magento\TestFramework\ObjectManagerFactory($this->dirList, $driverPool, $configFilePool);
+        $driverPool = new \Magento\Framework\Filesystem\DriverPool();
+        $configFilePool = new \Magento\Framework\Config\File\ConfigFilePool();
+        $this->_factory = new TestFramework\ObjectManagerFactory($this->dirList, $driverPool, $configFilePool);
 
         $this->_configDir = $this->dirList->getPath(DirectoryList::CONFIG);
         $this->globalConfigFile = $globalConfigFile;
@@ -200,7 +203,7 @@ class Application
     /**
      * Retrieve the database adapter instance.
      *
-     * @return \Magento\TestFramework\Db\AbstractDb
+     * @return TestFramework\Db\AbstractDb
      */
     public function getDbInstance()
     {
@@ -310,7 +313,7 @@ class Application
         $objectManager = Helper\Bootstrap::getObjectManager();
         /** @var \Psr\Log\LoggerInterface $logger */
         $logger = $objectManager->create(
-            \Magento\TestFramework\ErrorLog\Logger::class,
+            TestFramework\ErrorLog\Logger::class,
             [
                 'name' => 'integration-tests',
                 'handlers' => [
@@ -331,9 +334,8 @@ class Application
                 ]
             ]
         );
-
-        $objectManager->removeSharedInstance(\Magento\Framework\Logger\Monolog::class);
-        $objectManager->addSharedInstance($logger, \Magento\Framework\Logger\Monolog::class);
+        $objectManager->removeSharedInstance(LoggerInterface::class, true);
+        $objectManager->addSharedInstance($logger, LoggerInterface::class, true);
         return $logger;
     }
 
@@ -351,31 +353,35 @@ class Application
             ? $overriddenParams[\Magento\Framework\App\Bootstrap::INIT_PARAM_FILESYSTEM_DIR_PATHS]
             : [];
         $directoryList = new DirectoryList(BP, $directories);
-        /** @var \Magento\TestFramework\ObjectManager $objectManager */
+        /** @var TestFramework\ObjectManager $objectManager */
         $objectManager = Helper\Bootstrap::getObjectManager();
         if (!$objectManager) {
             $objectManager = $this->_factory->create($overriddenParams);
-            $objectManager->addSharedInstance($directoryList, \Magento\Framework\App\Filesystem\DirectoryList::class);
-            $objectManager->addSharedInstance($directoryList, \Magento\Framework\Filesystem\DirectoryList::class);
+            $objectManager->addSharedInstance(
+                $directoryList,
+                DirectoryList::class
+            );
+            $objectManager->addSharedInstance(
+                $directoryList,
+                \Magento\Framework\Filesystem\DirectoryList::class
+            );
         } else {
             $objectManager = $this->_factory->restore($objectManager, $directoryList, $overriddenParams);
         }
-        /** @var \Magento\TestFramework\App\Filesystem $filesystem */
-        $filesystem = $objectManager->get(\Magento\TestFramework\App\Filesystem::class);
+        /** @var TestFramework\App\Filesystem $filesystem */
+        $filesystem = $objectManager->get(TestFramework\App\Filesystem::class);
         $objectManager->removeSharedInstance(\Magento\Framework\Filesystem::class);
         $objectManager->addSharedInstance($filesystem, \Magento\Framework\Filesystem::class);
         Helper\Bootstrap::setObjectManager($objectManager);
         $this->initLogger();
-        $sequenceBuilder = $objectManager->get(\Magento\TestFramework\Db\Sequence\Builder::class);
+        $sequenceBuilder = $objectManager->get(TestFramework\Db\Sequence\Builder::class);
         $objectManager->addSharedInstance($sequenceBuilder, \Magento\SalesSequence\Model\Builder::class);
 
         $objectManagerConfiguration = [
             'preferences' => [
-                \Magento\Framework\App\State::class => \Magento\TestFramework\App\State::class,
-                \Magento\Framework\Mail\TransportInterface::class =>
-                    \Magento\TestFramework\Mail\TransportInterfaceMock::class,
-                \Magento\Framework\Mail\Template\TransportBuilder::class
-                => \Magento\TestFramework\Mail\Template\TransportBuilderMock::class,
+                \Magento\Framework\App\State::class => TestFramework\App\State::class,
+                Mail\TransportInterface::class => TestFramework\Mail\TransportInterfaceMock::class,
+                Mail\Template\TransportBuilder::class => TestFramework\Mail\Template\TransportBuilderMock::class,
             ]
         ];
         if ($this->loadTestExtensionAttributes) {
@@ -385,7 +391,7 @@ class Application
                     \Magento\Framework\Api\ExtensionAttribute\Config\Reader::class => [
                         'arguments' => [
                             'fileResolver' => [
-                                'instance' => \Magento\TestFramework\Api\Config\Reader\FileResolver::class
+                                'instance' => TestFramework\Api\Config\Reader\FileResolver::class
                             ],
                         ],
                     ],
@@ -400,7 +406,7 @@ class Application
             [
                 'core_app_init_current_store_after' => [
                     'integration_tests' => [
-                        'instance' => \Magento\TestFramework\Event\Magento::class,
+                        'instance' => TestFramework\Event\Magento::class,
                         'name' => 'integration_tests'
                     ]
                 ]
@@ -408,10 +414,10 @@ class Application
         );
 
         if ($this->canLoadArea) {
-            $this->loadArea(\Magento\TestFramework\Application::DEFAULT_APP_AREA);
+            $this->loadArea(TestFramework\Application::DEFAULT_APP_AREA);
         }
 
-        \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->configure(
+        TestFramework\Helper\Bootstrap::getObjectManager()->configure(
             $objectManager->get(\Magento\Framework\ObjectManager\DynamicConfigInterface::class)->getConfiguration()
         );
         \Magento\Framework\Phrase::setRenderer(
@@ -419,7 +425,7 @@ class Application
         );
 
         if ($this->canInstallSequence) {
-            /** @var \Magento\TestFramework\Db\Sequence $sequence */
+            /** @var TestFramework\Db\Sequence $sequence */
             $sequence = $objectManager->get(\Magento\TestFramework\Db\Sequence::class);
             $sequence->generateSequences();
         }
@@ -649,7 +655,7 @@ class Application
             // phpcs:ignore Magento2.Functions.DiscouragedFunction
             mkdir($dir, 0777, true);
             umask($old);
-            // phpcs:ignore Magento2.Functions.DiscouragedFunction
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction
         } elseif (!is_dir($dir)) {
             throw new \Magento\Framework\Exception\LocalizedException(__("'%1' is not a directory.", $dir));
         }

--- a/dev/tests/integration/framework/Magento/TestFramework/ObjectManager.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/ObjectManager.php
@@ -85,10 +85,12 @@ class ObjectManager extends \Magento\Framework\App\ObjectManager
      *
      * @param mixed $instance
      * @param string $className
+     * @param bool $forPreference Resolve preference for class
      * @return void
      */
-    public function addSharedInstance($instance, $className)
+    public function addSharedInstance($instance, $className, $forPreference = false)
     {
+        $className  = $forPreference ? $this->_config->getPreference($className) : $className;
         $this->_sharedInstances[$className] = $instance;
     }
 
@@ -96,10 +98,12 @@ class ObjectManager extends \Magento\Framework\App\ObjectManager
      * Remove shared instance.
      *
      * @param string $className
+     * @param bool $forPreference Resolve preference for class
      * @return void
      */
-    public function removeSharedInstance($className)
+    public function removeSharedInstance($className, $forPreference = false)
     {
+        $className  = $forPreference ? $this->_config->getPreference($className) : $className;
         unset($this->_sharedInstances[$className]);
     }
 
@@ -115,6 +119,8 @@ class ObjectManager extends \Magento\Framework\App\ObjectManager
     }
 
     /**
+     * Get object factory
+     *
      * @return \Magento\Framework\ObjectManager\FactoryInterface|\Magento\Framework\ObjectManager\Factory\Factory
      */
     public function getFactory()

--- a/dev/tests/integration/framework/Magento/TestFramework/ObjectManagerFactory.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/ObjectManagerFactory.php
@@ -5,12 +5,18 @@
  */
 namespace Magento\TestFramework;
 
+use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ObjectManager\ConfigLoader;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem\DriverPool;
+use Magento\Framework\Interception\PluginListInterface;
+use Magento\Framework\ObjectManager\ConfigLoaderInterface;
+use Magento\TestFramework\App\EnvironmentFactory;
+use Magento\TestFramework\Db\ConnectionAdapter;
 
 /**
- * Class ObjectManagerFactory
+ * Configure ObjectManagerFactory for testing purpose
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
@@ -21,7 +27,7 @@ class ObjectManagerFactory extends \Magento\Framework\App\ObjectManagerFactory
      *
      * @var string
      */
-    protected $_locatorClassName = \Magento\TestFramework\ObjectManager::class;
+    protected $_locatorClassName = ObjectManager::class;
 
     /**
      * Config class name
@@ -33,7 +39,7 @@ class ObjectManagerFactory extends \Magento\Framework\App\ObjectManagerFactory
     /**
      * @var string
      */
-    protected $envFactoryClassName = \Magento\TestFramework\App\EnvironmentFactory::class;
+    protected $envFactoryClassName = EnvironmentFactory::class;
 
     /**
      * @var array
@@ -50,21 +56,25 @@ class ObjectManagerFactory extends \Magento\Framework\App\ObjectManagerFactory
      */
     public function restore(ObjectManager $objectManager, $directoryList, array $arguments)
     {
-        \Magento\TestFramework\ObjectManager::setInstance($objectManager);
+        ObjectManager::setInstance($objectManager);
         $this->directoryList = $directoryList;
         $objectManager->configure($this->_primaryConfigData);
-        $objectManager->addSharedInstance($this->directoryList, \Magento\Framework\App\Filesystem\DirectoryList::class);
-        $objectManager->addSharedInstance($this->directoryList, \Magento\Framework\Filesystem\DirectoryList::class);
+        $objectManager->addSharedInstance($this->directoryList, DirectoryList::class);
+        $objectManager->addSharedInstance(
+            $this->directoryList,
+            \Magento\Framework\Filesystem\DirectoryList::class
+        );
         $deploymentConfig = $this->createDeploymentConfig($directoryList, $this->configFilePool, $arguments);
         $this->factory->setArguments($arguments);
-        $objectManager->addSharedInstance($deploymentConfig, \Magento\Framework\App\DeploymentConfig::class);
+        $objectManager->addSharedInstance($deploymentConfig, DeploymentConfig::class);
         $objectManager->addSharedInstance(
-            $objectManager->get(\Magento\Framework\App\ObjectManager\ConfigLoader::class),
-            \Magento\Framework\ObjectManager\ConfigLoaderInterface::class
+            $objectManager->get(ConfigLoader::class),
+            ConfigLoaderInterface::class,
+            true
         );
-        $objectManager->get(\Magento\Framework\Interception\PluginListInterface::class)->reset();
+        $objectManager->get(PluginListInterface::class)->reset();
         $objectManager->configure(
-            $objectManager->get(\Magento\Framework\App\ObjectManager\ConfigLoader::class)->load('global')
+            $objectManager->get(ConfigLoader::class)->load('global')
         );
 
         return $objectManager;
@@ -73,7 +83,7 @@ class ObjectManagerFactory extends \Magento\Framework\App\ObjectManagerFactory
     /**
      * Load primary config
      *
-     * @param \Magento\Framework\App\Filesystem\DirectoryList $directoryList
+     * @param DirectoryList $directoryList
      * @param DriverPool $driverPool
      * @param mixed $argumentMapper
      * @param string $appMode
@@ -85,7 +95,7 @@ class ObjectManagerFactory extends \Magento\Framework\App\ObjectManagerFactory
             $this->_primaryConfigData = array_replace(
                 parent::_loadPrimaryConfig($directoryList, $driverPool, $argumentMapper, $appMode),
                 [
-                    'default_setup' => ['type' => \Magento\TestFramework\Db\ConnectionAdapter::class]
+                    'default_setup' => ['type' => ConnectionAdapter::class]
                 ]
             );
             $diPreferences = [];

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Set/SaveTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/Set/SaveTest.php
@@ -25,12 +25,14 @@ use Magento\Framework\Message\MessageInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\TestCase\AbstractBackendController;
+use Psr\Log\LoggerInterface;
 
 /**
  * Testing for saving an existing or creating a new attribute set.
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @magentoAppArea adminhtml
+ * @magentoAppIsolation enabled
  */
 class SaveTest extends AbstractBackendController
 {
@@ -90,7 +92,7 @@ class SaveTest extends AbstractBackendController
     protected function setUp(): void
     {
         parent::setUp();
-        $this->logger = $this->_objectManager->get(Monolog::class);
+        $this->logger = $this->_objectManager->get(LoggerInterface::class);
         $this->syslogHandler = $this->_objectManager->create(
             Syslog::class,
             [

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Product/ViewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Product/ViewTest.php
@@ -30,6 +30,7 @@ use Magento\TestFramework\TestCase\AbstractController;
 /**
  * Integration test for product view front action.
  *
+ * @magentoAppIsolation enabled
  * @magentoAppArea frontend
  * @magentoDbIsolation enabled
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -362,7 +363,7 @@ class ViewTest extends AbstractController
         $logger = $this->getMockBuilder(LoggerInterface::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-        $this->_objectManager->addSharedInstance($logger, MagentoMonologLogger::class);
+        $this->_objectManager->addSharedInstance($logger, LoggerInterface::class, true);
 
         return $logger;
     }

--- a/dev/tests/integration/testsuite/Magento/Developer/Model/Logger/Handler/DebugTest.php
+++ b/dev/tests/integration/testsuite/Magento/Developer/Model/Logger/Handler/DebugTest.php
@@ -16,9 +16,11 @@ use Magento\Framework\Shell;
 use Magento\Setup\Mvc\Bootstrap\InitParamListener;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\ObjectManager;
+use Psr\Log\LoggerInterface;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @magentoAppIsolation enabled
  */
 class DebugTest extends \PHPUnit\Framework\TestCase
 {
@@ -76,7 +78,7 @@ class DebugTest extends \PHPUnit\Framework\TestCase
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->shell = $this->objectManager->get(Shell::class);
-        $this->logger = $this->objectManager->get(Monolog::class);
+        $this->logger = $this->objectManager->get(LoggerInterface::class);
         $this->deploymentConfig = $this->objectManager->get(DeploymentConfig::class);
 
         /** @var Filesystem $filesystem */

--- a/dev/tests/integration/testsuite/Magento/Framework/Code/Generator/AutoloaderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Code/Generator/AutoloaderTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject as MockObject;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @magentoAppIsolation enabled
+ */
 class AutoloaderTest extends TestCase
 {
     /**
@@ -28,21 +31,11 @@ class AutoloaderTest extends TestCase
         return ObjectManager::getInstance();
     }
 
-    /**
-     * @before
-     */
-    public function setupLoggerTestDouble(): void
+    protected function setUp(): void
     {
-        $loggerTestDouble = $this->getMockForAbstractClass(LoggerInterface::class);
-        $this->getTestFrameworkObjectManager()->addSharedInstance($loggerTestDouble, MagentoMonologLogger::class);
-    }
-
-    /**
-     * @after
-     */
-    public function removeLoggerTestDouble(): void
-    {
-        $this->getTestFrameworkObjectManager()->removeSharedInstance(MagentoMonologLogger::class);
+        $loggerTestDouble = $this->createMock(LoggerInterface::class);
+        $this->getTestFrameworkObjectManager()->addSharedInstance($loggerTestDouble, LoggerInterface::class, true);
+        // magentoAppIsolation will cleanup the mess
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Paypal/Controller/Payflow/SilentPostTest.php
+++ b/dev/tests/integration/testsuite/Magento/Paypal/Controller/Payflow/SilentPostTest.php
@@ -18,7 +18,11 @@ use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Email\Sender\OrderSender;
 use Magento\TestFramework\TestCase\AbstractController;
 use PHPUnit\Framework\MockObject_MockObject as MockObject;
+use Psr\Log\LoggerInterface;
 
+/**
+ * @magentoAppIsolation enabled
+ */
 class SilentPostTest extends AbstractController
 {
     /**
@@ -114,7 +118,7 @@ class SilentPostTest extends AbstractController
         $logger = $this->getMockBuilder(Monolog::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->_objectManager->addSharedInstance($logger, Monolog::class);
+        $this->_objectManager->addSharedInstance($logger, LoggerInterface::class, true);
 
         $exception = new CommandException(__('Response message from PayPal gateway'));
         $logger->expects(self::once())
@@ -125,7 +129,7 @@ class SilentPostTest extends AbstractController
 
         self::assertEquals(200, $this->getResponse()->getStatusCode());
 
-        $this->_objectManager->removeSharedInstance(Monolog::class);
+        $this->_objectManager->removeSharedInstance(LoggerInterface::class, true);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Store/App/Config/Source/InitialConfigSourceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Store/App/Config/Source/InitialConfigSourceTest.php
@@ -7,10 +7,12 @@ declare(strict_types=1);
 
 namespace Magento\Store\App\Config\Source;
 
+use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\DeploymentConfig\FileReader;
 use Magento\Framework\App\DeploymentConfig\Writer;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
@@ -18,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test that initial scopes config are loaded if database is available
+ * @magentoAppIsolation enabled
  */
 class InitialConfigSourceTest extends TestCase
 {
@@ -91,7 +94,7 @@ class InitialConfigSourceTest extends TestCase
      * @param array $websites
      * @param string $defaultWebsite
      * @param bool $offline
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      * @dataProvider getDefaultDataProvider
      */
     public function testGetWebsites(array $websites, string $defaultWebsite, bool $offline = false): void
@@ -114,28 +117,33 @@ class InitialConfigSourceTest extends TestCase
             [
                 [
                     'admin',
+                    'main',
+                ],
+                'main',
+                true
+            ],
+            [
+                [
+                    'admin',
                     'base',
                 ],
                 'base',
                 false
             ],
-            [
-                [
-                    'admin',
-                    'main',
-                ],
-                'main',
-                true
-            ]
         ];
     }
 
     private function clearConfig(string $type): void
     {
-        $this->filesystem->getDirectoryWrite(DirectoryList::CONFIG)->writeFile(
-            $this->configFilePool->getPath($type),
-            "<?php\n return [];\n"
-        );
+        $this->filesystem
+            ->getDirectoryWrite(DirectoryList::CONFIG)
+            ->writeFile(
+                $this->configFilePool->getPath($type),
+                "<?" . "php\n return [];\n"
+            );
+        /** @var DeploymentConfig $config */
+        $config = Bootstrap::getObjectManager()->get(DeploymentConfig::class);
+        $config->resetData();
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Swatches/Controller/Adminhtml/Product/AttributeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Swatches/Controller/Adminhtml/Product/AttributeTest.php
@@ -175,11 +175,8 @@ class AttributeTest extends \Magento\TestFramework\TestCase\AbstractBackendContr
      */
     public function getLargeSwatchesAmountAttributeData() : array
     {
-        $maxInputVars = ini_get('max_input_vars');
-        // Each option is at least 7 variables array for a visual swatch.
-        // Set options count to exceed max_input_vars by 20 options (140 variables).
-        $swatchVisualOptionsCount = (int)floor($maxInputVars / 7) + 20;
-        $swatchTextOptionsCount = (int)floor($maxInputVars / 4) + 80;
+        $swatchVisualOptionsCount = 2000;
+        $swatchTextOptionsCount = 2000;
         return [
             'visual swatches' => $this->getSwatchVisualDataSet($swatchVisualOptionsCount),
             'text swatches' => $this->getSwatchTextDataSet($swatchTextOptionsCount)

--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/blacklist/common.txt
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/blacklist/common.txt
@@ -8,6 +8,7 @@ lib/internal/Magento/Framework/Image/Adapter/ImageMagick.php
 lib/internal/Magento/Framework/Interception/Test/Unit/Code/Generator/InterceptorTest.php
 lib/internal/Magento/Framework/Interception/Test/Unit/Config/ConfigTest.php
 dev/tests/integration/framework/deployTestModules.php
+dev/tests/integration/testsuite/Magento/Framework/Code/Generator/AutoloaderTest.php
 dev/tests/integration/testsuite/Magento/Framework/Filter/DirectiveProcessor/SimpleDirectiveTest.php
 dev/tests/integration/testsuite/Magento/Framework/Session/ConfigTest.php
 dev/tests/integration/testsuite/Magento/Framework/Session/SessionManagerTest.php

--- a/lib/internal/Magento/Framework/App/Config/ConfigSourceAggregated.php
+++ b/lib/internal/Magento/Framework/App/Config/ConfigSourceAggregated.php
@@ -22,6 +22,9 @@ class ConfigSourceAggregated implements ConfigSourceInterface
     public function __construct(array $sources = [])
     {
         $this->sources = $sources;
+        uasort($this->sources, function ($firstItem, $secondItem) {
+            return $firstItem['sortOrder'] <=> $secondItem['sortOrder'];
+        });
     }
 
     /**
@@ -32,7 +35,6 @@ class ConfigSourceAggregated implements ConfigSourceInterface
      */
     public function get($path = '')
     {
-        $this->sortSources();
         $data = [];
         foreach ($this->sources as $sourceConfig) {
             /** @var ConfigSourceInterface $source */
@@ -45,17 +47,5 @@ class ConfigSourceAggregated implements ConfigSourceInterface
             }
         }
         return $data;
-    }
-
-    /**
-     * Sort sources
-     *
-     * @return void
-     */
-    private function sortSources()
-    {
-        uasort($this->sources, function ($firstItem, $secondItem) {
-            return $firstItem['sortOrder'] > $secondItem['sortOrder'];
-        });
     }
 }

--- a/lib/internal/Magento/Framework/Logger/Handler/Base.php
+++ b/lib/internal/Magento/Framework/Logger/Handler/Base.php
@@ -78,7 +78,7 @@ class Base extends StreamHandler
     /**
      * @inheritDoc
      */
-    public function write(array $record)
+    protected function write(array $record)
     {
         $logDir = $this->filesystem->getParentDirectory($this->url);
         if (!$this->filesystem->isDirectory($logDir)) {

--- a/lib/internal/Magento/Framework/Logger/LoggerProxy.php
+++ b/lib/internal/Magento/Framework/Logger/LoggerProxy.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Logger;
+
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Exception\RuntimeException;
+use Magento\Framework\ObjectManager\NoninterceptableInterface;
+use Magento\Framework\ObjectManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Create and use Logger implementation based on deployment configuration
+ */
+class LoggerProxy implements LoggerInterface, NoninterceptableInterface
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Proxy constructor
+     *
+     * @param ObjectManagerInterface $objectManager
+     */
+    public function __construct(
+        ObjectManagerInterface $objectManager
+    ) {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * Remove links to other objects.
+     *
+     * @return array
+     */
+    public function __sleep()
+    {
+        return [];
+    }
+
+    /**
+     * Retrieve ObjectManager from global scope
+     *
+     * @return void
+     */
+    public function __wakeup()
+    {
+        $this->objectManager = ObjectManager::getInstance();
+    }
+
+    /**
+     * Clone instance
+     *
+     * @return void
+     * @throws FileSystemException
+     * @throws RuntimeException
+     */
+    public function __clone()
+    {
+        $this->logger = clone $this->getLogger();
+    }
+
+    /**
+     * Get Logger instance
+     *
+     * @return LoggerInterface
+     * @throws FileSystemException
+     * @throws RuntimeException
+     */
+    private function getLogger(): LoggerInterface
+    {
+        if (!$this->logger) {
+            $deploymentConfig = $this->objectManager->get(DeploymentConfig::class);
+            $instanceName = $deploymentConfig->get('log/type') ?? Monolog::class;
+            $args = $deploymentConfig->get('log/args');
+
+            if ($args) {
+                $this->logger = $this->objectManager->create($instanceName, $args);
+            } else {
+                $this->logger = $this->objectManager->get($instanceName);
+            }
+        }
+        return $this->logger;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function emergency($message, array $context = [])
+    {
+        $this->getLogger()->emergency($message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function alert($message, array $context = [])
+    {
+        $this->getLogger()->alert($message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function critical($message, array $context = [])
+    {
+        $this->getLogger()->critical($message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function error($message, array $context = [])
+    {
+        $this->getLogger()->error($message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function warning($message, array $context = [])
+    {
+        $this->getLogger()->warning($message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function notice($message, array $context = [])
+    {
+        $this->getLogger()->notice($message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function info($message, array $context = [])
+    {
+        $this->getLogger()->info($message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function debug($message, array $context = [])
+    {
+        $this->getLogger()->debug($message, $context);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function log($level, $message, array $context = [])
+    {
+        $this->getLogger()->log($level, $message, $context);
+    }
+}

--- a/lib/internal/Magento/Framework/Logger/Test/Unit/LoggerProxyTest.php
+++ b/lib/internal/Magento/Framework/Logger/Test/Unit/LoggerProxyTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Logger\Test\Unit;
+
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Logger\LoggerProxy;
+use Magento\Framework\Logger\Monolog;
+use Magento\Framework\ObjectManagerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+class LoggerProxyTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @return array
+     */
+    public static function methodsList()
+    {
+        return [
+            [LogLevel::EMERGENCY],
+            [LogLevel::ALERT],
+            [LogLevel::CRITICAL],
+            [LogLevel::ERROR],
+            [LogLevel::WARNING],
+            [LogLevel::NOTICE],
+            [LogLevel::INFO],
+            [LogLevel::DEBUG],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider methodsList
+     * @param $method
+     */
+    public function logMessage($method)
+    {
+        $deploymentConfig = $this->getMockBuilder(DeploymentConfig::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $objectManager = $this->getMockBuilder(ObjectManagerInterface::class)
+            ->getMockForAbstractClass();
+
+        $logger = $this->getMockBuilder(LoggerInterface::class)
+            ->getMockForAbstractClass();
+
+        $objectManager->expects($this->at(0))
+            ->method('get')
+            ->with(DeploymentConfig::class)
+            ->willReturn($deploymentConfig);
+
+        $objectManager->expects($this->at(1))
+            ->method('get')
+            ->with(Monolog::class)
+            ->willReturn($logger);
+        $logger->expects($this->once())->method($method)->with('test');
+
+        $loggerProxy = new LoggerProxy($objectManager);
+        $loggerProxy->$method('test');
+    }
+
+    /**
+     * @test
+     */
+    public function createWithArguments()
+    {
+        $deploymentConfig = $this->getMockBuilder(DeploymentConfig::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $objectManager = $this->getMockBuilder(ObjectManagerInterface::class)
+            ->getMockForAbstractClass();
+
+        $logger = $this->getMockBuilder(LoggerInterface::class)
+            ->getMockForAbstractClass();
+
+        $args = ['name' => 'test'];
+        $deploymentConfig->expects($this->at(1))
+            ->method('get')
+            ->with('log/args')
+            ->willReturn($args);
+
+        $objectManager->expects($this->at(0))
+            ->method('get')
+            ->with(DeploymentConfig::class)
+            ->willReturn($deploymentConfig);
+
+        $objectManager->expects($this->once())
+            ->method('create')
+            ->with(Monolog::class, $args)
+            ->willReturn($logger);
+        $logger->expects($this->once())->method('log')->with(LogLevel::ALERT, 'test');
+
+        $loggerProxy = new LoggerProxy($objectManager);
+        $loggerProxy->log(LogLevel::ALERT, 'test');
+    }
+}


### PR DESCRIPTION
### Use Logger implementation based on deployment configuration

### Manual testing scenarios (*)
 -  Configure Magento to run in production mode
 -  Add `'log' => [ 'type' => \Monolog\Logger::class, 'args' => ['name' => 'test']],` line to app/etc/env.php file
 -  Delete var/log folder
 -  Run bin/magento s:s:d
 -  Test that errors is logged to StdError stream
 -  Test that var/log folder is not exists/empty


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29600: Use Logger implementation based on deployment configuration