### PR TITLE
Adding a GraphQL support for Newsletter subscription

### DIFF
--- a/app/code/Magento/NewsletterGraphQl/Model/Resolver/SubscribeNewsletter.php
+++ b/app/code/Magento/NewsletterGraphQl/Model/Resolver/SubscribeNewsletter.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\NewsletterGraphQl\Model\Resolver;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Newsletter\Model\SubscriptionManagerInterface;
+use Magento\Newsletter\Model\Config;
+use Magento\Store\Model\ScopeInterface;
+
+/**
+ * Subscribe newsletter resolver
+ */
+class SubscribeNewsletter implements ResolverInterface
+{
+    /**
+     * @var Subscriber
+     */
+    private $subscriber;
+
+    /**
+     * Subscriber constructor.
+     *
+     * @param SubscriptionManagerInterface $subscriptionManager
+     * @param Config $newsLetterConfig
+     */
+    public function __construct(
+        SubscriptionManagerInterface $subscriptionManager,
+        Config $newsLetterConfig
+    ) {
+        $this->newsLetterConfig = $newsLetterConfig;
+        $this->subscriptionManager = $subscriptionManager;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (empty($args['email']) || !isset($args['email'])) {
+            throw new GraphQlInputException(__('"email" value should be specified'));
+        } 
+        if (empty($args['storeId']) || !isset($args['storeId'])) {
+            throw new GraphQlInputException(__('"storeId" value should be specified'));
+        }       
+        $subscriber = $this->subscriptionManager->subscribe($args['email'], $args['storeId']);
+
+        return [
+            'result' => $subscriber->getStatus()
+        ];
+    }
+}

--- a/app/code/Magento/NewsletterGraphQl/README.md
+++ b/app/code/Magento/NewsletterGraphQl/README.md
@@ -1,0 +1,4 @@
+# NewsletterGraphQl
+
+**NewsletterGraphQl** provides type information for the GraphQl module
+to send newsletter.

--- a/app/code/Magento/NewsletterGraphQl/composer.json
+++ b/app/code/Magento/NewsletterGraphQl/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "magento/module-newsletter-graph-ql",
+    "description": "N/A",
+    "type": "magento2-module",
+    "require": {
+        "php": "~7.1.3||~7.2.0||~7.3.0",
+        "magento/framework": "*",
+        "magento/module-graph-ql": "*",
+        "magento/module-newsletter": "*",
+        "magento/module-store": "*"
+    },
+    "license": [
+        "OSL-3.0",
+        "AFL-3.0"
+    ],
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Magento\\NewsletterGraphQl\\": ""
+        }
+    }
+}

--- a/app/code/Magento/NewsletterGraphQl/etc/module.xml
+++ b/app/code/Magento/NewsletterGraphQl/etc/module.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Magento_NewsletterGraphQl">
+        <sequence>
+            <module name="Magento_Newsletter"/>
+        </sequence>
+    </module>
+</config>

--- a/app/code/Magento/NewsletterGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/NewsletterGraphQl/etc/schema.graphqls
@@ -1,0 +1,10 @@
+# Copyright © Magento, Inc. All rights reserved.
+# See COPYING.txt for license details.
+
+type Mutation {
+    subscribeNewsletter (email: String!, storeId: Int!): NewsletterOutput @resolver(class: "\\Magento\\NewsletterGraphQl\\Model\\Resolver\\SubscribeNewsletter") @doc(description:"Subscribe Newsletter")
+}
+
+type NewsletterOutput {
+    result: Boolean!
+}

--- a/app/code/Magento/NewsletterGraphQl/registration.php
+++ b/app/code/Magento/NewsletterGraphQl/registration.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_NewsletterGraphQl', __DIR__);


### PR DESCRIPTION
Current GraphQl schema does not support to subscribe newsletter from the front end. We have added a module NewsletterGraphQl module supports to submit newsletter subscription.

### Description (*)

This module is an additional GraphQL support to the Newsletter module, by supporting with subscribing newsletter feature for which we have implemented GraphQl schema and resolvers.

We can submit devdocs page related to this module once its approved and ready to merge with master.

### Manual testing scenarios (*)

1. Execute the below GraphQl query from the GraphQl client, which would respond with subscription status as boolean true/false: 

End point: https://<your magento 2.3 server url>/graphql

mutation {
    subscribeNewsletter (
        email: "johndoe@example.com",
        storeId: 1
    ) {
        result
    }
}

### Questions or comments

Could not find any unit test cases scenarios, and would be helpful further updates required if any.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
