### PR TITLE
AppState emulateAreaCode was not respected by file collector

### DIFF
--- a/lib/internal/Magento/Framework/View/File/Collector/Base.php
+++ b/lib/internal/Magento/Framework/View/File/Collector/Base.php
@@ -65,7 +65,7 @@ class Base implements CollectorInterface
         foreach ($sharedFiles as $file) {
             $result[] = $this->fileFactory->create($file->getFullPath(), $file->getComponentName(), null, true);
         }
-        $area = $theme->getData('area');
+        $area = $theme->getArea();
         $themeFiles = $this->componentDirSearch->collectFilesWithContext(
             ComponentRegistrar::MODULE,
             "view/{$area}/{$this->subDir}{$filePath}"

--- a/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/BaseTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/BaseTest.php
@@ -85,8 +85,7 @@ class BaseTest extends TestCase
             ->method('create')
             ->willReturn($this->createFileMock());
         $this->themeMock->expects($this->once())
-            ->method('getData')
-            ->with('area')
+            ->method('getArea')
             ->willReturn('frontend');
 
         $result = $this->fileCollector->getFiles($this->themeMock, '*.xml');


### PR DESCRIPTION
### Description (*)
The "hack" to emulate an area code via AppState->emulateAreaCode() is not respected by the base file collector. The consequence is that *.xml file in the emulated area is not found by the file collector.  

### Related Pull Requests

### Fixed Issues (if relevant)

### Manual testing scenarios (*)
The problem occurs in an extension I have built that require to access the adminhtml area from the graphql area. There are likely other modules in the Magento 2 that suffers from the same problem. However I can not point one such module without spending a considerable amount of time searching for it.  

The following snippet suffer from this bug,  
```
$data = $this->app_state->emulateAreaCode(   
  \Magento\Framework\App\Area::AREA_ADMINHTML,   
  [$this, "getDataSourceData"],  
  [$field, $args]
);  
```
### Questions or comments
I thinks someone more knowledgable should look into this issue. I have troubleshooted and my conclusions are as follows.  
  
The base file collector is accessing the area code of the Theme with a call to getData('area').  
The Theme has an override called getArea(), this method is never called by the base file collector.
This causes problems for modules that use "emulated area codes" via the   
\Magento\Framework\App\State->emulateAreaCode() method.
The emulated area code is then not respected by the file collector since it access the data directly and not via the intended getArea() method in the Theme.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29656: AppState emulateAreaCode was not respected by file collector