### PR TITLE
29200: Fix issue with non parsable time non UTC timezone

### DIFF
--- a/app/code/Magento/Security/Test/Mftf/Test/AdminCreateNewUserWithValidExpirationTest.xml
+++ b/app/code/Magento/Security/Test/Mftf/Test/AdminCreateNewUserWithValidExpirationTest.xml
@@ -25,7 +25,7 @@
         </after>
 
         <actionGroup ref="AdminOpenNewUserPageActionGroup" stepKey="openNewUserPage" />
-        <generateDate date="+5 day" format="M j, Y g:i:s A" stepKey="expiresDateTime"/>
+        <generateDate date="+5 day" format="M j, Y g:i:s A" timezone="America/Chicago" stepKey="expiresDateTime"/>
         <actionGroup ref="AdminFillInUserWithExpirationActionGroup" stepKey="fillInNewUserWithValidExpiration">
             <argument name="expires_at" value="{$expiresDateTime}"/>
         </actionGroup>

--- a/dev/tests/integration/testsuite/Magento/Security/Observer/AfterAdminUserSaveTest.php
+++ b/dev/tests/integration/testsuite/Magento/Security/Observer/AfterAdminUserSaveTest.php
@@ -23,7 +23,7 @@ class AfterAdminUserSaveTest extends \PHPUnit\Framework\TestCase
     public function testSaveNewUserExpiration()
     {
         $adminUserNameFromFixture = 'dummy_username';
-        $testDate = $this->getFutureDateInStoreTime();
+        $testDate = $this->getFutureDateTimestamp();
         $user = Bootstrap::getObjectManager()->create(\Magento\User\Model\User::class);
         $user->loadByUsername($adminUserNameFromFixture);
         $user->setExpiresAt($testDate);
@@ -46,7 +46,7 @@ class AfterAdminUserSaveTest extends \PHPUnit\Framework\TestCase
     public function testSaveNewUserExpirationInMinutes()
     {
         $adminUserNameFromFixture = 'dummy_username';
-        $testDate = $this->getFutureDateInStoreTime('+2 minutes');
+        $testDate = $this->getFutureDateTimestamp('+2 minutes');
         $user = Bootstrap::getObjectManager()->create(\Magento\User\Model\User::class);
         $user->loadByUsername($adminUserNameFromFixture);
         $user->setExpiresAt($testDate);
@@ -90,7 +90,7 @@ class AfterAdminUserSaveTest extends \PHPUnit\Framework\TestCase
     public function testChangeUserExpiration()
     {
         $adminUserNameFromFixture = 'adminUserNotExpired';
-        $testDate = $this->getFutureDateInStoreTime();
+        $testDate = $this->getFutureDateTimestamp();
         $user = Bootstrap::getObjectManager()->create(\Magento\User\Model\User::class);
         $user->loadByUsername($adminUserNameFromFixture);
 
@@ -114,13 +114,10 @@ class AfterAdminUserSaveTest extends \PHPUnit\Framework\TestCase
      * @return string
      * @throws \Exception
      */
-    private function getFutureDateInStoreTime($timeToAdd = '+20 days')
+    private function getFutureDateTimestamp($timeToAdd = '+20 days')
     {
-        /** @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface $locale */
-        $locale = Bootstrap::getObjectManager()->get(\Magento\Framework\Stdlib\DateTime\TimezoneInterface::class);
         $testDate = new \DateTime();
         $testDate->modify($timeToAdd);
-        $storeDate = $locale->date($testDate);
-        return $storeDate->format('Y-m-d H:i:s');
+        return $testDate->format('Y-m-d H:i:s');
     }
 }

--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
@@ -166,11 +166,12 @@ class Timezone implements TimezoneInterface
             ? $this->getConfigTimezone()
             : date_default_timezone_get();
 
+        $dateTimeZone = new \DateTimeZone($timezone);
         switch (true) {
             case (empty($date)):
-                return new \DateTime('now', new \DateTimeZone($timezone));
+                return new \DateTime('now', $dateTimeZone);
             case ($date instanceof \DateTime):
-                return $date->setTimezone(new \DateTimeZone($timezone));
+                return $date->setTimezone($dateTimeZone);
             case ($date instanceof \DateTimeImmutable):
                 return new \DateTime($date->format('Y-m-d H:i:s'), $date->getTimezone());
             case (!is_numeric($date)):
@@ -179,15 +180,15 @@ class Timezone implements TimezoneInterface
                     $locale,
                     \IntlDateFormatter::MEDIUM,
                     $timeType,
-                    new \DateTimeZone($timezone)
+                    $dateTimeZone
                 );
 
                 $date = $this->appendTimeIfNeeded($date, $includeTime, $timezone, $locale);
-                $date = $formatter->parse($date) ?: (new \DateTime($date))->getTimestamp();
+                $date = $formatter->parse($date) ?: (new \DateTime($date, $dateTimeZone))->getTimestamp();
                 break;
         }
 
-        return (new \DateTime(null, new \DateTimeZone($timezone)))->setTimestamp($date);
+        return (new \DateTime(null, $dateTimeZone))->setTimestamp($date);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/TimezoneTest.php
+++ b/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/TimezoneTest.php
@@ -98,7 +98,6 @@ class TimezoneTest extends TestCase
         /** @var Timezone $timezone */
         $timezone = $this->objectManager->getObject(Timezone::class, ['scopeConfig' => $this->scopeConfig]);
 
-        /** @var \DateTime $dateTime */
         $dateTime = $timezone->date($date, $locale, true, $includeTime);
         $this->assertEquals($expectedTimestamp, $dateTime->getTimestamp());
     }
@@ -150,6 +149,12 @@ class TimezoneTest extends TestCase
                 'el_GR', // locale
                 false, // include time
                 1635570000 // expected timestamp
+            ],
+            'Non parsable date format with time' => [
+                '19th July 2020 09:30:05',
+                'en_US',
+                'true',
+                1595169005
             ]
         ];
     }


### PR DESCRIPTION
### Description (*)
Fix behavior of \Magento\Framework\Stdlib\DateTime\Timezone::date() method when working with date strings, non parsable by  \IntlDateFormatter class

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#29200

### Manual testing scenarios (*)
1.Configure Magento instance to some non UTC timezone, e.g. Go Magento admin -> Stores -> Settings -> General -> General -> Locale Options and set Timezone to some non UTC timezone, e.g. *Central Standard Time (America/Chicago)*
2. Get an instance of \Magento\Framework\Stdlib\DateTime\Timezone class
3. Call method with any time string, which can't be parsed by \IntlDateFormatter, e.g. *19th July 2020 9:30:00*, *Monday 08:00* etc.
```
$objectManager = \Magento\Framework\App\ObjectManager::getInstance();
$timezone = $objectManager->create(\Magento\Framework\Stdlib\DateTime\Timezone::class);
$dateTime = $timezone->date('19th July 2019 09:30:00','en_US', 'en_US', true);
var_dump($dateTime);
```
#### Expected result (*)
Returned datetime object should match to time in argument and affected by timezone. E.g. the result of the code snipped above should be like:
```
class DateTime#638 (3) {
  public $date => string(26) "2020-07-19 09:30:00.000000"
  public $timezone_type => int(3)
  public $timezone => string(15) "America/Chicago"
}
```
#### Actual result (*)
1. Returned datetime object is actually for UTC timezone, but marked as for specific timezone, e.g.
```
class DateTime#638 (3) {
  public $date => string(26) "2020-07-19 04:30:00.000000" // UTC time
  public $timezone_type => int(3)
  public $timezone => string(15) "America/Chicago" //marked as Chicago time
}
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
