### PR TITLE
Set ID field name to quote item collection

### DIFF
--- a/app/code/Magento/Quote/Model/ResourceModel/Quote/Item/Collection.php
+++ b/app/code/Magento/Quote/Model/ResourceModel/Quote/Item/Collection.php
@@ -64,6 +64,11 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\VersionContro
     private $recollectQuote = false;
 
     /**
+     * @inheritDoc
+     */
+    protected $_idFieldName = 'item_id';
+
+    /**
      * @param \Magento\Framework\Data\Collection\EntityFactory $entityFactory
      * @param \Psr\Log\LoggerInterface $logger
      * @param \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Without this, the mass-action filter fails
since it depends on the collection having a valid
resource ID field name.

See `\Magento\Ui\Component\MassAction\Filter::getCollection`:

```
// ...

$collection->addFieldToFilter(
    $collection->getIdFieldName(), // <-- This currently returns NULL.
    ['in' => $filterIds]
);

return $collection;
```

### Manual testing scenarios (*)
1. Create a listing UI component with a data provider that uses the quote item collection. For example:
```
<virtualType name="CartItemDataSourceCollection" type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
    <arguments>
        <argument name="mainTable" xsi:type="string">quote_item</argument>
        <argument name="resourceModel" xsi:type="string">Magento\Quote\Model\ResourceModel\Quote\Item</argument>
    </arguments>
</virtualType>

<type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
    <arguments>
        <argument name="collections" xsi:type="array">
            <item name="prescription_counseling_service_cart_items_data_source" xsi:type="string">CartItemDataSourceCollection</item>
        </argument>
    </arguments>
</type>
```
2. Add a mass-action component to the listing with any mass-action. Implement the mass-action controller and be sure to use `\Magento\Ui\Component\MassAction\Filter::getCollection` in the controller to create the filtered mass-action collection. Without this PR's fix, it will fail since the collection ID field is not set when trying to get it in `magento/vendor/magento/module-ui/Component/MassAction/Filter.php:110`.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
