### PR TITLE
[MFTF] Added assertion to AssertAdminSuccessLoginActionGroup

### DIFF
--- a/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertAdminSuccessLoginActionGroup.xml
+++ b/app/code/Magento/Backend/Test/Mftf/ActionGroup/AssertAdminSuccessLoginActionGroup.xml
@@ -14,5 +14,6 @@
         </annotations>
 
         <waitForElementVisible selector="{{AdminHeaderSection.adminUserAccountText}}" stepKey="waitForAdminAccountTextVisible"/>
+        <seeElement selector="{{AdminHeaderSection.adminUserAccountText}}" stepKey="assertAdminAccountTextElement"/>
     </actionGroup>
 </actionGroups>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR adds assertion to `AssertAdminSuccessLoginActionGroup`
### Scenario:
We run `AdminLoginSuccessfulTest` and we didn't see any assertions
<img width="972" alt="Screenshot 2020-04-13 at 17 56 00" src="https://user-images.githubusercontent.com/13517181/79131558-77c05c00-7db1-11ea-8519-dca10c21efb3.png">
### Actual result 
<img width="1011" alt="Screenshot 2020-04-13 at 17 57 51" src="https://user-images.githubusercontent.com/13517181/79131620-8a3a9580-7db1-11ea-9a18-d99cec8a9480.png">

