### PR TITLE
Remove X-Frame-Options from pub/.htaccess

### DIFF
--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -225,9 +225,3 @@ ErrorDocument 403 /errors/404.php
             Require all denied
         </IfVersion>
     </Files>
-
-<IfModule mod_headers.c>
-    ############################################
-    ## Prevent clickjacking
-    Header set X-Frame-Options SAMEORIGIN
-</IfModule>


### PR DESCRIPTION
### Description (*)
+ Removed due to duplicate headers
+ Got removed from .htaccess in https://github.com/magento/magento2/commit/f831931213b8e55d275c17a76a21a4a53a671eeb#diff-8052c42ab3b8aa06a3f5f788a4ddccc2
+ Is being set by the app, configured in env.php https://devdocs.magento.com/guides/v2.4/config-guide/secy/secy-xframe.html#implement-x-frame-options

### Manual testing scenarios (*)
1. Configure X-Frame-Options in `env.php`
2. Run `curl -I -v --location-trusted '<your Magento storefront URL>'`
3. Search for `X-Frame-Options` 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29728: Remove X-Frame-Options from pub/.htaccess