### PR TITLE
Minor refactoring to AccessChangeQuoteControl and it's Unit Tests

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteRepository/Plugin/AccessChangeQuoteControl.php
+++ b/app/code/Magento/Quote/Model/QuoteRepository/Plugin/AccessChangeQuoteControl.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Quote\Model\QuoteRepository\Plugin;
 
@@ -32,16 +33,17 @@ class AccessChangeQuoteControl
     /**
      * Checks if change quote's customer id is allowed for current user.
      *
+     * A StateException is thrown if Guest's or Customer's customer_id not match user_id or unknown user type
+     *
      * @param CartRepositoryInterface $subject
      * @param CartInterface $quote
-     * @throws StateException if Guest has customer_id or Customer's customer_id not much with user_id
-     * or unknown user's type
      * @return void
+     * @throws StateException
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeSave(CartRepositoryInterface $subject, CartInterface $quote)
+    public function beforeSave(CartRepositoryInterface $subject, CartInterface $quote): void
     {
-        if (! $this->changeQuoteControl->isAllowed($quote)) {
+        if (!$this->changeQuoteControl->isAllowed($quote)) {
             throw new StateException(__("Invalid state change requested"));
         }
     }

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteRepository/Plugin/AccessChangeQuoteControlTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteRepository/Plugin/AccessChangeQuoteControlTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\Quote\Test\Unit\Model\QuoteRepository\Plugin;
 
 use Magento\Authorization\Model\UserContextInterface;
+use Magento\Framework\Exception\StateException;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Quote\Model\ChangeQuoteControl;
 use Magento\Quote\Model\Quote;
@@ -52,7 +53,7 @@ class AccessChangeQuoteControlTest extends TestCase
 
         $this->quoteMock = $this->getMockBuilder(Quote::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCustomerId'])
+            ->addMethods(['getCustomerId'])
             ->getMock();
 
         $this->quoteRepositoryMock = $this->getMockBuilder(QuoteRepository::class)
@@ -63,17 +64,10 @@ class AccessChangeQuoteControlTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $objectManagerHelper = new ObjectManager($this);
-        $this->accessChangeQuoteControl = $objectManagerHelper->getObject(
-            AccessChangeQuoteControl::class,
-            ['changeQuoteControl' => $this->changeQuoteControlMock]
-        );
+        $this->accessChangeQuoteControl = new AccessChangeQuoteControl($this->changeQuoteControlMock);
     }
 
-    /**
-     * User with role Customer and customer_id matches context user_id.
-     */
-    public function testBeforeSaveForCustomer()
+    public function testBeforeSaveForCustomerWithCustomerIdMatchinQuoteUserIdIsAllowed()
     {
         $this->quoteMock->method('getCustomerId')
             ->willReturn(1);
@@ -84,17 +78,12 @@ class AccessChangeQuoteControlTest extends TestCase
         $this->changeQuoteControlMock->method('isAllowed')
             ->willReturn(true);
 
-        $result = $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
-
-        $this->assertNull($result);
+        $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
     }
 
-    /**
-     * The user_id and customer_id from the quote are different.
-     */
-    public function testBeforeSaveException()
+    public function testBeforeSaveThrowsExceptionForCustomerWithCustomerIdNotMatchingQuoteUserId()
     {
-        $this->expectException('Magento\Framework\Exception\StateException');
+        $this->expectException(StateException::class);
         $this->expectExceptionMessage('Invalid state change requested');
         $this->quoteMock->method('getCustomerId')
             ->willReturn(2);
@@ -108,10 +97,7 @@ class AccessChangeQuoteControlTest extends TestCase
         $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
     }
 
-    /**
-     * User with role Admin and customer_id not much with user_id.
-     */
-    public function testBeforeSaveForAdmin()
+    public function testBeforeSaveForAdminUserRoleIsAllowed()
     {
         $this->quoteMock->method('getCustomerId')
             ->willReturn(2);
@@ -122,15 +108,10 @@ class AccessChangeQuoteControlTest extends TestCase
         $this->changeQuoteControlMock->method('isAllowed')
             ->willReturn(true);
 
-        $result = $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
-
-        $this->assertNull($result);
+        $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
     }
 
-    /**
-     * User with role Guest and customer_id === null.
-     */
-    public function testBeforeSaveForGuest()
+    public function testBeforeSaveForGuestIsAllowed()
     {
         $this->quoteMock->method('getCustomerId')
             ->willReturn(null);
@@ -141,17 +122,12 @@ class AccessChangeQuoteControlTest extends TestCase
         $this->changeQuoteControlMock->method('isAllowed')
             ->willReturn(true);
 
-        $result = $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
-
-        $this->assertNull($result);
+        $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
     }
 
-    /**
-     * User with role Guest and customer_id !== null.
-     */
-    public function testBeforeSaveForGuestException()
+    public function testBeforeSaveThrowsExceptionForGuestDoesNotEquals()
     {
-        $this->expectException('Magento\Framework\Exception\StateException');
+        $this->expectException(StateException::class);
         $this->expectExceptionMessage('Invalid state change requested');
         $this->quoteMock->method('getCustomerId')
             ->willReturn(1);
@@ -165,12 +141,9 @@ class AccessChangeQuoteControlTest extends TestCase
         $this->accessChangeQuoteControl->beforeSave($this->quoteRepositoryMock, $this->quoteMock);
     }
 
-    /**
-     * User with unknown role.
-     */
-    public function testBeforeSaveForUnknownUserTypeException()
+    public function testBeforeSaveThrowsExceptionForUnknownUserType()
     {
-        $this->expectException('Magento\Framework\Exception\StateException');
+        $this->expectException(StateException::class);
         $this->expectExceptionMessage('Invalid state change requested');
         $this->quoteMock->method('getCustomerId')
             ->willReturn(2);


### PR DESCRIPTION
### Description (*)
Improve the Unit Tests, adjust the plugin.
Introduced `: void` to return type of plugin, that does not require from us to make extra assertions in Unit Tests to the return type.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29672: Minor refactoring to AccessChangeQuoteControl and it's Unit Tests