### PR TITLE
MFTF: Fix the names for Action Groups, that are missing `ActionGroup` suffix

### DIFF
--- a/app/code/Magento/CatalogWidget/Test/Mftf/ActionGroup/AdminCreateBlockWithWidgetActionGroup.xml
+++ b/app/code/Magento/CatalogWidget/Test/Mftf/ActionGroup/AdminCreateBlockWithWidgetActionGroup.xml
@@ -8,7 +8,7 @@
 
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
-    <actionGroup name="AdminCreateBlockWithWidget">
+    <actionGroup name="AdminCreateBlockWithWidgetActionGroup">
         <annotations>
             <description>Inserts a Widget into a Block on the Block creation/edit page.</description>
         </annotations>

--- a/app/code/Magento/CatalogWidget/Test/Mftf/Test/CatalogProductListWidgetOperatorsTest.xml
+++ b/app/code/Magento/CatalogWidget/Test/Mftf/Test/CatalogProductListWidgetOperatorsTest.xml
@@ -46,7 +46,7 @@
             <argument name="CMSBlockPage" value="$$createPreReqBlock$$"/>
         </actionGroup>
 
-        <actionGroup ref="AdminCreateBlockWithWidget" stepKey="adminCreateBlockWithWidget">
+        <actionGroup ref="AdminCreateBlockWithWidgetActionGroup" stepKey="adminCreateBlockWithWidget">
             <argument name="addCondition" value="Price"/>
             <argument name="isCondition" value="greater than"/>
             <argument name="fieldCondition" value="20"/>
@@ -89,7 +89,7 @@
             <argument name="CMSBlockPage" value="$$createPreReqBlock$$"/>
         </actionGroup>
 
-        <actionGroup ref="AdminCreateBlockWithWidget" stepKey="adminCreateBlockWithWidgetLessThan">
+        <actionGroup ref="AdminCreateBlockWithWidgetActionGroup" stepKey="adminCreateBlockWithWidgetLessThan">
             <argument name="addCondition" value="Price"/>
             <argument name="isCondition" value="less than"/>
             <argument name="fieldCondition" value="20"/>
@@ -109,7 +109,7 @@
             <argument name="CMSBlockPage" value="$$createPreReqBlock$$"/>
         </actionGroup>
 
-        <actionGroup ref="AdminCreateBlockWithWidget" stepKey="adminCreateBlockWithWidgetEqualsOrGreaterThan">
+        <actionGroup ref="AdminCreateBlockWithWidgetActionGroup" stepKey="adminCreateBlockWithWidgetEqualsOrGreaterThan">
             <argument name="addCondition" value="Price"/>
             <argument name="isCondition" value="equals or greater than"/>
             <argument name="fieldCondition" value="50"/>
@@ -129,7 +129,7 @@
             <argument name="CMSBlockPage" value="$$createPreReqBlock$$"/>
         </actionGroup>
 
-        <actionGroup ref="AdminCreateBlockWithWidget" stepKey="adminCreateBlockWithWidgetEqualsOrLessThan">
+        <actionGroup ref="AdminCreateBlockWithWidgetActionGroup" stepKey="adminCreateBlockWithWidgetEqualsOrLessThan">
             <argument name="addCondition" value="Price"/>
             <argument name="isCondition" value="equals or less than"/>
             <argument name="fieldCondition" value="50"/>

--- a/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertThatShippingAndBillingAddressTheSameActionGroup.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertThatShippingAndBillingAddressTheSameActionGroup.xml
@@ -8,8 +8,7 @@
 
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
-    <!--Assert That Shipping And Billing Address are the same-->
-    <actionGroup name="AssertThatShippingAndBillingAddressTheSame">
+    <actionGroup name="AssertThatShippingAndBillingAddressTheSameActionGroup">
         <annotations>
             <description>Validates that the Shipping and Billing Addresses are the same.</description>
         </annotations>

--- a/app/code/Magento/Checkout/Test/Mftf/ActionGroup/FillShippingZipFormActionGroup.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/ActionGroup/FillShippingZipFormActionGroup.xml
@@ -8,14 +8,14 @@
 
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
-    <actionGroup name="FillShippingZipForm">
+    <actionGroup name="FillShippingZipFormActionGroup">
         <annotations>
             <description>Fills in the provided Address details (Country, State and Zip Code) in the 'Estimate Shipping and Tax' section of the Storefront Shopping Cart page.</description>
         </annotations>
         <arguments>
             <argument name="address"/>
         </arguments>
-        
+
         <conditionalClick stepKey="openShippingDetails" selector="{{CheckoutCartSummarySection.shippingHeading}}" dependentSelector="{{CheckoutCartSummarySection.country}}" visible="false"/>
         <waitForLoadingMaskToDisappear stepKey="waitForLoadingMask"/>
         <waitForElementVisible selector="{{CheckoutCartSummarySection.country}}" time="30" stepKey="waitForCountryFieldAppears"/>

