### PR TITLE
Fix retrieval of sitemaps for robots.txt if current store doesn't bel…

### DIFF
--- a/app/code/Magento/Sitemap/Block/Robots.php
+++ b/app/code/Magento/Sitemap/Block/Robots.php
@@ -74,10 +74,10 @@ class Robots extends AbstractBlock implements IdentityInterface
      */
     protected function _toHtml()
     {
-        $defaultStore = $this->storeManager->getDefaultStoreView();
+        $currentStore = $this->storeManager->getStore();
 
         /** @var \Magento\Store\Model\Website $website */
-        $website = $this->storeManager->getWebsite($defaultStore->getWebsiteId());
+        $website = $this->storeManager->getWebsite($currentStore->getWebsiteId());
 
         $storeIds = [];
         foreach ($website->getStoreIds() as $storeId) {


### PR DESCRIPTION
Fix retrieval of sitemaps for robots.txt if current store doesn't belong to the same website as the default store

Fixes https://github.com/magento/magento2/issues/28901

### Description (*)
Sitemaps can be attached to the robots.txt by configuration. Unfortunately, this works only for stores which belong to the same website as the default store. This fix changes that so sitemaps will be attached to robots.txt for alle stores.

### Manual testing scenarios (*)
1. Create a second website with store group and a store (it's important to not make the new store the default store)
2. Create a sitemap for the new store in Marketing -> Site Map and generate it
3. Activate the configuration setting Catalog => XML Sitemap => Search Engine Submission Settings => Enable Submission to Robots.txt
4. Call <base_url_of_new_store>/robots.txt in the browser
5. Check if there is a line like `Sitemap: <base_url_of_new_store>/sitemap_new_store.xml` at the bottom of the output.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
