### PR TITLE
Check if single store mode is enabled

### DIFF
--- a/app/code/Magento/Backend/Model/Session/Quote.php
+++ b/app/code/Magento/Backend/Model/Session/Quote.php
@@ -134,7 +134,7 @@ class Quote extends \Magento\Framework\Session\SessionManager
             $cookieMetadataFactory,
             $appState
         );
-        if ($this->_storeManager->hasSingleStore()) {
+        if ($this->_storeManager->isSingleStoreMode()) {
             $this->setStoreId($this->_storeManager->getStore(true)->getId());
         }
     }

--- a/app/code/Magento/Tax/Block/Adminhtml/Rate/Form.php
+++ b/app/code/Magento/Tax/Block/Adminhtml/Rate/Form.php
@@ -300,7 +300,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
         $form->setId(self::FORM_ELEMENT_ID);
         $form->setMethod('post');
 
-        if (!$this->_storeManager->hasSingleStore()) {
+        if (!$this->_storeManager->isSingleStoreMode()) {
             $form->addElement($this->_fieldsetFactory->create()->setLegend(__('Tax Titles')));
         }
 


### PR DESCRIPTION
### Description (*)
Check if single store mode is enabled, not just if there is a single store. Allowing you to select the store you wish to place the order under.

### Related Pull Requests

### Fixed Issues (if relevant)

### Manual testing scenarios (*)
1. Set up Magento with single store (store code `default`, website code `default`)
2. Configure web server so that when in the admin the `MAGE_RUN_CODE` is `admin`
3. Disable single store mode in the admin.
4. Configure a payment method to be enabled at admin level, but disabled for the `default` website
5. In the Magento admin, begin creating an order.
  - new customer
  - add product (if possible see below)
6. Payment methods should contain the one that is enabled at admin level and not at website level.

### Questions or comments
This issue is hard to completely show/explain, as it heavily dependant on store setup. For example:
- if not products are enabled for the admin, (only at website level) you will be unable to select products to add the order.
- Even though single store mode is disabled, you aren't presented with the option to select the store you wish to place the order for.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29445: Check if single store mode is enabled