### PR TITLE
wrong javascript variable scope stripTags

### DIFF
--- a/app/code/Magento/Email/view/adminhtml/templates/template/edit.phtml
+++ b/app/code/Magento/Email/view/adminhtml/templates/template/edit.phtml
@@ -114,18 +114,20 @@ require([
         },
 
         stripTags: function () {
+            var self = this;
+            
             confirm({
                 content: "<?= $block->escapeJs($block->escapeHtml(__('Are you sure you want to strip tags?'))) ?>",
                 actions: {
                     confirm: function () {
-                        this.unconvertedText = $('template_text').value;
+                        self.unconvertedText = $('template_text').value;
                         $('convert_button').hide();
                         $('template_text').value =  $('template_text').value.stripScripts().replace(
                             new RegExp('<style[^>]*>[\\S\\s]*?</style>', 'img'), ''
                         ).stripTags().strip();
                         $('convert_button_back').show();
                         $('field_template_styles').hide();
-                        this.typeChange = true;
+                        self.typeChange = true;
                         return false;
                     }
                 }


### PR DESCRIPTION
### Description (*)
New Email Template cannot be saved as TEXT-Template because of wrong javascript variable scope


### Manual testing scenarios (*)

1. Add new Template in Marketing -> Email Templates
2. Load some default Template to test
3. Click "Convert to Plain Text" and save
4. Template Type remains HTML and not TEXT
