### PR TITLE
Set all instances of cache context to be transient

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Flat.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Flat.php
@@ -115,7 +115,7 @@ class Flat implements \Magento\Framework\Indexer\ActionInterface, \Magento\Frame
     protected function getCacheContext()
     {
         if (!($this->cacheContext instanceof CacheContext)) {
-            return \Magento\Framework\App\ObjectManager::getInstance()->get(CacheContext::class);
+            return \Magento\Framework\App\ObjectManager::getInstance()->create(CacheContext::class);
         } else {
             return $this->cacheContext;
         }

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product.php
@@ -156,7 +156,7 @@ class Product implements \Magento\Framework\Indexer\ActionInterface, \Magento\Fr
     protected function getCacheContext()
     {
         if (!($this->cacheContext instanceof CacheContext)) {
-            return \Magento\Framework\App\ObjectManager::getInstance()->get(CacheContext::class);
+            return \Magento\Framework\App\ObjectManager::getInstance()->create(CacheContext::class);
         } else {
             return $this->cacheContext;
         }

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Rows.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Rows.php
@@ -69,7 +69,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
         IndexerRegistry $indexerRegistry = null
     ) {
         parent::__construct($resource, $storeManager, $config, $queryGenerator, $metadataPool);
-        $this->cacheContext = $cacheContext ?: ObjectManager::getInstance()->get(CacheContext::class);
+        $this->cacheContext = $cacheContext ?: ObjectManager::getInstance()->create(CacheContext::class);
         $this->eventManager = $eventManager ?: ObjectManager::getInstance()->get(EventManagerInterface::class);
         $this->indexerRegistry = $indexerRegistry ?: ObjectManager::getInstance()->get(IndexerRegistry::class);
     }

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Category/Action/Rows.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Category/Action/Rows.php
@@ -69,7 +69,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
         IndexerRegistry $indexerRegistry = null
     ) {
         parent::__construct($resource, $storeManager, $config, $queryGenerator, $metadataPool);
-        $this->cacheContext = $cacheContext ?: ObjectManager::getInstance()->get(CacheContext::class);
+        $this->cacheContext = $cacheContext ?: ObjectManager::getInstance()->create(CacheContext::class);
         $this->eventManager = $eventManager ?: ObjectManager::getInstance()->get(EventManagerInterface::class);
         $this->indexerRegistry = $indexerRegistry ?: ObjectManager::getInstance()->get(IndexerRegistry::class);
     }

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Eav.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Eav.php
@@ -103,7 +103,7 @@ class Eav implements \Magento\Framework\Indexer\ActionInterface, \Magento\Framew
     protected function getCacheContext()
     {
         if (!($this->cacheContext instanceof CacheContext)) {
-            return \Magento\Framework\App\ObjectManager::getInstance()->get(CacheContext::class);
+            return \Magento\Framework\App\ObjectManager::getInstance()->create(CacheContext::class);
         } else {
             return $this->cacheContext;
         }

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat.php
@@ -103,7 +103,7 @@ class Flat implements \Magento\Framework\Indexer\ActionInterface, \Magento\Frame
     protected function getCacheContext()
     {
         if (!($this->cacheContext instanceof CacheContext)) {
-            return \Magento\Framework\App\ObjectManager::getInstance()->get(CacheContext::class);
+            return \Magento\Framework\App\ObjectManager::getInstance()->create(CacheContext::class);
         } else {
             return $this->cacheContext;
         }

--- a/app/code/Magento/CatalogInventory/Model/Indexer/Stock.php
+++ b/app/code/Magento/CatalogInventory/Model/Indexer/Stock.php
@@ -106,7 +106,7 @@ class Stock implements \Magento\Framework\Indexer\ActionInterface, \Magento\Fram
     protected function getCacheContext()
     {
         if (!($this->cacheContext instanceof CacheContext)) {
-            return \Magento\Framework\App\ObjectManager::getInstance()->get(CacheContext::class);
+            return \Magento\Framework\App\ObjectManager::getInstance()->create(CacheContext::class);
         } else {
             return $this->cacheContext;
         }

--- a/app/code/Magento/CatalogRule/Model/Indexer/AbstractIndexer.php
+++ b/app/code/Magento/CatalogRule/Model/Indexer/AbstractIndexer.php
@@ -163,7 +163,7 @@ abstract class AbstractIndexer implements IndexerActionInterface, MviewActionInt
     protected function getCacheContext()
     {
         if (!($this->cacheContext instanceof CacheContext)) {
-            return \Magento\Framework\App\ObjectManager::getInstance()->get(CacheContext::class);
+            return \Magento\Framework\App\ObjectManager::getInstance()->create(CacheContext::class);
         } else {
             return $this->cacheContext;
         }

--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -1840,4 +1840,5 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\Indexer\CacheContext" shared="false" />
 </config>


### PR DESCRIPTION
### Description (*)
Cache context has no way to know which items have been cleaned. When an item is added to the context and then cleaned, this is not an issue. But as more items are added and cleaned, those earlier items are cleaned again and again. This results in an exponential performance drain. This PR seeks to remedy this by making all instances of cache context transient.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#29275

### Manual testing scenarios (*)
```php
$skus = [1000 product skus];
$products = [];
foreach ($skus as $sku) {
	$products[] = $this->productRepository->get($sku, true, 0, true);
}

foreach ($products as $product) {
	$product->setPrice(12);
	$this->productRepository->save($product);
}
```

Before applying these changes, put a debug in `\Magento\Indexer\Model\Indexer\CacheCleaner` looking at the value of `$identities` in `cleanCache()`. Watch the array grow with each product save, with the same identities being cleaned multiple times. Now apply the changes and see the `$identities` not grow.

### Questions or comments
Please give feedback. Thank you.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
