### PR TITLE
Added a default sort to the categories to sort by position. Fixes magento/catalog-storefront/104

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Category/CategoryFilter.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Category/CategoryFilter.php
@@ -13,6 +13,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Query\Resolver\Argument\SearchCriteria\ArgumentApplier\Filter;
+use Magento\Framework\GraphQl\Query\Resolver\Argument\SearchCriteria\ArgumentApplier\Sort;
 use Magento\Search\Model\Query;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\ScopeInterface;
@@ -71,6 +72,7 @@ class CategoryFilter
         $categoryIds = [];
         $criteria[Filter::ARGUMENT_NAME] = $this->formatMatchFilters($criteria['filters'], $store);
         $criteria[Filter::ARGUMENT_NAME][CategoryInterface::KEY_IS_ACTIVE] = ['eq' => 1];
+        $criteria[Sort::ARGUMENT_NAME][CategoryInterface::KEY_POSITION] = ['ASC'];
         $searchCriteria = $this->searchCriteriaBuilder->build('categoryList', $criteria);
         $pageSize = $criteria['pageSize'] ?? 20;
         $currentPage = $criteria['currentPage'] ?? 1;

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoriesQuery/CategoriesFilterTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoriesQuery/CategoriesFilterTest.php
@@ -649,15 +649,6 @@ QUERY;
                 '["category-1-2", "movable"]',
                 [
                     [
-                        'id' => '7',
-                        'name' => 'Movable',
-                        'url_key' => 'movable',
-                        'url_path' => 'movable',
-                        'children_count' => '0',
-                        'path' => '1/2/7',
-                        'position' => '3'
-                    ],
-                    [
                         'id' => '13',
                         'name' => 'Category 1.2',
                         'url_key' => 'category-1-2',
@@ -665,6 +656,15 @@ QUERY;
                         'children_count' => '0',
                         'path' => '1/2/3/13',
                         'position' => '2'
+                    ],
+                    [
+                        'id' => '7',
+                        'name' => 'Movable',
+                        'url_key' => 'movable',
+                        'url_path' => 'movable',
+                        'children_count' => '0',
+                        'path' => '1/2/7',
+                        'position' => '3'
                     ]
                 ]
             ],

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoriesQuery/CategoriesFilterTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoriesQuery/CategoriesFilterTest.php
@@ -204,8 +204,8 @@ QUERY;
         $this->assertEquals('Category 1.1', $firstChildCategory['name']);
         $this->assertEquals('Category 1.1 description.', $firstChildCategory['description']);
         $firstChildCategoryExpectedProducts = [
-            ['sku' => '12345', 'name' => 'Simple Product Two'],
-            ['sku' => 'simple', 'name' => 'Simple Product']
+            ['sku' => 'simple', 'name' => 'Simple Product'],
+            ['sku' => '12345', 'name' => 'Simple Product Two']
         ];
         $this->assertCategoryProducts($firstChildCategory, $firstChildCategoryExpectedProducts);
         $firstChildCategoryChildren = [['name' =>'Category 1.1.1']];
@@ -297,8 +297,8 @@ QUERY;
         $this->assertEquals('Its a description of Test Category 1.2', $firstChildCategory['description']);
 
         $firstChildCategoryExpectedProducts = [
-            ['sku' => 'simple-4', 'name' => 'Simple Product Three'],
-            ['sku' => 'simple', 'name' => 'Simple Product']
+            ['sku' => 'simple', 'name' => 'Simple Product'],
+            ['sku' => 'simple-4', 'name' => 'Simple Product Three']
         ];
         $this->assertCategoryProducts($firstChildCategory, $firstChildCategoryExpectedProducts);
         $firstChildCategoryChildren = [];

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryListTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryListTest.php
@@ -630,15 +630,6 @@ QUERY;
                 '["category-1-2", "movable"]',
                 [
                     [
-                        'id' => '7',
-                        'name' => 'Movable',
-                        'url_key' => 'movable',
-                        'url_path' => 'movable',
-                        'children_count' => '0',
-                        'path' => '1/2/7',
-                        'position' => '3'
-                    ],
-                    [
                         'id' => '13',
                         'name' => 'Category 1.2',
                         'url_key' => 'category-1-2',
@@ -646,6 +637,15 @@ QUERY;
                         'children_count' => '0',
                         'path' => '1/2/3/13',
                         'position' => '2'
+                    ],
+                    [
+                        'id' => '7',
+                        'name' => 'Movable',
+                        'url_key' => 'movable',
+                        'url_path' => 'movable',
+                        'children_count' => '0',
+                        'path' => '1/2/7',
+                        'position' => '3'
                     ]
                 ]
             ],

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryListTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryListTest.php
@@ -203,8 +203,8 @@ QUERY;
         $this->assertEquals('Category 1.1', $firstChildCategory['name']);
         $this->assertEquals('Category 1.1 description.', $firstChildCategory['description']);
         $firstChildCategoryExpectedProducts = [
-            ['sku' => '12345', 'name' => 'Simple Product Two'],
             ['sku' => 'simple', 'name' => 'Simple Product'],
+            ['sku' => '12345', 'name' => 'Simple Product Two']
         ];
         $this->assertCategoryProducts($firstChildCategory, $firstChildCategoryExpectedProducts);
         $firstChildCategoryChildren = [['name' =>'Category 1.1.1']];
