### PR TITLE
Fix notice when area has no frontname

### DIFF
--- a/lib/internal/Magento/Framework/App/AreaList.php
+++ b/lib/internal/Magento/Framework/App/AreaList.php
@@ -68,6 +68,10 @@ class AreaList
     public function getCodeByFrontName($frontName)
     {
         foreach ($this->_areas as $areaCode => &$areaInfo) {
+            if (!isset($areaInfo['frontName'])) {
+                continue;
+            }
+            
             if (!isset($areaInfo['frontName']) && isset($areaInfo['frontNameResolver'])) {
                 $resolver = $this->_resolverFactory->create($areaInfo['frontNameResolver']);
                 $areaInfo['frontName'] = $resolver->getFrontName(true);


### PR DESCRIPTION
The crontab entry in the AreaList has no frontname or frontnameResolver specified.
When Magento tries to resolve the frontName by code PHP will throw the following notice: "Notice: Trying to access array offset on value of type null in AreaList.php on line 80".

This PR makes sure area's without a frontname are not considered in the lookup method.
