### PR TITLE
Use Object Cache for Category Links to avoid redundant calls

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/CategoryLink.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/CategoryLink.php
@@ -194,6 +194,8 @@ class CategoryLink
             }
         }
 
+        $this->cleanCategoryLinksCache();
+
         return array_column($insertLinks, 'category_id');
     }
 
@@ -215,6 +217,8 @@ class CategoryLink
             'product_id = ?' => (int)$product->getId(),
             'category_id IN(?)' => array_column($deleteLinks, 'category_id')
         ]);
+
+        $this->cleanCategoryLinksCache();
 
         return array_column($deleteLinks, 'category_id');
     }
@@ -282,5 +286,20 @@ class CategoryLink
         sort($categoryIds);
 
         return sprintf('%d|%s', $productId, implode(',', $categoryIds));
+    }
+
+    /**
+     * Removes ObjectCache for Category Links
+     *
+     * @return void
+     */
+    private function cleanCategoryLinksCache(?string $cacheKey = null): void
+    {
+        if ($cacheKey) {
+            unset($this->productLinks[$cacheKey]);
+            return;
+        }
+
+        $this->productLinks = [];
     }
 }


### PR DESCRIPTION
### Description (*)
Having **52** products in cart, I get 156 requests to the database:
![image](https://user-images.githubusercontent.com/1639941/90322159-f7715980-df50-11ea-9484-de7dee34d3f4.png)
This PR goal is to reduce this to **52**.

After change, for 26 products:
![image](https://user-images.githubusercontent.com/1639941/90322406-dc541900-df53-11ea-86c1-471e287d05ba.png)


This is a part of #29376 process.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Continuation of #29376


### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29654: Use Object Cache for Category Links to avoid redundant calls