@@ -294,8 +294,8 @@ QUERY;
         $this->assertEquals('Its a description of Test Category 1.2', $firstChildCategory['description']);
 
         $firstChildCategoryExpectedProducts = [
-            ['sku' => 'simple-4', 'name' => 'Simple Product Three'],
-            ['sku' => 'simple', 'name' => 'Simple Product']
+            ['sku' => 'simple', 'name' => 'Simple Product'],
+            ['sku' => 'simple-4', 'name' => 'Simple Product Three']
         ];
         $this->assertCategoryProducts($firstChildCategory, $firstChildCategoryExpectedProducts);
         $firstChildCategoryChildren = [];

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductSearchTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductSearchTest.php
@@ -332,7 +332,7 @@ QUERY;
             $this->assertResponseFields(
                 $productItemsInResponse[$itemIndex][0],
                 [ 'name' => $filteredProducts[$itemIndex]->getName(),
-                  'sku' => $filteredProducts[$itemIndex]->getSku()
+                    'sku' => $filteredProducts[$itemIndex]->getSku()
                 ]
             );
         }
@@ -350,10 +350,10 @@ QUERY;
                 'options' => [
                     [
                         'label' => 'Option 3',
-                         'count' => 3,
-                         'value' => $optionValue
-                     ],
-                 ],
+                        'count' => 3,
+                        'value' => $optionValue
+                    ],
+                ],
             ]
         );
     }
@@ -535,10 +535,10 @@ QUERY;
         $expectedFilterLayers =
             [
                 ['name' => 'Category',
-                 'request_var'=> 'cat'
+                    'request_var'=> 'cat'
                 ],
                 ['name' => 'Second Test Configurable',
-                 'request_var'=> 'second_test_configurable'
+                    'request_var'=> 'second_test_configurable'
                 ]
             ];
         $layers = array_map(null, $expectedFilterLayers, $response['products']['filters']);
@@ -571,14 +571,14 @@ QUERY;
                         'label' => '10-20',
                         'value' => '10_20',
 
-                     ],
+                    ],
                     [
                         'count' => 1,
                         'label' => '40-50',
                         'value' => '40_50',
 
                     ],
-                 ],
+                ],
             ]
         );
         // Validate the custom attribute layer of aggregations from the response
@@ -605,9 +605,9 @@ QUERY;
         $this->assertResponseFields(
             $response['products']['aggregations'][1],
             [
-                 'attribute_code' => 'category_id',
-                 'count'=> 7,
-                 'label'=> 'Category'
+                'attribute_code' => 'category_id',
+                'count'=> 7,
+                'label'=> 'Category'
             ]
         );
     }
@@ -676,7 +676,7 @@ QUERY;
         $productRepository = ObjectManager::getInstance()->get(ProductRepositoryInterface::class);
         $product1 = $productRepository->get('simple');
         $product2 = $productRepository->get('simple-4');
