### PR TITLE
Created config used for showing/hiding clear cart button on the shopping cart view page.

### DIFF
--- a/app/code/Magento/Checkout/Block/Cart.php
+++ b/app/code/Magento/Checkout/Block/Cart.php
@@ -6,6 +6,7 @@
 namespace Magento\Checkout\Block;
 
 use Magento\Customer\Model\Context;
+use Magento\Store\Model\ScopeInterface;
 
 /**
  * Shopping cart block
@@ -14,6 +15,11 @@ use Magento\Customer\Model\Context;
  */
 class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
 {
+    /**
+     * Config settings path to determine is clear cart action enabled
+     */
+    public const XML_CONFIG_CLEAR_CART_ENABLED = 'checkout/cart/clear_cart_enabled';
+
     /**
      * @var \Magento\Catalog\Model\ResourceModel\Url
      */
@@ -68,7 +74,7 @@ class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
     }
 
     /**
-     * prepare cart items URLs
+     * Prepare cart items URLs
      *
      * @return void
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -110,6 +116,8 @@ class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
     }
 
     /**
+     * Checks is quote has error
+     *
      * @codeCoverageIgnore
      * @return bool
      */
@@ -119,6 +127,8 @@ class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
     }
 
     /**
+     * Returns quote items summary qty
+     *
      * @codeCoverageIgnore
      * @return int
      */
@@ -128,6 +138,8 @@ class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
     }
 
     /**
+     * Checks is wishlist is active
+     *
      * @codeCoverageIgnore
      * @return bool
      */
@@ -137,7 +149,7 @@ class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
         if ($isActive === null) {
             $isActive = $this->_scopeConfig->getValue(
                 'wishlist/general/active',
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                ScopeInterface::SCOPE_STORE
             ) && $this->httpContext->getValue(
                 Context::CONTEXT_AUTH
             );
@@ -147,6 +159,8 @@ class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
     }
 
     /**
+     * Returns checkout url
+     *
      * @codeCoverageIgnore
      * @return string
      */
@@ -156,6 +170,8 @@ class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
     }
 
     /**
+     * Returns continue shopping url
+     *
      * @return string
      */
     public function getContinueShoppingUrl()
@@ -172,6 +188,8 @@ class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
     }
 
     /**
+     * Checks is quote is virtual
+     *
      * @return bool
      * @codeCoverageIgnore
      * @SuppressWarnings(PHPMD.BooleanGetMethodName)
@@ -227,6 +245,8 @@ class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
     }
 
     /**
+     * Returns quote items count
+     *
      * @codeCoverageIgnore
      * @return int
      */
@@ -244,5 +264,23 @@ class Cart extends \Magento\Checkout\Block\Cart\AbstractCart
     public function getPagerHtml()
     {
         return $this->getChildHtml('pager');
+    }
+
+    /**
+     * Checks is clear cart action enabled
+     *
+     * @codeCoverageIgnore
+     * @return boolean
+     */
+    public function isClearCartEnabled()
+    {
+        $isEnabled = $this->_getData('clear_cart_enabled');
+        if ($isEnabled === null) {
+            $isEnabled = $this->_scopeConfig->getValue(
+                self::XML_CONFIG_CLEAR_CART_ENABLED,
+                ScopeInterface::SCOPE_STORE
+            );
+        }
+        return $isEnabled;
     }
 }

--- a/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AdminCheckoutClearCartEnabledActionGroup.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AdminCheckoutClearCartEnabledActionGroup.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminCheckoutClearCartEnabledActionGroup">
+        <annotations>
+            <description>Enable/disable showing clear shopping cart button on the cart page via checkout cart configuration.</description>
+        </annotations>
+        <arguments>
+            <argument name="value" type="string" defaultValue="Yes"/>
+        </arguments>
+        <scrollTo selector="{{AdminCheckoutConfigSection.clearCartEnabled}}" x="0" y="-100" stepKey="scrollToClearCartEnabled"/>
+        <uncheckOption selector="{{AdminCheckoutConfigSection.clearCartEnabledInherit}}" stepKey="uncheckUseSystem"/>
+        <selectOption selector="{{AdminCheckoutConfigSection.clearCartEnabled}}" userInput="{{value}}" stepKey="fillClearCartEnabled"/>
+        <click selector="{{AdminMainActionsSection.save}}" stepKey="clickSave"/>
+        <seeElement selector="{{AdminMessagesSection.success}}" stepKey="seeSuccessMessage"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AdminOpenSalesCheckoutConfigPageActionGroup.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AdminOpenSalesCheckoutConfigPageActionGroup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminOpenSalesCheckoutConfigPageActionGroup">
+        <arguments>
+            <argument name="tabGroupAnchor" type="string" defaultValue=""/>
+        </arguments>
+        <amOnPage url="{{AdminCheckoutConfigPage.url(tabGroupAnchor)}}" stepKey="openCheckoutConfigPage"/>
+        <waitForPageLoad stepKey="waitForCheckoutConfigPageLoad"/>
+    </actionGroup>
+</actionGroups>
+

