### PR TITLE
Feature/tablerate duplicate weight

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/ResourceModel/Carrier/Tablerate/CSV/ColumnResolver.php
+++ b/app/code/Magento/OfflineShipping/Model/ResourceModel/Carrier/Tablerate/CSV/ColumnResolver.php
@@ -12,7 +12,6 @@ class ColumnResolver
     const COLUMN_REGION = 'Region/State';
     const COLUMN_ZIP = 'Zip/Postal Code';
     const COLUMN_WEIGHT = 'Weight (and above)';
-    const COLUMN_WEIGHT_DESTINATION = 'Weight (and above)';
     const COLUMN_PRICE = 'Shipping Price';
 
     /**
@@ -23,7 +22,6 @@ class ColumnResolver
         self::COLUMN_REGION => 1,
         self::COLUMN_ZIP => 2,
         self::COLUMN_WEIGHT => 3,
-        self::COLUMN_WEIGHT_DESTINATION => 3,
         self::COLUMN_PRICE => 4,
     ];
 

--- a/app/code/Magento/OfflineShipping/Test/Unit/Model/ResourceModel/Carrier/Tablerate/CSV/ColumnResolverTest.php
+++ b/app/code/Magento/OfflineShipping/Test/Unit/Model/ResourceModel/Carrier/Tablerate/CSV/ColumnResolverTest.php
@@ -20,7 +20,6 @@ class ColumnResolverTest extends \PHPUnit\Framework\TestCase
         ColumnResolver::COLUMN_REGION => 'region value',
         ColumnResolver::COLUMN_ZIP => 'zip_value',
         ColumnResolver::COLUMN_WEIGHT => 'weight_value',
-        ColumnResolver::COLUMN_WEIGHT_DESTINATION => 'weight_destination_value',
         ColumnResolver::COLUMN_PRICE => 'price_value',
         self::CUSTOM_FIELD => 'custom_value',
     ];
@@ -86,10 +85,6 @@ class ColumnResolverTest extends \PHPUnit\Framework\TestCase
             ColumnResolver::COLUMN_WEIGHT => [
                 ColumnResolver::COLUMN_WEIGHT,
                 $this->values[ColumnResolver::COLUMN_WEIGHT],
-            ],
-            ColumnResolver::COLUMN_WEIGHT_DESTINATION => [
-                ColumnResolver::COLUMN_WEIGHT_DESTINATION,
-                $this->values[ColumnResolver::COLUMN_WEIGHT_DESTINATION],
             ],
             ColumnResolver::COLUMN_PRICE => [
                 ColumnResolver::COLUMN_PRICE,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Duplicated keys for Weight #27883,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
COLUMN_WEIGHT and COLUMN_WEIGHT_DESTINATION column both are same and not need COLUMN_WEIGHT_DESTINATION so removed it and tested

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
    If relevant, please provide a list of fixed issues in the format magento/magento2#27883.
    
1. magento/magento2#27883: Duplicated keys for Weight

### Manual testing scenarios (*)
1. ...
2. ...

### Questions or comments

### Contribution checklist (*)
 - [ ] COLUMN_WEIGHT and COLUMN_WEIGHT_DESTINATION column both are same and not need COLUMN_WEIGHT_DESTINATION so removed it and tested

