### PR TITLE
replaced deprecated  addWarning method with addWarningMessage method …

### DIFF
--- a/app/code/Magento/Security/Model/Plugin/Auth.php
+++ b/app/code/Magento/Security/Model/Plugin/Auth.php
@@ -43,7 +43,7 @@ class Auth
     {
         $this->sessionsManager->processLogin();
         if ($this->sessionsManager->getCurrentSession()->isOtherSessionsTerminated()) {
-            $this->messageManager->addWarning(__('All other open sessions for this account were terminated.'));
+            $this->messageManager->addWarningMessage(__('All other open sessions for this account were terminated.'));
         }
     }
 

--- a/app/code/Magento/Security/Model/Plugin/Auth.php
+++ b/app/code/Magento/Security/Model/Plugin/Auth.php
@@ -35,6 +35,8 @@ class Auth
     }
 
     /**
+     * Add warning message if other sessions terminated
+     *
      * @param \Magento\Backend\Model\Auth $authModel
      * @return void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
@@ -48,6 +50,8 @@ class Auth
     }
 
     /**
+     * Handle logout process
+     *
      * @param \Magento\Backend\Model\Auth $authModel
      * @return void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)

--- a/app/code/Magento/Security/Test/Unit/Model/Plugin/AuthTest.php
+++ b/app/code/Magento/Security/Test/Unit/Model/Plugin/AuthTest.php
@@ -64,7 +64,7 @@ class AuthTest extends TestCase
 
         $this->messageManager = $this->getMockForAbstractClass(
             ManagerInterface::class,
-            ['addWarning'],
+            ['addWarningMessage'],
             '',
             false
         );
@@ -100,7 +100,7 @@ class AuthTest extends TestCase
             ->method('isOtherSessionsTerminated')
             ->willReturn(true);
         $this->messageManager->expects($this->once())
-            ->method('addWarning')
+            ->method('addWarningMessage')
             ->with($warningMessage);
 
         $this->model->afterLogin($this->authMock);


### PR DESCRIPTION
…in Security module

Replace deprecated  addWarning method with addWarningMessage method in Magento core security module

### Description (*)

      addWarning method is deprecated, to replace the addWarning method with addWarningMessage method in Magento core security module

### Manual testing scenarios (*)

1. Logged in to your magento admin panel , go to Store ->  Configuration -> Advanced  -> Admin -> Security -> Admin Account Sharing -> NO
2. Logged in to your magento admin panel in a different browsers, in the current browser admin session will be created with the warning message.



### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#28308: replaced deprecated  addWarning method with addWarningMessage method …