### PR TITLE
#1391: SaveAssetsKeywordsInterface to delete obsolete keywords

### DIFF
--- a/app/code/Magento/MediaGallery/Model/ResourceModel/Keyword/SaveAssetLinks.php
+++ b/app/code/Magento/MediaGallery/Model/ResourceModel/Keyword/SaveAssetLinks.php
@@ -61,26 +61,18 @@ class SaveAssetLinks
      * @param int $assetId
      * @param KeywordInterface[] $keywordIds
      *
+     * @throws CouldNotDeleteException
      * @throws CouldNotSaveException
      */
     public function execute(int $assetId, array $keywordIds): void
     {
-        try {
-            $currentKeywordIds = $this->getCurrentKeywordIds($assetId);
+        $currentKeywordIds = $this->getCurrentKeywordIds($assetId);
 
-            $obsoleteKeywordIds = array_diff($currentKeywordIds, $keywordIds);
-            $newKeywordIds = array_diff($keywordIds, $currentKeywordIds);
+        $obsoleteKeywordIds = array_diff($currentKeywordIds, $keywordIds);
+        $newKeywordIds = array_diff($keywordIds, $currentKeywordIds);
 
-            $this->deleteAssetKeywords($assetId, $obsoleteKeywordIds);
-            $this->insertAssetKeywords($assetId, $newKeywordIds);
-
-        } catch (\Exception $exception) {
-            $this->logger->critical($exception);
-            throw new CouldNotSaveException(
-                __('Could not process asset keyword links'),
-                $exception
-            );
-        }
+        $this->deleteAssetKeywords($assetId, $obsoleteKeywordIds);
+        $this->insertAssetKeywords($assetId, $newKeywordIds);
     }
 
     /**
@@ -88,6 +80,8 @@ class SaveAssetLinks
      *
      * @param int $assetId
      * @param int[] $keywordIds
+     *
+     * @throws CouldNotSaveException
      */
     private function insertAssetKeywords(int $assetId, array $keywordIds): void
     {
@@ -111,6 +105,10 @@ class SaveAssetLinks
             );
         } catch (\Exception $exception) {
             $this->logger->critical($exception);
+            throw new CouldNotSaveException(
+                __('Could not save asset keyword links'),
+                $exception
+            );
         }
     }
 

--- a/app/code/Magento/MediaGallery/Model/ResourceModel/Keyword/SaveAssetLinks.php
+++ b/app/code/Magento/MediaGallery/Model/ResourceModel/Keyword/SaveAssetLinks.php
@@ -10,8 +10,10 @@ namespace Magento\MediaGallery\Model\ResourceModel\Keyword;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\DB\Adapter\Pdo\Mysql;
+use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\MediaGalleryApi\Api\Data\KeywordInterface;
+use Magento\MediaGalleryApi\Api\GetAssetsKeywordsInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -29,24 +31,32 @@ class SaveAssetLinks
     private $resourceConnection;
 
     /**
+     * @var GetAssetsKeywordsInterface
+     */
+    private $getAssetsKeywordsInterface;
+
+    /**
      * @var LoggerInterface
      */
     private $logger;
 
     /**
+     * @param GetAssetsKeywordsInterface $getAssetsKeywordsInterface
      * @param ResourceConnection $resourceConnection
      * @param LoggerInterface $logger
      */
     public function __construct(
+        GetAssetsKeywordsInterface $getAssetsKeywordsInterface,
         ResourceConnection $resourceConnection,
         LoggerInterface $logger
     ) {
+        $this->getAssetsKeywordsInterface = $getAssetsKeywordsInterface;
         $this->resourceConnection = $resourceConnection;
         $this->logger = $logger;
     }
 
     /**
-     * Save asset keywords links
+     * Process insert and deletion of asset keywords links
      *
      * @param int $assetId
      * @param KeywordInterface[] $keywordIds
@@ -56,20 +66,45 @@ class SaveAssetLinks
     public function execute(int $assetId, array $keywordIds): void
     {
         try {
-            $values = [];
-            foreach ($keywordIds as $keywordId) {
-                $values[] = [$assetId, $keywordId];
-            }
+            $this->deleteAssetKeywords($assetId, $keywordIds);
+            $this->insertAssetKeywords($assetId, $keywordIds);
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception);
+            throw new CouldNotSaveException(
+                __('Could not process asset keyword links'),
+                $exception
+            );
+        }
+    }
 
-            if (!empty($values)) {
-                /** @var Mysql $connection */
-                $connection = $this->resourceConnection->getConnection();
-                $connection->insertArray(
-                    $this->resourceConnection->getTableName(self::TABLE_ASSET_KEYWORD),
-                    [self::FIELD_ASSET_ID, self::FIELD_KEYWORD_ID],
-                    $values,
-                    AdapterInterface::INSERT_IGNORE
-                );
+    /**
+     * Save new asset keyword links
+     *
+     * @param int $assetId
+     * @param array $keywordIds
+     * @throws CouldNotSaveException
+     */
+    private function insertAssetKeywords(int $assetId, array $keywordIds): void
+    {
+        try {
+            if (!empty($keywordIds)) {
+                $values = [];
+                $keywordsToInsert = array_diff($keywordIds, $this->getCurrentKeywords($assetId));
+
+                foreach ($keywordsToInsert as $keywordId) {
+                    $values[] = [$assetId, $keywordId];
+                }
+
+                if (!empty($values)) {
+                    /** @var Mysql $connection */
+                    $connection = $this->resourceConnection->getConnection();
+                    $connection->insertArray(
+                        $this->resourceConnection->getTableName(self::TABLE_ASSET_KEYWORD),
+                        [self::FIELD_ASSET_ID, self::FIELD_KEYWORD_ID],
+                        $values,
+                        AdapterInterface::INSERT_IGNORE
+                    );
+                }
             }
         } catch (\Exception $exception) {
             $this->logger->critical($exception);
@@ -78,5 +113,76 @@ class SaveAssetLinks
                 $exception
             );
         }
