### PR TITLE
[Wishlist] Giving the possibility to set/update item description on item update

### DIFF
--- a/app/code/Magento/Wishlist/Model/Wishlist.php
+++ b/app/code/Magento/Wishlist/Model/Wishlist.php
@@ -181,6 +181,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * @param Json|null $serializer
      * @param StockRegistryInterface|null $stockRegistry
      * @param ScopeConfigInterface|null $scopeConfig
+     *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -226,6 +227,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
      *
      * @param int $customerId
      * @param bool $create Create wishlist if don't exists
+     *
      * @return $this
      */
     public function loadByCustomerId($customerId, $create = false)
@@ -274,6 +276,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * Load by sharing code
      *
      * @param string $code
+     *
      * @return $this
      */
     public function loadByCode($code)
@@ -370,6 +373,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * Retrieve wishlist item collection
      *
      * @return \Magento\Wishlist\Model\ResourceModel\Item\Collection
+     *
      * @throws NoSuchEntityException
      */
     public function getItemCollection()
@@ -389,6 +393,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * Retrieve wishlist item collection
      *
      * @param int $itemId
+     *
      * @return false|Item
      */
     public function getItem($itemId)
@@ -403,7 +408,9 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * Adding item to wishlist
      *
      * @param Item $item
+     *
      * @return $this
+     *
      * @throws Exception
      */
     public function addItem(Item $item)
@@ -424,9 +431,12 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * @param int|Product $product
      * @param DataObject|array|string|null $buyRequest
      * @param bool $forciblySetQty
+     *
      * @return Item|string
+     *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     *
      * @throws LocalizedException
      * @throws InvalidArgumentException
      */
@@ -529,7 +539,9 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * Set customer id
      *
      * @param int $customerId
+     *
      * @return $this
+     *
      * @throws LocalizedException
      */
     public function setCustomerId($customerId)
@@ -541,6 +553,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * Retrieve customer id
      *
      * @return int
+     *
      * @throws LocalizedException
      */
     public function getCustomerId()
@@ -552,6 +565,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * Retrieve data for save
      *
      * @return array
+     *
      * @throws LocalizedException
      */
     public function getDataForSave()
@@ -567,6 +581,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * Retrieve shared store ids for current website or all stores if $current is false
      *
      * @return array
+     *
      * @throws NoSuchEntityException
      */
     public function getSharedStoreIds()
@@ -590,6 +605,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * Set shared store ids
      *
      * @param array $storeIds
+     *
      * @return $this
      */
     public function setSharedStoreIds($storeIds)
@@ -602,6 +618,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * Retrieve wishlist store object
      *
      * @return \Magento\Store\Model\Store
+     *
      * @throws NoSuchEntityException
      */
     public function getStore()
@@ -616,6 +633,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * Set wishlist store
      *
      * @param Store $store
+     *
      * @return $this
      */
     public function setStore($store)
@@ -653,6 +671,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * Retrieve if product has stock or config is set for showing out of stock products
      *
      * @param int $productId
+     *
      * @return bool
      */
     private function isInStock($productId)
@@ -671,7 +690,9 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * Check customer is owner this wishlist
      *
      * @param int $customerId
+     *
      * @return bool
+     *
      * @throws LocalizedException
      */
     public function isOwner($customerId)
@@ -696,10 +717,13 @@ class Wishlist extends AbstractModel implements IdentityInterface
      * @param int|Item $itemId
      * @param DataObject $buyRequest
      * @param null|array|DataObject $params
+     *
      * @return $this
+     *
      * @throws LocalizedException
      *
      * @see \Magento\Catalog\Helper\Product::addParamsToBuyRequest()
+     *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */

--- a/app/code/Magento/Wishlist/Model/Wishlist.php
+++ b/app/code/Magento/Wishlist/Model/Wishlist.php
@@ -748,10 +748,11 @@ class Wishlist extends AbstractModel implements IdentityInterface
                 throw new LocalizedException(__($resultItem));
             }
 
+            if ($resultItem->getDescription() != $item->getDescription()) {
+                $resultItem->setDescription($item->getDescription())->save();
+            }
+
             if ($resultItem->getId() != $itemId) {
-                if ($resultItem->getDescription() != $item->getDescription()) {
-                    $resultItem->setDescription($item->getDescription())->save();
-                }
                 $item->isDeleted(true);
                 $this->setDataChanges(true);
             } else {

--- a/dev/tests/integration/testsuite/Magento/Wishlist/Model/WishlistTest.php
+++ b/dev/tests/integration/testsuite/Magento/Wishlist/Model/WishlistTest.php
@@ -218,6 +218,27 @@ class WishlistTest extends TestCase
     }
 
     /**
+     * Update description of wishlist item
+     *
+     * @magentoDataFixture Magento/Wishlist/_files/wishlist.php
+     *
+     * @return void
+     */
+    public function testUpdateItemDescriptionInWishList(): void
+    {
+        $itemDescription = 'Test Description';
+        $wishlist = $this->getWishlistByCustomerId->execute(1);
+        $item = $this->getWishlistByCustomerId->getItemBySku(1, 'simple');
+        $item->setDescription($itemDescription);
+        $this->assertNotNull($item);
+        $buyRequest = $this->dataObjectFactory->create(['data' => ['qty' => 55]]);
+        $wishlist->updateItem($item, $buyRequest);
+        $updatedItem = $this->getWishlistByCustomerId->getItemBySku(1, 'simple');
+        $this->assertEquals(55, $updatedItem->getQty());
+        $this->assertEquals($itemDescription, $updatedItem->getDescription());
+    }
+
+    /**
      * @return void
      */
     public function testUpdateNotExistingItemInWishList(): void


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR improves the wishlist item update, by allowing to update the description while updating the wishlist item.

The problem occurs, when we want to set/update the item description in the same time when we update item's quantity, which doesn't seem to be supported for now.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)

1. Create a simple product
2. Log in on the storefront
3. Add the simple product to wishlist
4. Now, programmatically, try to update the quantity and the description for this item.
```php
$wishlistId = 1;
$wishlistItemId = 1;

/** @var \Magento\Wishlist\Model\Wishlist $wishlist */
$wishlist = $objectManager->create(\Magento\Wishlist\Model\Wishlist::class);
$wishlistItemFactory = $objectManager->create(\Magento\Wishlist\Model\ItemFactory::class);
$wishlistItemResource = $objectManager->create(\Magento\Wishlist\Model\ResourceModel\Item::class);
$wishlist->load($wishlistId);

/** @var WishlistItem $wishlistItem */
$wishlistItem = $wishlistItemFactory->create();
$wishlistItemResource->load($wishlistItem, $wishlistItemId);
$wishlistItem->setDescription('My new description');
$wishlist->updateItem($wishlistItem, new \Magento\Framework\DataObject(['qty' => 22]));
```

After running this test code, we'll be able to see that we've updated only the qty, and not the description.
### Questions or comments
Looks like the description, is only used in case there is a new wishlist item created, which only happens if we're trying to update the item with some different options(custom options/super_attribute, etc) that are already added to wishlist.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#28261: [Wishlist] Giving the possibility to set/update item description on item update