### PR TITLE
MC-25348: Problems with cache when Merchant configure state for United States as not required

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/region-updater.js
@@ -194,6 +194,7 @@ define([
                         container.hide();
                     } else {
                         regionList.show();
+                        regionList.removeAttr('disabled');
                     }
                 }
 

--- a/app/code/Magento/Customer/Test/Mftf/Data/AddressData.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Data/AddressData.xml
@@ -206,6 +206,10 @@
         <data key="default_billing">true</data>
         <data key="default_shipping">false</data>
     </entity>
+    <entity name="CustomerUKAddress_Default_Addresses" type="address" extends="CustomerUKAddress">
+        <data key="default_billing">true</data>
+        <data key="default_shipping">true</data>
+    </entity>
     <entity name="addressNoZipNoState" type="address">
         <data key="country_id">United Kingdom</data>
         <array key="street">

--- a/app/code/Magento/Customer/Test/Mftf/Data/CustomerData.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Data/CustomerData.xml
@@ -245,6 +245,17 @@
         <requiredEntity type="address">US_Default_Billing_Address_TX</requiredEntity>
         <requiredEntity type="address">US_Default_Shipping_Address_CA</requiredEntity>
     </entity>
+    <entity name="Customer_UK_With_Default_Billing_Shipping_Addresses" type="customer">
+        <data key="group_id">1</data>
+        <data key="email" unique="prefix">John.Doe@example.com</data>
+        <data key="firstname">John</data>
+        <data key="lastname">Doe</data>
+        <data key="fullname">John Doe</data>
+        <data key="password">pwdTest123!</data>
+        <data key="store_id">0</data>
+        <data key="website_id">0</data>
+        <requiredEntity type="address">CustomerUKAddress_Default_Addresses</requiredEntity>
+    </entity>
     <entity name="Colorado_US_Customer" type="customer">
         <data key="group_id">1</data>
         <data key="default_billing">true</data>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressTest/StorefrontUpdateCustomerDefaultBillingAddressUsingOptionalSelectTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressTest/StorefrontUpdateCustomerDefaultBillingAddressUsingOptionalSelectTest.xml
@@ -32,13 +32,9 @@
         </actionGroup>
         <amOnPage url="customer/address/" stepKey="OpenCustomerUpdateAddress"/>
         <click stepKey="ClickEditDefaultBillingAddress" selector="{{StorefrontCustomerAddressesSection.editDefaultBillingAddress}}"/>
-        <fillField stepKey="fillCountry" userInput="EditedCountryBilling" selector="{{StorefrontCustomerAddressFormSection.country}}"/>
-        <fillField stepKey="fillRegion" userInput="EditedRegionBilling" selector="{{StorefrontCustomerAddressFormSection.region}}"/>
+        <selectOption selector="{{StorefrontCustomerAddressFormSection.country}}" userInput="{{US_Address_CA.country}}" stepKey="selectCountry"/>
+        <selectOption selector="{{StorefrontCustomerAddressFormSection.state}}" userInput="{{US_Address_CA.state}}"  stepKey="selectState"/>
         <click stepKey="saveCustomerAddress" selector="{{StorefrontCustomerAddressFormSection.saveAddress}}"/>
         <see userInput="You saved the address." stepKey="verifyAddressAdded"/>
-        <see userInput="EditedCountryBilling" selector="{{StorefrontCustomerAddressesSection.defaultBillingAddress}}" stepKey="checkNewAddressesCountryOnDefaultBilling"/>
-        <see userInput="EditedRegionBilling" selector="{{StorefrontCustomerAddressesSection.defaultBillingAddress}}" stepKey="checkNewAddressesRegionOnDefaultBilling"/>
-        <see userInput="{{US_Address_CA.country_id}}" selector="{{StorefrontCustomerAddressesSection.defaultBillingAddress}}" stepKey="checkNewAddressesFirstNameOnDefaultShipping"/>
-        <see userInput="{{US_Address_CA.region}}" selector="{{StorefrontCustomerAddressesSection.defaultBillingAddress}}" stepKey="checkNewAddressesLastNameOnDefaultShipping"/>
     </test>
 </tests>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressTest/StorefrontUpdateCustomerDefaultBillingAddressUsingOptionalSelectTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontUpdateCustomerAddressTest/StorefrontUpdateCustomerDefaultBillingAddressUsingOptionalSelectTest.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontUpdateCustomerDefaultBillingAddressUsingOptionalSelectTest">
+        <annotations>
+            <features value="Customer address"/>
+            <stories value="Implementing changing of address in case selected option was not required in Configuration"/>
+            <title value="Update default customer address via the Storefront using selection"/>
+            <description value="Storefront user should be able to create a new default address via the storefront"/>
+            <severity value="AVERAGE"/>
+            <testCaseId value="MC-25348"/>
+            <group value="customer"/>
+            <group value="testDebug"/>
+            <group value="update"/>
+        </annotations>
+        <before>
+            <createData entity="Customer_UK_With_Default_Billing_Shipping_Addresses" stepKey="createCustomer"/>
+        </before>
+        <after>
+            <deleteData createDataKey="createCustomer" stepKey="DeleteCustomer"/>
+        </after>
+
+        <!--Log in to Storefront as Customer 1 -->
+        <actionGroup ref="LoginToStorefrontActionGroup" stepKey="signUp">
+            <argument name="Customer" value="$$createCustomer$$"/>
+        </actionGroup>
+        <amOnPage url="customer/address/" stepKey="OpenCustomerUpdateAddress"/>
+        <click stepKey="ClickEditDefaultBillingAddress" selector="{{StorefrontCustomerAddressesSection.editDefaultBillingAddress}}"/>
+        <fillField stepKey="fillCountry" userInput="EditedCountryBilling" selector="{{StorefrontCustomerAddressFormSection.country}}"/>
+        <fillField stepKey="fillRegion" userInput="EditedRegionBilling" selector="{{StorefrontCustomerAddressFormSection.region}}"/>
+        <click stepKey="saveCustomerAddress" selector="{{StorefrontCustomerAddressFormSection.saveAddress}}"/>
+        <see userInput="You saved the address." stepKey="verifyAddressAdded"/>
+        <see userInput="EditedCountryBilling" selector="{{StorefrontCustomerAddressesSection.defaultBillingAddress}}" stepKey="checkNewAddressesCountryOnDefaultBilling"/>
+        <see userInput="EditedRegionBilling" selector="{{StorefrontCustomerAddressesSection.defaultBillingAddress}}" stepKey="checkNewAddressesRegionOnDefaultBilling"/>
+        <see userInput="{{US_Address_CA.country_id}}" selector="{{StorefrontCustomerAddressesSection.defaultBillingAddress}}" stepKey="checkNewAddressesFirstNameOnDefaultShipping"/>
+        <see userInput="{{US_Address_CA.region}}" selector="{{StorefrontCustomerAddressesSection.defaultBillingAddress}}" stepKey="checkNewAddressesLastNameOnDefaultShipping"/>
+    </test>
+</tests>


### PR DESCRIPTION
#25348 removing disabled status if the region is not required but allowed.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
After hours of debugging, I found that the issue is in the disabled select.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#25348: Problems with cache when Merchant configure state for United States as not required


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
Should I cover this with tests?
 
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
