### PR TITLE
#1713: Extract image extension from constant of SaveImageInformation to DI configuration

### DIFF
--- a/app/code/Magento/MediaGalleryIntegration/Plugin/SaveImageInformation.php
+++ b/app/code/Magento/MediaGalleryIntegration/Plugin/SaveImageInformation.php
@@ -21,8 +21,6 @@ use Psr\Log\LoggerInterface;
  */
 class SaveImageInformation
 {
-    private const IMAGE_FILE_NAME_PATTERN = '#\.(jpg|jpeg|gif|png)$# i';
-
     /**
      * @var IsPathExcludedInterface
      */
@@ -49,24 +47,32 @@ class SaveImageInformation
     private $synchronizeFiles;
 
     /**
+     * @var string[]
+     */
+    private $imageExtensions;
+
+    /**
      * @param Filesystem $filesystem
      * @param LoggerInterface $log
      * @param IsPathExcludedInterface $isPathExcluded
      * @param SynchronizeFilesInterface $synchronizeFiles
      * @param ConfigInterface $config
+     * @param array $imageExtensions
      */
     public function __construct(
         Filesystem $filesystem,
         LoggerInterface $log,
         IsPathExcludedInterface $isPathExcluded,
         SynchronizeFilesInterface $synchronizeFiles,
-        ConfigInterface $config
+        ConfigInterface $config,
+        array $imageExtensions
     ) {
         $this->log = $log;
         $this->isPathExcluded = $isPathExcluded;
         $this->filesystem = $filesystem;
         $this->synchronizeFiles = $synchronizeFiles;
         $this->config = $config;
+        $this->imageExtensions = $imageExtensions;
     }
 
     /**
@@ -75,6 +81,7 @@ class SaveImageInformation
      * @param Uploader $subject
      * @param array $result
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @return array
      */
     public function afterSave(Uploader $subject, array $result): array
     {
@@ -103,7 +110,7 @@ class SaveImageInformation
         try {
             return $path
                 && !$this->isPathExcluded->execute($path)
-                && preg_match(self::IMAGE_FILE_NAME_PATTERN, $path);
+                && preg_match('#\.(' . implode("|", $this->imageExtensions) . ')$# i', $path);
         } catch (\Exception $exception) {
             $this->log->critical($exception);
             return false;

--- a/app/code/Magento/MediaGalleryIntegration/etc/adminhtml/di.xml
+++ b/app/code/Magento/MediaGalleryIntegration/etc/adminhtml/di.xml
@@ -14,4 +14,14 @@
     <type name="Magento\Framework\File\Uploader">
         <plugin name="save_asset_image" type="Magento\MediaGalleryIntegration\Plugin\SaveImageInformation"/>
     </type>
+    <type name="Magento\MediaGalleryIntegration\Plugin\SaveImageInformation">
+        <arguments>
+            <argument name="imageExtensions" xsi:type="array">
+                <item name="jpg" xsi:type="string">jpg</item>
+                <item name="jpeg" xsi:type="string">jpeg</item>
+                <item name="gif" xsi:type="string">gif</item>
+                <item name="png" xsi:type="string">png</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
<!---
    Thank you for contributing to Adobe Stock Integration project.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR Extracts image extension constant of Magento/MediaGalleryIntegration/Plugin/SaveImageInformation.php to DI configuration.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/adobe-stock-integration#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes https://github.com/magento/adobe-stock-integration/issues/1713 : Extract image extension from constant of SaveImageInformation to DI configuration

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to media gallery
2. Click and Upload New Image.

### Expected results (*)
Able to upload image given it's the correct format(jpg,jpeg,gif,png).