### PR TITLE
MediaGalleryMetadata Skip segment reader if there is any kind of exception

### DIFF
--- a/app/code/Magento/MediaGalleryMetadata/Model/File/ExtractMetadata.php
+++ b/app/code/Magento/MediaGalleryMetadata/Model/File/ExtractMetadata.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace Magento\MediaGalleryMetadata\Model\File;
 
-use Magento\Framework\Exception\LocalizedException;
 use Magento\MediaGalleryMetadataApi\Api\Data\MetadataInterface;
 use Magento\MediaGalleryMetadataApi\Api\Data\MetadataInterfaceFactory;
 use Magento\MediaGalleryMetadataApi\Api\ExtractMetadataInterface;
@@ -90,7 +89,12 @@ class ExtractMetadata implements ExtractMetadataInterface
                 );
             }
 
-            $data = $segmentReader->execute($file);
+            try {
+                $data = $segmentReader->execute($file);
+            } catch (\Exception $exception) {
+                continue;
+            }
+
             $title = !empty($data->getTitle()) ? $data->getTitle() : $title;
             $description = !empty($data->getDescription()) ? $data->getDescription() : $description;
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1782: Exception from Metadata Reader can broke all readers

1. In php.ini disable exif extension
2. Install magento 2.4-develop

### Steps to reproduce (*)

1. Open new media gallery
2. Upload image with metadata dev/tests/acceptance/testsuite/_data/magento3.jpeg

Image metadata parsed and displayed in view details

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
