### PR TITLE
Fixed - Download link in order email shows incorrect escaped link

### DIFF
--- a/app/code/Magento/Sales/view/frontend/templates/email/items/creditmemo/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/creditmemo/default.phtml
@@ -4,6 +4,7 @@
  * See COPYING.txt for license details.
  */
 
+use Magento\Catalog\Api\Data\ProductCustomOptionInterface;
 ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrder(); ?>
@@ -11,13 +12,13 @@
     <td class="item-info<?= ($block->getItemOptions() ? ' has-extra' : '') ?>">
         <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
         <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
-        <?php if ($block->getItemOptions()) : ?>
+        <?php if ($block->getItemOptions()): ?>
             <dl>
-                <?php foreach ($block->getItemOptions() as $option) : ?>
+                <?php foreach ($block->getItemOptions() as $option): ?>
                     <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
                     <dd>
                         <?php
-                        if ($option['option_type'] == 'file') {
+                        if ($option['option_type'] == ProductCustomOptionInterface::OPTION_TYPE_FILE) {
                             /* @noEscape */
                             echo nl2br($option['value']);
                         } else {
@@ -29,7 +30,7 @@
             </dl>
         <?php endif; ?>
         <?php $addInfoBlock = $block->getProductAdditionalInformationBlock(); ?>
-        <?php if ($addInfoBlock) :?>
+        <?php if ($addInfoBlock): ?>
             <?= $addInfoBlock->setItem($_item->getOrderItem())->toHtml() ?>
         <?php endif; ?>
         <?= $block->escapeHtml($_item->getDescription()) ?>

--- a/app/code/Magento/Sales/view/frontend/templates/email/items/creditmemo/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/creditmemo/default.phtml
@@ -16,7 +16,14 @@
                 <?php foreach ($block->getItemOptions() as $option) : ?>
                     <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
                     <dd>
-                        <?= /* @noEscape */  nl2br($block->escapeHtml($option['value'])) ?>
+                        <?php
+                        if ($option['option_type'] == 'file') {
+                            /* @noEscape */
+                            echo nl2br($option['value']);
+                        } else {
+                            echo nl2br($block->escapeHtml($option['value']));
+                        }
+                        ?>
                     </dd>
                 <?php endforeach; ?>
             </dl>

--- a/app/code/Magento/Sales/view/frontend/templates/email/items/invoice/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/invoice/default.phtml
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+use Magento\Catalog\Api\Data\ProductCustomOptionInterface;
 ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrder(); ?>
@@ -10,13 +12,13 @@
     <td class="item-info<?= ($block->getItemOptions() ? ' has-extra' : '') ?>">
         <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
         <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
-        <?php if ($block->getItemOptions()) : ?>
+        <?php if ($block->getItemOptions()): ?>
             <dl>
-                <?php foreach ($block->getItemOptions() as $option) : ?>
+                <?php foreach ($block->getItemOptions() as $option): ?>
                     <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
                     <dd>
                         <?php
-                        if ($option['option_type'] == 'file') {
+                        if ($option['option_type'] == ProductCustomOptionInterface::OPTION_TYPE_FILE) {
                             /* @noEscape */
                             echo nl2br($option['value']);
                         } else {
@@ -28,7 +30,7 @@
             </dl>
         <?php endif; ?>
         <?php $addInfoBlock = $block->getProductAdditionalInformationBlock(); ?>
-        <?php if ($addInfoBlock) : ?>
+        <?php if ($addInfoBlock): ?>
             <?= $addInfoBlock->setItem($_item->getOrderItem())->toHtml() ?>
         <?php endif; ?>
         <?= $block->escapeHtml($_item->getDescription()) ?>

--- a/app/code/Magento/Sales/view/frontend/templates/email/items/invoice/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/invoice/default.phtml
@@ -15,7 +15,14 @@
                 <?php foreach ($block->getItemOptions() as $option) : ?>
                     <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
                     <dd>
-                        <?= /* @noEscape */  nl2br($block->escapeHtml($option['value'])) ?>
+                        <?php
+                        if ($option['option_type'] == 'file') {
+                            /* @noEscape */
+                            echo nl2br($option['value']);
+                        } else {
+                            echo nl2br($block->escapeHtml($option['value']));
+                        }
+                        ?>
                     </dd>
                 <?php endforeach; ?>
             </dl>

--- a/app/code/Magento/Sales/view/frontend/templates/email/items/order/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/order/default.phtml
@@ -21,7 +21,14 @@ $_order = $_item->getOrder();
             <?php foreach ($block->getItemOptions() as $option) : ?>
                 <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
                 <dd>
-                    <?= /* @noEscape */  nl2br($block->escapeHtml($option['value'])) ?>
+                    <?php
+                    if ($option['option_type'] == 'file') {
+                        /* @noEscape */
+                        echo nl2br($option['value']);
+                    } else {
+                        echo nl2br($block->escapeHtml($option['value']));
+                    }
+                    ?>
                 </dd>
             <?php endforeach; ?>
             </dl>

--- a/app/code/Magento/Sales/view/frontend/templates/email/items/order/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/order/default.phtml
@@ -16,9 +16,9 @@ $_order = $_item->getOrder();
     <td class="item-info<?= ($block->getItemOptions() ? ' has-extra' : '') ?>">
         <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
         <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
-        <?php if ($block->getItemOptions()) : ?>
+        <?php if ($block->getItemOptions()): ?>
             <dl class="item-options">
-            <?php foreach ($block->getItemOptions() as $option) : ?>
+            <?php foreach ($block->getItemOptions() as $option): ?>
                 <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
                 <dd>
                     <?php
@@ -34,7 +34,7 @@ $_order = $_item->getOrder();
             </dl>
         <?php endif; ?>
         <?php $addInfoBlock = $block->getProductAdditionalInformationBlock(); ?>
-        <?php if ($addInfoBlock) :?>
+        <?php if ($addInfoBlock): ?>
             <?= $addInfoBlock->setItem($_item)->toHtml() ?>
         <?php endif; ?>
         <?= $block->escapeHtml($_item->getDescription()) ?>
@@ -47,15 +47,17 @@ $_order = $_item->getOrder();
 <?php if ($_item->getGiftMessageId()
     && $_giftMessage = $this->helper(\Magento\GiftMessage\Helper\Message::class)
         ->getGiftMessage($_item->getGiftMessageId())
-) : ?>
+): ?>
     <tr>
     <td colspan="3" class="item-extra">
         <table class="message-gift">
             <tr>
                 <td>
                     <h3><?= $block->escapeHtml(__('Gift Message')) ?></h3>
-                    <strong><?= $block->escapeHtml(__('From:')) ?></strong> <?= $block->escapeHtml($_giftMessage->getSender()) ?>
-                    <br /><strong><?= $block->escapeHtml(__('To:')) ?></strong> <?= $block->escapeHtml($_giftMessage->getRecipient()) ?>
+                    <strong><?= $block->escapeHtml(__('From:')) ?></strong>
+                        <?= $block->escapeHtml($_giftMessage->getSender()) ?>
+                    <br /><strong><?= $block->escapeHtml(__('To:')) ?></strong>
+                        <?= $block->escapeHtml($_giftMessage->getRecipient()) ?>
                     <br /><strong><?= $block->escapeHtml(__('Message:')) ?></strong>
                     <br /><?= $block->escapeHtml($_giftMessage->getMessage()) ?>
                 </td>

--- a/app/code/Magento/Sales/view/frontend/templates/email/items/shipment/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/shipment/default.phtml
@@ -4,19 +4,21 @@
  * See COPYING.txt for license details.
  */
 
+use Magento\Catalog\Api\Data\ProductCustomOptionInterface;
+
 /** @var $_item \Magento\Sales\Model\Order\Item */
 $_item = $block->getItem() ?>
 <tr>
     <td class="item-info<?= ($block->getItemOptions() ? ' has-extra' : '') ?>">
         <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
         <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
-        <?php if ($block->getItemOptions()) : ?>
+        <?php if ($block->getItemOptions()): ?>
             <dl class="item-options">
-                <?php foreach ($block->getItemOptions() as $option) : ?>
+                <?php foreach ($block->getItemOptions() as $option): ?>
                     <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
                     <dd>
                         <?php
-                        if ($option['option_type'] == 'file') {
+                        if ($option['option_type'] == ProductCustomOptionInterface::OPTION_TYPE_FILE) {
                             /* @noEscape */
                             echo nl2br($option['value']);
                         } else {
@@ -28,7 +30,7 @@ $_item = $block->getItem() ?>
             </dl>
         <?php endif; ?>
         <?php $addInfoBlock = $block->getProductAdditionalInformationBlock(); ?>
-        <?php if ($addInfoBlock) : ?>
+        <?php if ($addInfoBlock): ?>
             <?= $addInfoBlock->setItem($_item->getOrderItem())->toHtml() ?>
         <?php endif; ?>
         <?= $block->escapeHtml($_item->getDescription()) ?>

--- a/app/code/Magento/Sales/view/frontend/templates/email/items/shipment/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/shipment/default.phtml
@@ -15,7 +15,14 @@ $_item = $block->getItem() ?>
                 <?php foreach ($block->getItemOptions() as $option) : ?>
                     <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
                     <dd>
-                        <?= /* @noEscape */  nl2br($option['value']) ?>
+                        <?php
+                        if ($option['option_type'] == 'file') {
+                            /* @noEscape */
+                            echo nl2br($option['value']);
+                        } else {
+                            echo nl2br($block->escapeHtml($option['value']));
+                        }
+                        ?>
                     </dd>
                 <?php endforeach; ?>
             </dl>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

- Fixed issue with escape html for option type file for order, invoice, shipment as well as creditmemo email template.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#28014: Download link in order email shows incorrect escaped link

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Tested in magento 2.3.3 instance for order, invoice,shipment as well as creditmemo email.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
