### PR TITLE
Fix unit tests with PHPUnit 9 errors

### DIFF
--- a/app/code/Magento/Captcha/Test/Unit/Model/Customer/Plugin/AjaxLoginTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Model/Customer/Plugin/AjaxLoginTest.php
@@ -63,7 +63,7 @@ class AjaxLoginTest extends TestCase
     /**
      * @var array
      */
-    protected $formIds;
+    protected $formIds = ['user_login'];
 
     /**
      * @var AjaxLogin
@@ -97,7 +97,6 @@ class AjaxLoginTest extends TestCase
             ->method('getCaptcha')
             ->willReturn($this->captchaMock);
 
-        $this->formIds = ['user_login'];
         $this->serializerMock = $this->createMock(Json::class);
 
         $this->model = new AjaxLogin(
@@ -194,7 +193,10 @@ class AjaxLoginTest extends TestCase
 
         $this->captchaMock->expects($this->once())->method('isRequired')->with($username)
             ->willReturn(false);
-        $this->captchaMock->expects($this->never())->method('logAttempt')->with($username);
+        $expectLogAttempt = $requestContent['captcha_form_id'] ?? false;
+        $this->captchaMock
+            ->expects($expectLogAttempt ? $this->once() : $this->never())
+            ->method('logAttempt')->with($username);
         $this->captchaMock->expects($this->never())->method('isCorrect');
 
         $closure = function () {

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/XmlCatalogGenerateCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/XmlCatalogGenerateCommandTest.php
@@ -97,7 +97,7 @@ class XmlCatalogGenerateCommandTest extends TestCase
             ->with(
                 $this->equalTo(['urn:magento:framework:Module/etc/module.xsd' => $fixtureXmlFile]),
                 $this->equalTo('test')
-            )->willReturn(null);
+            );
 
         $formats = ['vscode' => $vscodeFormatMock];
         $readFactory = $this->createMock(ReadFactory::class);

--- a/app/code/Magento/Persistent/Test/Unit/Model/QuoteManagerTest.php
+++ b/app/code/Magento/Persistent/Test/Unit/Model/QuoteManagerTest.php
@@ -230,7 +230,6 @@ class QuoteManagerTest extends TestCase
         $this->quoteMock->expects($this->once())->method('getItemsQty')->willReturn(1);
         $extensionAttributes = $this->getMockBuilder(CartExtensionInterface::class)
             ->addMethods(['getShippingAssignments', 'setShippingAssignments'])
-            ->disableArgumentCloning()
             ->getMockForAbstractClass();
         $shippingAssignment = $this->createMock(ShippingAssignmentInterface::class);
         $extensionAttributes->expects($this->once())

--- a/app/code/Magento/Persistent/Test/Unit/Model/QuoteManagerTest.php
+++ b/app/code/Magento/Persistent/Test/Unit/Model/QuoteManagerTest.php
@@ -228,13 +228,10 @@ class QuoteManagerTest extends TestCase
             ->method('removePersistentCookie')->willReturn($this->sessionMock);
         $this->quoteMock->expects($this->once())->method('isVirtual')->willReturn(false);
         $this->quoteMock->expects($this->once())->method('getItemsQty')->willReturn(1);
-        $extensionAttributes = $this->createPartialMock(
-            CartExtensionInterface::class,
-            [
-                'setShippingAssignments',
-                'getShippingAssignments'
-            ]
-        );
+        $extensionAttributes = $this->getMockBuilder(CartExtensionInterface::class)
+            ->addMethods(['getShippingAssignments', 'setShippingAssignments'])
+            ->disableArgumentCloning()
+            ->getMockForAbstractClass();
         $shippingAssignment = $this->createMock(ShippingAssignmentInterface::class);
         $extensionAttributes->expects($this->once())
             ->method('setShippingAssignments')

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Address/Total/SubtotalTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Address/Total/SubtotalTest.php
@@ -59,7 +59,7 @@ class SubtotalTest extends TestCase
 
         $this->stockRegistry = $this->createPartialMock(
             StockRegistry::class,
-            ['getStockItem', '__wakeup']
+            ['getStockItem']
         );
         $this->stockItemMock = $this->createPartialMock(
             \Magento\CatalogInventory\Model\Stock\Item::class,
@@ -110,10 +110,14 @@ class SubtotalTest extends TestCase
             ]
         );
         /** @var Address|MockObject $address */
-        $address = $this->createPartialMock(
-            Address::class,
-            ['setTotalQty', 'getTotalQty', 'removeItem', 'getQuote']
-        );
+        $address = $this->getMockBuilder(Address::class)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->onlyMethods(['removeItem', 'getQuote'])
+            ->addMethods(['setTotalQty', 'getTotalQty'])
+            ->getMock();
 
         /** @var Product|MockObject $product */
         $product = $this->createMock(Product::class);
