### PR TITLE
Removed a duplicate variable in Magento\QuoteGraphQl\Model\Resolver\Cart and in \Magento\QuoteGraphQl\Model\Resolver\SetBillingAddressOnCart

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/Cart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/Cart.php
@@ -43,7 +43,7 @@ class Cart implements ResolverInterface
         $maskedCartId = $args['cart_id'];
 
         $currentUserId = $context->getUserId();
-        $storeId = $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
+        $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
         $cart = $this->getCartForUser->execute($maskedCartId, $currentUserId, $storeId);
 
         return [

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/SetBillingAddressOnCart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/SetBillingAddressOnCart.php
@@ -65,7 +65,7 @@ class SetBillingAddressOnCart implements ResolverInterface
         }
         $billingAddress = $args['input']['billing_address'];
 
-        $storeId = $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
+        $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
         $cart = $this->getCartForUser->execute($maskedCartId, $context->getUserId(), $storeId);
         $this->checkCartCheckoutAllowance->execute($cart);
         $this->setBillingAddressOnCart->execute($context, $cart, $billingAddress);


### PR DESCRIPTION
### Description (*)
Simply removed a duplicate variable. Nothing more to it.
$storeId = $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
became
$storeId = (int)$context->getExtensionAttributes()->getStore()->getId();

### Related Pull Requests
-

### Fixed Issues (if relevant)
-

### Manual testing scenarios (*)
None required

### Questions or comments
-

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
