### PR TITLE
MFTF: Deprecate ActionGroup that should no longer be used

### DIFF
--- a/app/code/Magento/User/Test/Mftf/ActionGroup/LoginNewUserActionGroup.xml
+++ b/app/code/Magento/User/Test/Mftf/ActionGroup/LoginNewUserActionGroup.xml
@@ -5,10 +5,8 @@
   * See COPYING.txt for license details.
   */
 -->
-<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
-    <!--Login New User-->
-    <actionGroup name="LoginNewUser">
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="LoginNewUserActionGroup" deprecated="Use AdminLoginActionGroup instead">
         <annotations>
             <description>Goes to the Backend Admin Login page. Fill Username and Password. Click on Sign In.</description>
         </annotations>


### PR DESCRIPTION
### Description (*)
This PR deprecated ActionGroup that should not be used (is not used in Magento itself), as it's duplicate for existing `AdminLoginActionGroup`, but not following Magento Best Practices.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
