### PR TITLE
MFTF: Sharing Wishlist with more than allowed emails qty test

### DIFF
--- a/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontShareWishlistWithMoreThanMaximumAllowedEmailsQtyTest.xml
+++ b/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontShareWishlistWithMoreThanMaximumAllowedEmailsQtyTest.xml
@@ -19,16 +19,17 @@
         </annotations>
         <before>
             <magentoCLI command="config:set wishlist/email/number_limit 1" stepKey="changeEmailsQtyLimit"/>
-            <magentoCLI command="cache:clean" stepKey="cleanCache"/>
+            <magentoCLI command="cache:clean config" stepKey="cleanCache"/>
             <createData entity="SimpleSubCategory" stepKey="createCategory"/>
             <createData entity="SimpleProduct" stepKey="createProduct">
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
+            <magentoCLI command="cron:run --group=index" stepKey="runCronIndexer"/>
             <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
         </before>
         <after>
             <magentoCLI command="config:set wishlist/email/number_limit 10" stepKey="returnDefaultValue"/>
-            <magentoCLI command="cache:clean" stepKey="cacheClean"/>
+            <magentoCLI command="cache:clean config" stepKey="cacheClean"/>
             <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
             <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
             <actionGroup ref="StorefrontCustomerLogoutActionGroup" stepKey="logoutCustomer"/>

--- a/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontShareWishlistWithMoreThanMaximumAllowedEmailsQtyTest.xml
+++ b/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontShareWishlistWithMoreThanMaximumAllowedEmailsQtyTest.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontShareWishlistWithMoreThanMaximumAllowedEmailsQtyTest">
+        <annotations>
+            <features value="Wishlist"/>
+            <stories value="Sharing wishlist with more than Maximum Allowed Emails qty"/>
+            <title value="Sharing wishlist with more than Maximum Allowed Emails qty"/>
+            <description value="Customer should not have a possibility share wishlist with more than maximum allowed emails qty"/>
+            <group value="wishlist"/>
+            <group value="configuration"/>
+        </annotations>
+        <before>
+            <magentoCLI command="config:set wishlist/email/number_limit 1" stepKey="changeEmailsQtyLimit"/>
+            <magentoCLI command="cache:clean" stepKey="cleanCache"/>
+            <createData entity="SimpleSubCategory" stepKey="createCategory"/>
+            <createData entity="SimpleProduct" stepKey="createProduct">
+                <requiredEntity createDataKey="createCategory"/>
+            </createData>
+            <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
+        </before>
+        <after>
+            <magentoCLI command="config:set wishlist/email/number_limit 10" stepKey="returnDefaultValue"/>
+            <magentoCLI command="cache:clean" stepKey="cacheClean"/>
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
+            <actionGroup ref="StorefrontCustomerLogoutActionGroup" stepKey="logoutCustomer"/>
+            <deleteData createDataKey="createCustomer" stepKey="deleteCustomer"/>
+        </after>
+
+        <actionGroup ref="LoginToStorefrontActionGroup" stepKey="loginToStorefrontAccount">
+            <argument name="Customer" value="$createCustomer$"/>
+        </actionGroup>
+        <actionGroup ref="OpenStoreFrontProductPageActionGroup" stepKey="openProductPage">
+            <argument name="productUrlKey" value="$$createProduct.custom_attributes[url_key]$$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontCustomerAddProductToWishlistActionGroup" stepKey="addToWishlistProduct">
+            <argument name="productVar" value="$createProduct$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontShareCustomerWishlistActionGroup" stepKey="shareWishList">
+            <argument name="email" value="{{Wishlist.shareInfo_emails}}"/>
+            <argument name="message" value="{{Wishlist.shareInfo_message}}"/>
+        </actionGroup>
+        <actionGroup ref="AssertMessageCustomerChangeAccountInfoActionGroup" stepKey="assertMessage">
+            <argument name="message" value="Maximum of 1 emails can be sent."/>
+            <argument name="messageType" value="error"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontShareWishlistWithMoreThanMaximumAllowedEmailsQtyTest.xml
+++ b/app/code/Magento/Wishlist/Test/Mftf/Test/StorefrontShareWishlistWithMoreThanMaximumAllowedEmailsQtyTest.xml
@@ -14,6 +14,7 @@
             <stories value="Sharing wishlist with more than Maximum Allowed Emails qty"/>
             <title value="Sharing wishlist with more than Maximum Allowed Emails qty"/>
             <description value="Customer should not have a possibility share wishlist with more than maximum allowed emails qty"/>
+            <testCaseId value="MC-35167"/>
             <group value="wishlist"/>
             <group value="configuration"/>
         </annotations>


### PR DESCRIPTION
This PR contains a test for sharing customer's wishlist with more than allowed emails qty

**Steps to reproduce:**

1 - Set maximum allowed qty of emails for sharing
2 - Login as a customer
3 - Add product into wishlist
4 - Share wishlist with more than maximum allowed qty emails

### Resolved issues:
1. [x] resolves magento/magento2#28720: MFTF: Sharing Wishlist with more than allowed emails qty test