### PR TITLE
MFTF: Admin Deletes CMS Page

### DIFF
--- a/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminDeleteCmsPageFromGridActionGroup.xml
+++ b/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminDeleteCmsPageFromGridActionGroup.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminDeleteCmsPageFromGridActionGroup">
+        <arguments>
+            <argument name="urlKey" type="string"/>
+        </arguments>
+        <click selector="{{CmsPagesPageActionsSection.select(urlKey)}}" stepKey="clickSelect"/>
+        <click selector="{{CmsPagesPageActionsSection.delete(urlKey)}}" stepKey="clickDelete"/>
+        <waitForElementVisible selector="{{CmsPagesPageActionsSection.deleteConfirm}}" stepKey="waitForOkButtonToBeVisible"/>
+        <click selector="{{CmsPagesPageActionsSection.deleteConfirm}}" stepKey="clickOkButton"/>
+        <waitForPageLoad stepKey="waitForPageLoad3"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminSearchCmsPageInGridByUrlKeyActionGroup.xml
+++ b/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminSearchCmsPageInGridByUrlKeyActionGroup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminSearchCmsPageInGridByUrlKeyActionGroup">
+        <arguments>
+            <argument name="urlKey" type="string"/>
+        </arguments>
+        <click selector="{{CmsPagesPageActionsSection.filterButton}}" stepKey="clickFilterButton"/>
+        <fillField selector="{{CmsPagesPageActionsSection.URLKey}}" userInput="{{urlKey}}" stepKey="fillUrlKeyField"/>
+        <click selector="{{CmsPagesPageActionsSection.ApplyFiltersBtn}}" stepKey="clickApplyFiltersButton"/>
+        <waitForPageLoad stepKey="waitForPageLoading"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertAdminCmsPageIsNotInGridActionGroup.xml
+++ b/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertAdminCmsPageIsNotInGridActionGroup.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertAdminCmsPageIsNotInGridActionGroup">
+        <arguments>
+            <argument name="urlKey" type="string"/>
+        </arguments>
+        <dontSee userInput="{{urlKey}}" selector="{{CmsPagesPageActionsSection.gridDataRow}}" stepKey="dontSeeCmsPageInGrid"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Cms/Test/Mftf/Section/CmsPagesPageActionsSection.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Section/CmsPagesPageActionsSection.xml
@@ -30,5 +30,6 @@
         <element name="pageRowCheckboxByIdentifier" type="checkbox" selector="//table[@data-role='grid']//td[count(../../..//th[./*[.='URL Key']]/preceding-sibling::th) + 1][./*[.='{{identifier}}']]/../td//input[@data-action='select-row']"  parameterized="true" />
         <element name="massActionsButton" type="button" selector="//div[@class='admin__data-grid-header'][(not(ancestor::*[@class='sticky-header']) and not(contains(@style,'visibility: hidden'))) or (ancestor::*[@class='sticky-header' and not(contains(@style,'display: none'))])]//button[contains(@class, 'action-select')]" />
         <element name="massActionsOption" type="button" selector="//div[@class='admin__data-grid-header'][(not(ancestor::*[@class='sticky-header']) and not(contains(@style,'visibility: hidden'))) or (ancestor::*[@class='sticky-header' and not(contains(@style,'display: none'))])]//span[contains(@class, 'action-menu-item') and .= '{{action}}']" parameterized="true"/>
+        <element name="gridDataRow" type="input" selector=".data-row .data-grid-cell-content"/>
     </section>
 </sections>

--- a/app/code/Magento/Cms/Test/Mftf/Test/AdminDeleteCmsPageTest.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Test/AdminDeleteCmsPageTest.xml
@@ -25,6 +25,7 @@
             <actionGroup ref="SaveCmsPageActionGroup" stepKey="clickSaveCmsPageButton"/>
         </before>
         <after>
+            <actionGroup ref="AdminGridFilterResetActionGroup" stepKey="clearGridFilters"/>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="adminLogout"/>
         </after>
 

