### PR TITLE
allow the CookieManager class to write the session cookie instead of PHP

### DIFF
--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -236,7 +236,7 @@ class SessionManager implements SessionManagerInterface
         }
         //When we renew cookie, we should aware, that any other session client do not
         //change cookie too
-        $cookieValue = $sid ?: $this->cookieManager->getCookie($this->getName());
+        $cookieValue = $sid ?: $this->cookieManager->getCookie($this->getName()) ?: session_id();
         if ($cookieValue) {
             $metadata = $this->cookieMetadataFactory->createPublicCookieMetadata();
             $metadata->setPath($this->sessionConfig->getCookiePath());


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
* We are using di.xml to provide a custom CookieManager to work around issue #26377 - https://github.com/Veriteworks/CookieFix
* We discovered that the Magento session manager does not use CookieManager to set the PHPSESSID cookie, if it was not there before
* This prevents Magento from setting custom options on the session cookie, if the user did not already have a session cookie
* If the page makes any AJAX requests, the session cookie is set for those, so the CookieManager is then used and your session cookie will be updated with your custom options.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#27531: CookieManager is not used the first time the session cookie PHPSESSID is set

### Manual testing scenarios (*)
1. Create a module which overrides \Magento\Framework\Stdlib\CookieManagerInterface
2. Observe that if you do not have a PHPSESSID cookie, your custom module will not be used - PHP will set its own options

### Questions or comments
In investigating this, I can see potential for simplifying the session manager code.  It uses the ini_set functions to copy Magento config options into PHP ini option, purely for the case where session_start() is run when you have no session cookie.  It would be better to skip this, and ensure the CookieManager class is used every time, so that PHP never needs to write the session cookie itself. Then all the ini_set commands could be removed.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