--- a/app/code/Magento/Checkout/Test/Mftf/Data/ConfigData.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Data/ConfigData.xml
@@ -100,4 +100,15 @@
         <data key="label">Display number of items in cart</data>
         <data key="value">0</data>
     </entity>
+
+    <entity name="EnableClearCartButtonOnTheCartPage">
+        <data key="path">checkout/cart/clear_cart_enabled</data>
+        <data key="label">Display clear cart button on the cart page</data>
+        <data key="value">1</data>
+    </entity>
+    <entity name="DisableClearCartButtonOnTheCartPage">
+        <data key="path">checkout/cart/clear_cart_enabled</data>
+        <data key="label">Do not display clear cart button on the cart page</data>
+        <data key="value">0</data>
+    </entity>
 </entities>

--- a/app/code/Magento/Checkout/Test/Mftf/Page/AdminCheckoutConfigPage.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Page/AdminCheckoutConfigPage.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/PageObject.xsd">
+    <page name="AdminCheckoutConfigPage" url="admin/system_config/edit/section/checkout/{{tabLink}}" area="admin" parameterized="true" module="Magento_Checkout">
+        <section name="AdminCheckoutConfigSection"/>
+    </page>
+</pages>

--- a/app/code/Magento/Checkout/Test/Mftf/Section/AdminCheckoutConfigSection.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Section/AdminCheckoutConfigSection.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminCheckoutConfigSection">
+        <element name="clearCartEnabled" type="select" selector="#checkout_cart_clear_cart_enabled"/>
+        <element name="clearCartEnabledInherit" type="select" selector="#checkout_cart_clear_cart_enabled_inherit"/>
+    </section>
+</sections>

--- a/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutCartProductSection.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutCartProductSection.xml
@@ -48,6 +48,7 @@
         <element name="checkoutCartProductPrice" type="text" selector="//td[@class='col price']//span[@class='price']"/>
         <element name="checkoutCartSubtotal" type="text" selector="//td[@class='col subtotal']//span[@class='price']"/>
         <element name="emptyCart" selector=".cart-empty" type="text"/>
+        <element name="emptyCartButton" selector="#empty_cart_button" type="button"/>
         <!-- Required attention section -->
         <element name="removeProductBySku" type="button" selector="//div[contains(., '{{sku}}')]/ancestor::tbody//button" parameterized="true" timeout="30"/>
         <element name="failedItemBySku" type="block" selector="//div[contains(.,'{{sku}}')]/ancestor::tbody" parameterized="true" timeout="30"/>