--- a/app/code/Magento/Cms/Test/Mftf/Test/AdminDeleteCmsPageTest.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Test/AdminDeleteCmsPageTest.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminDeleteCmsPageTest">
+        <annotations>
+            <features value="Cms"/>
+            <stories value="Delete a CMS Page via the Admin"/>
+            <title value="Admin should be able to delete CMS Pages"/>
+            <description value="Admin should be able to delete CMS Pages"/>
+            <group value="Cms"/>
+            <group value="WYSIWYGDisabled"/>
+        </annotations>
+
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <actionGroup ref="AdminNavigateToPageGridActionGroup" stepKey="navigateToCmsPageGrid"/>
+            <actionGroup ref="CreateNewPageWithBasicValues" stepKey="createNewPageWithBasicValues"/>
+            <actionGroup ref="SaveCmsPageActionGroup" stepKey="clickSaveCmsPageButton"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="adminLogout"/>
+        </after>
+
+        <actionGroup ref="AdminSearchCmsPageInGridByUrlKeyActionGroup" stepKey="findCreatedCmsPage">
+            <argument name="urlKey" value="{{_defaultCmsPage.identifier}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminDeleteCmsPageFromGridActionGroup" stepKey="deleteCmsPage">
+            <argument name="urlKey" value="{{_defaultCmsPage.identifier}}"/>
+        </actionGroup>
+        <actionGroup ref="AssertMessageInAdminPanelActionGroup" stepKey="assertSuccessMessage">
+            <argument name="message" value="The page has been deleted."/>
+        </actionGroup>
+        <actionGroup ref="AdminSearchCmsPageInGridByUrlKeyActionGroup" stepKey="searchDeletedPage">
+            <argument name="urlKey" value="{{_defaultCmsPage.identifier}}"/>
+        </actionGroup>
+        <actionGroup ref="AssertAdminCmsPageIsNotInGridActionGroup" stepKey="assertCmsPageIsNotInGrid">
+            <argument name="urlKey" value="{{_defaultCmsPage.identifier}}"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/Cms/Test/Mftf/Test/AdminDeleteCmsPageTest.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Test/AdminDeleteCmsPageTest.xml
@@ -21,11 +21,12 @@
         <before>
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
             <actionGroup ref="AdminNavigateToPageGridActionGroup" stepKey="navigateToCmsPageGrid"/>
+            <actionGroup ref="ClearFiltersAdminDataGridActionGroup" stepKey="clearGridSearchFilters"/>
             <actionGroup ref="CreateNewPageWithBasicValues" stepKey="createNewPageWithBasicValues"/>
             <actionGroup ref="SaveCmsPageActionGroup" stepKey="clickSaveCmsPageButton"/>
         </before>
         <after>
-            <actionGroup ref="AdminGridFilterResetActionGroup" stepKey="clearGridFilters"/>
+            <actionGroup ref="ClearFiltersAdminDataGridActionGroup" stepKey="clearGridFilters"/>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="adminLogout"/>
         </after>
 

--- a/app/code/Magento/Widget/Test/Mftf/Test/ProductsListWidgetTest.xml
+++ b/app/code/Magento/Widget/Test/Mftf/Test/ProductsListWidgetTest.xml
@@ -34,6 +34,7 @@
         <!-- Create a CMS page containing the Products List widget -->
         <amOnPage url="{{CmsPagesPage.url}}" stepKey="amOnCmsList"/>
         <waitForPageLoad stepKey="waitForCmsList"/>
+        <conditionalClick selector="{{AdminDataGridHeaderSection.clearFilters}}" dependentSelector="{{AdminDataGridHeaderSection.clearFilters}}" visible="true" stepKey="clickClearFilters"/>
         <click selector="{{CmsPagesPageActionsSection.addNewPageButton}}" stepKey="clickAddNewPageButton"/>
         <fillField selector="{{CmsNewPagePageBasicFieldsSection.pageTitle}}" userInput="{{_newDefaultCmsPage.title}}" stepKey="fillPageTitle"/>
         <click selector="{{CmsNewPagePageContentSection.header}}" stepKey="expandContentSection"/>


### PR DESCRIPTION
This PR contains MFTF Test for deleting CMS page as Admin User

Steps to reproduce:
1 - Login As Admin
2 - Navigate to CMS Pages grid
3 - Create New CMS Page
4 - Find Created CMS Page in grid
5 - Delete Created CMS Page
6 - Perform Assertions

### Resolved issues:
1. [x] resolves magento/magento2#28202: MFTF: Admin Deletes CMS Page