### PR TITLE
Refactor not needed before and around plugins

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Plugin/StoreGroup.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat/Plugin/StoreGroup.php
@@ -5,18 +5,13 @@
  */
 namespace Magento\Catalog\Model\Indexer\Category\Flat\Plugin;
 
-use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
-use Magento\Framework\Model\AbstractModel;
-use Magento\Framework\Indexer\IndexerRegistry;
 use Magento\Catalog\Model\Indexer\Category\Flat\State;
+use Magento\Framework\Indexer\IndexerRegistry;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 
 class StoreGroup
 {
-    /**
-     * @var bool
-     */
-    private $needInvalidating;
-
     /**
      * @var IndexerRegistry
      */
@@ -49,34 +44,20 @@ class StoreGroup
     }
 
     /**
-     * Check if need invalidate flat category indexer
-     *
-     * @param AbstractDb $subject
-     * @param AbstractModel $group
-     *
-     * @return void
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
-    public function beforeSave(AbstractDb $subject, AbstractModel $group)
-    {
-        $this->needInvalidating = $this->validate($group);
-    }
-
-    /**
      * Invalidate flat category indexer if root category changed for store group
      *
      * @param AbstractDb $subject
-     * @param AbstractDb $objectResource
-     *
+     * @param AbstractDb $result
+     * @param AbstractModel $group
      * @return AbstractDb
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterSave(AbstractDb $subject, AbstractDb $objectResource)
+    public function afterSave(AbstractDb $subject, AbstractDb $result, AbstractModel $group)
     {
-        if ($this->needInvalidating && $this->state->isFlatEnabled()) {
+        if ($this->validate($group) && $this->state->isFlatEnabled()) {
             $this->indexerRegistry->get(State::INDEXER_ID)->invalidate();
         }
 
-        return $objectResource;
+        return $result;
     }
 }

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Plugin/StoreGroup.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Plugin/StoreGroup.php
@@ -5,19 +5,14 @@
  */
 namespace Magento\Catalog\Model\Indexer\Category\Product\Plugin;
 
-use Magento\Framework\Indexer\IndexerRegistry;
-use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
-use Magento\Framework\Model\AbstractModel;
 use Magento\Catalog\Model\Indexer\Category\Product;
 use Magento\Catalog\Model\Indexer\Category\Product\TableMaintainer;
+use Magento\Framework\Indexer\IndexerRegistry;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 
 class StoreGroup
 {
-    /**
-     * @var bool
-     */
-    private $needInvalidating;
-
     /**
      * @var IndexerRegistry
      */
@@ -41,35 +36,22 @@ class StoreGroup
     }
 
     /**
-     * Check if need invalidate flat category indexer
-     *
-     * @param AbstractDb $subject
-     * @param AbstractModel $group
-     *
-     * @return void
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
-    public function beforeSave(AbstractDb $subject, AbstractModel $group)
-    {
-        $this->needInvalidating = $this->validate($group);
-    }
-
-    /**
      * Invalidate flat product
      *
      * @param AbstractDb $subject
-     * @param AbstractDb $objectResource
+     * @param AbstractDb $result
+     * @param AbstractModel $group
      *
      * @return AbstractDb
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterSave(AbstractDb $subject, AbstractDb $objectResource)
+    public function afterSave(AbstractDb $subject, AbstractDb $result, AbstractModel $group)
     {
-        if ($this->needInvalidating) {
+        if ($this->validate($group)) {
             $this->indexerRegistry->get(Product::INDEXER_ID)->invalidate();
         }
 
-        return $objectResource;
+        return $result;
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Plugin/StoreView.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Plugin/StoreView.php
@@ -5,18 +5,18 @@
  */
 namespace Magento\Catalog\Model\Indexer\Category\Product\Plugin;
 
-use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 use Magento\Framework\Model\AbstractModel;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 
 class StoreView extends StoreGroup
 {
     /**
      * Validate changes for invalidating indexer
      *
-     * @param \Magento\Framework\Model\AbstractModel $store
+     * @param AbstractModel $store
      * @return bool
      */
-    protected function validate(\Magento\Framework\Model\AbstractModel $store)
+    protected function validate(AbstractModel $store)
     {
         return $store->isObjectNew() || $store->dataHasChangedFor('group_id');
     }
@@ -36,7 +36,7 @@ class StoreView extends StoreGroup
             $this->tableMaintainer->createTablesForStore($store->getId());
         }
 
