### PR TITLE
Fix generated code cleanup (for heavy load sites)

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Driver/File.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/File.php
@@ -441,8 +441,10 @@ class File implements DriverInterface
             $result = @unlink($fullPath);
         } else {
             if (PHP_OS === 'Windows') {
+                //phpcs:disable
                 $result = exec(sprintf("rd /s /q %s", escapeshellarg($fullPath)));
             } else {
+                //phpcs:disable
                 $result = exec(sprintf("rm -rf %s", escapeshellarg($fullPath)));
             }
             

--- a/lib/internal/Magento/Framework/Filesystem/Driver/File.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/File.php
@@ -440,7 +440,15 @@ class File implements DriverInterface
         if (is_link($fullPath)) {
             $result = @unlink($fullPath);
         } else {
-            $result = @rmdir($fullPath);
+            if (PHP_OS === 'Windows') {
+                $result = exec(sprintf("rd /s /q %s", escapeshellarg($fullPath)));
+            } else {
+                $result = exec(sprintf("rm -rf %s", escapeshellarg($fullPath)));
+            }
+            
+            if ($result === "") {
+                $result = true;
+            }
         }
         if (!$result) {
             throw new FileSystemException(


### PR DESCRIPTION
On sites under heavy load, while compiling dependency injection, the following error messages are displayed:

rm: cannot remove '/var/www/html/install/../generated/code/Magento': Directory not empty
The directory "/var/www/html/generated/code/Magento/Framework" cannot be deleted Warning!rmdir(/var/www/html/generated/code/Magento/Framework): Directory not empty

The issue happens even if Magento is in maintenance mode. The issue breaks the execution of bin/magento setup:di:compile command, leaving the site unusable.