### PR TITLE
add boolean selector for interactive installations

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Option/BooleanConfigOption.php
+++ b/lib/internal/Magento/Framework/Setup/Option/BooleanConfigOption.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Setup\Option;
+
+/**
+ * Select option in deployment config tool
+ */
+class BooleanConfigOption extends AbstractConfigOption
+{
+    /**#@+
+     * Frontend input types
+     */
+    const FRONTEND_WIZARD_RADIO = 'radio';
+
+    const SELECT_OPTIONS = ['no', 'yes'];
+    const INPUT_OPTIONS = ['0', '1', 'no', 'yes', 'false', 'true'];
+    const OPTIONS_POSITIVE = ['1', 'yes', 'true'];
+    /**#@- */
+
+    /**
+     * Constructor
+     *
+     * @param string $name
+     * @param string $frontendType
+     * @param string $configPath
+     * @param string $description
+     * @param string|null $defaultValue
+     * @param string|array|null $shortCut
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(
+        $name,
+        $configPath,
+        $description = '',
+        $defaultValue = '0',
+        $shortCut = null
+    ) {
+        parent::__construct(
+            $name,
+            self::FRONTEND_WIZARD_RADIO,
+            self::VALUE_REQUIRED,
+            $configPath,
+            $description,
+            $defaultValue,
+            $shortCut
+        );
+    }
+
+    /**
+     * Get available options
+     *
+     * @return array
+     */
+    public function getSelectOptions()
+    {
+        return self::SELECT_OPTIONS;
+    }
+
+    /**
+     * Validates input data
+     *
+     * @param mixed $data
+     * @return void
+     * @throws \InvalidArgumentException
+     */
+    public function validate($data)
+    {
+        if (!in_array(strtolower($data), self::INPUT_OPTIONS)) {
+            throw new \InvalidArgumentException("Value specified for '{$this->getName()}' is not supported: '{$data}'");
+        }
+        parent::validate($data);
+    }
+
+    /**
+     * @param string $option
+     *
+     * @return bool
+     */
+    public static function boolVal(string $option): bool
+    {
+        return in_array(strtolower($option), self::OPTIONS_POSITIVE);
+    }
+}

--- a/lib/internal/Magento/Framework/Setup/Option/BooleanConfigOption.php
+++ b/lib/internal/Magento/Framework/Setup/Option/BooleanConfigOption.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Framework\Setup\Option;
 
 /**
@@ -41,7 +43,7 @@ class BooleanConfigOption extends AbstractConfigOption
         parent::__construct(
             $name,
             self::FRONTEND_WIZARD_RADIO,
-            self::VALUE_REQUIRED,
+            self::VALUE_OPTIONAL,
             $configPath,
             $description,
             $defaultValue,
@@ -54,7 +56,7 @@ class BooleanConfigOption extends AbstractConfigOption
      *
      * @return array
      */
-    public function getSelectOptions()
+    public function getSelectOptions(): array
     {
         return self::SELECT_OPTIONS;
     }
@@ -66,9 +68,9 @@ class BooleanConfigOption extends AbstractConfigOption
      * @return void
      * @throws \InvalidArgumentException
      */