+    }
+
+    /**
+     * Delete obsolete asset keyword links
+     *
+     * @param int $assetId
+     * @param array $keywords
+     * @throws CouldNotDeleteException
+     */
+    private function deleteAssetKeywords(int $assetId, array $keywords): void
+    {
+        try {
+            $obsoleteKeywordIds = array_diff($this->getCurrentKeywords($assetId), $keywords);
+
+            if (!empty($obsoleteKeywordIds)) {
+                /** @var Mysql $connection */
+                $connection = $this->resourceConnection->getConnection();
+                $connection->delete(
+                    $connection->getTableName(
+                        self::TABLE_ASSET_KEYWORD
+                    ),
+                    [
+                        self::FIELD_KEYWORD_ID . ' in (?)' => $obsoleteKeywordIds,
+                        self::FIELD_ASSET_ID . ' = ?' => $assetId
+                    ]
+                );
+            }
+        } catch (\Exception $exception) {
+            $this->logger->critical($exception);
+            throw new CouldNotDeleteException(
+                __('Could not delete obsolete asset keyword links'),
+                $exception
+            );
+        }
+    }
+
+    /**
+     * Get current keyword data of an asset
+     *
+     * @param int $assetId
+     * @return array
+     */
+    private function getCurrentKeywords(int $assetId): array
+    {
+        $currentKeywordsData = $this->getAssetsKeywordsInterface->execute([$assetId]);
+
+        if (!empty($currentKeywordsData)) {
+            $currentKeywords = $this->getKeywordIdsFromKeywordData(
+                $currentKeywordsData[$assetId]->getKeywords()
+            );
+
+            return $currentKeywords;
+        }
+
+        return [];
+    }
+
+    /**
+     * Get keyword ids from keyword data
+     *
+     * @param array $keywordsData
+     * @return array
+     */
+    private function getKeywordIdsFromKeywordData(array $keywordsData): array
+    {
+        return array_map(
+            function (KeywordInterface $keyword): int {
+                return $keyword->getId();
+            },
+            $keywordsData
+        );
     }
 }

--- a/app/code/Magento/MediaGallery/Model/ResourceModel/Keyword/SaveAssetLinks.php
+++ b/app/code/Magento/MediaGallery/Model/ResourceModel/Keyword/SaveAssetLinks.php
@@ -88,35 +88,29 @@ class SaveAssetLinks
      *
      * @param int $assetId
      * @param int[] $keywordIds
