### PR TITLE
Fix #26002 categoryFilterList virtual type removed from catalog search

### DIFF
--- a/app/code/Magento/CatalogSearch/etc/di.xml
+++ b/app/code/Magento/CatalogSearch/etc/di.xml
@@ -135,16 +135,6 @@
     <type name="Magento\Catalog\Model\Layer\Search\CollectionFilter">
         <plugin name="searchQuery" type="Magento\CatalogSearch\Model\Layer\Search\Plugin\CollectionFilter" />
     </type>
-    <virtualType name="categoryFilterList" type="Magento\Catalog\Model\Layer\FilterList">
-        <arguments>
-            <argument name="filters" xsi:type="array">
-                <item name="attribute" xsi:type="string">Magento\CatalogSearch\Model\Layer\Filter\Attribute</item>
-                <item name="price" xsi:type="string">Magento\CatalogSearch\Model\Layer\Filter\Price</item>
-                <item name="decimal" xsi:type="string">Magento\CatalogSearch\Model\Layer\Filter\Decimal</item>
-                <item name="category" xsi:type="string">Magento\CatalogSearch\Model\Layer\Filter\Category</item>
-            </argument>
-        </arguments>
-    </virtualType>
     <virtualType name="searchFilterList" type="Magento\Catalog\Model\Layer\FilterList">
         <arguments>
             <argument name="filters" xsi:type="array">


### PR DESCRIPTION
### Description (*)
This PR removed categoryFilterList virtual type from catalog search, please refer #26002 for detail explanation about the issue.

### Fixed Issues (if relevant)
1. fixes magento/magento2#26002: When category selected from top level navigation, attributes populated from module-catalog-search instead of module-catalog

### Manual testing scenarios (*)
1. Category filter should works on both mysql, elasticsearch
2. when we goes category page with layered navigation should use Catalog FilterList (vendor/magento/module-catalog/Model/Layer/Filter/Attribute.php) instead of Category Search FilterList (ex: module-catalog-search/Model/Layer/Filter/Attribute.php)

### Questions or comments
please let me know if any feedback's

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
