### PR TITLE
Incorrect item subtotal on partial invoice email

### DIFF
--- a/app/code/Magento/Sales/view/frontend/templates/email/items/invoice/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/invoice/default.phtml
@@ -28,6 +28,6 @@
     </td>
     <td class="item-qty"><?= (float) $_item->getQty() ?></td>
     <td class="item-price">
-        <?= /* @noEscape */ $block->getItemPrice($_item->getOrderItem()) ?>
+        <?= /* @noEscape */ $block->getItemPrice($_item) ?>
     </td>
 </tr>


### PR DESCRIPTION
### Description (*)
Magento version 2.3.3 Incorrect item subtotal on partial invoice email.

### Fixed Issues (if relevant)
#28295 : Incorrect item subtotal on partial invoice email.

### Manual testing scenarios (*)
1> Add a product to cart
2> Increase quantity (6 for example)
3> Place order
4> Go to admin, open the order and click invoice
5> Update the quantity to half
6> Check Email Copy of Invoice and click Submit

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
