### PR TITLE
Remove area emulation from media-content:sync command

### DIFF
--- a/app/code/Magento/MediaContentSynchronization/Console/Command/Synchronize.php
+++ b/app/code/Magento/MediaContentSynchronization/Console/Command/Synchronize.php
@@ -7,8 +7,6 @@ declare(strict_types=1);
 
 namespace Magento\MediaContentSynchronization\Console\Command;
 
-use Magento\Framework\App\Area;
-use Magento\Framework\App\State;
 use Magento\Framework\Console\Cli;
 use Magento\MediaContentSynchronizationApi\Api\SynchronizeInterface;
 use Symfony\Component\Console\Command\Command;
@@ -26,20 +24,12 @@ class Synchronize extends Command
     private $synchronizeContent;
 
     /**
-     * @var State $state
-     */
-    private $state;
-
-    /**
      * @param SynchronizeInterface $synchronizeContent
-     * @param State $state
      */
     public function __construct(
-        SynchronizeInterface $synchronizeContent,
-        State $state
+        SynchronizeInterface $synchronizeContent
     ) {
         $this->synchronizeContent = $synchronizeContent;
-        $this->state = $state;
         parent::__construct();
     }
 
@@ -58,12 +48,7 @@ class Synchronize extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('Synchronizing content with assets...');
-        $this->state->emulateAreaCode(
-            Area::AREA_ADMINHTML,
-            function () {
-                $this->synchronizeContent->execute();
-            }
-        );
+        $this->synchronizeContent->execute();
         $output->writeln('Completed content synchronization.');
         return Cli::RETURN_SUCCESS;
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR Removes area emulation from `\Magento\MediaContentSynchronization\Console\Command\Synchronize::execute`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/adobe-stock-integration#1784: Remove area emulation from media-content:sync command

### Testing
1. Add some images from media gallery to the content of category, product, page and block
2. Clear `media_content_asset` database table
3. Run `media-content:sync` command
4. Verify all Used In links are correctly displayed in the asset details

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
