### PR TITLE
fix fatal error when exception was thrown

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
@@ -319,7 +319,7 @@ class Timezone implements TimezoneInterface
                 throw new LocalizedException(
                     new Phrase(
                         'The DateTime object timezone needs to be the same as the "%1" timezone in config.',
-                        $this->getConfigTimezone()
+                        [$this->getConfigTimezone()]
                     )
                 );
             }

--- a/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/TimezoneTest.php
+++ b/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/TimezoneTest.php
@@ -9,6 +9,7 @@ namespace Magento\Framework\Stdlib\Test\Unit\DateTime;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ScopeResolverInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\Stdlib\DateTime;
 use Magento\Framework\Stdlib\DateTime\Timezone;
@@ -206,6 +207,30 @@ class TimezoneTest extends TestCase
             $expectedResult()->format('DATE_ISO8601'),
             $this->getTimezone()->date($date)->format('DATE_ISO8601')
         );
+    }
+
+    /**
+     * Data provider for testException
+     *
+     * @return array
+     */
+    public function getConvertConfigTimeToUTCDataFixtures()
+    {
+        return [
+            'datetime' => [
+                new \DateTime('2016-10-10 10:00:00', new \DateTimeZone('UTC'))
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getConvertConfigTimeToUTCDataFixtures
+     */
+    public function testConvertConfigTimeToUtcException($date)
+    {
+        $this->expectException(LocalizedException::class);
+
+        $this->getTimezone()->convertConfigTimeToUtc($date);
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
In some specific cases method ```convertConfigTimeToUtc``` was throwing an exception. There was a bug in this part: incorrect params sent to ```Phrase``` constructor

### Related Pull Requests
<!-- related pull request placeholder -->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Try to convert date object from UTC to UTC

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29525: fix fatal error when exception was thrown