### PR TITLE
Unit Test / Deprecate / ObjectManager Helper

### DIFF
--- a/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php
+++ b/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php
@@ -155,6 +155,7 @@ class ObjectManager
      */
     public function getObject($className, array $arguments = [])
     {
+        // phpstan:ignore
         if (is_subclass_of($className, \Magento\Framework\Api\AbstractSimpleObjectBuilder::class)
             || is_subclass_of($className, \Magento\Framework\Api\Builder::class)
         ) {
@@ -333,13 +334,12 @@ class ObjectManager
      */
     private function _getMockObject($argClassName, array $arguments)
     {
+        // phpstan:ignore
         if (is_subclass_of($argClassName, \Magento\Framework\Api\ExtensibleObjectBuilder::class)) {
-            $object = $this->getBuilder($argClassName, $arguments);
-            return $object;
-        } else {
-            $object = $this->_createArgumentMock($argClassName, $arguments);
-            return $object;
+            return $this->getBuilder($argClassName, $arguments);
         }
+
+        return $this->_createArgumentMock($argClassName, $arguments);
     }
 
     /**

--- a/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php
+++ b/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php
@@ -8,6 +8,7 @@ namespace Magento\Framework\TestFramework\Unit\Helper;
 /**
  * Helper class for basic object retrieving, such as blocks, models etc...
  *
+ * @deprecated Class under test should be instantiated with `new` keyword with explicit dependencies declaration
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ObjectManager

--- a/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php
+++ b/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Framework\TestFramework\Unit\Helper;
 
+use PHPUnit\Framework\MockObject\MockObject;
+
 /**
  * Helper class for basic object retrieving, such as blocks, models etc...
  *
@@ -45,7 +47,7 @@ class ObjectManager
      *
      * @param string $argClassName
      * @param array $originalArguments
-     * @return null|object|\PHPUnit_Framework_MockObject_MockObject
+     * @return null|object|MockObject
      */
     protected function _createArgumentMock($argClassName, array $originalArguments)
     {
@@ -83,7 +85,7 @@ class ObjectManager
     /**
      * Retrieve specific mock of core resource model
      *
-     * @return \Magento\Framework\Module\ResourceInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @return \Magento\Framework\Module\ResourceInterface|MockObject
      */
     protected function _getResourceModelMock()
     {
@@ -109,7 +111,7 @@ class ObjectManager
      * Retrieve mock of core translator model
      *
      * @param string $className
-     * @return \Magento\Framework\TranslateInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @return \Magento\Framework\TranslateInterface|MockObject
      */
     protected function _getTranslatorMock($className)
     {
@@ -131,7 +133,7 @@ class ObjectManager
      * Get mock without call of original constructor
      *
      * @param string $className
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function _getMockWithoutConstructorCall($className)
     {
@@ -293,7 +295,7 @@ class ObjectManager
      *
      * @param string $className
      * @param array $data
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      * @throws \InvalidArgumentException
      */
     public function getCollectionMock($className, array $data)
@@ -327,7 +329,7 @@ class ObjectManager
      *
      * @param string $argClassName
      * @param array $arguments
-     * @return null|object|\PHPUnit_Framework_MockObject_MockObject
+     * @return null|object|MockObject
      */
     private function _getMockObject($argClassName, array $arguments)
     {


### PR DESCRIPTION
### Description (*)
During the **Magento 1** to **Magento 2** migration, the rush around forced Magento developers to make some compromises.
Last month we finally said Good Bye to Magento 1, but we still fight against the legacy we inherited.

One of the **Ancient Artifacts** is `\Magento\Framework\TestFramework\Unit\Helper\ObjectManager` which purpose was to mock all the dependencies that were not necessary to mock for specific Unit Tests. That enabled developers to introduce ugly classes with a few of dependencies.

In my personal opinion 2020 is about the time to stop this ridiculous practice and give up with using ObjectManager for instantiating classes under test and replace that with `new` keyword in Unit Tests.

#### Reason behind it

1. Need for mocking all the dependencies will make Developer think twice before introducing another few of dependencies.
1. Introducing new backwards-incompatible dependency to the class will result in Unit Tests failure, thus will point out Developer that he introduced the backwards-incompatible change.
1. ObjectManager hides the ugly complexity of Magento classes.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
PR makes an ugly world of Magento Unit Tests a slightly better place.

### Manual testing scenarios (*)
N/A

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29346: Unit Test / Deprecate / ObjectManager Helper