### PR TITLE
[vcl] Avoid conditional hashing when possible

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -127,31 +127,17 @@ sub vcl_hash {
     }
 
     # To make sure http users don't see ssl warning
-    if (req.http./* {{ ssl_offloaded_header }} */) {
-        hash_data(req.http./* {{ ssl_offloaded_header }} */);
-    }
+    hash_data(req.http./* {{ ssl_offloaded_header }} */);
+
     /* {{ design_exceptions_code }} */
 
     if (req.url ~ "/graphql") {
-        call process_graphql_headers;
-    }
-}
-
-sub process_graphql_headers {
-    if (req.http.X-Magento-Cache-Id) {
         hash_data(req.http.X-Magento-Cache-Id);
 
         # When the frontend stops sending the auth token, make sure users stop getting results cached for logged-in users
-        if (req.http.Authorization ~ "^Bearer") {
-            hash_data("Authorized");
-        }
-    }
+        hash_data(req.http.X-Magento-Cache-Id && req.http.Authorization ~ "^Bearer");
 
-    if (req.http.Store) {
         hash_data(req.http.Store);
-    }
-
-    if (req.http.Content-Currency) {
         hash_data(req.http.Content-Currency);
     }
 }


### PR DESCRIPTION
This depends on #28928 and extends the `vcl_hash` clean up started there.

Conditional hashing creates opportunities for collisions and should be avoided. It it's not possible, like in the case of the `X-Magento-Vary` cookie, a balancing `hash_data` call is added.

Note that it's not necessary to balance the calls in the `/graphql` since the URL is already part of the hash (via the built-in vcl) so we operate in a restricted subspace and collisions are not possible.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
