### PR TITLE
Fix shipping address id getter misspelling

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/Address.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/Address.php
@@ -9,9 +9,6 @@ namespace Magento\Sales\Model\ResourceModel\Order\Handler;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\ResourceModel\Attribute;
 
-/**
- * Class Address
- */
 class Address
 {
     /**

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/Address.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/Address.php
@@ -69,7 +69,7 @@ class Address
                 $attributesForSave[] = 'billing_address_id';
             }
             $shippingAddress = $order->getShippingAddress();
-            if ($shippingAddress && $order->getShippigAddressId() != $shippingAddress->getId()) {
+            if ($shippingAddress && $order->getShippingAddressId() != $shippingAddress->getId()) {
                 $order->setShippingAddressId($shippingAddress->getId());
                 $attributesForSave[] = 'shipping_address_id';
             }

--- a/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/Handler/AddressTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/Handler/AddressTest.php
@@ -134,6 +134,66 @@ class AddressTest extends TestCase
     }
 
     /**
+     * Test processing of the shipping address when shipping address id was not changed.
+     * setShippingAddressId and saveAttribute methods must not be executed.
+     */
+    public function testProcessShippingAddressNotChanged()
+    {
+        $this->orderMock->expects($this->exactly(2))
+            ->method('getAddresses')
+            ->willReturn([$this->addressMock]);
+        $this->addressMock->expects($this->once())
+            ->method('save')->willReturnSelf();
+        $this->orderMock->expects($this->once())
+            ->method('getBillingAddress')
+            ->willReturn(null);
+        $this->orderMock->expects($this->once())
+            ->method('getShippingAddress')
+            ->willReturn($this->addressMock);
+        $this->addressMock->expects($this->once())
+            ->method('getId')->willReturn(1);
+        $this->orderMock->expects($this->once())
+            ->method('getShippingAddressId')
+            ->willReturn(1);
+        $this->orderMock->expects($this->never())
+            ->method('setShippingAddressId')->willReturnSelf();
+        $this->attributeMock->expects($this->never())
+            ->method('saveAttribute')
+            ->with($this->orderMock, ['shipping_address_id'])->willReturnSelf();
+        $this->assertEquals($this->address, $this->address->process($this->orderMock));
+    }
+
+    /**
+     * Test processing of the billing address when billing address id was not changed.
+     * setBillingAddressId and saveAttribute methods must not be executed.
+     */
+    public function testProcessBillingAddressNotChanged()
+    {
+        $this->orderMock->expects($this->exactly(2))
+            ->method('getAddresses')
+            ->willReturn([$this->addressMock]);
+        $this->addressMock->expects($this->once())
+            ->method('save')->willReturnSelf();
+        $this->orderMock->expects($this->once())
+            ->method('getBillingAddress')
+            ->willReturn($this->addressMock);
+        $this->orderMock->expects($this->once())
+            ->method('getShippingAddress')
+            ->willReturn(null);
+        $this->addressMock->expects($this->once())
+            ->method('getId')->willReturn(1);
+        $this->orderMock->expects($this->once())
+            ->method('getBillingAddressId')
+            ->willReturn(1);
+        $this->orderMock->expects($this->never())
+            ->method('setBillingAddressId')->willReturnSelf();
+        $this->attributeMock->expects($this->never())
+            ->method('saveAttribute')
+            ->with($this->orderMock, ['billing_address_id'])->willReturnSelf();
+        $this->assertEquals($this->address, $this->address->process($this->orderMock));
+    }
+
+    /**
      * Test method removeEmptyAddresses
      */
     public function testRemoveEmptyAddresses()


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed a shipping address id getter misspelling in the sales order address save handler. Misspelt getter caused unneeded requests to the database on each order save which might create deadlocks.

### Manual testing scenarios (*)
This bug can not be validated manually as there're no effects visible on the front-end.
The fix includes Unit tests to validate that address save handler does not execute save attribute method when it's not needed.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#28982: Fix shipping address id getter misspelling