### PR TITLE
Fix used in entities of the same type are displayed separately in delete warning

### DIFF
--- a/app/code/Magento/MediaGalleryUi/view/adminhtml/web/js/action/deleteImageWithDetailConfirmation.js
+++ b/app/code/Magento/MediaGalleryUi/view/adminhtml/web/js/action/deleteImageWithDetailConfirmation.js
@@ -52,13 +52,15 @@ define([
          */
         getRecordRelatedContentMessage: function (images) {
             var usedInMessage = $t('The selected assets are used in the content of the following entities: '),
-                usedIn = [];
+                usedIn = {};
 
             $.each(images, function (key, image) {
                 $.each(image.details, function (sectionIndex, section) {
                     if (section.title === 'Used In' && _.isObject(section) && !_.isEmpty(section.value)) {
                         $.each(section.value, function (entityTypeIndex, entityTypeData) {
-                            usedIn.push(entityTypeData.name + '(' + entityTypeData.number + ')');
+                            usedIn[entityTypeData.name] = entityTypeData.name in usedIn ?
+                                usedIn[entityTypeData.name] + entityTypeData.number :
+                                entityTypeData.number;
                         });
                     }
                 });
@@ -68,7 +70,26 @@ define([
                 return '';
             }
 
-            return usedInMessage + usedIn.join(', ') + '.';
+            return usedInMessage + this.usedInObjectToString(usedIn);
+        },
+
+        /**
+         * Fromats usedIn object to string
+         *
+         * @param {Object} usedIn
+         * @return {String}
+         */
+        usedInObjectToString: function (usedIn) {
+            var message = '',
+                count = 0;
+
+            $.each(usedIn, function (entityName, number) {
+                count++;
+                message += entityName + '(' + number + ')';
+                message += count != Object.keys(usedIn).length ?  ', ' : '.';
+            });
+
+            return message;
         }
     };
 });

--- a/app/code/Magento/MediaGalleryUi/view/adminhtml/web/js/action/deleteImageWithDetailConfirmation.js
+++ b/app/code/Magento/MediaGalleryUi/view/adminhtml/web/js/action/deleteImageWithDetailConfirmation.js
@@ -86,7 +86,7 @@ define([
             $.each(usedIn, function (entityName, number) {
                 count++;
                 message += entityName + '(' + number + ')';
-                message += count != Object.keys(usedIn).length ?  ', ' : '.';
+                message += count !== Object.keys(usedIn).length ?  ', ' : '.';
             });
 
             return message;

--- a/app/code/Magento/MediaGalleryUi/view/adminhtml/web/js/action/deleteImageWithDetailConfirmation.js
+++ b/app/code/Magento/MediaGalleryUi/view/adminhtml/web/js/action/deleteImageWithDetailConfirmation.js
@@ -80,16 +80,13 @@ define([
          * @return {String}
          */
         usedInObjectToString: function (usedIn) {
-            var message = '',
-                count = 0;
+            var entities = [];
 
             $.each(usedIn, function (entityName, number) {
-                count++;
-                message += entityName + '(' + number + ')';
-                message += count !== Object.keys(usedIn).length ?  ', ' : '.';
+                entities.push(entityName + '(' + number + ')');
             });
 
-            return message;
+            return entities.join(', ') + '.';
         }
     };
 });


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1749

### Manual testing scenarios (*)
1. Add an image from media gallery to a category
2. Add another image from media gallery to a category
3. Try to delete both images together from the media gallery
4. See the delete confirmation popup

**Counts of asset usages should be aggregated by entity type: `Categories(2)` - only one `Categories` item should be displayed in the warning message**

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
