### PR TITLE
Allow to load base64 encoded images and fonts

### DIFF
--- a/app/code/Magento/Csp/Model/Policy/FetchPolicy.php
+++ b/app/code/Magento/Csp/Model/Policy/FetchPolicy.php
@@ -152,7 +152,28 @@ class FetchPolicy implements SimplePolicyInterface
      */
     public function getSchemeSources(): array
     {
+        if (!in_array('data', $this->schemeSources) &&
+            $this->isSelfAllowed() &&
+            $this->isDataSchemeAllowed()
+        ) {
+            $this->schemeSources[] = 'data';
+        }
+
         return $this->schemeSources;
+    }
+
+    /**
+     * Check if 'data:' scheme is allowed to fetch the source
+     * https://www.w3.org/TR/CSP/#framework-directive-source-list
+     *
+     * @return boolean
+     */
+    public function isDataSchemeAllowed(): bool
+    {
+        return in_array($this->getId(), [
+            'font-src',
+            'img-src',
+        ]);
     }
 
     /**
@@ -212,7 +233,7 @@ class FetchPolicy implements SimplePolicyInterface
                 $sources[] = $schemeSource .':';
             }
             if ($this->isSelfAllowed()) {
-                $sources[] = $this->getSelfSourceValue();
+                $sources[] = '\'self\'';
             }
             if ($this->isInlineAllowed()) {
                 $sources[] = '\'unsafe-inline\'';
@@ -235,34 +256,6 @@ class FetchPolicy implements SimplePolicyInterface
 
             return implode(' ', $sources);
         }
-    }
-
-    /**
-     * @return string
-     */
-    public function getSelfSourceValue(): string
-    {
-        $result = '\'self\'';
-
-        if ($this->isDataSchemeAllowed()) {
-            $result .= ' data:';
-        }
-
-        return $result;
-    }
-
-    /**
-     * Check if 'data:' scheme is allowed to fetch the source
-     * https://www.w3.org/TR/CSP/#framework-directive-source-list
-     *
-     * @return boolean
-     */
-    public function isDataSchemeAllowed(): bool
-    {
-        return in_array($this->getId(), [
-            'font-src',
-            'img-src',
-        ]);
     }
 
     /**

--- a/app/code/Magento/Csp/Model/Policy/FetchPolicy.php
+++ b/app/code/Magento/Csp/Model/Policy/FetchPolicy.php
@@ -261,7 +261,7 @@ class FetchPolicy implements SimplePolicyInterface
     {
         return in_array($this->getId(), [
             'font-src',
-            'image-src',
+            'img-src',
         ]);
     }
 

--- a/app/code/Magento/Csp/Model/Policy/FetchPolicy.php
+++ b/app/code/Magento/Csp/Model/Policy/FetchPolicy.php
@@ -212,7 +212,7 @@ class FetchPolicy implements SimplePolicyInterface
                 $sources[] = $schemeSource .':';
             }
             if ($this->isSelfAllowed()) {
-                $sources[] = '\'self\'';
+                $sources[] = $this->getSelfSourceValue();
             }
             if ($this->isInlineAllowed()) {
                 $sources[] = '\'unsafe-inline\'';
@@ -235,6 +235,34 @@ class FetchPolicy implements SimplePolicyInterface
 
             return implode(' ', $sources);
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function getSelfSourceValue(): string
+    {
+        $result = '\'self\'';
+
+        if ($this->isDataSchemeAllowed()) {
+            $result .= ' data:';
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if 'data:' scheme is allowed to fetch the source
+     * https://www.w3.org/TR/CSP/#framework-directive-source-list
+     *
+     * @return boolean
+     */
+    public function isDataSchemeAllowed(): bool
+    {
+        return in_array($this->getId(), [
+            'font-src',
+            'image-src',
+        ]);
     }
 
     /**


### PR DESCRIPTION
### Description
Recent 2.3.5 release added Content Security Policy and it doesn't allow to load images and fonts via `data:` scheme which is quite a popular method to load local resources. Additionally, it's used internally by the browser cache (Chrome) when you refresh the page.

### Manual testing scenarios
1. Open Luma homepage on Magento 2.3.5 and open browser console.
2. Refresh the page to trigger resource loading from the browser cache.
3. Inspect errors in the console:
  <img width="628" alt="Font errors in console" src="https://user-images.githubusercontent.com/306080/80577266-441b3e00-8a0f-11ea-8156-87f043503fd1.png">
4. Apply the path, and errors are gone.
   
### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
