### PR TITLE
Generetae thumbnails only if image have bigger size then defined in configuration, to aviod stretched images

### DIFF
--- a/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
@@ -628,13 +628,22 @@ class Storage extends \Magento\Framework\DataObject
         }
         $image = $this->_imageFactory->create();
         $image->open($source);
+
         $image->keepAspectRatio($keepRatio);
-        list($imageWidth, $imageHeight) = getimagesize($source);
+
+        list($imageWidth, $imageHeight) = @getimagesize($source);
         
-        $image->resize(
-            $this->_resizeParameters['width'] > $imageWidth ? $imageWidth : $this->_resizeParameters['width'],
-            $this->_resizeParameters['height'] > $imageHeight ? $imageHeight : $this->_resizeParameters['height']
-        );
+        if ($imageWidth && $imageHeight) {
+            $configWidth = $this->_resizeParameters['width'];
+            $configHeight = $this->_resizeParameters['height'];
+            $imageWidth = $configWidth > $imageWidth ? $imageWidth : $this->_resizeParameters['width'];
+            $imageHeight = $configHeight > $imageHeight ? $imageHeight : $this->_resizeParameters['height'];
+        } else {
+            $imageWidth = $this->_resizeParameters['width'];
+            $imageHeight = $this->_resizeParameters['height'];
+        }
+        
+        $image->resize($imageWidth, $imageHeight);
         $dest = $targetDir . '/' . $this->ioFile->getPathInfo($source)['basename'];
         $image->save($dest);
         if ($this->_directory->isFile($this->_directory->getRelativePath($dest))) {

--- a/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
@@ -631,17 +631,7 @@ class Storage extends \Magento\Framework\DataObject
 
         $image->keepAspectRatio($keepRatio);
 
-        list($imageWidth, $imageHeight) = @getimagesize($source);
-        
-        if ($imageWidth && $imageHeight) {
-            $configWidth = $this->_resizeParameters['width'];
-            $configHeight = $this->_resizeParameters['height'];
-            $imageWidth = $configWidth > $imageWidth ? $imageWidth : $configWidth;
-            $imageHeight = $configHeight > $imageHeight ? $imageHeight : $configHeight;
-        } else {
-            $imageWidth = $this->_resizeParameters['width'];
-            $imageHeight = $this->_resizeParameters['height'];
-        }
+        list($imageWidth, $imageHeight) = $this->getResizedParams($source);
         
         $image->resize($imageWidth, $imageHeight);
         $dest = $targetDir . '/' . $this->ioFile->getPathInfo($source)['basename'];
@@ -652,6 +642,29 @@ class Storage extends \Magento\Framework\DataObject
         return false;
     }
 
