### PR TITLE
Remove Extra White Spaces within HTML

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/account/link/authorization.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/link/authorization.phtml
@@ -12,7 +12,6 @@ if ($block->isLoggedIn()) {
 }
 ?>
 <li class="authorization-link" data-label="<?= $block->escapeHtml(__('or')) ?>">
-    <a <?= /* @noEscape */ $block->getLinkAttributes() ?><?= /* @noEscape */ $dataPostParam ?>>
-        <?= $block->escapeHtml($block->getLabel()) ?>
-    </a>
+    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>
+       <?= /* @noEscape */ $dataPostParam ?>><?= $block->escapeHtml($block->getLabel()) ?></a>
 </li>


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
While the template itself might look better when superposed, the resulting HTML is a link with additional spaces on each sides which doesn't look good on hover when underlined.




### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
Note: As all top links should use the same pattern, wrapping the label within a span tag wasn't an option.

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds are green)
