### PR TITLE
Introduce observers to track deleted entities

### DIFF
--- a/app/code/Magento/MediaContentCatalog/Observer/CategoryDelete.php
+++ b/app/code/Magento/MediaContentCatalog/Observer/CategoryDelete.php
@@ -17,7 +17,7 @@ use Magento\MediaContentApi\Model\GetEntityContentsInterface;
 use Magento\MediaContentApi\Api\ExtractAssetsFromContentInterface;
 
 /**
- * Observe the catalog_category_delete event and deletes relation between category content and media asset.
+ * Observe the catalog_category_delete_after event and deletes relation between category content and media asset.
  */
 class CategoryDelete implements ObserverInterface
 {
@@ -88,16 +88,16 @@ class CategoryDelete implements ObserverInterface
      */
     public function execute(Observer $observer): void
     {
-        $model = $observer->getEvent()->getData('category');
+        $category = $observer->getEvent()->getData('category');
         $contentAssetLinks = [];
         
-        if ($model instanceof CatalogCategory) {
+        if ($category instanceof CatalogCategory) {
             foreach ($this->fields as $field) {
                 $contentIdentity = $this->contentIdentityFactory->create(
                     [
                         self::TYPE => self::CONTENT_TYPE,
                         self::FIELD => $field,
-                        self::ENTITY_ID => (string) $model->getEntityId(),
+                        self::ENTITY_ID => (string) $category->getEntityId(),
                     ]
                 );
                 $content = implode(PHP_EOL, $this->getContent->execute($contentIdentity));

--- a/app/code/Magento/MediaContentCatalog/Observer/CategoryDelete.php
+++ b/app/code/Magento/MediaContentCatalog/Observer/CategoryDelete.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaContentCatalog\Observer;
+
+use Magento\Catalog\Model\Category as CatalogCategory;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\MediaContentApi\Api\Data\ContentIdentityInterfaceFactory;
+use Magento\MediaContentApi\Api\Data\ContentAssetLinkInterfaceFactory;
+use Magento\MediaContentApi\Api\DeleteContentAssetLinksInterface;
+use Magento\MediaContentApi\Model\GetEntityContentsInterface;
+use Magento\MediaContentApi\Api\ExtractAssetsFromContentInterface;
+
+/**
+ * Observe the catalog_category_delete event and deletes relation between category content and media asset.
+ */
+class CategoryDelete implements ObserverInterface
+{
+    private const CONTENT_TYPE = 'catalog_category';
+    private const TYPE = 'entityType';
+    private const ENTITY_ID = 'entityId';
+    private const FIELD = 'field';
+    
+    /**
+     * @var ContentIdentityInterfaceFactory
+     */
+    private $contentIdentityFactory;
+
+    /**
+      * @var ContentAssetLinkInterfaceFactory
+      */
+    private $contentAssetLinkFactory;
+
+    /**
+     * @var DeleteContentAssetLinksInterface
+     */
+    private $deleteContentAssetLinks;
+
+    /**
+     * @var array
+     */
+    private $fields;
+
+    /**
+     * @var GetEntityContentsInterface
+     */
+    private $getContent;
+
+    /**
+     * @var ExtractAssetsFromContentInterface
+     */
+    private $extractAssetsFromContent;
+    
+    /**
+     * @param ExtractAssetsFromContentInterface $extractAssetsFromContent
+     * @param GetEntityContentsInterface $getContent
+     * @param DeleteContentAssetLinksInterface $deleteContentAssetLinks
+     * @param ContentIdentityInterfaceFactory $contentIdentityFactory
+     * @param ContentAssetLinkInterfaceFactory $contentAssetLinkFactory
+     */
+    public function __construct(
+        ExtractAssetsFromContentInterface $extractAssetsFromContent,
+        GetEntityContentsInterface $getContent,
+        DeleteContentAssetLinksInterface $deleteContentAssetLinks,
+        ContentIdentityInterfaceFactory $contentIdentityFactory,
+        ContentAssetLinkInterfaceFactory $contentAssetLinkFactory,
+        array $fields
+    ) {
+        $this->extractAssetsFromContent = $extractAssetsFromContent;
+        $this->getContent = $getContent;
+        $this->deleteContentAssetLinks = $deleteContentAssetLinks;
+        $this->contentAssetLinkFactory = $contentAssetLinkFactory;
+        $this->contentIdentityFactory = $contentIdentityFactory;
+        $this->fields = $fields;
+    }
+
+    /**
+     * Retrieve the deleted category and  remove relation betwen category and asset
+     *
+     * @param Observer $observer
+     * @throws \Exception
+     */
+    public function execute(Observer $observer): void
+    {
+        $model = $observer->getEvent()->getData('category');
+        $contentAssetsLinks = [];
+        
+        if ($model instanceof CatalogCategory) {
+            foreach ($this->fields as $field) {
+                $contentIdentity = $this->contentIdentityFactory->create(
+                    [
+                        self::TYPE => self::CONTENT_TYPE,
+                        self::FIELD => $field,
+                        self::ENTITY_ID => (string) $model->getEntityId(),
+                    ]
+                );
+                $content = implode(PHP_EOL, $this->getContent->execute($contentIdentity));
+                $assets = $this->extractAssetsFromContent->execute($content);
+
+                foreach ($assets as $asset) {
+                    $contentAssetLinks[] = $this->contentAssetLinkFactory->create(
+                        [
+                            'assetId' => $asset->getId(),
+                            'contentIdentity' => $contentIdentity
+                        ]
+                    );
+                }
+            }
+            if (!empty($contentAssetLinks)) {
+                $this->deleteContentAssetLinks->execute($contentAssetLinks);
+            }
+        }
+    }
+}

--- a/app/code/Magento/MediaContentCatalog/Observer/CategoryDelete.php
+++ b/app/code/Magento/MediaContentCatalog/Observer/CategoryDelete.php
@@ -32,8 +32,8 @@ class CategoryDelete implements ObserverInterface
     private $contentIdentityFactory;
 
     /**
-      * @var ContentAssetLinkInterfaceFactory
-      */
+     * @var ContentAssetLinkInterfaceFactory
+     */
     private $contentAssetLinkFactory;
 
     /**
@@ -62,6 +62,7 @@ class CategoryDelete implements ObserverInterface
      * @param DeleteContentAssetLinksInterface $deleteContentAssetLinks
      * @param ContentIdentityInterfaceFactory $contentIdentityFactory
      * @param ContentAssetLinkInterfaceFactory $contentAssetLinkFactory
+     * @param array $fields
      */
     public function __construct(
         ExtractAssetsFromContentInterface $extractAssetsFromContent,
@@ -88,7 +89,7 @@ class CategoryDelete implements ObserverInterface
     public function execute(Observer $observer): void
     {
         $model = $observer->getEvent()->getData('category');
-        $contentAssetsLinks = [];
+        $contentAssetLinks = [];
         
         if ($model instanceof CatalogCategory) {
             foreach ($this->fields as $field) {

--- a/app/code/Magento/MediaContentCatalog/Observer/ProductDelete.php
+++ b/app/code/Magento/MediaContentCatalog/Observer/ProductDelete.php
@@ -32,8 +32,8 @@ class ProductDelete implements ObserverInterface
     private $contentIdentityFactory;
 
     /**
-      * @var ContentAssetLinkInterfaceFactory
-      */
+     * @var ContentAssetLinkInterfaceFactory
+     */
     private $contentAssetLinkFactory;
 
     /**
@@ -62,6 +62,7 @@ class ProductDelete implements ObserverInterface
      * @param DeleteContentAssetLinksInterface $deleteContentAssetLinks
      * @param ContentIdentityInterfaceFactory $contentIdentityFactory
      * @param ContentAssetLinkInterfaceFactory $contentAssetLinkFactory
+     * @param array $fields
      */
     public function __construct(
         ExtractAssetsFromContentInterface $extractAssetsFromContent,
@@ -88,7 +89,7 @@ class ProductDelete implements ObserverInterface
     public function execute(Observer $observer): void
     {
         $model = $observer->getEvent()->getData('product');
-        $contentAssetsLinks = [];
+        $contentAssetLinks = [];
         
         if ($model instanceof CatalogProduct) {
             foreach ($this->fields as $field) {

--- a/app/code/Magento/MediaContentCatalog/Observer/ProductDelete.php
+++ b/app/code/Magento/MediaContentCatalog/Observer/ProductDelete.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaContentCatalog\Observer;
+
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\MediaContentApi\Api\Data\ContentIdentityInterfaceFactory;
+use Magento\MediaContentApi\Api\Data\ContentAssetLinkInterfaceFactory;
+use Magento\MediaContentApi\Api\DeleteContentAssetLinksInterface;
+use Magento\MediaContentApi\Model\GetEntityContentsInterface;
+use Magento\MediaContentApi\Api\ExtractAssetsFromContentInterface;
+
+/**
+ * Observe the catalog_product_delete_before event and deletes relation between category content and media asset.
+ */
+class ProductDelete implements ObserverInterface
+{
+    private const CONTENT_TYPE = 'catalog_product';
+    private const TYPE = 'entityType';
+    private const ENTITY_ID = 'entityId';
+    private const FIELD = 'field';
+    
+    /**
+     * @var ContentIdentityInterfaceFactory
+     */
+    private $contentIdentityFactory;
+
+    /**
+      * @var ContentAssetLinkInterfaceFactory
+      */
+    private $contentAssetLinkFactory;
+
+    /**
+     * @var DeleteContentAssetLinksInterface
+     */
+    private $deleteContentAssetLinks;
+
+    /**
+     * @var array
+     */
+    private $fields;
+
+    /**
+     * @var GetEntityContentsInterface
+     */
+    private $getContent;
+
+    /**
+     * @var ExtractAssetsFromContentInterface
+     */
+    private $extractAssetsFromContent;
+    
+    /**
+     * @param ExtractAssetsFromContentInterface $extractAssetsFromContent
+     * @param GetEntityContentsInterface $getContent
+     * @param DeleteContentAssetLinksInterface $deleteContentAssetLinks
+     * @param ContentIdentityInterfaceFactory $contentIdentityFactory
+     * @param ContentAssetLinkInterfaceFactory $contentAssetLinkFactory
+     */
+    public function __construct(
+        ExtractAssetsFromContentInterface $extractAssetsFromContent,
+        GetEntityContentsInterface $getContent,
+        DeleteContentAssetLinksInterface $deleteContentAssetLinks,
+        ContentIdentityInterfaceFactory $contentIdentityFactory,
+        ContentAssetLinkInterfaceFactory $contentAssetLinkFactory,
+        array $fields
+    ) {
+        $this->extractAssetsFromContent = $extractAssetsFromContent;
+        $this->getContent = $getContent;
+        $this->deleteContentAssetLinks = $deleteContentAssetLinks;
+        $this->contentAssetLinkFactory = $contentAssetLinkFactory;
+        $this->contentIdentityFactory = $contentIdentityFactory;
+        $this->fields = $fields;
+    }
+
+    /**
+     * Retrieve the deleted product and  remove relation betwen product and asset
+     *
+     * @param Observer $observer
+     * @throws \Exception
+     */
+    public function execute(Observer $observer): void
+    {
+        $model = $observer->getEvent()->getData('product');
+        $contentAssetsLinks = [];
+        
+        if ($model instanceof CatalogProduct) {
+            foreach ($this->fields as $field) {
+                $contentIdentity = $this->contentIdentityFactory->create(
+                    [
+                        self::TYPE => self::CONTENT_TYPE,
+                        self::FIELD => $field,
+                        self::ENTITY_ID => (string) $model->getEntityId(),
+                    ]
+                );
+                $content = implode(PHP_EOL, $this->getContent->execute($contentIdentity));
+                $assets = $this->extractAssetsFromContent->execute($content);
+
+                foreach ($assets as $asset) {
+                    $contentAssetLinks[] = $this->contentAssetLinkFactory->create(
+                        [
+                            'assetId' => $asset->getId(),
+                            'contentIdentity' => $contentIdentity
+                        ]
+                    );
+                }
+            }
+            if (!empty($contentAssetLinks)) {
+                $this->deleteContentAssetLinks->execute($contentAssetLinks);
+            }
+        }
+    }
+}

--- a/app/code/Magento/MediaContentCatalog/Observer/ProductDelete.php
+++ b/app/code/Magento/MediaContentCatalog/Observer/ProductDelete.php
@@ -88,20 +88,20 @@ class ProductDelete implements ObserverInterface
      */
     public function execute(Observer $observer): void
     {
-        $model = $observer->getEvent()->getData('product');
+        $product = $observer->getEvent()->getData('product');
         $contentAssetLinks = [];
         
-        if ($model instanceof CatalogProduct) {
+        if ($product instanceof CatalogProduct) {
             foreach ($this->fields as $field) {
                 $contentIdentity = $this->contentIdentityFactory->create(
                     [
                         self::TYPE => self::CONTENT_TYPE,
                         self::FIELD => $field,
-                        self::ENTITY_ID => (string) $model->getEntityId(),
+                        self::ENTITY_ID => (string) $product->getEntityId(),
                     ]
                 );
-                $content = implode(PHP_EOL, $this->getContent->execute($contentIdentity));
-                $assets = $this->extractAssetsFromContent->execute($content);
+                $productContent = implode(PHP_EOL, $this->getContent->execute($contentIdentity));
+                $assets = $this->extractAssetsFromContent->execute($productContent);
 
                 foreach ($assets as $asset) {
                     $contentAssetLinks[] = $this->contentAssetLinkFactory->create(

--- a/app/code/Magento/MediaContentCatalog/etc/di.xml
+++ b/app/code/Magento/MediaContentCatalog/etc/di.xml
@@ -14,6 +14,22 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\MediaContentCatalog\Observer\ProductDelete">
+        <arguments>
+            <argument name="fields" xsi:type="array">
+                <item name="description" xsi:type="string">description</item>
+                <item name="short_description" xsi:type="string">short_description</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Magento\MediaContentCatalog\Observer\CategoryDelete">
+        <arguments>
+            <argument name="fields" xsi:type="array">
+                <item name="image" xsi:type="string">image</item>
+                <item name="description" xsi:type="string">description</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\MediaContentCatalog\Observer\Category">
         <arguments>
             <argument name="fields" xsi:type="array">

--- a/app/code/Magento/MediaContentCatalog/etc/events.xml
+++ b/app/code/Magento/MediaContentCatalog/etc/events.xml
@@ -9,6 +9,12 @@
     <event name="catalog_category_save_after">
         <observer name="media_content_catalog_category_save_after" instance="Magento\MediaContentCatalog\Observer\Category" />
     </event>
+   <event name="catalog_product_delete_before">
+        <observer name="media_content_catalog_product_delete_before" instance="Magento\MediaContentCatalog\Observer\ProductDelete" />
+    </event>
+   <event name="catalog_category_delete_before">
+        <observer name="media_content_catalog_category_delete_before" instance="Magento\MediaContentCatalog\Observer\CategoryDelete" />
+    </event>
     <event name="catalog_product_save_after">
         <observer name="media_content_catalog_product_save_after" instance="Magento\MediaContentCatalog\Observer\Product" />
     </event>

--- a/app/code/Magento/MediaContentCms/Observer/BlockDelete.php
+++ b/app/code/Magento/MediaContentCms/Observer/BlockDelete.php
@@ -88,20 +88,19 @@ class BlockDelete implements ObserverInterface
      */
     public function execute(Observer $observer): void
     {
-        $model = $observer->getEvent()->getData('object');
+        $block = $observer->getEvent()->getData('object');
         $contentAssetLinks = [];
         
-        if ($model instanceof CmsBlock) {
+        if ($block instanceof CmsBlock) {
             foreach ($this->fields as $field) {
                 $contentIdentity = $this->contentIdentityFactory->create(
                     [
                         self::TYPE => self::CONTENT_TYPE,
                         self::FIELD => $field,
-                        self::ENTITY_ID => (string) $model->getId(),
+                        self::ENTITY_ID => (string) $block->getId(),
                     ]
                 );
-                
-                $assets = $this->extractAssetsFromContent->execute((string) $model->getData($field));
+                $assets = $this->extractAssetsFromContent->execute((string) $block->getData($field));
                 
                 foreach ($assets as $asset) {
                     $contentAssetLinks[] = $this->contentAssetLinkFactory->create(

--- a/app/code/Magento/MediaContentCms/Observer/BlockDelete.php
+++ b/app/code/Magento/MediaContentCms/Observer/BlockDelete.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaContentCms\Observer;
+
+use Magento\Cms\Model\Block as CmsBlock;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\MediaContentApi\Api\Data\ContentIdentityInterfaceFactory;
+use Magento\MediaContentApi\Api\Data\ContentAssetLinkInterfaceFactory;
+use Magento\MediaContentApi\Api\DeleteContentAssetLinksInterface;
+use Magento\MediaContentApi\Model\GetEntityContentsInterface;
+use Magento\MediaContentApi\Api\ExtractAssetsFromContentInterface;
+
+/**
+ * Observe the adminhtml_cmspage_on_delete event and deletes relation between page content and media asset.
+ */
+class BlockDelete implements ObserverInterface
+{
+    private const CONTENT_TYPE = 'cms_block';
+    private const TYPE = 'entityType';
+    private const ENTITY_ID = 'entityId';
+    private const FIELD = 'field';
+    
+    /**
+     * @var ContentIdentityInterfaceFactory
+     */
+    private $contentIdentityFactory;
+
+    /**
+      * @var ContentAssetLinkInterfaceFactory
+      */
+    private $contentAssetLinkFactory;
+
+    /**
+     * @var DeleteContentAssetLinksInterface
+     */
+    private $deleteContentAssetLinks;
+
+    /**
+     * @var array
+     */
+    private $fields;
+
+    /**
+     * @var GetEntityContentsInterface
+     */
+    private $getContent;
+
+    /**
+     * @var ExtractAssetsFromContentInterface
+     */
+    private $extractAssetsFromContent;
+    
+    /**
+     * @param ExtractAssetsFromContentInterface $extractAssetsFromContent
+     * @param GetEntityContentsInterface $getContent
+     * @param DeleteContentAssetLinksInterface $deleteContentAssetLinks
+     * @param ContentIdentityInterfaceFactory $contentIdentityFactory
+     * @param ContentAssetLinkInterfaceFactory $contentAssetLinkFactory
+     */
+    public function __construct(
+        ExtractAssetsFromContentInterface $extractAssetsFromContent,
+        GetEntityContentsInterface $getContent,
+        DeleteContentAssetLinksInterface $deleteContentAssetLinks,
+        ContentIdentityInterfaceFactory $contentIdentityFactory,
+        ContentAssetLinkInterfaceFactory $contentAssetLinkFactory,
+        array $fields
+    ) {
+        $this->extractAssetsFromContent = $extractAssetsFromContent;
+        $this->getContent = $getContent;
+        $this->deleteContentAssetLinks = $deleteContentAssetLinks;
+        $this->contentAssetLinkFactory = $contentAssetLinkFactory;
+        $this->contentIdentityFactory = $contentIdentityFactory;
+        $this->fields = $fields;
+    }
+
+    /**
+     * Retrieve the deleted category and  remove relation betwen category and asset
+     *
+     * @param Observer $observer
+     * @throws \Exception
+     */
+    public function execute(Observer $observer): void
+    {
+        $model = $observer->getEvent()->getData('object');
+        $contentAssetsLinks = [];
+        
+        if ($model instanceof CmsBlock) {
+            foreach ($this->fields as $field) {
+                $contentIdentity = $this->contentIdentityFactory->create(
+                    [
+                        self::TYPE => self::CONTENT_TYPE,
+                        self::FIELD => $field,
+                        self::ENTITY_ID => (string) $model->getId(),
+                    ]
+                );
+                
+                $assets = $this->extractAssetsFromContent->execute((string) $model->getData($field));
+                
+                foreach ($assets as $asset) {
+                    $contentAssetLinks[] = $this->contentAssetLinkFactory->create(
+                        [
+                            'assetId' => $asset->getId(),
+                            'contentIdentity' => $contentIdentity
+                        ]
+                    );
+                }
+            }
+            if (!empty($contentAssetLinks)) {
+                $this->deleteContentAssetLinks->execute($contentAssetLinks);
+            }
+        }
+    }
+}

--- a/app/code/Magento/MediaContentCms/Observer/BlockDelete.php
+++ b/app/code/Magento/MediaContentCms/Observer/BlockDelete.php
@@ -32,8 +32,8 @@ class BlockDelete implements ObserverInterface
     private $contentIdentityFactory;
 
     /**
-      * @var ContentAssetLinkInterfaceFactory
-      */
+     * @var ContentAssetLinkInterfaceFactory
+     */
     private $contentAssetLinkFactory;
 
     /**
@@ -62,6 +62,7 @@ class BlockDelete implements ObserverInterface
      * @param DeleteContentAssetLinksInterface $deleteContentAssetLinks
      * @param ContentIdentityInterfaceFactory $contentIdentityFactory
      * @param ContentAssetLinkInterfaceFactory $contentAssetLinkFactory
+     * @param array $fields
      */
     public function __construct(
         ExtractAssetsFromContentInterface $extractAssetsFromContent,
@@ -88,7 +89,7 @@ class BlockDelete implements ObserverInterface
     public function execute(Observer $observer): void
     {
         $model = $observer->getEvent()->getData('object');
-        $contentAssetsLinks = [];
+        $contentAssetLinks = [];
         
         if ($model instanceof CmsBlock) {
             foreach ($this->fields as $field) {

--- a/app/code/Magento/MediaContentCms/Observer/PageDelete.php
+++ b/app/code/Magento/MediaContentCms/Observer/PageDelete.php
@@ -88,20 +88,20 @@ class PageDelete implements ObserverInterface
      */
     public function execute(Observer $observer): void
     {
-        $model = $observer->getEvent()->getData('object');
+        $page = $observer->getEvent()->getData('object');
         $contentAssetLinks = [];
         
-        if ($model instanceof CmsPage) {
+        if ($page instanceof CmsPage) {
             foreach ($this->fields as $field) {
                 $contentIdentity = $this->contentIdentityFactory->create(
                     [
                         self::TYPE => self::CONTENT_TYPE,
                         self::FIELD => $field,
-                        self::ENTITY_ID => (string) $model->getId(),
+                        self::ENTITY_ID => (string) $page->getId(),
                     ]
                 );
                 
-                $assets = $this->extractAssetsFromContent->execute((string) $model->getData($field));
+                $assets = $this->extractAssetsFromContent->execute((string) $page->getData($field));
                 
                 foreach ($assets as $asset) {
                     $contentAssetLinks[] = $this->contentAssetLinkFactory->create(

--- a/app/code/Magento/MediaContentCms/Observer/PageDelete.php
+++ b/app/code/Magento/MediaContentCms/Observer/PageDelete.php
@@ -17,7 +17,7 @@ use Magento\MediaContentApi\Model\GetEntityContentsInterface;
 use Magento\MediaContentApi\Api\ExtractAssetsFromContentInterface;
 
 /**
- * Observe the adminhtml_cmspage_on_delete event and deletes relation between page content and media asset.
+ * Observe the cms_page_delete_before event and deletes relation between page content and media asset.
  */
 class PageDelete implements ObserverInterface
 {
@@ -32,8 +32,8 @@ class PageDelete implements ObserverInterface
     private $contentIdentityFactory;
 
     /**
-      * @var ContentAssetLinkInterfaceFactory
-      */
+     * @var ContentAssetLinkInterfaceFactory
+     */
     private $contentAssetLinkFactory;
 
     /**
@@ -62,6 +62,7 @@ class PageDelete implements ObserverInterface
      * @param DeleteContentAssetLinksInterface $deleteContentAssetLinks
      * @param ContentIdentityInterfaceFactory $contentIdentityFactory
      * @param ContentAssetLinkInterfaceFactory $contentAssetLinkFactory
+     * @param arry $fields
      */
     public function __construct(
         ExtractAssetsFromContentInterface $extractAssetsFromContent,
@@ -88,7 +89,7 @@ class PageDelete implements ObserverInterface
     public function execute(Observer $observer): void
     {
         $model = $observer->getEvent()->getData('object');
-        $contentAssetsLinks = [];
+        $contentAssetLinks = [];
         
         if ($model instanceof CmsPage) {
             foreach ($this->fields as $field) {

--- a/app/code/Magento/MediaContentCms/Observer/PageDelete.php
+++ b/app/code/Magento/MediaContentCms/Observer/PageDelete.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MediaContentCms\Observer;
+
+use Magento\Cms\Model\Page as CmsPage;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\MediaContentApi\Api\Data\ContentIdentityInterfaceFactory;
+use Magento\MediaContentApi\Api\Data\ContentAssetLinkInterfaceFactory;
+use Magento\MediaContentApi\Api\DeleteContentAssetLinksInterface;
+use Magento\MediaContentApi\Model\GetEntityContentsInterface;
+use Magento\MediaContentApi\Api\ExtractAssetsFromContentInterface;
+
+/**
+ * Observe the adminhtml_cmspage_on_delete event and deletes relation between page content and media asset.
+ */
+class PageDelete implements ObserverInterface
+{
+    private const CONTENT_TYPE = 'cms_page';
+    private const TYPE = 'entityType';
+    private const ENTITY_ID = 'entityId';
+    private const FIELD = 'field';
+    
+    /**
+     * @var ContentIdentityInterfaceFactory
+     */
+    private $contentIdentityFactory;
+
+    /**
+      * @var ContentAssetLinkInterfaceFactory
+      */
+    private $contentAssetLinkFactory;
+
+    /**
+     * @var DeleteContentAssetLinksInterface
+     */
+    private $deleteContentAssetLinks;
+
+    /**
+     * @var array
+     */
+    private $fields;
+
+    /**
+     * @var GetEntityContentsInterface
+     */
+    private $getContent;
+
+    /**
+     * @var ExtractAssetsFromContentInterface
+     */
+    private $extractAssetsFromContent;
+    
+    /**
+     * @param ExtractAssetsFromContentInterface $extractAssetsFromContent
+     * @param GetEntityContentsInterface $getContent
+     * @param DeleteContentAssetLinksInterface $deleteContentAssetLinks
+     * @param ContentIdentityInterfaceFactory $contentIdentityFactory
+     * @param ContentAssetLinkInterfaceFactory $contentAssetLinkFactory
+     */
+    public function __construct(
+        ExtractAssetsFromContentInterface $extractAssetsFromContent,
+        GetEntityContentsInterface $getContent,
+        DeleteContentAssetLinksInterface $deleteContentAssetLinks,
+        ContentIdentityInterfaceFactory $contentIdentityFactory,
+        ContentAssetLinkInterfaceFactory $contentAssetLinkFactory,
+        array $fields
+    ) {
+        $this->extractAssetsFromContent = $extractAssetsFromContent;
+        $this->getContent = $getContent;
+        $this->deleteContentAssetLinks = $deleteContentAssetLinks;
+        $this->contentAssetLinkFactory = $contentAssetLinkFactory;
+        $this->contentIdentityFactory = $contentIdentityFactory;
+        $this->fields = $fields;
+    }
+
+    /**
+     * Retrieve the deleted category and  remove relation betwen category and asset
+     *
+     * @param Observer $observer
+     * @throws \Exception
+     */
+    public function execute(Observer $observer): void
+    {
+        $model = $observer->getEvent()->getData('object');
+        $contentAssetsLinks = [];
+        
+        if ($model instanceof CmsPage) {
+            foreach ($this->fields as $field) {
+                $contentIdentity = $this->contentIdentityFactory->create(
+                    [
+                        self::TYPE => self::CONTENT_TYPE,
+                        self::FIELD => $field,
+                        self::ENTITY_ID => (string) $model->getId(),
+                    ]
+                );
+                
+                $assets = $this->extractAssetsFromContent->execute((string) $model->getData($field));
+                
+                foreach ($assets as $asset) {
+                    $contentAssetLinks[] = $this->contentAssetLinkFactory->create(
+                        [
+                            'assetId' => $asset->getId(),
+                            'contentIdentity' => $contentIdentity
+                        ]
+                    );
+                }
+            }
+            if (!empty($contentAssetLinks)) {
+                $this->deleteContentAssetLinks->execute($contentAssetLinks);
+            }
+        }
+    }
+}

--- a/app/code/Magento/MediaContentCms/etc/di.xml
+++ b/app/code/Magento/MediaContentCms/etc/di.xml
@@ -20,4 +20,18 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\MediaContentCms\Observer\PageDelete">
+        <arguments>
+            <argument name="fields" xsi:type="array">
+                <item name="content" xsi:type="string">content</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Magento\MediaContentCms\Observer\BlockDelete">
+        <arguments>
+            <argument name="fields" xsi:type="array">
+                <item name="content" xsi:type="string">content</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/MediaContentCms/etc/events.xml
+++ b/app/code/Magento/MediaContentCms/etc/events.xml
@@ -6,8 +6,14 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="cms_page_delete_before">
+        <observer name="media_content_cms_page_delete_before" instance="Magento\MediaContentCms\Observer\PageDelete" />
+    </event>
     <event name="cms_page_save_after">
         <observer name="media_content_cms_page_save_after" instance="Magento\MediaContentCms\Observer\Page" />
+    </event>
+     <event name="cms_block_delete_before">
+        <observer name="media_content_cms_block_delete_before" instance="Magento\MediaContentCms\Observer\BlockDelete" />
     </event>
     <event name="cms_block_save_after">
         <observer name="media_content_cms_block_save_after" instance="Magento\MediaContentCms\Observer\Block" />


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1474: The "Used in" still displays that the image is used in a Product after the Product has been deleted
2. ...

### Manual testing scenarios (*)
1. Create a Product and add an image from Media Gallery
2. Go to Content - Media Gallery and View the Details of the image that was previously added to the Product
3. Verify that the Details display that the image is **Used In 1 Product**
4. Go to _Catalog - Products_ and **Delete** the previously created Product
6. Go to Go to Content - Media Gallery and View the Details of the image that was previously Used

The image is not Used in a product so it should not be displayed in Details
