### PR TITLE
Cleaned up duplicate variable assignments in the same line

### DIFF
--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/CategoryTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/CategoryTest.php
@@ -7,7 +7,7 @@
 namespace Magento\CatalogSearch\Test\Unit\Model\Layer\Filter;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Test for \Magento\CatalogSearch\Model\Layer\Filter\Category

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/CategoryTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/CategoryTest.php
@@ -81,7 +81,7 @@ class CategoryTest extends \PHPUnit\Framework\TestCase
             ->setMethods(['getState', 'getProductCollection'])
             ->getMock();
 
-        $this->fulltextCollection = $this->fulltextCollection = $this->getMockBuilder(
+        $this->fulltextCollection = $this->getMockBuilder(
             \Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection::class
         )
             ->disableOriginalConstructor()

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/DecimalTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/DecimalTest.php
@@ -7,7 +7,7 @@
 namespace Magento\CatalogSearch\Test\Unit\Model\Layer\Filter;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Test for \Magento\CatalogSearch\Model\Layer\Filter\Decimal

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/DecimalTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/DecimalTest.php
@@ -74,7 +74,7 @@ class DecimalTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->will($this->returnValue($this->filterItem));
 
-        $this->fulltextCollection = $this->fulltextCollection = $this->getMockBuilder(
+        $this->fulltextCollection = $this->getMockBuilder(
             \Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection::class
         )
             ->disableOriginalConstructor()

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/PriceTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/PriceTest.php
@@ -86,7 +86,7 @@ class PriceTest extends \PHPUnit\Framework\TestCase
             ->method('getState')
             ->will($this->returnValue($this->state));
 
-        $this->fulltextCollection = $this->fulltextCollection = $this->getMockBuilder(
+        $this->fulltextCollection = $this->getMockBuilder(
             \Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection::class
         )
             ->disableOriginalConstructor()

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/PriceTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/PriceTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 namespace Magento\CatalogSearch\Test\Unit\Model\Layer\Filter;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Test for \Magento\CatalogSearch\Model\Layer\Filter\Price

--- a/app/code/Magento/Reports/Block/Adminhtml/Grid.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Grid.php
@@ -209,7 +209,7 @@ class Grid extends \Magento\Backend\Block\Widget\Grid
         } elseif ($this->getRequest()->getParam('website')) {
             $storeIds = $this->_storeManager->getWebsite($this->getRequest()->getParam('website'))->getStoreIds();
         } elseif ($this->getRequest()->getParam('group')) {
-            $storeIds = $storeIds = $this->_storeManager->getGroup(
+            $storeIds = $this->_storeManager->getGroup(
                 $this->getRequest()->getParam('group')
             )->getStoreIds();
         }

--- a/app/code/Magento/Sales/Model/Order/Payment.php
+++ b/app/code/Magento/Sales/Model/Order/Payment.php
@@ -742,7 +742,7 @@ class Payment extends Info implements OrderPaymentInterface
                 $this->formatPrice($baseAmountToRefund)
             );
         }
-        $message = $message = $this->prependMessage($message);
+        $message = $this->prependMessage($message);
         $message = $this->_appendTransactionToMessage($transaction, $message);
         $orderState = $this->getOrderStateResolver()->getStateForOrder($this->getOrder());
         $statuses = $this->getOrder()->getConfig()->getStateStatuses($orderState, false);

--- a/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
@@ -21,7 +21,7 @@ abstract class AbstractAggregateCalculator extends AbstractCalculator
             $this->taxClassManagement->getTaxClassId($item->getTaxClassKey())
         );
         $rate = $this->calculationTool->getRate($taxRateRequest);
-        $storeRate = $storeRate = $this->calculationTool->getStoreRate($taxRateRequest, $this->storeId);
+        $storeRate = $this->calculationTool->getStoreRate($taxRateRequest, $this->storeId);
 
         $discountTaxCompensationAmount = 0;
         $applyTaxAfterDiscount = $this->config->applyTaxAfterDiscount($this->storeId);

--- a/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
@@ -39,7 +39,7 @@ class UnitBaseCalculator extends AbstractCalculator
             $this->taxClassManagement->getTaxClassId($item->getTaxClassKey())
         );
         $rate = $this->calculationTool->getRate($taxRateRequest);
