### PR TITLE
Updated unit tests to be compatible with PHPUnit 8

### DIFF
--- a/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Export/AdvancedPricingTest.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Export/AdvancedPricingTest.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace Magento\AdvancedPricingImportExport\Test\Unit\Model\Export;
 
-use Hoa\Iterator\Mock;
 use Magento\AdvancedPricingImportExport\Model\Export\AdvancedPricing;
 use Magento\Catalog\Model\Product\LinkTypeProvider;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
@@ -41,7 +40,7 @@ use Psr\Log\LoggerInterface;
 class AdvancedPricingTest extends TestCase
 {
     /**
-     * @var Timezone|Mock
+     * @var Timezone|MockObject
      */
     private $localeDateMock;
 

--- a/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricing/Validator/TierPriceTypeTest.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricing/Validator/TierPriceTypeTest.php
@@ -3,33 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdvancedPricingImportExport\Test\Unit\Model\Import\AdvancedPricing\Validator;
 
-use \Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing as AdvancedPricing;
+use Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing as AdvancedPricing;
+use Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing\Validator\TierPriceType;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
 
-/**
- * Class TierPriceTypeTest.
- */
-class TierPriceTypeTest extends \PHPUnit\Framework\TestCase
+class TierPriceTypeTest extends TestCase
 {
     /**
-     * @var  AdvancedPricing\Validator\TierPriceType
+     * @var TierPriceType
      */
     private $tierPriceType;
 
-    /**
-     * Set up.
-     *
-     * @return void
-     */
-    protected function setUp()
+    protected function setUp(): void
     {
-        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
-        $this->tierPriceType = $objectManager->getObject(
-            AdvancedPricing\Validator\TierPriceType::class,
-            []
-        );
+        $objectManager = new ObjectManager($this);
+        $this->tierPriceType = $objectManager->getObject(TierPriceType::class, []);
     }
 
     /**

--- a/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricing/ValidatorTest.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricing/ValidatorTest.php
@@ -3,45 +3,42 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\AdvancedPricingImportExport\Test\Unit\Model\Import\AdvancedPricing;
 
 use Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing\Validator as Validator;
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface as RowValidatorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class ValidatorTest extends \PHPUnit\Framework\TestCase
+class ValidatorTest extends TestCase
 {
     /**
-     * @var Validator |\PHPUnit_Framework_MockObject_MockObject
+     * @var Validator|MockObject
      */
-    protected $validator;
+    private $validatorMock;
 
     /**
-     * @var Validator |\PHPUnit_Framework_MockObject_MockObject
+     * @var Validator|MockObject
      */
-    protected $validators;
+    private $validatorsMock;
 
     /**
-     * @var RowValidatorInterface |\PHPUnit_Framework_MockObject_MockObject
+     * @var RowValidatorInterface|MockObject
      */
-    protected $validatorTest;
+    private $validatorTestMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->validatorTest = $this->getMockForAbstractClass(
-            \Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface::class,
-            [],
-            '',
-            false
-        );
+        $this->validatorTestMock = $this->getMockForAbstractClass(RowValidatorInterface::class, [], '', false);
         $messages = ['messages'];
-        $this->validatorTest->expects($this->any())->method('getMessages')->willReturn($messages);
-        $this->validators = [$this->validatorTest];
+        $this->validatorTestMock->expects($this->any())->method('getMessages')->willReturn($messages);
+        $this->validatorsMock = [$this->validatorTestMock];
 
-        $this->validator = $this->getMockBuilder(
-            \Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing\Validator::class
-        )
+        $this->validatorMock = $this->getMockBuilder(Validator::class)
             ->setMethods(['_clearMessages', '_addMessages'])
-            ->setConstructorArgs([$this->validators])
+            ->setConstructorArgs([$this->validatorsMock])
             ->getMock();
     }
 
@@ -49,32 +46,36 @@ class ValidatorTest extends \PHPUnit\Framework\TestCase
      * @dataProvider isValidDataProvider
      *
      * @param array $validatorResult
-     * @param bool  $expectedResult
+     * @param bool $expectedResult
+     * @throws \Zend_Validate_Exception
      */
     public function testIsValid($validatorResult, $expectedResult)
     {
-        $this->validator->expects($this->once())->method('_clearMessages');
+        $this->validatorMock->expects($this->once())->method('_clearMessages');
         $value = 'value';
-        $this->validatorTest->expects($this->once())->method('isValid')->with($value)->willReturn($validatorResult);
+        $this->validatorTestMock
+            ->expects($this->once())->method('isValid')
+            ->with($value)
+            ->willReturn($validatorResult);
 
-        $result = $this->validator->isValid($value);
+        $result = $this->validatorMock->isValid($value);
         $this->assertEquals($expectedResult, $result);
     }
 
     public function testIsValidAddMessagesCall()
     {
         $value = 'value';
-        $this->validatorTest->expects($this->once())->method('isValid')->willReturn(false);
-        $this->validator->expects($this->once())->method('_addMessages');
+        $this->validatorTestMock->expects($this->once())->method('isValid')->willReturn(false);
+        $this->validatorMock->expects($this->once())->method('_addMessages');
 
-        $this->validator->isValid($value);
+        $this->validatorMock->isValid($value);
     }
 
     public function testInit()
     {
-        $this->validatorTest->expects($this->once())->method('init');
+        $this->validatorTestMock->expects($this->once())->method('init');
 
-        $this->validator->init(null);
+        $this->validatorMock->init(null);
     }
 
     /**

--- a/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Indexer/Product/Price/Plugin/ImportTest.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Indexer/Product/Price/Plugin/ImportTest.php
@@ -3,93 +3,89 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\AdvancedPricingImportExport\Test\Unit\Model\Indexer\Product\Price\Plugin;
 
+use Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing;
 use Magento\AdvancedPricingImportExport\Model\Indexer\Product\Price\Plugin\Import as Import;
+use Magento\Catalog\Model\Indexer\Product\Price\Processor;
+use Magento\Framework\Indexer\IndexerInterface;
+use Magento\Framework\Indexer\IndexerRegistry;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class ImportTest extends \PHPUnit\Framework\TestCase
+class ImportTest extends TestCase
 {
     /**
-     * @var \Magento\Framework\Indexer\IndexerInterface |\PHPUnit_Framework_MockObject_MockObject
+     * @var IndexerInterface|MockObject
      */
-    private $indexer;
+    private $indexerMock;
 
     /**
-     * @var Import |\PHPUnit_Framework_MockObject_MockObject
+     * @var Import|MockObject
      */
-    private $import;
+    private $importMock;
 
     /**
-     * @var \Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing|\PHPUnit_Framework_MockObject_MockObject
+     * @var AdvancedPricing|MockObject
      */
-    private $advancedPricing;
+    private $advancedPricingMock;
 
     /**
-     * @var \Magento\Framework\Indexer\IndexerRegistry|\PHPUnit_Framework_MockObject_MockObject
+     * @var IndexerRegistry|MockObject
      */
-    private $indexerRegistry;
+    private $indexerRegistryMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->indexer = $this->getMockForAbstractClass(
-            \Magento\Framework\Indexer\IndexerInterface::class,
-            [],
-            '',
-            false
-        );
-        $this->indexerRegistry = $this->createMock(
-            \Magento\Framework\Indexer\IndexerRegistry::class
-        );
-        $this->import = new \Magento\AdvancedPricingImportExport\Model\Indexer\Product\Price\Plugin\Import(
-            $this->indexerRegistry
-        );
-        $this->advancedPricing = $this->createMock(
-            \Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing::class
-        );
-        $this->indexerRegistry->expects($this->any())
+        $this->indexerMock = $this->getMockForAbstractClass(IndexerInterface::class, [], '', false);
+        $this->indexerRegistryMock = $this->createMock(IndexerRegistry::class);
+        $this->importMock = new Import($this->indexerRegistryMock);
+        $this->advancedPricingMock = $this->createMock(AdvancedPricing::class);
+        $this->indexerRegistryMock->expects($this->any())
             ->method('get')
-            ->with(\Magento\Catalog\Model\Indexer\Product\Price\Processor::INDEXER_ID)
-            ->willReturn($this->indexer);
+            ->with(Processor::INDEXER_ID)
+            ->willReturn($this->indexerMock);
     }
 
     public function testAfterSaveReindexIsOnSave()
     {
-        $this->indexer->expects($this->once())
+        $this->indexerMock->expects($this->once())
             ->method('isScheduled')
             ->willReturn(false);
-        $this->indexer->expects($this->once())
+        $this->indexerMock->expects($this->once())
             ->method('invalidate');
-        $this->import->afterSaveAdvancedPricing($this->advancedPricing);
+        $this->importMock->afterSaveAdvancedPricing($this->advancedPricingMock);
     }
 
     public function testAfterSaveReindexIsOnSchedule()
     {
-        $this->indexer->expects($this->once())
+        $this->indexerMock->expects($this->once())
             ->method('isScheduled')
             ->willReturn(true);
-        $this->indexer->expects($this->never())
+        $this->indexerMock->expects($this->never())
             ->method('invalidate');
-        $this->import->afterSaveAdvancedPricing($this->advancedPricing);
+        $this->importMock->afterSaveAdvancedPricing($this->advancedPricingMock);
     }
 
     public function testAfterDeleteReindexIsOnSave()
     {
-        $this->indexer->expects($this->once())
+        $this->indexerMock->expects($this->once())
             ->method('isScheduled')
             ->willReturn(false);
-        $this->indexer->expects($this->once())
+        $this->indexerMock->expects($this->once())
             ->method('invalidate');
-        $this->import->afterSaveAdvancedPricing($this->advancedPricing);
+        $this->importMock->afterSaveAdvancedPricing($this->advancedPricingMock);
     }
 
     public function testAfterDeleteReindexIsOnSchedule()
     {
-        $this->indexer->expects($this->once())
+        $this->indexerMock->expects($this->once())
             ->method('isScheduled')
             ->willReturn(true);
-        $this->indexer->expects($this->never())
+        $this->indexerMock->expects($this->never())
             ->method('invalidate');
-        $this->import->afterSaveAdvancedPricing($this->advancedPricing);
+        $this->importMock->afterSaveAdvancedPricing($this->advancedPricingMock);
     }
 }


### PR DESCRIPTION
Magento is slowly moving towards the latest dependencies in the PHP world. Part of this is to have (at least) supported version of PHPUnit ( https://phpunit.de/supported-versions.html )

### Description (*)
Updated the tests of Magento_AdvancedPricingImportExport module to be compatible with PHPUnit 8.

### Fixed Issues
1. magento/magento2#27500: Unit Tests incompatible with PHPUnit 8

### Manual testing scenarios (*)
vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/AdvancedPricingImportExport

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
