### PR TITLE
Fixes incorrectly nested html in the product items list template.

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
@@ -242,8 +242,8 @@ $_item = null;
                                         <?php // phpcs:disable ?>
                                         <div class="product actions product-item-actions">
                                             <?php if ($showCart):?>
+                                                <div class="actions-primary">
                                                 <?php if ($_item->isSaleable()):?>
-                                                    <div class="actions-primary">
                                                     <?php if (!$_item->getTypeInstance()->isPossibleBuyFromList($_item)):?>
                                                         <button
                                                                 class="action tocart primary"


### PR DESCRIPTION
### Description (*)
[MC-30989](https://github.com/magento/magento2/commit/909d4790eea44e57b1c8682149764087d3980653) introduced an incorrectly nested html structure in both Magento 2.3.5 and `2.4-develop`

See https://github.com/magento/magento2/issues/27920 for more details.

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/27920: [2.3.5] Incorrect html structure after MC-30989

### Manual testing scenarios (*)
1. Setup a clean Magento 2.3.5 or 2.4-develop (I've used commit 1e28f35a6de15f65371c64afda7531611d1be242)
2. Create a couple of simple products in the backend of Magento which are saleable
3. Open the first product you created and link the other products as crosssells to it
4. Reindex & flush caches
5. In the frontend, put that first product in your cart and go the the cart page
6. Look at the layout of the crosssells, it looks correct:
<img width="1290" alt="crosssells-correct" src="https://user-images.githubusercontent.com/85479/79903158-e5543400-8412-11ea-9af7-adaeb318662a.png">

7. Simulate that the products are not saleable by changing the method `Magento\Catalog\Model\Product::isSaleable` to always return `false`
8. Refresh the cart page, see that the layout of the crosssell products is completely broken
<img width="1280" alt="crosssells-incorrect" src="https://user-images.githubusercontent.com/85479/79903199-f00ec900-8412-11ea-8d59-8e492ecfc930.png">
9. After applying this fix the layout will not look broken again

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
