### PR TITLE
Added collectionFormat option, updated array param name

### DIFF
--- a/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
+++ b/app/code/Magento/Webapi/Model/Rest/Swagger/Generator.php
@@ -45,6 +45,11 @@ class Generator extends AbstractSchemaGenerator
     private const XML_SCHEMA_PARAMWRAPPER = 'request';
 
     /**
+     * Node value for collectionFormat option for query parameters
+     */
+    private const XML_SCHEMA_QUERY_COLLECTION_FORMAT_VALUE = 'multi';
+
+    /**
      * Swagger factory instance.
      *
      * @var SwaggerFactory
@@ -399,6 +404,14 @@ class Generator extends AbstractSchemaGenerator
         if (isset($required)) {
             $param['required'] = $required;
         }
+
+        // array types require collectionFormat = multi and '[]' appended to name, in order to properly send
+        // multiple values
+        if (!$this->getSimpleType($type)) {
+            $param['name'] .= '[]';
+            $param['collectionFormat'] = self::XML_SCHEMA_QUERY_COLLECTION_FORMAT_VALUE;
+        }
+
         return $param;
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR is updating the way Swagger schema is generated. Currently, it's not possible to properly send GET requests that accept `array` as parameter. This is due to generated schema configuration.

GET request sending array values should look like this:
`http://some-domain.com/rest/V1/store/storeConfigs?storeCodes[]=default&storeCodes[]=test`
with `[]` explicitly added in the request param names, and param names being duplicated for each value.

This PR is forcing that format on array query parameters when generating Swagger schema:
- parameter name has an appended `[]`
- new schema parameter option is added `collectionFormat` which is required for Swagger to properly format values.

Swagger documentation states the following for `collectionFormat` option:

> collectionFormat specifies the array format (a single parameter with multiple parameter or multiple parameters with the same name) and the separator for array items.

and for `multi` value

> Multiple parameter instances rather than multiple values. This is only supported for the in: query and in: formData parameters. Example: `foo=value&foo=another_value`

https://swagger.io/docs/specification/2-0/describing-parameters (look for `collectionFormat`) 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #13143: Swagger get store information gives error


### Manual testing scenarios (*)
This can be tested by following the steps from the original issue #13143
1. Go to Swagger
2. open storeStoreConfigManagerV1
3. Method GET /V1/store/storeConfigs
4. Values for search: add new item for each of the stores, e.g. 'default' and 'test' as 2 separate items

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
