### PR TITLE
Fix Issues 29213

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Price.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Price.php
@@ -162,7 +162,7 @@ class Price extends \Magento\Backend\Block\Widget\Grid\Column\Filter\AbstractFil
     /**
      * Retrieve filter value
      *
-     * @param null $index
+     * @param string|null $index
      * @return array|null
      */
     public function getValue($index = null)

--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Price.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Price.php
@@ -194,11 +194,11 @@ class Price extends \Magento\Backend\Block\Widget\Grid\Column\Filter\AbstractFil
         $rate = $this->_getRate($displayCurrency, $this->_getColumnCurrencyCode());
 
         if (isset($value['from'])) {
-            $value['from'] *= $rate;
+            $value['from'] = (float) $value['from'] * $rate;
         }
 
         if (isset($value['to'])) {
-            $value['to'] *= $rate;
+            $value['to'] = (float) $value['to'] * $rate;
         }
 
         $this->prepareRates($displayCurrency);

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Column/Filter/PriceTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Column/Filter/PriceTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Backend\Test\Unit\Block\Widget\Grid\Column\Filter;
+
+use Magento\Backend\Block\Context;
+use Magento\Backend\Block\Widget\Grid\Column;
+use Magento\Backend\Block\Widget\Grid\Column\Filter\Price;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\DB\Helper;
+use Magento\Directory\Model\Currency;
+use Magento\Directory\Model\Currency\DefaultLocator;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class PriceTest extends TestCase
+{
+    /** @var RequestInterface|MockObject  */
+    private $_requestMock;
+
+    /** @var Context|MockObject */
+    private $context;
+
+    /** @var Helper|MockObject */
+    private $helper;
+
+    /** @var Currency|MockObject */
+    private $currency;
+
+    /** @var DefaultLocator|MockObject */
+    private $currencyLocator;
+
+    /** @var Column|MockObject */
+    private $columnMock;
+
+    /** @var Price  */
+    private $blockPrice;
+
+    protected function setUp(): void
+    {
+        $this->_requestMock = $this->getMockForAbstractClass(RequestInterface::class);
+
+        $this->context = $this->createMock(Context::class);
+        $this->context->expects($this->any())->method('getRequest')->willReturn($this->_requestMock);
+
+        $this->helper = $this->createMock(Helper::class);
+
+        $this->currency = $this->getMockBuilder(Currency::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getAnyRate'])
+            ->getMock();
+
+        $this->currencyLocator = $this->createMock(DefaultLocator::class);
+
+        $this->columnMock = $this->getMockBuilder(Column::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCurrencyCode'])
+            ->getMock();
+
+        $helper = new ObjectManager($this);
+
+        $this->blockPrice = $helper->getObject(Price::class, [
+            'context'         => $this->context,
+            'resourceHelper'  => $this->helper,
+            'currencyModel'   => $this->currency,
+            'currencyLocator' => $this->currencyLocator
+        ]);
+        $this->blockPrice->setColumn($this->columnMock);
+    }
+
+    public function testGetCondition()
+    {
+        $this->currencyLocator->expects(
+            $this->any()
+        )->method(
+            'getDefaultCurrency'
+        )->with(
+            $this->_requestMock
+        )->willReturn(
+            'defaultCurrency'
+        );
+
+        $this->currency->expects($this->at(0))
+            ->method('getAnyRate')
+            ->with('defaultCurrency')
+            ->willReturn(1.0);
+
+        $testValue = [
+            'value' => [
+                'from' => '1234a',
+            ]
+        ];
+
+        $this->blockPrice->addData($testValue);
+        $this->assertEquals(['from' => 1234], $this->blockPrice->getCondition());
+    }
+}

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Column/Filter/PriceTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Column/Filter/PriceTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
 class PriceTest extends TestCase
 {
     /** @var RequestInterface|MockObject  */
-    private $_requestMock;
+    private $requestMock;
 
     /** @var Context|MockObject */
     private $context;
@@ -43,10 +43,10 @@ class PriceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->_requestMock = $this->getMockForAbstractClass(RequestInterface::class);
+        $this->requestMock = $this->getMockForAbstractClass(RequestInterface::class);
 
         $this->context = $this->createMock(Context::class);
-        $this->context->expects($this->any())->method('getRequest')->willReturn($this->_requestMock);
+        $this->context->expects($this->any())->method('getRequest')->willReturn($this->requestMock);
 
         $this->helper = $this->createMock(Helper::class);
 
@@ -80,7 +80,7 @@ class PriceTest extends TestCase
         )->method(
             'getDefaultCurrency'
         )->with(
-            $this->_requestMock
+            $this->requestMock
         )->willReturn(
             'defaultCurrency'
         );


### PR DESCRIPTION
### Description (*)
If use Magento\Backend\Block\Widget\Grid\Column\Filter\Price::getCondition method and Magento\Backend\Block\Widget\Grid\Column\Filter\Price::getValue() return array with indexes 'from' or 'to' string data, then PHP throw notice exception and Magento break apply filter, redirect to some page

### Fixed Issues (if relevant)
1. Fixes magento/magento2#29213

### Manual testing scenarios (*)
1. Create Grid Block with deprecated functionality extended class Magento\Backend\Block\Widget\Grid\Extended
2. Add column type price `$this->addColumn( 'total_price', [ 'header' => __('Total Price'), 'index' => 'total_price', 'type' => 'price', 'currency_code' => (string)$this->_scopeConfig ->getValue(Currency::XML_PATH_CURRENCY_BASE), ] );`
3. Apply a filter on this field. Example: '123a'
4. Apply filter price to 123 cost

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
