### PR TITLE
Added observing event trigger "change"

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js
@@ -284,9 +284,9 @@ define([
                     this._resetChildren(element.nextSetting);
                 } else {
                     if (!!document.documentMode) { //eslint-disable-line
-                        this.inputSimpleProduct.val(element.options[element.selectedIndex].config.allowedProducts[0]);
+                        this.inputSimpleProduct.val(element.options[element.selectedIndex].config.allowedProducts[0]).trigger("change");
                     } else {
-                        this.inputSimpleProduct.val(element.selectedOptions[0].config.allowedProducts[0]);
+                        this.inputSimpleProduct.val(element.selectedOptions[0].config.allowedProducts[0]).trigger("change");
                     }
                 }
             } else {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Added event trigger of type "change" whenever user chooses a variant
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Visit product page where $product->getTypeId()=="configurable"
2. In this page, jQuery can not detect "change" or bind it to hidden input element "selected_configurable_option" but with my changes, developers can observe the change and use it for various purposes

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