+    /**
+     * Return width height for the image resizing.
+     *
+     * @param string $source
+     */
+    private function getResizedParams(string $source): array
+    {
+        $configWidth = $this->_resizeParameters['width'];
+        $configHeight = $this->_resizeParameters['height'];
+
+        //phpcs:ignore Generic.PHP.NoSilencedErrors
+        list($imageWidth, $imageHeight) = @getimagesize($source);
+     
+        if ($imageWidth && $imageHeight) {
+            $imageWidth = $configWidth > $imageWidth ? $imageWidth : $configWidth;
+            $imageHeight = $configHeight > $imageHeight ? $imageHeight : $configHeight;
+        } else {
+            return [$configWidth, $configHeight];
+        }
+
+        return  [$imageWidth, $imageHeight];
+    }
+    
     /**
      * Resize images on the fly in controller action
      *

--- a/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
@@ -646,6 +646,7 @@ class Storage extends \Magento\Framework\DataObject
      * Return width height for the image resizing.
      *
      * @param string $source
+     * @return array
      */
     private function getResizedParams(string $source): array
     {
@@ -658,11 +659,10 @@ class Storage extends \Magento\Framework\DataObject
         if ($imageWidth && $imageHeight) {
             $imageWidth = $configWidth > $imageWidth ? $imageWidth : $configWidth;
             $imageHeight = $configHeight > $imageHeight ? $imageHeight : $configHeight;
-        } else {
-            return [$configWidth, $configHeight];
-        }
 
-        return  [$imageWidth, $imageHeight];
+            return  [$imageWidth, $imageHeight];
+        }
+        return [$configWidth, $configHeight];
     }
     
     /**

--- a/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
@@ -636,8 +636,8 @@ class Storage extends \Magento\Framework\DataObject
         if ($imageWidth && $imageHeight) {
             $configWidth = $this->_resizeParameters['width'];
             $configHeight = $this->_resizeParameters['height'];
-            $imageWidth = $configWidth > $imageWidth ? $imageWidth : $this->_resizeParameters['width'];
-            $imageHeight = $configHeight > $imageHeight ? $imageHeight : $this->_resizeParameters['height'];
+            $imageWidth = $configWidth > $imageWidth ? $imageWidth : $configWidth;
+            $imageHeight = $configHeight > $imageHeight ? $imageHeight : $configHeight;
         } else {
             $imageWidth = $this->_resizeParameters['width'];
             $imageHeight = $this->_resizeParameters['height'];

--- a/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
+++ b/app/code/Magento/Cms/Model/Wysiwyg/Images/Storage.php
@@ -629,7 +629,12 @@ class Storage extends \Magento\Framework\DataObject
         $image = $this->_imageFactory->create();
         $image->open($source);
         $image->keepAspectRatio($keepRatio);
-        $image->resize($this->_resizeParameters['width'], $this->_resizeParameters['height']);
+        list($imageWidth, $imageHeight) = getimagesize($source);
+        
+        $image->resize(
+            $this->_resizeParameters['width'] > $imageWidth ? $imageWidth : $this->_resizeParameters['width'],
+            $this->_resizeParameters['height'] > $imageHeight ? $imageHeight : $this->_resizeParameters['height']
+        );
         $dest = $targetDir . '/' . $this->ioFile->getPathInfo($source)['basename'];
         $image->save($dest);
         if ($this->_directory->isFile($this->_directory->getRelativePath($dest))) {

--- a/dev/tests/integration/testsuite/Magento/Cms/Model/Wysiwyg/Images/StorageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Model/Wysiwyg/Images/StorageTest.php
@@ -167,7 +167,9 @@ class StorageTest extends \PHPUnit\Framework\TestCase
     public function testUploadFileWithExcludedDirPath(): void
     {
         $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
-        $this->expectExceptionMessage('We can\'t upload the file to current folder right now. Please try another folder.');
+        $this->expectExceptionMessage(
+            'We can\'t upload the file to current folder right now. Please try another folder.'
+        );
 
         $fileName = 'magento_small_image.jpg';
         $tmpDirectory = $this->filesystem->getDirectoryWrite(\Magento\Framework\App\Filesystem\DirectoryList::SYS_TMP);
@@ -335,7 +337,7 @@ class StorageTest extends \PHPUnit\Framework\TestCase
                     'width' => 1024,
                     'height' => 768,
                 ],
-               true
+                true
             ],
             [
                 [

--- a/dev/tests/integration/testsuite/Magento/Cms/Model/Wysiwyg/Images/StorageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Cms/Model/Wysiwyg/Images/StorageTest.php
@@ -296,6 +296,58 @@ class StorageTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Verify thumbnail generation for diferent sizes
+     *
+     * @param array $sizes
+     * @param bool $resized
+     * @dataProvider getThumbnailsSizes
+     */
+    public function testResizeFile(array $sizes, bool $resized): void
+    {
+        $root = $this->storage->getCmsWysiwygImages()->getStorageRoot();
+        $path = $root . '/' . 'testfile.png';
+        $this->generateImage($path, $sizes['width'], $sizes['height']);
+        $this->storage->resizeFile($path);
+
+        $thumbPath =   $this->storage->getThumbnailPath($path);
+        list($imageWidth, $imageHeight) = getimagesize($thumbPath);
+
+        $this->assertEquals(
+            $resized ? $this->storage->getResizeWidth() : $sizes['width'],
+            $imageWidth
+        );
+        $this->assertLessThanOrEqual(
+            $resized ? $this->storage->getResizeHeight() : $sizes['height'],
+            $imageHeight
+        );
+
+        $this->storage->deleteFile($path);
+    }
+
+    /**
+     * Provide sizes for resizeFile test
+     */
+    public function getThumbnailsSizes(): array
+    {
+        return [
+            [
+                [
+                    'width' => 1024,
+                    'height' => 768,
+                ],
+               true
+            ],
+            [
+                [
+                    'width' => 20,
+                    'height' => 20,
+                ],
+                false
+            ]
+        ];
+    }
+
+    /**
      * Provide scenarios for testing getThumbnailUrl()
      *
      * @return array


### PR DESCRIPTION


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
--> 
https://github.com/magento/adobe-stock-integration/issues/1422 Small image is stretched all over the image thumbnail 

### Manual testing scenarios (*)
1. Go to **Content - Media Gallery** 
2. Upload a small image to the Media Gallery
3. Observe the image thumbnail 

The image is not stretched and displayed as it is


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
