### PR TITLE
UPS Shipment Tracking: Show "Delivered On" only when package has actually been delivered

### DIFF
--- a/app/code/Magento/Ups/Plugin/Block/DataProviders/Tracking/ChangeTitle.php
+++ b/app/code/Magento/Ups/Plugin/Block/DataProviders/Tracking/ChangeTitle.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Ups\Plugin\Block\DataProviders\Tracking;
+
+use Magento\Ups\Model\Carrier;
+use Magento\Shipping\Model\Tracking\Result\Status;
+use Magento\Shipping\Block\DataProviders\Tracking\DeliveryDateTitle as Subject;
+
+/**
+ * Plugin to change the "Delivery on" title to a customized value for UPS
+ */
+class ChangeTitle
+{
+    /**
+     * Modify title only when UPS is used as carrier
+     *
+     * @param Subject $subject
+     * @param \Magento\Framework\Phrase|string $result
+     * @param Status $trackingStatus
+     * @return \Magento\Framework\Phrase|string
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function afterGetTitle(Subject $subject, $result, Status $trackingStatus)
+    {
+        if ($trackingStatus->getCarrier() === Carrier::CODE) {
+            $result = __('Status Updated On:');
+        }
+        return $result;
+    }
+}

--- a/app/code/Magento/Ups/Test/Unit/Plugin/Block/DataProviders/Tracking/ChangeTitleTest.php
+++ b/app/code/Magento/Ups/Test/Unit/Plugin/Block/DataProviders/Tracking/ChangeTitleTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Ups\Test\Unit\Plugin\Block\DataProviders\Tracking;
+
+use Magento\Ups\Model\Carrier;
+use Magento\Ups\Plugin\Block\DataProviders\Tracking\ChangeTitle;
+use Magento\Framework\Phrase;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Shipping\Block\DataProviders\Tracking\DeliveryDateTitle;
+use Magento\Shipping\Model\Tracking\Result\Status;
+use Magento\Ups\Model\Carrier as UpsCarrier;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit Test for @see ChangeTitle
+ */
+class ChangeTitleTest extends TestCase
+{
+    /**
+     * @var ChangeTitle|MockObject
+     */
+    private $plugin;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $objectManagerHelper = new ObjectManager($this);
+        $this->plugin = $objectManagerHelper->getObject(ChangeTitle::class);
+    }
+
+    /**
+     * Check if DeliveryDateTitle was changed if the carrier is UPS
+     *
+     * @param string $carrierCode
+     * @param string $originalResult
+     * @param Phrase|string $finalResult
+     * @dataProvider testAfterGetTitleDataProvider
+     */
+    public function testAfterGetTitle(string $carrierCode, string $originalResult, $finalResult)
+    {
+        /** @var DeliveryDateTitle|MockObject $subjectMock */
+        $subjectMock = $this->getMockBuilder(DeliveryDateTitle::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        /** @var Status|MockObject $trackingStatusMock */
+        $trackingStatusMock = $this->getMockBuilder(Status::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCarrier'])
+            ->getMock();
+        $trackingStatusMock->expects($this::once())
+            ->method('getCarrier')
+            ->willReturn($carrierCode);
+
+        $actual = $this->plugin->afterGetTitle($subjectMock, $originalResult, $trackingStatusMock);
+
+        $this->assertEquals($finalResult, $actual);
+    }
+
+    /**
+     * Data provider
+     *
+     * @return array
+     */
+    public function testAfterGetTitleDataProvider(): array
+    {
+        return [
+            [Carrier::CODE, 'Original Title', __('Status Updated On:')],
+            ['not-fedex', 'Original Title', 'Original Title'],
+        ];
+    }
+}

--- a/app/code/Magento/Ups/etc/di.xml
+++ b/app/code/Magento/Ups/etc/di.xml
@@ -28,4 +28,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Shipping\Block\DataProviders\Tracking\DeliveryDateTitle">
+        <plugin name="ups_update_delivery_date_title" type="Magento\Ups\Plugin\Block\DataProviders\Tracking\ChangeTitle"/>
+    </type>
 </config>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

The UPS Tracking API returns the activity status code "D" for delivered packages. The delivery properties of the tracking object should only be set if we see this status code. Otherwise packages that are still in transit show as delivered, incorrectly.

Consider the following extract of a UPS tracking API response:

```xml
...
    <Package>
      <TrackingNumber>*REMOVED*</TrackingNumber>
      <DeliveryIndicator>N</DeliveryIndicator>
      <Activity>
        <ActivityLocation>
          <Address>
            <City>Secaucus</City>
            <StateProvinceCode>NJ</StateProvinceCode>
            <CountryCode>US</CountryCode>
          </Address>
        </ActivityLocation>
        <Status>
          <StatusType>
            <Code>I</Code>
            <Description>Departed from Facility</Description>
          </StatusType>
          <StatusCode>
            <Code>DP</Code>
          </StatusCode>
        </Status>
        <Date>20200711</Date>
        <Time>034100</Time>
        <GMTDate>2020-07-11</GMTDate>
        <GMTTime>07:41:00</GMTTime>
        <GMTOffset>-04:00</GMTOffset>
        <NextScheduleActivity>
          <Date>2020-07-15</Date>
          <Time>235900</Time>
        </NextScheduleActivity>
      </Activity>
      <Activity>
        <ActivityLocation>
          <Address>
            <City>New York</City>
            <StateProvinceCode>NY</StateProvinceCode>
            <CountryCode>US</CountryCode>
          </Address>
        </ActivityLocation>
        <Status>
          <StatusType>
            <Code>I</Code>
            <Description>Origin Scan</Description>
          </StatusType>
          <StatusCode>
            <Code>OR</Code>
          </StatusCode>
        </Status>
        <Date>20200710</Date>
        <Time>202339</Time>
        <GMTDate>2020-07-11</GMTDate>
        <GMTTime>00:23:39</GMTTime>
        <GMTOffset>-04:00</GMTOffset>
      </Activity>
...
```

In this case, the package is still in transit. However, because the check for the `DeliveryStatus` is missing, the package would incorrectly show as delivered in Magento, and display the date/time of the first activity as _Delivered On_.

### Related Pull Requests
<!-- related pull request placeholder -->
None

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Couldn't find any open issues related to this.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
You will need a valid UPS tracking number and UPS API keys to test this.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
Let me know if you need samples of the UPS tracking API response.

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29659: UPS Shipment Tracking: Show "Delivered On" only when package has actually been delivered