### PR TITLE
magento/magento2#28568:GraphQL query returns admin option value label…

### DIFF
--- a/app/code/Magento/CatalogGraphQl/DataProvider/Product/LayeredNavigation/Builder/Attribute.php
+++ b/app/code/Magento/CatalogGraphQl/DataProvider/Product/LayeredNavigation/Builder/Attribute.php
@@ -71,7 +71,7 @@ class Attribute implements LayerBuilderInterface
      */
     public function build(AggregationInterface $aggregation, ?int $storeId): array
     {
-        $attributeOptions = $this->getAttributeOptions($aggregation);
+        $attributeOptions = $this->getAttributeOptions($aggregation, $storeId);
 
         // build layer per attribute
         $result = [];
@@ -133,10 +133,11 @@ class Attribute implements LayerBuilderInterface
      * Get list of attributes with options
      *
      * @param AggregationInterface $aggregation
+     * @param int|null $storeId
      * @return array
      * @throws \Zend_Db_Statement_Exception
      */
-    private function getAttributeOptions(AggregationInterface $aggregation): array
+    private function getAttributeOptions(AggregationInterface $aggregation, ?int $storeId): array
     {
         $attributeOptionIds = [];
         $attributes = [];
@@ -154,6 +155,6 @@ class Attribute implements LayerBuilderInterface
             return [];
         }
 
-        return $this->attributeOptionProvider->getOptions(\array_merge(...$attributeOptionIds), $attributes);
+        return $this->attributeOptionProvider->getOptions(\array_merge(...$attributeOptionIds), $storeId, $attributes);
     }
 }


### PR DESCRIPTION
### Description (*)

This is for #28568 and #28572 

### Related Pull Requests

N/A

### Fixed Issues (if relevant)

1. Fixes magento/magento2#28568: Query returns admin option value label within aggregations
2. Fixes magento/magento2#28572: Custom attribute aggregations should return store specific option values

### Manual testing scenarios (*)

Check fixed issue for testing steps and expected results.

### Questions or comments

N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
