### PR TITLE
Refactor - cleanup unnecessary around plugins

### DIFF
--- a/app/code/Magento/AdvancedSearch/Model/Indexer/Fulltext/Plugin/CustomerGroup.php
+++ b/app/code/Magento/AdvancedSearch/Model/Indexer/Fulltext/Plugin/CustomerGroup.php
@@ -36,18 +36,17 @@ class CustomerGroup extends AbstractPlugin
      * Invalidate indexer on customer group save
      *
      * @param Group $subject
-     * @param \Closure $proceed
+     * @param Attribute $result
      * @param AbstractModel $group
      * @return Attribute
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundSave(
+    public function afterSave(
         Group $subject,
-        \Closure $proceed,
+        Attribute $result,
         AbstractModel $group
     ) {
         $needInvalidation = $group->isObjectNew() || $group->dataHasChangedFor('tax_class_id');
-        $result = $proceed($group);
         if ($needInvalidation) {
             $this->indexerRegistry->get(Fulltext::INDEXER_ID)->invalidate();
         }

--- a/app/code/Magento/AdvancedSearch/Test/Unit/Model/Indexer/Fulltext/Plugin/CustomerGroupTest.php
+++ b/app/code/Magento/AdvancedSearch/Test/Unit/Model/Indexer/Fulltext/Plugin/CustomerGroupTest.php
@@ -118,7 +118,7 @@ class CustomerGroupTest extends TestCase
      *
      * @return array
      */
-    public function aroundSaveDataProvider(): array
+    public function afterSaveDataProvider(): array
     {
         return [
             [false, false, 0],

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Price/Plugin/CustomerGroup.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Price/Plugin/CustomerGroup.php
@@ -72,19 +72,19 @@ class CustomerGroup
      * Update price index after customer group saved
      *
      * @param GroupRepositoryInterface $subject
-     * @param \Closure $proceed
+     * @param GroupInterface $result
      * @param GroupInterface $group
      *
      * @return GroupInterface
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundSave(
+    public function afterSave(
         GroupRepositoryInterface $subject,
-        \Closure $proceed,
+        GroupInterface $result,
         GroupInterface $group
     ) {
         $isGroupNew = $group->getId() === null;
-        $group = $proceed($group);
+        $group = $result;
         if ($isGroupNew) {
             foreach ($this->getAffectedDimensions((string)$group->getId()) as $dimensions) {
                 $this->tableMaintainer->createTablesForDimensions($dimensions);

--- a/app/code/Magento/CatalogInventory/Plugin/MassUpdateProductAttribute.php
+++ b/app/code/Magento/CatalogInventory/Plugin/MassUpdateProductAttribute.php
@@ -81,11 +81,10 @@ class MassUpdateProductAttribute
      * Around execute plugin
      *
      * @param Save $subject
-     * @param callable $proceed
      *
-     * @return \Magento\Framework\Controller\ResultInterface
+     * @return array
      */
-    public function aroundExecute(Save $subject, callable $proceed)
+    public function beforeExecute(Save $subject)
     {
         try {
             /** @var \Magento\Framework\App\RequestInterface $request */
@@ -101,16 +100,16 @@ class MassUpdateProductAttribute
                 $this->updateInventoryInProducts($productIds, $websiteId, $inventoryData);
             }
 
-            return $proceed();
+            return [];
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $this->messageManager->addErrorMessage($e->getMessage());
-            return $proceed();
+            return [];
         } catch (\Exception $e) {
             $this->messageManager->addExceptionMessage(
                 $e,
                 __('Something went wrong while updating the product(s) attributes.')
             );
-            return $proceed();
+            return [];
         }
     }
 

--- a/app/code/Magento/CatalogSearch/Model/Attribute/SearchWeight.php
+++ b/app/code/Magento/CatalogSearch/Model/Attribute/SearchWeight.php
@@ -40,21 +40,20 @@ class SearchWeight
      *   when an attribute's search weight is changed.
      *
      * @param \Magento\Catalog\Model\ResourceModel\Attribute $subject
-     * @param \Closure $proceed
+     * @param \Magento\Catalog\Model\ResourceModel\Attribute $proceed
      * @param \Magento\Framework\Model\AbstractModel $attribute
      * @return \Magento\Catalog\Model\ResourceModel\Attribute
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundSave(
+    public function afterSave(
         \Magento\Catalog\Model\ResourceModel\Attribute $subject,
-        \Closure $proceed,
+        \Magento\Catalog\Model\ResourceModel\Attribute $result,
         \Magento\Framework\Model\AbstractModel $attribute
     ) {
         $isNew = $attribute->isObjectNew();
         $isWeightChanged = $attribute->dataHasChangedFor('search_weight');
 
-        $result = $proceed($attribute);
         if ($isNew || $isWeightChanged) {
             $this->config->reset();
         }

--- a/app/code/Magento/CatalogUrlRewrite/Model/Category/Plugin/Category/Remove.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Category/Plugin/Category/Remove.php
@@ -53,19 +53,18 @@ class Remove
      * Remove product urls from storage
      *
      * @param \Magento\Catalog\Model\ResourceModel\Category $subject
-     * @param \Closure $proceed
+     * @param mixed $result
      * @param \Magento\Catalog\Api\Data\CategoryInterface $category
      * @return mixed
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundDelete(
+    public function afterDelete(
         \Magento\Catalog\Model\ResourceModel\Category $subject,
-        \Closure $proceed,
+        $result,
         \Magento\Catalog\Api\Data\CategoryInterface $category
     ) {
         $categoryIds = $this->childrenCategoriesProvider->getChildrenIds($category, true);
         $categoryIds[] = $category->getId();
-        $result = $proceed($category);
         foreach ($categoryIds as $categoryId) {
             $this->deleteRewritesForCategory($categoryId);
         }

--- a/app/code/Magento/ConfigurableProduct/Helper/Product/Configuration/Plugin.php
+++ b/app/code/Magento/ConfigurableProduct/Helper/Product/Configuration/Plugin.php
@@ -12,23 +12,23 @@ class Plugin
      * Retrieve configuration options for configurable product
      *
      * @param \Magento\Catalog\Helper\Product\Configuration $subject
-     * @param callable $proceed
+     * @param array $result
      * @param \Magento\Catalog\Model\Product\Configuration\Item\ItemInterface $item
      *
      * @return array
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundGetOptions(
+    public function afterGetOptions(
         \Magento\Catalog\Helper\Product\Configuration $subject,
-        \Closure $proceed,
+        $result,
         \Magento\Catalog\Model\Product\Configuration\Item\ItemInterface $item
     ) {
         $product = $item->getProduct();
         $typeId = $product->getTypeId();
         if ($typeId == \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE) {
             $attributes = $product->getTypeInstance()->getSelectedAttributesInfo($product);
-            return array_merge($attributes, $proceed($item));
+            return array_merge($attributes, $result);
         }
-        return $proceed($item);
+        return $result;
     }
 }

--- a/app/code/Magento/ConfigurableProduct/Model/Entity/Product/Attribute/Group/AttributeMapper/Plugin.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Entity/Product/Attribute/Group/AttributeMapper/Plugin.php
@@ -41,19 +41,18 @@ class Plugin
      * Add is_configurable field to attribute presentation
      *
      * @param \Magento\Catalog\Model\Entity\Product\Attribute\Group\AttributeMapperInterface $subject
-     * @param callable $proceed
+     * @param array $result
      * @param \Magento\Eav\Model\Entity\Attribute $attribute
      *
      * @return array
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundMap(
+    public function afterMap(
         \Magento\Catalog\Model\Entity\Product\Attribute\Group\AttributeMapperInterface $subject,
-        \Closure $proceed,
+        $result,
         \Magento\Eav\Model\Entity\Attribute $attribute
     ) {
         $setId = $this->registry->registry('current_attribute_set')->getId();
-        $result = $proceed($attribute);
         if (!isset($this->configurableAttributes[$setId])) {
             $this->configurableAttributes[$setId] = $this->attributeFactory->create()->getUsedAttributes($setId);
         }

--- a/app/code/Magento/ConfigurableProduct/Plugin/Model/ResourceModel/Product.php
+++ b/app/code/Magento/ConfigurableProduct/Plugin/Model/ResourceModel/Product.php
@@ -129,18 +129,17 @@ class Product
      * Gather configurable parent ids of product being deleted and reindex after delete is complete.
      *
      * @param \Magento\Catalog\Model\ResourceModel\Product $subject
-     * @param \Closure $proceed
+     * @param \Magento\Catalog\Model\ResourceModel\Product $result
      * @param \Magento\Catalog\Model\Product $product
      * @return \Magento\Catalog\Model\ResourceModel\Product
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundDelete(
+    public function afterDelete(
         \Magento\Catalog\Model\ResourceModel\Product $subject,
-        \Closure $proceed,
+        \Magento\Catalog\Model\ResourceModel\Product $result,
         \Magento\Catalog\Model\Product $product
     ) {
         $configurableProductIds = $this->configurable->getParentIdsByChild($product->getId());
-        $result = $proceed($product);
         $this->productIndexer->executeList($configurableProductIds);
 
         return $result;

--- a/app/code/Magento/Customer/Model/Plugin/CustomerFlushFormKey.php
+++ b/app/code/Magento/Customer/Model/Plugin/CustomerFlushFormKey.php
@@ -37,13 +37,12 @@ class CustomerFlushFormKey
     /**
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @param FlushFormKey $subject
-     * @param callable $proceed
-     * @param $args
+     * @param $result
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function aroundExecute(FlushFormKey $subject, callable $proceed, ...$args)
+    public function afterExecute(FlushFormKey $subject, $result)
     {
         $currentFormKey = $this->dataFormKey->getFormKey();
-        $proceed(...$args);
         $beforeParams = $this->session->getBeforeRequestParams();
         if (isset($beforeParams['form_key']) && $beforeParams['form_key'] === $currentFormKey) {
             $beforeParams['form_key'] = $this->dataFormKey->getFormKey();

--- a/app/code/Magento/Downloadable/Model/Product/TypeTransitionManager/Plugin/Downloadable.php
+++ b/app/code/Magento/Downloadable/Model/Product/TypeTransitionManager/Plugin/Downloadable.php
@@ -60,7 +60,7 @@ class Downloadable
         );
         $downloadableData = $this->request->getPost('downloadable');
         $hasDownloadableData = false;
-        if (isset($downloadableData)) {
+        if ($isTypeCompatible && isset($downloadableData)) {
             foreach ($downloadableData as $data) {
                 foreach ($data as $rowData) {
                     if (empty($rowData['is_delete'])) {

--- a/app/code/Magento/GroupedProduct/Helper/Product/Configuration/Plugin/Grouped.php
+++ b/app/code/Magento/GroupedProduct/Helper/Product/Configuration/Plugin/Grouped.php
@@ -11,15 +11,15 @@ class Grouped
      * Retrieves grouped product options list
      *
      * @param \Magento\Catalog\Helper\Product\Configuration $subject
-     * @param callable $proceed
+     * @param array $result
      * @param \Magento\Catalog\Model\Product\Configuration\Item\ItemInterface $item
      *
      * @return array
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundGetOptions(
+    public function afterGetOptions(
         \Magento\Catalog\Helper\Product\Configuration $subject,
-        \Closure $proceed,
+        $result,
         \Magento\Catalog\Model\Product\Configuration\Item\ItemInterface $item
     ) {
         $product = $item->getProduct();
@@ -41,7 +41,7 @@ class Grouped
                 }
             }
 
-            $options = array_merge($options, $proceed($item));
+            $options = array_merge($options, $result);
             $isUnConfigured = true;
             foreach ($options as &$option) {
                 if ($option['value']) {
@@ -51,6 +51,6 @@ class Grouped
             }
             return $isUnConfigured ? [] : $options;
         }
-        return $proceed($item);
+        return $result;
     }
 }

--- a/app/code/Magento/GroupedProduct/Model/ResourceModel/Product/Link/RelationPersister.php
+++ b/app/code/Magento/GroupedProduct/Model/ResourceModel/Product/Link/RelationPersister.php
@@ -9,6 +9,7 @@ namespace Magento\GroupedProduct\Model\ResourceModel\Product\Link;
 use Magento\Catalog\Model\ProductLink\LinkFactory;
 use Magento\Catalog\Model\ResourceModel\Product\Link;
 use Magento\Catalog\Model\ResourceModel\Product\Relation;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\GroupedProduct\Model\ResourceModel\Product\Link as GroupedLink;
 
 class RelationPersister
@@ -63,16 +64,16 @@ class RelationPersister
      * Remove grouped products from product relation table
      *
      * @param Link $subject
-     * @param \Closure $proceed
+     * @param Link $result
      * @param int $linkId
      * @return Link
+     * @throws LocalizedException
      */
-    public function aroundDeleteProductLink(Link $subject, \Closure $proceed, $linkId)
+    public function afterDeleteProductLink(Link $subject, Link $result, $linkId)
     {
         /** @var \Magento\Catalog\Model\ProductLink\Link $link */
         $link = $this->linkFactory->create();
         $subject->load($link, $linkId, $subject->getIdFieldName());
-        $result = $proceed($linkId);
         if ($link->getLinkTypeId() == GroupedLink::LINK_TYPE_GROUPED) {
             $this->relationProcessor->removeRelations(
                 $link->getProductId(),

--- a/app/code/Magento/Theme/Model/Indexer/Design/Config/Plugin/Store.php
+++ b/app/code/Magento/Theme/Model/Indexer/Design/Config/Plugin/Store.php
@@ -29,14 +29,13 @@ class Store
      * Invalidate design config grid indexer on store creation
      *
      * @param StoreStore $subject
-     * @param \Closure $proceed
+     * @param StoreStore $result
      * @return StoreStore
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundSave(StoreStore $subject, \Closure $proceed)
+    public function afterSave(StoreStore $subject, StoreStore $result)
     {
         $isObjectNew = $subject->getId() == 0;
-        $result = $proceed();
         if ($isObjectNew) {
             $this->indexerRegistry->get(Config::DESIGN_CONFIG_GRID_INDEXER_ID)->invalidate();
         }

--- a/app/code/Magento/Theme/Model/Indexer/Design/Config/Plugin/Website.php
+++ b/app/code/Magento/Theme/Model/Indexer/Design/Config/Plugin/Website.php
@@ -29,14 +29,13 @@ class Website
      * Invalidate design config grid indexer on website creation
      *
      * @param StoreWebsite $subject
-     * @param \Closure $proceed
+     * @param StoreWebsite $result
      * @return StoreWebsite
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundSave(StoreWebsite $subject, \Closure $proceed)
+    public function afterSave(StoreWebsite $subject, StoreWebsite $result)
     {
         $isObjectNew = $subject->getId() == 0;
-        $result = $proceed();
         if ($isObjectNew) {
             $this->indexerRegistry->get(Config::DESIGN_CONFIG_GRID_INDEXER_ID)->invalidate();
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Changed the following around plugins to before and after plugins:


    after:
    
            \Magento\GroupedProduct\Helper\Product\Configuration\Plugin\Grouped::afterGetOptions
            \Magento\ConfigurableProduct\Helper\Product\Configuration\Plugin::afterGetOptions
            \Magento\AdvancedSearch\Model\Indexer\Fulltext\Plugin\CustomerGroup::afterSave
            \Magento\Catalog\Model\Indexer\Product\Price\Plugin\CustomerGroup::afterSave
            \Magento\CatalogSearch\Model\Attribute\SearchWeight::afterSave
            \Magento\CatalogUrlRewrite\Model\Category\Plugin\Category\Remove::afterDelete
            \Magento\ConfigurableProduct\Model\Entity\Product\Attribute\Group\AttributeMapper\Plugin::afterMap
            \Magento\ConfigurableProduct\Plugin\Model\ResourceModel\Product::afterDelete
            \Magento\Customer\Model\Plugin\CustomerFlushFormKey::afterExecute
            \Magento\GroupedProduct\Model\ResourceModel\Product\Link\RelationPersister::afterDeleteProductLink
            \Magento\Theme\Model\Indexer\Design\Config\Plugin\Store::afterSave
            \Magento\Theme\Model\Indexer\Design\Config\Plugin\Website::afterSave
    
    before:
    
            \Magento\CatalogInventory\Plugin\MassUpdateProductAttribute::beforeExecute

Starting from Magento 2.2 it is no longer necessary to use around plugins in cases which you now could just use an after which also contains the parameters.

This refactor is because of performance reasons:
![image](https://user-images.githubusercontent.com/6040343/84946876-a2000400-b0e9-11ea-9703-236071d88a9a.png)
source:
https://devdocs.magento.com/guides/v2.4/extension-dev-guide/plugins.html#around-methods


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#27912


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
