### PR TITLE
fix to add shipping data to quote, so free shipping cart rule can be applied

### DIFF
--- a/app/code/Magento/Quote/Model/ShippingMethodManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingMethodManagement.php
@@ -335,6 +335,7 @@ class ShippingMethodManagement implements
         if ($isCustomerGroupChanged) {
             $quote->setCustomerGroupId($quoteCustomerGroupId);
         }
+        $quote->save();
         return $output;
     }
 


### PR DESCRIPTION
Fix to add shipping data to quote, so free shipping cart rule can be applied.
Description (*)
free shipping shopping cart rule not applied in cart page even after shipping country, state and postcode is applied to cart, when cart rule was shipping country/state/Postcode based condition 

 Fixed Issues 
1. Fixes magento/magento2#27974: free shipping shopping cart rule not applied in cart page, when cart rule has shipping country/state/Postcode based condition

Manual testing scenarios (*)

1. In Store > configurations > sales > shipping > select the origin
2. Enable 'free shipping' shipping method along with any other shipping method
3. Create shopping cart rule, with condition based on shipping country/state/Postcode and cart rule's action 'Free shipping' is enabled with the 'for shipment with matching items' condition.
4. Apply the shipping cart rule in cart page with shipping country/state/Postcode applied in estimate shipping. Cart rule is applied in frontend.
 
 Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests
 - [x] All automated tests passed successfully
