### PR TITLE
Fix code breaking comma in array_merge_recursive

### DIFF
--- a/setup/src/Magento/Setup/Module.php
+++ b/setup/src/Magento/Setup/Module.php
@@ -78,7 +78,7 @@ class Module implements
             include __DIR__ . '/../../../config/router.config.php',
             include __DIR__ . '/../../../config/di.config.php',
             include __DIR__ . '/../../../config/states.install.config.php',
-            include __DIR__ . '/../../../config/languages.config.php',
+            include __DIR__ . '/../../../config/languages.config.php'
         );
         // phpcs:enable
         return $result;


### PR DESCRIPTION
The unnecessary comma caused an error message when the cache status was read (php ./bin/magento cache:status).

The error message: "Parse error: syntax error, unexpected ')' in ./setup/src/Magento/Setup/Module.php on line 82"

After removal of the comma, all code relating to this class kept working as intended.

### Resolved issues:
1. [x] resolves magento/magento2#29756: Fix code breaking comma in array_merge_recursive