### PR TITLE
[Backport] MC-31544: Email Template New Pickup Order or add New Template order items are missing in Mail

### DIFF
--- a/app/code/Magento/Sales/Block/Order/Email/Creditmemo/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Creditmemo/Items.php
@@ -5,6 +5,13 @@
  */
 namespace Magento\Sales\Block\Order\Email\Creditmemo;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\View\Element\Template\Context;
+use Magento\Sales\Api\CreditmemoRepositoryInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\Data\CreditmemoInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+
 /**
  * Sales Order Email creditmemo items
  *
@@ -15,6 +22,36 @@ namespace Magento\Sales\Block\Order\Email\Creditmemo;
 class Items extends \Magento\Sales\Block\Items\AbstractItems
 {
     /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var CreditmemoRepositoryInterface
+     */
+    private $creditmemoRepository;
+
+    /**
+     * @param Context $context
+     * @param array $data
+     * @param OrderRepositoryInterface|null $orderRepository
+     * @param CreditmemoRepositoryInterface|null $creditmemoRepository
+     */
+    public function __construct(
+        Context $context,
+        array $data = [],
+        ?OrderRepositoryInterface $orderRepository = null,
+        ?CreditmemoRepositoryInterface $creditmemoRepository = null
+    ) {
+        $this->orderRepository =
+            $orderRepository ?: ObjectManager::getInstance()->get(OrderRepositoryInterface::class);
+        $this->creditmemoRepository =
+            $creditmemoRepository ?: ObjectManager::getInstance()->get(CreditmemoRepositoryInterface::class);
+
+        parent::__construct($context, $data);
+    }
+
+    /**
      * Prepare item before output
      *
      * @param \Magento\Framework\View\Element\AbstractBlock $renderer
@@ -24,5 +61,55 @@ class Items extends \Magento\Sales\Block\Items\AbstractItems
     {
         $renderer->getItem()->setOrder($this->getOrder());
         $renderer->getItem()->setSource($this->getCreditmemo());
+    }
+
+    /**
+     * Returns order.
+     *
+     * Custom email templates are only allowed to use scalar values for variable data.
+     * So order is loaded by order_id, that is passed to block from email template.
+     * For legacy custom email templates it can pass as an object.
+     *
+     * @return OrderInterface|null
+     */
+    public function getOrder()
+    {
+        $order = $this->getData('order');
+        if ($order !== null) {
+            return $order;
+        }
+
+        $orderId = (int)$this->getData('order_id');
+        if ($orderId) {
+            $order = $this->orderRepository->get($orderId);
+            $this->setData('order', $order);
+        }
+
+        return $this->getData('order');
+    }
+
+    /**
+     * Returns creditmemo.
+     *
+     * Custom email templates are only allowed to use scalar values for variable data.
+     * So creditmemo is loaded by creditmemo_id, that is passed to block from email template.
+     * For legacy custom email templates it can pass as an object.
+     *
+     * @return CreditmemoInterface|null
+     */
+    public function getCreditmemo()
+    {
+        $creditmemo = $this->getData('creditmemo');
+        if ($creditmemo !== null) {
+            return $creditmemo;
+        }
+
+        $creditmemoId = (int)$this->getData('creditmemo_id');
+        if ($creditmemoId) {
+            $creditmemo = $this->creditmemoRepository->get($creditmemoId);
+            $this->setData('creditmemo', $creditmemo);
+        }
+
+        return $this->getData('creditmemo');
     }
 }

