### PR TITLE
Set property to false to avoid state being ignored on bookmark

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
@@ -16,7 +16,7 @@ define([
             visibleRecord: null,
             height: 0,
             displayedRecord: {},
-            lastOpenedImage: null,
+            lastOpenedImage: false,
             fields: {
                 previewUrl: 'preview_url',
                 title: 'title'

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
@@ -167,7 +167,7 @@ define([
          * Close image preview
          */
         hide: function () {
-            this.lastOpenedImage(null);
+            this.lastOpenedImage(false);
             this.visibleRecord(null);
             this.height(0);
             this._selectRow(null);

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
@@ -167,7 +167,7 @@ define([
          * Close image preview
          */
         hide: function () {
-            this.lastOpenedImage(false);
+            this.lastOpenedImage(null);
             this.visibleRecord(null);
             this.height(0);
             this._selectRow(null);

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/image-preview.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/image-preview.test.js
@@ -51,14 +51,18 @@ define([
             imagePreview.visibleRecord = ko.observable(1);
         });
 
-        describe('show method', function () {
-            it('show image', function () {
-                var mockImg = document.createElement('img'),
-                    hide = spyOn(imagePreview, 'hide');
+        describe('verify show && hide record', function () {
 
+            it('show image', function () {
+                var mockImg = document.createElement('img');
+
+                imagePreview.visibleRecord(2);
                 spyOn($.fn, 'get').and.returnValue(mockImg);
                 imagePreview.show(record);
-                expect(hide).toHaveBeenCalledTimes(1);
+                expect(imagePreview.lastOpenedImage()).toBe(record._rowIndex);
+
+                imagePreview.hide();
+                expect(imagePreview.lastOpenedImage()).toBe(false);
             });
 
         });

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/image-preview.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/image-preview.test.js
@@ -62,7 +62,7 @@ define([
                 expect(imagePreview.lastOpenedImage()).toBe(record._rowIndex);
 
                 imagePreview.hide();
-                expect(imagePreview.lastOpenedImage()).toBe(false);
+                expect(imagePreview.lastOpenedImage()).toBe(null);
             });
 
         });

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/image-preview.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/columns/image-preview.test.js
@@ -62,7 +62,7 @@ define([
                 expect(imagePreview.lastOpenedImage()).toBe(record._rowIndex);
 
                 imagePreview.hide();
-                expect(imagePreview.lastOpenedImage()).toBe(null);
+                expect(imagePreview.lastOpenedImage()).toBe(false);
             });
 
         });


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
There is a problem where the lastOpenedImage property which isn't saved on the Default bookmark, the preview object looked like this: `"preview":{"visible":true,"sorting":false}`

This creates an issue where is that lastOpenedImage is a state of the preview component, and when we close the preview, that is set to null, as consequence, the bookmark object gets updated with this: "preview":{"visible":true,"sorting":false,"lastOpenedImage":null}

As a result, the comparison of the bookmarks is different from the Default, so the component allows us to save a new bookmark.

From my investigation, the state wasn't being saved on the Default bookmark because the lastOpenedImage property on the preview component is defined as null, and from what I could see, it's ignored. By setting that property as false, it allows the component to initialize the state correctly and the Default bookmarks receive the lastOpenedImage as null.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/adobe-stock-integration#1342: Possible to save Adobe Stock grid view to bookmarks after opening and closing image preview

Closes https://github.com/magento/adobe-stock-integration/issues/1342

### Manual testing scenarios (*)
1. Create a new admin user (otherwise, the user will have the Default bookmark saved on the DB) or truncate ui_bookmarks table.
2. Follow the steps here #1342 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
