### PR TITLE
Fixed condition for products list widget

### DIFF
--- a/app/code/Magento/CatalogWidget/Model/Rule/Condition/Product.php
+++ b/app/code/Magento/CatalogWidget/Model/Rule/Condition/Product.php
@@ -179,8 +179,14 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
                 $storeId = $connection->getIfNullSql($alias . '.store_id', $this->storeManager->getStore()->getId());
                 $linkField = $attribute->getEntity()->getLinkField();
 
+                $table = $collection->getTable('catalog_product_entity_varchar');
+                
+                if ($attribute->getBackendType() === 'text') {
+                    $table = $collection->getTable('catalog_product_entity_text');
+                }
+                
                 $collection->getSelect()->join(
-                    [$alias => $collection->getTable('catalog_product_entity_varchar')],
+                    [$alias => $table],
                     "($alias.$linkField = e.$linkField) AND ($alias.store_id = $storeId)" .
                     " AND ($alias.attribute_id = {$attribute->getId()})",
                     []


### PR DESCRIPTION
Steps to Reproduce
- Create new Magento instance with sample data
- Edit cms block Home Page
- Edit widget product list (Hot Sellers) and add a condition product attribute "Description" contains "The"

Expected result: products are displayed for which description contains "The"
Actual result: products no displayed