-        $storeRate = $storeRate = $this->calculationTool->getStoreRate($taxRateRequest, $this->storeId);
+        $storeRate = $this->calculationTool->getStoreRate($taxRateRequest, $this->storeId);
 
         // Calculate $priceInclTax
         $applyTaxAfterDiscount = $this->config->applyTaxAfterDiscount($this->storeId);

--- a/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
@@ -10,7 +10,13 @@ use Magento\Tax\Api\Data\QuoteDetailsItemInterface;
 class UnitBaseCalculator extends AbstractCalculator
 {
     /**
-     * {@inheritdoc}
+     * @param $amount
+     * @param null $rate
+     * @param null $direction
+     * @param string $type
+     * @param bool $round
+     * @param null $item
+     * @return float
      */
     protected function roundAmount(
         $amount,
@@ -31,7 +37,7 @@ class UnitBaseCalculator extends AbstractCalculator
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function calculateWithTaxInPrice(QuoteDetailsItemInterface $item, $quantity, $round = true)
     {
@@ -104,7 +110,7 @@ class UnitBaseCalculator extends AbstractCalculator
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function calculateWithTaxNotInPrice(QuoteDetailsItemInterface $item, $quantity, $round = true)
     {

--- a/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
@@ -10,12 +10,14 @@ use Magento\Tax\Api\Data\QuoteDetailsItemInterface;
 class UnitBaseCalculator extends AbstractCalculator
 {
     /**
-     * @param $amount
-     * @param null $rate
-     * @param null $direction
+     * Determines the rounding operation type and rounds the amount
+     *
+     * @param float $amount
+     * @param string $rate
+     * @param bool $direction
      * @param string $type
      * @param bool $round
-     * @param null $item
+     * @param QuoteDetailsItemInterface $item
      * @return float
      */
     protected function roundAmount(

--- a/dev/tests/api-functional/testsuite/Magento/Customer/Api/CustomerRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Customer/Api/CustomerRepositoryTest.php
@@ -698,7 +698,7 @@ class CustomerRepositoryTest extends WebapiAbstract
         $builder = Bootstrap::getObjectManager()->create(\Magento\Framework\Api\FilterBuilder::class);
         $customerData1 = $this->_createCustomer();
         $customerData2 = $this->_createCustomer();
-        $filter1 = $filter1 = $builder->setField(Customer::EMAIL)
+        $filter1 = $builder->setField(Customer::EMAIL)
             ->setValue($customerData1[Customer::EMAIL])
             ->create();
         $filter2 = $builder->setField(Customer::EMAIL)
@@ -736,7 +736,7 @@ class CustomerRepositoryTest extends WebapiAbstract
         $builder = Bootstrap::getObjectManager()->create(\Magento\Framework\Api\FilterBuilder::class);
         $customerData1 = $this->_createCustomer();
         $customerData2 = $this->_createCustomer();
-        $filter1 = $filter1 = $builder->setField(Customer::EMAIL)
+        $filter1 = $builder->setField(Customer::EMAIL)
             ->setValue($customerData1[Customer::EMAIL])
             ->create();
         $filter2 = $builder->setField(Customer::EMAIL)

--- a/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Product/Additional.php
+++ b/dev/tests/functional/tests/app/Magento/Catalog/Test/Block/Product/Additional.php
@@ -99,7 +99,7 @@ class Additional extends Block
         $selector = '';
         $dom = new \DOMDocument();
         $dom->loadHTML($stringWithHtml);
-        $xmlStructure = $xmlStructure = $dom->saveXML();
+        $xmlStructure = $dom->saveXML();
         $parser = xml_parser_create();
         xml_parse_into_struct($parser, $xmlStructure, $htmlData);
         $htmlData = array_slice($htmlData, 2, -2); //Remove <html> and <body> tags

--- a/lib/internal/Magento/Framework/GraphQl/Schema/Type/Input/InputObjectType.php
+++ b/lib/internal/Magento/Framework/GraphQl/Schema/Type/Input/InputObjectType.php
@@ -56,7 +56,7 @@ class InputObjectType extends \Magento\Framework\GraphQl\Schema\Type\InputObject
         ];
         foreach ($configElement->getFields() as $field) {
             if ($this->scalarTypes->isScalarType($field->getTypeName())) {
-                $type = $type = $this->wrappedTypeProcessor->processScalarWrappedType($field);
+                $type = $this->wrappedTypeProcessor->processScalarWrappedType($field);
             } else {
                 if ($field->getTypeName() == $configElement->getName()) {
                     $type = $this;

--- a/lib/internal/Magento/Framework/GraphQl/Schema/Type/Input/InputObjectType.php
+++ b/lib/internal/Magento/Framework/GraphQl/Schema/Type/Input/InputObjectType.php
@@ -13,9 +13,6 @@ use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Schema\Type\ScalarTypes;
 use Magento\Framework\GraphQl\Schema\Type\TypeRegistry;
 
-/**
- * Class InputObjectType
- */
 class InputObjectType extends \Magento\Framework\GraphQl\Schema\Type\InputObjectType
 {
     /**

--- a/setup/src/Magento/Setup/Fixtures/ImagesFixture.php
+++ b/setup/src/Magento/Setup/Fixtures/ImagesFixture.php
@@ -142,6 +142,8 @@ class ImagesFixture extends Fixture
     }
 
     /**
+     * Executes the fixture
+     *
      * @throws \Exception
      */
     public function execute()
@@ -171,6 +173,8 @@ class ImagesFixture extends Fixture
     }
 
     /**
+     * Prints information about the amount of generated images
+     *
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @throws \Magento\Framework\Exception\ValidatorException
      */

--- a/setup/src/Magento/Setup/Fixtures/ImagesFixture.php
+++ b/setup/src/Magento/Setup/Fixtures/ImagesFixture.php
@@ -142,7 +142,6 @@ class ImagesFixture extends Fixture
     }
 
     /**
-     * {@inheritdoc}
      * @throws \Exception
      */
     public function execute()
@@ -154,7 +153,7 @@ class ImagesFixture extends Fixture
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getActionTitle()
     {
@@ -162,7 +161,7 @@ class ImagesFixture extends Fixture
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function introduceParamLabels()
     {
@@ -172,8 +171,8 @@ class ImagesFixture extends Fixture
     }
 
     /**
-     * {@inheritdoc}
-     * @throws ValidatorException
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @throws \Magento\Framework\Exception\ValidatorException
      */
     public function printInfo(OutputInterface $output)
     {
@@ -237,8 +236,7 @@ class ImagesFixture extends Fixture
     }
 
     /**
-     * Create generator that creates image files and puts them to appropriate media folder
-     * in memory-safe way
+     * Create generator that creates image files and puts them to appropriate media folder in memory-safe way
      *
      * @return \Generator
      * @throws \Magento\Framework\Exception\FileSystemException

--- a/setup/src/Magento/Setup/Fixtures/ImagesFixture.php
+++ b/setup/src/Magento/Setup/Fixtures/ImagesFixture.php
@@ -440,7 +440,7 @@ class ImagesFixture extends Fixture
     private function getProductsCount()
     {
         if ($this->productsCountCache === null) {
-            $select = $select = $this->getDbConnection()
+            $select = $this->getDbConnection()
                 ->select()
                 ->from(['product_entity' => $this->getTable('catalog_product_entity')], [])
                 ->columns([
@@ -462,7 +462,7 @@ class ImagesFixture extends Fixture
      */
     private function getImagesCount()
     {
-        $select = $select = $this->getDbConnection()
+        $select = $this->getDbConnection()
             ->select()
             ->from(['product_entity' => $this->getTable('catalog_product_entity_media_gallery')], [])
             ->columns([


### PR DESCRIPTION
### Description (*)
This is a simple cleanup of two assignments to the same variable occurring in the same line.
Created by using the following regex:
 (\$.*) \= \1 = (with space before to exclude things like self::$loader = $loader = new \Composer\Autoload\ClassLoader(); and with space after to make sure it's an assignment and not anything else like ===)
And replacing with:
 $1 = (also with space before and after to keep the formatting right)

### Related Pull Requests
-

### Fixed Issues (if relevant)
-

### Manual testing scenarios (*)
none required

### Questions or comments
-

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
