### PR TITLE
Fixed issue where removing breadcrumbs removes the page title

### DIFF
--- a/app/code/Magento/Catalog/Block/Breadcrumbs.php
+++ b/app/code/Magento/Catalog/Block/Breadcrumbs.php
@@ -4,8 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-
 /**
  * Catalog breadcrumbs
  */
@@ -43,7 +41,11 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      */
     public function getTitleSeparator($store = null)
     {
-        $separator = (string)$this->_scopeConfig->getValue('catalog/seo/title_separator', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store);
+        $separator = (string)$this->_scopeConfig->getValue(
+            'catalog/seo/title_separator',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
         return ' ' . $separator . ' ';
     }
 

--- a/app/code/Magento/Catalog/Block/Breadcrumbs.php
+++ b/app/code/Magento/Catalog/Block/Breadcrumbs.php
@@ -4,6 +4,8 @@
  * See COPYING.txt for license details.
  */
 
+// @codingStandardsIgnoreFile
+
 /**
  * Catalog breadcrumbs
  */
@@ -41,11 +43,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      */
     public function getTitleSeparator($store = null)
     {
-        $separator = (string)$this->_scopeConfig->getValue(
-            'catalog/seo/title_separator',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
-            $store
-        );
+        $separator = (string)$this->_scopeConfig->getValue('catalog/seo/title_separator', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $store);
         return ' ' . $separator . ' ';
     }
 
@@ -56,6 +54,7 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      */
     protected function _prepareLayout()
     {
+        $title = [];
         if ($breadcrumbsBlock = $this->getLayout()->getBlock('breadcrumbs')) {
             $breadcrumbsBlock->addCrumb(
                 'home',
@@ -66,7 +65,6 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
                 ]
             );
 
-            $title = [];
             $path = $this->_catalogData->getBreadcrumbPath();
 
             foreach ($path as $name => $breadcrumb) {
@@ -75,7 +73,18 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
             }
 
             $this->pageConfig->getTitle()->set(join($this->getTitleSeparator(), array_reverse($title)));
+
+            return parent::_prepareLayout();
         }
+
+        $path = $this->_catalogData->getBreadcrumbPath();
+
+        foreach ($path as $name => $breadcrumb) {
+            $title[] = $breadcrumb['label'];
+        }
+
+        $this->pageConfig->getTitle()->set(join($this->getTitleSeparator(), array_reverse($title)));
+
         return parent::_prepareLayout();
     }
 }

--- a/app/code/Magento/Catalog/Block/Breadcrumbs.php
+++ b/app/code/Magento/Catalog/Block/Breadcrumbs.php
@@ -54,7 +54,8 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
      */
     protected function _prepareLayout()
     {
-        $title = [];
+        $path = $this->_catalogData->getBreadcrumbPath();
+
         if ($breadcrumbsBlock = $this->getLayout()->getBlock('breadcrumbs')) {
             $breadcrumbsBlock->addCrumb(
                 'home',
@@ -64,27 +65,13 @@ class Breadcrumbs extends \Magento\Framework\View\Element\Template
                     'link' => $this->_storeManager->getStore()->getBaseUrl()
                 ]
             );
-
-            $path = $this->_catalogData->getBreadcrumbPath();
-
             foreach ($path as $name => $breadcrumb) {
                 $breadcrumbsBlock->addCrumb($name, $breadcrumb);
-                $title[] = $breadcrumb['label'];
             }
-
-            $this->pageConfig->getTitle()->set(join($this->getTitleSeparator(), array_reverse($title)));
-
-            return parent::_prepareLayout();
         }
 
-        $path = $this->_catalogData->getBreadcrumbPath();
-
-        foreach ($path as $name => $breadcrumb) {
-            $title[] = $breadcrumb['label'];
-        }
-
+        $title = array_column($path, 'label');
         $this->pageConfig->getTitle()->set(join($this->getTitleSeparator(), array_reverse($title)));
-
         return parent::_prepareLayout();
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
There was an issue in the [2.1 branch](https://github.com/magento/magento2/issues/4427) where if you removed the breadcrumbs via XML:
`<referenceBlock name="breadcrumbs" remove="true" />`, the page title would also be removed, leaving behind empty `<title>` tags in the `<head>`. This fixed in the 2.1 branch, but it seems that some regression has occurred and it is back. I'm reapplying that code change.

### Related Pull Requests
The [original PR is here](https://github.com/magento/magento2/pull/9324).

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Remove breadcrumbs block in XML <referenceBlock name="breadcrumbs" remove="true"/>
2. Go to the category view or product view page
3. Check Page title in browser tab

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29651: Fixed issue where removing breadcrumbs removes the page title