### PR TITLE
{ASI} :- Image size is not passed to image-uploader when inserting an image from new media gallery

### DIFF
--- a/app/code/Magento/MediaGallery/Model/Asset.php
+++ b/app/code/Magento/MediaGallery/Model/Asset.php
@@ -24,6 +24,7 @@ class Asset extends AbstractExtensibleModel implements AssetInterface
     private const CONTENT_TYPE = 'content_type';
     private const WIDTH = 'width';
     private const HEIGHT = 'height';
+    private const SIZE = 'size';
     private const CREATED_AT = 'created_at';
     private const UPDATED_AT = 'updated_at';
 
@@ -87,6 +88,14 @@ class Asset extends AbstractExtensibleModel implements AssetInterface
     public function getHeight(): int
     {
         return (int) $this->getData(self::HEIGHT);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSize(): int
+    {
+        return (int) $this->getData(self::SIZE);
     }
 
     /**

--- a/app/code/Magento/MediaGallery/Test/Unit/Model/DataExtractorTest.php
+++ b/app/code/Magento/MediaGallery/Test/Unit/Model/DataExtractorTest.php
@@ -67,7 +67,7 @@ class DataExtractorTest extends TestCase
      * @param array $data
      * @param object $model
      */
-    protected function checkAssetValues(array $expectedData, array $data, $model)
+    private function checkAssetValues(array $expectedData, array $data, $model)
     {
         foreach ($expectedData as $expectedDataKey => $expectedDataItem) {
             $this->assertEquals($data[$expectedDataKey] ?? null, $model->{$expectedDataItem['method']}());
@@ -81,7 +81,7 @@ class DataExtractorTest extends TestCase
      * @param array $data
      * @param object $model
      */
-    protected function checkKeyWordValues(array $expectedData, array $data, $model)
+    private function checkKeyWordValues(array $expectedData, array $data, $model)
     {
         foreach ($expectedData as $expectedDataKey => $expectedDataItem) {
             $this->assertEquals($data[$expectedDataKey] ?? null, $model->{$expectedDataItem['method']}());

--- a/app/code/Magento/MediaGallery/Test/Unit/Model/DataExtractorTest.php
+++ b/app/code/Magento/MediaGallery/Test/Unit/Model/DataExtractorTest.php
@@ -9,10 +9,9 @@ namespace Magento\MediaGallery\Test\Unit\Model;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\MediaGallery\Model\Asset;
+use Magento\MediaGallery\Model\DataExtractor;
 use Magento\MediaGallery\Model\Keyword;
 use Magento\MediaGalleryApi\Api\Data\AssetInterface;
-use Magento\MediaGalleryApi\Api\Data\KeywordInterface;
-use Magento\MediaGallery\Model\DataExtractor;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -54,8 +53,13 @@ class DataExtractorTest extends TestCase
                 'data' => $data,
             ]
         );
-        $receivedData = $this->dataExtractor->extract($model, $interfaceClass);
-        $this->checkValues($expectedData, $receivedData, $model);
+        if ($interfaceClass) {
+            $receivedData = $this->dataExtractor->extract($model, $interfaceClass);
+            $this->checkAssetValues($expectedData, $receivedData, $model);
+        } else {
+            $receivedData = $this->dataExtractor->extract($model);
+            $this->checkKeyWordValues($expectedData, $receivedData, $model);
+        }
     }
 
     /**
@@ -63,13 +67,27 @@ class DataExtractorTest extends TestCase
      * @param array $data
      * @param object $model
      */
-    protected function checkValues(array $expectedData, array $data, $model)
+    protected function checkAssetValues(array $expectedData, array $data, $model)
     {
         foreach ($expectedData as $expectedDataKey => $expectedDataItem) {
             $this->assertEquals($data[$expectedDataKey] ?? null, $model->{$expectedDataItem['method']}());
             $this->assertEquals($data[$expectedDataKey] ?? null, $expectedDataItem['value']);
         }
-        $this->assertEquals(array_keys($expectedData), array_keys($expectedData));
+        $this->assertEquals(array_keys($expectedData), array_keys($data));
+    }
+
+    /**
+     * @param array $expectedData
+     * @param array $data
+     * @param object $model
+     */
+    protected function checkKeyWordValues(array $expectedData, array $data, $model)
+    {
+        foreach ($expectedData as $expectedDataKey => $expectedDataItem) {
+            $this->assertEquals($data[$expectedDataKey] ?? null, $model->{$expectedDataItem['method']}());
+            $this->assertEquals($data[$expectedDataKey] ?? null, $expectedDataItem['value']);
+        }
+        $this->assertEquals(array_keys($expectedData), array_keys(array_slice($data, 0, 2)));
     }
 
     /**
@@ -102,13 +120,17 @@ class DataExtractorTest extends TestCase
                         'value' => 'content_type',
                         'method' => 'getContentType',
                     ],
+                    'height' => [
+                        'value' => 4,
+                        'method' => 'getHeight',
+                    ],
                     'width' => [
                         'value' => 3,
                         'method' => 'getWidth',
                     ],
-                    'height' => [
-                        'value' => 4,
-                        'method' => 'getHeight',
+                    'size' => [
+                        'value' => 300,
+                        'method' => 'getSize',
                     ],
                     'created_at' => [
                         'value' => '2019-11-28 10:40:09',
@@ -122,7 +144,7 @@ class DataExtractorTest extends TestCase
             ],
             'Keyword conversion without interface' => [
                 Keyword::class,
-                null,
+                '',
                 [
                     'id' => [
                         'value' => 2,

--- a/app/code/Magento/MediaGallery/etc/db_schema.xml
+++ b/app/code/Magento/MediaGallery/etc/db_schema.xml
@@ -14,7 +14,7 @@
         <column xsi:type="varchar" name="content_type" length="255" nullable="true" comment="Content Type"/>
         <column xsi:type="int" name="width" padding="10" unsigned="true" nullable="false" identity="false" default="0" comment="Width"/>
         <column xsi:type="int" name="height" padding="10" unsigned="true" nullable="false" identity="false" default="0" comment="Height"/>
-        <column xsi:type="int" name="size" padding="10" unsigned="true" nullable="false" identity="false" default="0" comment="Size"/>
+        <column xsi:type="int" name="size" padding="10" unsigned="true" nullable="false" identity="false" comment="Asset file size in bytes"/>
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP" comment="Created At"/>
         <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP" comment="Updated At"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">

--- a/app/code/Magento/MediaGallery/etc/db_schema.xml
+++ b/app/code/Magento/MediaGallery/etc/db_schema.xml
@@ -14,6 +14,7 @@
         <column xsi:type="varchar" name="content_type" length="255" nullable="true" comment="Content Type"/>
         <column xsi:type="int" name="width" padding="10" unsigned="true" nullable="false" identity="false" default="0" comment="Width"/>
         <column xsi:type="int" name="height" padding="10" unsigned="true" nullable="false" identity="false" default="0" comment="Height"/>
+        <column xsi:type="int" name="size" padding="10" unsigned="true" nullable="false" identity="false" default="0" comment="Size"/>
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP" comment="Created At"/>
         <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP" comment="Updated At"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">

--- a/app/code/Magento/MediaGallery/etc/db_schema_whitelist.json
+++ b/app/code/Magento/MediaGallery/etc/db_schema_whitelist.json
@@ -8,6 +8,7 @@
             "content_type": true,
             "width": true,
             "height": true,
+            "size": true,
             "created_at": true,
             "updated_at": true
         },

--- a/app/code/Magento/MediaGalleryApi/Api/Data/AssetInterface.php
+++ b/app/code/Magento/MediaGalleryApi/Api/Data/AssetInterface.php
@@ -66,7 +66,7 @@ interface AssetInterface extends ExtensibleDataInterface
     public function getWidth(): int;
 
     /**
-     * Retrieve full licensed asset's width
+     * Retrieve full licensed asset's size
      *
      * @return int
      */

--- a/app/code/Magento/MediaGalleryApi/Api/Data/AssetInterface.php
+++ b/app/code/Magento/MediaGalleryApi/Api/Data/AssetInterface.php
@@ -66,7 +66,7 @@ interface AssetInterface extends ExtensibleDataInterface
     public function getWidth(): int;
 
     /**
-     * Retrieve full licensed asset's size
+     * Retrieve asset file size in bytes
      *
      * @return int
      */

--- a/app/code/Magento/MediaGalleryApi/Api/Data/AssetInterface.php
+++ b/app/code/Magento/MediaGalleryApi/Api/Data/AssetInterface.php
@@ -66,6 +66,13 @@ interface AssetInterface extends ExtensibleDataInterface
     public function getWidth(): int;
 
     /**
+     * Retrieve full licensed asset's width
+     *
+     * @return int
+     */
+    public function getSize(): int;
+
+    /**
      * Get created at
      *
      * @return string


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR is the part of Adobe stock integration

### Dependent to
https://github.com/magento/adobe-stock-integration/pull/1021
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1010: Image size is not passed to image-uploader when inserting an image from new media gallery

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
