### PR TITLE
MFTF: Storefront Disabled Customer Wishlist Functionality Test

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductPageAddToWishlistButtonIsNotPresentActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertProductPageAddToWishlistButtonIsNotPresentActionGroup.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontAssertProductPageAddToWishlistButtonIsNotPresentActionGroup">
+        <dontSee userInput="Add to Wish List" selector="{{StorefrontProductPageSection.addToWishlist}}" stepKey="dontSeeElement"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontAssertCustomerSidebarItemIsNotPresentActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontAssertCustomerSidebarItemIsNotPresentActionGroup.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontAssertCustomerSidebarItemIsNotPresentActionGroup">
+        <arguments>
+            <argument name="itemName" type="string"/>
+        </arguments>
+        <dontSee userInput="{{itemName}}" selector="{{StorefrontCustomerSidebarSection.sidebarTab(itemName)}}" stepKey="dontSeeElement"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Wishlist/Test/Mftf/Test/AdminDisableCustomerWishlistTest.xml
+++ b/app/code/Magento/Wishlist/Test/Mftf/Test/AdminDisableCustomerWishlistTest.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminDisableCustomerWishlistTest">
+        <annotations>
+            <features value="Wishlist"/>
+            <stories value="Wishlist Disabling"/>
+            <title value="Admin Disabling Wishlist in configurations"/>
+            <description value="Admin should be able disable Wishlist functionality in system configurations. Wishlist elements should be not visible for customers"/>
+            <group value="wishlist"/>
+            <group value="configuration"/>
+        </annotations>
+        <before>
+            <magentoCLI command="config:set wishlist/general/active 0" stepKey="disableWishlist"/>
+            <magentoCLI command="cache:clean" stepKey="cleanCache"/>
+            <createData entity="SimpleSubCategory" stepKey="createCategory"/>
+            <createData entity="SimpleProduct" stepKey="createProduct">
+                <requiredEntity createDataKey="createCategory"/>
+            </createData>
+            <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
+        </before>
+        <after>
+            <magentoCLI command="config:set wishlist/general/active 1" stepKey="enableWishlist"/>
+            <magentoCLI command="cache:clean" stepKey="cacheClean"/>
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
+            <actionGroup ref="StorefrontCustomerLogoutActionGroup" stepKey="logoutCustomer"/>
+            <deleteData createDataKey="createCustomer" stepKey="deleteCustomer"/>
+        </after>
+
+        <actionGroup ref="LoginToStorefrontActionGroup" stepKey="loginToStorefrontAccount">
+            <argument name="Customer" value="$createCustomer$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontAssertCustomerSidebarItemIsNotPresentActionGroup" stepKey="assertItemIsNotPresent">
+            <argument name="itemName" value="My Wish List"/>
+        </actionGroup>
+        <actionGroup ref="OpenStoreFrontProductPageActionGroup" stepKey="openProductPage">
+            <argument name="productUrlKey" value="$$createProduct.custom_attributes[url_key]$$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontAssertProductPageAddToWishlistButtonIsNotPresentActionGroup" stepKey="assertButtonIsAbsent"/>
+    </test>
+</tests>

--- a/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDisabledCustomerWishlistFunctionalityTest.xml
+++ b/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDisabledCustomerWishlistFunctionalityTest.xml
@@ -14,6 +14,7 @@
             <stories value="Disabled Wishlist Functionality"/>
             <title value="Wishlist Functionality is disabled in system configurations and not visible on FE"/>
             <description value="Customer should not see wishlist functionality if it's disabled"/>
+            <testCaseId value="MC-35200"/>
             <group value="wishlist"/>
             <group value="configuration"/>
         </annotations>

--- a/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDisabledCustomerWishlistFunctionalityTest.xml
+++ b/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDisabledCustomerWishlistFunctionalityTest.xml
@@ -19,16 +19,17 @@
         </annotations>
         <before>
             <magentoCLI command="config:set wishlist/general/active 0" stepKey="disableWishlist"/>
-            <magentoCLI command="cache:clean" stepKey="cleanCache"/>
+            <magentoCLI command="cache:clean config" stepKey="cleanCache"/>
             <createData entity="SimpleSubCategory" stepKey="createCategory"/>
             <createData entity="SimpleProduct" stepKey="createProduct">
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
+            <magentoCLI command="cron:run --group=index" stepKey="runCronIndexer"/>
             <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
         </before>
         <after>
             <magentoCLI command="config:set wishlist/general/active 1" stepKey="enableWishlist"/>
-            <magentoCLI command="cache:clean" stepKey="cacheClean"/>
+            <magentoCLI command="cache:clean config" stepKey="cacheClean"/>
             <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
             <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
             <actionGroup ref="StorefrontCustomerLogoutActionGroup" stepKey="logoutCustomer"/>

--- a/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDisabledCustomerWishlistFunctionalityTest.xml
+++ b/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontDisabledCustomerWishlistFunctionalityTest.xml
@@ -8,12 +8,12 @@
 
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
-    <test name="AdminDisableCustomerWishlistTest">
+    <test name="StorefrontDisabledCustomerWishlistFunctionalityTest">
         <annotations>
             <features value="Wishlist"/>
-            <stories value="Wishlist Disabling"/>
-            <title value="Admin Disabling Wishlist in configurations"/>
-            <description value="Admin should be able disable Wishlist functionality in system configurations. Wishlist elements should be not visible for customers"/>
+            <stories value="Disabled Wishlist Functionality"/>
+            <title value="Wishlist Functionality is disabled in system configurations and not visible on FE"/>
+            <description value="Customer should not see wishlist functionality if it's disabled"/>
             <group value="wishlist"/>
             <group value="configuration"/>
         </annotations>


### PR DESCRIPTION
This PR contains a test for disabling Wishlist functionality.
Wishlist Functionality is disabled in system configurations and should be not visible on FE

**Steps to reproduce:**
1 - Disable Wishlist in configs
2 - Login to Storefront
3 - Perform Assertions

### Resolved issues:
1. [x] resolves magento/magento2#28744: MFTF: Storefront Disabled Customer Wishlist Functionality Test