### PR TITLE
#28947 Fix scope reset on new synonym form

### DIFF
--- a/app/code/Magento/Search/Test/Mftf/ActionGroup/AdminFillNewSearchSynonymsActionGroup.xml
+++ b/app/code/Magento/Search/Test/Mftf/ActionGroup/AdminFillNewSearchSynonymsActionGroup.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminFillNewSearchSynonymsActionGroup">
+        <annotations>
+            <description>Fills the search synonyms form field.</description>
+        </annotations>
+        <arguments>
+            <argument name="scope_id" type="string"/>
+            <argument name="synonyms" type="string"/>
+            <argument name="merge" type="string"/>
+        </arguments>
+
+        <selectOption selector="{{AdminSearchSynonymsNewSection.scope}}" userInput="{{scope_id}}" stepKey="selectScope"/>
+        <fillField selector="{{AdminSearchSynonymsNewSection.synonyms}}" userInput="{{synonyms}}" stepKey="fillSynonyms"/>
+        <checkOption selector="{{AdminSearchSynonymsNewSection.merge}}" stepKey="checkCheckbox"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Search/Test/Mftf/ActionGroup/AdminFillNewSearchSynonymsActionGroup.xml
+++ b/app/code/Magento/Search/Test/Mftf/ActionGroup/AdminFillNewSearchSynonymsActionGroup.xml
@@ -15,7 +15,6 @@
         <arguments>
             <argument name="scope_id" type="string"/>
             <argument name="synonyms" type="string"/>
-            <argument name="merge" type="string"/>
         </arguments>
 
         <selectOption selector="{{AdminSearchSynonymsNewSection.scope}}" userInput="{{scope_id}}" stepKey="selectScope"/>

--- a/app/code/Magento/Search/Test/Mftf/ActionGroup/AdminNavigateToNewSearchSynonymsPageActionGroup.xml
+++ b/app/code/Magento/Search/Test/Mftf/ActionGroup/AdminNavigateToNewSearchSynonymsPageActionGroup.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminNavigateToNewSearchSynonymsPageActionGroup">
+        <click stepKey="clickNewSynonymsGroupButton" selector="{{AdminSearchSynonymsGridSection.add}}"/>
+        <waitForPageLoad stepKey="waitForNewSearchSynonymsPageLoaded"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Search/Test/Mftf/Data/SearchSynonymsData.xml
+++ b/app/code/Magento/Search/Test/Mftf/Data/SearchSynonymsData.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<entities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:DataGenerator/etc/dataProfileSchema.xsd">
+    <entity name="AdminSearchSynonyms" type="SearchSynonyms">
+        <data key="pageTitle">Search Synonyms</data>
+        <data key="title">Search Synonyms</data>
+        <data key="dataUiId">magento-search-search-synonyms</data>
+    </entity>
+</entities>

--- a/app/code/Magento/Search/Test/Mftf/Section/AdminSearchSynonymsGridSection.xml
+++ b/app/code/Magento/Search/Test/Mftf/Section/AdminSearchSynonymsGridSection.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminSearchSynonymsGridSection">
+        <element name="add" type="button" selector=".page-actions-buttons #add"/>
+    </section>
+</sections>

--- a/app/code/Magento/Search/Test/Mftf/Section/AdminSearchSynonymsNewSection.xml
+++ b/app/code/Magento/Search/Test/Mftf/Section/AdminSearchSynonymsNewSection.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminSearchSynonymsNewSection">
+        <element name="save" type="button" selector="//button[@id='save']"/>
+        <element name="resetButton" type="button" selector="//button[@id='reset']"/>
+        <element name="scope" type="select" selector="//select[@name='scope_id']"/>
+        <element name="synonyms" type="textarea" selector="//textarea[@name='synonyms']"/>
+        <element name="merge" type="checkbox" selector="//input[@name='mergeOnConflict']"/>
+    </section>
+</sections>

--- a/app/code/Magento/Search/Test/Mftf/Test/AdminNewSearchSynonymsFormResetTest.xml
+++ b/app/code/Magento/Search/Test/Mftf/Test/AdminNewSearchSynonymsFormResetTest.xml
@@ -24,7 +24,6 @@
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
 
-        <!--TEST BODY -->
         <actionGroup ref="AdminNavigateMenuActionGroup" stepKey="navigateToSearchSynonymsPage">
             <argument name="menuUiId" value="{{AdminMenuMarketing.dataUiId}}"/>
             <argument name="submenuUiId" value="{{AdminSearchSynonyms.dataUiId}}"/>
@@ -35,7 +34,6 @@
         <actionGroup ref="AdminFillNewSearchSynonymsActionGroup" stepKey="fillNewSearchSynonyms">
             <argument name="scope_id" value="1:1"/>
             <argument name="synonyms" value="Test Synonyms"/>
-            <argument name="merge" value="true"/>
         </actionGroup>
 
         <click selector="{{AdminSearchSynonymsNewSection.resetButton}}" stepKey="clickResetButton"/>
