### PR TITLE
Fix type hint for Select::where

### DIFF
--- a/lib/internal/Magento/Framework/DB/Select.php
+++ b/lib/internal/Magento/Framework/DB/Select.php
@@ -91,6 +91,12 @@ class Select extends \Zend_Db_Select
      * $select->where('id = :id');
      * </code>
      *
+     * You may also construct IN statements:
+     *
+     * <code>
+     * $select->where('entity_id IN (?)', ['1', '2', '3']);
+     * </code>
+     *
      * Note that it is more correct to use named bindings in your
      * queries for values other than strings. When you use named
      * bindings, don't forget to pass the values when actually
@@ -101,7 +107,7 @@ class Select extends \Zend_Db_Select
      * </code>
      *
      * @param string $cond The WHERE condition.
-     * @param string $value OPTIONAL A single value to quote into the condition.
+     * @param string|array|null $value OPTIONAL An optional single or array value to quote into the condition.
      * @param string|int|null $type OPTIONAL The type of the given value
      * @return \Magento\Framework\DB\Select
      */


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Static analysis in our modules breaks due to invalid type hints on this method. The array type hint was added.

### Manual testing scenarios (*)
1. Observe the code
2. Observe how the code is used
3. Observe the docblock type hint
4. Realise it's wrong

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
