### PR TITLE
Unit Test / Bugfix / Inverted Expected value with actual one

### DIFF
--- a/app/code/Magento/Newsletter/Test/Unit/Model/SubscriptionManagerTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Model/SubscriptionManagerTest.php
@@ -136,11 +136,8 @@ class SubscriptionManagerTest extends TestCase
             ->with(Subscriber::XML_PATH_CONFIRMATION_FLAG, ScopeInterface::SCOPE_STORE, $storeId)
             ->willReturn($isConfirmNeed);
 
-        $this->assertEquals(
-            $subscriber,
-            $this->subscriptionManager->subscribe($email, $storeId)
-        );
-        $this->assertEquals($subscriber->getData(), $expectedData);
+        $this->assertEquals($subscriber, $this->subscriptionManager->subscribe($email, $storeId));
+        $this->assertEquals($expectedData, $subscriber->getData());
     }
 
     /**
@@ -308,7 +305,7 @@ class SubscriptionManagerTest extends TestCase
             $subscriber,
             $this->subscriptionManager->subscribeCustomer($customerId, $storeId)
         );
-        $this->assertEquals($subscriber->getData(), $expectedData);
+        $this->assertEquals($expectedData, $subscriber->getData());
     }
 
     /**
@@ -553,7 +550,7 @@ class SubscriptionManagerTest extends TestCase
             $subscriber,
             $this->subscriptionManager->unsubscribeCustomer($customerId, $storeId)
         );
-        $this->assertEquals($subscriber->getData(), $expectedData);
+        $this->assertEquals($expectedData, $subscriber->getData());
     }
 
     /**


### PR DESCRIPTION
### Description (*)
The values were compared invalid way (opposite): `expected` vs actual values.
I swapped them, also verified if there are no such examples across the platform, but haven't found any other.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29283: Unit Test / Bugfix / Inverted Expected value with actual one