### PR TITLE
MFTF: Admin Delete Newsletter Subscriber

### DIFF
--- a/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminMarketingDeleteNewsletterSubscriberFromGridActionGroup.xml
+++ b/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminMarketingDeleteNewsletterSubscriberFromGridActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminMarketingDeleteNewsletterSubscriberFromGridActionGroup">
+        <click selector="{{AdminNewsletterSubscriberGridSection.rowCheckbox('1')}}" stepKey="clickOnFirstCheckbox"/>
+        <selectOption selector="{{AdminNewsletterSubscriberGridSection.actionsDropdown}}" userInput="Delete" stepKey="selectDelete"/>
+        <click selector="{{AdminNewsletterSubscriberGridSection.submit}}" stepKey="clickSubmitBtn"/>
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+        <click selector="{{AdminNewsletterSubscriberGridSection.okButton}}" stepKey="clickOkButton"/>
+        <waitForPageLoad stepKey="waitForResultsLoading"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminMarketingFindNewsletterSubscribersInGridActionGroup.xml
+++ b/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AdminMarketingFindNewsletterSubscribersInGridActionGroup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminMarketingFindNewsletterSubscribersInGridActionGroup">
+        <arguments>
+            <argument name="email" type="string"/>
+        </arguments>
+
+        <click stepKey="resetFilter" selector="{{AdminNewsletterSubscriberGridSection.resetFilter}}"/>
+        <waitForPageLoad stepKey="waitForPageLoading"/>
+        <fillField stepKey="fillEmailField" selector="{{AdminNewsletterSubscriberGridSection.emailField}}" userInput="{{email}}"/>
+        <click stepKey="clickSearchButton" selector="{{AdminNewsletterSubscriberGridSection.searchButton}}"/>
+        <waitForPageLoad stepKey="waitForResultsLoading"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AssertAdminDeletedNewsletterSubscriberIsNotInGridActionGroup.xml
+++ b/app/code/Magento/Newsletter/Test/Mftf/ActionGroup/AssertAdminDeletedNewsletterSubscriberIsNotInGridActionGroup.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertAdminDeletedNewsletterSubscriberIsNotInGridActionGroup">
+        <arguments>
+            <argument name="email" type="string"/>
+        </arguments>
+        <dontSee selector="{{AdminNewsletterSubscriberGridSection.email('1')}}" userInput="{{email}}" stepKey="dontSeeSubscriber"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Newsletter/Test/Mftf/Section/AdminNewsletterSubscriberGridSection.xml
+++ b/app/code/Magento/Newsletter/Test/Mftf/Section/AdminNewsletterSubscriberGridSection.xml
@@ -12,5 +12,12 @@
         <element name="type" type="text" selector="//table[contains(@class, 'data-grid')]/tbody/tr[{{row}}][@data-role='row']/td[@data-column='type']" parameterized="true"/>
         <element name="firstName" type="text" selector="//table[contains(@class, 'data-grid')]/tbody/tr[{{row}}][@data-role='row']/td[@data-column='firstname']" parameterized="true"/>
         <element name="lastName" type="text" selector="//table[contains(@class, 'data-grid')]/tbody/tr[{{row}}][@data-role='row']/td[@data-column='lastname']" parameterized="true"/>
+        <element name="resetFilter" type="button" selector=".action-default.scalable.action-reset.action-tertiary"/>
+        <element name="emailField" type="input" selector=".col-email #subscriberGrid_filter_email"/>
+        <element name="searchButton" type="button" selector="//*[@class='admin__filter-actions']//*[text()='Search']"/>
+        <element name="rowCheckbox" type="checkbox" selector="table.data-grid tbody > tr:nth-of-type({{row}}) td.data-grid-checkbox-cell input" parameterized="true"/>
+        <element name="actionsDropdown" type="select" selector=".admin__grid-massaction-form #subscriberGrid_massaction-select"/>
+        <element name="submit" type="button" selector="//*[@class='admin__grid-massaction-form']//*[text()='Submit']"/>
+        <element name="okButton" type="button" selector="//footer[@class='modal-footer']/button[contains(@class, 'action-accept')]" timeout="30"/>
     </section>
 </sections>

--- a/app/code/Magento/Newsletter/Test/Mftf/Test/AdminMarketingDeleteNewsletterSubscriberTest.xml
+++ b/app/code/Magento/Newsletter/Test/Mftf/Test/AdminMarketingDeleteNewsletterSubscriberTest.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminMarketingDeleteNewsletterSubscriberTest">
+        <annotations>
+            <features value="Newsletter"/>
+            <stories value="Subscribers Deleting"/>
+            <title value="Admin deletes newsletter subscribers"/>
+            <description value="Admin should be able delete newsletter subscribers"/>
+            <group value="newsletter"/>
+        </annotations>
+        <before>
+            <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
+        </before>
+        <after>
+            <deleteData createDataKey="createCustomer" stepKey="deleteCreatedCustomer"/>
+        </after>
+
+        <actionGroup ref="LoginToStorefrontActionGroup" stepKey="loginAsCustomer">
+            <argument name="Customer" value="$$createCustomer$$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontCustomerNavigateToNewsletterPageActionGroup" stepKey="navigateToNewsletterPage"/>
+        <actionGroup ref="StorefrontCustomerUpdateGeneralSubscriptionActionGroup" stepKey="subscribeToNewsletter"/>
+        <actionGroup ref="AdminLoginActionGroup" stepKey="LoginAsAdmin"/>
+        <actionGroup ref="AdminNavigateMenuActionGroup" stepKey="navigateToNewsletterSubscribersPage">
+            <argument name="menuUiId" value="{{AdminMenuMarketing.dataUiId}}"/>
+            <argument name="submenuUiId" value="{{AdminMenuMarketingCommunicationsNewsletterSubscribers.dataUiId}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminMarketingFindNewsletterSubscribersInGridActionGroup" stepKey="findSubscriber">
+            <argument name="email" value="{{Simple_US_Customer.email}}"/>
+        </actionGroup>
+        <actionGroup ref="AdminMarketingDeleteNewsletterSubscriberFromGridActionGroup" stepKey="deleteSubscriber"/>
+        <actionGroup ref="AssertMessageInAdminPanelActionGroup" stepKey="assertSuccessMessage">
+            <argument name="message" value="Total of 1 record(s) were deleted."/>
+        </actionGroup>
+        <actionGroup ref="AdminMarketingFindNewsletterSubscribersInGridActionGroup" stepKey="findDeletedSubscriber">
+            <argument name="email" value="{{Simple_US_Customer.email}}"/>
+        </actionGroup>
+        <actionGroup ref="AssertAdminDeletedNewsletterSubscriberIsNotInGridActionGroup" stepKey="dontSeeSubscriber">
+            <argument name="email" value="{{Simple_US_Customer.email}}"/>
+        </actionGroup>
+    </test>
+</tests>


### PR DESCRIPTION
This PR contains a test for deleting newsletter subscriber as Admin User

**Steps to reproduce:**

1 - Subscribe a customer for newsletter

2 - Navigate as Admin User to Admin>Marketing>Newsletter Subscribers

3 - Find subscriber on grid

4 - Delete Subscriber

5 - Perform Assertions

### Resolved issues:
1. [x] resolves magento/magento2#29032: MFTF: Admin Delete Newsletter Subscriber