### PR TITLE
Remove redundant  init method

### DIFF
--- a/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/TierPrice.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/TierPrice.php
@@ -9,11 +9,14 @@ declare(strict_types=1);
 namespace Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing\Validator;
 
 use Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing;
+use Magento\CatalogImportExport\Model\Import\Product;
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface;
 use Magento\CatalogImportExport\Model\Import\Product\StoreResolver;
+use Magento\CatalogImportExport\Model\Import\Product\Validator\AbstractImportValidator;
 use Magento\CatalogImportExport\Model\Import\Product\Validator\AbstractPrice;
 use Magento\Customer\Api\GroupRepositoryInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Exception\LocalizedException;
 
 class TierPrice extends AbstractPrice
 {
@@ -48,7 +51,12 @@ class TierPrice extends AbstractPrice
     }
 
     /**
-     * {@inheritdoc}
+     * Initialize method
+     *
+     * @param Product $context
+     *
+     * @return RowValidatorInterface|AbstractImportValidator|void
+     * @throws LocalizedException
      */
     public function init($context)
     {
@@ -59,6 +67,8 @@ class TierPrice extends AbstractPrice
     }
 
     /**
+     * Add decimal error
+     *
      * @param string $attribute
      *
      * @return void

--- a/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/TierPrice.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/TierPrice.php
@@ -3,15 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+declare(strict_types=1);
+
 namespace Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing\Validator;
 
 use Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing;
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface;
+use Magento\CatalogImportExport\Model\Import\Product\StoreResolver;
+use Magento\CatalogImportExport\Model\Import\Product\Validator\AbstractPrice;
+use Magento\Customer\Api\GroupRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
 
-class TierPrice extends \Magento\CatalogImportExport\Model\Import\Product\Validator\AbstractPrice
+class TierPrice extends AbstractPrice
 {
     /**
-     * @var \Magento\CatalogImportExport\Model\Import\Product\StoreResolver
+     * @var StoreResolver
      */
     protected $storeResolver;
 