-        return parent::afterSave($subject, $objectResource);
+        return parent::afterSave($subject, $objectResource, $store);
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Eav/Plugin/StoreView.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Eav/Plugin/StoreView.php
@@ -3,21 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Catalog\Model\Indexer\Product\Eav\Plugin;
+
+use Magento\Catalog\Model\Indexer\Product\Eav\Processor;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Store\Model\ResourceModel\Store;
 
 class StoreView
 {
     /**
      * Product attribute indexer processor
      *
-     * @var \Magento\Catalog\Model\Indexer\Product\Eav\Processor
+     * @var Processor
      */
     protected $_indexerEavProcessor;
 
     /**
-     * @param \Magento\Catalog\Model\Indexer\Product\Eav\Processor $indexerEavProcessor
+     * @param Processor $indexerEavProcessor
      */
-    public function __construct(\Magento\Catalog\Model\Indexer\Product\Eav\Processor $indexerEavProcessor)
+    public function __construct(Processor $indexerEavProcessor)
     {
         $this->_indexerEavProcessor = $indexerEavProcessor;
     }
@@ -25,18 +30,19 @@ class StoreView
     /**
      * Before save handler
      *
-     * @param \Magento\Store\Model\ResourceModel\Store $subject
-     * @param \Magento\Framework\Model\AbstractModel $object
+     * @param Store $subject
+     * @param Store $result
+     * @param AbstractModel $object
      *
-     * @return void
+     * @return Store
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeSave(
-        \Magento\Store\Model\ResourceModel\Store $subject,
-        \Magento\Framework\Model\AbstractModel $object
-    ) {
-        if ((!$object->getId() || $object->dataHasChangedFor('group_id')) && $object->getIsActive()) {
+    public function afterSave(Store $subject, Store $result, AbstractModel $object)
+    {
+        if (($object->isObjectNew() || $object->dataHasChangedFor('group_id')) && $object->getIsActive()) {
             $this->_indexerEavProcessor->markIndexerAsInvalid();
         }
+
+        return $result;
     }
 }

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Plugin/Store.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Plugin/Store.php
@@ -6,19 +6,23 @@
 
 namespace Magento\Catalog\Model\Indexer\Product\Flat\Plugin;
 
+use Magento\Catalog\Model\Indexer\Product\Flat\Processor;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Store\Model\ResourceModel\Store as StoreResourceModel;
+
 class Store
 {
     /**
      * Product flat indexer processor
      *
-     * @var \Magento\Catalog\Model\Indexer\Product\Flat\Processor
+     * @var Processor
      */
     protected $_productFlatIndexerProcessor;
 
     /**
-     * @param \Magento\Catalog\Model\Indexer\Product\Flat\Processor $productFlatIndexerProcessor
+     * @param Processor $productFlatIndexerProcessor
      */
-    public function __construct(\Magento\Catalog\Model\Indexer\Product\Flat\Processor $productFlatIndexerProcessor)
+    public function __construct(Processor $productFlatIndexerProcessor)
     {
         $this->_productFlatIndexerProcessor = $productFlatIndexerProcessor;
     }
@@ -26,18 +30,19 @@ class Store
     /**
      * Before save handler
      *
-     * @param \Magento\Store\Model\ResourceModel\Store $subject
-     * @param \Magento\Framework\Model\AbstractModel $object
+     * @param StoreResourceModel $subject
+     * @param StoreResourceModel $result
+     * @param AbstractModel $object
      *
-     * @return void
+     * @return StoreResourceModel
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeSave(
-        \Magento\Store\Model\ResourceModel\Store $subject,
-        \Magento\Framework\Model\AbstractModel $object
-    ) {
-        if (!$object->getId() || $object->dataHasChangedFor('group_id')) {
+    public function afterSave(StoreResourceModel $subject, StoreResourceModel $result, AbstractModel $object)
+    {
+        if ($object->isObjectNew() || $object->dataHasChangedFor('group_id')) {
             $this->_productFlatIndexerProcessor->markIndexerAsInvalid();
         }
+
+        return $result;
     }
 }

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Plugin/StoreGroup.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Plugin/StoreGroup.php
@@ -6,19 +6,23 @@
 
 namespace Magento\Catalog\Model\Indexer\Product\Flat\Plugin;
 
+use Magento\Catalog\Model\Indexer\Product\Flat\Processor;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Store\Model\ResourceModel\Group;
+
 class StoreGroup
 {
     /**
      * Product flat indexer processor
      *
-     * @var \Magento\Catalog\Model\Indexer\Product\Flat\Processor
+     * @var Processor
      */
     protected $_productFlatIndexerProcessor;
 
     /**
-     * @param \Magento\Catalog\Model\Indexer\Product\Flat\Processor $productFlatIndexerProcessor
+     * @param Processor $productFlatIndexerProcessor
      */
-    public function __construct(\Magento\Catalog\Model\Indexer\Product\Flat\Processor $productFlatIndexerProcessor)
+    public function __construct(Processor $productFlatIndexerProcessor)
     {
         $this->_productFlatIndexerProcessor = $productFlatIndexerProcessor;
     }
@@ -26,18 +30,19 @@ class StoreGroup
     /**
      * Before save handler
      *
-     * @param \Magento\Store\Model\ResourceModel\Group $subject
-     * @param \Magento\Framework\Model\AbstractModel $object
+     * @param Group $subject
+     * @param Group $result
+     * @param AbstractModel $object
      *
-     * @return void
+     * @return Group
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeSave(
-        \Magento\Store\Model\ResourceModel\Group $subject,
-        \Magento\Framework\Model\AbstractModel $object
-    ) {
-        if (!$object->getId() || $object->dataHasChangedFor('root_category_id')) {
+    public function afterSave(Group $subject, Group $result, AbstractModel $object)
+    {
+        if ($object->isObjectNew() || $object->dataHasChangedFor('root_category_id')) {
             $this->_productFlatIndexerProcessor->markIndexerAsInvalid();
         }
+
+        return $result;
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/Flat/Plugin/StoreGroupTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/Flat/Plugin/StoreGroupTest.php
@@ -11,7 +11,6 @@ use Magento\Catalog\Model\Indexer\Category\Flat\Plugin\StoreGroup;
 use Magento\Catalog\Model\Indexer\Category\Flat\State;
 use Magento\Framework\Indexer\IndexerInterface;
 use Magento\Framework\Indexer\IndexerRegistry;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Store\Model\Group as GroupModel;
 use Magento\Store\Model\ResourceModel\Group;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -22,32 +21,32 @@ class StoreGroupTest extends TestCase
     /**
      * @var MockObject|IndexerInterface
      */
-    protected $indexerMock;
+    private $indexerMock;
 
     /**
      * @var MockObject|State
      */
-    protected $stateMock;
+    private $stateMock;
 
     /**
      * @var StoreGroup
      */
-    protected $model;
+    private $model;
 
     /**
      * @var MockObject|Group
      */
-    protected $subjectMock;
+    private $subjectMock;
 
     /**
      * @var IndexerRegistry|MockObject
      */
-    protected $indexerRegistryMock;
+    private $indexerRegistryMock;
 
     /**
      * @var MockObject|GroupModel
      */
-    protected $groupMock;
+    private $groupMock;
 
     protected function setUp(): void
     {
@@ -70,14 +69,10 @@ class StoreGroupTest extends TestCase
 
         $this->indexerRegistryMock = $this->createPartialMock(IndexerRegistry::class, ['get']);
 
-        $this->model = (new ObjectManager($this))
-            ->getObject(
-                StoreGroup::class,
-                ['indexerRegistry' => $this->indexerRegistryMock, 'state' => $this->stateMock]
-            );
+        $this->model = new StoreGroup($this->indexerRegistryMock, $this->stateMock);
     }
 
-    public function testBeforeAndAfterSave()
+    public function testAfterSave(): void
     {
         $this->stateMock->expects($this->once())->method('isFlatEnabled')->willReturn(true);
         $this->indexerMock->expects($this->once())->method('invalidate');
@@ -90,14 +85,14 @@ class StoreGroupTest extends TestCase
             ->with('root_category_id')
             ->willReturn(true);
         $this->groupMock->expects($this->once())->method('isObjectNew')->willReturn(false);
-        $this->model->beforeSave($this->subjectMock, $this->groupMock);
+
         $this->assertSame(
             $this->subjectMock,
             $this->model->afterSave($this->subjectMock, $this->subjectMock, $this->groupMock)
         );
     }
 
-    public function testBeforeAndAfterSaveNotNew()
+    public function testAfterSaveNotNew(): void
     {
         $this->stateMock->expects($this->never())->method('isFlatEnabled');
         $this->groupMock->expects($this->once())
@@ -105,7 +100,7 @@ class StoreGroupTest extends TestCase
             ->with('root_category_id')
             ->willReturn(true);
         $this->groupMock->expects($this->once())->method('isObjectNew')->willReturn(true);
-        $this->model->beforeSave($this->subjectMock, $this->groupMock);
+
         $this->assertSame(
             $this->subjectMock,
             $this->model->afterSave($this->subjectMock, $this->subjectMock, $this->groupMock)

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/Flat/Plugin/StoreViewTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/Flat/Plugin/StoreViewTest.php
@@ -12,6 +12,7 @@ use Magento\Catalog\Model\Indexer\Category\Flat\State;
 use Magento\Framework\Indexer\IndexerInterface;
 use Magento\Framework\Indexer\IndexerRegistry;
 use Magento\Store\Model\ResourceModel\Store;
+use Magento\Store\Model\Store as StoreModel;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -20,27 +21,27 @@ class StoreViewTest extends TestCase
     /**
      * @var MockObject|IndexerInterface
      */
-    protected $indexerMock;
+    private $indexerMock;
 
     /**
      * @var MockObject|State
      */
-    protected $stateMock;
+    private $stateMock;
 
     /**
      * @var StoreView
      */
-    protected $model;
+    private $model;
 
     /**
      * @var IndexerRegistry|MockObject
      */
-    protected $indexerRegistryMock;
+    private $indexerRegistryMock;
 
     /**
-     * @var MockObject
+     * @var Store|MockObject
      */
-    protected $subjectMock;
+    private $subjectMock;
 
     protected function setUp(): void
     {
@@ -65,50 +66,51 @@ class StoreViewTest extends TestCase
         $this->model = new StoreView($this->indexerRegistryMock, $this->stateMock);
     }
 
-    public function testBeforeAndAfterSaveNewObject()
+    public function testAfterSaveNewObject(): void
     {
         $this->mockConfigFlatEnabled();
         $this->mockIndexerMethods();
         $storeMock = $this->createPartialMock(
-            \Magento\Store\Model\Store::class,
+            StoreModel::class,
             ['isObjectNew', 'dataHasChangedFor']
         );
         $storeMock->expects($this->once())->method('isObjectNew')->willReturn(true);
-        $this->model->beforeSave($this->subjectMock, $storeMock);
+
         $this->assertSame(
             $this->subjectMock,
             $this->model->afterSave($this->subjectMock, $this->subjectMock, $storeMock)
         );
     }
 
-    public function testBeforeAndAfterSaveHasChanged()
+    public function testAfterSaveHasChanged(): void
     {
         $storeMock = $this->createPartialMock(
-            \Magento\Store\Model\Store::class,
+            StoreModel::class,
             ['isObjectNew', 'dataHasChangedFor']
         );
-        $this->model->beforeSave($this->subjectMock, $storeMock);
+
         $this->assertSame(
             $this->subjectMock,
             $this->model->afterSave($this->subjectMock, $this->subjectMock, $storeMock)
         );
     }
 
-    public function testBeforeAndAfterSaveNoNeed()
+    public function testAfterSaveNoNeed(): void
     {
         $this->mockConfigFlatEnabledNever();
+
         $storeMock = $this->createPartialMock(
-            \Magento\Store\Model\Store::class,
+            StoreModel::class,
             ['isObjectNew', 'dataHasChangedFor']
         );
-        $this->model->beforeSave($this->subjectMock, $storeMock);
+
         $this->assertSame(
             $this->subjectMock,
             $this->model->afterSave($this->subjectMock, $this->subjectMock, $storeMock)
         );
     }
 
-    protected function mockIndexerMethods()
+    private function mockIndexerMethods(): void
     {
         $this->indexerMock->expects($this->once())->method('invalidate');
         $this->indexerRegistryMock->expects($this->once())
@@ -117,12 +119,12 @@ class StoreViewTest extends TestCase
             ->willReturn($this->indexerMock);
     }
 
-    protected function mockConfigFlatEnabled()
+    private function mockConfigFlatEnabled(): void
     {
         $this->stateMock->expects($this->once())->method('isFlatEnabled')->willReturn(true);
     }
 
-    protected function mockConfigFlatEnabledNever()
+    private function mockConfigFlatEnabledNever(): void
     {
         $this->stateMock->expects($this->never())->method('isFlatEnabled');
     }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/Product/Plugin/StoreViewTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/Product/Plugin/StoreViewTest.php
@@ -27,27 +27,27 @@ class StoreViewTest extends TestCase
     /**
      * @var MockObject|IndexerInterface
      */
-    protected $indexerMock;
+    private $indexerMock;
 
     /**
      * @var StoreView
      */
-    protected $model;
+    private $model;
 
     /**
      * @var IndexerRegistry|MockObject
      */
-    protected $indexerRegistryMock;
+    private $indexerRegistryMock;
 
     /**
      * @var TableMaintainer|MockObject
      */
-    protected $tableMaintainer;
+    private $tableMaintainerMock;
 
     /**
-     * @var MockObject
+     * @var Group|MockObject
      */
-    protected $subject;
+    private $subjectMock;
 
     protected function setUp(): void
     {
@@ -60,7 +60,7 @@ class StoreViewTest extends TestCase
             true,
             ['getId', 'getState']
         );
-        $this->subject = $this->createMock(Group::class);
+        $this->subjectMock = $this->createMock(Group::class);
         $this->indexerRegistryMock = $this->createPartialMock(IndexerRegistry::class, ['get']);
         $this->storeMock = $this->createPartialMock(
             Store::class,
@@ -70,47 +70,56 @@ class StoreViewTest extends TestCase
                 'dataHasChangedFor'
             ]
         );
-        $this->tableMaintainer = $this->createPartialMock(
+        $this->tableMaintainerMock = $this->createPartialMock(
             TableMaintainer::class,
             [
                 'createTablesForStore'
             ]
         );
 
-        $this->model = new StoreView($this->indexerRegistryMock, $this->tableMaintainer);
+        $this->model = new StoreView($this->indexerRegistryMock, $this->tableMaintainerMock);
     }
 
-    public function testAroundSaveNewObject()
+    public function testAfterSaveNewObject(): void
     {
         $this->mockIndexerMethods();
         $this->storeMock->expects($this->atLeastOnce())->method('isObjectNew')->willReturn(true);
         $this->storeMock->expects($this->atLeastOnce())->method('getId')->willReturn(1);
-        $this->model->beforeSave($this->subject, $this->storeMock);
-        $this->assertSame($this->subject, $this->model->afterSave($this->subject, $this->subject, $this->storeMock));
+
+        $this->assertSame(
+            $this->subjectMock,
+            $this->model->afterSave($this->subjectMock, $this->subjectMock, $this->storeMock)
+        );
     }
 
-    public function testAroundSaveHasChanged()
+    public function testAfterSaveHasChanged(): void
     {
         $this->mockIndexerMethods();
         $this->storeMock->expects($this->once())
             ->method('dataHasChangedFor')
             ->with('group_id')
             ->willReturn(true);
-        $this->model->beforeSave($this->subject, $this->storeMock);
-        $this->assertSame($this->subject, $this->model->afterSave($this->subject, $this->subject, $this->storeMock));
+
+        $this->assertSame(
+            $this->subjectMock,
+            $this->model->afterSave($this->subjectMock, $this->subjectMock, $this->storeMock)
+        );
     }
 
-    public function testAroundSaveNoNeed()
+    public function testAfterSaveNoNeed(): void
     {
         $this->storeMock->expects($this->once())
             ->method('dataHasChangedFor')
             ->with('group_id')
             ->willReturn(false);
-        $this->model->beforeSave($this->subject, $this->storeMock);
-        $this->assertSame($this->subject, $this->model->afterSave($this->subject, $this->subject, $this->storeMock));
+
+        $this->assertSame(
+            $this->subjectMock,
+            $this->model->afterSave($this->subjectMock, $this->subjectMock, $this->storeMock)
+        );
     }
 
-    private function mockIndexerMethods()
+    private function mockIndexerMethods(): void
     {
         $this->indexerMock->expects($this->once())->method('invalidate');
         $this->indexerRegistryMock->expects($this->once())

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Eav/Plugin/StoreViewTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Eav/Plugin/StoreViewTest.php
@@ -11,50 +11,81 @@ use Magento\Catalog\Model\Indexer\Product\Eav\Plugin\StoreView;
 use Magento\Catalog\Model\Indexer\Product\Eav\Processor;
 use Magento\Framework\Model\AbstractModel;
 use Magento\Store\Model\ResourceModel\Store;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class StoreViewTest extends TestCase
 {
     /**
-     * @param array $data
-     * @dataProvider beforeSaveDataProvider
+     * @var Processor|MockObject
      */
-    public function testBeforeSave(array $data)
+    private $eavProcessorMock;
+    /**
+     * @var Store|MockObject
+     */
+    private $subjectMock;
+    /**
+     * @var AbstractModel|MockObject
+     */
+    private $objectMock;
+
+    /**
+     * @var StoreView
+     */
+    private $storeViewPlugin;
+
+    protected function setUp(): void
     {
-        $eavProcessorMock = $this->getMockBuilder(Processor::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $matcher = $data['matcher'];
-        $eavProcessorMock->expects($this->$matcher())
-            ->method('markIndexerAsInvalid');
-
-        $subjectMock = $this->getMockBuilder(Store::class)
+        $this->eavProcessorMock = $this->getMockBuilder(Processor::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $objectMock = $this->getMockBuilder(AbstractModel::class)
+        $this->subjectMock = $this->getMockBuilder(Store::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->objectMock = $this->getMockBuilder(AbstractModel::class)
             ->disableOriginalConstructor()
             ->setMethods(['getId', 'dataHasChangedFor', 'getIsActive'])
             ->getMock();
-        $objectMock->expects($this->any())
+
+        $this->storeViewPlugin = new StoreView($this->eavProcessorMock);
+    }
+
+    /**
+     * @param array $data
+     * @dataProvider beforeSaveDataProvider
+     */
+    public function testAfterSave(array $data): void
+    {
+        $matcher = $data['matcher'];
+
+        $this->eavProcessorMock->expects($this->$matcher())
+            ->method('markIndexerAsInvalid');
+
+        $this->objectMock->expects($this->any())
             ->method('getId')
             ->willReturn($data['object_id']);
-        $objectMock->expects($this->any())
+
+        $this->objectMock->expects($this->any())
             ->method('dataHasChangedFor')
             ->with('group_id')
             ->willReturn($data['has_group_id_changed']);
-        $objectMock->expects($this->any())
+
+        $this->objectMock->expects($this->any())
             ->method('getIsActive')
             ->willReturn($data['is_active']);
 
-        $model = new StoreView($eavProcessorMock);
-        $model->beforeSave($subjectMock, $objectMock);
+        $this->assertSame(
+            $this->subjectMock,
+            $this->storeViewPlugin->afterSave($this->subjectMock, $this->subjectMock, $this->objectMock)
+        );
     }
 
     /**
      * @return array
      */
-    public function beforeSaveDataProvider()
+    public function beforeSaveDataProvider(): array
     {
         return [
             [

--- a/app/code/Magento/CatalogInventory/Model/Indexer/Stock/Plugin/StoreGroup.php
+++ b/app/code/Magento/CatalogInventory/Model/Indexer/Stock/Plugin/StoreGroup.php
@@ -3,19 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\CatalogInventory\Model\Indexer\Stock\Plugin;
+
+use Magento\CatalogInventory\Model\Indexer\Stock\Processor;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Store\Model\ResourceModel\Group;
 
 class StoreGroup
 {
     /**
-     * @var \Magento\CatalogInventory\Model\Indexer\Stock\Processor
+     * @var Processor
      */
     protected $_indexerProcessor;
 
     /**
-     * @param \Magento\CatalogInventory\Model\Indexer\Stock\Processor  $indexerProcessor
+     * @param Processor $indexerProcessor
      */
-    public function __construct(\Magento\CatalogInventory\Model\Indexer\Stock\Processor $indexerProcessor)
+    public function __construct(Processor $indexerProcessor)
     {
         $this->_indexerProcessor = $indexerProcessor;
     }
@@ -23,18 +28,19 @@ class StoreGroup
     /**
      * Before save handler
      *
-     * @param \Magento\Store\Model\ResourceModel\Group $subject
-     * @param \Magento\Framework\Model\AbstractModel $object
+     * @param Group $subject
+     * @param Group $result
+     * @param AbstractModel $object
      *
-     * @return void
+     * @return Group
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeSave(
-        \Magento\Store\Model\ResourceModel\Group $subject,
-        \Magento\Framework\Model\AbstractModel $object
-    ) {
-        if (!$object->getId() || $object->dataHasChangedFor('website_id')) {
+    public function afterSave(Group $subject, Group $result, AbstractModel $object)
+    {
+        if ($object->isObjectNew() || $object->dataHasChangedFor('website_id')) {
             $this->_indexerProcessor->markIndexerAsInvalid();
         }
+
+        return $result;
     }
 }

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/Indexer/Stock/Plugin/StoreGroupTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/Indexer/Stock/Plugin/StoreGroupTest.php
@@ -12,7 +12,6 @@ namespace Magento\CatalogInventory\Test\Unit\Model\Indexer\Stock\Plugin;
 
 use Magento\CatalogInventory\Model\Indexer\Stock\Plugin\StoreGroup;
 use Magento\CatalogInventory\Model\Indexer\Stock\Processor;
-use Magento\Framework\Indexer\IndexerInterface;
 use Magento\Framework\Model\AbstractModel;
 use Magento\Store\Model\ResourceModel\Group;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -23,24 +22,24 @@ class StoreGroupTest extends TestCase
     /**
      * @var StoreGroup
      */
-    protected $_model;
+    private $model;
 
     /**
-     * @var IndexerInterface|MockObject
+     * @var Processor|MockObject
      */
-    protected $_indexerMock;
+    private $indexerProcessorMock;
 
     protected function setUp(): void
     {
-        $this->_indexerMock = $this->createMock(Processor::class);
-        $this->_model = new StoreGroup($this->_indexerMock);
+        $this->indexerProcessorMock = $this->createMock(Processor::class);
+        $this->model = new StoreGroup($this->indexerProcessorMock);
     }
 
     /**
      * @param array $data
-     * @dataProvider beforeSaveDataProvider
+     * @dataProvider afterSaveDataProvider
      */
-    public function testBeforeSave(array $data)
+    public function testAfterSave(array $data): void
     {
         $subjectMock = $this->createMock(Group::class);
         $objectMock = $this->createPartialMock(
@@ -55,16 +54,19 @@ class StoreGroupTest extends TestCase
             ->with('website_id')
             ->willReturn($data['has_website_id_changed']);
 
-        $this->_indexerMock->expects($this->once())
+        $this->indexerProcessorMock->expects($this->once())
             ->method('markIndexerAsInvalid');
 
-        $this->_model->beforeSave($subjectMock, $objectMock);
+        $this->assertSame(
+            $subjectMock,
+            $this->model->afterSave($subjectMock, $subjectMock, $objectMock)
+        );
     }
 
     /**
      * @return array
      */
-    public function beforeSaveDataProvider()
+    public function afterSaveDataProvider(): array
     {
         return [
             [

--- a/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Plugin/Store/Group.php
+++ b/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Plugin/Store/Group.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\CatalogSearch\Model\Indexer\Fulltext\Plugin\Store;
 
-use Magento\CatalogSearch\Model\Indexer\Fulltext\Plugin\AbstractPlugin as AbstractIndexerPlugin;
-use Magento\Store\Model\ResourceModel\Group as StoreGroupResourceModel;
-use Magento\Framework\Model\AbstractModel;
 use Magento\CatalogSearch\Model\Indexer\Fulltext as FulltextIndexer;
+use Magento\CatalogSearch\Model\Indexer\Fulltext\Plugin\AbstractPlugin as AbstractIndexerPlugin;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Store\Model\ResourceModel\Group as StoreGroupResourceModel;
 
 /**
  * Plugin for Magento\Store\Model\ResourceModel\Group
@@ -16,36 +16,18 @@ use Magento\CatalogSearch\Model\Indexer\Fulltext as FulltextIndexer;
 class Group extends AbstractIndexerPlugin
 {
     /**
-     * @var bool
-     */
-    private $needInvalidation;
-
-    /**
-     * Check if indexer requires invalidation after store group save
-     *
-     * @param StoreGroupResourceModel $subject
-     * @param AbstractModel $group
-     * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
-    public function beforeSave(StoreGroupResourceModel $subject, AbstractModel $group)
-    {
-        $this->needInvalidation = !$group->isObjectNew() && $group->dataHasChangedFor('website_id');
-    }
-
-    /**
      * Invalidate indexer on store group save
      *
      * @param StoreGroupResourceModel $subject
      * @param StoreGroupResourceModel $result
+     * @param AbstractModel $group
      * @return StoreGroupResourceModel
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterSave(StoreGroupResourceModel $subject, StoreGroupResourceModel $result)
+    public function afterSave(StoreGroupResourceModel $subject, StoreGroupResourceModel $result, AbstractModel $group)
     {
-        if ($this->needInvalidation) {
+        if (!$group->isObjectNew() && $group->dataHasChangedFor('website_id')) {
             $this->indexerRegistry->get(FulltextIndexer::INDEXER_ID)->invalidate();
         }
 

--- a/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Plugin/Store/View.php
+++ b/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Plugin/Store/View.php
@@ -5,10 +5,10 @@
  */
 namespace Magento\CatalogSearch\Model\Indexer\Fulltext\Plugin\Store;
 
-use Magento\CatalogSearch\Model\Indexer\Fulltext\Plugin\AbstractPlugin as AbstractIndexerPlugin;
-use Magento\Store\Model\ResourceModel\Store as StoreResourceModel;
-use Magento\Framework\Model\AbstractModel;
 use Magento\CatalogSearch\Model\Indexer\Fulltext as FulltextIndexer;
+use Magento\CatalogSearch\Model\Indexer\Fulltext\Plugin\AbstractPlugin as AbstractIndexerPlugin;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Store\Model\ResourceModel\Store as StoreResourceModel;
 
 /**
  * Plugin for Magento\Store\Model\ResourceModel\Store
@@ -16,36 +16,18 @@ use Magento\CatalogSearch\Model\Indexer\Fulltext as FulltextIndexer;
 class View extends AbstractIndexerPlugin
 {
     /**
-     * @var bool
-     */
-    private $needInvalidation;
-
-    /**
-     * Check if indexer requires invalidation after store view save
-     *
-     * @param StoreResourceModel $subject
-     * @param AbstractModel $store
-     * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
-    public function beforeSave(StoreResourceModel $subject, AbstractModel $store)
-    {
-        $this->needInvalidation = $store->isObjectNew();
-    }
-
-    /**
      * Invalidate indexer on store view save
      *
      * @param StoreResourceModel $subject
      * @param StoreResourceModel $result
+     * @param AbstractModel $store
      * @return StoreResourceModel
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterSave(StoreResourceModel $subject, StoreResourceModel $result)
+    public function afterSave(StoreResourceModel $subject, StoreResourceModel $result, AbstractModel $store)
     {
-        if ($this->needInvalidation) {
+        if ($store->isObjectNew()) {
             $this->indexerRegistry->get(FulltextIndexer::INDEXER_ID)->invalidate();
         }
 

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Indexer/Fulltext/Plugin/Store/ViewTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Indexer/Fulltext/Plugin/Store/ViewTest.php
@@ -11,7 +11,6 @@ use Magento\CatalogSearch\Model\Indexer\Fulltext as FulltextIndexer;
 use Magento\CatalogSearch\Model\Indexer\Fulltext\Plugin\Store\View as StoreViewIndexerPlugin;
 use Magento\Framework\Indexer\IndexerInterface;
 use Magento\Framework\Indexer\IndexerRegistry;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Store\Model\ResourceModel\Store as StoreResourceModel;
 use Magento\Store\Model\Store;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -23,11 +22,6 @@ class ViewTest extends TestCase
      * @var StoreViewIndexerPlugin
      */
     private $plugin;
-
-    /**
-     * @var ObjectManagerHelper
-     */
-    private $objectManagerHelper;
 
     /**
      * @var IndexerRegistry|MockObject
@@ -64,20 +58,16 @@ class ViewTest extends TestCase
             ->setMethods(['isObjectNew'])
             ->getMock();
 
-        $this->objectManagerHelper = new ObjectManagerHelper($this);
-        $this->plugin = $this->objectManagerHelper->getObject(
-            StoreViewIndexerPlugin::class,
-            ['indexerRegistry' => $this->indexerRegistryMock]
-        );
+        $this->plugin = new StoreViewIndexerPlugin($this->indexerRegistryMock);
     }
 
     /**
      * @param bool $isObjectNew
      * @param int $invalidateCounter
      *
-     * @dataProvider beforeAfterSaveDataProvider
+     * @dataProvider afterSaveDataProvider
      */
-    public function testBeforeAfterSave($isObjectNew, $invalidateCounter)
+    public function testAfterSave(bool $isObjectNew, int $invalidateCounter): void
     {
         $this->prepareIndexer($invalidateCounter);
         $this->storeMock->expects(static::once())
@@ -86,14 +76,16 @@ class ViewTest extends TestCase
         $this->indexerMock->expects(static::exactly($invalidateCounter))
             ->method('invalidate');
 
-        $this->plugin->beforeSave($this->subjectMock, $this->storeMock);
-        $this->assertSame($this->subjectMock, $this->plugin->afterSave($this->subjectMock, $this->subjectMock));
+        $this->assertSame(
+            $this->subjectMock,
+            $this->plugin->afterSave($this->subjectMock, $this->subjectMock, $this->storeMock)
+        );
     }
 
     /**
      * @return array
      */
-    public function beforeAfterSaveDataProvider()
+    public function afterSaveDataProvider(): array
     {
         return [
             [false, 0],
@@ -101,7 +93,7 @@ class ViewTest extends TestCase
         ];
     }
 
-    public function testAfterDelete()
+    public function testAfterDelete(): void
     {
         $this->prepareIndexer(1);
         $this->indexerMock->expects(static::once())
@@ -116,7 +108,7 @@ class ViewTest extends TestCase
      * @param int $invalidateCounter
      * @return void
      */
-    private function prepareIndexer($invalidateCounter)
+    private function prepareIndexer(int $invalidateCounter): void
     {
         $this->indexerRegistryMock->expects(static::exactly($invalidateCounter))
             ->method('get')

--- a/app/code/Magento/Theme/Model/Indexer/Design/Config/Plugin/Store.php
+++ b/app/code/Magento/Theme/Model/Indexer/Design/Config/Plugin/Store.php
@@ -6,7 +6,7 @@
 namespace Magento\Theme\Model\Indexer\Design\Config\Plugin;
 
 use Magento\Framework\Indexer\IndexerRegistry;
-use Magento\Store\Model\Store as StoreStore;
+use Magento\Store\Model\Store as StoreModel;
 use Magento\Theme\Model\Data\Design\Config;
 
 class Store
@@ -19,42 +19,41 @@ class Store
     /**
      * @param IndexerRegistry $indexerRegistry
      */
-    public function __construct(
-        IndexerRegistry $indexerRegistry
-    ) {
+    public function __construct(IndexerRegistry $indexerRegistry)
+    {
         $this->indexerRegistry = $indexerRegistry;
     }
 
     /**
      * Invalidate design config grid indexer on store creation
      *
-     * @param StoreStore $subject
-     * @param \Closure $proceed
-     * @return StoreStore
+     * @param StoreModel $subject
+     * @param StoreModel $result
+     * @return StoreModel
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function aroundSave(StoreStore $subject, \Closure $proceed)
+    public function afterSave(StoreModel $subject, StoreModel $result)
     {
-        $isObjectNew = $subject->getId() == 0;
-        $result = $proceed();
-        if ($isObjectNew) {
+        if ($result->isObjectNew()) {
             $this->indexerRegistry->get(Config::DESIGN_CONFIG_GRID_INDEXER_ID)->invalidate();
         }
+
         return $result;
     }
 
     /**
      * Invalidate design config grid indexer on store removal
      *
-     * @param StoreStore $subject
-     * @param StoreStore $result
-     * @return StoreStore
+     * @param StoreModel $subject
+     * @param StoreModel $result
+     * @return StoreModel
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function afterDelete(StoreStore $subject, $result)
+    public function afterDelete(StoreModel $subject, $result)
     {
         $this->indexerRegistry->get(Config::DESIGN_CONFIG_GRID_INDEXER_ID)->invalidate();
+
         return $result;
     }
 }

--- a/app/code/Magento/Theme/Test/Unit/Model/Indexer/Design/Config/Plugin/StoreTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Indexer/Design/Config/Plugin/StoreTest.php
@@ -9,6 +9,7 @@ namespace Magento\Theme\Test\Unit\Model\Indexer\Design\Config\Plugin;
 
 use Magento\Framework\Indexer\IndexerInterface;
 use Magento\Framework\Indexer\IndexerRegistry;
+use Magento\Store\Model\Store as StoreModel;
 use Magento\Theme\Model\Data\Design\Config;
 use Magento\Theme\Model\Indexer\Design\Config\Plugin\Store;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -17,10 +18,10 @@ use PHPUnit\Framework\TestCase;
 class StoreTest extends TestCase
 {
     /** @var Store */
-    protected $model;
+    private $model;
 
     /** @var IndexerRegistry|MockObject */
-    protected $indexerRegistryMock;
+    private $indexerRegistryMock;
 
     protected function setUp(): void
     {
@@ -31,21 +32,15 @@ class StoreTest extends TestCase
         $this->model = new Store($this->indexerRegistryMock);
     }
 
-    public function testAroundSave()
+    public function testAfterSave(): void
     {
-        $subjectId = 0;
-
-        /** @var \Magento\Store\Model\Store|MockObject $subjectMock */
-        $subjectMock = $this->getMockBuilder(\Magento\Store\Model\Store::class)
+        /** @var StoreModel|MockObject $subjectMock */
+        $subjectMock = $this->getMockBuilder(StoreModel::class)
             ->disableOriginalConstructor()
             ->getMock();
         $subjectMock->expects($this->once())
-            ->method('getId')
-            ->willReturn($subjectId);
-
-        $closureMock = function () use ($subjectMock) {
-            return $subjectMock;
-        };
+            ->method('isObjectNew')
+            ->willReturn(true);
 
         /** @var IndexerInterface|MockObject $indexerMock */
         $indexerMock = $this->getMockBuilder(IndexerInterface::class)
@@ -58,35 +53,29 @@ class StoreTest extends TestCase
             ->with(Config::DESIGN_CONFIG_GRID_INDEXER_ID)
             ->willReturn($indexerMock);
 
-        $this->assertEquals($subjectMock, $this->model->aroundSave($subjectMock, $closureMock));
+        $this->assertSame($subjectMock, $this->model->afterSave($subjectMock, $subjectMock));
     }
 
-    public function testAroundSaveWithExistentSubject()
+    public function testAfterSaveWithExistentSubject(): void
     {
-        $subjectId = 1;
-
-        /** @var \Magento\Store\Model\Store|MockObject $subjectMock */
-        $subjectMock = $this->getMockBuilder(\Magento\Store\Model\Store::class)
+        /** @var StoreModel|MockObject $subjectMock */
+        $subjectMock = $this->getMockBuilder(StoreModel::class)
             ->disableOriginalConstructor()
             ->getMock();
         $subjectMock->expects($this->once())
-            ->method('getId')
-            ->willReturn($subjectId);
-
-        $closureMock = function () use ($subjectMock) {
-            return $subjectMock;
-        };
+            ->method('isObjectNew')
+            ->willReturn(false);
 
         $this->indexerRegistryMock->expects($this->never())
             ->method('get');
 
-        $this->assertEquals($subjectMock, $this->model->aroundSave($subjectMock, $closureMock));
+        $this->assertSame($subjectMock, $this->model->afterSave($subjectMock, $subjectMock));
     }
 
-    public function testAfterDelete()
+    public function testAfterDelete(): void
     {
-        /** @var \Magento\Store\Model\Store|MockObject $subjectMock */
-        $subjectMock = $this->getMockBuilder(\Magento\Store\Model\Store::class)
+        /** @var StoreModel|MockObject $subjectMock */
+        $subjectMock = $this->getMockBuilder(StoreModel::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -101,6 +90,6 @@ class StoreTest extends TestCase
             ->with(Config::DESIGN_CONFIG_GRID_INDEXER_ID)
             ->willReturn($indexerMock);
 
-        $this->assertEquals($subjectMock, $this->model->afterDelete($subjectMock, $subjectMock));
+        $this->assertSame($subjectMock, $this->model->afterDelete($subjectMock, $subjectMock));
     }
 }


### PR DESCRIPTION
### Description (*)
Refactored some parts that using both before and after plugins for save method, also one that uses around.

It's possible to do because of replacing `!$object->getId()` to `$object->isObjectNew()` which is true even after saving the model

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29653: Refactor not needed before and around plugins