### PR TITLE
Added missing translation for modal title & buttons on admin

### DIFF
--- a/app/code/Magento/CatalogInventory/i18n/en_US.csv
+++ b/app/code/Magento/CatalogInventory/i18n/en_US.csv
@@ -70,3 +70,4 @@ Stock,Stock
 "Use Config Settings","Use Config Settings"
 "Qty Uses Decimals","Qty Uses Decimals"
 "Allow Multiple Boxes for Shipping","Allow Multiple Boxes for Shipping"
+"Done","Done"

--- a/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml
+++ b/app/code/Magento/CatalogInventory/view/adminhtml/ui_component/product_form.xml
@@ -11,7 +11,7 @@
             <options>
                 <option name="buttons" xsi:type="array">
                     <item name="0" xsi:type="array">
-                        <item name="text" xsi:type="string">Done</item>
+                        <item name="text" xsi:type="string" translate="true">Done</item>
                         <item name="class" xsi:type="string">action-primary</item>
                         <item name="actions" xsi:type="array">
                             <item name="0" xsi:type="array">
@@ -21,7 +21,7 @@
                         </item>
                     </item>
                 </option>
-                <option name="title" xsi:type="string">Advanced Inventory</option>
+                <option name="title" xsi:type="string" translate="true">Advanced Inventory</option>
             </options>
             <onCancel>actionDone</onCancel>
             <dataScope>data.product</dataScope>

--- a/app/code/Magento/Customer/i18n/en_US.csv
+++ b/app/code/Magento/Customer/i18n/en_US.csv
@@ -541,3 +541,4 @@ Addresses,Addresses
 "The Date of Birth should not be greater than today.","The Date of Birth should not be greater than today."
 "The store view is not in the associated website.","The store view is not in the associated website."
 "The Store View selected for sending Welcome email from is not related to the customer's associated website.","The Store View selected for sending Welcome email from is not related to the customer's associated website."
+"Add/Update Address","Add/Update Address"

--- a/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
+++ b/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
@@ -474,7 +474,7 @@
         <modal name="customer_address_update_modal">
             <settings>
                 <options>
-                    <option name="title" xsi:type="string">Add/Update Address</option>
+                    <option name="title" xsi:type="string" translate="true">Add/Update Address</option>
                 </options>
             </settings>
             <insertForm name="update_customer_address_form_loader" component="Magento_Customer/js/form/components/insert-form">


### PR DESCRIPTION
### Description (*)
Added missing translation for modal title & buttons in modal (Customers -> Add New Address, Edit Product -> Advanced Inventory) on Admin.

### Related Pull Requests
NA

### Manual testing scenarios (*)
1. Magento/Customer/i18n/en_US.csv (`"Add/Update Address","Test Add/Update Address"`)
2. Go to Admin Customers -> Addresses -> Add New Address -> see Modal Title (Add/Update Address)
3. Magento/CatalogInventory/i18n/en_US.csv (`"Advanced Inventory","Test Advanced Inventory"`)
3. Go to Admin Catalog -> products -> Edit/Add product -> click "Advanced Inventory" ->  see Modal Title (Advanced Inventory) & Modal Button (Done)

### Questions or comments
NA

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#28201: Added missing translation for modal title & buttons on admin