### PR TITLE
#1618: Duplicated items in Used in Entities filters

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/ui-select.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/ui-select.js
@@ -153,8 +153,8 @@ define([
             showPath: true,
             labelsDecoration: false,
             disableLabel: false,
-            filterRateLimit: 1000,
-            filterRateLimitMethod: 'notifyWhenChangesStop',
+            filterRateLimit: 500,
+            filterRateLimitMethod: 'notifyAtFixedRate',
             closeBtnLabel: $t('Done'),
             optgroupTmpl: 'ui/grid/filters/elements/ui-select-optgroup',
             quantityPlaceholder: $t('options'),
@@ -1167,7 +1167,7 @@ define([
                 return;
             }
 
-            if (searchKey !== this.lastSearchKey || currentPage === 1) {
+            if (currentPage === 1) {
                 this.options([]);
             }
             this.processRequest(searchKey, currentPage);

--- a/app/code/Magento/Ui/view/base/web/js/form/element/ui-select.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/ui-select.js
@@ -153,8 +153,8 @@ define([
             showPath: true,
             labelsDecoration: false,
             disableLabel: false,
-            filterRateLimit: 500,
-            filterRateLimitMethod: 'notifyAtFixedRate',
+            filterRateLimit: 1000,
+            filterRateLimitMethod: 'notifyWhenChangesStop',
             closeBtnLabel: $t('Done'),
             optgroupTmpl: 'ui/grid/filters/elements/ui-select-optgroup',
             quantityPlaceholder: $t('options'),
@@ -1167,7 +1167,7 @@ define([
                 return;
             }
 
-            if (searchKey !== this.lastSearchKey) {
+            if (searchKey !== this.lastSearchKey || currentPage === 1) {
                 this.options([]);
             }
             this.processRequest(searchKey, currentPage);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Prevent simultaneous requests when user types search key in `ui-select`.
### Related Pull Requests
<!-- related pull request placeholder -->
_N/A_
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes https://github.com/magento/adobe-stock-integration/issues/1618

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Go to Content - Media Gallery
2. Click Filters
3. Expand, for example, Used in Pages filter
4. Start typing page into Page Title field

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
_N/A_
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
