### PR TITLE
Added null page attribute value to url generate parameters

### DIFF
--- a/app/code/Magento/Swatches/Block/LayeredNavigation/RenderLayered.php
+++ b/app/code/Magento/Swatches/Block/LayeredNavigation/RenderLayered.php
@@ -57,6 +57,13 @@ class RenderLayered extends Template
     protected $mediaHelper;
 
     /**
+     * Html pager block
+     *
+     * @var \Magento\Theme\Block\Html\Pager
+     */
+    private $htmlPagerBlock;
+
+    /**
      * @param Template\Context $context
      * @param Attribute $eavAttribute
      * @param AttributeFactory $layerAttribute
@@ -70,12 +77,14 @@ class RenderLayered extends Template
         AttributeFactory $layerAttribute,
         \Magento\Swatches\Helper\Data $swatchHelper,
         \Magento\Swatches\Helper\Media $mediaHelper,
+        \Magento\Theme\Block\Html\Pager $htmlPagerBlock,
         array $data = []
     ) {
         $this->eavAttribute = $eavAttribute;
         $this->layerAttribute = $layerAttribute;
         $this->swatchHelper = $swatchHelper;
         $this->mediaHelper = $mediaHelper;
+        $this->htmlPagerBlock = $htmlPagerBlock;
 
         parent::__construct($context, $data);
     }
@@ -132,7 +141,10 @@ class RenderLayered extends Template
      */
     public function buildUrl($attributeCode, $optionId)
     {
-        $query = [$attributeCode => $optionId];
+        $query = [
+            $attributeCode => $optionId,
+            $this->htmlPagerBlock->getPageVarName() => null
+        ];
         return $this->_urlBuilder->getUrl('*/*/*', ['_current' => true, '_use_rewrite' => true, '_query' => $query]);
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Query parameters passed to buildUrl() method were missing page attribute, which should be set to null in order to reset page value.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#27989

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Go to Storefront;
2. Go to Men->Tops->Hoodies & Sweatshirts category (for example);
3. Go to the second 2 page;
4. On filter panel choose black from Color (for example);

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
