### PR TITLE
[MFTF] fixed test `AdminLoginWithRestrictPermissionTest`

### DIFF
--- a/app/code/Magento/Backend/Test/Mftf/Test/AdminLoginWithRestrictPermissionTest.xml
+++ b/app/code/Magento/Backend/Test/Mftf/Test/AdminLoginWithRestrictPermissionTest.xml
@@ -24,12 +24,12 @@
             <!--Create user role-->
             <actionGroup ref="AdminFillUserRoleRequiredDataActionGroup" stepKey="fillUserRoleRequiredData">
                 <argument name="User" value="adminRole"/>
-                <argument name="restrictedRole" value="Media Gallery"/>
+                <argument name="restrictedRole" value="Global Search"/>
             </actionGroup>
             <actionGroup ref="AdminUserClickRoleResourceTabActionGroup" stepKey="switchToRoleResourceTab"/>
             <actionGroup ref="AdminAddRestrictedRoleActionGroup" stepKey="addRestrictedRoleStores">
                 <argument name="User" value="adminRole"/>
-                <argument name="restrictedRole" value="Media Gallery"/>
+                <argument name="restrictedRole" value="Global Search"/>
             </actionGroup>
             <actionGroup ref="AdminUserSaveRoleActionGroup" stepKey="saveRole"/>
             <!--Create user and assign role to it-->


### PR DESCRIPTION
### Description (*)
Media Gallery ACL resource is now used for the Media Gallery page introduced in Adobe Stock Integration core bundled extension, so it is not suitable be used for this test.

Updated `AdminLoginWithRestrictPermissionTest` test to use the ACL resource that is not assigned to any pages.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
