### PR TITLE
Issue: #27570 Fixed issue of payment title in store view

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Payment/Info.php
+++ b/app/code/Magento/Sales/Model/Order/Payment/Info.php
@@ -105,6 +105,8 @@ class Info extends AbstractModel implements InfoInterface
     }
 
     /**
+     * Get the current order to manipulate order details
+     *
      * @return mixed
      * @throws \Magento\Framework\Exception\LocalizedException
      */


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The payment method title was not proper based on the store view on the order view page in the admin panel. It was showing the default config value for the payment method title always.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#27570

### Preconditions (*)
1. Magento multi-store setup (Store A, store B)
2. 'Cache on delivery' payment method is enabled

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Change 'Cache on Delivery' method title in the scope of store B configurations in Stores -> Config -> 2. Sales Methods -> Payment Methods -> Cache On Delivery
3. Place the Order with 'cache on delivery' in the scope of Store B.
4. Open order details in Admin Panel

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
