### PR TITLE
API catalog product render list response missing search criteria and total count #24719

### DIFF
--- a/app/code/Magento/Catalog/Api/Data/ProductRenderSearchResultsInterface.php
+++ b/app/code/Magento/Catalog/Api/Data/ProductRenderSearchResultsInterface.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -8,6 +7,7 @@
 namespace Magento\Catalog\Api\Data;
 
 use Magento\Framework\Api\SearchResultsInterface;
+
 /**
  * Dto that holds render information about products
  */
@@ -24,7 +24,7 @@ interface ProductRenderSearchResultsInterface extends SearchResultsInterface
      * Set list of products rendered information
      *
      * @api
-     * @param \Magento\Catalog\Api\Data\ProductRenderInterface[] $items
+     * @param  \Magento\Catalog\Api\Data\ProductRenderInterface[] $items
      * @return $this
      */
     public function setItems(array $items);

--- a/app/code/Magento/Catalog/Api/Data/ProductRenderSearchResultsInterface.php
+++ b/app/code/Magento/Catalog/Api/Data/ProductRenderSearchResultsInterface.php
@@ -7,10 +7,11 @@
 
 namespace Magento\Catalog\Api\Data;
 
+use Magento\Framework\Api\SearchResultsInterface;
 /**
  * Dto that holds render information about products
  */
-interface ProductRenderSearchResultsInterface
+interface ProductRenderSearchResultsInterface extends SearchResultsInterface
 {
     /**
      * Get list of products rendered information

--- a/app/code/Magento/Catalog/Model/ProductRenderList.php
+++ b/app/code/Magento/Catalog/Model/ProductRenderList.php
@@ -111,9 +111,9 @@ class ProductRenderList implements ProductRenderListInterface
         }
 
         $searchResult = $this->searchResultFactory->create();
-        $searchResult->setItems($items);
-        $searchResult->setTotalCount(count($items));
         $searchResult->setSearchCriteria($searchCriteria);
+        $searchResult->setTotalCount($productCollection->getSize());
+        $searchResult->setItems($items);
 
         return $searchResult;
     }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductRenderListTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductRenderListTest.php
@@ -12,6 +12,7 @@ use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Framework\Api\Search\SearchCriteria;
 use Magento\Framework\Api\Search\SearchResultInterface;
 use Magento\Framework\Data\CollectionModifier;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -21,28 +22,28 @@ class ProductRenderListTest extends \PHPUnit\Framework\TestCase
     /** @var \Magento\Catalog\Model\ProductRenderRepository */
     private $model;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var \MockObject */
     private $collectionFactoryMock;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var \MockObject */
     private $collectionProcessorMock;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var \MockObject */
     private $productRenderCollectorCompositeMock;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var \MockObject */
     private $productRenderSearchResultsFactoryMock;
 
-    /** @var \Magento\Catalog\Model\ProductRenderFactory|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \Magento\Catalog\Model\ProductRenderFactory|\MockObject */
     private $productRenderFactoryMock;
 
-    /** @var \Magento\Catalog\Model\Config|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \Magento\Catalog\Model\Config|\MockObject */
     private $configMock;
 
-    /** @var Visibility|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var Visibility|\MockObject */
     private $productVisibility;
 
-    /** @var CollectionModifier|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var CollectionModifier|\MockObject */
     private $collectionModifier;
 
     public function setUp()

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductRenderListTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductRenderListTest.php
@@ -167,16 +167,16 @@ class ProductRenderListTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->willReturn($searchResult);
         $searchResult->expects($this->once())
+            ->method('setSearchCriteria')
+            ->with($searchCriteria);
+        $searchResult->expects($this->once())
+            ->method('setTotalCount')
+            ->with(null);
+        $searchResult->expects($this->once())
             ->method('setItems')
             ->with([
                 1 => $productRender
             ]);
-        $searchResult->expects($this->once())
-            ->method('setTotalCount')
-            ->with(1);
-        $searchResult->expects($this->once())
-            ->method('setSearchCriteria')
-            ->with($searchCriteria);
 
         $this->assertEquals($searchResult, $this->model->getList($searchCriteria, $storeId, $currencyCode));
     }


### PR DESCRIPTION
Explain to PR is https://github.com/magento/magento2/issues/24719

Preconditions (*)
Magento 2.3.x
Steps to reproduce (*)
Go to the postman and use this URL and param with the GET method
URL: http://www.example.com/rest/V1/products-render-info
Param:
searchCriteria[filter_groups][0][filters][0][field] => category_id
searchCriteria[filter_groups][0][filters][0][value] => 4 ( Any Category id )
searchCriteria[filter_groups][0][filters][0][condition_type] => eq
searchCriteria[sort_orders][0][field] => name
searchCriteria[sort_orders][0][direction] => ASC
storeId => 1
currencyCode => USD
searchCriteria[pageSize] => 5
searchCriteria[currentPage] => 1 
Expected result (*)
As per the getList method code, the response should contain items with data, Search criteria with filters and sort options and the total number of products

getList Method code:
getList

Actual result (*)
In response, we get items data only.
