### PR TITLE
Add Regions for Uruguay.

### DIFF
--- a/app/code/Magento/Directory/Setup/Patch/Data/AddDataForUruguay.php
+++ b/app/code/Magento/Directory/Setup/Patch/Data/AddDataForUruguay.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Directory\Setup\Patch\Data;
+
+use Magento\Directory\Setup\DataInstaller;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+/**
+ * Class AddDataForUruguay
+ */
+class AddDataForUruguay implements DataPatchInterface
+{
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private $moduleDataSetup;
+
+    /**
+     * @var \Magento\Directory\Setup\DataInstallerFactory
+     */
+    private $dataInstallerFactory;
+
+    /**
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     * @param \Magento\Directory\Setup\DataInstallerFactory $dataInstallerFactory
+     */
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup,
+        \Magento\Directory\Setup\DataInstallerFactory $dataInstallerFactory
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+        $this->dataInstallerFactory = $dataInstallerFactory;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function apply()
+    {
+        /** @var DataInstaller $dataInstaller */
+        $dataInstaller = $this->dataInstallerFactory->create();
+        $dataInstaller->addCountryRegions(
+            $this->moduleDataSetup->getConnection(),
+            $this->getDataForUruguay()
+        );
+    }
+
+    /**
+     * Uruguay states data.
+     *
+     * @return array
+     */
+    private function getDataForUruguay()
+    {
+        return [
+            ['UY', 'UY-AR', 'Artigas'],
+            ['UY', 'UY-CA', 'Canelones'],
+            ['UY', 'UY-CL', 'Cerro Largo'],
+            ['UY', 'UY-CO', 'Colonia'],
+            ['UY', 'UY-DU', 'Durazno'],
+            ['UY', 'UY-FS', 'Flores'],
+            ['UY', 'UY-FD', 'Florida'],
+            ['UY', 'UY-LA', 'Lavalleja'],
+            ['UY', 'UY-MA', 'Maldonado'],
+            ['UY', 'UY-MO', 'Montevideo'],
+            ['UY', 'UY-PA', 'Paysandu'],
+            ['UY', 'UY-RN', 'Río Negro'],
+            ['UY', 'UY-RV', 'Rivera'],
+            ['UY', 'UY-RO', 'Rocha'],
+            ['UY', 'UY-SA', 'Salto'],
+            ['UY', 'UY-SJ', 'San José'],
+            ['UY', 'UY-SO', 'Soriano'],
+            ['UY', 'UY-TA', 'Tacuarembó'],
+            ['UY', 'UY-TT', 'Treinta y Tres']
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getDependencies()
+    {
+        return [
+            InitializeDirectoryData::class,
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+}

--- a/app/code/Magento/Directory/Setup/Patch/Data/AddDataForUruguay.php
+++ b/app/code/Magento/Directory/Setup/Patch/Data/AddDataForUruguay.php
@@ -3,7 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 declare(strict_types=1);
 
 namespace Magento\Directory\Setup\Patch\Data;
@@ -41,7 +40,7 @@ class AddDataForUruguay implements DataPatchInterface
     }
 
     /**
-     * @return $this|AddDataForUruguay
+     * @inheritdoc
      */
     public function apply()
     {
@@ -87,9 +86,8 @@ class AddDataForUruguay implements DataPatchInterface
 
     /**
      * @inheritdoc
-     * @return array
      */
-    public static function getDependencies(): array
+    public static function getDependencies()
     {
         return [
             InitializeDirectoryData::class,
@@ -98,9 +96,8 @@ class AddDataForUruguay implements DataPatchInterface
 
     /**
      * @inheritdoc
-     * @return array
      */
-    public function getAliases(): array
+    public function getAliases()
     {
         return [];
     }

--- a/app/code/Magento/Directory/Setup/Patch/Data/AddDataForUruguay.php
+++ b/app/code/Magento/Directory/Setup/Patch/Data/AddDataForUruguay.php
@@ -9,11 +9,12 @@ declare(strict_types=1);
 namespace Magento\Directory\Setup\Patch\Data;
 
 use Magento\Directory\Setup\DataInstaller;
+use Magento\Directory\Setup\DataInstallerFactory;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 
 /**
- * Class AddDataForUruguay
+ * Add Uruguay States/Regions
  */
 class AddDataForUruguay implements DataPatchInterface
 {
@@ -23,24 +24,24 @@ class AddDataForUruguay implements DataPatchInterface
     private $moduleDataSetup;
 
     /**
-     * @var \Magento\Directory\Setup\DataInstallerFactory
+     * @var DataInstallerFactory
      */
     private $dataInstallerFactory;
 
     /**
      * @param ModuleDataSetupInterface $moduleDataSetup
-     * @param \Magento\Directory\Setup\DataInstallerFactory $dataInstallerFactory
+     * @param DataInstallerFactory $dataInstallerFactory
      */
     public function __construct(
         ModuleDataSetupInterface $moduleDataSetup,
-        \Magento\Directory\Setup\DataInstallerFactory $dataInstallerFactory
+        DataInstallerFactory $dataInstallerFactory
     ) {
         $this->moduleDataSetup = $moduleDataSetup;
         $this->dataInstallerFactory = $dataInstallerFactory;
     }
 
     /**
-     * @inheritdoc
+     * @return $this|AddDataForUruguay
      */
     public function apply()
     {
@@ -50,6 +51,8 @@ class AddDataForUruguay implements DataPatchInterface
             $this->moduleDataSetup->getConnection(),
             $this->getDataForUruguay()
         );
+
+        return $this;
     }
 
     /**
@@ -57,7 +60,7 @@ class AddDataForUruguay implements DataPatchInterface
      *
      * @return array
      */
-    private function getDataForUruguay()
+    private function getDataForUruguay(): array
     {
         return [
             ['UY', 'UY-AR', 'Artigas'],
@@ -84,8 +87,9 @@ class AddDataForUruguay implements DataPatchInterface
 
     /**
      * @inheritdoc
+     * @return array
      */
-    public static function getDependencies()
+    public static function getDependencies(): array
     {
         return [
             InitializeDirectoryData::class,
@@ -94,8 +98,9 @@ class AddDataForUruguay implements DataPatchInterface
 
     /**
      * @inheritdoc
+     * @return array
      */
-    public function getAliases()
+    public function getAliases(): array
     {
         return [];
     }


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Regions for Uruguay will be added with this PR. Regions are using the ISO 3166-2 code (the regions table can be check here [https://en.wikipedia.org/wiki/ISO_3166-2:UY](https://en.wikipedia.org/wiki/ISO_3166-2:UY))


### Manual testing scenarios (*)
1. Once you finish the installation the country should show you Regions on shipping estimation, checkout or when you edit the customer address form.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29729: Add Regions for Uruguay.