### PR TITLE
MFTF: Replace redundant Xpath for `@id` attribute with CSS selector

### DIFF
--- a/app/code/Magento/Backend/Test/Mftf/Section/AdminMenuSection.xml
+++ b/app/code/Magento/Backend/Test/Mftf/Section/AdminMenuSection.xml
@@ -17,11 +17,11 @@
         <element name="widgets" type="button" selector="#nav li[data-ui-id='menu-magento-widget-cms-widget-instance']"/>
         <element name="stores" type="button" selector="#menu-magento-backend-stores"/>
         <element name="configuration" type="button" selector="#nav li[data-ui-id='menu-magento-config-system-config']"/>
-        <element name="dashboard" type="button" selector="//li[@id='menu-magento-backend-dashboard']"/>
-        <element name="sales" type="button" selector="//li[@id='menu-magento-sales-sales']"/>
-        <element name="marketing" type="button" selector="//li[@id='menu-magento-backend-marketing']"/>
-        <element name="system" type="button" selector="//li[@id='menu-magento-backend-system']"/>
-        <element name="findPartners" type="button" selector="//li[@id='menu-magento-marketplace-partners']"/>
+        <element name="dashboard" type="button" selector="#menu-magento-backend-dashboard"/>
+        <element name="sales" type="button" selector="#menu-magento-sales-sales"/>
+        <element name="marketing" type="button" selector="#menu-magento-backend-marketing"/>
+        <element name="system" type="button" selector="#menu-magento-backend-system"/>
+        <element name="findPartners" type="button" selector="#menu-magento-marketplace-partners"/>
 
         <!-- Navigate menu selectors -->
         <element name="menuItem" type="button" selector="li[data-ui-id='menu-{{dataUiId}}']" parameterized="true" timeout="30"/>

--- a/app/code/Magento/Bundle/Test/Mftf/Section/BundleStorefrontSection.xml
+++ b/app/code/Magento/Bundle/Test/Mftf/Section/BundleStorefrontSection.xml
@@ -14,8 +14,8 @@
         <element name="bundleOptionSelection" type="checkbox" selector="//div[@class='nested options-list']/div[{{optionNumber}}]/label[@class='label']" parameterized="true"/>
         <!--Description-->
         <!--CE exclusively-->
-        <element name="longDescriptionText" type="text" selector="//*[@id='description']/div/div" timeout="30"/>
-        <element name="shortDescriptionText" type="text" selector="//div[@class='product attribute overview']" timeout="30"/>
+        <element name="longDescriptionText" type="text" selector="#description>div>div" timeout="30"/>
+        <element name="shortDescriptionText" type="text" selector="div.product attribute overview" timeout="30"/>
         <!--NameOfProductOnProductPage-->
         <element name="bundleProductName" type="text" selector="//*[@id='maincontent']//span[@itemprop='name']"/>
         <!--PageNotFoundErrorMessage-->

--- a/app/code/Magento/Bundle/Test/Mftf/Section/BundleStorefrontSection.xml
+++ b/app/code/Magento/Bundle/Test/Mftf/Section/BundleStorefrontSection.xml
@@ -15,7 +15,7 @@
         <!--Description-->
         <!--CE exclusively-->
         <element name="longDescriptionText" type="text" selector="#description>div>div" timeout="30"/>
-        <element name="shortDescriptionText" type="text" selector="div.product attribute overview" timeout="30"/>
+        <element name="shortDescriptionText" type="text" selector="div.product.attribute.overview" timeout="30"/>
         <!--NameOfProductOnProductPage-->
         <element name="bundleProductName" type="text" selector="//*[@id='maincontent']//span[@itemprop='name']"/>
         <!--PageNotFoundErrorMessage-->

--- a/app/code/Magento/Bundle/Test/Mftf/Section/StorefrontBundledSection.xml
+++ b/app/code/Magento/Bundle/Test/Mftf/Section/StorefrontBundledSection.xml
@@ -17,7 +17,7 @@
         <element name="updateCart" type="button" selector="#product-updatecart-button" timeout="30"/>
         <element name="configuredPrice" type="block" selector=".price-configured_price .price"/>
         <element name="fixedPricing" type="text" selector="//div[@class='price-box price-final_price']//span[@id]//..//span[contains(text(),'{{var1}}')]" parameterized="true"/>
-        <element name="customizeProduct" type="button" selector="//*[@id='bundle-slide']"/>
+        <element name="customizeProduct" type="button" selector="#bundle-slide"/>
         <element name="customizableBundleItemOption" type="text" selector="//div[@class='field choice'][1]//input[@type='checkbox']"/>
         <element name="customizableBundleItemOption2" type="text" selector="//div[@class='field choice'][2]//input[@type='checkbox']"/>
         <element name="nthOptionDiv" type="block" selector="#product-options-wrapper div.field.option:nth-of-type({{var}})" parameterized="true"/>

