### PR TITLE
Fixes unstable email integration tests

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Newsletter/Model/SubscriberTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Model/SubscriberTest.php
@@ -89,7 +89,7 @@ class SubscriberTest extends TestCase
         $this->assertEquals($subscriber, $subscriber->unsubscribe());
         $this->assertContains(
             'You have been unsubscribed from the newsletter.',
-            $this->transportBuilder->getSentMessage()->getRawMessage()
+            $this->transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent()
         );
         $this->assertEquals(Subscriber::STATUS_UNSUBSCRIBED, $subscriber->getSubscriberStatus());
         // Subscribe and verify
@@ -97,7 +97,7 @@ class SubscriberTest extends TestCase
         $this->assertEquals(Subscriber::STATUS_SUBSCRIBED, $subscriber->getSubscriberStatus());
         $this->assertContains(
             'You have been successfully subscribed to our newsletter.',
-            $this->transportBuilder->getSentMessage()->getRawMessage()
+            $this->transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent()
         );
     }
 
@@ -116,14 +116,14 @@ class SubscriberTest extends TestCase
         $this->assertEquals(Subscriber::STATUS_UNSUBSCRIBED, $subscriber->getSubscriberStatus());
         $this->assertContains(
             'You have been unsubscribed from the newsletter.',
-            $this->transportBuilder->getSentMessage()->getRawMessage()
+            $this->transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent()
         );
         // Subscribe and verify
         $this->assertSame($subscriber, $subscriber->subscribeCustomerById(1));
         $this->assertEquals(Subscriber::STATUS_SUBSCRIBED, $subscriber->getSubscriberStatus());
         $this->assertContains(
             'You have been successfully subscribed to our newsletter.',
-            $this->transportBuilder->getSentMessage()->getRawMessage()
+            $this->transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent()
         );
     }
 
@@ -143,7 +143,7 @@ class SubscriberTest extends TestCase
         $subscriber->confirm($subscriber->getSubscriberConfirmCode());
         $this->assertContains(
             'You have been successfully subscribed to our newsletter.',
-            $this->transportBuilder->getSentMessage()->getRawMessage()
+            $this->transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent()
         );
     }
 

--- a/dev/tests/integration/testsuite/Magento/ProductAlert/Model/EmailTest.php
+++ b/dev/tests/integration/testsuite/Magento/ProductAlert/Model/EmailTest.php
@@ -101,8 +101,8 @@ class EmailTest extends \PHPUnit\Framework\TestCase
         $this->_emailModel->send();
 
         $this->assertContains(
-            'Smith,',
-            $this->transportBuilder->getSentMessage()->getRawMessage()
+            'John Smith,',
+            $this->transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent()
         );
     }
 

--- a/dev/tests/integration/testsuite/Magento/ProductAlert/Model/ObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/ProductAlert/Model/ObserverTest.php
@@ -70,8 +70,8 @@ class ObserverTest extends \PHPUnit\Framework\TestCase
     {
         $this->observer->process();
         $this->assertContains(
-            'ohn Smith,',
-            $this->transportBuilder->getSentMessage()->getRawMessage()
+            'John Smith,',
+            $this->transportBuilder->getSentMessage()->getBody()->getParts()[0]->getRawContent()
         );
     }
 


### PR DESCRIPTION
### Description (*)
This is re-adding the fixes added in https://github.com/magento/magento2/pull/25296

Following changes made the email integration tests unstable again:
- [MC-31752](https://github.com/magento/magento2/commit/811097da79b9bcd65c2b8e260715aa77f56beaaf) reverted some changes done by https://github.com/magento/magento2/pull/25296 for no good reason
- [MC-19918](https://github.com/magento/magento2/commit/efd77d3e7faf175c48bae45d3b1c237a00b37043) reverted some changes done by https://github.com/magento/magento2/pull/25296 for no good reason

### Related Pull Requests
Should fix integration tests which now fail in https://github.com/magento/magento2/pull/27888

### Fixed Issues (if relevant)
- None

### Manual testing scenarios (*)
See https://github.com/magento/magento2/pull/25296

### Questions or comments
Can we do something to avoid Magento core devs for re-introducing this incorrect way of testing email content?

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
