### PR TITLE
Deprecate AbstractAction and it's public methods

### DIFF
--- a/lib/internal/Magento/Framework/App/Action/AbstractAction.php
+++ b/lib/internal/Magento/Framework/App/Action/AbstractAction.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * Abstract redirect/forward action class
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -11,10 +9,12 @@ use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\ResponseInterface;
 
 /**
+ * Abstract redirect/forward action class
+ *
  * @deprecated Use \Magento\Framework\App\ActionInterface
  * @see https://community.magento.com/t5/Magento-DevBlog/Decomposition-of-Magento-Controllers/ba-p/430883
  */
-abstract class AbstractAction implements ActionInterface
+abstract class AbstractAction implements \Magento\Framework\App\ActionInterface
 {
     /**
      * @var \Magento\Framework\App\RequestInterface

--- a/lib/internal/Magento/Framework/App/Action/AbstractAction.php
+++ b/lib/internal/Magento/Framework/App/Action/AbstractAction.php
@@ -10,7 +10,11 @@ namespace Magento\Framework\App\Action;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\ResponseInterface;
 
-abstract class AbstractAction implements \Magento\Framework\App\ActionInterface
+/**
+ * @deprecated Use \Magento\Framework\App\ActionInterface
+ * @see https://community.magento.com/t5/Magento-DevBlog/Decomposition-of-Magento-Controllers/ba-p/430883
+ */
+abstract class AbstractAction implements ActionInterface
 {
     /**
      * @var \Magento\Framework\App\RequestInterface
@@ -56,6 +60,7 @@ abstract class AbstractAction implements \Magento\Framework\App\ActionInterface
      * Retrieve request object
      *
      * @return \Magento\Framework\App\RequestInterface
+     * @deprecated This method should not be used anymore. Inject `RequestInterface` into constructor instead
      */
     public function getRequest()
     {
@@ -66,6 +71,7 @@ abstract class AbstractAction implements \Magento\Framework\App\ActionInterface
      * Retrieve response object
      *
      * @return \Magento\Framework\App\ResponseInterface
+     * @deprecated This method should not be used anymore. Inject `ResponseInterface` into constructor instead
      */
     public function getResponse()
     {

--- a/lib/internal/Magento/Framework/App/Action/AbstractAction.php
+++ b/lib/internal/Magento/Framework/App/Action/AbstractAction.php
@@ -11,7 +11,7 @@ use Magento\Framework\App\ResponseInterface;
 /**
  * Abstract redirect/forward action class
  *
- * @deprecated You should avoid inheritance in your controllers
+ * @deprecated Inheritance in controllers should be avoided in favor of composition
  * @see \Magento\Framework\App\ActionInterface
  */
 abstract class AbstractAction implements \Magento\Framework\App\ActionInterface

--- a/lib/internal/Magento/Framework/App/Action/AbstractAction.php
+++ b/lib/internal/Magento/Framework/App/Action/AbstractAction.php
@@ -11,8 +11,8 @@ use Magento\Framework\App\ResponseInterface;
 /**
  * Abstract redirect/forward action class
  *
- * @deprecated Use \Magento\Framework\App\ActionInterface
- * @see https://community.magento.com/t5/Magento-DevBlog/Decomposition-of-Magento-Controllers/ba-p/430883
+ * @deprecated You should avoid inheritance in your controllers
+ * @see \Magento\Framework\App\ActionInterface
  */
 abstract class AbstractAction implements \Magento\Framework\App\ActionInterface
 {
@@ -60,7 +60,6 @@ abstract class AbstractAction implements \Magento\Framework\App\ActionInterface
      * Retrieve request object
      *
      * @return \Magento\Framework\App\RequestInterface
-     * @deprecated This method should not be used anymore. Inject `RequestInterface` into constructor instead
      */
     public function getRequest()
     {
@@ -71,7 +70,6 @@ abstract class AbstractAction implements \Magento\Framework\App\ActionInterface
      * Retrieve response object
      *
      * @return \Magento\Framework\App\ResponseInterface
-     * @deprecated This method should not be used anymore. Inject `ResponseInterface` into constructor instead
      */
     public function getResponse()
     {

--- a/lib/internal/Magento/Framework/App/Action/Action.php
+++ b/lib/internal/Magento/Framework/App/Action/Action.php
@@ -23,8 +23,8 @@ use Magento\Framework\UrlInterface;
  * It contains standard action behavior (event dispatching, flag checks)
  * Action classes that do not extend from this class will lose this behavior and might not function correctly
  *
- * @deprecated Use \Magento\Framework\App\ActionInterface
- * @see https://community.magento.com/t5/Magento-DevBlog/Decomposition-of-Magento-Controllers/ba-p/430883
+ * @deprecated You should avoid inheritance in your controllers
+ * @see \Magento\Framework\App\ActionInterface
  *
  * phpcs:disable Magento2.Classes.AbstractApi
  * @api

--- a/lib/internal/Magento/Framework/App/Action/Action.php
+++ b/lib/internal/Magento/Framework/App/Action/Action.php
@@ -24,6 +24,7 @@ use Magento\Framework\UrlInterface;
  * Action classes that do not extend from this class will lose this behavior and might not function correctly
  *
  * @deprecated Use \Magento\Framework\App\ActionInterface
+ * @see https://community.magento.com/t5/Magento-DevBlog/Decomposition-of-Magento-Controllers/ba-p/430883
  *
  * phpcs:disable Magento2.Classes.AbstractApi
  * @api

--- a/lib/internal/Magento/Framework/App/Action/Action.php
+++ b/lib/internal/Magento/Framework/App/Action/Action.php
@@ -23,7 +23,7 @@ use Magento\Framework\UrlInterface;
  * It contains standard action behavior (event dispatching, flag checks)
  * Action classes that do not extend from this class will lose this behavior and might not function correctly
  *
- * @deprecated You should avoid inheritance in your controllers
+ * @deprecated Inheritance in controllers should be avoided in favor of composition
  * @see \Magento\Framework\App\ActionInterface
  *
  * phpcs:disable Magento2.Classes.AbstractApi


### PR DESCRIPTION
### Description (*)
[Abstract Action and Action class should not be used](https://community.magento.com/t5/Magento-DevBlog/Decomposition-of-Magento-Controllers/ba-p/430883)

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
CC: @lenaorobei 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
