### PR TITLE
Change type of message after canceling the PayPal Express Checkout

### DIFF
--- a/app/code/Magento/Paypal/Controller/Express/AbstractExpress/Cancel.php
+++ b/app/code/Magento/Paypal/Controller/Express/AbstractExpress/Cancel.php
@@ -31,11 +31,11 @@ class Cancel extends \Magento\Paypal\Controller\Express\AbstractExpress
                     ->unsLastSuccessQuoteId()
                     ->unsLastOrderId()
                     ->unsLastRealOrderId();
-                $this->messageManager->addSuccessMessage(
+                $this->messageManager->addWarningMessage(
                     __('Express Checkout and Order have been canceled.')
                 );
             } else {
-                $this->messageManager->addSuccessMessage(
+                $this->messageManager->addWarningMessage(
                     __('Express Checkout has been canceled.')
                 );
             }

--- a/app/code/Magento/Paypal/Controller/Express/AbstractExpress/Cancel.php
+++ b/app/code/Magento/Paypal/Controller/Express/AbstractExpress/Cancel.php
@@ -31,11 +31,11 @@ class Cancel extends \Magento\Paypal\Controller\Express\AbstractExpress
                     ->unsLastSuccessQuoteId()
                     ->unsLastOrderId()
                     ->unsLastRealOrderId();
-                $this->messageManager->addWarningMessage(
+                $this->messageManager->addErrorMessage(
                     __('Express Checkout and Order have been canceled.')
                 );
             } else {
-                $this->messageManager->addWarningMessage(
+                $this->messageManager->addErrorMessage(
                     __('Express Checkout has been canceled.')
                 );
             }


### PR DESCRIPTION
### Description (*)
Canceling the Express Checkout currently results a success message. The combination "canceling" and "success" looks not correct to me. My suggestion is to replace "addSuccessMessage" with "addErrorMessage" to give the message the correct feeling.

### Manual testing scenarios (*)
1. Add product to the cart
2. Go to the cart
3. Checkout with PayPal
4. Close the PayPal modal
5. Check if the cancelation message is an error message and not a success message

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
