### PR TITLE
Fix for magento/magento2#29315: \Magento\Config\Model\Config\Source\Email\Tem…

### DIFF
--- a/app/code/Magento/Config/Model/Config/Source/Email/Template.php
+++ b/app/code/Magento/Config/Model/Config/Source/Email/Template.php
@@ -60,10 +60,12 @@ class Template extends \Magento\Framework\DataObject implements \Magento\Framewo
             $this->_coreRegistry->register('config_system_email_template', $collection);
         }
         $options = $collection->toOptionArray();
-        $templateId = str_replace('/', '_', $this->getPath());
-        $templateLabel = $this->_emailConfig->getTemplateLabel($templateId);
-        $templateLabel = __('%1 (Default)', $templateLabel);
-        array_unshift($options, ['value' => $templateId, 'label' => $templateLabel]);
+        if (!empty($this->getPath())) {
+            $templateId = str_replace('/', '_', $this->getPath());
+            $templateLabel = $this->_emailConfig->getTemplateLabel($templateId);
+            $templateLabel = __('%1 (Default)', $templateLabel);
+            array_unshift($options, ['value' => $templateId, 'label' => $templateLabel]);
+        }
         return $options;
     }
 }

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Source/Email/TemplateTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Source/Email/TemplateTest.php
@@ -131,8 +131,12 @@ class TemplateTest extends TestCase
             $this->never()
         )->method(
             'getTemplateLabel'
-        )->with('')
-        ->willThrowException(new \UnexpectedValueException("Email template '' is not defined."));
+        )->with(
+            ''
+        )
+        ->willThrowException(
+            new \UnexpectedValueException("Email template '' is not defined.")
+        );
 
         $expectedResult = [
             [
@@ -146,4 +150,5 @@ class TemplateTest extends TestCase
         ];
 
         $this->assertEquals($expectedResult, $this->_model->toOptionArray());
-    }}
+    }
+}

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Source/Email/TemplateTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Source/Email/TemplateTest.php
@@ -102,4 +102,48 @@ class TemplateTest extends TestCase
         $this->_model->setPath('template/new');
         $this->assertEquals($expectedResult, $this->_model->toOptionArray());
     }
-}
+
+    public function testToOptionArrayWithoutPath()
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->expects(
+            $this->once()
+        )->method(
+            'toOptionArray'
+        )->willReturn(
+            [
+                ['value' => 'template_one', 'label' => 'Template One'],
+                ['value' => 'template_two', 'label' => 'Template Two'],
+            ]
+        );
+
+        $this->_coreRegistry->expects(
+            $this->once()
+        )->method(
+            'registry'
+        )->with(
+            'config_system_email_template'
+        )->willReturn(
+            $collection
+        );
+
+        $this->_emailConfig->expects(
+            $this->never()
+        )->method(
+            'getTemplateLabel'
+        )->with('')
+        ->willThrowException(new \UnexpectedValueException("Email template '' is not defined."));
+
+        $expectedResult = [
+            [
+                'value' => 'template_one',
+                'label' => 'Template One',
+            ],
+            [
+                'value' => 'template_two',
+                'label' => 'Template Two',
+            ],
+        ];
+
+        $this->assertEquals($expectedResult, $this->_model->toOptionArray());
+    }}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Adds a guard to `\Magento\Config\Model\Config\Source\Email\Template::toOptionArray` which protects against throwing an unhandled exception when a user has not called `$this->setPath()` before calling `toOptionArray()`

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#29315

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a custom module, plugin, or Observer
2. Inject a concrete instance of \Magento\Framework\ObjectManagerInterface ($this->_objectManager) through the constructor
3. Execute the following:
$sourceModelObj = $this->_objectManager->create('\Magento\Config\Model\Config\Source\Email\Template');
$optionsArray = $sourceModelObj->toOptionArray();
4. Notice unhandled exception is written to the screen

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
I included a Unit test in `app/code/Magento/Config/Test/Unit/Model/Config/Source/Email/TemplateTest.php` to illustrate the issue and test for it.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
