### PR TITLE
Fix #26504 - Broken reference errors pilling up logs

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/GeneratorPool.php
+++ b/lib/internal/Magento/Framework/View/Layout/GeneratorPool.php
@@ -5,11 +5,15 @@
  */
 namespace Magento\Framework\View\Layout;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\State;
 use Magento\Framework\View\Layout\Condition\ConditionFactory;
+use Psr\Log\LoggerInterface;
 
 /**
  * Pool of generators for structural elements
  * @api
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class GeneratorPool
 {
@@ -24,31 +28,39 @@ class GeneratorPool
     protected $generators = [];
 
     /**
-     * @var \Psr\Log\LoggerInterface
+     * @var LoggerInterface
      */
     protected $logger;
 
     /**
-     * @var \Magento\Framework\View\Layout\Condition\ConditionFactory
+     * @var ConditionFactory
      */
     private $conditionFactory;
 
     /**
+     * @var State
+     */
+    private $state;
+
+    /**
      * @param ScheduledStructure\Helper $helper
      * @param ConditionFactory $conditionFactory
-     * @param \Psr\Log\LoggerInterface $logger
+     * @param LoggerInterface $logger
      * @param array|null $generators
+     * @param State|null $state
      */
     public function __construct(
         ScheduledStructure\Helper $helper,
         ConditionFactory $conditionFactory,
-        \Psr\Log\LoggerInterface $logger,
-        array $generators = null
+        LoggerInterface $logger,
+        array $generators = null,
+        ?State $state = null
     ) {
         $this->helper = $helper;
         $this->conditionFactory = $conditionFactory;
         $this->logger = $logger;
         $this->addGenerators($generators);
+        $this->state = $state ?? ObjectManager::getInstance()->get(State::class);
     }
 
     /**
@@ -226,7 +238,9 @@ class GeneratorPool
             $structure->setAsChild($element, $destination, $alias);
             $structure->reorderChildElement($destination, $element, $siblingName, $isAfter);
         } catch (\OutOfBoundsException $e) {
-            $this->logger->warning('Broken reference: ' . $e->getMessage());
+            if ($this->state->getMode() === State::MODE_DEVELOPER) {
+                $this->logger->warning('Broken reference: ' . $e->getMessage());
+            }
         }
         $scheduledStructure->unsetElementFromBrokenParentList($element);
         return $this;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
All of other **Broken reference** logs across Magento are only logged in developer mode. This PR fixes the only place from which it was logged also in production mode, possibly causing pilling up of logs

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#26504

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Please check fixed issue for steps to reproduce

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
