### PR TITLE
25091-config-wishlist-options-issue

### DIFF
--- a/app/code/Magento/Wishlist/view/frontend/web/js/add-to-wishlist.js
+++ b/app/code/Magento/Wishlist/view/frontend/web/js/add-to-wishlist.js
@@ -64,40 +64,27 @@ define([
          */
         _updateWishlistData: function (event) {
             var dataToAdd = {},
-                isFileUploaded = false,
-                self = this;
+                element = $(event.target);
 
-            if (event.handleObj.selector == this.options.qtyInfo) { //eslint-disable-line eqeqeq
-                this._updateAddToWishlistButton({});
-                event.stopPropagation();
-
-                return;
-            }
-            $(event.handleObj.selector).each(function (index, element) {
-                if ($(element).is('input[type=text]') ||
-                    $(element).is('input[type=email]') ||
-                    $(element).is('input[type=number]') ||
-                    $(element).is('input[type=hidden]') ||
-                    $(element).is('input[type=checkbox]:checked') ||
-                    $(element).is('input[type=radio]:checked') ||
-                    $(element).is('textarea') ||
-                    $('#' + element.id + ' option:selected').length
-                ) {
-                    if ($(element).data('selector') || $(element).attr('name')) {
-                        dataToAdd = $.extend({}, dataToAdd, self._getElementData(element));
-                    }
-
-                    return;
-                }
-
-                if ($(element).is('input[type=file]') && $(element).val()) {
-                    isFileUploaded = true;
-                }
-            });
-
-            if (isFileUploaded) {
+            if (element.is('input[type=file]') && element.val()) {
                 this.bindFormSubmit();
             }
+
+            if (!element.is(this.options.qtyInfo) &&
+                element.is('input[type=text]') ||
+                element.is('input[type=email]') ||
+                element.is('input[type=number]') ||
+                element.is('input[type=hidden]') ||
+                element.is('input[type=checkbox]:checked') ||
+                element.is('input[type=radio]:checked') ||
+                element.is('textarea') ||
+                $('#' + element.id + ' option:selected').length
+            ) {
+                if (element.data('selector') || element.attr('name')) {
+                    dataToAdd = $.extend(dataToAdd, this._getElementData(element));
+                }
+            }
+
             this._updateAddToWishlistButton(dataToAdd);
             event.stopPropagation();
         },


### PR DESCRIPTION
### Description (*)
Fixed add to wishlist logic for configurable products on product listing page.

### Fixed Issues (if relevant)
1. magento/magento2#25091: Product option not reflated at my wish list when added from listing page

### Manual testing scenarios (*)
1. Log in as customer
2. go to product listing page
3. find config product and select options
4. add product to wish list
5. check product options on customer wish list page 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
