### PR TITLE
Fix #28947 - Proper reset action for select component

### DIFF
--- a/app/code/Magento/Search/Test/Mftf/Page/AdminSearchSynonymsNewPage.xml
+++ b/app/code/Magento/Search/Test/Mftf/Page/AdminSearchSynonymsNewPage.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/PageObject.xsd">
+    <page name="AdminSearchSynonymsNewPage" url="/search/synonyms/new/" area="admin" module="Magento_Search">
+        <section name="AdminSearchSynonymsNewSection"/>
+    </page>
+</pages>

--- a/app/code/Magento/Search/Test/Mftf/Section/AdminSearchSynonymsNewSection.xml
+++ b/app/code/Magento/Search/Test/Mftf/Section/AdminSearchSynonymsNewSection.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminSearchSynonymsNewSection">
+        <element name="resetButton" type="button" selector="//button[@id='reset']"/>
+        <element name="scope" type="select" selector="//select[@name='scope_id']"/>
+        <element name="synonyms" type="textarea" selector="//textarea[@name='synonyms']"/>
+    </section>
+</sections>

--- a/app/code/Magento/Search/Test/Mftf/Test/AdminSynonymsNewGroupFormResetTest.xml
+++ b/app/code/Magento/Search/Test/Mftf/Test/AdminSynonymsNewGroupFormResetTest.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminSynonymsNewGroupFormResetTest">
+        <annotations>
+            <features value="Search"/>
+            <stories value="Reset synonym group form"/>
+            <title value="Admin reset synonym group form"/>
+            <description value="When admin uses reset button on new synonym group form all fields should be set to default values"/>
+            <severity value="AVERAGE"/>
+            <group value="Search"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
+        </after>
+
+        <amOnPage url="{{AdminSearchSynonymsNewPage.url}}" stepKey="openAdminSearchSynonymsNewPage"/>
+        <waitForPageLoad stepKey="waitForAdminSearchSynonymsNewPageLoad"/>
+
+        <selectOption selector="{{AdminSearchSynonymsNewSection.scope}}" userInput="1:1" stepKey="selectScope"/>
+        <fillField selector="{{AdminSearchSynonymsNewSection.synonyms}}" userInput="Synonym Example" stepKey="fillSynonyms"/>
+        <click selector="{{AdminSearchSynonymsNewSection.resetButton}}" stepKey="clickResetButton"/>
+
+        <grabValueFrom selector="{{AdminSearchSynonymsNewSection.scope}}" stepKey="grabScopeValue"/>
+        <assertEquals stepKey="assertScopeDefaultValue">
+            <expectedResult type="string">0:0</expectedResult>
+            <actualResult type="string">$grabScopeValue</actualResult>
+        </assertEquals>
+
+        <grabValueFrom selector="{{AdminSearchSynonymsNewSection.synonyms}}" stepKey="grabSynonymsValue"/>
+        <assertEmpty stepKey="assertSynonymsDefaultValue">
+            <actualResult type="string">$grabSynonymsValue</actualResult>
+        </assertEmpty>
+    </test>
+</tests>

--- a/app/code/Magento/Ui/view/base/web/js/form/element/select.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/select.js
@@ -300,6 +300,18 @@ define([
         },
 
         /**
+         * Clears select value and error.
+         *
+         * @returns {Abstract} Chainable.
+         */
+        reset: function () {
+            this.clear();
+            this.error(false);
+
+            return this;
+        },
+
+        /**
          * Initializes observable properties of instance
          *
          * @returns {Object} Chainable.


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR adds `reset` method to the select component, which was previously inherited from `abstract` parent component, and was not working correctly, since it was created there for text field.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#28947

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Please check fixed issue for steps to test

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
