### PR TITLE
[bugfix] The store logo is missing when using the Magento_blank theme 

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Theme/layout/default.xml
+++ b/app/design/frontend/Magento/blank/Magento_Theme/layout/default.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="logo">
+            <arguments>
+                <argument name="logo_width" xsi:type="number">170</argument>
+            </arguments>
+        </referenceBlock>
+    </body>
+</page>

--- a/app/design/frontend/Magento/blank/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Theme/web/css/source/_module.less
@@ -368,7 +368,7 @@
     }
 
     .logo {
-        margin: -8px auto 25px 0;
+        margin: 0 auto 25px 0;
 
         img {
             max-height: inherit;


### PR DESCRIPTION
### Description (*)
This PR fixes the store logo visibility on the storefront when using the `Magento_blank` theme for the store.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)

1. magento/magento2#27496 : The store logo is missing when using the Magento_blank theme

### Manual testing scenarios (*)
Please check the original issue's description.

### Result
| Desktop | Tablet | Mobile |
| -------- | ------ | ------- | 
| ![Result desktop](https://user-images.githubusercontent.com/13456702/77906615-ea4d1a00-7290-11ea-8495-08a9adb0dd02.png) | ![Result tablet](https://user-images.githubusercontent.com/13456702/77906683-05b82500-7291-11ea-9eea-20fcd28f3ccc.png) | ![Result mobile](https://user-images.githubusercontent.com/13456702/77906641-f46f1880-7290-11ea-85e6-004a9dfcbb9d.png) |

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
