### PR TITLE
Sitemap Observer Unit Test improvement: Expect email notification to send, and simplify setup a bit.

### DIFF
--- a/app/code/Magento/Sitemap/Test/Unit/Model/ObserverTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/ObserverTest.php
@@ -28,37 +28,37 @@ class ObserverTest extends \PHPUnit\Framework\TestCase
     private $observer;
 
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     private $scopeConfigMock;
 
     /**
-     * @var \Magento\Sitemap\Model\ResourceModel\Sitemap\CollectionFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Sitemap\Model\ResourceModel\Sitemap\CollectionFactory|\PHPUnit\Framework\MockObject\MockObject
      */
     private $collectionFactoryMock;
 
     /**
-     * @var \Magento\Sitemap\Model\ResourceModel\Sitemap\Collection|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Sitemap\Model\ResourceModel\Sitemap\Collection|\PHPUnit\Framework\MockObject\MockObject
      */
     private $sitemapCollectionMock;
 
     /**
-     * @var \Magento\Sitemap\Model\Sitemap|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Sitemap\Model\Sitemap|\PHPUnit\Framework\MockObject\MockObject
      */
     private $sitemapMock;
 
     /**
-     * @var \Magento\Framework\ObjectManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\ObjectManagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     private $objectManagerMock;
 
     /**
-     * @var Emulation|\PHPUnit_Framework_MockObject_MockObject
+     * @var Emulation|\PHPUnit\Framework\MockObject\MockObject
      */
     private $appEmulationMock;
 
     /**
-     * @var EmailNotification|\PHPUnit_Framework_MockObject_MockObject
+     * @var EmailNotification|\PHPUnit\Framework\MockObject\MockObject
      */
     private $emailNotificationMock;
 

--- a/app/code/Magento/Sitemap/Test/Unit/Model/ObserverTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/ObserverTest.php
@@ -64,18 +64,19 @@ class ObserverTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $this->objectManagerMock = $this->getMockBuilder(\Magento\Framework\ObjectManagerInterface::class)
-            ->getMock();
-        $this->scopeConfigMock = $this->getMockBuilder(\Magento\Framework\App\Config\ScopeConfigInterface::class)
-            ->getMock();
+        $this->objectManagerMock = $this->createMock(
+            \Magento\Framework\ObjectManagerInterface::class
+        );
+        $this->scopeConfigMock = $this->createMock(
+            \Magento\Framework\App\Config\ScopeConfigInterface::class
+        );
         $this->collectionFactoryMock = $this->getMockBuilder(
             \Magento\Sitemap\Model\ResourceModel\Sitemap\CollectionFactory::class
         )->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
-        $this->sitemapCollectionMock = $this->createPartialMock(
-            \Magento\Sitemap\Model\ResourceModel\Sitemap\Collection::class,
-            ['getIterator']
+        $this->sitemapCollectionMock = $this->createMock(
+            \Magento\Sitemap\Model\ResourceModel\Sitemap\Collection::class
         );
         $this->sitemapMock = $this->createPartialMock(
             \Magento\Sitemap\Model\Sitemap::class,
@@ -129,6 +130,10 @@ class ObserverTest extends \PHPUnit\Framework\TestCase
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             )
             ->willReturn('error-recipient@example.com');
+
+        $this->emailNotificationMock->expects($this->once())
+            ->method('sendErrors')
+            ->with(['Sitemap Exception']);
 
         $this->observer->scheduledGenerateSitemaps();
     }

--- a/app/code/Magento/Sitemap/Test/Unit/Model/ObserverTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/ObserverTest.php
@@ -133,7 +133,7 @@ class ObserverTest extends \PHPUnit\Framework\TestCase
 
         $this->emailNotificationMock->expects($this->once())
             ->method('sendErrors')
-            ->with(['Sitemap Exception']);
+            ->with([$exception]);
 
         $this->observer->scheduledGenerateSitemaps();
     }

--- a/app/code/Magento/Sitemap/Test/Unit/Model/ObserverTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/ObserverTest.php
@@ -11,7 +11,7 @@ use Magento\Sitemap\Model\EmailNotification;
 use Magento\Store\Model\App\Emulation;
 
 /**
- * Class ObserverTest
+ * Class for ObserverTest
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Add an expect for the emailNotification's sendErrors method. This makes the test match its title (testScheduledGenerateSitemapsSendsExceptionEmail) better.

Also try to be more consistent when calling PHPUnit's TestCase's mock creation functions in setUp; favour createMock.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. install magento
2. in root, call vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/Sitemap/Test/Unit/Model/ObserverTest.php

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [-] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
