### PR TITLE
Fixed #26118 Cms Block Graphql Scope wise Data issue

### DIFF
--- a/app/code/Magento/Cms/Model/BlockRepository.php
+++ b/app/code/Magento/Cms/Model/BlockRepository.php
@@ -133,7 +133,6 @@ class BlockRepository implements BlockRepositoryInterface
     public function getById($blockId)
     {
         $block = $this->blockFactory->create();
-        $block->setStoreId($this->storeManager->getStore()->getId());
         $this->resource->load($block, $blockId);
         if (!$block->getId()) {
             throw new NoSuchEntityException(__('The CMS block with the "%1" ID doesn\'t exist.', $blockId));

--- a/app/code/Magento/Cms/Model/BlockRepository.php
+++ b/app/code/Magento/Cms/Model/BlockRepository.php
@@ -133,6 +133,7 @@ class BlockRepository implements BlockRepositoryInterface
     public function getById($blockId)
     {
         $block = $this->blockFactory->create();
+        $block->setStoreId($this->storeManager->getStore()->getId());
         $this->resource->load($block, $blockId);
         if (!$block->getId()) {
             throw new NoSuchEntityException(__('The CMS block with the "%1" ID doesn\'t exist.', $blockId));

--- a/app/code/Magento/CmsGraphQl/Model/Resolver/DataProvider/Block.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/DataProvider/Block.php
@@ -9,7 +9,9 @@ namespace Magento\CmsGraphQl\Model\Resolver\DataProvider;
 
 use Magento\Cms\Api\BlockRepositoryInterface;
 use Magento\Cms\Api\Data\BlockInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
 use Magento\Widget\Model\Template\FilterEmulate;
 
 /**
@@ -26,17 +28,35 @@ class Block
      * @var FilterEmulate
      */
     private $widgetFilter;
+    
+    /**
+     * @var \Magento\Framework\Api\SearchCriteriaBuilder
+     */
+    protected $searchCriteriaBuilder;
+
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    private $storeManager;
 
     /**
      * @param BlockRepositoryInterface $blockRepository
      * @param FilterEmulate $widgetFilter
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         BlockRepositoryInterface $blockRepository,
-        FilterEmulate $widgetFilter
+        FilterEmulate $widgetFilter,
+        SearchCriteriaBuilder $searchCriteriaBuilder = null,
+        StoreManagerInterface $storeManager = null
     ) {
         $this->blockRepository = $blockRepository;
         $this->widgetFilter = $widgetFilter;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder ?: \Magento\Framework
+            \App\ObjectManager::getInstance()->get(SearchCriteriaBuilder::class);
+        $this->storeManager = $storeManager ?: \Magento\Framework
+            \App\ObjectManager::getInstance()->get(StoreManagerInterface::class);
     }
 
     /**
@@ -48,9 +68,13 @@ class Block
      */
     public function getData(string $blockIdentifier): array
     {
-        $block = $this->blockRepository->getById($blockIdentifier);
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter('identifier', $blockIdentifier, 'eq')
+            ->addFilter('store_id', $this->storeManager->getStore()->getId(), 'eq')
+            ->addFilter('is_active', true, 'eq')->create();
+        $block = current($this->blockRepository->getList($searchCriteria)->getItems());
 
-        if (false === $block->isActive()) {
+        if (empty($block)) {
             throw new NoSuchEntityException(
                 __('The CMS block with the "%1" ID doesn\'t exist.', $blockIdentifier)
             );


### PR DESCRIPTION
Fixed  #26118 cmsBlocks that has scope limited to specific Store View can be seen on other Store Views in case there are Blocks with identical identifiers on both Store Views

<!---
Please review our guidelines before adding a new issue: https://github.com/magento/magento2/wiki/Issue-reporting-guidelines
Fields marked with (*) are required. Please don't remove the template.
-->

### Preconditions (*)
<!---
Provide the exact Magento version (example: 2.2.5) and any important information on the environment where a bug is reproducible.
-->
Case 1:
1 Website, 1 Store, 2 Store Views

Case 2:
2 Websites, 2 Stores (one per website), 2 Store Views (one per store)

I will demonstrate case 2, because I believe it has higher severity.
1. Navigate to Stores > Settings > All Stores
2. Create Websites
 - Name: {English Website, German Website}
 - Code: {engsite, germsite}
3. Create Stores
 - Name: {English Store, German Store}
 - Code: {engstore, germstore}
4. Create Store Views
 - Name: {English Store View, German Store View}
 - Code: {engstv, germstv}
5. Verify

| Web Site                        | Store                                        | Store View                          |
|---------------------------------|----------------------------------------------|-------------------------------------|
| English Website</br>(Code: engsite)  | English Store</br>(Code: engstore)                | English Store View</br>(Code: engstv)    |
| German Website</br>(Code: germsite)  | German Store</br>(Code: germstore)                | German Store View</br>(Code: germstv)    |
| Main Website</br>(Code: base)        | Main Website Store</br>(Code: main_website_store) | Default Store View</br>(Code: default)   |
6. In the **General/Store Email Addresses** inside of the **General Contact** section **Sender Name** for the **Default Config** is set to `Owner` and "Use Website" is checked
7. In the **General/Store Email Addresses** inside of the **General Contact** section **Sender Email** for the **Default Config** is set to `owner@example.com` and "Use Website" is checked
8. In the **General/General** inside of the **Store Information** section **Store Name** for the **Default Config** is empty.
9. Navigate to Content > Elements > Blocks and create 
 - Block Title: Test Block English
 - Identifier: test-block
 - Store View: English Store View (exclusively)
Content:
```html
<h1>H1 Eng</h1>
<p>{{config path="trans_email/ident_general/name"}}</p>
<p>{{config path="trans_email/ident_general/email"}}</p>
<p>{{config path="general/store_information/name"}}</p>
```
10. Click Save and duplicate. Enable the page. and set identifier to "test-block-2". And Save block.
11. Navigate to Content > Elements > Blocks and create 
 - Block Title: Test Block German
 - Identifier: test-block
 - Store View: German Store View (exclusively)
Content:
```html
<h1>H1 Germ</h1>
<p>{{config path="trans_email/ident_general/name"}}</p>
<p>{{config path="trans_email/ident_general/email"}}</p>
<p>{{config path="general/store_information/name"}}</p>
```
12. Navigate to Content > Elements > Pages and edit "no-route"
13. Don't change anything, just click "Save and duplicate" button
14. Change the information to satisfy next conditions:
 - Enable Page - Yes
 - Page Title - 404 Not Found Alternative
 - URL Key - no-route-alternative
 - Page in Websites - German Store View (exclusively)
 - Content - leave unchanged for this moment
15. Click save:
16. Scroll to content and paste in editor mode. 
```html
<dd>
    <ul class="disc">
        <li>If you typed the URL directly, please make sure the spelling is correct.</li>
        <li>If you clicked on a link to get here, the link is outdated.</li>
    </ul>
</dd>
</dl>
<dl>
    <dt>What can you do?</dt>
    <dd>Have no fear, help is near! There are many ways you can get back on track with Magento Store.</dd>
</dl>
<p>Store variable:</p>
<p>{{config path="general/store_information/name"}}</p>
<p>Block:</p>
<p>{{widget type="Magento\Cms\Block\Widget\Block" template="widget/static_block/default.phtml" block_id="4"}}&nbsp;</p>
<dl>
    <dd>
        <ul class="disc">
            <li><a href="#">Go back</a> to the previous page.</li>
            <li>Use the search bar at the top of the page to search for your products.</li>
            <li>Follow these links to get you back on track!<br><a href="{{store url=&quot;&quot;}}">Store Home</a> <span class="separator">|</span> <a href="{{store url=&quot;customer/account&quot;}}">My Account</a></li>
        </ul>
    </dd>
</dl>
```
17. Switch to WYSIWYG mode and replace the CMS Static Block by selecting it from the grid that appears when you click "Select Block" button in Widget Options section. Chose "Test Block English". It is negative testing. The point here is to select the block that is restricted to the scope that is inappropriate here. Click "Save"
18. Navigate to Stores > Settings > Configuration > General > Web > URL Options and set **Add Store Code to Urls** to Yes globally
19. Navigate to Stores > Settings > Configuration > General > Web > Default Pages
20. Change scope to "German Store View"
21. Change **CMS No Route Page** to "404 Not Found Alternative"
22. Save and Flush Cache

### Steps to reproduce (*)
<!---
Important: Provide a set of clear steps to reproduce this bug. We can not provide support without clear instructions on how to reproduce.
-->
1. Navigate to {{base_url}}/germstv/the-page-was-never-found.html
2. Verify that page contains "Block:", is displayed correctly but the content of the block element is not displayed.
3. Perform 2 assertions and compare actual and expected result after each assertion:

#### Assertion 1
Query:
```graphql
query showCmsBlock(
  $identifiers: [String]
) {
  storeConfig {
    code
  }
  cmsBlocks(
    identifiers: $identifiers
  ) {
    items {
      content
      title
      identifier
    }
  }
}
```

Variables:
```json
{
  "identifiers": ["test-block-2"]
}
```

Headers:
```json
{
  "Store": "germstv"
}
```

#### Assertion 2
Query:
```graphql
query showCmsBlock(
  $identifiers: [String]
) {
  storeConfig {
    code
  }
  cmsBlocks(
    identifiers: $identifiers
  ) {
    items {
      content
      title
      identifier
    }
  }
}
```

Variables:
```json
{
  "identifiers": ["test-block"]
}
```
Headers:
```json
{
  "Store": "germstv"
}
```

### Expected result (*)
<!--- Tell us what do you expect to happen. -->
#### Assertion 1.
The scope is not ignored
1) there should be restrictions by store
2) unassigned store cannot be viewed in the browser
3) disabled store is not reachable in any way at least from external. Only admin token should allow such things.
```graphql
{
  "errors": [
    {
      "message": "The CMS block with the \"test-block-2\" ID doesn't exist.",
      "category": "graphql-no-such-entity",
      "locations": [
        {
          "line": 6,
          "column": 5
        }
      ],
      "path": [
        "cmsBlocks",
        "items",
        0
      ]
    }
  ],
  "data": {
    "storeConfig": {
      "code": "germstv"
    },
    "cmsBlocks": {
      "items": [
        null
      ]
    }
  }
}
```

#### Assertion 2
```graphql
{
  "data": {
    "storeConfig": {
      "code": "germstv"
    },
    "cmsBlocks": {
      "items": [
        {
          "content": "<h1>H1 Germ</h1>\r\n<p>Owner Germ</p>\r\n<p>owner_germ@example.com</p>\r\n<p>German Store View</p>",
          "title": "Test Block German",
          "identifier": "test-block"
        }
      ]
    }
  }
}
```

### Actual result (*)
<!--- Tell us what happened instead. Include error messages and issues. -->

#### Assertion 1
The scope was ignored. Sensitive data like email, telephone number, etc. is shown even if:
1) everything according to preconditions (**test-coverage**)
2) the store is not the current store (**test-coverage**)
3) the store is disabled (**test-coverage**)
```graphql
{
  "data": {
    "storeConfig": {
      "code": "germstv"
    },
    "cmsBlocks": {
      "items": [
        {
          "content": "<h1>H1 Eng</h1>\r\n<p>Owner Germ</p>\r\n<p>owner_germ@example.com</p>\r\n<p>German Store View</p>",
          "title": "Test Block English",
          "identifier": "test-block-2"
        }
      ]
    }
  }
}
```

#### Assertion 2
The title and the content are wrong. Only values of variables are correct, but not the selection of the variables (**test-coverage**)
```graphql
{
  "data": {
    "storeConfig": {
      "code": "germstv"
    },
    "cmsBlocks": {
      "items": [
        {
          "content": "<h1>H1 Eng</h1>\r\n<p>Owner Germ</p>\r\n<p>owner_germ@example.com</p>\r\n<p>German Store View</p>",
          "title": "Test Block English",
          "identifier": "test-block"
        }
      ]
    }
  }
}
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
