### PR TITLE
Display Stock (Only X Left) Even when Negative

### DIFF
--- a/app/code/Magento/CatalogInventory/Block/Stockqty/DefaultStockqty.php
+++ b/app/code/Magento/CatalogInventory/Block/Stockqty/DefaultStockqty.php
@@ -27,4 +27,14 @@ class DefaultStockqty extends AbstractStockqty implements \Magento\Framework\Dat
     {
         return $this->getProduct()->getIdentities();
     }
+
+    /**
+     * Retrieve manage stock value
+     *
+     * @return \Magento\CatalogInventory\Api\Data\StockItemInterface
+     */
+    public function getStock()
+    {
+        return $this->stockRegistry->getStockItem($this->getProduct()->getId());
+    }
 }

--- a/app/code/Magento/CatalogInventory/Block/Stockqty/DefaultStockqty.php
+++ b/app/code/Magento/CatalogInventory/Block/Stockqty/DefaultStockqty.php
@@ -19,19 +19,6 @@ namespace Magento\CatalogInventory\Block\Stockqty;
 class DefaultStockqty extends AbstractStockqty implements \Magento\Framework\DataObject\IdentityInterface
 {
     /**
-     * Render block HTML
-     *
-     * @return string
-     */
-    protected function _toHtml()
-    {
-        if (!$this->isMsgVisible()) {
-            return '';
-        }
-        return parent::_toHtml();
-    }
-
-    /**
      * Return identifiers for produced content
      *
      * @return array

--- a/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/default.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/default.phtml
@@ -8,12 +8,12 @@
  * @var $block \Magento\CatalogInventory\Block\Stockqty\DefaultStockqty
  */
 ?>
-<?php if($block->getThresholdQty() != 0): ?>
-    <?php if($block->getStockQtyLeft() > 0): ?>
+<?php if ($block->getThresholdQty() && $block->getStock()->getManageStock()): ?>
+    <?php if ($block->getStockQtyLeft() > 0): ?>
         <div class="availability only" title="<?= $block->escapeHtmlAttr(__('Only %1 left', ($block->getStockQtyLeft()))) ?>">
             <?= /* @noEscape */ __('Only %1 left', "<strong>{$block->escapeHtml($block->getStockQtyLeft())}</strong>") ?>
         </div>
-    <?php else: ?>
+    <?php elseif ($block->getStock()->getBackOrders() != 0): ?>
         <div class="cart item message notice">
             <div>We don't have as many quantity as you requested, but we'll back order.</div>
         </div>

--- a/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/default.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/default.phtml
@@ -8,8 +8,14 @@
  * @var $block \Magento\CatalogInventory\Block\Stockqty\DefaultStockqty
  */
 ?>
-<?php if ($block->isMsgVisible()) : ?>
-    <div class="availability only" title="<?= $block->escapeHtmlAttr(__('Only %1 left', ($block->getStockQtyLeft()))) ?>">
-        <?= /* @noEscape */ __('Only %1 left', "<strong>{$block->escapeHtml($block->getStockQtyLeft())}</strong>") ?>
-    </div>
-<?php endif ?>
+<?php if($block->getThresholdQty() != 0): ?>
+    <?php if($block->getStockQtyLeft() > 0): ?>
+        <div class="availability only" title="<?= $block->escapeHtmlAttr(__('Only %1 left', ($block->getStockQtyLeft()))) ?>">
+            <?= /* @noEscape */ __('Only %1 left', "<strong>{$block->escapeHtml($block->getStockQtyLeft())}</strong>") ?>
+        </div>
+    <?php else: ?>
+        <div class="cart item message notice">
+            <div>We don't have as many quantity as you requested, but we'll back order.</div>
+        </div>
+    <?php endif; ?>
+<?php endif; ?>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Display Stock (Only X Left) Even when Negative

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#27361 : Display Stock (Only X Left) Even when Negative

### Manual testing scenarios (*)

1.Add Product and Set Inventory to 0 or Negative
2.Navigate to Stores->Configuration->Catalog->Inventory
3.Display Out of Stock Products->Yes
4.Only X left Threshold->10000
5.Display Products Availability in Stock on Storefront-> Yes
6. Manage Stock->Yes
7.Backorders->Allow Qty Below 0 and Notify Customer

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)