### PR TITLE
[Variable] Fix PHPUnit 8 compatibility issues

### DIFF
--- a/app/code/Magento/Variable/Test/Unit/Controller/Adminhtml/System/Variable/ValidateTest.php
+++ b/app/code/Magento/Variable/Test/Unit/Controller/Adminhtml/System/Variable/ValidateTest.php
@@ -3,85 +3,107 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Variable\Test\Unit\Controller\Adminhtml\System\Variable;
+
+use Magento\Backend\App\Action\Context;
+use Magento\Backend\Model\View\Result\ForwardFactory;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Framework\Registry;
+use Magento\Framework\View\Element\Messages;
+use Magento\Framework\View\LayoutFactory;
+use Magento\Framework\View\LayoutInterface;
+use Magento\Framework\View\Result\PageFactory;
+use Magento\Variable\Controller\Adminhtml\System\Variable\Validate;
+use Magento\Variable\Model\Variable;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ValidateTest
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class ValidateTest extends \PHPUnit\Framework\TestCase
+class ValidateTest extends TestCase
 {
     /**
-     * @var \Magento\Variable\Model\Variable|\PHPUnit_Framework_MockObject_MockObject
+     * @var Variable|MockObject
      */
-    protected $variableMock;
+    private $variableMock;
 
     /**
-     * @var \Magento\Framework\View\LayoutInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var LayoutInterface|MockObject
      */
-    protected $layoutMock;
+    private $layoutMock;
 
     /**
-     * @var \Magento\Framework\App\RequestInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var RequestInterface|MockObject
      */
     protected $requestMock;
 
     /**
-     * @var \Magento\Variable\Controller\Adminhtml\System\Variable\Validate | \PHPUnit_Framework_MockObject_MockObject
+     * @var Validate|MockObject
      */
-    protected $validateMock;
+    private $validateMock;
 
     /**
-     * @var \Magento\Framework\Controller\Result\Json | \PHPUnit_Framework_MockObject_MockObject
+     * @var Json|MockObject
      */
-    protected $resultJsonMock;
+    private $resultJsonMock;
 
     /**
-     * @var \Magento\Framework\Message\ManagerInterface | \PHPUnit_Framework_MockObject_MockObject
+     * @var ManagerInterface|MockObject
      */
-    protected $messageManagerMock;
+    private $messageManagerMock;
 
-    protected function setUp()
+    /**
+     * Set Up
+     */
+    protected function setUp(): void
     {
         $this->validateMock = $this->getMockBuilder(
-            \Magento\Variable\Controller\Adminhtml\System\Variable\Validate::class
+            Validate::class
         )->disableOriginalConstructor()
             ->getMock();
 
         $this->variableMock = $this->getMockBuilder(
-            \Magento\Variable\Model\Variable::class
+            Variable::class
         )->disableOriginalConstructor()
             ->getMock();
         $this->variableMock->expects($this->any())
             ->method('addData')
             ->willReturnSelf();
 
-        $messagesMock = $this->getMockBuilder(\Magento\Framework\View\Element\Messages::class)
+        $messagesMock = $this->getMockBuilder(Messages::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->layoutMock = $this->getMockBuilder(\Magento\Framework\View\LayoutInterface::class)
+        $this->layoutMock = $this->getMockBuilder(LayoutInterface::class)
             ->setMethods(['initMessages', 'getMessagesBlock'])
             ->getMockForAbstractClass();
         $this->layoutMock->expects($this->any())
             ->method('getMessagesBlock')
             ->willReturn($messagesMock);
-        $layoutFactoryMock = $this->getMockBuilder(\Magento\Framework\View\LayoutFactory::class)
+        $layoutFactoryMock = $this->getMockBuilder(LayoutFactory::class)
             ->setMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $layoutFactoryMock->expects($this->any())->method('create')->willReturn($this->layoutMock);
 
-        $this->requestMock = $this->getMockBuilder(\Magento\Framework\App\RequestInterface::class)
+        $this->requestMock = $this->getMockBuilder(RequestInterface::class)
             ->disableOriginalConstructor()
             ->setMethods(['getPost'])
             ->getMockForAbstractClass();
-        $responseMock = $this->getMockBuilder(\Magento\Framework\App\ResponseInterface::class)
+        $responseMock = $this->getMockBuilder(ResponseInterface::class)
             ->setMethods(['setError', 'setHtmlMessage'])
             ->getMockForAbstractClass();
-        $this->messageManagerMock = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
+        $this->messageManagerMock = $this->getMockBuilder(ManagerInterface::class)
             ->getMockForAbstractClass();
-        $contextMock = $this->getMockBuilder(\Magento\Backend\App\Action\Context::class)
+        $contextMock = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
             ->getMock();
         $contextMock->expects($this->any())
@@ -91,29 +113,29 @@ class ValidateTest extends \PHPUnit\Framework\TestCase
         $contextMock->expects($this->any())
             ->method('getMessageManager')->will($this->returnValue($this->messageManagerMock));
 
-        $this->resultJsonMock = $this->getMockBuilder(\Magento\Framework\Controller\Result\Json::class)
+        $this->resultJsonMock = $this->getMockBuilder(Json::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $resultJsonFactoryMock = $this->getMockBuilder(\Magento\Framework\Controller\Result\JsonFactory::class)
+        $resultJsonFactoryMock = $this->getMockBuilder(JsonFactory::class)
             ->setMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $resultJsonFactoryMock->expects($this->any())->method('create')->willReturn($this->resultJsonMock);
 
-        $coreRegistryMock = $this->getMockBuilder(\Magento\Framework\Registry::class)
+        $coreRegistryMock = $this->getMockBuilder(Registry::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->validateMock = $this->getMockBuilder(
-            \Magento\Variable\Controller\Adminhtml\System\Variable\Validate::class
+            Validate::class
         )->setConstructorArgs(
             [
                 $contextMock,
                 $coreRegistryMock,
-                $this->getMockBuilder(\Magento\Backend\Model\View\Result\ForwardFactory::class)
+                $this->getMockBuilder(ForwardFactory::class)
                     ->disableOriginalConstructor()->setMethods(['create'])->getMock(),
                 $resultJsonFactoryMock,
-                $this->getMockBuilder(\Magento\Framework\View\Result\PageFactory::class)
+                $this->getMockBuilder(PageFactory::class)
                     ->disableOriginalConstructor()->setMethods(['create'])->getMock(),
                 $layoutFactoryMock,
             ]
@@ -124,11 +146,14 @@ class ValidateTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test variable validation
+     *
      * @param mixed $result
      * @param string[] $responseArray
+     *
      * @dataProvider executeDataProvider
      */
-    public function testExecute($result, $responseArray)
+    public function testExecute($result, $responseArray): void
     {
         $getParamMap = [
             ['variable_id', null, null],
@@ -159,9 +184,11 @@ class ValidateTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Validation cases data provider
+     *
      * @return array
      */
-    public function executeDataProvider()
+    public function executeDataProvider(): array
     {
         return [
             [ false, ['error' => false]],

--- a/app/code/Magento/Variable/Test/Unit/Controller/Adminhtml/System/Variable/ValidateTest.php
+++ b/app/code/Magento/Variable/Test/Unit/Controller/Adminhtml/System/Variable/ValidateTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class ValidateTest
+ * Variable validate test
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */

--- a/app/code/Magento/Variable/Test/Unit/Model/Source/VariablesTest.php
+++ b/app/code/Magento/Variable/Test/Unit/Model/Source/VariablesTest.php
@@ -3,39 +3,51 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Variable\Test\Unit\Model\Source;
+
+use Magento\Config\Model\Config\Structure\SearchInterface;
+use Magento\Config\Model\Config\StructureElementInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Variable\Model\Source\Variables;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit test for Magento\Variable\Model\Source\Variables
  */
-class VariablesTest extends \PHPUnit\Framework\TestCase
+class VariablesTest extends TestCase
 {
     /**
      * Variables model
      *
-     * @var \Magento\Variable\Model\Source\Variables
+     * @var Variables
      */
-    protected $model;
+    private $model;
 
     /**
      * Config variables
      *
      * @var array
      */
-    protected $configVariables;
+    private $configVariables;
 
     /**
-     * @var \Magento\Config\Model\Config\Structure\SearchInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var SearchInterface|MockObject
      */
     private $configMock;
 
-    protected function setup()
+    /**
+     * Set Up
+     */
+    protected function setup(): void
     {
-        $this->configMock = $this->getMockBuilder(\Magento\Config\Model\Config\Structure\SearchInterface::class)
+        $this->configMock = $this->getMockBuilder(SearchInterface::class)
             ->setMethods(['getElementByConfigPath'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-        $helper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $helper = new ObjectManager($this);
         $this->configVariables = [
             'web' => [
                 'web/unsecure/base_url' => '1',
@@ -43,7 +55,7 @@ class VariablesTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $element1 = $this->getMockBuilder(\Magento\Config\Model\Config\StructureElementInterface::class)
+        $element1 = $this->getMockBuilder(StructureElementInterface::class)
             ->disableOriginalConstructor()
             ->setMethods(['getLabel'])
             ->getMockForAbstractClass();
@@ -59,13 +71,16 @@ class VariablesTest extends \PHPUnit\Framework\TestCase
             ['web/secure/base_url', $element2]
         ]);
 
-        $this->model = $helper->getObject(\Magento\Variable\Model\Source\Variables::class, [
+        $this->model = $helper->getObject(Variables::class, [
             'configStructure' => $this->configMock,
             'configPaths' => $this->configVariables
         ]);
     }
 
-    public function testToOptionArrayWithoutGroup()
+    /**
+     * Testing to option array without group
+     */
+    public function testToOptionArrayWithoutGroup(): void
     {
         $optionArray = $this->model->toOptionArray();
         $this->assertEquals(count($this->configVariables['web']), count($optionArray));
@@ -78,7 +93,10 @@ class VariablesTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function testToOptionArrayWithGroup()
+    /**
+     * Testing to option array with group
+     */
+    public function testToOptionArrayWithGroup(): void
     {
         $optionArray = $this->model->toOptionArray(true);
         $this->assertEquals('Web', $optionArray[0]['label']);
@@ -96,7 +114,7 @@ class VariablesTest extends \PHPUnit\Framework\TestCase
     /**
      * Get expected results for options array
      */
-    private function getExpectedOptionsResults()
+    private function getExpectedOptionsResults(): array
     {
         return [
             [

--- a/app/code/Magento/Variable/Test/Unit/Model/Variable/ConfigTest.php
+++ b/app/code/Magento/Variable/Test/Unit/Model/Variable/ConfigTest.php
@@ -130,8 +130,8 @@ class ConfigTest extends TestCase
         // Verify custom plugin config is present
         $this->assertSame($customVal, $customPluginConfig[$customKey]);
         // Verify added plugin config is present
-        $this->assertStringContainsString($this->actionUrl, $addedPluginConfig['options']['onclick']['subject']);
-        $this->assertStringContainsString($this->actionUrl, $addedPluginConfig['options']['url']);
-        $this->assertStringContainsString($this->jsPluginSourceUrl, $addedPluginConfig['src']);
+        $this->assertContains($this->actionUrl, $addedPluginConfig['options']['onclick']['subject']);
+        $this->assertContains($this->actionUrl, $addedPluginConfig['options']['url']);
+        $this->assertContains($this->jsPluginSourceUrl, $addedPluginConfig['src']);
     }
 }

--- a/app/code/Magento/Variable/Test/Unit/Model/Variable/ConfigTest.php
+++ b/app/code/Magento/Variable/Test/Unit/Model/Variable/ConfigTest.php
@@ -13,8 +13,13 @@ use Magento\Variable\Model\ResourceModel\Variable\Collection;
 use Magento\Variable\Model\ResourceModel\Variable\CollectionFactory;
 use Magento\Variable\Model\Source\Variables;
 use Magento\Variable\Model\Variable\Config;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class ConfigTest extends \PHPUnit\Framework\TestCase
+/**
+ * Test for variable config
+ */
+class ConfigTest extends TestCase
 {
     /**
      * @var Config
@@ -22,12 +27,12 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     private $model;
 
     /**
-     * @var Repository|\PHPUnit_Framework_MockObject_MockObject
+     * @var Repository|MockObject
      */
     private $assetRepoMock;
 
     /**
-     * @var UrlInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var UrlInterface|MockObject
      */
     private $urlMock;
 
@@ -42,24 +47,24 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
     private $jsPluginSourceUrl = 'js-plugin-source';
 
     /**
-     * @var Variables|\PHPUnit_Framework_MockObject_MockObject
+     * @var Variables|MockObject
      */
     private $storeVariablesMock;
 
     /**
-     * @var CollectionFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var CollectionFactory|MockObject
      */
     private $customVarsCollectionFactoryMock;
 
     /**
-     * @var Collection|\PHPUnit_Framework_MockObject_MockObject
+     * @var Collection|MockObject
      */
     private $customVarsCollectionMock;
 
     /**
      * Set up before tests
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->assetRepoMock = $this->getMockBuilder(Repository::class)
             ->disableOriginalConstructor()
@@ -125,8 +130,8 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         // Verify custom plugin config is present
         $this->assertSame($customVal, $customPluginConfig[$customKey]);
         // Verify added plugin config is present
-        $this->assertContains($this->actionUrl, $addedPluginConfig['options']['onclick']['subject']);
-        $this->assertContains($this->actionUrl, $addedPluginConfig['options']['url']);
-        $this->assertContains($this->jsPluginSourceUrl, $addedPluginConfig['src']);
+        $this->assertStringContainsString($this->actionUrl, $addedPluginConfig['options']['onclick']['subject']);
+        $this->assertStringContainsString($this->actionUrl, $addedPluginConfig['options']['url']);
+        $this->assertStringContainsString($this->jsPluginSourceUrl, $addedPluginConfig['src']);
     }
 }

--- a/app/code/Magento/Variable/Test/Unit/Model/Variable/DataTest.php
+++ b/app/code/Magento/Variable/Test/Unit/Model/Variable/DataTest.php
@@ -9,12 +9,16 @@ declare(strict_types=1);
 namespace Magento\Variable\Test\Unit\Model\Variable;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Magento\Variable\Model\Variable\Data as VariableDataModel;
 use Magento\Variable\Model\ResourceModel\Variable\CollectionFactory as VariableCollectionFactory;
 use Magento\Variable\Model\ResourceModel\Variable\Collection as VariableCollection;
 use Magento\Variable\Model\Source\Variables as StoreVariables;
 
+/**
+ * Class DataTest
+ */
 class DataTest extends TestCase
 {
     /**
@@ -28,19 +32,19 @@ class DataTest extends TestCase
     private $objectManagerHelper;
 
     /**
-     * @var StoreVariables|PHPUnit_Framework_MockObject_MockObject
+     * @var StoreVariables|MockObject
      */
     private $storesVariablesMock;
 
     /**
-     * @var VariableCollectionFactory|PHPUnit_Framework_MockObject_MockObject
+     * @var VariableCollectionFactory|MockObject
      */
     private $variableCollectionFactoryMock;
 
     /**
      * Set up before tests
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->storesVariablesMock = $this->createMock(StoreVariables::class);
         $this->variableCollectionFactoryMock = $this->getMockBuilder(
@@ -60,7 +64,7 @@ class DataTest extends TestCase
     /**
      * Test getDefaultVariables() function
      */
-    public function testGetDefaultVariables()
+    public function testGetDefaultVariables(): void
     {
         $storesVariablesData = [
             [
@@ -94,7 +98,7 @@ class DataTest extends TestCase
     /**
      * Test getCustomVariables() function
      */
-    public function testGetCustomVariables()
+    public function testGetCustomVariables(): void
     {
         $customVariables = [
             [

--- a/app/code/Magento/Variable/Test/Unit/Model/Variable/DataTest.php
+++ b/app/code/Magento/Variable/Test/Unit/Model/Variable/DataTest.php
@@ -17,7 +17,7 @@ use Magento\Variable\Model\ResourceModel\Variable\Collection as VariableCollecti
 use Magento\Variable\Model\Source\Variables as StoreVariables;
 
 /**
- * Class DataTest
+ * Test variable data model
  */
 class DataTest extends TestCase
 {

--- a/app/code/Magento/Variable/Test/Unit/Model/VariableTest.php
+++ b/app/code/Magento/Variable/Test/Unit/Model/VariableTest.php
@@ -3,57 +3,71 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Variable\Test\Unit\Model;
 
+use Magento\Framework\Escaper;
+use Magento\Framework\Phrase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Variable\Model\ResourceModel\Variable as VariableResourceModel;
 use Magento\Variable\Model\ResourceModel\Variable\Collection;
+use Magento\Variable\Model\Variable;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class VariableTest extends \PHPUnit\Framework\TestCase
+/**
+ * Variable model test
+ */
+class VariableTest extends TestCase
 {
     /**
-     * @var  \Magento\Variable\Model\Variable
+     * @var  Variable
      */
     private $model;
 
     /**
-     * @var \Magento\Framework\Escaper|\PHPUnit_Framework_MockObject_MockObject
+     * @var Escaper|MockObject
      */
     private $escaperMock;
 
     /**
-     * @var \Magento\Variable\Model\ResourceModel\Variable|\PHPUnit_Framework_MockObject_MockObject
+     * @var VariableResourceModel|MockObject
      */
     private $resourceMock;
 
     /**
-     * @var \Magento\Variable\Model\ResourceModel\Variable\Collection|\PHPUnit_Framework_MockObject_MockObject
+     * @var Collection|MockObject
      */
     private $resourceCollectionMock;
 
     /**
-     * @var  \Magento\Framework\Phrase
+     * @var  Phrase
      */
     private $validationFailedPhrase;
 
     /**
-     * @var  \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     * @var  ObjectManager
      */
     private $objectManager;
 
-    protected function setUp()
+    /**
+     * Set Up
+     */
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
-        $this->escaperMock = $this->getMockBuilder(\Magento\Framework\Escaper::class)
+        $this->escaperMock = $this->getMockBuilder(Escaper::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->resourceMock = $this->getMockBuilder(\Magento\Variable\Model\ResourceModel\Variable::class)
+        $this->resourceMock = $this->getMockBuilder(VariableResourceModel::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->resourceCollectionMock = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->model = $this->objectManager->getObject(
-            \Magento\Variable\Model\Variable::class,
+            Variable::class,
             [
                 'escaper' => $this->escaperMock,
                 'resource' => $this->resourceMock,
@@ -63,17 +77,23 @@ class VariableTest extends \PHPUnit\Framework\TestCase
         $this->validationFailedPhrase = __('Validation has failed.');
     }
 
-    public function testGetValueHtml()
+    /**
+     * Test get html value
+     */
+    public function testGetValueHtml(): void
     {
-        $type = \Magento\Variable\Model\Variable::TYPE_HTML;
+        $type = Variable::TYPE_HTML;
         $html = '<html/>';
         $this->model->setData('html_value', $html);
         $this->assertSame($html, $this->model->getValue($type));
     }
 
-    public function testGetValueEmptyHtml()
+    /**
+     * Test get empty html value
+     */
+    public function testGetValueEmptyHtml(): void
     {
-        $type = \Magento\Variable\Model\Variable::TYPE_HTML;
+        $type = Variable::TYPE_HTML;
         $html = '';
         $plain = 'unescaped_plain_text';
         $escapedPlain = 'escaped_plain_text';
@@ -86,27 +106,41 @@ class VariableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($escapedPlain, $this->model->getValue($type));
     }
 
-    public function testGetValueText()
+    /**
+     * Test get text value
+     */
+    public function testGetValueText(): void
     {
-        $type = \Magento\Variable\Model\Variable::TYPE_TEXT;
+        $type = Variable::TYPE_TEXT;
         $plain = 'plain';
         $this->model->setData('plain_value', $plain);
         $this->assertSame($plain, $this->model->getValue($type));
     }
 
     /**
+     * Test validating missing information
+     *
+     * @param $code
+     * @param $name
+     *
      * @dataProvider validateMissingInfoDataProvider
      */
-    public function testValidateMissingInfo($code, $name)
+    public function testValidateMissingInfo($code, $name): void
     {
         $this->model->setCode($code)->setName($name);
         $this->assertEquals($this->validationFailedPhrase, $this->model->validate());
     }
 
     /**
+     * Testing validation
+     *
+     * @param $variableArray
+     * @param $objectId
+     * @param $expectedResult
+     *
      * @dataProvider validateDataProvider
      */
-    public function testValidate($variableArray, $objectId, $expectedResult)
+    public function testValidate($variableArray, $objectId, $expectedResult): void
     {
         $code = 'variable_code';
         $this->model->setCode($code)->setName('some_name');
@@ -118,7 +152,10 @@ class VariableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedResult, $this->model->validate($variableArray));
     }
 
-    public function testGetVariablesOptionArrayNoGroup()
+    /**
+     * Test get variables option array without group
+     */
+    public function testGetVariablesOptionArrayNoGroup(): void
     {
         $origOptions = [
             ['value' => 'VAL', 'label' => 'LBL'],
@@ -138,7 +175,10 @@ class VariableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($transformedOptions, $this->model->getVariablesOptionArray());
     }
 
-    public function testGetVariablesOptionArrayWithGroup()
+    /**
+     * Test get variables option array with group
+     */
+    public function testGetVariablesOptionArrayWithGroup(): void
     {
         $origOptions = [
             ['value' => 'VAL', 'label' => 'LBL'],
@@ -164,9 +204,11 @@ class VariableTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Validation rules data provider
+     *
      * @return array
      */
-    public function validateDataProvider()
+    public function validateDataProvider(): array
     {
         $variable = [
             'variable_id' => 'matching_id',
@@ -179,9 +221,11 @@ class VariableTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Validation missing info data provider
+     *
      * @return array
      */
-    public function validateMissingInfoDataProvider()
+    public function validateMissingInfoDataProvider(): array
     {
         return [
             'Missing code' => ['', 'some-name'],


### PR DESCRIPTION
### Description (*)
This PR fixes the PHPUnit 8 compatibility issues of existing unit tests for `Magento_Variable` module. Performed minor code refactoring and code style fixes.

Note: 
We have 1 warning that can't be fixed because these new methods doesn't exists in phpunit 6:
```
1) Magento\Variable\Test\Unit\Model\Variable\ConfigTest::testGetWysiwygPluginSettings
Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
```
### Related Pull Requests
N/A

### Fixed Issues (if relevant)

1. magento/magento2#27500: Unit Tests incompatible with PHPUnit 8

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run tests with PHPUnit 6: `vendor/phpunit/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/Variable/`
2. Install PHPUnit 8 and run the same tests.

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
