### PR TITLE
[AdvancedSearch] Fix PHPUnit 8 compatibility issues

### DIFF
--- a/app/code/Magento/AdvancedSearch/Test/Unit/Block/SearchDataTest.php
+++ b/app/code/Magento/AdvancedSearch/Test/Unit/Block/SearchDataTest.php
@@ -3,62 +3,76 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdvancedSearch\Test\Unit\Block;
 
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Magento\AdvancedSearch\Block\SearchData;
+use Magento\AdvancedSearch\Model\SuggestedQueriesInterface;
+use Magento\Framework\View\Element\Template\Context as TemplateContext;
+use Magento\Search\Model\QueryFactoryInterface;
+use Magento\Search\Model\QueryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class SearchDataTest extends \PHPUnit\Framework\TestCase
+/**
+ * @covers \Magento\AdvancedSearch\Block\SearchData
+ */
+class SearchDataTest extends TestCase
 {
-    /** @var  \Magento\Framework\View\Element\Template\Context|MockObject */
-    private $context;
-
     /**
-     * @var \Magento\Search\Model\QueryFactoryInterface|MockObject
-     */
-    private $queryFactory;
-
-    /**
-     * @var \Magento\Search\Model\Query|MockObject
-     */
-    private $searchQuery;
-
-    /**
-     * @var \Magento\AdvancedSearch\Model\SuggestedQueriesInterface|MockObject
-     */
-    private $dataProvider;
-
-    /**
-     * @var \Magento\AdvancedSearch\Block\SearchData
+     * Testable Object
+     *
+     * @var SearchData
      */
     private $block;
 
-    protected function setUp()
+    /**
+     * @var TemplateContext|MockObject
+     */
+    private $contextMock;
+
+    /**
+     * @var QueryFactoryInterface|MockObject
+     */
+    private $queryFactoryMock;
+
+    /**
+     * @var QueryInterface|MockObject
+     */
+    private $searchQueryMock;
+
+    /**
+     * @var SuggestedQueriesInterface|MockObject
+     */
+    private $dataProvider;
+
+    protected function setUp(): void
     {
-        $this->dataProvider = $this->getMockBuilder(\Magento\AdvancedSearch\Model\SuggestedQueriesInterface::class)
+        $this->dataProvider = $this->getMockBuilder(SuggestedQueriesInterface::class)
             ->disableOriginalConstructor()
             ->setMethods(['getItems', 'isResultsCountEnabled'])
             ->getMockForAbstractClass();
 
-        $this->searchQuery = $this->getMockBuilder(\Magento\Search\Model\QueryInterface::class)
+        $this->searchQueryMock = $this->getMockBuilder(QueryInterface::class)
             ->disableOriginalConstructor()
             ->setMethods(['getQueryText'])
             ->getMockForAbstractClass();
-        $this->queryFactory = $this->getMockBuilder(\Magento\Search\Model\QueryFactoryInterface::class)
+        $this->queryFactoryMock = $this->getMockBuilder(QueryFactoryInterface::class)
             ->disableOriginalConstructor()
             ->setMethods(['get'])
             ->getMockForAbstractClass();
-        $this->queryFactory->expects($this->once())
+        $this->queryFactoryMock->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($this->searchQuery));
-        $this->context = $this->getMockBuilder(\Magento\Framework\View\Element\Template\Context::class)
+            ->will($this->returnValue($this->searchQueryMock));
+        $this->contextMock = $this->getMockBuilder(TemplateContext::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->block = $this->getMockBuilder(\Magento\AdvancedSearch\Block\SearchData::class)->setConstructorArgs(
+        $this->block = $this->getMockBuilder(SearchData::class)->setConstructorArgs(
             [
-                $this->context,
+                $this->contextMock,
                 $this->dataProvider,
-                $this->queryFactory,
+                $this->queryFactoryMock,
                 'Test Title',
                 [],
             ]
@@ -67,27 +81,27 @@ class SearchDataTest extends \PHPUnit\Framework\TestCase
             ->getMockForAbstractClass();
     }
 
-    public function testGetSuggestions()
+    public function testGetSuggestions(): void
     {
         $value = [1, 2, 3, 100500];
 
         $this->dataProvider->expects($this->once())
             ->method('getItems')
-            ->with($this->searchQuery)
+            ->with($this->searchQueryMock)
             ->will($this->returnValue($value));
         $actualValue = $this->block->getItems();
         $this->assertEquals($value, $actualValue);
     }
 
-    public function testGetLink()
+    public function testGetLink(): void
     {
-        $searchQuery = 'Some test search query';
+        $searchQueryMock = 'Some test search query';
         $expectedResult = '?q=Some+test+search+query';
-        $actualResult = $this->block->getLink($searchQuery);
+        $actualResult = $this->block->getLink($searchQueryMock);
         $this->assertEquals($expectedResult, $actualResult);
     }
 
-    public function testIsShowResultsCount()
+    public function testIsShowResultsCount(): void
     {
         $value = 'qwertyasdfzxcv';
         $this->dataProvider->expects($this->once())

--- a/app/code/Magento/AdvancedSearch/Test/Unit/Controller/Adminhtml/Search/System/Config/TestConnectionTest.php
+++ b/app/code/Magento/AdvancedSearch/Test/Unit/Controller/Adminhtml/Search/System/Config/TestConnectionTest.php
@@ -3,70 +3,82 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\AdvancedSearch\Test\Unit\Controller\Adminhtml\Search\System\Config;
 
 use Magento\AdvancedSearch\Controller\Adminhtml\Search\System\Config\TestConnection;
-use Magento\AdvancedSearch\Model\Client\ClientResolver;
 use Magento\AdvancedSearch\Model\Client\ClientInterface;
+use Magento\AdvancedSearch\Model\Client\ClientResolver;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Request\Http as HttpRequest;
+use Magento\Framework\App\Response\Http as HttpResponse;
+use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\Filter\StripTags;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
- * Class TestConnectionTest
- *
+ * @covers \Magento\AdvancedSearch\Controller\Adminhtml\Search\System\Config\TestConnection
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class TestConnectionTest extends \PHPUnit\Framework\TestCase
+class TestConnectionTest extends TestCase
 {
     /**
-     * @var \Magento\Framework\App\Request\Http|\PHPUnit_Framework_MockObject_MockObject
+     * Testable Object
+     *
+     * @var TestConnection
      */
-    protected $requestMock;
+    private $controller;
 
     /**
-     * @var ClientResolver|\PHPUnit_Framework_MockObject_MockObject
+     * @var HttpRequest|MockObject
+     */
+    private $requestMock;
+
+    /**
+     * @var ClientResolver|MockObject
      */
     private $clientResolverMock;
 
     /**
-     * @var ClientInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ClientInterface|MockObject
      */
     private $clientMock;
 
     /**
-     * @var \Magento\Framework\Controller\Result\Json|\PHPUnit_Framework_MockObject_MockObject
+     * @var Json|MockObject
      */
-    private $resultJson;
+    private $resultJsonMock;
 
     /**
-     * @var \Magento\Framework\Controller\Result\JsonFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var JsonFactory|MockObject
      */
-    private $resultJsonFactory;
+    private $resultJsonFactoryMock;
 
     /**
-     * @var \Magento\Framework\Filter\StripTags|\PHPUnit_Framework_MockObject_MockObject
+     * @var StripTags|MockObject
      */
     private $tagFilterMock;
-
-    /**
-     * @var TestConnection
-     */
-    private $controller;
 
     /**
      * Setup test function
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
-        $helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
-        $this->requestMock = $this->createPartialMock(\Magento\Framework\App\Request\Http::class, ['getParams']);
-        $responseMock = $this->createMock(\Magento\Framework\App\Response\Http::class);
+        $helper = new ObjectManager($this);
+        $this->requestMock = $this->createPartialMock(HttpRequest::class, ['getParams']);
+        $responseMock = $this->createMock(HttpResponse::class);
 
-        $context = $this->getMockBuilder(\Magento\Backend\App\Action\Context::class)
+        $context = $this->getMockBuilder(Context::class)
             ->setMethods(['getRequest', 'getResponse', 'getMessageManager', 'getSession'])
             ->setConstructorArgs(
                 $helper->getConstructArguments(
-                    \Magento\Backend\App\Action\Context::class,
+                    Context::class,
                     [
                         'request' => $this->requestMock
                     ]
@@ -76,23 +88,23 @@ class TestConnectionTest extends \PHPUnit\Framework\TestCase
         $context->expects($this->once())->method('getRequest')->will($this->returnValue($this->requestMock));
         $context->expects($this->once())->method('getResponse')->will($this->returnValue($responseMock));
 
-        $this->clientResolverMock = $this->getMockBuilder(\Magento\AdvancedSearch\Model\Client\ClientResolver::class)
+        $this->clientResolverMock = $this->getMockBuilder(ClientResolver::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
 
-        $this->clientMock = $this->createMock(\Magento\AdvancedSearch\Model\Client\ClientInterface::class);
+        $this->clientMock = $this->createMock(ClientInterface::class);
 
-        $this->resultJson = $this->getMockBuilder(\Magento\Framework\Controller\Result\Json::class)
+        $this->resultJsonMock = $this->getMockBuilder(Json::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->resultJsonFactory = $this->getMockBuilder(\Magento\Framework\Controller\Result\JsonFactory::class)
+        $this->resultJsonFactoryMock = $this->getMockBuilder(JsonFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
 
-        $this->tagFilterMock = $this->getMockBuilder(\Magento\Framework\Filter\StripTags::class)
+        $this->tagFilterMock = $this->getMockBuilder(StripTags::class)
             ->disableOriginalConstructor()
             ->setMethods(['filter'])
             ->getMock();
@@ -100,28 +112,28 @@ class TestConnectionTest extends \PHPUnit\Framework\TestCase
         $this->controller = new TestConnection(
             $context,
             $this->clientResolverMock,
-            $this->resultJsonFactory,
+            $this->resultJsonFactoryMock,
             $this->tagFilterMock
         );
     }
 
-    public function testExecuteEmptyEngine()
+    public function testExecuteEmptyEngine(): void
     {
         $this->requestMock->expects($this->once())->method('getParams')
             ->will($this->returnValue(['engine' => '']));
 
-        $this->resultJsonFactory->expects($this->once())->method('create')
-            ->will($this->returnValue($this->resultJson));
+        $this->resultJsonFactoryMock->expects($this->once())->method('create')
+            ->will($this->returnValue($this->resultJsonMock));
 
         $result = ['success' => false, 'errorMessage' => 'Missing search engine parameter.'];
 
-        $this->resultJson->expects($this->once())->method('setData')
+        $this->resultJsonMock->expects($this->once())->method('setData')
             ->with($this->equalTo($result));
 
         $this->controller->execute();
     }
 
-    public function testExecute()
+    public function testExecute(): void
     {
         $this->requestMock->expects($this->once())->method('getParams')
             ->will($this->returnValue(['engine' => 'engineName']));
@@ -133,18 +145,18 @@ class TestConnectionTest extends \PHPUnit\Framework\TestCase
         $this->clientMock->expects($this->once())->method('testConnection')
             ->will($this->returnValue(true));
 
-        $this->resultJsonFactory->expects($this->once())->method('create')
-            ->will($this->returnValue($this->resultJson));
+        $this->resultJsonFactoryMock->expects($this->once())->method('create')
+            ->will($this->returnValue($this->resultJsonMock));
 
         $result = ['success' => true, 'errorMessage' => ''];
 
-        $this->resultJson->expects($this->once())->method('setData')
+        $this->resultJsonMock->expects($this->once())->method('setData')
             ->with($this->equalTo($result));
 
         $this->controller->execute();
     }
 
-    public function testExecutePingFailed()
+    public function testExecutePingFailed(): void
     {
         $this->requestMock->expects($this->once())->method('getParams')
             ->will($this->returnValue(['engine' => 'engineName']));
@@ -156,12 +168,12 @@ class TestConnectionTest extends \PHPUnit\Framework\TestCase
         $this->clientMock->expects($this->once())->method('testConnection')
             ->will($this->returnValue(false));
 
-        $this->resultJsonFactory->expects($this->once())->method('create')
-            ->will($this->returnValue($this->resultJson));
+        $this->resultJsonFactoryMock->expects($this->once())->method('create')
+            ->will($this->returnValue($this->resultJsonMock));
 
         $result = ['success' => false, 'errorMessage' => ''];
 
-        $this->resultJson->expects($this->once())->method('setData')
+        $this->resultJsonMock->expects($this->once())->method('setData')
             ->with($this->equalTo($result));
 
         $this->controller->execute();

--- a/app/code/Magento/AdvancedSearch/Test/Unit/Model/Client/ClientResolverTest.php
+++ b/app/code/Magento/AdvancedSearch/Test/Unit/Model/Client/ClientResolverTest.php
@@ -3,34 +3,44 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdvancedSearch\Test\Unit\Model\Client;
 
+use InvalidArgumentException;
+use LogicException;
 use Magento\AdvancedSearch\Model\Client\ClientFactoryInterface;
 use Magento\AdvancedSearch\Model\Client\ClientInterface;
 use Magento\AdvancedSearch\Model\Client\ClientOptionsInterface;
 use Magento\AdvancedSearch\Model\Client\ClientResolver;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Search\EngineResolverInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class ClientResolverTest extends \PHPUnit\Framework\TestCase
+/**
+ * @covers \Magento\AdvancedSearch\Model\Client\ClientResolver
+ */
+class ClientResolverTest extends TestCase
 {
     /**
-     * @var ClientResolver|\PHPUnit_Framework_MockObject_MockObject
+     * Testable Object
+     *
+     * @var ClientResolver
      */
     private $model;
 
     /**
-     * @var ObjectManagerInterface |\PHPUnit_Framework_MockObject_MockObject
+     * @var ObjectManagerInterface|MockObject
      */
     private $objectManager;
 
     /**
-     * @var EngineResolverInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var EngineResolverInterface|MockObject
      */
     private $engineResolverMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->engineResolverMock = $this->getMockBuilder(EngineResolverInterface::class)
             ->getMockForAbstractClass();
@@ -45,7 +55,7 @@ class ClientResolverTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $this->engineResolverMock->expects($this->once())->method('getCurrentSearchEngine')
             ->will($this->returnValue('engineName'));
@@ -78,11 +88,9 @@ class ClientResolverTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(ClientInterface::class, $result);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testCreateExceptionThrown()
+    public function testCreateExceptionThrown(): void
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->objectManager->expects($this->once())->method('create')
             ->with($this->equalTo('engineFactoryClass'))
             ->will($this->returnValue('t'));
@@ -90,15 +98,13 @@ class ClientResolverTest extends \PHPUnit\Framework\TestCase
         $this->model->create('engineName');
     }
 
-    /**
-     * @expectedException LogicException
-     */
-    public function testCreateLogicException()
+    public function testCreateLogicException(): void
     {
+        $this->expectException(LogicException::class);
         $this->model->create('input');
     }
 
-    public function testGetCurrentEngine()
+    public function testGetCurrentEngine(): void
     {
         $this->engineResolverMock->expects($this->once())->method('getCurrentSearchEngine')
             ->will($this->returnValue('engineName'));

--- a/app/code/Magento/AdvancedSearch/Test/Unit/Model/Indexer/Fulltext/Plugin/CustomerGroupTest.php
+++ b/app/code/Magento/AdvancedSearch/Test/Unit/Model/Indexer/Fulltext/Plugin/CustomerGroupTest.php
@@ -3,52 +3,65 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdvancedSearch\Test\Unit\Model\Indexer\Fulltext\Plugin;
 
-use Magento\AdvancedSearch\Model\Indexer\Fulltext\Plugin\CustomerGroup;
+use Magento\AdvancedSearch\Model\Client\ClientOptionsInterface;
+use Magento\AdvancedSearch\Model\Indexer\Fulltext\Plugin\CustomerGroup as CustomerGroupPlugin;
+use Magento\CatalogSearch\Model\Indexer\Fulltext as FulltextIndexer;
+use Magento\Customer\Model\Group as CustomerGroupModel;
+use Magento\Customer\Model\ResourceModel\Group as CustomerGroupResourceModel;
+use Magento\Framework\Indexer\IndexerInterface;
+use Magento\Framework\Indexer\IndexerRegistry;
 use Magento\Framework\Search\EngineResolverInterface;
+use PHPUnit\Framework\TestCase;
 
-class CustomerGroupTest extends \PHPUnit\Framework\TestCase
+/**
+ * @covers \Magento\AdvancedSearch\Model\Indexer\Fulltext\Plugin\CustomerGroup
+ */
+class CustomerGroupTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\Indexer\IndexerInterface
+     * Testable Object
+     *
+     * @var CustomerGroupPlugin
      */
-    protected $indexerMock;
+    private $model;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Customer\Model\ResourceModel\Group
+     * @var IndexerInterface|MockObject
      */
-    protected $subjectMock;
+    private $indexerMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\AdvancedSearch\Model\Client\ClientOptionsInterface
+     * @var Group|MockObject
      */
-    protected $customerOptionsMock;
+    private $subjectMock;
 
     /**
-     * @var \Magento\Framework\Indexer\IndexerRegistry|\PHPUnit_Framework_MockObject_MockObject
+     * @var ClientOptionsInterface|MockObject
      */
-    protected $indexerRegistryMock;
+    private $customerOptionsMock;
 
     /**
-     * @var EngineResolverInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var IndexerRegistry|MockObject
      */
-    protected $engineResolverMock;
+    private $indexerRegistryMock;
 
     /**
-     * @var CustomerGroup
+     * @var EngineResolverInterface|MockObject
      */
-    protected $model;
+    private $engineResolverMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->subjectMock = $this->createMock(\Magento\Customer\Model\ResourceModel\Group::class);
+        $this->subjectMock = $this->createMock(CustomerGroupResourceModel::class);
         $this->customerOptionsMock = $this->createMock(
-            \Magento\AdvancedSearch\Model\Client\ClientOptionsInterface::class
+            ClientOptionsInterface::class
         );
         $this->indexerMock = $this->getMockForAbstractClass(
-            \Magento\Framework\Indexer\IndexerInterface::class,
+            IndexerInterface::class,
             [],
             '',
             false,
@@ -57,14 +70,14 @@ class CustomerGroupTest extends \PHPUnit\Framework\TestCase
             ['getId', 'getState', '__wakeup']
         );
         $this->indexerRegistryMock = $this->createPartialMock(
-            \Magento\Framework\Indexer\IndexerRegistry::class,
+            IndexerRegistry::class,
             ['get']
         );
         $this->engineResolverMock = $this->createPartialMock(
-            \Magento\Search\Model\EngineResolver::class,
+            EngineResolverInterface::class,
             ['getCurrentSearchEngine']
         );
-        $this->model = new CustomerGroup(
+        $this->model = new CustomerGroupPlugin(
             $this->indexerRegistryMock,
             $this->customerOptionsMock,
             $this->engineResolverMock
@@ -79,14 +92,18 @@ class CustomerGroupTest extends \PHPUnit\Framework\TestCase
      * @return void
      * @dataProvider aroundSaveDataProvider
      */
-    public function testAroundSave($searchEngine, $isObjectNew, $isTaxClassIdChanged, $invalidateCounter)
-    {
+    public function testAroundSave(
+        string $searchEngine,
+        bool $isObjectNew,
+        bool $isTaxClassIdChanged,
+        int $invalidateCounter
+    ): void {
         $this->engineResolverMock->expects($this->once())
             ->method('getCurrentSearchEngine')
             ->will($this->returnValue($searchEngine));
 
         $groupMock = $this->createPartialMock(
-            \Magento\Customer\Model\Group::class,
+            CustomerGroupModel::class,
             ['dataHasChangedFor', 'isObjectNew', '__wakeup']
         );
         $groupMock->expects($this->any())->method('isObjectNew')->will($this->returnValue($isObjectNew));
@@ -95,7 +112,7 @@ class CustomerGroupTest extends \PHPUnit\Framework\TestCase
             ->with('tax_class_id')
             ->will($this->returnValue($isTaxClassIdChanged));
 
-        $closureMock = function (\Magento\Customer\Model\Group $object) use ($groupMock) {
+        $closureMock = function (CustomerGroupModel $object) use ($groupMock) {
             $this->assertEquals($object, $groupMock);
             return $this->subjectMock;
         };
@@ -103,7 +120,7 @@ class CustomerGroupTest extends \PHPUnit\Framework\TestCase
         $this->indexerMock->expects($this->exactly($invalidateCounter))->method('invalidate');
         $this->indexerRegistryMock->expects($this->exactly($invalidateCounter))
             ->method('get')
-            ->with(\Magento\CatalogSearch\Model\Indexer\Fulltext::INDEXER_ID)
+            ->with(FulltextIndexer::INDEXER_ID)
             ->will($this->returnValue($this->indexerMock));
 
         $this->assertEquals(
@@ -113,9 +130,11 @@ class CustomerGroupTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Data Provider for testAroundSave
+     *
      * @return array
      */
-    public function aroundSaveDataProvider()
+    public function aroundSaveDataProvider(): array
     {
         return [
             ['mysql', false, false, 0],

--- a/app/code/Magento/AdvancedSearch/Test/Unit/Model/Recommendations/DataProviderTest.php
+++ b/app/code/Magento/AdvancedSearch/Test/Unit/Model/Recommendations/DataProviderTest.php
@@ -8,26 +8,29 @@ declare(strict_types=1);
 namespace Magento\AdvancedSearch\Test\Unit\Model\Recommendations;
 
 use Magento\AdvancedSearch\Model\Recommendations\DataProvider;
-use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use Magento\Catalog\Model\Layer\Resolver;
 use Magento\AdvancedSearch\Model\ResourceModel\Recommendations;
 use Magento\AdvancedSearch\Model\ResourceModel\RecommendationsFactory;
+use Magento\Catalog\Model\Layer as SearchLayer;
+use Magento\Catalog\Model\Layer\Resolver;
+use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\Search\Model\QueryInterface;
 use Magento\Search\Model\QueryResult;
 use Magento\Search\Model\QueryResultFactory;
-use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
-use Magento\Catalog\Model\Layer as SearchLayer;
 use Magento\Store\Model\ScopeInterface;
-use Magento\Search\Model\QueryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
+ * @covers \Magento\AdvancedSearch\Model\Recommendations\DataProvider
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
- *
- * Class \Magento\AdvancedSearch\Test\Unit\Model\Recommendations\DataProviderTest
  */
-class DataProviderTest extends \PHPUnit\Framework\TestCase
+class DataProviderTest extends TestCase
 {
     /**
+     * Testable Object
+     *
      * @var DataProvider;
      */
     private $model;
@@ -38,41 +41,41 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
     private $objectManagerHelper;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ScopeConfigInterface
+     * @var ScopeConfigInterface|MockObject
      */
     private $scopeConfigMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Resolver
+     * @var Resolver|MockObject
      */
     private $layerResolverMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|SearchLayer
+     * @var SearchLayer|MockObject
      */
     private $searchLayerMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|RecommendationsFactory
+     * @var RecommendationsFactory|MockObject
      */
     private $recommendationsFactoryMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Recommendations
+     * @var Recommendations|MockObject
      */
     private $recommendationsMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|Resolver
+     * @var Resolver|MockObject
      */
-    private $queryResultFactory;
+    private $queryResultFactoryMock;
 
     /**
      * Set up test environment.
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
         $this->layerResolverMock = $this->getMockBuilder(Resolver::class)
@@ -93,7 +96,7 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
 
         $this->recommendationsMock = $this->createMock(Recommendations::class);
 
-        $this->queryResultFactory = $this->getMockBuilder(QueryResultFactory::class)
+        $this->queryResultFactoryMock = $this->getMockBuilder(QueryResultFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
@@ -105,7 +108,7 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
                 'scopeConfig' => $this->scopeConfigMock,
                 'layerResolver' => $this->layerResolverMock,
                 'recommendationsFactory' => $this->recommendationsFactoryMock,
-                'queryResultFactory' => $this->queryResultFactory
+                'queryResultFactory' => $this->queryResultFactoryMock
             ]
         );
     }
@@ -115,7 +118,7 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testGetItemsWhenDisabledSearchRecommendations()
+    public function testGetItemsWhenDisabledSearchRecommendations(): void
     {
         $isEnabledSearchRecommendations = false;
 
@@ -136,7 +139,7 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testGetItemsWhenEnabledSearchRecommendations()
+    public function testGetItemsWhenEnabledSearchRecommendations(): void
     {
         $storeId = 1;
         $searchRecommendationsCountConfig = 2;
@@ -181,7 +184,7 @@ class DataProviderTest extends \PHPUnit\Framework\TestCase
                 ]
             );
         $queryResultMock = $this->createMock(QueryResult::class);
-        $this->queryResultFactory->expects($this->any())->method('create')->willReturn($queryResultMock);
+        $this->queryResultFactoryMock->expects($this->any())->method('create')->willReturn($queryResultMock);
 
         $result = $this->model->getItems($queryInterfaceMock);
         $this->assertEquals(2, count($result));

--- a/app/code/Magento/AdvancedSearch/Test/Unit/Model/ResourceModel/IndexTest.php
+++ b/app/code/Magento/AdvancedSearch/Test/Unit/Model/ResourceModel/IndexTest.php
@@ -3,54 +3,64 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdvancedSearch\Test\Unit\Model\ResourceModel;
 
 use Magento\AdvancedSearch\Model\ResourceModel\Index;
-use Magento\Store\Model\StoreManagerInterface;
-use Magento\Framework\Model\ResourceModel\Db\Context;
-use Magento\Framework\EntityManager\MetadataPool;
-use Magento\Store\Api\Data\StoreInterface;
-use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Catalog\Model\Indexer\Product\Price\DimensionCollectionFactory;
 use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\DB\Select;
+use Magento\Framework\EntityManager\MetadataPool;
+use Magento\Framework\Indexer\MultiDimensionProvider;
+use Magento\Framework\Indexer\ScopeResolver\IndexScopeResolver;
+use Magento\Framework\Model\ResourceModel\Db\Context;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Traversable;
 
 /**
+ * @covers \Magento\AdvancedSearch\Model\ResourceModel\Index
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class IndexTest extends \PHPUnit\Framework\TestCase
+class IndexTest extends TestCase
 {
     /**
+     * Testable Object
+     *
      * @var Index
      */
     private $model;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var StoreManagerInterface|MockObject
      */
     private $storeManagerMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var Context|MockObject
      */
     private $resourceContextMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var MetadataPool|MockObject
      */
     private $metadataPoolMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var AdapterInterface|MockObject
      */
     private $adapterMock;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var ResourceConnection|MockObject
      */
     private $resourceConnectionMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
         $this->resourceContextMock = $this->createMock(Context::class);
@@ -59,18 +69,23 @@ class IndexTest extends \PHPUnit\Framework\TestCase
             ->method('getResources')
             ->willReturn($this->resourceConnectionMock);
         $this->adapterMock = $this->createMock(AdapterInterface::class);
-        $this->resourceConnectionMock->expects($this->any())->method('getConnection')->willReturn($this->adapterMock);
+        $this->resourceConnectionMock->expects($this->any())
+            ->method('getConnection')
+            ->willReturn($this->adapterMock);
         $this->metadataPoolMock = $this->createMock(MetadataPool::class);
 
-        $indexScopeResolverMock = $this->createMock(
-            \Magento\Framework\Indexer\ScopeResolver\IndexScopeResolver::class
-        );
-        $traversableMock = $this->createMock(\Traversable::class);
-        $dimensionsMock = $this->createMock(\Magento\Framework\Indexer\MultiDimensionProvider::class);
+        /** @var IndexScopeResolver|MockObject $indexScopeResolverMock */
+        $indexScopeResolverMock = $this->createMock(IndexScopeResolver::class);
+
+        /** @var Traversable|MockObject $traversableMock */
+        $traversableMock = $this->createMock(Traversable::class);
+
+        /** @var MultiDimensionProvider|MockObject $dimensionsMock */
+        $dimensionsMock = $this->createMock(MultiDimensionProvider::class);
         $dimensionsMock->method('getIterator')->willReturn($traversableMock);
-        $dimensionFactoryMock = $this->createMock(
-            \Magento\Catalog\Model\Indexer\Product\Price\DimensionCollectionFactory::class
-        );
+
+        /** @var DimensionCollectionFactory|MockObject $dimensionFactoryMock */
+        $dimensionFactoryMock = $this->createMock(DimensionCollectionFactory::class);
         $dimensionFactoryMock->method('create')->willReturn($dimensionsMock);
 
         $this->model = new Index(
@@ -83,13 +98,15 @@ class IndexTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetPriceIndexDataUsesFrontendPriceIndexerTable()
+    public function testGetPriceIndexDataUsesFrontendPriceIndexerTable(): void
     {
         $storeId = 1;
         $storeMock = $this->createMock(StoreInterface::class);
         $storeMock->expects($this->any())->method('getId')->willReturn($storeId);
         $storeMock->method('getWebsiteId')->willReturn(1);
-        $this->storeManagerMock->expects($this->once())->method('getStore')->with($storeId)->willReturn($storeMock);
+        $this->storeManagerMock->expects($this->once())
+            ->method('getStore')
+            ->with($storeId)->willReturn($storeMock);
 
         $selectMock = $this->createMock(Select::class);
         $selectMock->expects($this->any())->method('from')->willReturnSelf();

--- a/app/code/Magento/AdvancedSearch/Test/Unit/Model/SuggestedQueriesTest.php
+++ b/app/code/Magento/AdvancedSearch/Test/Unit/Model/SuggestedQueriesTest.php
@@ -3,42 +3,56 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\AdvancedSearch\Test\Unit\Model;
 
+use InvalidArgumentException;
+use Magento\AdvancedSearch\Model\SuggestedQueries;
+use Magento\AdvancedSearch\Model\SuggestedQueriesInterface;
+use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Search\EngineResolverInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use Magento\Framework\ObjectManagerInterface;
+use Magento\Search\Model\EngineResolver;
+use Magento\Search\Model\QueryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class SuggestedQueriesTest extends \PHPUnit\Framework\TestCase
+/**
+ * @covers \Magento\AdvancedSearch\Model\SuggestedQueries
+ */
+class SuggestedQueriesTest extends TestCase
 {
     /**
-     * @var \Magento\AdvancedSearch\Model\SuggestedQueries;
+     * Testable Object
+     *
+     * @var SuggestedQueries;
      */
-    protected $model;
+    private $model;
 
     /**
-     * @var EngineResolverInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var EngineResolverInterface|MockObject
      */
-    protected $engineResolverMock;
+    private $engineResolverMock;
 
     /**
-     * @var ObjectManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var ObjectManagerInterface|MockObject
      */
-    protected $objectManagerMock;
+    private $objectManagerMock;
 
     /**
      * @var ObjectManagerHelper
      */
-    protected $objectManagerHelper;
+    private $objectManagerHelper;
 
     /**
      * Set up test environment.
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->engineResolverMock = $this->getMockBuilder(\Magento\Search\Model\EngineResolver::class)
+        $this->engineResolverMock = $this->getMockBuilder(EngineResolver::class)
             ->setMethods(['getCurrentSearchEngine'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -46,19 +60,15 @@ class SuggestedQueriesTest extends \PHPUnit\Framework\TestCase
             ->method('getCurrentSearchEngine')
             ->willReturn('my_engine');
 
-        /**
-         * @var \Magento\AdvancedSearch\Model\SuggestedQueriesInterface|
-         *     \PHPUnit_Framework_MockObject_MockObject
-         */
-        $suggestedQueriesMock = $this->createMock(\Magento\AdvancedSearch\Model\SuggestedQueriesInterface::class);
+        /** @var SuggestedQueriesInterface|MockObject $suggestedQueriesMock */
+        $suggestedQueriesMock = $this->createMock(SuggestedQueriesInterface::class);
         $suggestedQueriesMock->expects($this->any())
             ->method('isResultsCountEnabled')
             ->willReturn(true);
         $suggestedQueriesMock->expects($this->any())
             ->method('getItems')
             ->willReturn([]);
-
-        $this->objectManagerMock = $this->getMockBuilder(\Magento\Framework\ObjectManagerInterface::class)
+        $this->objectManagerMock = $this->getMockBuilder(ObjectManagerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->objectManagerMock->expects($this->any())
@@ -68,7 +78,7 @@ class SuggestedQueriesTest extends \PHPUnit\Framework\TestCase
 
         $this->objectManagerHelper = new ObjectManagerHelper($this);
         $this->model = $this->objectManagerHelper->getObject(
-            \Magento\AdvancedSearch\Model\SuggestedQueries::class,
+            SuggestedQueries::class,
             [
                 'engineResolver' => $this->engineResolverMock,
                 'objectManager' => $this->objectManagerMock,
@@ -82,7 +92,7 @@ class SuggestedQueriesTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testIsResultsCountEnabled()
+    public function testIsResultsCountEnabled(): void
     {
         $result = $this->model->isResultsCountEnabled();
         $this->assertTrue($result);
@@ -90,13 +100,12 @@ class SuggestedQueriesTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test isResultsCountEnabled() method failure.
-     * @expectedException \InvalidArgumentException
      *
      * @return void
      */
-    public function testIsResultsCountEnabledException()
+    public function testIsResultsCountEnabledException(): void
     {
-        $objectManagerMock = $this->getMockBuilder(\Magento\Framework\ObjectManagerInterface::class)
+        $objectManagerMock = $this->getMockBuilder(ObjectManagerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $objectManagerMock->expects($this->once())
@@ -104,15 +113,16 @@ class SuggestedQueriesTest extends \PHPUnit\Framework\TestCase
             ->willReturn(null);
 
         $objectManagerHelper = new ObjectManagerHelper($this);
-        /* @var $model \Magento\AdvancedSearch\Model\SuggestedQueries */
+        /* @var SuggestedQueries $model */
         $model = $objectManagerHelper->getObject(
-            \Magento\AdvancedSearch\Model\SuggestedQueries::class,
+            SuggestedQueries::class,
             [
                 'engineResolver' => $this->engineResolverMock,
                 'objectManager' => $objectManagerMock,
                 'data' => ['my_engine' => 'search_engine']
             ]
         );
+        $this->expectException(InvalidArgumentException::class);
         $model->isResultsCountEnabled();
     }
 
@@ -121,10 +131,10 @@ class SuggestedQueriesTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function testGetItems()
+    public function testGetItems(): void
     {
-        /** @var $queryInterfaceMock \Magento\Search\Model\QueryInterface */
-        $queryInterfaceMock = $this->createMock(\Magento\Search\Model\QueryInterface::class);
+        /** @var QueryInterface|MockObject $queryInterfaceMock */
+        $queryInterfaceMock = $this->createMock(QueryInterface::class);
         $result = $this->model->getItems($queryInterfaceMock);
         $this->assertEquals([], $result);
     }


### PR DESCRIPTION
### Description (*)
This PR fixes the PHPUnit 8 compatibility issues of existing unit tests for `Magento_AdvancedSearch` module. Performed minor code refactoring and code style fixes.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)

1. magento/magento2#27500: Unit Tests incompatible with PHPUnit 8

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run tests with PHPUnit 6: `vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/AdvancedSearch/`
2. Install PHPUnit 8 and run the same tests.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
