### PR TITLE
Fix duplicate css when enable critical path

### DIFF
--- a/app/code/Magento/Theme/Controller/Result/AsyncCssPlugin.php
+++ b/app/code/Magento/Theme/Controller/Result/AsyncCssPlugin.php
@@ -10,6 +10,9 @@ namespace Magento\Theme\Controller\Result;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Framework\App\Response\Http;
+use Magento\Framework\App\Response\HttpInterface as HttpResponseInterface;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\View\Result\Layout;
 
 /**
  * Plugin for asynchronous CSS loading.
@@ -32,48 +35,94 @@ class AsyncCssPlugin
     }
 
     /**
-     * Load CSS asynchronously if it is enabled in configuration.
+     * Extracts styles to head after critical css if critical path feature is enabled.
      *
-     * @param Http $subject
-     * @return void
+     * @param Layout $subject
+     * @param Layout $result
+     * @param HttpResponseInterface|ResponseInterface $httpResponse
+     * @return Layout (That should be void, actually)
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeSendResponse(Http $subject): void
+    public function afterRenderResult(Layout $subject, Layout $result, ResponseInterface $httpResponse)
     {
-        $content = $subject->getContent();
+        if (!$this->isCssCriticalEnabled()) {
+            return $result;
+        }
 
-        if (\is_string($content) && strpos($content, '</body') !== false && $this->scopeConfig->isSetFlag(
-            self::XML_PATH_USE_CSS_CRITICAL_PATH,
-            ScopeInterface::SCOPE_STORE
-        )) {
-            $cssMatches = [];
-            // add link rel preload to style sheets
-            $content = preg_replace_callback(
-                '@<link\b.*?rel=("|\')stylesheet\1.*?/>@',
-                function ($matches) use (&$cssMatches) {
-                    $cssMatches[] = $matches[0];
-                    preg_match('@href=("|\')(.*?)\1@', $matches[0], $hrefAttribute);
-                    $href = $hrefAttribute[2];
-                    if (preg_match('@media=("|\')(.*?)\1@', $matches[0], $mediaAttribute)) {
-                        $media = $mediaAttribute[2];
-                    }
-                    $media = $media ?? 'all';
-                    $loadCssAsync = sprintf(
-                        '<link rel="preload" as="style" media="%s"' .
-                         ' onload="this.onload=null;this.rel=\'stylesheet\'"' .
-                        ' href="%s" />',
-                        $media,
-                        $href
-                    );
+        $content = (string)$httpResponse->getContent();
+        $headCloseTag = '</head>';
 
-                    return $loadCssAsync;
-                },
-                $content
-            );
+        $headEndTagFound = strpos($content, $headCloseTag) !== false;
 
-            if (!empty($cssMatches)) {
-                $content = str_replace('</body', implode("\n", $cssMatches) . "\n</body", $content);
-                $subject->setContent($content);
+        if ($headEndTagFound) {
+            $styles = $this->extractLinkTags($content);
+            if ($styles) {
+                $newHeadEndTagPosition = strrpos($content, $headCloseTag);
+                $content = substr_replace($content, $styles . "\n", $newHeadEndTagPosition, 0);
+                $httpResponse->setContent($content);
             }
         }
+
+        return $result;
+    }
+
+    /**
+     * Extracts link tags found in given content.
+     *
+     * @param string $content
+     */
+    private function extractLinkTags(string &$content): string
+    {
+        $styles = '';
+        $styleOpen = '<link';
+        $styleClose = '>';
+        $styleOpenPos = strpos($content, $styleOpen);
+
+        while ($styleOpenPos !== false) {
+            $styleClosePos = strpos($content, $styleClose, $styleOpenPos);
+            $style = substr($content, $styleOpenPos, $styleClosePos - $styleOpenPos + strlen($styleClose));
+
+            if (!preg_match('@rel=["\']stylesheet["\']@', $style)) {
+                // Link is not a stylesheet, search for another one after it.
+                $styleOpenPos = strpos($content, $styleOpen, $styleClosePos);
+                continue;
+            }
+            // Remove the link from HTML to add it before </head> tag later.
+            $content = str_replace($style, '', $content);
+
+            if (!preg_match('@href=("|\')(.*?)\1@', $style, $hrefAttribute)) {
+                throw new \RuntimeException("Invalid link {$style} syntax provided");
+            }
+            $href = $hrefAttribute[2];
+
+            if (preg_match('@media=("|\')(.*?)\1@', $style, $mediaAttribute)) {
+                $media = $mediaAttribute[2];
+            }
+            $media = $media ?? 'all';
+
+            $style = sprintf(
+                '<link rel="stylesheet" media="print" onload="this.onload=null;this.media=\'%s\'" href="%s">',
+                $media,
+                $href
+            );
+            $styles .= "\n" . $style;
+            // Link was cut out, search for the next one at its former position.
+            $styleOpenPos = strpos($content, $styleOpen, $styleOpenPos);
+        }
+
+        return $styles;
+    }
+
+    /**
+     * Returns information whether css critical path is enabled
+     *
+     * @return bool
+     */
+    private function isCssCriticalEnabled(): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_USE_CSS_CRITICAL_PATH,
+            ScopeInterface::SCOPE_STORE
+        );
     }
 }