--- a/app/code/Magento/Sales/Block/Order/Email/Invoice/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Invoice/Items.php
@@ -6,6 +6,13 @@
 
 namespace Magento\Sales\Block\Order\Email\Invoice;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\View\Element\Template\Context;
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\InvoiceRepositoryInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+
 /**
  * Sales Order Email Invoice items
  *
@@ -14,6 +21,36 @@ namespace Magento\Sales\Block\Order\Email\Invoice;
  */
 class Items extends \Magento\Sales\Block\Items\AbstractItems
 {
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var InvoiceRepositoryInterface
+     */
+    private $invoiceRepository;
+
+    /**
+     * @param Context $context
+     * @param array $data
+     * @param OrderRepositoryInterface|null $orderRepository
+     * @param InvoiceRepositoryInterface|null $invoiceRepository
+     */
+    public function __construct(
+        Context $context,
+        array $data = [],
+        ?OrderRepositoryInterface $orderRepository = null,
+        ?InvoiceRepositoryInterface $invoiceRepository = null
+    ) {
+        $this->orderRepository =
+            $orderRepository ?: ObjectManager::getInstance()->get(OrderRepositoryInterface::class);
+        $this->invoiceRepository =
+            $invoiceRepository ?: ObjectManager::getInstance()->get(InvoiceRepositoryInterface::class);
+
+        parent::__construct($context, $data);
+    }
+
     /**
      * Prepare item before output
      *
@@ -24,5 +61,55 @@ class Items extends \Magento\Sales\Block\Items\AbstractItems
     {
         $renderer->getItem()->setOrder($this->getOrder());
         $renderer->getItem()->setSource($this->getInvoice());
+    }
+
+    /**
+     * Returns order.
+     *
+     * Custom email templates are only allowed to use scalar values for variable data.
+     * So order is loaded by order_id, that is passed to block from email template.
+     * For legacy custom email templates it can pass as an object.
+     *
+     * @return OrderInterface|null
+     */
+    public function getOrder()
+    {
+        $order = $this->getData('order');
+        if ($order !== null) {
+            return $order;
+        }
+
+        $orderId = (int)$this->getData('order_id');
+        if ($orderId) {
+            $order = $this->orderRepository->get($orderId);
+            $this->setData('order', $order);
+        }
+
+        return $this->getData('order');
+    }
+
+    /**
+     * Returns invoice.
+     *
+     * Custom email templates are only allowed to use scalar values for variable data.
+     * So invoice is loaded by invoice_id, that is passed to block from email template.
+     * For legacy custom email templates it can pass as an object.
+     *
+     * @return InvoiceInterface|null
+     */
+    public function getInvoice()
+    {
+        $invoice = $this->getData('invoice');
+        if ($invoice !== null) {
+            return $invoice;
+        }
+
+        $invoiceId = (int)$this->getData('invoice_id');
+        if ($invoiceId) {
+            $invoice = $this->invoiceRepository->get($invoiceId);
+            $this->setData('invoice', $invoice);
+        }
+
+        return $this->getData('invoice');
     }
 }

