### PR TITLE
Allow virtual proxies to work

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/InterceptableValidator.php
+++ b/lib/internal/Magento/Framework/ObjectManager/InterceptableValidator.php
@@ -13,11 +13,10 @@ class InterceptableValidator
      */
     public function validate($className)
     {
-        return !$this->isInterceptor($className) && $this->isInterceptable($className);
+        return !$this->isInterceptor($className) && !$this->isProxy($className) && $this->isInterceptable($className);
     }
 
     /**
-     *
      * Check if instance type is interceptor
      *
      * @param string $instanceName
@@ -26,6 +25,20 @@ class InterceptableValidator
     private function isInterceptor($instanceName)
     {
         return $this->endsWith($instanceName, '\Interceptor');
+    }
+
+    /**
+     * Check if instance type is proxy
+     *
+     * @param string $instanceName
+     * @return bool
+     */
+    private function isProxy($instanceName)
+    {
+        return $this->endsWith(
+            $instanceName,
+            '\\' . ucfirst(\Magento\Framework\ObjectManager\Code\Generator\Proxy::ENTITY_TYPE)
+        );
     }
 
     /**
@@ -39,7 +52,7 @@ class InterceptableValidator
     {
         return !is_subclass_of(
             $instanceName,
-            '\\' . \Magento\Framework\ObjectManager\Code\Generator\Proxy::NON_INTERCEPTABLE_INTERFACE
+            '\\' . \Magento\Framework\ObjectManager\NoninterceptableInterface::class
         );
     }
 

--- a/lib/internal/Magento/Framework/ObjectManager/InterceptableValidator.php
+++ b/lib/internal/Magento/Framework/ObjectManager/InterceptableValidator.php
@@ -22,7 +22,7 @@ class InterceptableValidator
      * @param string $instanceName
      * @return bool
      */
-    private function isInterceptor($instanceName)
+    private function isInterceptor(string $instanceName): bool
     {
         return $this->endsWith($instanceName, '\Interceptor');
     }
@@ -33,12 +33,9 @@ class InterceptableValidator
      * @param string $instanceName
      * @return bool
      */
-    private function isProxy($instanceName)
+    private function isProxy(string $instanceName): bool
     {
-        return $this->endsWith(
-            $instanceName,
-            '\\' . ucfirst(\Magento\Framework\ObjectManager\Code\Generator\Proxy::ENTITY_TYPE)
-        );
+        return $this->endsWith($instanceName, '\Proxy');
     }
 
     /**
@@ -48,11 +45,11 @@ class InterceptableValidator
      * @param string $instanceName
      * @return bool
      */
-    private function isInterceptable($instanceName)
+    private function isInterceptable(string $instanceName): bool
     {
         return !is_subclass_of(
             $instanceName,
-            '\\' . \Magento\Framework\ObjectManager\NoninterceptableInterface::class
+            \Magento\Framework\ObjectManager\NoninterceptableInterface::class
         );
     }
 
@@ -63,7 +60,7 @@ class InterceptableValidator
      * @param string $needle
      * @return bool
      */
-    private function endsWith($haystack, $needle)
+    private function endsWith(string $haystack, string $needle): bool
     {
         // Search forward starting from end minus needle length characters
         $temp = strlen($haystack) - strlen($needle);

--- a/setup/src/Magento/Setup/Module/Di/Code/Generator/InterceptionConfigurationBuilder.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Generator/InterceptionConfigurationBuilder.php
@@ -11,8 +11,8 @@ use Magento\Framework\App\Area;
 use Magento\Framework\App\Cache\Manager;
 use Magento\Framework\App\Interception\Cache\CompiledConfig;
 use Magento\Framework\Interception\Config\Config as InterceptionConfig;
-use Magento\Setup\Module\Di\Code\Reader\Type;
 use Magento\Framework\ObjectManager\InterceptableValidator;
+use Magento\Setup\Module\Di\Code\Reader\Type;
 
 class InterceptionConfigurationBuilder
 {
@@ -138,22 +138,26 @@ class InterceptionConfigurationBuilder
                 $pluginListCloned->setScopePriorityScheme($scopePriority);
             }
             $key = implode('', $scopePriority);
-            $inheritedConfig[$key] = $this->filterNullInheritance($pluginListCloned->getPluginsConfig());
+            $inheritedConfig[$key] = $this->filterPluginsConfig($pluginListCloned->getPluginsConfig());
         }
         return $inheritedConfig;
     }
 
     /**
-     * Filters plugin inheritance list for instances without plugins, and abstract/interface
+     * Filters plugin inheritance list for instances without plugins, abstract/interface, and non-interceptable.
      *
      * @param array $pluginInheritance
      * @return array
      */
