### PR TITLE
Cannot Create Credit Memos with ZeroGrandTotal via Order/Invoice Service

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Validation/QuantityValidator.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Validation/QuantityValidator.php
@@ -94,7 +94,7 @@ class QuantityValidator implements ValidatorInterface
             }
         }
 
-        if ($entity->getGrandTotal() <= 0) {
+        if (!$entity->isValidGrandTotal()) {
             $messages[] = __('The credit memo\'s total must be positive.');
         } elseif ($totalQuantity <= 0 && !$this->canRefundShipping($order)) {
             $messages[] = __('You can\'t create a creditmemo without products.');


### PR DESCRIPTION
When creating credit memos via the orderService, allowZeroGrandTotal is ignored

Steps to reproduce:

1. Have 0 Subtotal order
2. try to cancel it via Services, for example:

        \Magento\Sales\Api\RefundOrderInterface $orderRefunder,
        \Magento\Sales\Api\RefundInvoiceInterface $invoiceRefunder

                $invoiceRefunder->execute(
                    $invoice->getId(),
                    [],
                    false,
                    true
                );

   or

       $this->orderRefunder->execute(
                $id,
                [],
                true
            );

Leads to errors like:

      The credit memo's total must be positive.


See also https://github.com/magento/magento2/pull/16005