--- a/app/code/Magento/Sales/Block/Order/Email/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items.php
@@ -11,10 +11,61 @@
  */
 namespace Magento\Sales\Block\Order\Email;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\View\Element\Template\Context;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+
 /**
+ * Sales Order Email items.
+ *
  * @api
  * @since 100.0.2
  */
 class Items extends \Magento\Sales\Block\Items\AbstractItems
 {
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @param Context $context
+     * @param array $data
+     * @param OrderRepositoryInterface|null $orderRepository
+     */
+    public function __construct(
+        Context $context,
+        array $data = [],
+        ?OrderRepositoryInterface $orderRepository = null
+    ) {
+        $this->orderRepository = $orderRepository ?: ObjectManager::getInstance()->get(OrderRepositoryInterface::class);
+
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * Returns order.
+     *
+     * Custom email templates are only allowed to use scalar values for variable data.
+     * So order is loaded by order_id, that is passed to block from email template.
+     * For legacy custom email templates it can pass as an object.
+     *
+     * @return OrderInterface|null
+     */
+    public function getOrder()
+    {
+        $order = $this->getData('order');
+
+        if ($order !== null) {
+            return $order;
+        }
+        $orderId = (int)$this->getData('order_id');
+        if ($orderId) {
+            $order = $this->orderRepository->get($orderId);
+            $this->setData('order', $order);
+        }
+
+        return $this->getData('order');
+    }
 }

--- a/app/code/Magento/Sales/Block/Order/Email/Shipment/Items.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Shipment/Items.php
@@ -6,6 +6,13 @@
 
 namespace Magento\Sales\Block\Order\Email\Shipment;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\View\Element\Template\Context;
+use Magento\Sales\Api\Data\ShipmentInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Api\ShipmentRepositoryInterface;
+
 /**
  * Sales Order Email Shipment items
  *
@@ -14,6 +21,36 @@ namespace Magento\Sales\Block\Order\Email\Shipment;
  */
 class Items extends \Magento\Sales\Block\Items\AbstractItems
 {
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var ShipmentRepositoryInterface
+     */
+    private $shipmentRepository;
+
+    /**
+     * @param Context $context
+     * @param array $data
+     * @param OrderRepositoryInterface|null $orderRepository
+     * @param ShipmentRepositoryInterface|null $creditmemoRepository
+     */
+    public function __construct(
+        Context $context,
+        array $data = [],
+        ?OrderRepositoryInterface $orderRepository = null,
+        ?ShipmentRepositoryInterface $creditmemoRepository = null
+    ) {
+        $this->orderRepository =
+            $orderRepository ?: ObjectManager::getInstance()->get(OrderRepositoryInterface::class);
+        $this->shipmentRepository =
+            $creditmemoRepository ?: ObjectManager::getInstance()->get(ShipmentRepositoryInterface::class);
+
+        parent::__construct($context, $data);
+    }
+
     /**
      * Prepare item before output
      *
@@ -24,5 +61,55 @@ class Items extends \Magento\Sales\Block\Items\AbstractItems
     {
         $renderer->getItem()->setOrder($this->getOrder());
         $renderer->getItem()->setSource($this->getShipment());
+    }
+
+    /**
+     * Returns order.
+     *
+     * Custom email templates are only allowed to use scalar values for variable data.
+     * So order is loaded by order_id, that is passed to block from email template.
+     * For legacy custom email templates it can pass as an object.
+     *
+     * @return OrderInterface|null
+     */
+    public function getOrder()
+    {
+        $order = $this->getData('order');
+        if ($order !== null) {
+            return $order;
+        }
+
+        $orderId = (int)$this->getData('order_id');
+        if ($orderId) {
+            $order = $this->orderRepository->get($orderId);
+            $this->setData('order', $order);
+        }
+
+        return $this->getData('order');
+    }
+
+    /**
+     * Returns shipment.
+     *
+     * Custom email templates are only allowed to use scalar values for variable data.
+     * So shipment is loaded by shipment_id, that is passed to block from email template.
+     * For legacy custom email templates it can pass as an object.
+     *
+     * @return ShipmentInterface|null
+     */
+    public function getShipment()
+    {
+        $shipment = $this->getData('shipment');
+        if ($shipment !== null) {
+            return $shipment;
+        }
+
+        $shipmentId = (int)$this->getData('shipment_id');
+        if ($shipmentId) {
+            $shipment = $this->shipmentRepository->get($shipmentId);
+            $this->setData('shipment', $shipment);
+        }
+
+        return $this->getData('shipment');
     }
 }

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/CreditmemoSender.php
@@ -17,7 +17,7 @@ use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\DataObject;
 
 /**
- * Class CreditmemoSender
+ * Sends order creditmemo email to the customer.
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
@@ -108,7 +108,9 @@ class CreditmemoSender extends Sender
 
             $transport = [
                 'order' => $order,
+                'order_id' => $order->getId(),
                 'creditmemo' => $creditmemo,
+                'creditmemo_id' => $creditmemo->getId(),
                 'comment' => $creditmemo->getCustomerNoteNotify() ? $creditmemo->getCustomerNote() : '',
                 'billing' => $order->getBillingAddress(),
                 'payment_html' => $this->getPaymentHtml($order),

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/InvoiceSender.php
@@ -17,7 +17,7 @@ use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\DataObject;
 
 /**
- * Class InvoiceSender
+ * Sends order invoice email to the customer.
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
@@ -108,7 +108,9 @@ class InvoiceSender extends Sender
 
             $transport = [
                 'order' => $order,
+                'order_id' => $order->getId(),
                 'invoice' => $invoice,
+                'invoice_id' => $invoice->getId(),
                 'comment' => $invoice->getCustomerNoteNotify() ? $invoice->getCustomerNote() : '',
                 'billing' => $order->getBillingAddress(),
                 'payment_html' => $this->getPaymentHtml($order),

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
@@ -16,7 +16,8 @@ use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\DataObject;
 
 /**
- * Class OrderSender
+ * Sends order email to the customer.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class OrderSender extends Sender
@@ -125,6 +126,7 @@ class OrderSender extends Sender
     {
         $transport = [
             'order' => $order,
+            'order_id' => $order->getId(),
             'billing' => $order->getBillingAddress(),
             'payment_html' => $this->getPaymentHtml($order),
             'store' => $order->getStore(),

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/ShipmentSender.php
@@ -108,7 +108,9 @@ class ShipmentSender extends Sender
 
             $transport = [
                 'order' => $order,
+                'order_id' => $order->getId(),
                 'shipment' => $shipment,
+                'shipment_id' => $shipment->getId(),
                 'comment' => $shipment->getCustomerNoteNotify() ? $shipment->getCustomerNote() : '',
                 'billing' => $order->getBillingAddress(),
                 'payment_html' => $this->getPaymentHtml($order),

--- a/app/code/Magento/Sales/Model/Order/Shipment/Sender/EmailSender.php
+++ b/app/code/Magento/Sales/Model/Order/Shipment/Sender/EmailSender.php
@@ -104,7 +104,9 @@ class EmailSender extends Sender implements SenderInterface
 
             $transport = [
                 'order' => $order,
+                'order_id' => $order->getId(),
                 'shipment' => $shipment,
+                'shipment_id' => $shipment->getId(),
                 'comment' => $comment ? $comment->getComment() : '',
                 'billing' => $order->getBillingAddress(),
                 'payment_html' => $this->getPaymentHtml($order),

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/AbstractSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/AbstractSenderTest.php
@@ -95,7 +95,7 @@ abstract class AbstractSenderTest extends \PHPUnit\Framework\TestCase
         $this->orderMock = $this->createPartialMock(
             \Magento\Sales\Model\Order::class,
             [
-                'getStore', 'getBillingAddress', 'getPayment',
+                'getId', 'getStore', 'getBillingAddress', 'getPayment',
                 '__wakeup', 'getCustomerIsGuest', 'getCustomerName',
                 'getCustomerEmail', 'getShippingAddress', 'setSendEmail',
                 'setEmailSent', 'getCreatedAtFormatted', 'getIsNotVirtual',

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/CreditmemoSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/CreditmemoSenderTest.php
@@ -12,6 +12,10 @@ use Magento\Sales\Model\Order\Email\Sender\CreditmemoSender;
  */
 class CreditmemoSenderTest extends AbstractSenderTest
 {
+    private const CREDITMEMO_ID = 1;
+
+    private const ORDER_ID = 1;
+
     /**
      * @var \Magento\Sales\Model\Order\Email\Sender\CreditmemoSender
      */
@@ -40,6 +44,7 @@ class CreditmemoSenderTest extends AbstractSenderTest
             \Magento\Sales\Model\Order\Creditmemo::class,
             [
                 'getStore',
+                'getId',
                 '__wakeup',
                 'getOrder',
                 'setSendEmail',
@@ -54,6 +59,10 @@ class CreditmemoSenderTest extends AbstractSenderTest
         $this->creditmemoMock->expects($this->any())
             ->method('getOrder')
             ->will($this->returnValue($this->orderMock));
+        $this->creditmemoMock->method('getId')
+            ->willReturn(self::CREDITMEMO_ID);
+        $this->orderMock->method('getId')
+            ->willReturn(self::ORDER_ID);
 
         $this->identityContainerMock = $this->createPartialMock(
             \Magento\Sales\Model\Order\Email\Container\CreditmemoIdentity::class,
@@ -142,7 +151,9 @@ class CreditmemoSenderTest extends AbstractSenderTest
                 ->with(
                     [
                         'order' => $this->orderMock,
+                        'order_id' => self::ORDER_ID,
                         'creditmemo' => $this->creditmemoMock,
+                        'creditmemo_id' => self::CREDITMEMO_ID,
                         'comment' => $customerNoteNotify ? $comment : '',
                         'billing' => $addressMock,
                         'payment_html' => 'payment',
@@ -285,7 +296,9 @@ class CreditmemoSenderTest extends AbstractSenderTest
             ->with(
                 [
                     'order' => $this->orderMock,
+                    'order_id' => self::ORDER_ID,
                     'creditmemo' => $this->creditmemoMock,
+                    'creditmemo_id' => self::CREDITMEMO_ID,
                     'comment' => '',
                     'billing' => $addressMock,
                     'payment_html' => 'payment',

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/InvoiceSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/InvoiceSenderTest.php
@@ -12,6 +12,10 @@ use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
  */
 class InvoiceSenderTest extends AbstractSenderTest
 {
+    private const INVOICE_ID = 1;
+
+    private const ORDER_ID = 1;
+
     /**
      * @var \Magento\Sales\Model\Order\Email\Sender\InvoiceSender
      */
@@ -40,6 +44,7 @@ class InvoiceSenderTest extends AbstractSenderTest
             \Magento\Sales\Model\Order\Invoice::class,
             [
                 'getStore',
+                'getId',
                 '__wakeup',
                 'getOrder',
                 'setSendEmail',
@@ -54,6 +59,11 @@ class InvoiceSenderTest extends AbstractSenderTest
         $this->invoiceMock->expects($this->any())
             ->method('getOrder')
             ->will($this->returnValue($this->orderMock));
+
+        $this->invoiceMock->method('getId')
+            ->willReturn(self::INVOICE_ID);
+        $this->orderMock->method('getId')
+            ->willReturn(self::ORDER_ID);
 
         $this->identityContainerMock = $this->createPartialMock(
             \Magento\Sales\Model\Order\Email\Container\InvoiceIdentity::class,
@@ -148,7 +158,9 @@ class InvoiceSenderTest extends AbstractSenderTest
                 ->with(
                     [
                         'order' => $this->orderMock,
+                        'order_id' => self::ORDER_ID,
                         'invoice' => $this->invoiceMock,
+                        'invoice_id' => self::INVOICE_ID,
                         'comment' => $customerNoteNotify ? $comment : '',
                         'billing' => $addressMock,
                         'payment_html' => 'payment',
@@ -287,7 +299,9 @@ class InvoiceSenderTest extends AbstractSenderTest
             ->with(
                 [
                     'order' => $this->orderMock,
+                    'order_id' => self::ORDER_ID,
                     'invoice' => $this->invoiceMock,
+                    'invoice_id' => self::INVOICE_ID,
                     'comment' => '',
                     'billing' => $addressMock,
                     'payment_html' => 'payment',

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/OrderSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/OrderSenderTest.php
@@ -9,6 +9,8 @@ use Magento\Sales\Model\Order\Email\Sender\OrderSender;
 
 class OrderSenderTest extends AbstractSenderTest
 {
+    private const ORDER_ID = 1;
+
     /**
      * @var \Magento\Sales\Model\Order\Email\Sender\OrderSender
      */
@@ -35,6 +37,9 @@ class OrderSenderTest extends AbstractSenderTest
         $this->identityContainerMock->expects($this->any())
             ->method('getStore')
             ->will($this->returnValue($this->storeMock));
+
+        $this->orderMock->method('getId')
+            ->willReturn(self::ORDER_ID);
 
         $this->sender = new OrderSender(
             $this->templateContainerMock,
@@ -127,6 +132,7 @@ class OrderSenderTest extends AbstractSenderTest
                     ->with(
                         [
                             'order' => $this->orderMock,
+                            'order_id' => self::ORDER_ID,
                             'billing' => $addressMock,
                             'payment_html' => 'payment',
                             'store' => $this->storeMock,
@@ -295,6 +301,7 @@ class OrderSenderTest extends AbstractSenderTest
             ->with(
                 [
                     'order' => $this->orderMock,
+                    'order_id' => self::ORDER_ID,
                     'billing' => $addressMock,
                     'payment_html' => 'payment',
                     'store' => $this->storeMock,

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/ShipmentSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/ShipmentSenderTest.php
@@ -12,6 +12,10 @@ use Magento\Sales\Model\Order\Email\Sender\ShipmentSender;
  */
 class ShipmentSenderTest extends AbstractSenderTest
 {
+    private const SHIPMENT_ID = 1;
+
+    private const ORDER_ID = 1;
+
     /**
      * @var \Magento\Sales\Model\Order\Email\Sender\ShipmentSender
      */
@@ -40,6 +44,7 @@ class ShipmentSenderTest extends AbstractSenderTest
             \Magento\Sales\Model\Order\Shipment::class,
             [
                 'getStore',
+                'getId',
                 '__wakeup',
                 'getOrder',
                 'setSendEmail',
@@ -54,6 +59,11 @@ class ShipmentSenderTest extends AbstractSenderTest
         $this->shipmentMock->expects($this->any())
             ->method('getOrder')
             ->will($this->returnValue($this->orderMock));
+
+        $this->shipmentMock->method('getId')
+            ->willReturn(self::SHIPMENT_ID);
+        $this->orderMock->method('getId')
+            ->willReturn(self::ORDER_ID);
 
         $this->identityContainerMock = $this->createPartialMock(
             \Magento\Sales\Model\Order\Email\Container\ShipmentIdentity::class,
@@ -148,7 +158,9 @@ class ShipmentSenderTest extends AbstractSenderTest
                 ->with(
                     [
                         'order' => $this->orderMock,
+                        'order_id' => self::ORDER_ID,
                         'shipment' => $this->shipmentMock,
+                        'shipment_id' => self::SHIPMENT_ID,
                         'comment' => $customerNoteNotify ? $comment : '',
                         'billing' => $addressMock,
                         'payment_html' => 'payment',
@@ -288,7 +300,9 @@ class ShipmentSenderTest extends AbstractSenderTest
             ->with(
                 [
                     'order' => $this->orderMock,
+                    'order_id' => self::ORDER_ID,
                     'shipment' => $this->shipmentMock,
+                    'shipment_id' => self::SHIPMENT_ID,
                     'comment' => '',
                     'billing' => $addressMock,
                     'payment_html' => 'payment',

--- a/app/code/Magento/Sales/view/frontend/email/creditmemo_new.html
+++ b/app/code/Magento/Sales/view/frontend/email/creditmemo_new.html
@@ -22,6 +22,8 @@
 "var store_hours":"Store Hours",
 "var creditmemo":"Credit Memo",
 "var order":"Order",
+"var order_id": "Order DB Id",
+"var creditmemo_id": "Credit Memo DB Id",
 "var order_data.is_not_virtual":"Order Type"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -82,7 +84,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_creditmemo_items" creditmemo=$creditmemo order=$order}}
+            {{layout handle="sales_email_order_creditmemo_items" creditmemo_id=$creditmemo_id order_id=$order_id}}
         </td>
     </tr>
 </table>

--- a/app/code/Magento/Sales/view/frontend/email/creditmemo_new_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/creditmemo_new_guest.html
@@ -21,7 +21,9 @@
 "var store_hours":"Store Hours",
 "var creditmemo":"Credit Memo",
 "var order":"Order",
-"var order_data.is_not_virtual":"Order Type"
+"var order_data.is_not_virtual":"Order Type",
+"var order_id": "Order DB Id",
+"var creditmemo_id": "Credit Memo DB Id"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -80,7 +82,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_creditmemo_items" creditmemo=$creditmemo order=$order}}
+            {{layout handle="sales_email_order_creditmemo_items" creditmemo_id=$creditmemo_id order_id=$order_id}}
         </td>
     </tr>
 </table>

--- a/app/code/Magento/Sales/view/frontend/email/invoice_new.html
+++ b/app/code/Magento/Sales/view/frontend/email/invoice_new.html
@@ -22,6 +22,8 @@
 "var store_hours":"Store Hours",
 "var invoice": "Invoice",
 "var order": "Order",
+"var order_id": "Order DB Id",
+"var invoice_id": "Invoice DB Id",
 "var order_data.is_not_virtual": "Order Type"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -82,7 +84,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout area="frontend" handle="sales_email_order_invoice_items" invoice=$invoice order=$order}}
+            {{layout area="frontend" handle="sales_email_order_invoice_items" invoice_id=$invoice_id order_id=$order_id}}
         </td>
     </tr>
 </table>

--- a/app/code/Magento/Sales/view/frontend/email/invoice_new_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/invoice_new_guest.html
@@ -21,6 +21,8 @@
 "var store_hours":"Store Hours",
 "var invoice": "Invoice",
 "var order": "Order",
+"var order_id": "Order DB Id",
+"var invoice_id": "Invoice DB Id",
 "var order_data.is_not_virtual": "Order Type"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -80,7 +82,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_invoice_items" invoice=$invoice order=$order}}
+            {{layout handle="sales_email_order_invoice_items" invoice_id=$invoice_id order_id=$order_id}}
         </td>
     </tr>
 </table>

--- a/app/code/Magento/Sales/view/frontend/email/order_new.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_new.html
@@ -22,6 +22,7 @@
 "var this.getUrl($store,'customer/account/',[_nosid:1])":"Customer Account URL",
 "var order_data.is_not_virtual":"Order Type",
 "var order":"Order",
+"var order_id": "Order DB Id",
 "var order_data.customer_name":"Customer Name"
 } @-->
 
@@ -90,7 +91,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_items" order=$order area="frontend"}}
+            {{layout handle="sales_email_order_items" order_id=$order_id area="frontend"}}
         </td>
     </tr>
 </table>

--- a/app/code/Magento/Sales/view/frontend/email/order_new_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/order_new_guest.html
@@ -21,6 +21,7 @@
 "var store_email":"Store Email",
 "var store_hours":"Store Hours",
 "var order_data.is_not_virtual":"Order Type",
+"var order_id": "Order DB Id",
 "var order":"Order"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -85,7 +86,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_items" order=$order}}
+            {{layout handle="sales_email_order_items" order_id=$order_id }}
         </td>
     </tr>
 </table>

--- a/app/code/Magento/Sales/view/frontend/email/shipment_new.html
+++ b/app/code/Magento/Sales/view/frontend/email/shipment_new.html
@@ -23,7 +23,9 @@
 "var store_hours":"Store Hours",
 "var order_data.is_not_virtual": "Order Type",
 "var shipment": "Shipment",
-"var order": "Order"
+"var order": "Order",
+"var order_id": "Order DB Id",
+"var shipment_id": "Shipment DB Id"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -59,7 +61,7 @@
                 </tr>
             </table>
             {{/depend}}
-            {{layout handle="sales_email_order_shipment_track" shipment=$shipment order=$order}}
+            {{layout handle="sales_email_order_shipment_track" shipment_id=$shipment_id order_id=$order_id}}
             <table class="order-details">
                 <tr>
                     <td class="address-details">
@@ -86,7 +88,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_shipment_items" shipment=$shipment order=$order}}
+            {{layout handle="sales_email_order_shipment_items" shipment_id=$shipment_id order_id=$order_id}}
         </td>
     </tr>
 </table>

--- a/app/code/Magento/Sales/view/frontend/email/shipment_new_guest.html
+++ b/app/code/Magento/Sales/view/frontend/email/shipment_new_guest.html
@@ -22,7 +22,9 @@
 "var store_hours":"Store Hours",
 "var order_data.is_not_virtual": "Order Type",
 "var shipment": "Shipment",
-"var order": "Order"
+"var order": "Order",
+"var order_id": "Order DB Id",
+"var shipment_id": "Shipment DB Id"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -57,7 +59,7 @@
                 </tr>
             </table>
             {{/depend}}
-            {{layout handle="sales_email_order_shipment_track" shipment=$shipment order=$order}}
+            {{layout handle="sales_email_order_shipment_track" shipment_id=$shipment_id order_id=$order_id}}
             <table class="order-details">
                 <tr>
                     <td class="address-details">
@@ -84,7 +86,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_shipment_items" shipment=$shipment order=$order}}
+            {{layout handle="sales_email_order_shipment_items" shipment_id=$shipment_id order_id=$order_id}}
         </td>
     </tr>
 </table>

--- a/app/code/Magento/Sales/view/frontend/layout/sales_email_order_shipment_track.xml
+++ b/app/code/Magento/Sales/view/frontend/layout/sales_email_order_shipment_track.xml
@@ -8,7 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <update handle="sales_email_order_shipment_renderers"/>
     <body>
-        <block class="Magento\Framework\View\Element\Template" name="sales.order.email.shipment.track" template="Magento_Sales::email/shipment/track.phtml">
+        <block class="Magento\Sales\Block\Order\Email\Shipment\Items" name="sales.order.email.shipment.track" template="Magento_Sales::email/shipment/track.phtml">
             <arguments>
                 <argument name="tracking_url" xsi:type="object">Magento\Sales\Block\DataProviders\Email\Shipment\TrackingUrl</argument>
             </arguments>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/creditmemo_new.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/creditmemo_new.html
@@ -20,6 +20,8 @@
 "var store_email":"Store Email",
 "var creditmemo":"Credit Memo",
 "var order":"Order",
+"var order_id": "Order DB Id",
+"var creditmemo_id": "Credit Memo DB Id",
 "var order_data.is_not_virtual":"Order Type"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -79,7 +81,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_creditmemo_items" creditmemo=$creditmemo order=$order}}
+            {{layout handle="sales_email_order_creditmemo_items" creditmemo_id=$creditmemo_id order_id=$order_id}}
         </td>
     </tr>
 </table>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/creditmemo_new_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/creditmemo_new_guest.html
@@ -19,6 +19,8 @@
 "var store_email":"Store Email",
 "var creditmemo":"Credit Memo",
 "var order":"Order",
+"var order_id": "Order DB Id",
+"var creditmemo_id": "Credit Memo DB Id",
 "var order_data.is_not_virtual":"Order Type"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -77,7 +79,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_creditmemo_items" creditmemo=$creditmemo order=$order}}
+            {{layout handle="sales_email_order_creditmemo_items" creditmemo_id=$creditmemo_id order_id=$order_id}}
         </td>
     </tr>
 </table>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/invoice_new.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/invoice_new.html
@@ -20,6 +20,8 @@
 "var store_email":"Store Email",
 "var invoice": "Invoice",
 "var order": "Order",
+"var order_id": "Order DB Id",
+"var invoice_id": "Invoice DB Id",
 "var order_data.is_not_virtual": "Order Type"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -79,7 +81,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout area="frontend" handle="sales_email_order_invoice_items" invoice=$invoice order=$order}}
+            {{layout area="frontend" handle="sales_email_order_invoice_items" invoice_id=$invoice_id order_id=$order_id}}
         </td>
     </tr>
 </table>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/invoice_new_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/invoice_new_guest.html
@@ -19,6 +19,8 @@
 "var store_email":"Store Email",
 "var invoice": "Invoice",
 "var order": "Order",
+"var order_id": "Order DB Id",
+"var invoice_id": "Invoice DB Id",
 "var order_data.is_not_virtual": "Order Type"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -77,7 +79,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_invoice_items" invoice=$invoice order=$order}}
+            {{layout handle="sales_email_order_invoice_items" invoice_id=$invoice_id order_id=$order_id}}
         </td>
     </tr>
 </table>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/order_new.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/order_new.html
@@ -20,6 +20,7 @@
 "var order":"Order",
 "var order_data.is_not_virtual":"Order Type",
 "var order_data.customer_name":"Customer Name",
+"var order_id": "Order DB Id",
 "var this.getUrl($store,'customer/account/',[_nosid:1])":"Customer Account URL"
 } @-->
 
@@ -85,7 +86,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_items" order=$order area="frontend"}}
+            {{layout handle="sales_email_order_items" order_id=$order_id area="frontend"}}
         </td>
     </tr>
 </table>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/order_new_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/order_new_guest.html
@@ -19,6 +19,7 @@
 "var store.frontend_name":"Store Frontend Name",
 "var store_email":"Store Email",
 "var order":"Order",
+"var order_id": "Order DB Id",
 "var order_data.is_not_virtual":"Order Type"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -82,7 +83,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_items" order=$order}}
+            {{layout handle="sales_email_order_items" order_id=$order_id}}
         </td>
     </tr>
 </table>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_new.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_new.html
@@ -21,7 +21,9 @@
 "var store_email":"Store Email",
 "var order_data.is_not_virtual": "Order Type",
 "var shipment": "Shipment",
-"var order": "Order"
+"var order": "Order",
+"var order_id": "Order DB Id",
+"var shipment_id": "Shipment DB Id"
 } @-->
 {{template config_path="design/email/header_template"}}
 
@@ -55,7 +57,7 @@
                 </tr>
             </table>
             {{/depend}}
-            {{layout handle="sales_email_order_shipment_track" shipment=$shipment order=$order}}
+            {{layout handle="sales_email_order_shipment_track" shipment_id=$shipment_id order_id=$order_id}}
             <table class="order-details">
                 <tr>
                     <td class="address-details">
@@ -82,7 +84,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_shipment_items" shipment=$shipment order=$order}}
+            {{layout handle="sales_email_order_shipment_items" shipment_id=$shipment_id order_id=$order_id}}
         </td>
     </tr>
 </table>

--- a/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_new_guest.html
+++ b/app/design/frontend/Magento/luma/Magento_Sales/email/shipment_new_guest.html
@@ -21,6 +21,8 @@
 "var order_data.is_not_virtual": "Order Type",
 "var shipment": "Shipment",
 "var order": "Order",
+"var order_id": "Order DB Id",
+"var shipment_id": "Shipment DB Id",
 "var this.getUrl($store,'customer/account/',[_nosid:1])":"Customer Account URL"
 } @-->
 {{template config_path="design/email/header_template"}}
@@ -54,7 +56,7 @@
                 </tr>
             </table>
             {{/depend}}
-            {{layout handle="sales_email_order_shipment_track" shipment=$shipment order=$order}}
+            {{layout handle="sales_email_order_shipment_track" shipment_id=$shipment_id order_id=$order_id}}
             <table class="order-details">
                 <tr>
                     <td class="address-details">
@@ -81,7 +83,7 @@
                     {{/depend}}
                 </tr>
             </table>
-            {{layout handle="sales_email_order_shipment_items" shipment=$shipment order=$order}}
+            {{layout handle="sales_email_order_shipment_items" shipment_id=$shipment_id order_id=$order_id}}
         </td>
     </tr>
 </table>


### PR DESCRIPTION
### Description
- Original issue: https://github.com/magento/magento2/issues/26882

The issue was resolved in `2.4-develop` https://github.com/magento/magento2/issues/26882#issuecomment-611523401

This backports https://github.com/magento/magento2/commit/1f4166bc94bc3143e30e1f66243391ccd8434f1f

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