@@ -161,10 +165,13 @@ class SubtotalTest extends TestCase
         $shippingAssignmentMock->expects($this->exactly(2))->method('getShipping')->willReturn($shipping);
         $shippingAssignmentMock->expects($this->once())->method('getItems')->willReturn([$quoteItem]);
 
-        $total = $this->createPartialMock(
-            Total::class,
-            ['setBaseVirtualAmount', 'setVirtualAmount']
-        );
+        $total = $this->getMockBuilder(Total::class)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->addMethods(['setVirtualAmount', 'setBaseVirtualAmount'])
+            ->getMock();
         $total->expects($this->once())->method('setBaseVirtualAmount')->willReturnSelf();
         $total->expects($this->once())->method('setVirtualAmount')->willReturnSelf();
 
@@ -185,7 +192,10 @@ class SubtotalTest extends TestCase
         ];
 
         $quoteMock = $this->createMock(Quote::class);
-        $totalMock = $this->createPartialMock(Total::class, ['getSubtotal']);
+        $totalMock = $this->getMockBuilder(Total::class)
+            ->addMethods(['getSubtotal'])
+            ->disableArgumentCloning()
+            ->getMockForAbstractClass();
         $totalMock->expects($this->once())->method('getSubtotal')->willReturn(100);
 
         $this->assertEquals($expectedResult, $this->subtotalModel->fetch($quoteMock, $totalMock));
@@ -229,13 +239,14 @@ class SubtotalTest extends TestCase
         $address->expects($this->once())
             ->method('removeItem')
             ->with($addressItemId);
-        $addressItem = $this->createPartialMock(
-            AddressItem::class,
-            [
-                'getId',
-                'getQuoteItemId'
-            ]
-        );
+        $addressItem = $this->getMockBuilder(AddressItem::class)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->onlyMethods(['getId'])
+            ->addMethods(['getQuoteItemId'])
+            ->getMock();
         $addressItem->setAddress($address);
         $addressItem->method('getId')
             ->willReturn($addressItemId);

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Address/Total/SubtotalTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Address/Total/SubtotalTest.php
@@ -112,9 +112,6 @@ class SubtotalTest extends TestCase
         /** @var Address|MockObject $address */
         $address = $this->getMockBuilder(Address::class)
             ->disableOriginalConstructor()
-            ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->disallowMockingUnknownTypes()
             ->onlyMethods(['removeItem', 'getQuote'])
             ->addMethods(['setTotalQty', 'getTotalQty'])
             ->getMock();
@@ -167,9 +164,6 @@ class SubtotalTest extends TestCase
 
         $total = $this->getMockBuilder(Total::class)
             ->disableOriginalConstructor()
-            ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->disallowMockingUnknownTypes()
             ->addMethods(['setVirtualAmount', 'setBaseVirtualAmount'])
             ->getMock();
         $total->expects($this->once())->method('setBaseVirtualAmount')->willReturnSelf();
@@ -194,7 +188,6 @@ class SubtotalTest extends TestCase
         $quoteMock = $this->createMock(Quote::class);
         $totalMock = $this->getMockBuilder(Total::class)
             ->addMethods(['getSubtotal'])
-            ->disableArgumentCloning()
             ->getMockForAbstractClass();
         $totalMock->expects($this->once())->method('getSubtotal')->willReturn(100);
 
@@ -241,9 +234,6 @@ class SubtotalTest extends TestCase
             ->with($addressItemId);
         $addressItem = $this->getMockBuilder(AddressItem::class)
             ->disableOriginalConstructor()
-            ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->disallowMockingUnknownTypes()
             ->onlyMethods(['getId'])
             ->addMethods(['getQuoteItemId'])
             ->getMock();

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/CreditmemoFactoryTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/CreditmemoFactoryTest.php
@@ -51,9 +51,6 @@ class CreditmemoFactoryTest extends TestCase
     {
         $this->orderItemMock = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->disallowMockingUnknownTypes()
             ->onlyMethods(['getChildrenItems', 'isDummy', 'getId', 'getParentItemId'])
             ->addMethods(['getHasChildren'])
             ->getMock();

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/CreditmemoFactoryTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/CreditmemoFactoryTest.php
@@ -49,10 +49,14 @@ class CreditmemoFactoryTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->orderItemMock = $this->createPartialMock(
-            Item::class,
-            ['getChildrenItems', 'isDummy', 'getHasChildren', 'getId', 'getParentItemId']
-        );
+        $this->orderItemMock = $this->getMockBuilder(Item::class)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->onlyMethods(['getChildrenItems', 'isDummy', 'getId', 'getParentItemId'])
+            ->addMethods(['getHasChildren'])
+            ->getMock();
         $this->orderChildItemOneMock = $this->createPartialMock(
             Item::class,
             ['getQtyToRefund', 'getId']

--- a/lib/internal/Magento/Framework/Pricing/Test/Unit/Adjustment/CollectionTest.php
+++ b/lib/internal/Magento/Framework/Pricing/Test/Unit/Adjustment/CollectionTest.php
@@ -71,7 +71,6 @@ class CollectionTest extends TestCase
     /**
      * @param string[] $adjustments
      * @param string[] $expectedResult
-     *
      * @dataProvider getItemsDataProvider
      */
     public function testGetItems($adjustments, $expectedResult)
@@ -92,7 +91,7 @@ class CollectionTest extends TestCase
             [['adj1'], ['adj1']],
             [['adj4'], ['adj4']],
             [['adj1', 'adj4'], ['adj1', 'adj4']],
-            [['adj1', 'adj2', 'adj3', 'adj4'], ['adj3', 'adj1', 'adj2', 'adj4']],
+            [['adj1', 'adj2', 'adj3', 'adj4'], ['adj3', 'adj1', 'adj2', 'adj4']]
         ];
     }
 