-     * @throws CouldNotSaveException
      */
     private function insertAssetKeywords(int $assetId, array $keywordIds): void
     {
+        if (empty($keywordIds)) {
+            return;
+        }
         try {
-            if (!empty($keywordIds)) {
-                $values = [];
+            $values = [];
 
-                foreach ($keywordIds as $keywordId) {
-                    $values[] = [$assetId, $keywordId];
-                }
-
-                if (!empty($values)) {
-                    /** @var Mysql $connection */
-                    $connection = $this->resourceConnection->getConnection();
-                    $connection->insertArray(
-                        $this->resourceConnection->getTableName(self::TABLE_ASSET_KEYWORD),
-                        [self::FIELD_ASSET_ID, self::FIELD_KEYWORD_ID],
-                        $values,
-                        AdapterInterface::INSERT_IGNORE
-                    );
-                }
+            foreach ($keywordIds as $keywordId) {
+                $values[] = [$assetId, $keywordId];
             }
+
+            /** @var Mysql $connection */
+            $connection = $this->resourceConnection->getConnection();
+            $connection->insertArray(
+                $this->resourceConnection->getTableName(self::TABLE_ASSET_KEYWORD),
+                [self::FIELD_ASSET_ID, self::FIELD_KEYWORD_ID],
+                $values,
+                AdapterInterface::INSERT_IGNORE
+            );
         } catch (\Exception $exception) {
             $this->logger->critical($exception);
-            throw new CouldNotSaveException(
-                __('Could not save asset keyword links'),
-                $exception
-            );
         }
     }
 
@@ -129,20 +123,21 @@ class SaveAssetLinks
      */
     private function deleteAssetKeywords(int $assetId, array $obsoleteKeywordIds): void
     {
+        if (empty($obsoleteKeywordIds)) {
+            return;
+        }
         try {
-            if (!empty($obsoleteKeywordIds)) {
-                /** @var Mysql $connection */
-                $connection = $this->resourceConnection->getConnection();
-                $connection->delete(
-                    $connection->getTableName(
-                        self::TABLE_ASSET_KEYWORD
-                    ),
-                    [
-                        self::FIELD_KEYWORD_ID . ' in (?)' => $obsoleteKeywordIds,
-                        self::FIELD_ASSET_ID . ' = ?' => $assetId
-                    ]
-                );
-            }
+            /** @var Mysql $connection */
+            $connection = $this->resourceConnection->getConnection();
+            $connection->delete(
+                $connection->getTableName(
+                    self::TABLE_ASSET_KEYWORD
+                ),
+                [
+                    self::FIELD_KEYWORD_ID . ' in (?)' => $obsoleteKeywordIds,
+                    self::FIELD_ASSET_ID . ' = ?' => $assetId
+                ]
+            );
         } catch (\Exception $exception) {
             $this->logger->critical($exception);
             throw new CouldNotDeleteException(

--- a/app/code/Magento/MediaGallery/Model/ResourceModel/Keyword/SaveAssetsKeywords.php
+++ b/app/code/Magento/MediaGallery/Model/ResourceModel/Keyword/SaveAssetsKeywords.php
@@ -93,18 +93,16 @@ class SaveAssetsKeywords implements SaveAssetsKeywordsInterface
             $data[] = $keyword->getKeyword();
         }
 
-        if (empty($data)) {
-            return;
+        if (!empty($data)) {
+            /** @var Mysql $connection */
+            $connection = $this->resourceConnection->getConnection();
+            $connection->insertArray(
+                $this->resourceConnection->getTableName(self::TABLE_KEYWORD),
+                [self::KEYWORD],
+                $data,
+                AdapterInterface::INSERT_IGNORE
+            );
         }
-
-        /** @var Mysql $connection */
-        $connection = $this->resourceConnection->getConnection();
-        $connection->insertArray(
-            $this->resourceConnection->getTableName(self::TABLE_KEYWORD),
-            [self::KEYWORD],
-            $data,
-            AdapterInterface::INSERT_IGNORE
-        );
 
         $this->saveAssetLinks->execute($assetId, $this->getKeywordIds($data));
     }

--- a/app/code/Magento/MediaGallery/Test/Unit/Model/ResourceModel/Keyword/SaveAssetLinksTest.php
+++ b/app/code/Magento/MediaGallery/Test/Unit/Model/ResourceModel/Keyword/SaveAssetLinksTest.php
@@ -11,6 +11,7 @@ use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\MediaGallery\Model\ResourceModel\Keyword\SaveAssetLinks;
+use Magento\MediaGalleryApi\Api\GetAssetsKeywordsInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -33,6 +34,11 @@ class SaveAssetLinksTest extends TestCase
     private $resourceConnectionMock;
 
     /**
+     * @var GetAssetsKeywordsInterface
+     */
+    private $getAssetsKeywords;
+
+    /**
      * @var LoggerInterface|MockObject
      */
     private $loggerMock;
@@ -44,9 +50,11 @@ class SaveAssetLinksTest extends TestCase
     {
         $this->connectionMock = $this->getMockForAbstractClass(AdapterInterface::class);
         $this->resourceConnectionMock = $this->createMock(ResourceConnection::class);
+        $this->getAssetsKeywords = $this->getMockForAbstractClass(GetAssetsKeywordsInterface::class);
         $this->loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
 
         $this->sut = new SaveAssetLinks(
+            $this->getAssetsKeywords,
             $this->resourceConnectionMock,
             $this->loggerMock
         );
@@ -60,6 +68,7 @@ class SaveAssetLinksTest extends TestCase
      * @param int $assetId
      * @param array $keywordIds
      * @param array $values
+     * @throws CouldNotSaveException
      */
     public function testAssetKeywordsSave(int $assetId, array $keywordIds, array $values): void
     {

--- a/dev/tests/integration/testsuite/Magento/MediaGallery/Model/ResourceModel/AssetKeywordsTest.php
+++ b/dev/tests/integration/testsuite/Magento/MediaGallery/Model/ResourceModel/AssetKeywordsTest.php
@@ -66,74 +66,57 @@ class AssetKeywordsTest extends TestCase
      *
      * @magentoDataFixture Magento/MediaGallery/_files/media_asset.php
      * @dataProvider keywordsProvider
-     * @param array $keywords
+     * @param array|null $keywords
+     * @param array|null $updatedKeywords
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function testSaveAndGetKeywords(array $keywords): void
+    public function testSaveAndGetKeywords(array $keywords = [], array $updatedKeywords = []): void
     {
-        $keywords = ['pear', 'plum'];
-        $updatedKeywords = ['pear', 'apple','orange'];
-
         $loadedAssets = $this->getAssetsByPath->execute([self::FIXTURE_ASSET_PATH]);
         $this->assertCount(1, $loadedAssets);
         $loadedAsset = current($loadedAssets);
 
+        $this->updateAssetKeywords($loadedAsset->getId(), $keywords);
+        $this->updateAssetKeywords($loadedAsset->getId(), $updatedKeywords);
+    }
+
+    /**
+     * Update Asset keywords
+     *
+     * @param int $assetId
+     * @param array|null $keywords
+     */
+    private function updateAssetKeywords(int $assetId, array $keywords = []): void
+    {
         $assetKeywords = $this->assetsKeywordsFactory->create(
             [
-                'assetId' => $loadedAsset->getId(),
+                'assetId' => $assetId,
                 'keywords' => $this->getKeywords($keywords)
             ]
         );
 
         $this->saveAssetsKeywords->execute([$assetKeywords]);
-        $loadedAssetKeywords = $this->getAssetsKeywords->execute([$loadedAsset->getId()]);
+        $loadedAssetKeywords = $this->getAssetsKeywords->execute([$assetId]);
 
-        $this->assertCount(1, $loadedAssetKeywords);
+        if (!empty($keywords)) {
+            $this->assertCount(1, $loadedAssetKeywords);
+            /** @var AssetKeywordsInterface $loadedAssetKeyword */
+            $loadedAssetKeyword = current($loadedAssetKeywords);
 
-        /** @var AssetKeywordsInterface $loadedAssetKeyword */
-        $loadedAssetKeyword = current($loadedAssetKeywords);
+            $loadedKeywords = $loadedAssetKeyword->getKeywords();
 
-        $loadedKeywords = $loadedAssetKeyword->getKeywords();
+            $this->assertEquals(count($keywords), count($loadedKeywords));
 
-        $this->assertEquals(count($keywords), count($loadedKeywords));
+            $loadedKeywordStrings = [];
+            foreach ($loadedKeywords as $loadedKeywordObject) {
+                $loadedKeywordStrings[] = $loadedKeywordObject->getKeyword();
+            }
 
-        $loadedKeywordStrings = [];
-        foreach ($loadedKeywords as $loadedKeywordObject) {
-            $loadedKeywordStrings[] = $loadedKeywordObject->getKeyword();
+            sort($loadedKeywordStrings);
+            sort($keywords);
+
+            $this->assertEquals($keywords, $loadedKeywordStrings);
         }
-
-        sort($loadedKeywordStrings);
-        sort($keywords);
-
-        $this->assertEquals($keywords, $loadedKeywordStrings);
-
-        $updatedAssetKeywords = $this->assetsKeywordsFactory->create(
-            [
-                'assetId' => $loadedAsset->getId(),
-                'keywords' => $this->getKeywords($updatedKeywords)
-            ]
-        );
-        $this->saveAssetsKeywords->execute([$updatedAssetKeywords]);
-        $updatedLoadedAssetKeywords = $this->getAssetsKeywords->execute([$loadedAsset->getId()]);
-
-        $this->assertCount(1, $updatedLoadedAssetKeywords);
-
-        /** @var AssetKeywordsInterface $updatedLoadedAssetKeywords */
-        $updatedLoadedAssetKeywords = current($updatedLoadedAssetKeywords);
-
-        $updatedLoadedKeywords = $updatedLoadedAssetKeywords->getKeywords();
-
-        $this->assertEquals(count($updatedKeywords), count($updatedLoadedKeywords));
-
-        $updatedLoadedKeywordStrings = [];
-        foreach ($updatedLoadedKeywords as $updatedLoadedKeywordObject) {
-            $updatedLoadedKeywordStrings[] = $updatedLoadedKeywordObject->getKeyword();
-        }
-
-        sort($updatedLoadedKeywordStrings);
-        sort($updatedKeywords);
-
-        $this->assertEquals($updatedKeywords, $updatedLoadedKeywordStrings);
     }
 
     /**
@@ -144,10 +127,17 @@ class AssetKeywordsTest extends TestCase
     public function keywordsProvider(): array
     {
         return [
-            [['one-keyword']],
-            [['кириллица']],
-            [['plum', 'pear']],
-            [[]]
+            [['one-keyword'],['plum','orange']],
+            [['кириллица'],[]],
+            [[],['plum']],
+            [['plum', 'pear'],['plum','pear']],
+            [['plum', 'pear'],['plum','orange']],
+            [['plum', 'pear','grape'],['plum','orange']],
+            [['plum', 'pear','grape'],['mango']],
+            [['plum', 'pear','grape'],['orange']],
+            [['plum', 'pear','grape'],[]],
+            [['plum', 'pear'],['plum', 'pear','grape','mango','orange']],
+            [[],[]]
         ];
     }
 

--- a/dev/tests/integration/testsuite/Magento/MediaGallery/Model/ResourceModel/AssetKeywordsTest.php
+++ b/dev/tests/integration/testsuite/Magento/MediaGallery/Model/ResourceModel/AssetKeywordsTest.php
@@ -70,14 +70,14 @@ class AssetKeywordsTest extends TestCase
      * @param string[] $updatedKeywords
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function testSaveAndGetKeywords(array $keywords = [], array $updatedKeywords = []): void
+    public function testSaveAndGetKeywords(array $keywords, array $updatedKeywords): void
     {
         $loadedAssets = $this->getAssetsByPath->execute([self::FIXTURE_ASSET_PATH]);
         $this->assertCount(1, $loadedAssets);
         $loadedAsset = current($loadedAssets);
 
         $this->updateAssetKeywords($loadedAsset->getId(), $keywords);
-        $this->updateAssetKeywords($loadedAsset->getId(), $updatedKeywords, $keywords);
+        $this->updateAssetKeywords($loadedAsset->getId(), $updatedKeywords);
     }
 
     /**
@@ -85,9 +85,8 @@ class AssetKeywordsTest extends TestCase
      *
      * @param int $assetId
      * @param string[] $keywords
-     * @param string[] $currentKeywords
      */
-    private function updateAssetKeywords(int $assetId, array $keywords = [], array $currentKeywords = []): void
+    private function updateAssetKeywords(int $assetId, array $keywords): void
     {
         $assetKeywords = $this->assetsKeywordsFactory->create(
             [
@@ -99,28 +98,28 @@ class AssetKeywordsTest extends TestCase
         $this->saveAssetsKeywords->execute([$assetKeywords]);
         $loadedAssetKeywords = $this->getAssetsKeywords->execute([$assetId]);
 
-        $currentKeywords = empty($keywords) ? $currentKeywords : $keywords;
-        $expectedCount = !empty($currentKeywords) ? 1 : 0;
+        if (empty($keywords)) {
+            $this->assertEmpty($loadedAssetKeywords);
+            return;
+        }
 
-        $this->assertCount($expectedCount, $loadedAssetKeywords);
+        $this->assertCount(1, $loadedAssetKeywords);
         /** @var AssetKeywordsInterface $loadedAssetKeyword */
         $loadedAssetKeyword = current($loadedAssetKeywords);
 
-        $loadedKeywords = !empty($loadedAssetKeyword) ? $loadedAssetKeyword->getKeywords() : [];
+        $loadedKeywords = $loadedAssetKeyword->getKeywords();
 
-        $this->assertEquals(count($currentKeywords), count($loadedKeywords));
+        $this->assertEquals(count($keywords), count($loadedKeywords));
 
         $loadedKeywordStrings = [];
-        if (!empty($loadedKeywords)) {
-            foreach ($loadedKeywords as $loadedKeywordObject) {
-                $loadedKeywordStrings[] = $loadedKeywordObject->getKeyword();
-            }
+        foreach ($loadedKeywords as $loadedKeywordObject) {
+            $loadedKeywordStrings[] = $loadedKeywordObject->getKeyword();
         }
 
         sort($loadedKeywordStrings);
-        sort($currentKeywords);
+        sort($keywords);
 
-        $this->assertEquals($currentKeywords, $loadedKeywordStrings);
+        $this->assertEquals($keywords, $loadedKeywordStrings);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/MediaGallery/Model/ResourceModel/AssetKeywordsTest.php
+++ b/dev/tests/integration/testsuite/Magento/MediaGallery/Model/ResourceModel/AssetKeywordsTest.php
@@ -72,6 +72,7 @@ class AssetKeywordsTest extends TestCase
     public function testSaveAndGetKeywords(array $keywords): void
     {
         $keywords = ['pear', 'plum'];
+        $updatedKeywords = ['pear', 'apple','orange'];
 
         $loadedAssets = $this->getAssetsByPath->execute([self::FIXTURE_ASSET_PATH]);
         $this->assertCount(1, $loadedAssets);
@@ -105,6 +106,34 @@ class AssetKeywordsTest extends TestCase
         sort($keywords);
 
         $this->assertEquals($keywords, $loadedKeywordStrings);
+
+        $updatedAssetKeywords = $this->assetsKeywordsFactory->create(
+            [
+                'assetId' => $loadedAsset->getId(),
+                'keywords' => $this->getKeywords($updatedKeywords)
+            ]
+        );
+        $this->saveAssetsKeywords->execute([$updatedAssetKeywords]);
+        $updatedLoadedAssetKeywords = $this->getAssetsKeywords->execute([$loadedAsset->getId()]);
+
+        $this->assertCount(1, $updatedLoadedAssetKeywords);
+
+        /** @var AssetKeywordsInterface $updatedLoadedAssetKeywords */
+        $updatedLoadedAssetKeywords = current($updatedLoadedAssetKeywords);
+
+        $updatedLoadedKeywords = $updatedLoadedAssetKeywords->getKeywords();
+
+        $this->assertEquals(count($updatedKeywords), count($updatedLoadedKeywords));
+
+        $updatedLoadedKeywordStrings = [];
+        foreach ($updatedLoadedKeywords as $updatedLoadedKeywordObject) {
+            $updatedLoadedKeywordStrings[] = $updatedLoadedKeywordObject->getKeyword();
+        }
+
+        sort($updatedLoadedKeywordStrings);
+        sort($updatedKeywords);
+
+        $this->assertEquals($updatedKeywords, $updatedLoadedKeywordStrings);
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
https://github.com/magento/adobe-stock-integration/issues/1391

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1391

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Edit Image details
2. Add / remove new keyword tags
3. Should delete old keyword asset links not specified on the parameters and insert the new ones.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