@@ -27,14 +34,14 @@ class TierPrice extends \Magento\CatalogImportExport\Model\Import\Product\Valida
     ];
 
     /**
-     * @param \Magento\Customer\Api\GroupRepositoryInterface $groupRepository
-     * @param \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder
-     * @param \Magento\CatalogImportExport\Model\Import\Product\StoreResolver $storeResolver
+     * @param GroupRepositoryInterface $groupRepository
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     * @param StoreResolver $storeResolver
      */
     public function __construct(
-        \Magento\Customer\Api\GroupRepositoryInterface $groupRepository,
-        \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder,
-        \Magento\CatalogImportExport\Model\Import\Product\StoreResolver $storeResolver
+        GroupRepositoryInterface $groupRepository,
+        SearchCriteriaBuilder $searchCriteriaBuilder,
+        StoreResolver $storeResolver
     ) {
         $this->storeResolver = $storeResolver;
         parent::__construct($groupRepository, $searchCriteriaBuilder);
@@ -53,6 +60,7 @@ class TierPrice extends \Magento\CatalogImportExport\Model\Import\Product\Valida
 
     /**
      * @param string $attribute
+     *
      * @return void
      */
     protected function addDecimalError($attribute)
@@ -83,12 +91,12 @@ class TierPrice extends \Magento\CatalogImportExport\Model\Import\Product\Valida
     }
 
     /**
-     * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
      * Validation
      *
      * @param mixed $value
      * @return bool
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
      */
     public function isValid($value)
     {
@@ -133,6 +141,7 @@ class TierPrice extends \Magento\CatalogImportExport\Model\Import\Product\Valida
      * Check if at list one value and length are valid
      *
      * @param array $value
+     *
      * @return bool
      */
     protected function isValidValueAndLength(array $value)
@@ -150,6 +159,7 @@ class TierPrice extends \Magento\CatalogImportExport\Model\Import\Product\Valida
      * Check if value has empty columns
      *
      * @param array $value
+     *
      * @return bool
      */
     protected function hasEmptyColumns(array $value)

--- a/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/TierPriceType.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/TierPriceType.php
@@ -4,28 +4,24 @@
  * See COPYING.txt for license details.
  */
 
+declare(strict_types=1);
+
 namespace Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing\Validator;
 
 use Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing;
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface;
+use Magento\CatalogImportExport\Model\Import\Product\Validator\AbstractImportValidator;
 
 /**
  * Class TierPriceType validates tier price type.
  */
-class TierPriceType extends \Magento\CatalogImportExport\Model\Import\Product\Validator\AbstractImportValidator
+class TierPriceType extends AbstractImportValidator
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function init($context)
-    {
-        return parent::init($context);
-    }
-
     /**
      * Validate tier price type.
      *
      * @param array $value
+     *
      * @return bool
      */
     public function isValid($value)

--- a/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/Website.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/Website.php
@@ -3,42 +3,39 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+declare(strict_types=1);
+
 namespace Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing\Validator;
 
 use Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing;
-use Magento\CatalogImportExport\Model\Import\Product\Validator\AbstractImportValidator;
 use Magento\CatalogImportExport\Model\Import\Product\RowValidatorInterface;
+use Magento\CatalogImportExport\Model\Import\Product\StoreResolver;
+use Magento\CatalogImportExport\Model\Import\Product\Validator\AbstractImportValidator;
+use Magento\Store\Model\Website as WebsiteModel;
 
 class Website extends AbstractImportValidator implements RowValidatorInterface
 {
     /**
-     * @var \Magento\CatalogImportExport\Model\Import\Product\StoreResolver
+     * @var StoreResolver
      */
     protected $storeResolver;
 
     /**
-     * @var \Magento\Store\Model\Website
+     * @var WebsiteModel
      */
     protected $websiteModel;
 
     /**
-     * @param \Magento\CatalogImportExport\Model\Import\Product\StoreResolver $storeResolver
-     * @param \Magento\Store\Model\Website $websiteModel
+     * @param StoreResolver $storeResolver
+     * @param WebsiteModel $websiteModel
      */
     public function __construct(
-        \Magento\CatalogImportExport\Model\Import\Product\StoreResolver $storeResolver,
-        \Magento\Store\Model\Website $websiteModel
+        StoreResolver $storeResolver,
+        WebsiteModel $websiteModel
     ) {
         $this->storeResolver = $storeResolver;
         $this->websiteModel = $websiteModel;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function init($context)
-    {
-        return parent::init($context);
     }
 
     /**
@@ -46,6 +43,7 @@ class Website extends AbstractImportValidator implements RowValidatorInterface
      *
      * @param array $value
      * @param string $websiteCode
+     *
      * @return bool
      */
     protected function isWebsiteValid($value, $websiteCode)
@@ -63,6 +61,7 @@ class Website extends AbstractImportValidator implements RowValidatorInterface
      * Validate value
      *
      * @param mixed $value
+     *
      * @return bool
      */
     public function isValid($value)
@@ -85,6 +84,7 @@ class Website extends AbstractImportValidator implements RowValidatorInterface
      */
     public function getAllWebsitesValue()
     {
-        return AdvancedPricing::VALUE_ALL_WEBSITES . ' ['.$this->websiteModel->getBaseCurrency()->getCurrencyCode().']';
+        return AdvancedPricing::VALUE_ALL_WEBSITES .
+            ' [' . $this->websiteModel->getBaseCurrency()->getCurrencyCode() . ']';
     }
 }

--- a/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/Website.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/Website.php
@@ -60,7 +60,7 @@ class Website extends AbstractImportValidator implements RowValidatorInterface
     /**
      * Validate value
      *
-     * @param mixed $value
+     * @param array $value
      *
      * @return bool
      */


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR removes redundant init method in 
`app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/Website.php` and `app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing/Validator/TierPriceType.php`
this method just call parent public method


### Resolved issues:
1. [x] resolves magento/magento2#29009: Remove redundant  init method