### PR TITLE
Fix An error occurred during delete folder from a media gallery.

### DIFF
--- a/lib/web/mage/adminhtml/browser.js
+++ b/lib/web/mage/adminhtml/browser.js
@@ -418,7 +418,10 @@ define([
                         }).done($.proxy(function () {
                             self.tree.jstree('refresh', self.activeNode.id);
                             self.reload();
-                            $(window).trigger('fileDeleted.mediabrowser');
+                            $(window).trigger('fileDeleted.mediabrowser', {
+                                ids: self.activeNode.id
+                            });
+
                         }, this));
                     },
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
https://github.com/magento/adobe-stock-integration/issues/1144 An error occurred during delete folder from a media gallery.

### Manual testing scenarios (*)
Go to the Catalog -> Categories
Select the default one
Press Content -> Select from Gallery
At the open media, gallery menu try to delete a folder

### Expected result (*)
A folder can be deleted and page is unblocked

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
