### PR TITLE
Move localstorage polyfill to frontend

### DIFF
--- a/app/code/Magento/Theme/view/base/requirejs-config.js
+++ b/app/code/Magento/Theme/view/base/requirejs-config.js
@@ -60,27 +60,6 @@ var config = {
     }
 };
 
-/* eslint-disable max-depth */
-/**
- * Adds polyfills only for browser contexts which prevents bundlers from including them.
- */
-if (typeof window !== 'undefined' && window.document) {
-    /**
-     * Polyfill localStorage and sessionStorage for browsers that do not support them.
-     */
-    try {
-        if (!window.localStorage || !window.sessionStorage) {
-            throw new Error();
-        }
-
-        localStorage.setItem('storage_test', 1);
-        localStorage.removeItem('storage_test');
-    } catch (e) {
-        config.deps.push('mage/polyfill');
-    }
-}
-/* eslint-enable max-depth */
-
 require(['jquery'], function ($) {
     'use strict';
 

--- a/app/code/Magento/Theme/view/frontend/requirejs-config.js
+++ b/app/code/Magento/Theme/view/frontend/requirejs-config.js
@@ -49,3 +49,24 @@ var config = {
         }
     }
 };
+
+/* eslint-disable max-depth */
+/**
+ * Adds polyfills only for browser contexts which prevents bundlers from including them.
+ */
+if (typeof window !== 'undefined' && window.document) {
+    /**
+     * Polyfill localStorage and sessionStorage for browsers that do not support them.
+     */
+    try {
+        if (!window.localStorage || !window.sessionStorage) {
+            throw new Error();
+        }
+
+        localStorage.setItem('storage_test', 1);
+        localStorage.removeItem('storage_test');
+    } catch (e) {
+        config.deps.push('mage/polyfill');
+    }
+}
+/* eslint-enable max-depth */


### PR DESCRIPTION
### Description (*)
This PR moves localstorage polyfill from base to frontend area, based on the following feedback https://github.com/magento/magento2/pull/27619#issuecomment-642121163

/CC @krzksz @omiroshnichenko

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Storage polyfill is only loaded and applied when either localStorage or sessionStorage are not available.


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#28900: Move localstorage polyfill to frontend