--- a/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontOpenMiniCartActionGroup/ClickViewAndEditCartFromMiniCartActionGroup.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/ActionGroup/StorefrontOpenMiniCartActionGroup/ClickViewAndEditCartFromMiniCartActionGroup.xml
@@ -7,7 +7,7 @@
 -->
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
-    <actionGroup name="clickViewAndEditCartFromMiniCartActionGroup">
+    <actionGroup name="ClickViewAndEditCartFromMiniCartActionGroup">
         <annotations>
             <description>Clicks on the Storefront Mini Shopping Cart icon. Clicks on the 'View and Edit Cart' link. Validates that the URL is present and correct. PLEASE NOTE: The URL is Hardcoded.</description>
         </annotations>

--- a/app/code/Magento/Checkout/Test/Mftf/Test/IdentityOfDefaultBillingAndShippingAddressTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/IdentityOfDefaultBillingAndShippingAddressTest.xml
@@ -72,7 +72,7 @@
         <actionGroup ref="StorefrontOpenMyAccountPageActionGroup" stepKey="goToMyAccountPage" />
 
         <!-- Assert That Shipping And Billing Address are the same -->
-        <actionGroup ref="AssertThatShippingAndBillingAddressTheSame" stepKey="assertThatShippingAndBillingAddressTheSame"/>
+        <actionGroup ref="AssertThatShippingAndBillingAddressTheSameActionGroup" stepKey="assertThatShippingAndBillingAddressTheSame"/>
 
         <after>
             <!-- Delete created Product -->

--- a/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutAsCustomerUsingDefaultAddressTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutAsCustomerUsingDefaultAddressTest.xml
@@ -51,7 +51,7 @@
 
         <!-- Go to shopping cart -->
         <actionGroup ref="ClickViewAndEditCartFromMiniCartActionGroup" stepKey="goToShoppingCartFromMinicart"/>
-        <actionGroup ref="FillShippingZipForm" stepKey="fillShippingZipForm">
+        <actionGroup ref="FillShippingZipFormActionGroup" stepKey="fillShippingZipForm">
             <argument name="address" value="US_Address_CA"/>
         </actionGroup>
         <click selector="{{CheckoutCartSummarySection.proceedToCheckout}}" stepKey="clickProceedToCheckout"/>

--- a/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutAsCustomerUsingNewAddressTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutAsCustomerUsingNewAddressTest.xml
@@ -51,7 +51,7 @@
 
         <!-- Go to shopping cart -->
         <actionGroup ref="ClickViewAndEditCartFromMiniCartActionGroup" stepKey="goToShoppingCartFromMinicart"/>
-        <actionGroup ref="FillShippingZipForm" stepKey="fillShippingZipForm">
+        <actionGroup ref="FillShippingZipFormActionGroup" stepKey="fillShippingZipForm">
             <argument name="address" value="US_Address_CA"/>
         </actionGroup>
         <click selector="{{CheckoutCartSummarySection.proceedToCheckout}}" stepKey="clickProceedToCheckout"/>

--- a/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutAsCustomerUsingNonDefaultAddressTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutAsCustomerUsingNonDefaultAddressTest.xml
@@ -51,7 +51,7 @@
 
         <!-- Go to shopping cart -->
         <actionGroup ref="ClickViewAndEditCartFromMiniCartActionGroup" stepKey="goToShoppingCartFromMinicart"/>
-        <actionGroup ref="FillShippingZipForm" stepKey="fillShippingZipForm">
+        <actionGroup ref="FillShippingZipFormActionGroup" stepKey="fillShippingZipForm">
             <argument name="address" value="US_Address_CA"/>
         </actionGroup>
         <click selector="{{CheckoutCartSummarySection.proceedToCheckout}}" stepKey="clickProceedToCheckout"/>

--- a/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutUsingSignInLinkTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutUsingSignInLinkTest.xml
@@ -51,7 +51,7 @@
 
         <!-- Go to shopping cart -->
         <actionGroup ref="ClickViewAndEditCartFromMiniCartActionGroup" stepKey="goToShoppingCartFromMinicart"/>
-        <actionGroup ref="FillShippingZipForm" stepKey="fillShippingZipForm">
+        <actionGroup ref="FillShippingZipFormActionGroup" stepKey="fillShippingZipForm">
             <argument name="address" value="US_Address_CA"/>
         </actionGroup>
         <click selector="{{CheckoutCartSummarySection.proceedToCheckout}}" stepKey="clickProceedToCheckout"/>