--- a/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckRenderingClearCartButtonOnTheCartPageBasedOnStoresConfigurationTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckRenderingClearCartButtonOnTheCartPageBasedOnStoresConfigurationTest.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontCheckRenderingClearCartButtonOnTheCartPageBasedOnStoresConfigurationTest">
+        <annotations>
+            <features value="Checkout"/>
+            <stories value="Shopping Cart"/>
+            <title value="Check rendering/not rendering clear cart button on the cart page based on checkout cart stores configuration"/>
+            <description value="Check rendering/not rendering clear cart button on the cart page based on checkout cart stores configuration"/>
+            <severity value="MAJOR"/>
+            <group value="shoppingCart"/>
+        </annotations>
+
+        <before>
+            <!-- Create simple product -->
+            <createData entity="SimpleProduct2" stepKey="createProduct"/>
+        </before>
+        <after>
+            <!-- Delete simple product -->
+            <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
+
+            <!-- Disable rendering clear cart button on the cart page -->
+            <magentoCLI command="config:set {{DisableClearCartButtonOnTheCartPage.path}} {{DisableClearCartButtonOnTheCartPage.value}}" stepKey="disableClearCart"/>
+
+            <!-- Log out -->
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
+        </after>
+        <!-- Add product to cart -->
+        <actionGroup ref="OpenStoreFrontProductPageActionGroup" stepKey="openProductPage">
+            <argument name="productUrlKey" value="$$createProduct.custom_attributes[url_key]$$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontAddProductToCartActionGroup" stepKey="addProductToCart">
+            <argument name="product" value="$$createProduct$$"/>
+            <argument name="productCount" value="1"/>
+        </actionGroup>
+
+        <!-- Navigate to cart page -->
+        <actionGroup ref="StorefrontOpenCartFromMinicartActionGroup" stepKey="openShoppingCart"/>
+        <waitForPageLoad stepKey="waitForShoppingCartLoad" />
+
+        <!-- Assert that empty cart button is not rendered on the cart page -->
+        <dontSeeElement selector="{{CheckoutCartProductSection.emptyCartButton}}" stepKey="dontSeeClearCartButton"/>
+
+        <!-- Open new browser's window and login as Admin -->
+        <openNewTab stepKey="openNewTab"/>
+        <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+
+        <!-- Navigate to checkout cart configuration --> 
+        <actionGroup ref="AdminOpenSalesCheckoutConfigPageActionGroup" stepKey="openCheckoutCartConfig">
+            <argument name="tabGroupAnchor" value="#checkout_cart-link"/>
+        </actionGroup>
+
+        <!-- Enable clear cart button -->
+        <actionGroup ref="AdminCheckoutClearCartEnabledActionGroup" stepKey="enableClearCartButton"/>
+
+        <!-- Flush cache -->
+        <magentoCLI command="cache:flush" stepKey="cacheFlush"/>
+
+        <!-- Back to the Cart page and refresh the page -->
+        <switchToPreviousTab stepKey="switchToPreviousTab"/>
+        <reloadPage stepKey="refreshPage"/>
+        <waitForPageLoad stepKey="waitPageReload"/>
+
+        <!-- Assert that empty cart button is rendered on the cart page -->
+        <seeElement selector="{{CheckoutCartProductSection.emptyCartButton}}" stepKey="SeeClearCartButton"/>
+    </test>
+</tests>

--- a/app/code/Magento/Checkout/etc/adminhtml/system.xml
+++ b/app/code/Magento/Checkout/etc/adminhtml/system.xml
@@ -48,6 +48,10 @@
                     <label>Show Cross-sell Items in the Shopping Cart</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="clear_cart_enabled" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Show "Clear Shopping Cart" button on the cart page</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
             <group id="cart_link" translate="label" sortOrder="3" showInDefault="1" showInWebsite="1">
                 <label>My Cart Link</label>

--- a/app/code/Magento/Checkout/etc/config.xml
+++ b/app/code/Magento/Checkout/etc/config.xml
@@ -19,6 +19,7 @@
                 <redirect_to_cart>0</redirect_to_cart>
                 <number_items_to_display_pager>20</number_items_to_display_pager>
                 <crosssell_enabled>1</crosssell_enabled>
+                <clear_cart_enabled>0</clear_cart_enabled>
             </cart>
             <cart_link>
                 <use_qty>1</use_qty>

--- a/app/code/Magento/Checkout/i18n/en_US.csv
+++ b/app/code/Magento/Checkout/i18n/en_US.csv
@@ -183,3 +183,4 @@ Payment,Payment
 "Close","Close"
 "Show Cross-sell Items in the Shopping Cart","Show Cross-sell Items in the Shopping Cart"
 "You added %1 to your <a href=""%2"">shopping cart</a>.","You added %1 to your <a href=""%2"">shopping cart</a>."
+"Show ""Clear Shopping Cart"" button on the cart page","Show ""Clear Shopping Cart"" button on the cart page"

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
@@ -20,7 +20,7 @@
           class="form form-cart">
     <?= $block->getBlockHtml('formkey') ?>
     <div class="cart table-wrapper<?= $mergedCells == 2 ? ' detailed' : '' ?>">
