### PR TITLE
improve and make more strict autoload.php

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -5,36 +5,48 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 use Magento\Framework\Autoload\AutoloaderRegistry;
 use Magento\Framework\Autoload\ClassLoaderWrapper;
 
 /**
  * Shortcut constant for the root directory
  */
-define('BP', dirname(__DIR__));
+\define('BP', \dirname(__DIR__));
 
-define('VENDOR_PATH', BP . '/app/etc/vendor_path.php');
+\define('VENDOR_PATH', BP . '/app/etc/vendor_path.php');
 
-if (!file_exists(VENDOR_PATH)) {
+if (!\is_readable(VENDOR_PATH)) {
     throw new \Exception(
         'We can\'t read some files that are required to run the Magento application. '
          . 'This usually means file permissions are set incorrectly.'
     );
 }
 
-$vendorDir = require VENDOR_PATH;
-$vendorAutoload = BP . "/{$vendorDir}/autoload.php";
+$vendorAutoload = (
+    static function (): ?string {
+        $vendorDir = require VENDOR_PATH;
 
-/* 'composer install' validation */
-if (file_exists($vendorAutoload)) {
-    $composerAutoloader = include $vendorAutoload;
-} else if (file_exists("{$vendorDir}/autoload.php")) {
-	$vendorAutoload = "{$vendorDir}/autoload.php";
-	$composerAutoloader = include $vendorAutoload;
-} else {
+        $vendorAutoload = BP . "/{$vendorDir}/autoload.php";
+        if (\is_readable($vendorAutoload)) {
+            return $vendorAutoload;
+        }
+
+        $vendorAutoload = "{$vendorDir}/autoload.php";
+        if (\is_readable($vendorAutoload)) {
+            return $vendorAutoload;
+        }
+
+        return null;
+    }
+)();
+
+if ($vendorAutoload === null) {
     throw new \Exception(
         'Vendor autoload is not found. Please run \'composer install\' under application root directory.'
     );
 }
 
+$composerAutoloader = include $vendorAutoload;
 AutoloaderRegistry::registerAutoloader(new ClassLoaderWrapper($composerAutoloader));


### PR DESCRIPTION
### Description (*)
two improvements:
1. use `is_readable` instead of `file_exists`. if we use `require` or `include` on a existing file that is not readable php generate errors. So we need to chech if file_exists and is_readable (`is_readable` do both things)
2. provide an anonymous function to determinate `$vendorAutoload`, it's allow us to have a more readable code with early return.

### Related Pull Requests
none

### Fixed Issues (if relevant)
none

### Manual testing scenarios (*)
not necessary, if CI passes this code is good, it's only technical improvement.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29527: improve and make more strict autoload.php