### PR TITLE
Checkout: Placing an order using the enter key causes a redirect to t…

### DIFF
--- a/app/code/Magento/OfflinePayments/view/frontend/web/js/view/payment/method-renderer/purchaseorder-method.js
+++ b/app/code/Magento/OfflinePayments/view/frontend/web/js/view/payment/method-renderer/purchaseorder-method.js
@@ -26,6 +26,19 @@ define([
         },
 
         /**
+         *
+         * @param data
+         * @param event
+         */
+        placeOrderKeyUpdate: function (data, event) {
+            var self = this;
+            var keyCode = event.keyCode || event.which;
+            if (keyCode == '13'){
+                self.placeOrder();
+            }
+        },
+
+        /**
          * @return {Object}
          */
         getData: function () {

--- a/app/code/Magento/OfflinePayments/view/frontend/web/template/payment/purchaseorder-form.html
+++ b/app/code/Magento/OfflinePayments/view/frontend/web/template/payment/purchaseorder-form.html
@@ -24,7 +24,7 @@
             <!-- ko template: getTemplate() --><!-- /ko -->
             <!--/ko-->
         </div>
-        <form id="purchaseorder-form" class="form form-purchase-order" data-role="purchaseorder-form">
+        <form id="purchaseorder-form" class="form form-purchase-order" data-role="purchaseorder-form" onSubmit="return false;">
             <fieldset class="fieldset payment method" data-bind='attr: {id: "payment_form_" + getCode()}'>
                 <div class="field field-number required">
                     <label for="po_number" class="label">
@@ -37,7 +37,8 @@
                                data-validate="{required:true}"
                                data-bind='
                                 attr: {title: $t("Purchase Order Number")},
-                                value: purchaseOrderNumber'
+                                value: purchaseOrderNumber,
+                                event:{keyup: placeOrderKeyUpdate}'
                                class="input-text"/>
                     </div>
                 </div>


### PR DESCRIPTION
Tis pull request is for solve issue number 27925

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Checkout page reload when press enter key on "Purchase Order Numer" field in purchase Order payment method.

### Fixed Issues (if relevant)
[#27925](https://github.com/magento/magento2/issues/27925) : Checkout: Placing an order using the enter key causes a redirect to the checkout

### Manual testing scenarios (*)

1. Add a product to the cart and proceed to the checkout
2. Enter your shipping details and proceed to "Review & Payments"
3. Select "Purchase Order" as your payment of choice
4. Enter a random "Purchase Order Number"
5. Press enter while the focus is still on the "Purchase Order Numer" field.

**Expected Result**
- the form should be submitted (and validated) on keyboard Enter. Order is placed

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
