### PR TITLE
CSP: Allow to load base64 encoded images and fonts

### DIFF
--- a/app/code/Magento/Csp/etc/config.xml
+++ b/app/code/Magento/Csp/etc/config.xml
@@ -191,6 +191,9 @@
                         <policy_id>img-src</policy_id>
                         <self>1</self>
                         <inline>1</inline>
+                        <schemes>
+                            <data>data</data>
+                        </schemes>
                         <eval>0</eval>
                         <dynamic>0</dynamic>
                     </images>
@@ -219,6 +222,9 @@
                         <policy_id>font-src</policy_id>
                         <self>1</self>
                         <inline>1</inline>
+                        <schemes>
+                            <data>data</data>
+                        </schemes>
                         <eval>0</eval>
                         <dynamic>0</dynamic>
                     </fonts>

--- a/app/code/Magento/Csp/etc/config.xml
+++ b/app/code/Magento/Csp/etc/config.xml
@@ -85,6 +85,9 @@
                         <policy_id>img-src</policy_id>
                         <self>1</self>
                         <inline>1</inline>
+                        <schemes>
+                            <data>data</data>
+                        </schemes>
                         <eval>0</eval>
                         <dynamic>0</dynamic>
                     </images>
@@ -113,6 +116,9 @@
                         <policy_id>font-src</policy_id>
                         <self>1</self>
                         <inline>1</inline>
+                        <schemes>
+                            <data>data</data>
+                        </schemes>
                         <eval>0</eval>
                         <dynamic>0</dynamic>
                     </fonts>


### PR DESCRIPTION
> I've made a PR into this (2.3) branch because 2.4-develop branch doesn't have the same [config.xml](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Csp/etc/config.xml) file (`<policies>` section is missing). 

### Description
Recent 2.3.5 release added Content Security Policy and it doesn't allow to load images and fonts via `data:` scheme which is quite a popular method to load local resources. Additionally, it's used internally by the browser cache (Chrome) when you refresh the page.

### Manual testing scenarios
1. Open Luma homepage on Magento 2.3.5 and open browser console.
2. Refresh the page to trigger resource loading from the browser cache.
3. Inspect errors in the console:
  <img width="628" alt="Font errors in console" src="https://user-images.githubusercontent.com/306080/80577266-441b3e00-8a0f-11ea-8156-87f043503fd1.png">
4. Apply the path, and errors are gone.
   
### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
