### PR TITLE
Add additional parameter to getPathInfo method

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Io/File.php
+++ b/lib/internal/Magento/Framework/Filesystem/Io/File.php
@@ -900,10 +900,12 @@ class File extends AbstractIo
      * Get path info
      *
      * @param string $path
+     * @param null   $options
+     *
      * @return mixed
      */
-    public function getPathInfo($path)
+    public function getPathInfo($path, $options = null)
     {
-        return pathinfo($path);
+        return pathinfo($path, $options);
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR add additional parameter to `lib/internal/Magento/Framework/Filesystem/Io/File.php::getPathInfo()`  
according documentation https://www.php.net/manual/en/function.pathinfo.php `pathinfo` has two parameters. 
Also I see a lot of cases where `pathinfo` are used directly instead 
 using `lib/internal/Magento/Framework/Filesystem/Io/File.php::getPathInfo()` https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php#L211 