-        $filteredProducts = [$product2, $product1];
+        $filteredProducts = [$product1, $product2];
         $productItemsInResponse = array_map(null, $response['products']['items'], $filteredProducts);
         //phpcs:ignore Generic.CodeAnalysis.ForLoopWithTestFunctionCall
         for ($itemIndex = 0; $itemIndex < count($filteredProducts); $itemIndex++) {
@@ -702,9 +702,9 @@ QUERY;
         $expectedCategoryInAggregations =
             [
                 [
-                  'count' =>  2,
-                  'label' => 'Category 1',
-                  'value'=> '3'
+                    'count' =>  2,
+                    'label' => 'Category 1',
+                    'value'=> '3'
                 ],
                 [
                     'count'=> 1,
@@ -965,8 +965,8 @@ QUERY;
             $this->assertResponseFields(
                 $productItemsInResponse[$itemIndex][0],
                 [ 'name' => $filteredProducts[$itemIndex]->getName(),
-                  'sku' => $filteredProducts[$itemIndex]->getSku(),
-                  'url_key'=> $filteredProducts[$itemIndex]->getUrlKey()
+                    'sku' => $filteredProducts[$itemIndex]->getSku(),
+                    'url_key'=> $filteredProducts[$itemIndex]->getUrlKey()
                 ]
             );
         }
@@ -1541,7 +1541,7 @@ QUERY;
 QUERY;
 
         $response = $this->graphQlQuery($query);
-         $this->assertEquals(2, $response['products']['total_count'], 'Incorrect count of products returned');
+        $this->assertEquals(2, $response['products']['total_count'], 'Incorrect count of products returned');
         /** @var CategoryLinkManagement $productLinks */
         $productLinks = ObjectManager::getInstance()->get(CategoryLinkManagement::class);
         /** @var CategoryRepositoryInterface $categoryRepository */
@@ -1560,32 +1560,30 @@ QUERY;
             $this->assertEquals($response['products']['items'][$itemIndex]['type_id'], $product->getTypeId());
             $this->assertNotEmpty($response['products']['items'][$itemIndex]['categories']);
 
-            // uncomment after fix test. DON'T forget to remove UnusedLocalVariables skip in doc block
-
-            // $categoryIds  = $product->getCategoryIds();
-            // foreach ($categoryIds as $index => $value) {
-            //     $categoryIds[$index] = (int)$value;
-            // }
-            // $categoryInResponse = array_map(
-            //     null,
-            //     $categoryIds,
-            //     $response['products']['items'][$itemIndex]['categories']
-            // );
-            // foreach ($categoryInResponse as $key => $categoryData) {
-            //     $this->assertNotEmpty($categoryData);
-            //     /** @var CategoryInterface | Category $category */
-            //     $category = $categoryRepository->get($categoryInResponse[$key][0]);
-            //     $this->assertResponseFields(
-            //         $categoryInResponse[$key][1],
-            //         [
-            //             'name' => $category->getName(),
-            //            'id' => $category->getId(),
-            //             'path' => $category->getPath(),
-            //             'children_count' => $category->getChildrenCount(),
-            //             'product_count' => $category->getProductCount(),
-            //         ]
-            //    );
-            // }
+            $categoryIds  = $product->getCategoryIds();
+            foreach ($categoryIds as $index => $value) {
+                $categoryIds[$index] = (int)$value;
+            }
+            $categoryInResponse = array_map(
+                null,
+                $categoryIds,
+                $response['products']['items'][$itemIndex]['categories']
+            );
+            foreach ($categoryInResponse as $key => $categoryData) {
+                $this->assertNotEmpty($categoryData);
+                /** @var CategoryInterface | Category $category */
+                $category = $categoryRepository->get($categoryInResponse[$key][0]);
+                $this->assertResponseFields(
+                    $categoryInResponse[$key][1],
+                    [
+                        'name' => $category->getName(),
+                        'id' => $category->getId(),
+                        'path' => $category->getPath(),
+                        'children_count' => $category->getChildrenCount(),
+                        'product_count' => $category->getProductCount(),
+                    ]
+                );
+            }
         }
         $this->markTestIncomplete(
             'Sort order is incorrect. Fix: https://github.com/magento/catalog-storefront/issues/104'
@@ -2513,12 +2511,12 @@ QUERY;
                                 'currency' => 'USD'
                             ]
                         ],
-                            'regularPrice' => [
-                                'amount' => [
-                                    'value' => $filteredProducts[$itemIndex]->getPrice(),
-                                    'currency' => 'USD'
-                                ]
+                        'regularPrice' => [
+                            'amount' => [
+                                'value' => $filteredProducts[$itemIndex]->getPrice(),
+                                'currency' => 'USD'
                             ]
+                        ]
 
                     ],
                     'type_id' =>$filteredProducts[$itemIndex]->getTypeId(),

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductViewTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductViewTest.php
@@ -232,7 +232,7 @@ class ProductViewTest extends GraphQlAbstract
             special_from_date
             special_price
             special_to_date
-            swatch_image            
+            swatch_image
             tier_price
             tier_prices
             {
@@ -279,11 +279,11 @@ QUERY;
         $this->assertArrayHasKey('websites', $response['products']['items'][0]);
         $this->assertWebsites($product, $response['products']['items'][0]['websites']);
         self::assertEquals(
-            'Movable Position 2',
+            'Filter category',
             $responseObject->getData('products/items/0/categories/0/name')
         );
         self::assertEquals(
-            'Filter category',
+            'Movable Position 2',
             $responseObject->getData('products/items/0/categories/1/name')
         );
         //canonical_url will be null unless the admin setting catalog/seo/product_canonical_tag is turned ON
@@ -1054,7 +1054,7 @@ QUERY;
 
         $query = <<<QUERY
 {
-    products(filter: 
+    products(filter:
              {
              sku: {in:["12345"]}
              }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This fixed a bug where the default GraphQL Category method does not sort by category position. By adding this filter results are returned in the correct order.

### Related Pull Requests
<!-- related pull request placeholder -->
https://github.com/magento/catalog-storefront/pull/173

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/catalog-storefront#104

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
