### PR TITLE
Correct height for media gallery images

### DIFF
--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/files.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/files.phtml
@@ -12,6 +12,11 @@ $_height = $block->getImagesHeight();
 ?>
 <?php if ($block->getFilesCount() > 0) : ?>
     <?php foreach ($block->getFiles() as $file) : ?>
+<?php
+$src = $block->escapeHtmlAttr($block->getFileThumbUrl($file));
+$width = $block->escapeHtml($block->getFileWidth($file));
+$height = $block->escapeHtml($block->getFileHeight($file));
+?>
     <div
         data-row="file"
         class="filecnt"
@@ -19,13 +24,13 @@ $_height = $block->getImagesHeight();
         data-size="<?= $block->escapeHtmlAttr($file->getSize()) ?>"
         data-mime-type="<?= $block->escapeHtmlAttr($file->getMimeType()) ?>"
     >
-        <p class="nm" style="height:<?= $block->escapeHtmlAttr($_height) ?>px;">
+        <p class="nm" style="min-height: 72px;">
         <?php if ($block->getFileThumbUrl($file)) : ?>
-            <img src="<?= $block->escapeHtmlAttr($block->getFileThumbUrl($file)) ?>" alt="<?= $block->escapeHtmlAttr($block->getFileName($file)) ?>"/>
+            <img src="<?= $src ?>" alt="<?= $block->escapeHtmlAttr($block->getFileName($file)) ?>"/>
         <?php endif; ?>
         </p>
         <?php if ($block->getFileWidth($file)) : ?>
-            <small><?= $block->escapeHtml($block->getFileWidth($file)) ?>x<?= $block->escapeHtml($block->getFileHeight($file)) ?> <?= $block->escapeHtml(__('px.')) ?></small><br/>
+            <small><?= $width ?>x<?= $height ?> <?= $block->escapeHtml(__('px.')) ?></small><br/>
         <?php endif; ?>
         <small><?= $block->escapeHtml($block->getFileShortName($file)) ?></small>
     </div>

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/files.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/files.phtml
@@ -7,7 +7,6 @@
 /** @var $block \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Files */
 
 $_width  = $block->getImagesWidth();
-$_height = $block->getImagesHeight();
 
 ?>
 <?php if ($block->getFilesCount() > 0) : ?>

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/files.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/files.phtml
@@ -9,13 +9,14 @@
 $_width  = $block->getImagesWidth();
 
 ?>
-<?php if ($block->getFilesCount() > 0) : ?>
-    <?php foreach ($block->getFiles() as $file) : ?>
-<?php
-$src = $block->escapeHtmlAttr($block->getFileThumbUrl($file));
-$width = $block->escapeHtml($block->getFileWidth($file));
-$height = $block->escapeHtml($block->getFileHeight($file));
-?>
+<?php if ($block->getFilesCount() > 0): ?>
+    <?php foreach ($block->getFiles() as $file): ?>
+        <?php
+            $src = $block->getFileThumbUrl($file);
+            $width = $block->getFileWidth($file);
+            $height = $block->getFileHeight($file);
+            $filename = $block->getFileName($file);
+        ?>
     <div
         data-row="file"
         class="filecnt"
@@ -23,17 +24,18 @@ $height = $block->escapeHtml($block->getFileHeight($file));
         data-size="<?= $block->escapeHtmlAttr($file->getSize()) ?>"
         data-mime-type="<?= $block->escapeHtmlAttr($file->getMimeType()) ?>"
     >
-        <p class="nm" style="min-height: 72px;">
-        <?php if ($block->getFileThumbUrl($file)) : ?>
-            <img src="<?= $src ?>" alt="<?= $block->escapeHtmlAttr($block->getFileName($file)) ?>"/>
+        <p class="nm">
+        <?php if ($block->getFileThumbUrl($file)): ?>
+            <img src="<?= $block->escapeHtmlAttr($src) ?>" alt="<?= $block->escapeHtmlAttr($filename) ?>"/>
         <?php endif; ?>
         </p>
-        <?php if ($block->getFileWidth($file)) : ?>
-            <small><?= $width ?>x<?= $height ?> <?= $block->escapeHtml(__('px.')) ?></small><br/>
+        <?php if ($block->getFileWidth($file)): ?>
+              <small><?= $block->escapeHtmlAttr($width) ?>x<?= $block->escapeHtmlAttr($height) ?>
+                                                                   <?= $block->escapeHtml(__('px.')) ?></small><br/>
         <?php endif; ?>
         <small><?= $block->escapeHtml($block->getFileShortName($file)) ?></small>
     </div>
     <?php endforeach; ?>
-<?php else : ?>
+<?php else: ?>
     <div class="empty"><?= $block->escapeHtml(__('No files found')) ?></div>
 <?php endif; ?>

--- a/app/design/adminhtml/Magento/backend/web/css/source/components/_file-insertion.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/components/_file-insertion.less
@@ -52,6 +52,7 @@
     }
 
     p {
+        min-height: 72px;
         text-align: center;
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Remove image height usage from Paragraph as this is not necessary.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

N/A

### Manual testing scenarios (*)
1. Verify Media gallery images displayed correctly in all sizes.
2. Define any custom sizes in di.xml Magento/Cms/etc/di.xml
```
    <type name="Magento\Cms\Model\Wysiwyg\Images\Storage">
        <arguments>
            <argument name="resizeParameters" xsi:type="array">
                <item name="height" xsi:type="number">75</item>
                <item name="width" xsi:type="number">100</item>
            </argument>
   </type>
```
Verify All images displayed correctly


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
