### PR TITLE
Deploy all used locales

### DIFF
--- a/app/code/Magento/Deploy/Package/LocaleResolver.php
+++ b/app/code/Magento/Deploy/Package/LocaleResolver.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Deploy\Package;
+
+use InvalidArgumentException;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\AppInterface;
+use Magento\Framework\Config\ConfigOptionsListConstants;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Validator\Locale;
+use Magento\Store\Model\Config\StoreView;
+use Magento\User\Api\Data\UserInterface;
+use Magento\User\Model\ResourceModel\User\Collection as UserCollection;
+use Magento\User\Model\ResourceModel\User\CollectionFactory as UserCollectionFactory;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Deployment Package Locale Resolver class
+ */
+class LocaleResolver
+{
+    /**
+     * Parameter to force deploying certain languages for the admin, without any users having configured them yet.
+     */
+    const ADMIN_LOCALES_FOR_DEPLOY = 'admin_locales_for_deploy';
+
+    /**
+     * @var StoreView
+     */
+    private $storeView;
+
+    /**
+     * @var UserCollectionFactory
+     */
+    private $userCollFactory;
+
+    /**
+     * @var DeploymentConfig
+     */
+    private $deploymentConfig;
+
+    /**
+     * @var Locale
+     */
+    private $locale;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var array|null
+     */
+    private $usedStoreLocales;
+
+    /**
+     * @var array|null
+     */
+    private $usedAdminLocales;
+
+    /**
+     * LocaleResolver constructor.
+     *
+     * @param StoreView $storeView
+     * @param UserCollectionFactory $userCollectionFactory
+     * @param DeploymentConfig $deploymentConfig
+     * @param Locale $locale
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        StoreView $storeView,
+        UserCollectionFactory $userCollectionFactory,
+        DeploymentConfig $deploymentConfig,
+        Locale $locale,
+        LoggerInterface $logger
+    ) {
+        $this->storeView = $storeView;
+        $this->userCollFactory = $userCollectionFactory;
+        $this->deploymentConfig = $deploymentConfig;
+        $this->locale = $locale;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Get locales that are used for a given theme.
+     * If it is a frontend theme, return supported frontend languages.
+     * If it is an adminhtml theme, return languages that admin users have configured together with deployment config.
+     *
+     * @param Package $package
+     *
+     * @return array
+     */
+    public function getUsedPackageLocales(Package $package): array
+    {
+        switch ($package->getArea()) {
+            case Area::AREA_ADMINHTML:
+                $locales = $this->getUsedAdminLocales();
+                break;
+            case Area::AREA_FRONTEND:
+                $locales = $this->getUsedStoreLocales();
+                break;
+            default:
+                $locales = array_merge($this->getUsedAdminLocales(), $this->getUsedStoreLocales());
+        }
+        return $this->validateLocales($locales);
+    }
+
+    /**
+     * Get used admin user locales, en_US is always included by default.
+     *
+     * @return array
+     */
+    private function getUsedAdminLocales(): array
+    {
+        if ($this->usedAdminLocales === null) {
+            $deploymentConfig = $this->getDeploymentAdminLocales();
+            $this->usedAdminLocales = array_merge([AppInterface::DISTRO_LOCALE_CODE], $deploymentConfig);
+
+            if (!$this->isDbConnectionAvailable()) {
+                return $this->usedAdminLocales;
+            }
+
+            /** @var UserCollection $userCollection */
+            $userCollection = $this->userCollFactory->create();
+            /** @var UserInterface $adminUser */
+            foreach ($userCollection as $adminUser) {
+                $this->usedAdminLocales[] = $adminUser->getInterfaceLocale();
+            }
+        }
+        return $this->usedAdminLocales;
+    }
+
+    /**
+     * Get used store locales.
+     *
+     * @return array
+     */
+    private function getUsedStoreLocales(): array
+    {
+        if ($this->usedStoreLocales === null) {
+            $this->usedStoreLocales = $this->isDbConnectionAvailable()
+                ? $this->storeView->retrieveLocales()
+                : [AppInterface::DISTRO_LOCALE_CODE];
+        }
+        return $this->usedStoreLocales;
+    }
+
+    /**
+     * Strip out duplicates and break on invalid locale codes.
+     *
+     * @param array $usedLocales
+     *
+     * @return array
+     * @throws InvalidArgumentException if unknown locale is provided by the store configuration
+     */
+    private function validateLocales(array $usedLocales): array
+    {
+        return array_map(
+            function ($locale) {
+                if (!$this->locale->isValid($locale)) {
+                    throw new InvalidArgumentException(
+                        $locale . ' argument has invalid value, run info:language:list for list of available locales'
+                    );
+                }
+
+                return $locale;
+            },
+            array_unique($usedLocales)
+        );
+    }
+
+    /**
+     * Check if a database connection is already set up.
+     *
+     * @return bool
+     */
+    private function isDbConnectionAvailable(): bool
+    {
+        try {
+            $connections = $this->deploymentConfig->get(ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTIONS, []);
+        } catch (LocalizedException $exception) {
+            $this->logger->critical($exception);
+        }
+        return !empty($connections);
+    }
+
+    /**
+     * Retrieve deployment configuration for admin locales that have to be deployed.
+     *
+     * @return array|mixed|string|null
+     */
+    private function getDeploymentAdminLocales(): array
+    {
+        try {
+            return $this->deploymentConfig
+                ->get(self::ADMIN_LOCALES_FOR_DEPLOY, []);
+        } catch (LocalizedException $exception) {
+            return [];
+        }
+    }
+}