-    private function filterNullInheritance($pluginInheritance)
+    private function filterPluginsConfig($pluginInheritance)
     {
         $filteredData = [];
         foreach ($pluginInheritance as $instance => $plugins) {
-            if ($plugins === null || !$this->typeReader->isConcrete($instance)) {
+            if (
+                $plugins === null ||
+                !$this->typeReader->isConcrete($instance) ||
+                !$this->interceptableValidator->validate($instance)
+            ) {
                 continue;
             }
 

--- a/setup/src/Magento/Setup/Module/Di/Code/Scanner/XmlScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Scanner/XmlScanner.php
@@ -105,12 +105,6 @@ class XmlScanner implements ScannerInterface
             if (false === $isClassExists) {
                 if (class_exists($entityName) || interface_exists($entityName)) {
                     $filteredEntities[] = $className;
-                } else {
-                    $this->_log->add(
-                        \Magento\Setup\Module\Di\Compiler\Log\Log::CONFIGURATION_ERROR,
-                        $className,
-                        'Invalid proxy class for ' . substr($className, 0, -5)
-                    );
                 }
             }
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

### Summary

It is impossible to make virtual proxies to work. Motivation and use case are described below in the description. This is the summary of changes proposed.

- \Magento\Setup\Module\Di\Code\Scanner\XmlScanner: Limit responsibility to filter entities, do not complain about non existing classes
- \Magento\Framework\ObjectManager\InterceptableValidator: Use \Magento\Framework\ObjectManager\NoninterceptableInterface::class to check interceptability, check \Proxy suffix in instance name
- \Magento\Setup\Module\Di\Code\Generator\InterceptionConfigurationBuilder: Filter plugins config to skip not interceptable classes, according to modified interceptable validator

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

I'll try to explain the use case and motivation of this PR as clear as possible.

The use case is the following:

I have an existing, configurable class, called **RegularPolygon**. Its name and number of sides are configurable. So given RegularPolygon class, **I want to create an Square class**. To achieve that, I create a **virtual type Square, based on RegularPolygon**, with name Square and number of sides = 4:
```
<!-- Declare square -->
<virtualType name="Interactiv4\VirtualProxy\Model\RegularPolygon\Square" type="Interactiv4\VirtualProxy\Model\RegularPolygon">
  <arguments>
    <argument name="name" xsi:type="string">Square</argument>
    <argument name="sides" xsi:type="number">4</argument>
  </arguments>
</virtualType>
```

So far so good. But now, let's say I discover **RegularPolygon have slow loading dependencies**, and that I may not need to get Square instantiated in classes where I have it injected. So in fact, **I want to inject a Square\Proxy class**, to get it instantiated only when really needed.

No problem, I can do that, even if Square is a virtual type, because **original type proxy**, RegularPolygon\Proxy, **allows to get injected in its constructor the subject instance name** to be instantiated when needed. **So I define Square\Proxy as a virtual type for the original proxy**, injecting my new Square instance name:
```
<virtualType name="Interactiv4\VirtualProxy\Model\RegularPolygon\Square\Proxy" type="Interactiv4\VirtualProxy\Model\RegularPolygon\Proxy">
  <arguments>
    <!-- Reference to square virtual type defined above -->
    <argument name="instanceName" xsi:type="string">Interactiv4\VirtualProxy\Model\RegularPolygon\Square</argument>
  </arguments>
</virtualType>
``` 

I'm in developer mode, and it all seems to work properly. I can inject virtual proxy anywhere, and it gets instantiated only when needed, cool. Time to switch to production mode, (or at least run **setup:di:compile**):
![Captura de pantalla 2020-04-07 a las 18 23 46](https://user-images.githubusercontent.com/17545750/78694479-fd995e80-78fc-11ea-9a8b-65f5b65933c4.png)

Oops, compilation fails !! I expected to have it working in production mode as it works in developer mode...

Before taking a further look at that, I'll explain another strange behaviour related with this.

I'm in developer mode again. I've implemented a **beforeGetPerimeter plugin, to increase by 100** the value the original method receives:
```
<!-- Intercept perimeter parameter to increase it by 100 -->
<!-- Apply to original type, so it applies to its virtual types -->
<!-- I expect to get side length increased by 100 -->
<type name="Interactiv4\VirtualProxy\Model\RegularPolygon">
  <plugin 
    name="Interactiv4\VirtualProxy\Plugin\RegularPolygon\InterceptPerimeterParameterPlugin"
    type="Interactiv4\VirtualProxy\Plugin\RegularPolygon\InterceptPerimeterParameterPlugin"
sortOrder="10"/>
</type>
```

 I've also implemented a configurable command, which receives either the original Square virtual type, or its proxy (`interactiv4:virtual-proxy:test-original` and `interactiv4:virtual-proxy:test-proxy`, respectively):
```
<!-- Declare test commands -->
<!-- Test command: original -->
  <virtualType name="Interactiv4\VirtualProxy\Console\TestOriginalCommand" type="Interactiv4\VirtualProxy\Console\Command\TestCommand">
  <arguments>
    <!-- Use original implementation -->
    <argument name="name" xsi:type="string">test-original</argument>
    <argument name="regularPolygon" xsi:type="object">Interactiv4\VirtualProxy\Model\RegularPolygon\Square</argument>
  </arguments>
</virtualType>
<!-- Test command: proxy -->
<virtualType name="Interactiv4\VirtualProxy\Console\TestProxyCommand" type="Interactiv4\VirtualProxy\Console\Command\TestCommand">
  <arguments>
    <!-- Use proxy implementation -->
    <argument name="name" xsi:type="string">test-proxy</argument>
    <argument name="regularPolygon" xsi:type="object">Interactiv4\VirtualProxy\Model\RegularPolygon\Square\Proxy</argument>
  </arguments>
</virtualType>
<!-- Inject commands into command list -->
<type name="Magento\Framework\Console\CommandListInterface">
  <arguments>
    <argument name="commands" xsi:type="array">
      <item name="Interactiv4\VirtualProxy\Console\TestOriginalCommand" xsi:type="object">Interactiv4\VirtualProxy\Console\TestOriginalCommand</item>
      <item name="Interactiv4\VirtualProxy\Console\TestProxyCommand" xsi:type="object">Interactiv4\VirtualProxy\Console\TestProxyCommand</item>
    </argument>
  </arguments>
</type>
```

My **expected result** for getPerimeter, with a side length of 5, is:
(100 (plugin addition) + 5) * 4 = **420**.

Let's see what happens in both cases:
```
$ bin/magento interactiv4:virtual-proxy:test-original --side-length 5
420
$ bin/magento interactiv4:virtual-proxy:test-proxy --side-length 5
820
```

Surprisingly, using the proxy class modifies the original result !! **Execution is entering into plugin 2 times:**
(100 (plugin addition) **+ 100 (second plugin addition)** + 5) * 4 = **820**.

The explanation to this behaviour is, if you take a look in generated/code folder, you will see a **Proxy\Interceptor class** (\Interactiv4\VirtualProxy\Model\RegularPolygon\Proxy\Interceptor) has been generated, **thing that shouldn't have occurred, since Proxy is an instance of \Magento\Framework\ObjectManager\NoninterceptableInterface**... This makes plugin to be executed 2 times: one for the Proxy\Interceptor, and another for the original class interceptor (as one is a subclass of the another and they inherit plugins). The main point is, that Proxy\Interceptor shouldn't have been generated and should not exist.

Result is the same after running setup:di:compile; metadata includes Proxy\Interceptor as the candidate to be instantiated, instead of Proxy class.

Putting all together, this PR makes needed adaptations to avoid Proxy\Interceptor class generation, even when it is a virtual proxy, and adapts code compilation to take care of this virtual proxies.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)

I've written a sample module describing the use case, with two simple command for testing described behaviour. It can be found at https://bitbucket.org/interactiv4/module-virtual-proxy.
Installation instructions are located at https://bitbucket.org/interactiv4/module-virtual-proxy/src/0/README.md.

Use case explanation and virtual classes definitions are located at https://bitbucket.org/interactiv4/module-virtual-proxy/src/0/etc/di.xml.

1. Run following installation commands:

```
composer config repositories.virtual-proxy vcs https://bitbucket.org/interactiv4/module-virtual-proxy
composer require --dev 'interactiv4/module-virtual-proxy:@dev'
bin/magento setup:upgrade

```

2. Compare the results before and after applying this changes by executing:

```
touch var/.regenerate
bin/magento interactiv4:virtual-proxy:test-original --side-length 5
bin/magento interactiv4:virtual-proxy:test-proxy --side-length 5
bin/magento setup:di:compile
bin/magento interactiv4:virtual-proxy:test-original --side-length 5
bin/magento interactiv4:virtual-proxy:test-proxy --side-length 5
```

Before applying changes (current) (different results, compilation error):
![Captura de pantalla 2020-04-07 a las 18 50 42](https://user-images.githubusercontent.com/17545750/78697205-ba40ef00-7900-11ea-9a1b-9e2563daae4a.png)

After applying changes (expected) (same result, compilation ok):
![Captura de pantalla 2020-04-07 a las 18 52 52](https://user-images.githubusercontent.com/17545750/78697385-02f8a800-7901-11ea-9181-582485df6085.png)


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30934: Allow virtual proxies to work