### PR TITLE
Remove redundant argument in method useProductItem

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/Compare/ListCompare.php
+++ b/app/code/Magento/Catalog/Block/Product/Compare/ListCompare.php
@@ -149,7 +149,7 @@ class ListCompare extends \Magento\Catalog\Block\Product\AbstractProduct
             $this->_compareProduct->setAllowUsedFlat(false);
 
             $this->_items = $this->_itemCollectionFactory->create();
-            $this->_items->useProductItem(true)->setStoreId($this->_storeManager->getStore()->getId());
+            $this->_items->useProductItem()->setStoreId($this->_storeManager->getStore()->getId());
 
             if ($this->httpContext->getValue(Context::CONTEXT_AUTH)) {
                 $this->_items->setCustomerId($this->currentCustomer->getCustomerId());

--- a/app/code/Magento/Catalog/Helper/Product/Compare.php
+++ b/app/code/Magento/Catalog/Helper/Product/Compare.php
@@ -279,7 +279,7 @@ class Compare extends \Magento\Framework\Url\Helper\Data
             // cannot be placed in constructor because of the cyclic dependency which cannot be fixed with proxy class
             // collection uses this helper in constructor when calling isEnabledFlat() method
             $this->_itemCollection = $this->_itemCollectionFactory->create();
-            $this->_itemCollection->useProductItem(true)->setStoreId($this->_storeManager->getStore()->getId());
+            $this->_itemCollection->useProductItem()->setStoreId($this->_storeManager->getStore()->getId());
 
             if ($this->_customerSession->isLoggedIn()) {
                 $this->_itemCollection->setCustomerId($this->_customerSession->getCustomerId());
@@ -313,7 +313,7 @@ class Compare extends \Magento\Framework\Url\Helper\Data
     {
         /** @var $collection Collection */
         $collection = $this->_itemCollectionFactory->create()
-            ->useProductItem(true);
+            ->useProductItem();
         if (!$logout && $this->_customerSession->isLoggedIn()) {
             $collection->setCustomerId($this->_customerSession->getCustomerId());
         } elseif ($this->_customerId) {

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Sidebar/Compared.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Sidebar/Compared.php
@@ -46,23 +46,15 @@ class Compared extends \Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Abstr
         $collection = $this->getData('item_collection');
         if ($collection === null) {
             if ($collection = $this->getCreateOrderModel()->getCustomerCompareList()) {
-                $collection = $collection->getItemCollection()->useProductItem(
-                    true
-                )->setStoreId(
-                    $this->getQuote()->getStoreId()
-                )->addStoreFilter(
-                    $this->getQuote()->getStoreId()
-                )->setCustomerId(
-                    $this->getCustomerId()
-                )->addAttributeToSelect(
-                    'name'
-                )->addAttributeToSelect(
-                    'price'
-                )->addAttributeToSelect(
-                    'image'
-                )->addAttributeToSelect(
-                    'status'
-                )->load();
+                $collection = $collection->getItemCollection()
+                    ->useProductItem()
+                    ->setStoreId($this->getQuote()->getStoreId())
+                    ->addStoreFilter($this->getQuote()->getStoreId())
+                    ->setCustomerId($this->getCustomerId())
+                    ->addAttributeToSelect('name')
+                    ->addAttributeToSelect('price')->addAttributeToSelect('image')
+                    ->addAttributeToSelect('status')
+                    ->load();
             }
             $this->setData('item_collection', $collection);
         }

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Sidebar/Pcompared.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Sidebar/Pcompared.php
@@ -89,13 +89,11 @@ class Pcompared extends \Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\Abst
             // get products to skip
             $skipProducts = [];
             if ($collection = $this->getCreateOrderModel()->getCustomerCompareList()) {
-                $collection = $collection->getItemCollection()->useProductItem(
-                    true
-                )->setStoreId(
-                    $this->getStoreId()
-                )->setCustomerId(
-                    $this->getCustomerId()
-                )->load();
+                $collection = $collection->getItemCollection()
+                    ->useProductItem()
+                    ->setStoreId($this->getStoreId())
+                    ->setCustomerId($this->getCustomerId())
+                    ->load();
                 foreach ($collection as $_item) {
                     $skipProducts[] = $_item->getProductId();
                 }

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Product/CompareTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Product/CompareTest.php
@@ -412,7 +412,7 @@ class CompareTest extends \Magento\TestFramework\TestCase\AbstractController
         $compareItems = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
             \Magento\Catalog\Model\ResourceModel\Product\Compare\Item\Collection::class
         );
-        $compareItems->useProductItem(true);
+        $compareItems->useProductItem();
         // important
         $compareItems->setVisitorId(
             \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I see that method `useProductItem(true)` get `true` as argument 
But actually if i will see in https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Catalog/Model/ResourceModel/Product/Compare/Item/Collection.php#L367 I see that method `useProductItem()` does not accept any argument
