### PR TITLE
Assign user to role and roles list commands

### DIFF
--- a/app/code/Magento/Authorization/Command/AdminRolesListCommand.php
+++ b/app/code/Magento/Authorization/Command/AdminRolesListCommand.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Authorization\Command;
+
+use Magento\Authorization\Model\GetAdminRolesList;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableFactory;
+
+/**
+ * Class AdminRolesListCommand is cli command for showing all existing admin role ids and names
+ */
+class AdminRolesListCommand extends Command
+{
+    /**
+     * @var GetAdminRolesList
+     */
+    private $getAdminRolesListService;
+
+    /**
+     * @var TableFactory
+     */
+    private $tableFactory;
+
+    /**
+     * @param GetAdminRolesList $getAdminRolesListService
+     * @param TableFactory $tableFactory
+     * @param string|null $name
+     */
+    public function __construct(
+        GetAdminRolesList $getAdminRolesListService,
+        TableFactory $tableFactory,
+        string $name = null
+    ) {
+        parent::__construct($name);
+        $this->getAdminRolesListService = $getAdminRolesListService;
+        $this->tableFactory = $tableFactory;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function configure(): void
+    {
+        $this->setName("admin:role:list");
+        $this->setDescription("Shows all existing admin role ids and names");
+        parent::configure();
+    }
+
+    /**
+     * Provides table with admin roles
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        $output->writeln('Existing admin roles:');
+        $table = $this->tableFactory->create(['output' => $output]);
+        $table->setHeaders(['Role ID', 'Role Name']);
+        $table->setRows($this->getAdminRolesListService->execute());
+        $table->render();
+    }
+}

--- a/app/code/Magento/Authorization/Model/GetAdminRolesList.php
+++ b/app/code/Magento/Authorization/Model/GetAdminRolesList.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Authorization\Model;
+
+use Magento\Authorization\Model\ResourceModel\Role\Grid\CollectionFactory;
+
+/**
+ * Class GetAdminRolesList provides information about all existing group roles
+ */
+class GetAdminRolesList
+{
+    /**
+     * @var CollectionFactory
+     */
+    private $rolesGridCollectionFactory;
+
+    /**
+     * @param CollectionFactory $rolesGridCollectionFactory
+     */
+    public function __construct(
+        CollectionFactory $rolesGridCollectionFactory
+    ) {
+        $this->rolesGridCollectionFactory = $rolesGridCollectionFactory;
+    }
+
+    /**
+     * Provides information about all existing group roles
+     *
+     * @return array
+     */
+    public function execute(): array
+    {
+        return $this->rolesGridCollectionFactory->create()
+            ->addFieldToSelect('role_id')
+            ->addFieldToSelect('role_name')
+            ->load()
+            ->toArray()['items'];
+    }
+}

--- a/app/code/Magento/Authorization/Test/Integration/Console/Command/AdminRolesListCommandTest.php
+++ b/app/code/Magento/Authorization/Test/Integration/Console/Command/AdminRolesListCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Authorization\Test\Integration\Console\Command;
+
+use Magento\Authorization\Command\AdminRolesListCommand;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class AdminRolesListCommandTes
+ */
+class AdminRolesListCommandTest extends TestCase
+{
+    /**
+     * @magentoDataFixture ./../../../../app/code/Magento/Authorization/Test/Integration/_files/test_role.php
+     */
+    public function testExecute(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $command = $objectManager->get(AdminRolesListCommand::class);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+        $this->assertStringContainsString('Role ID ', $commandTester->getDisplay());
+        $this->assertStringContainsString('Role Name', $commandTester->getDisplay());
+        $this->assertStringContainsString('test_role', $commandTester->getDisplay());
+    }
+}

--- a/app/code/Magento/Authorization/Test/Integration/_files/test_role.php
+++ b/app/code/Magento/Authorization/Test/Integration/_files/test_role.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Authorization\Model\Acl\Role\Group as RoleGroup;
+use Magento\Authorization\Model\ResourceModel\Role as RoleResource;
+use Magento\Authorization\Model\RoleFactory;
+use Magento\Authorization\Model\RulesFactory;
+use Magento\Authorization\Model\UserContextInterface;
+use Magento\Backend\App\Area\FrontNameResolver;
+use Magento\TestFramework\Helper\Bootstrap;
+
+Bootstrap::getInstance()->loadArea(FrontNameResolver::AREA_CODE);
+$objectManager = Bootstrap::getObjectManager();
+/** @var RoleResource $roleResource */
+$roleResource = $objectManager->get(RoleResource::class);
+/** @var RoleFactory $roleFactory */
+$roleFactory = $objectManager->get(RoleFactory::class);
+$role = $roleFactory->create();
+$role->setName('test_role')
+    ->setPid(0)
+    ->setRoleType(RoleGroup::ROLE_TYPE)
+    ->setUserType(UserContextInterface::USER_TYPE_ADMIN);
+
+$roleResource->save($role);
+$ruleFactory = $objectManager->get(RulesFactory::class);
+$ruleFactory->create()->setRoleId($role->getId())->setResources(['Magento_Backend::all'])->saveRel();

--- a/app/code/Magento/Authorization/etc/di.xml
+++ b/app/code/Magento/Authorization/etc/di.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Authorization\Model\Role" shared="false" />
     <type name="Magento\Authorization\Model\ResourceModel\Rules">
         <arguments>
@@ -24,4 +25,11 @@
         </arguments>
     </type>
     <preference for="Magento\Authorization\Model\UserContextInterface" type="Magento\Authorization\Model\CompositeUserContext"/>
+    <type name="Magento\Framework\Console\CommandListInterface">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="adminRolesListCommand" xsi:type="object">Magento\Authorization\Command\AdminRolesListCommand</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/User/Console/AssignAdminToRoleCommand.php
+++ b/app/code/Magento/User/Console/AssignAdminToRoleCommand.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\User\Console;
+
+use InvalidArgumentException;
+use Magento\Authorization\Model\GetAdminRolesList;
+use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\User\Model\AssignUserToRole;
+use Magento\User\Model\GetAdminUserList;
+use Magento\User\Model\User;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * Class AssignAdminToRoleCommand assigns role to user
+ */
+class AssignAdminToRoleCommand extends Command
+{
+    private const USER_NAME_OPTION = 'username';
+    private const ROLE_ID_OPTION = 'role-id';
+
+    /**
+     * @var AssignUserToRole
+     */
+    private $assignUserToRoleService;
+
+    /**
+     * @var GetAdminRolesList
+     */
+    private $getAdminRolesListService;
+
+    /**
+     * @var GetAdminUserList
+     */
+    private $getAdminUserListService;
+
+    /**
+     * @param AssignUserToRole $assignUserToRoleService
+     * @param GetAdminRolesList $getAdminRolesListService
+     * @param GetAdminUserList $getAdminUserListService
+     * @param string|null $name
+     */
+    public function __construct(
+        AssignUserToRole $assignUserToRoleService,
+        GetAdminRolesList $getAdminRolesListService,
+        GetAdminUserList $getAdminUserListService,
+        string $name = null
+    ) {
+        parent::__construct($name);
+        $this->assignUserToRoleService = $assignUserToRoleService;
+        $this->getAdminRolesListService = $getAdminRolesListService;
+        $this->getAdminUserListService = $getAdminUserListService;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function configure(): void
+    {
+        $this->setName("admin:user:assign-role");
+        $this->setDescription("Assigns user to role");
+        $this->setDefinition($this->getOptionsList());
+
+        parent::configure();
+    }
+
+    /**
+     * Assigns role to user
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return void
+     * @throws AlreadyExistsException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        $this->assignUserToRoleService->execute(
+            $input->getOption(self::USER_NAME_OPTION),
+            (int)$input->getOption(self::ROLE_ID_OPTION)
+        );
+        $output->writeln("User assigned to the role.");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        /** @var QuestionHelper $questionHelper */
+        $questionHelper = $this->getHelper('question');
+
+        if (!$input->getOption(self::USER_NAME_OPTION)) {
+            $question = new Question('<question>Admin username:</question> ', '');
+            $userList = $this->getAdminUserListService->execute();
+            $question->setValidator(function ($value) use ($userList) {
+                /** @var User $user */
+                foreach ($userList as $user) {
+                    if ($user->getUserName() === $value) {
+                        return $value;
+                    }
+                }
+                throw new InvalidArgumentException(sprintf(AssignUserToRole::USER_DOES_NOT_EXISTS_ERROR_MSG, $value));
+            });
+
+            $input->setOption(
+                self::USER_NAME_OPTION,
+                $questionHelper->ask($input, $output, $question)
+            );
+        }
+
+        if (!$input->getOption(self::ROLE_ID_OPTION)) {
+            $question = new Question('<question>Role ID:</question> ', '');
+            $rolesList = $this->getAdminRolesListService->execute();
+            $question->setValidator(function ($value) use ($rolesList) {
+                foreach ($rolesList as $role) {
+                    if ($role['role_id'] === $value) {
+                        return $value;
+                    }
+                }
+                throw new InvalidArgumentException(sprintf(AssignUserToRole::ROLE_DOES_NOT_EXISTS_ERROR_MSG, $value));
+            });
+
+            $input->setOption(
+                self::ROLE_ID_OPTION,
+                $questionHelper->ask($input, $output, $question)
+            );
+        }
+    }
+
+    /**
+     * Get list of arguments for the command
+     *
+     * @return InputOption[]
+     */
+    public function getOptionsList(): array
+    {
+        return [
+            new InputOption(
+                self::USER_NAME_OPTION,
+                null,
+                InputOption::VALUE_REQUIRED,
+                '(Required) Admin Username'
+            ),
+            new InputOption(
+                self::ROLE_ID_OPTION,
+                null,
+                InputOption::VALUE_REQUIRED,
+                '(Required) Role ID'
+            )
+        ];
+    }
+}

--- a/app/code/Magento/User/Model/AssignUserToRole.php
+++ b/app/code/Magento/User/Model/AssignUserToRole.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\User\Model;
+
+use Exception;
+use InvalidArgumentException;
+use Magento\Authorization\Model\Acl\Role\Group;
+use Magento\Authorization\Model\ResourceModel\Role as RoleResource;
+use Magento\Authorization\Model\Role;
+use Magento\Authorization\Model\RoleFactory;
+use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\User\Model\ResourceModel\User as UserResource;
+
+/**
+ * Class AssignUserToRole assigns user to role by username and role id
+ */
+class AssignUserToRole
+{
+    public const USER_DOES_NOT_EXISTS_ERROR_MSG = 'There is no user with User name "%s"';
+    public const ROLE_DOES_NOT_EXISTS_ERROR_MSG = 'There is no role with Role ID "%s"';
+    public const USER_ALREADY_ASSIGNED_ERROR_MSG = 'User with User name %s is already assigned to Role with ID "%s"';
+    /**
+     * @var RoleFactory
+     */
+    private $roleFactory;
+
+    /**
+     * @var UserResource
+     */
+    private $userResource;
+
+    /**
+     * @var RoleResource
+     */
+    private $roleResource;
+
+    /**
+     * @var UserFactory
+     */
+    private $userFactory;
+
+    /**
+     * @param RoleFactory $roleFactory
+     * @param UserFactory $userFactory
+     * @param UserResource $userResource
+     * @param RoleResource $roleResource
+     */
+    public function __construct(
+        RoleFactory $roleFactory,
+        UserFactory $userFactory,
+        UserResource $userResource,
+        RoleResource $roleResource
+    ) {
+        $this->roleFactory = $roleFactory;
+        $this->userResource = $userResource;
+        $this->roleResource = $roleResource;
+        $this->userFactory = $userFactory;
+    }
+
+    /**
+     * Assigns user to role
+     *
+     * @param string $userName
+     * @param int $roleId
+     *
+     * @throws AlreadyExistsException
+     * @throws Exception
+     */
+    public function execute(string $userName, int $roleId): void
+    {
+        $user = $this->userFactory->create();
+        $this->userResource->load($user, $userName, 'username');
+        $this->validateUserExists($userName, $user);
+        $this->validateParentRoleExists($roleId);
+
+        $userRole = $this->roleFactory->create();
+        $this->roleResource->load($userRole, $user->getId(), 'user_id');
+        $this->validateUserIsNotAssignedToRole($roleId, $userRole, $user);
+        $user->setRoleId($roleId);
+        $this->userResource->save($user);
+    }
+
+    /**
+     * Checks that user exists
+     *
+     * @param string $userName
+     * @param User $user
+     *
+     * @return void
+     * @throws Exception
+     */
+    private function validateUserExists(string $userName, User $user): void
+    {
+        if (!$user->getId()) {
+            throw new InvalidArgumentException(
+                sprintf(self::USER_DOES_NOT_EXISTS_ERROR_MSG, $userName)
+            );
+        }
+    }
+
+    /**
+     * Check that Role exists
+     *
+     * @param int $roleId
+     * @throws Exception
+     */
+    private function validateParentRoleExists(int $roleId): void
+    {
+        $role = $this->roleFactory->create();
+        $this->roleResource->load($role, $roleId);
+        if (!$role || !$this->isGroupTypeRole($role)) {
+            throw new InvalidArgumentException(
+                sprintf(self::ROLE_DOES_NOT_EXISTS_ERROR_MSG, $roleId)
+            );
+        }
+    }
+
+    /**
+     * Checks that role is group role
+     *
+     * @param Role $role
+     *
+     * @return bool
+     */
+    private function isGroupTypeRole(Role $role): bool
+    {
+        return $role->getRoleType() === Group::ROLE_TYPE;
+    }
+
+    /**
+     * Check user is not assigned to given role
+     *
+     * @param int $parentRoleId
+     * @param Role $role
+     * @param User $user
+     * @throws Exception
+     */
+    private function validateUserIsNotAssignedToRole(int $parentRoleId, Role $role, User $user): void
+    {
+        if ((int)$role->getParentId() === $parentRoleId && (int)$role->getUserId() === (int)$user->getId()) {
+            throw new InvalidArgumentException(
+                sprintf(self::USER_ALREADY_ASSIGNED_ERROR_MSG, $user->getUsername(), $parentRoleId)
+            );
+        }
+    }
+}

--- a/app/code/Magento/User/Model/GetAdminUserList.php
+++ b/app/code/Magento/User/Model/GetAdminUserList.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\User\Model;
+
+use Magento\User\Model\ResourceModel\User\Collection;
+use Magento\User\Model\ResourceModel\User\CollectionFactory as UserCollectionFactory;
+
+/**
+ * Class GetAdminUserList provides list of all admin users in the system
+ */
+class GetAdminUserList
+{
+    /**
+     * @var UserCollectionFactory
+     */
+    private $userCollectionFactory;
+
+    /**
+     * GetAdminUserList constructor
+     *
+     * @param UserCollectionFactory $userCollectionFactory
+     */
+    public function __construct(
+        UserCollectionFactory $userCollectionFactory
+    ) {
+        $this->userCollectionFactory = $userCollectionFactory;
+    }
+
+    /**
+     * Provides admin users list
+     *
+     * @return Collection
+     */
+    public function execute(): Collection
+    {
+        return $this->userCollectionFactory->create()->addFieldToSelect('username')->load();
+    }
+}

--- a/app/code/Magento/User/Test/Integration/Console/Command/AssignAdminToRoleCommandTest.php
+++ b/app/code/Magento/User/Test/Integration/Console/Command/AssignAdminToRoleCommandTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\User\Test\Integration\Console\Command;
+
+use InvalidArgumentException;
+use Magento\Authorization\Model\ResourceModel\Role as RoleResource;
+use Magento\Authorization\Model\Role;
+use Magento\Authorization\Model\RoleFactory;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\User\Console\AssignAdminToRoleCommand;
+use Magento\User\Model\AssignUserToRole;
+use Magento\User\Model\ResourceModel\User as UserResource;
+use Magento\User\Model\User;
+use Magento\User\Model\UserFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class AssignAdminToRoleCommandTest tests AssignAdminToRoleCommand
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class AssignAdminToRoleCommandTest extends TestCase
+{
+    private const USER_NAME_OPTION = '--username';
+
+    private const ROLE_ID_OPTION = '--role-id';
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var CommandTester
+     */
+    private $commandTester;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+        /** @var AssignAdminToRoleCommand $command */
+        $command = $this->objectManager->get(AssignAdminToRoleCommand::class);
+        $helperSet = new HelperSet([new QuestionHelper()]);
+        $command->setHelperSet($helperSet);
+        $this->commandTester = new CommandTester($command);
+    }
+
+    /**
+     * @magentoDataFixture ./../../../../app/code/Magento/User/Test/Integration/_files/test_user.php
+     * @magentoDataFixture ./../../../../app/code/Magento/Authorization/Test/Integration/_files/test_role.php
+     */
+    public function testCommandAssignedExistingUserToExistingRole(): void
+    {
+        $testUser = $this->getTestUser();
+        $role = $this->getTestRole();
+        $this->commandTester->execute(
+            [self::USER_NAME_OPTION => 'test_user', self::ROLE_ID_OPTION => $role->getId()],
+            ['interactive' => false]
+        );
+        $this->assertSame((int)$role->getId(), (int)$testUser->getAclRole());
+    }
+
+    /**
+     * @magentoDataFixture ./../../../../app/code/Magento/User/Test/Integration/_files/test_user.php
+     */
+    public function testCommandAssignedExistingUserToNonExistingRole(): void
+    {
+        $nonExistingRoleId = '999999';
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            sprintf(AssignUserToRole::ROLE_DOES_NOT_EXISTS_ERROR_MSG, $nonExistingRoleId)
+        );
+        $this->commandTester->execute(
+            [self::USER_NAME_OPTION => 'test_user', self::ROLE_ID_OPTION => $nonExistingRoleId],
+            ['interactive' => false]
+        );
+    }
+
+    /**
+     * @magentoDataFixture ./../../../../app/code/Magento/Authorization/Test/Integration/_files/test_role.php
+     */
+    public function testCommandAssignedNonExistingUserToExistingRole(): void
+    {
+        $role = $this->getTestRole();
+        $this->expectException(InvalidArgumentException::class);
+        $nonExistingUserName = 'non_existing_user';
+        $this->expectExceptionMessage(
+            sprintf(AssignUserToRole::USER_DOES_NOT_EXISTS_ERROR_MSG, $nonExistingUserName)
+        );
+        $this->commandTester->execute(
+            [self::USER_NAME_OPTION => $nonExistingUserName, self::ROLE_ID_OPTION => $role->getId()],
+            ['interactive' => false]
+        );
+    }
+
+    /**
+     * @return User
+     */
+    private function getTestUser(): User
+    {
+        $userResource = $this->objectManager->get(UserResource::class);
+        $testUser = $this->objectManager->get(UserFactory::class)->create();
+        $userResource->load($testUser, 'test_user', 'username');
+
+        return $testUser;
+    }
+
+    /**
+     * @return Role
+     */
+    private function getTestRole(): Role
+    {
+        $roleResource = $this->objectManager->get(RoleResource::class);
+        $roleFactory = $this->objectManager->get(RoleFactory::class);
+        $role = $roleFactory->create();
+        $roleResource->load($role, 'test_role', 'role_name');
+
+        return $role;
+    }
+}

