### PR TITLE
#19710 Respect theme model for view configuration keep_frame check on…

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
@@ -10,6 +10,7 @@ namespace Magento\Catalog\Model\Product\Image;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\View\ConfigInterface;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Theme\Model\ThemeInterface;
 use Magento\Catalog\Model\Product\Image;
 
 /**
@@ -53,6 +54,11 @@ class ParamsBuilder
     private $viewConfig;
 
     /**
+     * @var ThemeInterface
+     */
+    private $themeModel;
+
+    /**
      * @param ScopeConfigInterface $scopeConfig
      * @param ConfigInterface $viewConfig
      */
@@ -69,17 +75,22 @@ class ParamsBuilder
      *
      * @param array $imageArguments
      * @param int $scopeId
+     * @param ThemeInterface $theme
      * @return array
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    public function build(array $imageArguments, int $scopeId = null): array
+    public function build(array $imageArguments, int $scopeId = null, $theme = null): array
     {
         $miscParams = [
             'image_type' => $imageArguments['type'] ?? null,
             'image_height' => $imageArguments['height'] ?? null,
             'image_width' => $imageArguments['width'] ?? null,
         ];
+
+        if ($theme) {
+            $this->themeModel = $theme;
+        }
 
         $overwritten = $this->overwriteDefaultValues($imageArguments);
         $watermark = isset($miscParams['image_type']) ? $this->getWatermark($miscParams['image_type'], $scopeId) : [];
@@ -170,7 +181,7 @@ class ParamsBuilder
      */
     private function hasDefaultFrame(): bool
     {
-        return (bool) $this->viewConfig->getViewConfig(['area' => \Magento\Framework\App\Area::AREA_FRONTEND])
+        return (bool) $this->viewConfig->getViewConfig(['area' => \Magento\Framework\App\Area::AREA_FRONTEND, 'themeModel' => $this->themeModel])
             ->getVarValue('Magento_Catalog', 'product_image_white_borders');
     }
 }

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -250,7 +250,7 @@ class ImageResize
             $images = $config->getMediaEntities('Magento_Catalog', ImageHelper::MEDIA_TYPE_CONFIG_NODE);
             foreach ($images as $imageId => $imageData) {
                 foreach ($stores as $store) {
-                    $data = $this->paramsBuilder->build($imageData, (int) $store->getId());
+                    $data = $this->paramsBuilder->build($imageData, (int) $store->getId(), $theme);
                     $uniqIndex = $this->getUniqueImageIndex($data);
                     $data['id'] = $imageId;
                     $viewImages[$uniqIndex] = $data;


### PR DESCRIPTION
… image resize

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

Fix wrong image cache path issue with _keep_frame_ argument not respecting theme settings

### Description (*)

Image resize command doesn't respect _product_image_white_borders_ config for all themes causing wrong image display

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1.  Fixes magento/magento2#19710 
Magento 2.3 images cache generation generates wrong hash for some images with a custom theme that has the keep_frame var set to 0

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Configure Magento 2 with two themes using opposite _product_image_white_borders_ config in etc/view.xml 
2. Run _catalog:image:resize_ command and check if proper paths to media/catalog/product/cache/ were generated

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [] All new or changed code is covered with unit/integration tests (if applicable)
 - [] All automated tests passed successfully (all builds are green)