-        <?php if ($block->getPagerHtml()) :?>
+        <?php if ($block->getPagerHtml()):?>
             <div class="cart-products-toolbar cart-products-toolbar-top toolbar"
                  data-attribute="cart-products-toolbar-top"><?= $block->getPagerHtml() ?>
             </div>
@@ -38,32 +38,34 @@
                     <th class="col subtotal" scope="col"><span><?= $block->escapeHtml(__('Subtotal')) ?></span></th>
                 </tr>
             </thead>
-            <?php foreach ($block->getItems() as $_item) :?>
+            <?php foreach ($block->getItems() as $_item):?>
                 <?= $block->getItemHtml($_item) ?>
             <?php endforeach ?>
         </table>
-        <?php if ($block->getPagerHtml()) :?>
+        <?php if ($block->getPagerHtml()):?>
             <div class="cart-products-toolbar cart-products-toolbar-bottom toolbar"
                  data-attribute="cart-products-toolbar-bottom"><?= $block->getPagerHtml() ?>
             </div>
         <?php endif ?>
     </div>
     <div class="cart main actions">
-        <?php if ($block->getContinueShoppingUrl()) :?>
+        <?php if ($block->getContinueShoppingUrl()):?>
             <a class="action continue"
                href="<?= $block->escapeUrl($block->getContinueShoppingUrl()) ?>"
                title="<?= $block->escapeHtml(__('Continue Shopping')) ?>">
                 <span><?= $block->escapeHtml(__('Continue Shopping')) ?></span>
             </a>
         <?php endif; ?>
-        <button type="button"
-                name="update_cart_action"
-                data-cart-empty=""
-                value="empty_cart"
-                title="<?= $block->escapeHtml(__('Clear Shopping Cart')) ?>"
-                class="action clear" id="empty_cart_button">
-            <span><?= $block->escapeHtml(__('Clear Shopping Cart')) ?></span>
-        </button>
+        <?php if ($block->isClearCartEnabled()): ?>
+            <button type="button"
+                    name="update_cart_action"
+                    data-cart-empty=""
+                    value="empty_cart"
+                    title="<?= $block->escapeHtml(__('Clear Shopping Cart')) ?>"
+                    class="action clear" id="empty_cart_button">
+                <span><?= $block->escapeHtml(__('Clear Shopping Cart')) ?></span>
+            </button>
+        <?php endif; ?>
         <button type="submit"
                 name="update_cart_action"
                 data-cart-item-update=""

--- a/app/design/frontend/Magento/luma/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_extends.less
@@ -1570,8 +1570,7 @@
         margin-bottom: @indent__base;
 
         .actions.main {
-            .continue,
-            .clear {
+            .continue {
                 display: none;
             }
         }


### PR DESCRIPTION
Created config used for showing/hiding a clear cart button on the shopping cart view page. Modified styles in the luma theme which hide the clear cart button.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
By default button for clearing shopping cart ("Clear Shopping Cart") is rendered on the shopping cart page to the left of the "Update Shopping Cart" button but it is hidden for the Luma theme (due to styles).
This PR adds stores configuration which is used to determine is clear cart action is enabled.
#### Configuration Path:
Tab **SALES** -> section **Checkout** -> group **Shopping Cart** -> field select **Show "Clear Shopping Cart" button on the cart page** (default value is "No"):
![image](https://user-images.githubusercontent.com/17883826/79856123-94bde600-83d4-11ea-841c-e56560c4dd82.png)
Checking this configuration is used in the template of "\Magento\Checkout\Block\Cart\Grid" block for identifying to render or not "Clear Shopping Cart" button (will be rendered only if the mentioned config is set to "Yes").

Also modified CSS rule in Luma theme styles which hides the "Clear Shopping Cart" button.


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add some products to the cart.
2. Navigate to the cart page. "Clear Shopping Cart" button is not rendered.
3. Log in to the Magento admin panel, open store configuration.
4. Change stores configuration 'Show "Clear Shopping Cart" button on the cart page' (see description) to yes. Clear configuration cache.
5. Reload fronted cart page. "Clear Shopping Cart" button is rendered.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#28705: Created config used for showing/hiding clear cart button on the shopping cart view page.