--- a/app/code/Magento/User/Test/Integration/_files/test_user.php
+++ b/app/code/Magento/User/Test/Integration/_files/test_user.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Backend\App\Area\FrontNameResolver;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\User\Model\ResourceModel\User as UserResource;
+use Magento\User\Model\UserFactory;
+
+Bootstrap::getInstance()->loadArea(FrontNameResolver::AREA_CODE);
+$objectManager = Bootstrap::getObjectManager();
+/** @var UserFactory $userFactory */
+$userFactory = $objectManager->create(UserFactory::class);
+/** @var UserResource $userResource */
+$userResource = $objectManager->create(UserResource::class);
+$user = $userFactory->create(['data' =>  [
+    "username" => "test_user",
+    "firstname" => "Test",
+    "lastname" => "Dev",
+    "email" => "de@de.de",
+    "password" => "admin123",
+    "password_confirmation" => "admin123",
+    "interface_locale" => "en_US",
+    "is_active" => 1,
+    "limit" => "20",
+    "page" => "1",
+    "assigned_user_role" => "",
+    "role_name" => "",
+    "extra" => null,
+]]);
+$user->setHasDataChanges(true);
+$userResource->save($user);
+$user->getId();

--- a/app/code/Magento/User/etc/di.xml
+++ b/app/code/Magento/User/etc/di.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Authorization\Model\Role">
         <plugin name="updateRoleUsersAcl" type="Magento\User\Model\Plugin\AuthorizationRole" sortOrder="20"/>
     </type>
@@ -13,7 +14,10 @@
     <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">
-                <item name="UnlockAdminAccountCommand" xsi:type="object">Magento\User\Console\UnlockAdminAccountCommand</item>
+                <item name="UnlockAdminAccountCommand"
+                      xsi:type="object">Magento\User\Console\UnlockAdminAccountCommand</item>
+                <item name="assignAdminToRoleCommand"
+                      xsi:type="object">Magento\User\Console\AssignAdminToRoleCommand</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
### Description (*)
Creates Admin-role management commands.

### Manual testing scenarios (*)
1. Run `bin/magento admin:role:list`
2. Get some of the existing roles and save role ID
3. Create new admin user from admin panel
4. Run `bin/magento admin:user:assign-role --username={USER_NAME} --role-id={SAVED_ROLE_ID}`
5. Check that user assigned to role

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#28803: Assign user to role and roles list commands
