### PR TITLE
MFTF: Admin Delete Customer Test Refactoring

### DIFF
--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertAdminCustomerIsNotInGridActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertAdminCustomerIsNotInGridActionGroup.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertAdminCustomerIsNotInGridActionGroup">
+        <arguments>
+            <argument name="message" type="string"/>
+        </arguments>
+        <see userInput="{{message}}" selector="{{AdminCustomerGridSection.customerGrid}}" stepKey="seeEmptyRecordMessage"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/Test/AdminDeleteCustomerTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/AdminDeleteCustomerTest.xml
@@ -19,29 +19,24 @@
         </annotations>
 
         <before>
-            <!-- Create Customer -->
             <createData entity="CustomerEntityOne" stepKey="createCustomer"/>
-            <!-- Login as admin -->
             <actionGroup ref="AdminLoginActionGroup" stepKey="login"/>
         </before>
         <after>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
 
-        <!-- Delete created customer -->
         <actionGroup ref="DeleteCustomerByEmailActionGroup" stepKey="deleteCustomer">
             <argument name="email" value="$$createCustomer.email$$"/>
         </actionGroup>
-        <seeElement selector="{{CustomersPageSection.deletedSuccessMessage}}" stepKey="seeSuccessMessage"/>
-        <waitForPageLoad stepKey="waitForCustomerGridPageToLoad"/>
-
-        <!--Assert Customer is not in Grid -->
-        <click selector="{{AdminCustomerFiltersSection.filtersButton}}" stepKey="clickFilterButton"/>
-        <conditionalClick selector="{{AdminDataGridHeaderSection.clearFilters}}" dependentSelector="{{AdminDataGridHeaderSection.clearFilters}}" visible="true" stepKey="cleanFiltersIfTheySet"/>
-        <waitForPageLoad stepKey="waitForClearFilters1"/>
-        <fillField selector="{{AdminCustomerFiltersSection.emailInput}}" userInput="$$createCustomer.email$$" stepKey="filterEmail"/>
-        <click selector="{{AdminCustomerFiltersSection.apply}}" stepKey="applyFilter"/>
-        <waitForPageLoad stepKey="waitForPageToLoad"/>
-        <see selector="{{AdminCustomerGridSection.customerGrid}}" userInput="We couldn't find any records." stepKey="seeEmptyRecordMessage"/>
+        <actionGroup ref="AssertMessageInAdminPanelActionGroup" stepKey="assertSuccessMessage">
+            <argument name="message" value="A total of 1 record(s) were deleted."/>
+        </actionGroup>
+        <actionGroup ref="AdminFilterCustomerByEmail" stepKey="findDeletedCustomer">
+            <argument name="email" value="$$createCustomer.email$$"/>
+        </actionGroup>
+        <actionGroup ref="AssertAdminCustomerIsNotInGridActionGroup" stepKey="assertCustomerIsNotInGrid">
+            <argument name="message" value="We couldn't find any records."/>
+        </actionGroup>
     </test>
 </tests>


### PR DESCRIPTION
This PR contains refactored MFTF Test for deleting customer entity as Admin User

Steps to reproduce:
1 - Create Customer entity
2 - Login As Admin
3 - Delete created customer
4 - Perform Assertions

### Resolved issues:
1. [x] resolves magento/magento2#29589: MFTF: Admin Delete Customer Test Refactoring