### PR TITLE
Fix Parameter Tokenizer omitting first char of key

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Filter/Template/Tokenizer/ParameterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Filter/Template/Tokenizer/ParameterTest.php
@@ -3,20 +3,33 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Framework\Filter\Template\Tokenizer;
 
-class ParameterTest extends \PHPUnit\Framework\TestCase
+use Magento\Catalog\Block\Product\Widget\NewWidget;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test for \Magento\Framework\Filter\Template\Tokenizer\Parameter.
+ */
+class ParameterTest extends TestCase
 {
     /**
+     * Test for getValue
+     *
+     * @dataProvider getValueDataProvider
+     *
      * @param string $string
      * @param array $values
-     * @dataProvider getValueDataProvider
+     * @return void
      */
-    public function testGetValue($string, $values)
+    public function testGetValue($string, $values): void
     {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        /** @var \Magento\Framework\Filter\Template\Tokenizer\Parameter $parameter */
-        $parameter = $objectManager->create(\Magento\Framework\Filter\Template\Tokenizer\Parameter::class);
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Parameter $parameter */
+        $parameter = $objectManager->create(Parameter::class);
         $parameter->setString($string);
 
         foreach ($values as $value) {
@@ -25,30 +38,36 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test for tokenize
+     *
      * @dataProvider tokenizeDataProvider
+     *
      * @param string $string
      * @param array $params
+     * @return void
      */
-    public function testTokenize($string, $params)
+    public function testTokenize($string, $params): void
     {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        /** @var \Magento\Framework\Filter\Template\Tokenizer\Parameter $parameter */
-        $parameter = $objectManager->create(\Magento\Framework\Filter\Template\Tokenizer\Parameter::class);
+        $objectManager = Bootstrap::getObjectManager();
+        $parameter = $objectManager->create(Parameter::class);
         $parameter->setString($string);
+
         $this->assertEquals($params, $parameter->tokenize());
     }
 
     /**
+     * DataProvider for testTokenize
+     *
      * @return array
      */
-    public function tokenizeDataProvider()
+    public function tokenizeDataProvider(): array
     {
         return [
             [
                 ' type="Magento\\Catalog\\Block\\Product\\Widget\\NewWidget" display_type="all_products"'
                 . ' products_count="10" template="product/widget/new/content/new_grid.phtml"',
                 [
-                    'type' => \Magento\Catalog\Block\Product\Widget\NewWidget::class,
+                    'type' => NewWidget::class,
                     'display_type' => 'all_products',
                     'products_count' => 10,
                     'template' => 'product/widget/new/content/new_grid.phtml'
@@ -58,12 +77,24 @@ class ParameterTest extends \PHPUnit\Framework\TestCase
                 ' type="Magento\Catalog\Block\Product\Widget\NewWidget" display_type="all_products"'
                 . ' products_count="10" template="product/widget/new/content/new_grid.phtml"',
                 [
-                    'type' => \Magento\Catalog\Block\Product\Widget\NewWidget::class,
+                    'type' => NewWidget::class,
                     'display_type' => 'all_products',
                     'products_count' => 10,
                     'template' => 'product/widget/new/content/new_grid.phtml'
                 ]
-            ]
+            ],
+            [
+                sprintf(
+                    'type="%s" display_type="all_products" products_count="1" template="content/new_grid.phtml"',
+                    NewWidget::class
+                ),
+                [
+                    'type' => NewWidget::class,
+                    'display_type' => 'all_products',
+                    'products_count' => 1,
+                    'template' => 'content/new_grid.phtml'
+                ],
+            ],
         ];
     }
 

--- a/dev/tests/integration/testsuite/Magento/Framework/Filter/Template/Tokenizer/ParameterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Filter/Template/Tokenizer/ParameterTest.php
@@ -46,7 +46,7 @@ class ParameterTest extends TestCase
      * @param array $params
      * @return void
      */
-    public function testTokenize($string, $params): void
+    public function testTokenize(string $string, array $params): void
     {
         $objectManager = Bootstrap::getObjectManager();
         $parameter = $objectManager->create(Parameter::class);

--- a/lib/internal/Magento/Framework/Filter/Template/Tokenizer/AbstractTokenizer.php
+++ b/lib/internal/Magento/Framework/Filter/Template/Tokenizer/AbstractTokenizer.php
@@ -115,7 +115,7 @@ abstract class AbstractTokenizer
      */
     public function isWhiteSpace()
     {
-        return trim($this->char()) != $this->char();
+        return $this->_string === '' ?: trim($this->char()) !== $this->char();
     }
 
     /**

--- a/lib/internal/Magento/Framework/Filter/Template/Tokenizer/Parameter.php
+++ b/lib/internal/Magento/Framework/Filter/Template/Tokenizer/Parameter.php
@@ -22,7 +22,9 @@ class Parameter extends \Magento\Framework\Filter\Template\Tokenizer\AbstractTok
         do {
             if ($this->isWhiteSpace()) {
                 continue;
-            } elseif ($this->char() != '=') {
+            }
+
+            if ($this->char() !== '=') {
                 $parameterName .= $this->char();
             } else {
                 $parameters[$parameterName] = $this->getValue();

--- a/lib/internal/Magento/Framework/Filter/Template/Tokenizer/Parameter.php
+++ b/lib/internal/Magento/Framework/Filter/Template/Tokenizer/Parameter.php
@@ -19,7 +19,7 @@ class Parameter extends \Magento\Framework\Filter\Template\Tokenizer\AbstractTok
     {
         $parameters = [];
         $parameterName = '';
-        while ($this->next()) {
+        do {
             if ($this->isWhiteSpace()) {
                 continue;
             } elseif ($this->char() != '=') {
@@ -28,7 +28,7 @@ class Parameter extends \Magento\Framework\Filter\Template\Tokenizer\AbstractTok
                 $parameters[$parameterName] = $this->getValue();
                 $parameterName = '';
             }
-        }
+        } while ($this->next());
         return $parameters;
     }
 


### PR DESCRIPTION
### Description (*)
\Magento\Framework\Filter\Template\Tokenizer\Parameter has to use a do-while-loop. not a while loop. Else the first char is ignored because $this->next() set the pointer to the second char before getting the first char. (copied from @bernd-reindl)

### Fixed Issues (if relevant)
1. Fixes magento/magento2#29185 

### Manual testing scenarios (*)
1. Create Custom Directive (for me typo3url with link parameter eg. {{typo3_link url='imprint'}}
2. Use it in template (eg. email footer) 
3. Debug the new custom directive process($value, array $parameters, ?string $html) function
4. Take a look at the $parameters array.
5. It should contain `url => "imprint`" but is actually `rl => "imprint"`


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
