### PR TITLE
Cleanup Mage bootstrap dependencies

### DIFF
--- a/app/code/Magento/Theme/view/frontend/requirejs-config.js
+++ b/app/code/Magento/Theme/view/frontend/requirejs-config.js
@@ -34,8 +34,6 @@ var config = {
     },
     deps: [
         'jquery/jquery.mobile.custom',
-        'mage/common',
-        'mage/dataPost',
         'mage/bootstrap'
     ],
     config: {

--- a/lib/web/mage/bootstrap.js
+++ b/lib/web/mage/bootstrap.js
@@ -6,6 +6,8 @@
 define([
     'jquery',
     'mage/apply/main',
+    'mage/common',
+    'mage/dataPost',
     'Magento_Ui/js/lib/knockout/bootstrap'
 ], function ($, mage) {
     'use strict';

--- a/lib/web/mage/common.js
+++ b/lib/web/mage/common.js
@@ -12,40 +12,38 @@ define([
     /* Form with auto submit feature */
     $('form[data-auto-submit="true"]').submit();
 
-    //Add form keys.
-    $(document).on(
-        'submit',
-        'form',
-        function (e) {
-            var formKeyElement,
-                existingFormKeyElement,
-                isKeyPresentInForm,
-                isActionExternal,
-                baseUrl = window.BASE_URL,
-                form = $(e.target),
-                formKey = $('input[name="form_key"]').val(),
-                formMethod = form.prop('method'),
-                formAction = form.prop('action');
-
+    /**
+     * Sets proper form key for every form that gets submitted on the page.
+     */
+    $(document).on('submit', 'form', function (e) {
+        var baseUrl = window.BASE_URL,
+            $form = $(e.target),
+            $formKeyElement,
+            formKey = $('input[name="form_key"]').val(),
+            formMethod = $form.prop('method'),
+            formAction = $form.prop('action'),
             isActionExternal = formAction.indexOf(baseUrl) !== 0;
 
-            existingFormKeyElement = form.find('input[name="form_key"]');
-            isKeyPresentInForm = existingFormKeyElement.length;
-
-            /* Verifies that existing auto-added form key is a direct form child element,
-               protection from a case when one form contains another form. */
-            if (isKeyPresentInForm && existingFormKeyElement.attr('auto-added-form-key') === '1') {
-                isKeyPresentInForm = form.find('> input[name="form_key"]').length;
-            }
-
-            if (formKey && !isKeyPresentInForm && !isActionExternal && formMethod !== 'get') {
-                formKeyElement = document.createElement('input');
-                formKeyElement.setAttribute('type', 'hidden');
-                formKeyElement.setAttribute('name', 'form_key');
-                formKeyElement.setAttribute('value', formKey);
-                formKeyElement.setAttribute('auto-added-form-key', '1');
-                form.get(0).appendChild(formKeyElement);
-            }
+        /**
+         * Take action only for internal forms that are not using GET method.
+         */
+        if (isActionExternal || formMethod === 'get') {
+            return;
         }
-    );
+
+        /**
+         * Verifies that existing auto-added form key is a direct form child element.
+         */
+        $formKeyElement = $form.children('input[name="form_key"]');
+
+        if (!$formKeyElement.length) {
+            $formKeyElement = $('<input>').prop({
+                type: 'hidden',
+                name: 'form_key'
+            });
+            $form.append($formKeyElement);
+        }
+
+        $formKeyElement.val(formKey);
+    });
 });

--- a/lib/web/mage/dataPost.js
+++ b/lib/web/mage/dataPost.js
@@ -5,15 +5,13 @@
 
 define([
     'jquery',
-    'mage/template',
-    'Magento_Ui/js/modal/confirm',
     'jquery-ui-modules/widget'
-], function ($, mageTemplate, uiConfirm) {
+], function ($) {
     'use strict';
 
     $.widget('mage.dataPost', {
         options: {
-            formTemplate: '<form action="<%- data.action %>" method="post">' +
+            formTemplate: '<form action="<%- data.action %>" method="post" hidden>' +
             '<% _.each(data.data, function(value, index) { %>' +
             '<input name="<%- index %>" value="<%- value %>">' +
             '<% }) %></form>',
@@ -56,43 +54,51 @@ define([
          * @param {Object} params
          */
         postData: function (params) {
-            var formKey = $(this.options.formKeyInputSelector).val(),
-                $form, input;
+            var $form,
+                formKey = $(this.options.formKeyInputSelector).val(),
+                paramsData = params.data;
 
             if (formKey) {
-                params.data['form_key'] = formKey;
+                paramsData['form_key'] = formKey;
             }
 
-            $form = $(mageTemplate(this.options.formTemplate, {
-                data: params
-            }));
-
-            if (params.files) {
-                $form[0].enctype = 'multipart/form-data';
-                $.each(params.files, function (key, files) {
-                    if (files instanceof FileList) {
-                        input = document.createElement('input');
-                        input.type = 'file';
-                        input.name = key;
-                        input.files = files;
-                        $form[0].appendChild(input);
-                    }
-                });
-            }
-
-            if (params.data.confirmation) {
-                uiConfirm({
-                    content: params.data.confirmationMessage,
-                    actions: {
-                        /** @inheritdoc */
-                        confirm: function () {
-                            $form.appendTo('body').hide().submit();
+            require(['mage/template'], function(mageTemplate) {
+                $form = $(mageTemplate(this.options.formTemplate, {
+                    data: params
+                }));
+    
+                if (params.files) {
+                    $form.prop('enctype', 'multipart/form-data');
+    
+                    $.each(params.files, function (inputName, files) {
+                        if (files instanceof FileList) {
+                            $form.append(
+                                $('<input>').prop({
+                                    type: 'file',
+                                    name: inputName,
+                                    file: files
+                                })
+                            );
                         }
-                    }
-                });
-            } else {
-                $form.appendTo('body').hide().submit();
-            }
+                    });
+                }
+    
+                if (paramsData.confirmation) {
+                    require(['Magento_Ui/js/modal/confirm'], function (uiConfirm) {
+                        uiConfirm({
+                            content: paramsData.confirmationMessage,
+                            actions: {
+                                /** @inheritdoc */
+                                confirm: function () {
+                                    $form.appendTo('body').submit();
+                                }
+                            }
+                        });
+                    });
+                } else {
+                    $form.appendTo('body').submit();
+                }
+            });
         }
     });
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR is a part of my effort to improve Magento 2 frontend performance.

In this PR I'm cleaning-up both `common` and `dataPost` modules and moving them from `deps` to normal dependencies so it is possible to create mixins for them. I'm also moving some of the dependencies from top-level definition to the moment when they are actually needed so we are not loading and waiting for redundant files.

### Related Pull Requests
<!-- related pull request placeholder -->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Links with `data-post` are still submitted properly (e.g. add to wishlist links).
2. I'm not sure how to test `mage/common`, but I'll try to check when it is applied.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