--- a/app/code/Magento/Captcha/Test/Mftf/Section/CaptchaFormsDisplayingSection.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/Section/CaptchaFormsDisplayingSection.xml
@@ -14,7 +14,7 @@
         <element name="customer" type="button" selector="//div[@class='admin__page-nav-title title _collapsible']//strong[text()='Customers']"/>
         <element name="customerConfig" type="text" selector="//span[text()='Customer Configuration']"/>
         <element name="captcha" type="button" selector="#customer_captcha-head"/>
-        <element name="dependent" type="button" selector="//a[@id='customer_captcha-head' and @class='open']"/>
+        <element name="dependent" type="button" selector="a#customer_captcha-head.open"/>
         <element name="forms" type="multiselect" selector="#customer_captcha_forms"/>
         <element name="createUser" type="multiselect" selector="//select[@id='customer_captcha_forms']/option[@value='user_create']"/>
         <element name="forgotpassword" type="multiselect" selector="//select[@id='customer_captcha_forms']/option[@value='user_forgotpassword']"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductFormSection/ProductDescriptionWYSIWYGToolbarSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductFormSection/ProductDescriptionWYSIWYGToolbarSection.xml
@@ -8,7 +8,7 @@
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="ProductDescriptionWYSIWYGToolbarSection">
-        <element name="TinyMCE4" type="button" selector="//div[@id='editorproduct_form_description']//*[contains(@class,'mce-branding')]"/>
+        <element name="TinyMCE4" type="button" selector="div#editorproduct_form_description .mce-branding"/>
         <element name="showHideBtn" type="button" selector="#toggleproduct_form_description"/>
         <element name="InsertImageBtn" type="button" selector="#buttonsproduct_form_description &gt; .scalable.action-add-image.plugin"/>
         <element name="Style" type="button" selector="//div[@id='editorproduct_form_description']//span[text()='Paragraph']"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductFormSection/ProductWYSIWYGSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminProductFormSection/ProductWYSIWYGSection.xml
@@ -8,12 +8,12 @@
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="ProductWYSIWYGSection">
-        <element name="Switcher" type="button" selector="//select[@id='dropdown-switcher']"/>
+        <element name="Switcher" type="button" selector="select#dropdown-switcher"/>
         <element name="v436" type="button" selector="//select[@id='dropdown-switcher']/option[text()='TinyMCE 4.3.6']"/>
         <element name="v3" type="button" selector="//select[@id='dropdown-switcher']/option[text()='TinyMCE 3.6(Deprecated)']"/>
         <element name="TinymceDescription3" type="button" selector="//span[text()='Description']"/>
         <element name="SaveConfig" type="button" selector="#save"/>
         <element name="v4" type="button" selector="#category_form_description_v4"/>
-        <element name="WYSIWYGBtn" type="button" selector=".//button[@class='action-default scalable action-wysiwyg']"/>
+        <element name="WYSIWYGBtn" type="button" selector="button.action-default.scalable.action-wysiwyg"/>
     </section>
 </sections>

--- a/app/code/Magento/Cms/Test/Mftf/Section/CmsPagesPageActionsSection.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Section/CmsPagesPageActionsSection.xml
@@ -12,7 +12,7 @@
         <element name="filterButton" type="input" selector="//button[text()='Filters']"/>
         <element name="URLKey" type="input" selector="//div[@class='admin__form-field-control']/input[@name='identifier']"/>
         <element name="ApplyFiltersBtn" type="button" selector="//span[text()='Apply Filters']"/>
-        <element name="searchInput" type="input" selector="//*[@id='fulltext']"/>
+        <element name="searchInput" type="input" selector="#fulltext"/>
         <element name="searchButton" type="button" selector="//*[@id='fulltext']/parent::*/button"/>
         <element name="addNewPageButton" type="button" selector="#add" timeout="30"/>
         <element name="select" type="button" selector="//div[text()='{{var1}}']/parent::td//following-sibling::td[@class='data-grid-actions-cell']//button[text()='Select']" parameterized="true"/>

--- a/app/code/Magento/Cms/Test/Mftf/Section/TinyMCESection/MediaGallerySection.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Section/TinyMCESection/MediaGallerySection.xml
@@ -9,7 +9,7 @@
 	xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="MediaGallerySection">
         <element name="Browse" type="button" selector=".mce-i-browse"/>
-        <element name="browseForImage" type="button" selector="//*[@id='srcbrowser']"/>
+        <element name="browseForImage" type="button" selector="#srcbrowser"/>
         <element name="BrowseUploadImage" type="file" selector=".fileupload"/>
         <element name="image" type="text" selector="//small[text()='{{var1}}']" parameterized="true"/>
         <element name="imageOrImageCopy" type="text" selector="//div[contains(@class,'media-gallery-modal')]//img[contains(@alt, '{{arg1}}.{{arg2}}')]|//img[contains(@alt,'{{arg1}}_') and contains(@alt,'.{{arg2}}')]" parameterized="true"/>


### PR DESCRIPTION
### Description (*)
Although there is no difference in performance, readability of CSS selectors is much better, especially when we have elements having it's unique ID attribute. That is why I want to encourage MFTF users to use CSS selectors instead of enforcing Xpath when it's not necessary.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