-    public function validate($data)
+    public function validate($data): void
     {
-        if (!in_array(strtolower($data), self::INPUT_OPTIONS)) {
+        if (!in_array(strtolower((string)$data), self::INPUT_OPTIONS)) {
             throw new \InvalidArgumentException("Value specified for '{$this->getName()}' is not supported: '{$data}'");
         }
         parent::validate($data);

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList.php
@@ -11,6 +11,7 @@ use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Config\ConfigOptionsListConstants;
 use Magento\Framework\Encryption\KeyValidator;
 use Magento\Framework\Setup\ConfigOptionsListInterface;
+use Magento\Framework\Setup\Option\BooleanConfigOption;
 use Magento\Framework\Setup\Option\FlagConfigOption;
 use Magento\Framework\Setup\Option\TextConfigOption;
 use Magento\Setup\Model\ConfigOptionsList\DriverOptions;
@@ -196,7 +197,7 @@ class ConfigOptionsList implements ConfigOptionsListInterface
                 'Full path of server certificate file in order to establish db connection through SSL',
                 ''
             ),
-            new FlagConfigOption(
+            new BooleanConfigOption(
                 ConfigOptionsListConstants::INPUT_KEY_DB_SSL_VERIFY,
                 ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT_DRIVER_OPTIONS .
                 '/' . ConfigOptionsListConstants::KEY_MYSQL_SSL_VERIFY,

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
@@ -7,12 +7,11 @@ declare(strict_types=1);
 
 namespace Magento\Setup\Model\ConfigOptionsList;
 
-use Magento\Framework\Setup\ConfigOptionsListInterface;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Config\Data\ConfigData;
 use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Setup\ConfigOptionsListInterface;
 use Magento\Framework\Setup\Option\BooleanConfigOption;
-use Magento\Framework\Setup\Option\FlagConfigOption;
 use Magento\Framework\Setup\Option\SelectConfigOption;
 use Magento\Framework\Setup\Option\TextConfigOption;
 use Magento\Setup\Validator\RedisConnectionValidator;

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
@@ -11,6 +11,7 @@ use Magento\Framework\Setup\ConfigOptionsListInterface;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Config\Data\ConfigData;
 use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Setup\Option\BooleanConfigOption;
 use Magento\Framework\Setup\Option\FlagConfigOption;
 use Magento\Framework\Setup\Option\SelectConfigOption;
 use Magento\Framework\Setup\Option\TextConfigOption;
@@ -147,7 +148,7 @@ class Cache implements ConfigOptionsListInterface
                 self::CONFIG_PATH_CACHE_ID_PREFIX,
                 'ID prefix for cache keys'
             ),
-            new FlagConfigOption(
+            new BooleanConfigOption(
                 self::INPUT_KEY_CACHE_ALLOW_PARALLEL_CACHE_GENERATION,
                 self::CONFIG_PATH_ALLOW_PARALLEL_CACHE_GENERATION,
                 'Allow generate cache in non-blocking way'

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigOptionsList/CacheTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\Setup\Test\Unit\Model\ConfigOptionsList;
 
 use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Setup\Option\BooleanConfigOption;
 use Magento\Framework\Setup\Option\FlagConfigOption;
 use Magento\Framework\Setup\Option\SelectConfigOption;
 use Magento\Framework\Setup\Option\TextConfigOption;
@@ -84,7 +85,7 @@ class CacheTest extends TestCase
         $this->assertEquals('cache-id-prefix', $options[7]->getName());
 
         $this->assertArrayHasKey(8, $options);
-        $this->assertInstanceOf(FlagConfigOption::class, $options[8]);
+        $this->assertInstanceOf(BooleanConfigOption::class, $options[8]);
         $this->assertEquals('allow-parallel-generation', $options[8]->getName());
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR introduces a boolean radio option for the interactive CLI installation and the `setup:config:set` command.
This one model resolves a couple of issues:
In `setup:config:set` the "flag" type options will always be reset to their default value if not explicitly defined.
```
bin/magento setup:config:set --consumers-wait-for-messages=1 --enable-debug-logging=1 --enable-syslog-logging=1
Overwrite the existing configuration for enable-debug-logging?[Y/n]
Overwrite the existing configuration for enable-syslog-logging?[Y/n]
Overwrite the existing configuration for consumers-wait-for-messages?[Y/n]
Overwrite the existing configuration for db-ssl-verify?[Y/n]
Overwrite the existing configuration for allow-parallel-generation?[Y/n]
```
Notice that I did not specify `db-ssl-verify` or `allow-parallel-generation`. After hitting enter 5 times, these two values have been reset to their default value, regardless of their value before that. This issue is not fixed.

The following questions have been altered:

```
Enable debug logging?
  [0] 1
  [1]
  [2] 1
  [3] 0
Enable syslog logging?
  [0] 1
  [1]
  [2] 1
  [3] 0
Should consumers wait for a message from the queue??
  [0] 1
  [1]
  [2] 1
  [3] 0
```

Now becomes:

```
Enable debug logging?
  [0] no
  [1] yes
Enable syslog logging?
  [0] no
  [1] yes
Should consumers wait for a message from the queue??
  [0] no
  [1] yes
```

A correct answer to these questions was impossible before this PR:

```
Enable debug logging?
  [0] 1
  [1]
  [2] 1
  [3] 0
 > 2
PHP Fatal error:  Uncaught TypeError: trim() expects parameter 1 to be string, int given in /Users/evers/web/AntonEvers/magento2/setup/src/Magento/Setup/Console/Command/InstallCommand.php:412
Stack trace:
#0 /Users/evers/web/AntonEvers/magento2/setup/src/Magento/Setup/Console/Command/InstallCommand.php(412): trim(1)
#1 /Users/evers/web/AntonEvers/magento2/vendor/symfony/console/Helper/QuestionHelper.php(470): Magento\Setup\Console\Command\InstallCommand->Magento\Setup\Console\Command\{closure}(1)
#2 /Users/evers/web/AntonEvers/magento2/vendor/symfony/console/Helper/QuestionHelper.php(68): Symfony\Component\Console\Helper\QuestionHelper->validateAttempts(Object(Closure), Object(Symfony\Component\Console\Output\StreamOutput), Object(Symfony\Component\Console\Question\ChoiceQuestion))
#3 /Users/evers/web/AntonEvers/magento2/setup/src/Magento/Setup/Console/Command/InstallCommand.php(422): Symfony\Component\Console\Helper\QuestionHelper->ask(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ in /Users/evers/web/AntonEvers/magento2/setup/src/Magento/Setup/Console/Command/InstallCommand.php on line 412

Fatal error: Uncaught TypeError: trim() expects parameter 1 to be string, int given in /Users/evers/web/AntonEvers/magento2/setup/src/Magento/Setup/Console/Command/InstallCommand.php:412
Stack trace:
#0 /Users/evers/web/AntonEvers/magento2/setup/src/Magento/Setup/Console/Command/InstallCommand.php(412): trim(1)
#1 /Users/evers/web/AntonEvers/magento2/vendor/symfony/console/Helper/QuestionHelper.php(470): Magento\Setup\Console\Command\InstallCommand->Magento\Setup\Console\Command\{closure}(1)
#2 /Users/evers/web/AntonEvers/magento2/vendor/symfony/console/Helper/QuestionHelper.php(68): Symfony\Component\Console\Helper\QuestionHelper->validateAttempts(Object(Closure), Object(Symfony\Component\Console\Output\StreamOutput), Object(Symfony\Component\Console\Question\ChoiceQuestion))
#3 /Users/evers/web/AntonEvers/magento2/setup/src/Magento/Setup/Console/Command/InstallCommand.php(422): Symfony\Component\Console\Helper\QuestionHelper->ask(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ in /Users/evers/web/AntonEvers/magento2/setup/src/Magento/Setup/Console/Command/InstallCommand.php on line 412
```

Now the input accepts the following values when manual input is needed: `0`, `false`, `no`, `1`, `true`, `yes`.
And for interactive input it merely asks:
```
  [0] no
  [1] yes
```

The `--db-ssl-verify` and `--allow-parallel-generation` options in `setup:config:set` now also allow to be set to false. Before this they could only be set to true with the command, and would need manual changes to revert that.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