--- a/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutWithAllProductTypesTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/OnePageCheckoutWithAllProductTypesTest.xml
@@ -163,7 +163,7 @@
 
         <!--Go to shopping cart-->
         <actionGroup ref="ClickViewAndEditCartFromMiniCartActionGroup" stepKey="goToShoppingCartFromMinicart"/>
-        <actionGroup ref="FillShippingZipForm" stepKey="fillShippingZipForm">
+        <actionGroup ref="FillShippingZipFormActionGroup" stepKey="fillShippingZipForm">
             <argument name="address" value="US_Address_CA"/>
         </actionGroup>
 

--- a/app/code/Magento/Persistent/Test/Mftf/ActionGroup/StorefrontAssertPersistentRegistrationPageFieldsActionGroup.xml
+++ b/app/code/Magento/Persistent/Test/Mftf/ActionGroup/StorefrontAssertPersistentRegistrationPageFieldsActionGroup.xml
@@ -8,7 +8,7 @@
 
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
-    <actionGroup name="StorefrontAssertPersistentRegistrationPageFields" extends="StorefrontAssertRegistrationPageFields">
+    <actionGroup name="StorefrontAssertPersistentRegistrationPageFieldsActionGroup" extends="StorefrontAssertRegistrationPageFields">
         <seeCheckboxIsChecked selector="{{StorefrontCustomerSignInFormSection.rememberMe}}" after="seeConfirmPasswordField" stepKey="seeRememberMeChecked"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Persistent/Test/Mftf/Test/StorefrontVerifyShoppingCartPersistenceUnderLongTermCookieTest.xml
+++ b/app/code/Magento/Persistent/Test/Mftf/Test/StorefrontVerifyShoppingCartPersistenceUnderLongTermCookieTest.xml
@@ -51,7 +51,7 @@
         <!-- 1. Go to storefront and click the Create an Account link-->
         <amOnPage url="{{StorefrontHomePage.url}}" stepKey="amOnHomePage"/>
         <click selector="{{StorefrontPanelHeaderSection.createAnAccountLink}}" stepKey="clickCreateAnAccountLink" />
-        <actionGroup ref="StorefrontAssertPersistentRegistrationPageFields" stepKey="assertPersistentRegistrationPageFields"/>
+        <actionGroup ref="StorefrontAssertPersistentRegistrationPageFieldsActionGroup" stepKey="assertPersistentRegistrationPageFields"/>
 
         <!-- 2. Fill fields for registration, set password and unselect the Remember Me checkbox-->
         <actionGroup ref="StorefrontCreateCustomerOnRegisterPageDoNotRememberMeActionGroup" stepKey="registrationJohnSmithCustomer">

--- a/app/code/Magento/Tax/Test/Mftf/Test/AdminDeleteTaxRuleTest.xml
+++ b/app/code/Magento/Tax/Test/Mftf/Test/AdminDeleteTaxRuleTest.xml
@@ -64,7 +64,7 @@
             <argument name="productCount" value="1" />
         </actionGroup>
         <actionGroup ref="StorefrontOpenCartFromMinicartActionGroup" stepKey="openShoppingCart" />
-        <actionGroup ref="FillShippingZipForm" stepKey="fillShippingZipForm">
+        <actionGroup ref="FillShippingZipFormActionGroup" stepKey="fillShippingZipForm">
             <argument name="address" value="US_Address_Utah" />
         </actionGroup>
         <scrollTo selector="{{StorefrontProductPageSection.orderTotal}}" x="0" y="-80" stepKey="scrollToOrderTotal"/>

--- a/app/code/Magento/Tax/Test/Mftf/Test/AdminUpdateTaxRuleWithFixedZipUtahTest.xml
+++ b/app/code/Magento/Tax/Test/Mftf/Test/AdminUpdateTaxRuleWithFixedZipUtahTest.xml
@@ -91,7 +91,7 @@
             <argument name="productCount" value="1" />
         </actionGroup>
         <actionGroup ref="StorefrontOpenCartFromMinicartActionGroup" stepKey="openShoppingCart" />
-        <actionGroup ref="FillShippingZipForm" stepKey="fillShippingZipForm">
+        <actionGroup ref="FillShippingZipFormActionGroup" stepKey="fillShippingZipForm">
             <argument name="address" value="US_Address_Utah" />
         </actionGroup>
         <scrollTo selector="{{StorefrontProductPageSection.orderTotal}}" x="0" y="-80" stepKey="scrollToOrderTotal"/>


### PR DESCRIPTION
### Description (*)
Magento Functional Testing Framework expects all the filenames for Action Groups end with `ActionGroup` suffix. This is also expected filenames to be compliant with the Action Group name inside. According to that requirements, I've added `ActionGroup` suffix to the groups that were missing such, and applied changes to the Tests that were referring to modified AGs.

### Related Pull Requests
- https://github.com/magento/partners-magento2ee/pull/268
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
