### PR TITLE
Fixed the wrong code style in return type declaration

### DIFF
--- a/app/code/Magento/Captcha/CustomerData/Captcha.php
+++ b/app/code/Magento/Captcha/CustomerData/Captcha.php
@@ -58,7 +58,7 @@ class Captcha extends DataObject implements SectionSourceInterface
     /**
      * @inheritdoc
      */
-    public function getSectionData() :array
+    public function getSectionData(): array
     {
         $data = [];
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This pull request (PR) fixes the wrong code style of the return type declaration

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29712: Fixed the wrong code style in return type declaration