### PR TITLE
Fixed clear checkout session for paypal to prevent multiple order creation from one obsolete quote (#29013)

### DIFF
--- a/app/code/Magento/Paypal/Observer/OnCheckoutSuccessClearQuote.php
+++ b/app/code/Magento/Paypal/Observer/OnCheckoutSuccessClearQuote.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Paypal\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Session\Generic;
+
+class OnCheckoutSuccessClearQuote implements ObserverInterface
+{
+    /**
+     * @var Generic
+     */
+    private Generic $checkoutSession;
+
+    /**
+     * OnCheckoutSuccessClearQuote constructor.
+     * @param Generic $checkoutSession
+     */
+    public function __construct(Generic $checkoutSession)
+    {
+        $this->checkoutSession = $checkoutSession;
+    }
+
+    /**
+     * Regularly magento uses checkout session. For paypal checkout it uses custom Generic session.
+     * <virtualType name="Magento\Paypal\Model\Session" type="Magento\Framework\Session\Generic">
+     * On success this session also need to be cleared.
+     *
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer): void
+    {
+        $this->checkoutSession->clearStorage();
+    }
+}

--- a/app/code/Magento/Paypal/etc/frontend/di.xml
+++ b/app/code/Magento/Paypal/etc/frontend/di.xml
@@ -181,4 +181,9 @@
             <argument name="localeResolver" xsi:type="object">Magento\Paypal\Model\Express\LocaleResolver</argument>
         </arguments>
     </type>
+    <type name="Magento\Paypal\Observer\OnCheckoutSuccessClearQuote">
+        <arguments>
+            <argument name="checkoutSession" xsi:type="object">Magento\Paypal\Model\Session</argument>
+        </arguments>
+    </type>
 </config>

--- a/app/code/Magento/Paypal/etc/frontend/events.xml
+++ b/app/code/Magento/Paypal/etc/frontend/events.xml
@@ -15,4 +15,7 @@
     <event name="shortcut_buttons_container">
         <observer name="paypal_shortcuts" instance="Magento\Paypal\Observer\AddPaypalShortcutsObserver"/>
     </event>
+    <event name="checkout_quote_destroy">
+        <observer name="on_checkout_success_clear_quote" instance="Magento\Paypal\Observer\OnCheckoutSuccessClearQuote"/>
+    </event>
 </config>


### PR DESCRIPTION
### Description (*)
Regularly magento uses checkout session. For paypal checkout it uses custom Generic session.
`<virtualType name="Magento\Paypal\Model\Session" type="Magento\Framework\Session\Generic">`
On checkout/onepage/success this session also needs to be cleared.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#29013

### Manual testing scenarios (*)

1. Add Product in Cart
2. Go to the checkout page
3. Place an order with PayPal Express
4. It will redirect to paypal/express/review/ page
5. Place order
6. Redirecting to Success page
7. Now go back to PayPal/express/review/ page (Alt + <-)
8. Now Click on Place Order button
9. It will display "PayPal Express Checkout Token does not exist." error but Order Placed successfully wit

### Questions or comments
Is the unit test useless here? The fix is really easy and simply calls the method of another class.

### Contribution checklist (*)
 - [*] Pull request has a meaningful description of its purpose
 - [*] All commits are accompanied by meaningful commit messages
 - [*] All new or changed code is covered with unit/integration tests (if applicable)
 - [*] All automated tests passed successfully (all builds are green)