@@ -100,7 +99,6 @@ class CollectionTest extends TestCase
      * @param string[] $adjustments
      * @param string $code
      * @param $expectedResult
-     *
      * @dataProvider getItemByCodeDataProvider
      */
     public function testGetItemByCode($adjustments, $code, $expectedResult)

--- a/lib/internal/Magento/Framework/Pricing/Test/Unit/Adjustment/CollectionTest.php
+++ b/lib/internal/Magento/Framework/Pricing/Test/Unit/Adjustment/CollectionTest.php
@@ -50,6 +50,7 @@ class CollectionTest extends TestCase
             'adj3' => $adj3,
             'adj4' => $adj4,
         ];
+        $this->adjustmentsData = $adjustmentsData;
 
         /** @var Pool|MockObject $adjustmentPool */
         $adjustmentPool = $this->getMockBuilder(Pool::class)
@@ -64,14 +65,13 @@ class CollectionTest extends TestCase
                 return $adjustmentsData[$code];
             }
         );
-
         $this->adjustmentPool = $adjustmentPool;
-        $this->adjustmentsData = $adjustmentsData;
     }
 
     /**
      * @param string[] $adjustments
      * @param string[] $expectedResult
+     *
      * @dataProvider getItemsDataProvider
      */
     public function testGetItems($adjustments, $expectedResult)
@@ -92,7 +92,7 @@ class CollectionTest extends TestCase
             [['adj1'], ['adj1']],
             [['adj4'], ['adj4']],
             [['adj1', 'adj4'], ['adj1', 'adj4']],
-            [['adj1', 'adj2', 'adj3', 'adj4'], ['adj3', 'adj1', 'adj2', 'adj4']]
+            [['adj1', 'adj2', 'adj3', 'adj4'], ['adj3', 'adj1', 'adj2', 'adj4']],
         ];
     }
 
@@ -100,6 +100,7 @@ class CollectionTest extends TestCase
      * @param string[] $adjustments
      * @param string $code
      * @param $expectedResult
+     *
      * @dataProvider getItemByCodeDataProvider
      */
     public function testGetItemByCode($adjustments, $code, $expectedResult)
@@ -108,7 +109,7 @@ class CollectionTest extends TestCase
 
         $item = $collection->getItemByCode($code);
 
-        $this->assertEquals($expectedResult, $item->getAdjustmentCode());
+        $this->assertEquals($expectedResult, $item->getSortOrder());
     }
 
     /**
@@ -117,11 +118,11 @@ class CollectionTest extends TestCase
     public function getItemByCodeDataProvider()
     {
         return [
-            [['adj1'], 'adj1', $this->adjustmentsData['adj1']],
-            [['adj1', 'adj2', 'adj3', 'adj4'], 'adj1', $this->adjustmentsData['adj1']],
-            [['adj1', 'adj2', 'adj3', 'adj4'], 'adj2', $this->adjustmentsData['adj2']],
-            [['adj1', 'adj2', 'adj3', 'adj4'], 'adj3', $this->adjustmentsData['adj3']],
-            [['adj1', 'adj2', 'adj3', 'adj4'], 'adj4', $this->adjustmentsData['adj4']],
+            [['adj1'], 'adj1', 10],
+            [['adj1', 'adj2', 'adj3', 'adj4'], 'adj1', 10],
+            [['adj1', 'adj2', 'adj3', 'adj4'], 'adj2', 20],
+            [['adj1', 'adj2', 'adj3', 'adj4'], 'adj3', 5],
+            [['adj1', 'adj2', 'adj3', 'adj4'], 'adj4', Pool::DEFAULT_SORT_ORDER],
         ];
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Most of the failing tests are due to:
- Depending on setUp logic in dataProviders, while dataProvider code is called before setUp
- Trying to mock non-existing methods with createPartialMock which is prohibited in PHPUnit 9

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29329: Fix unit tests with PHPUnit 9 errors