### PR TITLE
Added Magento_TranslationGraphQl module to support PWA Studio Localization

### DIFF
--- a/app/code/Magento/TranslationGraphQl/Model/Resolver/AvailableLocales.php
+++ b/app/code/Magento/TranslationGraphQl/Model/Resolver/AvailableLocales.php
@@ -15,8 +15,7 @@ use Magento\Store\Api\StoreConfigManagerInterface;
 use Magento\Store\Api\StoreRepositoryInterface;
 
 /**
- * Class AvailableLocales
- * @package Magento\TranslationGraphQl\Model\Resolver
+ * Retrieval of available locales configured for all store views
  */
 class AvailableLocales implements ResolverInterface
 {
@@ -63,7 +62,8 @@ class AvailableLocales implements ResolverInterface
      *
      * @return array
      */
-    private function getLocales(): array {
+    private function getLocales(): array
+    {
         $locales = [];
         $stores = $this->storeRepository->getList();
 

--- a/app/code/Magento/TranslationGraphQl/Model/Resolver/AvailableLocales.php
+++ b/app/code/Magento/TranslationGraphQl/Model/Resolver/AvailableLocales.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\TranslationGraphQl\Model\Resolver;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Store\Api\Data\WebsiteInterface;
+use Magento\Store\Api\StoreConfigManagerInterface;
+use Magento\Store\Api\StoreRepositoryInterface;
+
+/**
+ * Class AvailableLocales
+ * @package Magento\TranslationGraphQl\Model\Resolver
+ */
+class AvailableLocales implements ResolverInterface
+{
+    /**
+     * @var StoreRepositoryInterface
+     */
+    private $storeRepository;
+
+    /**
+     * @var StoreConfigManagerInterface
+     */
+    private $storeConfigManager;
+
+    /**
+     * Translations constructor.
+     * @param StoreRepositoryInterface $storeRepository
+     * @param StoreConfigManagerInterface $configManager
+     */
+    public function __construct(
+        StoreRepositoryInterface $storeRepository,
+        StoreConfigManagerInterface $configManager
+    ) {
+        $this->storeRepository = $storeRepository;
+        $this->storeConfigManager = $configManager;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        return [
+            'items' => $this->getLocales()
+        ];
+    }
+
+    /**
+     * Get all locales configured
+     *
+     * @return array
+     */
+    private function getLocales(): array {
+        $locales = [];
+        $stores = $this->storeRepository->getList();
+
+        $storeCodes = [];
+        /** @var WebsiteInterface $website */
+        foreach ($stores as $store) {
+            $storeCodes[] = $store->getCode();
+        }
+
+        $storeConfigs = $this->storeConfigManager->getStoreConfigs($storeCodes);
+        foreach ($storeConfigs as $storeConfig) {
+            $locale = $storeConfig->getLocale();
+            $locales[$locale] = [
+                'locale' => $locale
+            ];
+        }
+
+        return $locales;
+    }
+}

--- a/app/code/Magento/TranslationGraphQl/Model/Resolver/Translations.php
+++ b/app/code/Magento/TranslationGraphQl/Model/Resolver/Translations.php
@@ -14,8 +14,7 @@ use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Framework\TranslateInterface;
 
 /**
- * Class Translations
- * @package Magento\TranslationGraphQl\Model\Resolver
+ * Resolver for retrieving translated phrases
  */
 class Translations implements ResolverInterface
 {

--- a/app/code/Magento/TranslationGraphQl/Model/Resolver/Translations.php
+++ b/app/code/Magento/TranslationGraphQl/Model/Resolver/Translations.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\TranslationGraphQl\Model\Resolver;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\TranslateInterface;
+
+/**
+ * Class Translations
+ * @package Magento\TranslationGraphQl\Model\Resolver
+ */
+class Translations implements ResolverInterface
+{
+    /**
+     * @var TranslateInterface
+     */
+    private $translate;
+
+    /**
+     * Translations constructor.
+     * @param TranslateInterface $translate
+     */
+    public function __construct(
+        TranslateInterface $translate
+    ) {
+        $this->translate = $translate;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        $this->translate->setLocale($args['locale']);
+        $this->translate->loadData();
+
+        $phrases = $this->getPhrases($args);
+        $translatedPhrases = $this->getTranslatedPhrases($phrases);
+
+        return [
+            'items' => $translatedPhrases,
+        ];
+    }
+
+    /**
+     * Get phrases to be translated
+     *
+     * @param array $args
+     * @return string[]
+     * @throws GraphQlInputException
+     */
+    private function getPhrases(array $args): array
+    {
+        if (!isset($args['phrases']) || !is_array($args['phrases']) || count($args['phrases']) === 0) {
+            throw new GraphQlInputException(__('"Phrases" to be translated must be specified'));
+        }
+
+        return $args['phrases'];
+    }
+
+    /**
+     * Get translated phrases
+     *
+     * @param array $phrases
+     * @return array
+     */
+    private function getTranslatedPhrases(array $phrases): array
+    {
+        $data = $this->translate->getData();
+        $translatedPrases = [];
+        foreach ($phrases as $phrase) {
+            $translatedPrases[$phrase] = [
+                'original' => $phrase,
+                'translated' => array_key_exists($phrase, $data) ? $data[$phrase] : $phrase
+            ];
+        }
+        return $translatedPrases;
+    }
+}

--- a/app/code/Magento/TranslationGraphQl/README.md
+++ b/app/code/Magento/TranslationGraphQl/README.md
@@ -1,0 +1,4 @@
+# TranslationGraphQl
+
+**TranslationGraphQl** provides type information for the GraphQl module
+to fetch translated phrases by a defined locale

--- a/app/code/Magento/TranslationGraphQl/composer.json
+++ b/app/code/Magento/TranslationGraphQl/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
         "magento/framework": "*",
-        "magento/module-translation": "*"
+        "magento/module-translation": "*",
+        "magento/module-store": "*"
     },
     "suggest": {
         "magento/module-graph-ql": "*"

--- a/app/code/Magento/TranslationGraphQl/composer.json
+++ b/app/code/Magento/TranslationGraphQl/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "magento/module-translation-graph-ql",
+    "description": "N/A",
+    "type": "magento2-module",
+    "require": {
+        "php": "~7.1.3||~7.2.0||~7.3.0",
+        "magento/framework": "*",
+        "magento/module-translation": "*"
+    },
+    "suggest": {
+        "magento/module-graph-ql": "*"
+    },
+    "license": [
+        "OSL-3.0",
+        "AFL-3.0"
+    ],
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Magento\\TranslationGraphQl\\": ""
+        }
+    }
+}

--- a/app/code/Magento/TranslationGraphQl/etc/module.xml
+++ b/app/code/Magento/TranslationGraphQl/etc/module.xml
@@ -9,6 +9,7 @@
     <module name="Magento_TranslationGraphQl">
         <sequence>
             <module name="Magento_Translation"/>
+            <module name="Magento_Store"/>
         </sequence>
     </module>
 </config>

--- a/app/code/Magento/TranslationGraphQl/etc/module.xml
+++ b/app/code/Magento/TranslationGraphQl/etc/module.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Magento_TranslationGraphQl">
+        <sequence>
+            <module name="Magento_Translation"/>
+        </sequence>
+    </module>
+</config>

--- a/app/code/Magento/TranslationGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/TranslationGraphQl/etc/schema.graphqls
@@ -1,3 +1,5 @@
+# Copyright © Magento, Inc. All rights reserved.
+# See COPYING.txt for license details.
 type Query {
     translate (
         locale: String @doc(description: "Desired Locale eg: en_US or ca_FR")

--- a/app/code/Magento/TranslationGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/TranslationGraphQl/etc/schema.graphqls
@@ -1,0 +1,27 @@
+type Query {
+    translate (
+        locale: String @doc(description: "Desired Locale eg: en_US or ca_FR")
+        phrases: [String] @doc(description: "List of phrases to translate")
+    ): Phrases
+    @resolver(class: "Magento\\TranslationGraphQl\\Model\\Resolver\\Translations")
+    @doc(description: "Retrieve translations")
+    @cache(cacheable: false)
+    availableLocales: Locales @resolver(class: "Magento\\TranslationGraphQl\\Model\\Resolver\\AvailableLocales") @doc(description: "Get list of available locales") @cache(cacheable: false)
+}
+
+type Phrases @doc(description: "Array of Phrases") {
+    items: [Phrase] @doc(description: "An array of Phrases to be translated")
+}
+
+type Phrase @doc(description: "Phrase defines original and translated phrases") {
+    original: String @doc(description: "Original Phrase")
+    translated: String @doc(description: "Translated Phrase")
+}
+
+type Locales @doc(description: "Array of Locales") {
+    items: [Locale] @doc(description: "An array of Locales available")
+}
+
+type Locale @doc(description: "Locale code provided from store views") {
+    locale: String @doc(description: "Locale code provided from store views")
+}

--- a/app/code/Magento/TranslationGraphQl/registration.php
+++ b/app/code/Magento/TranslationGraphQl/registration.php
@@ -5,4 +5,5 @@
  */
 
 use \Magento\Framework\Component\ComponentRegistrar;
+
 ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_TranslationGraphQl', __DIR__);

--- a/app/code/Magento/TranslationGraphQl/registration.php
+++ b/app/code/Magento/TranslationGraphQl/registration.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use \Magento\Framework\Component\ComponentRegistrar;
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_TranslationGraphQl', __DIR__);

--- a/composer.json
+++ b/composer.json
@@ -255,6 +255,7 @@
         "magento/module-theme": "*",
         "magento/module-theme-graph-ql": "*",
         "magento/module-translation": "*",
+        "magento/module-translation-graph-ql": "*",
         "magento/module-ui": "*",
         "magento/module-ups": "*",
         "magento/module-url-rewrite": "*",


### PR DESCRIPTION
### Description (*)
This pull request adds a GraphQL module for the Magento_Translation module. It creates two GraphQL queries to:

1. Retrieve translated phrases for a supplied locale
2. Retrieval of available locales configured within Magento

This feature is to support the Localization tasks in the PWA Studio Project - https://github.com/magento/pwa-studio/issues/669

In the PWA Studio project, a Buildpack command extracts phrases from the PWA Project and requests translated phrases from the Magento backend. This effort is to allow PWA Studio to feature localisation and multiple store views. The Available Locales query is used by PWA Studio Buildpack to know what locales it should query for.

### Related Pull Requests
PWA Studio work (pending finalisation and review) - https://github.com/magento/pwa-studio/compare/develop...chris-brabender:feature/prototype-v2?expand=1

### Manual testing scenarios (*)
Using postman for example, you can provide a GraphQL payload similar to:

`{
    translate (
        locale: "fr_CA"
        phrases: ["General", "Add to Cart", "Api Keys", "Behavior"]
    ) {
        items {
            original
            translated
        }
    }
}`

This assumes you have a French language pack installed.

![Screen Shot 2020-04-04 at 5 34 01 PM](https://user-images.githubusercontent.com/5144830/78461857-8795bd00-769a-11ea-929d-8f169108525d.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