--- a/app/code/Magento/Deploy/Test/Unit/Package/LocaleResolverTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Package/LocaleResolverTest.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Deploy\Test\Unit\Package;
+
+use Magento\Deploy\Package\LocaleResolver;
+use Magento\Deploy\Package\Package;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\AppInterface;
+use Magento\Framework\Validator\Locale;
+use Magento\Store\Model\Config\StoreView;
+use Magento\User\Api\Data\UserInterface;
+use Magento\User\Model\ResourceModel\User\Collection;
+use Magento\User\Model\ResourceModel\User\CollectionFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Deployment Package LocaleResolver class unit tests
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class LocaleResolverTest extends TestCase
+{
+    /**
+     * @var LocaleResolver
+     */
+    private $localeResolver;
+
+    /**
+     * @var Package|MockObject
+     */
+    private $package;
+
+    /**
+     * @var StoreView|MockObject
+     */
+    private $storeView;
+
+    /**
+     * @var CollectionFactory|MockObject
+     */
+    private $userCollectionFactory;
+
+    /**
+     * @var DeploymentConfig|MockObject
+     */
+    private $deploymentConfig;
+
+    /**
+     * @var Locale|MockObject
+     */
+    private $locale;
+
+    /**
+     * @var MockObject|LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var Collection|MockObject
+     */
+    private $userCollection;
+
+    /**
+     * @var UserInterface|MockObject
+     */
+    private $adminUser;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->package = $this->createMock(Package::class);
+        $this->storeView = $this->createMock(StoreView::class);
+        $this->adminUser = $this->getMockForAbstractClass(UserInterface::class);
+        $this->userCollection = $this->createMock(Collection::class);
+        $this->userCollectionFactory = $this->createMock(CollectionFactory::class);
+        $this->userCollectionFactory->method('create')->willReturn($this->userCollection);
+        $this->deploymentConfig = $this->createMock(DeploymentConfig::class);
+        $this->locale = $this->createMock(Locale::class);
+        $this->logger = $this->getMockForAbstractClass(
+            LoggerInterface::class,
+            ['critical'],
+            '',
+            false
+        );
+        $this->localeResolver = new LocaleResolver(
+            $this->storeView,
+            $this->userCollectionFactory,
+            $this->deploymentConfig,
+            $this->locale,
+            $this->logger
+        );
+    }
+
+    /**
+     * Test Get Used Package Locales when there is no DB connection set up yet
+     * Should only return en_US by default
+     */
+    public function testGetUsedPackageLocalesNoDb()
+    {
+        $this->package->expects(static::exactly(1))->method('getArea')->willReturn(Area::AREA_FRONTEND);
+        $this->deploymentConfig->expects(static::exactly(1))->method('get')->willReturn([]);
+        $this->storeView->expects(static::exactly(0))->method('retrieveLocales');
+        $this->userCollectionFactory->expects(static::exactly(0))->method('create');
+        $this->locale->method('isValid')->willReturn(true);
+
+        $locales = $this->localeResolver->getUsedPackageLocales($this->package);
+        static::assertEquals(
+            [AppInterface::DISTRO_LOCALE_CODE],
+            $locales
+        );
+    }
+
+    /**
+     * Test Get Used Package Locales when there is no DB connection set up yet
+     * Should only return en_US by default
+     */
+    public function testGetUsedPackageLocalesNoDbWithDeployment()
+    {
+        $this->package->expects(static::exactly(1))->method('getArea')->willReturn(Area::AREA_ADMINHTML);
+        $this->deploymentConfig->expects(static::exactly(2))->method('get')->willReturn(['zh_SG'], []);
+        $this->storeView->expects(static::exactly(0))->method('retrieveLocales');
+        $this->userCollectionFactory->expects(static::exactly(0))->method('create');
+        $this->locale->method('isValid')->willReturn(true);
+
+        $locales = $this->localeResolver->getUsedPackageLocales($this->package);
+        static::assertEquals(
+            [AppInterface::DISTRO_LOCALE_CODE, 'zh_SG'],
+            $locales
+        );
+    }
+
+    /**
+     * Test Get Used Package Locales when there is no DB connection set up yet
+     * Should only return en_US by default
+     */
+    public function testGetUsedPackageLocalesIllegalLocale()
+    {
+        $this->package->expects(static::exactly(1))->method('getArea')->willReturn(Area::AREA_ADMINHTML);
+        $this->deploymentConfig->expects(static::exactly(2))->method('get')->willReturn(['en_DE'], []);
+        $this->storeView->expects(static::exactly(0))->method('retrieveLocales');
+        $this->userCollectionFactory->expects(static::exactly(0))->method('create');
+        $this->locale->method('isValid')->willReturn(true, false);
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage(
+            'en_DE argument has invalid value, run info:language:list for list of available locales'
+        );
+        $this->localeResolver->getUsedPackageLocales($this->package);
+    }
+
+    /**
+     * Test Get Used Package Locales for a frontend theme
+     * Should return used frontend languages
+     */
+    public function testGetUsedPackageLocalesFrontend()
+    {
+        $this->package->expects(static::exactly(1))->method('getArea')->willReturn(Area::AREA_FRONTEND);
+        $this->deploymentConfig->expects(static::exactly(1))->method('get')->willReturn(['default' => []]);
+        $this->storeView->expects(static::exactly(1))->method('retrieveLocales')->willReturn(['de_DE', 'en_GB']);
+        $this->userCollectionFactory->expects(static::exactly(0))->method('create');
+        $this->locale->method('isValid')->willReturn(true);
+
+        $locales = $this->localeResolver->getUsedPackageLocales($this->package);
+        static::assertEquals(
+            ['de_DE', 'en_GB'],
+            $locales
+        );
+    }
+
+    /**
+     * Test Get Used Package Locales for an admin theme
+     * Should return used admin languages, admin deployment configuration languages and en_US by default
+     */
+    public function testGetUsedPackageLocalesAdmin()
+    {
+        $this->package->expects(static::exactly(1))->method('getArea')->willReturn(Area::AREA_ADMINHTML);
+        $this->deploymentConfig->expects(static::exactly(2))->method('get')->willReturn(['de_AT'], ['default' => []]);
+        $this->storeView->expects(static::exactly(0))->method('retrieveLocales');
+        $this->userCollectionFactory->expects(static::exactly(1))->method('create');
+        $this->locale->method('isValid')->willReturn(true);
+        $this->adminUser->expects(static::exactly(2))->method('getInterfaceLocale')->willReturn('nl_NL', 'fr_FR');
+        $this->userCollection->method('getIterator')->willReturn(new \ArrayIterator([
+            $this->adminUser,
+            $this->adminUser,
+        ]));
+
+        $locales = $this->localeResolver->getUsedPackageLocales($this->package);
+        static::assertEquals(
+            [AppInterface::DISTRO_LOCALE_CODE, 'de_AT', 'nl_NL', 'fr_FR'],
+            $locales
+        );
+    }
+
+    /**
+     * Test Get Used Package Locales for a theme that is neither frontend nor admin (hypothetical)
+     * Should return both used admin and used frontend languages, plus en_US by default
+     */
+    public function testGetUsedPackageLocalesDefault()
+    {
+        $this->package->expects(static::exactly(1))->method('getArea')->willReturn(Area::AREA_GLOBAL);
+        $this->deploymentConfig->expects(static::exactly(3))->method('get')
+            ->willReturn(['de_AT'], ['default' => []], ['default' => []]);
+        $this->storeView->expects(static::exactly(1))->method('retrieveLocales')->willReturn(['en_IE', 'fr_LU']);
+        $this->userCollectionFactory->expects(static::exactly(1))->method('create');
+        $this->locale->method('isValid')->willReturn(true);
+        $this->adminUser->expects(static::exactly(2))->method('getInterfaceLocale')->willReturn('nl_NL', 'fr_FR');
+        $this->userCollection->method('getIterator')->willReturn(new \ArrayIterator([
+            $this->adminUser,
+            $this->adminUser,
+        ]));
+
+        $locales = $this->localeResolver->getUsedPackageLocales($this->package);
+        static::assertEquals(
+            [AppInterface::DISTRO_LOCALE_CODE, 'de_AT', 'nl_NL', 'fr_FR', 'en_IE', 'fr_LU'],
+            $locales
+        );
+    }
+}

