### PR TITLE
Remove over complicated setup for closing minicart dropdown

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/minicart.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/minicart.js
@@ -124,20 +124,6 @@ define([
         },
 
         /**
-         * @return {Boolean}
-         */
-        closeSidebar: function () {
-            var minicart = $('[data-block="minicart"]');
-
-            minicart.on('click', '[data-action="close"]', function (event) {
-                event.stopPropagation();
-                minicart.find('[data-role="dropdownDialog"]').dropdownDialog('close');
-            });
-
-            return true;
-        },
-
-        /**
          * @param {String} productType
          * @return {*|String}
          */

--- a/app/code/Magento/Checkout/view/frontend/web/template/minicart/content.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/minicart/content.html
@@ -21,7 +21,12 @@
             id="btn-minicart-close"
             class="action close"
             data-action="close"
-            data-bind="attr: { title: $t('Close') }">
+            data-bind="
+                attr: {
+                    title: $t('Close')
+                },
+                click: closeMinicart()
+            ">
         <span translate="'Close'"/>
     </button>
 
@@ -74,7 +79,6 @@
 
     <ifnot args="getCartParam('summary_count')">
         <strong class="subtitle empty"
-                data-bind="visible: closeSidebar()"
                 translate="'You have no items in your shopping cart.'"
         />
         <if args="getCartParam('cart_empty_message')">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When investigating minicart code I've noticed a bit strange way to add event listener to elements that are supposed to close minicart when clicked.

Please first look on removed line with `data-bind="visible: closeSidebar()"`. `visible` knockout binding is used to control whether the element should be shown. However, the `closeSidebar` function is always returning `true` value. The side effect of this function is it setup an event listeners to `[data-action="close"]` elements, which will close the minicart dropdown.

This pull request removes `closeSidebar` function and the knockout binding on completely unrelated element. Instead, the appropriate click binding is added to the only `[data-action="close"]` element I've found.

### Manual testing scenarios (*)
1. Open minibasket
2. Close with an "X" button
3. Add a product to basket
4. Open, close minibasket
5. Open basket and click on "Proceed to Checkout"

### Questions or comments
I've searched the codebase for elements with `data-action="close"` to ensure that it will not break any other functionality. However I'm guessing some modules may using this "API".

Other question is whether `data-action="close"` attribute is needed. By searching in a code it doesn't seem to have a purpose, but it increase HTML to content ratio.

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29161: Remove over complicated setup for closing minicart dropdown