### PR TITLE
Fix: The Translation Shouldn't be Translated Back

### DIFF
--- a/lib/internal/Magento/Framework/Locale/TranslatedLists.php
+++ b/lib/internal/Magento/Framework/Locale/TranslatedLists.php
@@ -215,6 +215,6 @@ class TranslatedLists implements ListsInterface
 
         $translation = (new RegionBundle())->get($locale)['Countries'][$value];
 
-        return $translation ? (string)__($translation) : $translation;
+        return $translation ? (string) $translation : $translation;
     }
 }


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
As a locale is specified through the $locale parameter, it shouldn't be translated over using the Magento __() function. The goal is relying on the framework in order to obtain an accurate translation.


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

Example:
Current Locale Context: "en_US"
Parameters: $value = "US", $locale = "fr_FR"

Expected Result:
États-Unis

Actual Result:
United States

Cause:
__("États-Unis") = United States
The Magento __() function translates the "États-Unis" string to "United States".


### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