--- a/setup/src/Magento/Setup/Console/Command/DeployStaticContentCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DeployStaticContentCommand.php
@@ -20,14 +20,14 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Deploy\Service\DeployStaticContent;
 
 /**
- * Deploy static content command
+ * Command to Deploy Static Content
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class DeployStaticContentCommand extends Command
 {
     /**
-     * Default language value
+     * Default language value. Always used for adminhtml, fallback if no frontend locale is supplied.
      */
     const DEFAULT_LANGUAGE_VALUE = 'en_US';
 
@@ -82,7 +82,7 @@ class DeployStaticContentCommand extends Command
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      * @throws \InvalidArgumentException
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
@@ -96,7 +96,10 @@ class DeployStaticContentCommand extends Command
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
      * @throws \InvalidArgumentException
      * @throws LocalizedException
      */
@@ -119,7 +122,8 @@ class DeployStaticContentCommand extends Command
         $this->inputValidator->validate($input);
 
         $options = $input->getOptions();
-        $options[Options::LANGUAGE] = $input->getArgument(Options::LANGUAGES_ARGUMENT) ?: ['all'];
+        $languageOption = $options[Options::LANGUAGE] ?: ['all'];
+        $options[Options::LANGUAGE] = $input->getArgument(Options::LANGUAGES_ARGUMENT) ?: $languageOption;
         $refreshOnly = isset($options[Options::REFRESH_CONTENT_VERSION_ONLY])
             && $options[Options::REFRESH_CONTENT_VERSION_ONLY];
 
@@ -161,6 +165,8 @@ class DeployStaticContentCommand extends Command
     }
 
     /**
+     * Retrieve application state
+     *
      * @return State
      */
     private function getAppState()


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
`bin/magento setup:static-content:deploy --language=all` currently only
deploys en_US, instead of the requested "all". This pull request aims to deploy all used languages for the frontend and all configured languages by admin users, when no language parameter is given. en_US is always additionally deployed by default.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Configure multiple store views with different locales.
2. Configure a locale other than en_US for your admin user.
3. run `bin/magento setup:static-content:deploy --language=all` and verify that all configured languages, plus en_US are deployed.
4. run `bin/magento setup:static-content:deploy --language=all --exclude-language=en_US` and verify that en_US is skipped.
5. run `bin/magento setup:static-content:deploy en_US` and verify that only en_US is deployed
6. run `bin/magento setup:static-content:deploy --language=en_US` and verify that only en_US is deployed
7. run `bin/magento setup:static-content:deploy -l en_US` and verify that only en_US is deployed
8. run `bin/magento setup:static-content:deploy --language=en_US en_UK` and verify that only en_UK is deployed as the languages argument precedes over the language option

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29218: Deploy all used locales