### PR TITLE
Implement missing sortOrder for Plugins in PageCache module

### DIFF
--- a/app/code/Magento/PageCache/etc/frontend/di.xml
+++ b/app/code/Magento/PageCache/etc/frontend/di.xml
@@ -7,22 +7,21 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Framework\App\FrontControllerInterface">
-        <plugin name="front-controller-builtin-cache" type="Magento\PageCache\Model\App\FrontController\BuiltinPlugin"/>
-        <plugin name="front-controller-varnish-cache" type="Magento\PageCache\Model\App\FrontController\VarnishPlugin"/>
+        <plugin name="front-controller-builtin-cache" type="Magento\PageCache\Model\App\FrontController\BuiltinPlugin" sortOrder="100"/>
+        <plugin name="front-controller-varnish-cache" type="Magento\PageCache\Model\App\FrontController\VarnishPlugin" sortOrder="100"/>
     </type>
     <type name="Magento\Framework\Controller\ResultInterface">
-        <plugin name="result-builtin-cache" type="Magento\PageCache\Model\Controller\Result\BuiltinPlugin"/>
-        <plugin name="result-varnish-cache" type="Magento\PageCache\Model\Controller\Result\VarnishPlugin"/>
+        <plugin name="result-builtin-cache" type="Magento\PageCache\Model\Controller\Result\BuiltinPlugin" sortOrder="100"/>
+        <plugin name="result-varnish-cache" type="Magento\PageCache\Model\Controller\Result\VarnishPlugin" sortOrder="100"/>
     </type>
     <type name="Magento\Framework\View\Layout">
-        <plugin name="layout-model-caching-unique-name" type="Magento\PageCache\Model\Layout\LayoutPlugin"/>
-        <plugin name="core-session-depersonalize"
-                type="Magento\PageCache\Model\Layout\DepersonalizePlugin" sortOrder="1"/>
+        <plugin name="layout-model-caching-unique-name" type="Magento\PageCache\Model\Layout\LayoutPlugin" sortOrder="100"/>
+        <plugin name="core-session-depersonalize" type="Magento\PageCache\Model\Layout\DepersonalizePlugin" sortOrder="100"/>
     </type>
     <type name="Magento\Framework\View\Model\Layout\Merge">
-        <plugin name="layout-merge-plugin" type="Magento\PageCache\Model\Layout\MergePlugin"/>
+        <plugin name="layout-merge-plugin" type="Magento\PageCache\Model\Layout\MergePlugin" sortOrder="100"/>
     </type>
     <type name="Magento\Framework\App\Response\Http">
-        <plugin name="response-http-page-cache" type="Magento\PageCache\Model\App\Response\HttpPlugin"/>
+        <plugin name="response-http-page-cache" type="Magento\PageCache\Model\App\Response\HttpPlugin" sortOrder="100"/>
     </type>
 </config>


### PR DESCRIPTION
### Description (*)
During work with #27270 I noticed that there is no way to inject plugin optimizing the Layout output, by default when there is no `sortOrder` for PageCache plugins - it's assumed to be `0`, so you need to use negative value for your plugin (eg. `-10`) optimizing output.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
This change **is not backwards incompatible**, so that does not need additional architects' approval.
![image](https://user-images.githubusercontent.com/1639941/81220170-2e92af00-8fe1-11ea-913c-a6e339e4cd77.png)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
