### PR TITLE
Can not create a subfolder with the same name as the main folder

### DIFF
--- a/app/code/Magento/MediaGallery/Model/Directory/Command/CreateByPaths.php
+++ b/app/code/Magento/MediaGallery/Model/Directory/Command/CreateByPaths.php
@@ -63,7 +63,7 @@ class CreateByPaths implements CreateDirectoriesByPathsInterface
                 //phpcs:ignore Magento2.Functions.DiscouragedFunction
                 $name = basename($path);
                 //phpcs:ignore Magento2.Functions.DiscouragedFunction
-                $folder = str_replace($name, '', $path);
+                $folder = substr($path, 0, strrpos($path, $name));
 
                 $this->storage->createDirectory(
                     $name,

--- a/dev/tests/integration/testsuite/Magento/MediaGallery/Model/Directory/Command/CreateByPathsTest.php
+++ b/dev/tests/integration/testsuite/Magento/MediaGallery/Model/Directory/Command/CreateByPathsTest.php
@@ -95,9 +95,23 @@ class CreateByPathsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test create child directory with the same name as parent
+     */
+    public function testCreateChildDirectoryTheSameNameAsParentDirectory(): void
+    {
+        $dir = self::TEST_DIRECTORY_NAME;
+        $childPath = $dir . '/' . $dir;
+
+        $this->createByPaths->execute([$dir]);
+        $this->assertFileExists($this->mediaDirectoryPath . $dir);
+        $this->createByPaths->execute([$childPath]);
+        $this->assertFileExists($this->mediaDirectoryPath . $childPath);
+    }
+
+    /**
      * @throws \Magento\Framework\Exception\FileSystemException
      */
-    public static function tearDownAfterClass()
+    protected function tearDown()
     {
         $filesystem = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
             ->get(\Magento\Framework\Filesystem::class);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Closes magento/adobe-stock-integration#1270, covered by test

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1270: Can not create a subfolder with the same name as the main folder

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Please see https://github.com/magento/adobe-stock-integration/issues/1270

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
