### PR TITLE
#27370 Internet explorer issue:Default billing/shipping address not showing

### DIFF
--- a/app/code/Magento/Customer/view/adminhtml/web/template/default-address.html
+++ b/app/code/Magento/Customer/view/adminhtml/web/template/default-address.html
@@ -20,7 +20,7 @@
                 </if>
                 <if args="address.street">
                     <text args="address.street" if="_.isString(address.street)"/>
-                    <text args="_.values(address.street).filter(value => _.isString(value)).join(', ')"
+                    <text args="_.filter(_.values(address.street), function (value) { return _.isString(value)}).join(', ')"
                           ifnot="_.isString(address.street)"/>
                     <br/>
                 </if>

--- a/app/code/Magento/Customer/view/adminhtml/web/template/default-address.html
+++ b/app/code/Magento/Customer/view/adminhtml/web/template/default-address.html
@@ -1,3 +1,9 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
 <div data-bind="attr: {class: contentClass}">
     <div data-bind="attr: {class: 'fieldset-wrapper address-information ' + defaultAddressClass}">
         <address>


### PR DESCRIPTION
### Description (*)
This PR applies fixes to show the customer addresses under Addresses tab on a Customer Edit page in the admin area

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
1. magento/magento2#27370: Internet explorer issue:Default billing/shipping address not showing

### Manual testing scenarios (*)
Please see the original issue.

The result should look like in other browsers.

IE 11 result
![Result - IE11](https://user-images.githubusercontent.com/13456702/77232291-ca3e9c00-6ba8-11ea-8da0-6d602a59667e.png)

Google Chrome result
![Result - Chrome](https://user-images.githubusercontent.com/13456702/77232306-db87a880-6ba8-11ea-8a4c-a920f54c008f.png)



### Questions or comments
Should I provide an MFTF test for this case?

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