@@ -56,6 +54,5 @@
             <expectedResult type="string">false</expectedResult>
             <actualResult type="string">$grabMergeValue</actualResult>
         </assertEquals>
-        <!--END TEST BODY -->
     </test>
 </tests>

--- a/app/code/Magento/Search/Test/Mftf/Test/AdminNewSearchSynonymsFormResetTest.xml
+++ b/app/code/Magento/Search/Test/Mftf/Test/AdminNewSearchSynonymsFormResetTest.xml
@@ -14,6 +14,7 @@
             <stories value="Reset new search synonyms group form"/>
             <title value="Admin reset new search synonyms group form"/>
             <description value="When admin users reset button on new search synonyms form all fields should be set to default values"/>
+            <testCaseId value="MC-36382"/>
             <severity value="AVERAGE"/>
             <group value="Search"/>
         </annotations>

--- a/app/code/Magento/Search/Test/Mftf/Test/AdminNewSearchSynonymsFormResetTest.xml
+++ b/app/code/Magento/Search/Test/Mftf/Test/AdminNewSearchSynonymsFormResetTest.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    /**
+    * Copyright © Magento, Inc. All rights reserved.
+    * See COPYING.txt for license details.
+    */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminNewSearchSynonymsFormResetTest">
+        <annotations>
+            <features value="Search"/>
+            <stories value="Reset new search synonyms group form"/>
+            <title value="Admin reset new search synonyms group form"/>
+            <description value="When admin users reset button on new search synonyms form all fields should be set to default values"/>
+            <severity value="AVERAGE"/>
+            <group value="Search"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="LoginAsAdmin"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
+        </after>
+
+        <!--TEST BODY -->
+        <actionGroup ref="AdminNavigateMenuActionGroup" stepKey="navigateToSearchSynonymsPage">
+            <argument name="menuUiId" value="{{AdminMenuMarketing.dataUiId}}"/>
+            <argument name="submenuUiId" value="{{AdminSearchSynonyms.dataUiId}}"/>
+        </actionGroup>
+
+        <actionGroup ref="AdminNavigateToNewSearchSynonymsPageActionGroup" stepKey="navigateToNewSearchSynonymsPage"/>
+
+        <actionGroup ref="AdminFillNewSearchSynonymsActionGroup" stepKey="fillNewSearchSynonyms">
+            <argument name="scope_id" value="1:1"/>
+            <argument name="synonyms" value="Test Synonyms"/>
+            <argument name="merge" value="true"/>
+        </actionGroup>
+
+        <click selector="{{AdminSearchSynonymsNewSection.resetButton}}" stepKey="clickResetButton"/>
+
+        <grabValueFrom selector="{{AdminSearchSynonymsNewSection.scope}}" stepKey="grabScopeValue"/>
+        <assertEquals stepKey="assertScopeDefaultValue">
+            <expectedResult type="string">0:0</expectedResult>
+            <actualResult type="string">$grabScopeValue</actualResult>
+        </assertEquals>
+
+        <grabValueFrom selector="{{AdminSearchSynonymsNewSection.synonyms}}" stepKey="grabSynonymsValue"/>
+        <assertEmpty stepKey="assertSynonymsDefaultValue">
+            <actualResult type="string">$grabSynonymsValue</actualResult>
+        </assertEmpty>
+
+        <grabValueFrom selector="{{AdminSearchSynonymsNewSection.merge}}" stepKey="grabMergeValue"/>
+        <assertEquals stepKey="assertMergeDefaultValue">
+            <expectedResult type="string">false</expectedResult>
+            <actualResult type="string">$grabMergeValue</actualResult>
+        </assertEquals>
+        <!--END TEST BODY -->
+    </test>
+</tests>

--- a/app/code/Magento/Search/view/adminhtml/ui_component/search_synonyms_form.xml
+++ b/app/code/Magento/Search/view/adminhtml/ui_component/search_synonyms_form.xml
@@ -63,14 +63,14 @@
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">block</item>
-                    <item name="default" xsi:type="number">0</item>
+                    <item name="default" xsi:type="string">0:0</item>
                 </item>
             </argument>
             <settings>
                 <validation>
                     <rule name="required-entry" xsi:type="boolean">true</rule>
                 </validation>
-                <dataType>int</dataType>
+                <dataType>text</dataType>
                 <tooltip>
                     <link>https://docs.magento.com/m2/ce/user_guide/stores/websites-stores-views.html</link>
                     <description translate="true">You can adjust the scope of this synonym group by selecting an option from the list.</description>


### PR DESCRIPTION
### Description (*)
This PR to update correct default value "0:0" & data type for scope field in new synonym group form. that's why reset not working due to incorrect default value on new form.

### Related Pull Requests
https://github.com/magento/magento2/pull/29193 - I guess this js change not required because rest of the select resetting works fine in other forms (ex: customer form)

### Fixed Issues (if relevant)
1. Fixes magento/magento2#28947

### Manual testing scenarios (*)
1. please check steps to reproduce on #28947

### Questions or comments
NA

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
