### PR TITLE
Allow multiple queues of the same type to run for multiple Magento sites on same server

### DIFF
--- a/lib/internal/Magento/Framework/Lock/Backend/Database.php
+++ b/lib/internal/Magento/Framework/Lock/Backend/Database.php
@@ -175,7 +175,7 @@ class Database implements \Magento\Framework\Lock\LockManagerInterface
      */
     private function getPrefix(): string
     {
-        if ($this->prefix === null) {
+        if ($this->prefix === null || $this->prefix === '') {
             $this->prefix = (string)$this->deploymentConfig->get(
                 ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT
                 . '/'


### PR DESCRIPTION
### Description (*)
I ran into an issue with running two Magento 2.3.4 sites on a single server. Only one queue "type" would run at a time. As you can see below, the first queue is from the Magento installation in the `/srv/www/magento-dev` directory and the next three are from the `/srv/www/magento-staging` Magento install.

```
deploy@s1-dev:/srv/www/magento-staging/current$ ps aux | egrep "PID|queue:consumers:start"
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
www-data 12297  1.7  0.4 494436 131316 ?       S    19:55   0:00 /usr/bin/php7.2 /srv/www/magento-dev/releases/20200413194935/bin/magento queue:consumers:start exportProcessor --single-thread --max-messages=10000
www-data 15778  0.0  0.6 599692 219740 ?       S    Apr07   9:32 /usr/bin/php7.2 /srv/www/magento-staging/releases/20200328191752/bin/magento queue:consumers:start product_action_attribute.update --single-thread --max-messages=10000
www-data 15780  0.0  0.6 600188 224428 ?       S    Apr07   9:38 /usr/bin/php7.2 /srv/www/magento-staging/releases/20200328191752/bin/magento queue:consumers:start product_action_attribute.website.update --single-thread --max-messages=10000
www-data 15784  0.0  0.7 601988 230360 ?       S    Apr07   9:24 /usr/bin/php7.2 /srv/www/magento-staging/releases/20200328191752/bin/magento queue:consumers:start codegeneratorProcessor --single-thread --max-messages=10000
```

I added some logging code to `\Magento\Framework\Lock\Backend\Database::isLocked`:

```
    public function isLocked(string $name): bool
    {
        if (!$this->deploymentConfig->isDbAvailable()) {
            return false;
        };

        $name = $this->addPrefix($name);

        // core edit
        file_put_contents(BP . '/var/log/queue_locks.log', date('c') . ' Selecting this lock: ' . $name . PHP_EOL, FILE_APPEND);
        // end edit
        return (bool)$this->resource->getConnection()->query(
            "SELECT IS_USED_LOCK(?);",
            [$name]
        )->fetchColumn();
    }
```

Here is some example output in the log files:

```
$ tail -fn0 /srv/www/magento-*/shared/var/log/199_queue_locks.log
==> /srv/www/magento-staging/shared/var/log/199_queue_locks.log <==
2020-04-23T20:48:03+00:00 Selecting this lock: |286bdca01f4e2a9e806c91b07bb7a331
2020-04-23T20:48:03+00:00 Selecting this lock: |f2afa4da6394fe696fadfa2c01315aaf
2020-04-23T20:48:03+00:00 Selecting this lock: |ce1236e8aa198c32f33e7e38fe53e800
2020-04-23T20:48:03+00:00 Selecting this lock: |06fe09e47d8e8a9242ab1cb9fcd447b9
2020-04-23T20:48:03+00:00 Selecting this lock: |f5a4b92626f17dee203246d9580d0f1a

==> /srv/www/magento-dev/shared/var/log/199_queue_locks.log <==
2020-04-23T20:48:04+00:00 Selecting this lock: |286bdca01f4e2a9e806c91b07bb7a331
2020-04-23T20:48:04+00:00 Selecting this lock: |f2afa4da6394fe696fadfa2c01315aaf
2020-04-23T20:48:04+00:00 Selecting this lock: |ce1236e8aa198c32f33e7e38fe53e800
2020-04-23T20:48:04+00:00 Selecting this lock: |06fe09e47d8e8a9242ab1cb9fcd447b9
2020-04-23T20:48:04+00:00 Selecting this lock: |f5a4b92626f17dee203246d9580d0f1a
```

As you can see, the database "prefix" was not getting added. I dug into this more and found that an empty string was being passed into the `$prefix` argument in `\Magento\Framework\Lock\Backend\Database::__construct`. Unfortunately I could not reproduce this on my local environment, so I was not able to debug this on the Staging server to determine _why_ the `$prefix` argument was an empty string.
