### PR TITLE
CSP: Fixed insert product video from youtube

### DIFF
--- a/app/code/Magento/ProductVideo/etc/csp_whitelist.xml
+++ b/app/code/Magento/ProductVideo/etc/csp_whitelist.xml
@@ -10,6 +10,7 @@
     <policies>
         <policy id="script-src">
             <values>
+                <value id="www_googleapis_com" type="host">www.googleapis.com</value>
                 <value id="youtube_cdn" type="host">s.ytimg.com</value>
                 <value id="google_video" type="host">www.googleapis.com</value>
                 <value id="vimeo" type="host">vimeo.com</value>
@@ -19,6 +20,11 @@
         <policy id="img-src">
             <values>
                 <value id="vimeo_cdn" type="host">*.vimeocdn.com</value>
+            </values>
+        </policy>
+        <policy id="frame-src">
+            <values>
+                <value id="www_youtube_com" type="host">www.youtube.com</value>
             </values>
         </policy>
     </policies>

--- a/app/code/Magento/Tinymce3/etc/csp_whitelist.xml
+++ b/app/code/Magento/Tinymce3/etc/csp_whitelist.xml
@@ -21,7 +21,7 @@
         </policy>
         <policy id="img-src">
             <values>
-                <value id="youtube_cdn" type="host">s.ytimg.com</value>
+                <value id="youtube_cdn" type="host">*.ytimg.com</value>
             </values>
         </policy>
     </policies>


### PR DESCRIPTION
> I've made a PR into this (2.3) branch because 2.4-develop branch doesn't have files to patch

### Description
Recent 2.3.5 release added Content Security Policy and it doesn't allow to use ProductVideos module.

### Manual testing scenarios (*)
1. Open Magento 2.3.5 backend and navigate to edit product page.
2. Switch to Images and Video section and press "Add Video".
3. Open browser console.
4. Insert youtube URL into the URL field and inspect console:

    <img width="616" alt="Blocked youtube script" src="https://user-images.githubusercontent.com/306080/80719783-a30eaf00-8b04-11ea-9078-aaad4c8a0c96.png">

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)