### PR TITLE
Fix the minicart items actions alignment for tablet and desktop devices

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
@@ -135,7 +135,7 @@
         .product {
             .actions {
                 float: right;
-                margin: -24px 0 0;
+                margin: -28px 0 0;
                 text-align: right;
 
                 > .primary,

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
@@ -145,7 +145,7 @@
         .product {
             .actions {
                 float: right;
-                margin: -24px 0 0;
+                margin: -28px 0 0;
 
                 > .primary,
                 > .secondary {


### PR DESCRIPTION
### Description (*)
This PR aims to adjust properly the minicart item actions position for tablet and desktop devices.

### Related Pull Requests
1. https://github.com/magento/magento2/pull/26654 - Closed due to inactivity + the solution seems still to not do the job

### Fixed Issues (if relevant)

1. magento/magento2#26652: In the minicart edit and remove icon is not aligned.

### Manual testing scenarios (*)
Please check the original issue.

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
