### PR TITLE
Improved logic selecting for displaying bulk related status messages in the backend system messages area.

### DIFF
--- a/app/code/Magento/AsynchronousOperations/Test/Unit/Model/ResourceModel/System/Message/Collection/Synchronized/PluginTest.php
+++ b/app/code/Magento/AsynchronousOperations/Test/Unit/Model/ResourceModel/System/Message/Collection/Synchronized/PluginTest.php
@@ -134,6 +134,7 @@ class PluginTest extends TestCase
         $userBulks = [$bulkMock];
         $userId = 1;
         $bulkUuid = 2;
+        $ignoredBulkLimit = 5;
         $bulkArray = [
             'status' => BulkSummaryInterface::NOT_STARTED
         ];
@@ -154,11 +155,15 @@ class PluginTest extends TestCase
         $this->userContextMock->expects($this->once())->method('getUserId')->willReturn($userId);
         $this->bulkNotificationMock
             ->expects($this->once())
-            ->method('getAcknowledgedBulksByUser')
+            ->method('getIgnoredBulksByUser')
+            ->with($userId, $ignoredBulkLimit)
+            ->willReturn($userBulks);
+        $this->bulkNotificationMock
+            ->expects($this->once())
+            ->method('getIgnoredBulksCountByUser')
             ->with($userId)
-            ->willReturn([]);
+            ->willReturn(1);
         $this->statusMapper->expects($this->once())->method('operationStatusToBulkSummaryStatus');
-        $this->bulkStatusMock->expects($this->once())->method('getBulksByUser')->willReturn($userBulks);
         $result2 = $this->plugin->afterToArray($this->collectionMock, $result);
         $this->assertEquals(2, $result2['totalRecords']);
     }

--- a/dev/tests/integration/testsuite/Magento/AsynchronousOperations/Model/BulkNotificationManagementTest.php
+++ b/dev/tests/integration/testsuite/Magento/AsynchronousOperations/Model/BulkNotificationManagementTest.php
@@ -77,5 +77,17 @@ class BulkNotificationManagementTest extends \PHPUnit\Framework\TestCase
         // 'bulk-uuid-5' and 'bulk-uuid-4' are marked as acknowledged in fixture. Fixture creates 5 bulks in total.
         $ignoredBulks = $this->model->getIgnoredBulksByUser(1);
         $this->assertCount(3, $ignoredBulks);
+        $ignoredBulksWithLimit = $this->model->getIgnoredBulksByUser(1, 2);
+        $this->assertCount(2, $ignoredBulksWithLimit);
+    }
+
+    /**
+     * @magentoDataFixture Magento/AsynchronousOperations/_files/acknowledged_bulk.php
+     */
+    public function testGetIgnoredBulksCount()
+    {
+        // 'bulk-uuid-5' and 'bulk-uuid-4' are marked as acknowledged in fixture. Fixture creates 5 bulks in total.
+        $ignoredBulksCount = $this->model->getIgnoredBulksCountByUser(1);
+        $this->assertEquals(3, $ignoredBulksCount);
     }
 }


### PR DESCRIPTION
Improved logic selecting for displaying bulk related status messages in the backend system messages area.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This pull request modifies classes "Magento\AsynchronousOperations\Model\ResourceModel\System\Message\Collection\Synchronized\Plugin" and "Magento\AsynchronousOperations\Model\BulkNotificationManagement" to optimize process collecting bulks status messages for displaying in backend system messages area.
Origin code of Magento\AsynchronousOperations\Model\ResourceModel\System\Message\Collection\Synchronized\Plugin::afterToArray() (app/code/Magento/AsynchronousOperations/Model/ResourceModel/System/Message/Collection/Synchronized/Plugin.php:85) plugin's method does lot of redundant extra job:
- Firstly it fetches all user-related bulks
- Then it fetches only acknowledged bulks and collects related bulk ids (lines ).
 `$userBulks = $this->bulkStatus->getBulksByUser($userId);
   $acknowledgedBulks = $this->getAcknowledgedBulksUuid(
            $this->bulkNotificationManagement->getAcknowledgedBulksByUser($userId)
   );`
 - Then plugin iterates over all user-related bulks  and processes bulk messages only for not acknowleged bulks.
- After processing messages for all needed bulks plugin adds to $result['items'] array only 5 first messages:
`
  if (!empty($bulkMessages)) {
            $result['totalRecords'] += count($bulkMessages);
            $bulkMessages = array_slice($bulkMessages, 0, 5);
            $result['items'] = array_merge($bulkMessages, $result['items']);
  }
`
To optimize this process and reduce queries to the database for fetching bulk operation data was implemented next changes:

1. I added changes to the Magento\AsynchronousOperations\Model\BulkNotificationManagement class.
 - I added a new optional parameter to the "getIgnoredBulksByUser" method to allow limit returned bulks. I also moved logic preparing bulk items collection in the separate private method  "getIgnoredBulksCollectionByUser" (for further reusing this logic in another new method "getIgnoredBulksCountByUser" ).
- Created a new method "getIgnoredBulksCountByUser" which returns a total count of user bulks that were not acknowledged yet.
2. I modified Magento\AsynchronousOperations\Model\ResourceModel\System\Message\Collection\Synchronized\Plugin::afterToArray() method.
- Replaced logic fetching all user bulks and acknowledged bucks with fetching only "ignored bulks" limited to 5 items using BulkNotificationManagement::getIgnoredBulksByUser() method call with 2-nd "limit" argument.
- For calculating total qty of not acknowledged bulks (for updating $result['totalRecords']) used BulkNotificationManagement::getIgnoredBulksCountByUser() method call.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29730: Improved logic selecting for displaying bulk related status messages in the backend system messages area.