### PR TITLE
Swagger get store information gives error #13143

### DIFF
--- a/app/code/Magento/Store/etc/webapi.xml
+++ b/app/code/Magento/Store/etc/webapi.xml
@@ -32,7 +32,7 @@
     </route>
 
     <!-- Store Config -->
-    <route url="/V1/store/storeConfigs" method="GET">
+    <route url="/V1/store/storeConfigs" method="POST">
         <service class="Magento\Store\Api\StoreConfigManagerInterface" method="getStoreConfigs"/>
         <resources>
             <resource ref="Magento_Backend::store"/>

--- a/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
@@ -460,9 +460,6 @@ class ServiceInputProcessor implements ServicePayloadConverterInterface
         if ($isArrayType && isset($data['item'])) {
             $data = $this->_removeSoapItemNode($data);
         }
-        if ($isArrayType && is_string($data)) {
-            $data = explode(',', $data);
-        }
         if ($this->typeProcessor->isTypeSimple($type) || $this->typeProcessor->isTypeAny($type)) {
             $result = $this->typeProcessor->processSimpleAndAnyType($data, $type);
         } else {

--- a/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
@@ -460,6 +460,9 @@ class ServiceInputProcessor implements ServicePayloadConverterInterface
         if ($isArrayType && isset($data['item'])) {
             $data = $this->_removeSoapItemNode($data);
         }
+        if ($isArrayType && is_string($data)) {
+            $data = explode(',', $data);
+        }
         if ($this->typeProcessor->isTypeSimple($type) || $this->typeProcessor->isTypeAny($type)) {
             $result = $this->typeProcessor->processSimpleAndAnyType($data, $type);
         } else {


### PR DESCRIPTION
### Description (*)
Base issue https://github.com/magento/magento2/issues/13143

Steps to reproduce
Go to Swagger
open storeStoreConfigManagerV1
Method GET /V1/store/storeConfigs
Add Items: `default` and `test`

Or
http://yourdomain.com/rest/V1/store/storeConfigs?storeCodes[]=default&storeCodes[]=test

### Comments
This fix looks like and quick and resolved only this one request. I have checked other web-api calls and they use another structure(for example `searchCriteria` or used only simple types). 
I propose to create a ticket and get approval in architecture Magento git repository for totally rebuild `storeConfigs` query.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
