### PR TITLE
Check 'Email Copy of Shipment' by default

### DIFF
--- a/app/code/Magento/Shipping/view/adminhtml/templates/create/items.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/create/items.phtml
@@ -101,7 +101,8 @@
                            class="admin__control-checkbox"
                            name="shipment[send_email]"
                            value="1"
-                           type="checkbox"/>
+                           type="checkbox"
+                           checked="checked"/>
                     <label class="admin__field-label"
                            for="send_email">
                         <span><?= $block->escapeHtml(__('Email Copy of Shipment')) ?></span></label>


### PR DESCRIPTION
Check 'Email Copy of Shipment' by default

### Description (*)
The shipment option 'Email Copy of Shipment' is not checked by default. This option should be op-out, rather than opt-in.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
1. N/A

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Change configuration `Sales Emails -> Shipment -> Enabled` to `Yes`.
2. Place an order.
3. Create an invoice for placed order.
4. Go to the shipment create form for placed order.
5. Note that the option ''Email Copy of Shipment' is not checked.

### Questions or comments
None

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
