### PR TITLE
[vcl] don't set TTL to 0

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish4.vcl
+++ b/app/code/Magento/PageCache/etc/varnish4.vcl
@@ -166,7 +166,7 @@ sub vcl_backend_response {
 
     # cache only successfully responses and 404s
     if (beresp.status != 200 && beresp.status != 404) {
-        set beresp.ttl = 0s;
+        set beresp.ttl = 120s;
         set beresp.uncacheable = true;
         return (deliver);
     } elsif (beresp.http.Cache-Control ~ "private") {

--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -166,11 +166,9 @@ sub vcl_backend_response {
     }
 
     # cache only successfully responses and 404s
-    if (beresp.status != 200 && beresp.status != 404) {
-        set beresp.ttl = 0s;
-        set beresp.uncacheable = true;
-        return (deliver);
-    } elsif (beresp.http.Cache-Control ~ "private") {
+    if (beresp.status != 200 &&
+            beresp.status != 404 &&
+            beresp.http.Cache-Control ~ "private") {
         set beresp.uncacheable = true;
         set beresp.ttl = 86400s;
         return (deliver);

--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -165,12 +165,10 @@ sub vcl_backend_response {
         set beresp.http.X-Magento-Cache-Control = beresp.http.Cache-Control;
     }
 
-    # cache only successfully responses and 404s
-    if (beresp.status != 200 && beresp.status != 404) {
-        set beresp.ttl = 0s;
-        set beresp.uncacheable = true;
-        return (deliver);
-    } elsif (beresp.http.Cache-Control ~ "private") {
+    # cache only successfully responses and 404s that are not marked as private
+    if (beresp.status != 200 &&
+            beresp.status != 404 &&
+            beresp.http.Cache-Control ~ "private") {
         set beresp.uncacheable = true;
         set beresp.ttl = 86400s;
         return (deliver);


### PR DESCRIPTION
Because of request coalescing, setting the TTL to 0s actually causes
backend request queueing, meaning that for one specific object,
Varnish will only allow one request at a time.

For Varnish 4, set the TTL to 2 minutes, leveraging Hit-for-Pass and
Varnish will transform any hit into a pass for the next 2 minutes,
preventing queueing.

For 5 and 6, the default mechanism is Hit-for-Miss, which works the same
as HfP with the added bonus that if the response changes and we we decide
to cache it, this will override the HfM TTL. So we can set the TTL for
one day.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
