### PR TITLE
Simplify version constraint for the php-amqplib/php-amqplib package, …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "monolog/monolog": "^1.17",
         "paragonie/sodium_compat": "^1.6",
         "pelago/emogrifier": "^3.1.0",
-        "php-amqplib/php-amqplib": "~2.7.0||~2.10.0",
+        "php-amqplib/php-amqplib": "~2.10.0",
         "phpseclib/mcrypt_compat": "1.0.8",
         "phpseclib/phpseclib": "2.0.*",
         "ramsey/uuid": "~3.8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e86af25d9a4a1942c437cca58f9f1efb",
+    "content-hash": "80ab7a930d23672d15c2ffda23f89a15",
     "packages": [
         {
             "name": "colinmollenhour/cache-backend-file",


### PR DESCRIPTION
…now that the php extension sockets is considered required for Magento.

### Description (*)
As requested in https://github.com/magento/magento2/issues/27200 by @melnikovi, here's a pull request which simplifies the version constraint on the `php-amqplib/php-amqplib` package now that the php extension `sockets` is considered required for Magento 2.

Version 2.7 of `php-amqplib/php-amqplib` didn't require the `sockets` extension, but since version 2.8.1 it became required.

This prevents developers from accidentally updating the `composer.lock` file inside this github repo as well as inside projects where it changes the version of `php-amqplib/php-amqplib` based on if they have the `sockets` extension installed or not, which can be quite annoying to deal with.

### Related Pull Requests

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/magento2/issues/27200

### Manual testing scenarios (*)
1. Have a PHP installation where the `sockets` extension is not installed
2. Try to install Magento using composer after this fix, it should no longer work.

### Questions or comments
I'm not entirely sure, but should we also define `ext-sockets` in the `composer.json` file of Magento 2? I'm a bit confused about [the comment](https://github.com/magento/devdocs/pull/6922#issuecomment-605032752) from @dobooth if the list of extensions in devdocs is solely generated from the `composer.json` file, or from all composer dependencies?

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