--- a/app/code/Magento/Theme/etc/frontend/di.xml
+++ b/app/code/Magento/Theme/etc/frontend/di.xml
@@ -26,11 +26,9 @@
     <type name="Magento\Framework\Controller\ResultInterface">
         <plugin name="result-messages" type="Magento\Theme\Controller\Result\MessagePlugin"/>
     </type>
-    <type name="Magento\Framework\App\Response\Http">
-        <plugin name="asyncCssLoad" type="Magento\Theme\Controller\Result\AsyncCssPlugin"/>
-    </type>
     <type name="Magento\Framework\View\Result\Layout">
-        <plugin name="deferJsToFooter" type="Magento\Theme\Controller\Result\JsFooterPlugin" sortOrder="-10"/>
+        <plugin name="asyncCssLoad" type="Magento\Theme\Controller\Result\AsyncCssPlugin" />
+        <plugin name="deferJsToFooter" type="Magento\Theme\Controller\Result\JsFooterPlugin" sortOrder="-10" />
     </type>
     <type name="Magento\Theme\Block\Html\Header\CriticalCss">
         <arguments>

--- a/app/code/Magento/Theme/view/frontend/layout/default_head_blocks.xml
+++ b/app/code/Magento/Theme/view/frontend/layout/default_head_blocks.xml
@@ -18,6 +18,7 @@
                     <argument name="criticalCssViewModel" xsi:type="object">Magento\Theme\Block\Html\Header\CriticalCss</argument>
                 </arguments>
             </block>
+            <!-- Todo: Block css_rel_preload_script will be removed in next release as polyfill isn't used anymore -->
             <block name="css_rel_preload_script" ifconfig="dev/css/use_css_critical_path" template="Magento_Theme::js/css_rel_preload.phtml"/>
         </referenceBlock>
         <referenceContainer name="after.body.start">

--- a/app/code/Magento/Theme/view/frontend/templates/html/main_css_preloader.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/main_css_preloader.phtml
@@ -4,12 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ */
+
 ?>
 <div data-role="main-css-loader" class="loading-mask">
     <div class="loader">
-        <img src="<?= $block->escapeUrl($block->getViewFileUrl('images/loader-1.gif')); ?>"
-             alt="<?= $block->escapeHtml(__('Loading...')); ?>">
+        <img src="<?= $escaper->escapeUrl($block->getViewFileUrl('images/loader-1.gif')); ?>"
+             alt="<?= $escaper->escapeHtml(__('Loading...')); ?>">
     </div>
     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
         "position: absolute;",

--- a/app/code/Magento/Theme/view/frontend/templates/js/css_rel_preload.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/js/css_rel_preload.phtml
@@ -2,12 +2,12 @@
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
+ * @deprecated as polyfill isn't used anymore
  */
 
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
 
-<?php $scriptString = <<<script
+$scriptString = <<<script
 
     /*! loadCSS rel=preload polyfill. [c]2017 Filament Group, Inc. MIT License */
     !function(t){"use strict";t.loadCSS||(t.loadCSS=function(){});var e=loadCSS.relpreload={};
@@ -24,5 +24,3 @@
     ("undefined"!=typeof global?global:this);
 
 script;
-?>
-<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>

--- a/dev/tests/integration/testsuite/Magento/Framework/Interception/PluginListGeneratorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Interception/PluginListGeneratorTest.php
@@ -11,8 +11,14 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\TestFramework\Application;
 use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
 
-class PluginListGeneratorTest extends \PHPUnit\Framework\TestCase
+/**
+ * Provide tests for PluginListGeneratorTest
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class PluginListGeneratorTest extends TestCase
 {
     /**
      * Generated plugin list config for frontend scope
@@ -93,8 +99,7 @@ class PluginListGeneratorTest extends \PHPUnit\Framework\TestCase
         $expected = [
             1 => [
                 0 => 'genericHeaderPlugin',
-                1 => 'asyncCssLoad',
-                2 => 'response-http-page-cache'
+                1 => 'response-http-page-cache'
             ]
         ];
         // Here in test is assumed that this class below has 3 plugins. But the amount of plugins and class itself
@@ -104,6 +109,7 @@ class PluginListGeneratorTest extends \PHPUnit\Framework\TestCase
             $configData[2],
             'Processed plugin does not exist in the processed plugins array.'
         );
+
         $this->assertSame(
             $expected,
             $configData[2]['Magento\\Framework\\App\\Response\\Http_sendResponse___self'],
@@ -116,7 +122,7 @@ class PluginListGeneratorTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    private function getCustomDirs()
+    private function getCustomDirs(): array
     {
         $path = DirectoryList::PATH;
         $generated = "{$this->application->getTempDir()}/generated";


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR continue great works https://github.com/magento/magento2/pull/27211 by @krzksz in latest codebase
This PR aim to bring patch fix issue css show twice. Before the fix magento place redundant link style at bottom of page before body close end

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#26498

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Enable critical path css
2. Run deploy static content + clean cache
3. Go to homepage inspect in browser element "page-wrapper"
4. We will see 2 file styles-l.css have style apply for that element
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
