### PR TITLE
Redirecting users to sales order history page

### DIFF
--- a/app/code/Magento/Sales/Controller/Guest/Form.php
+++ b/app/code/Magento/Sales/Controller/Guest/Form.php
@@ -63,7 +63,7 @@ class Form extends \Magento\Framework\App\Action\Action implements HttpGetAction
     public function execute()
     {
         if ($this->customerSession->isLoggedIn()) {
-            return $this->resultRedirectFactory->create()->setPath('customer/account/');
+            return $this->resultRedirectFactory->create()->setPath('sales/order/history');
         }
 
         $resultPage = $this->resultPageFactory->create();

--- a/app/code/Magento/Sales/Controller/Guest/Form.php
+++ b/app/code/Magento/Sales/Controller/Guest/Form.php
@@ -18,7 +18,7 @@ use Magento\Framework\View\Result\PageFactory;
 use Magento\Sales\Helper\Guest as GuestHelper;
 
 /**
- * Class Form
+ * Class Form - display Sales and Returns form for guest users
  */
 class Form extends \Magento\Framework\App\Action\Action implements HttpGetActionInterface
 {

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Guest/FormTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Guest/FormTest.php
@@ -55,7 +55,7 @@ class FormTest extends AbstractController
     {
         $this->login(1);
         $this->dispatch('sales/guest/form/');
-        $this->assertRedirect($this->stringContains('customer/account'));
+        $this->assertRedirect($this->stringContains('sales/order/history'));
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
If the guest user visits _http://local.magento.com/sales/guest/form/_ in Magento, then It will display a page with the Orders and Returns form. 

But when the logged-in users visit  _http://local.magento.com/sales/guest/form/_ in Magento, then It will redirect to the customer dashboard page.

If we redirect the user to the sales order history page instead of customer dashboard page. It would provide more user experience.
Therefore, I changed the redirection URL to the sales order history page.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Access the URL as the guest user, It redirects to the order and returns form.
2. Access the URL as the logged-in user, It redirects to the sales order history page.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
