### PR TITLE
Fix issue product name in minicart render wrong with special characters

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_sidebar_item_renderers.xml
+++ b/app/code/Magento/Checkout/view/frontend/layout/checkout_cart_sidebar_item_renderers.xml
@@ -21,7 +21,7 @@
                             </item>
                             <item name="children" xsi:type="array">
                                 <item name="item.renderer" xsi:type="array">
-                                    <item name="component" xsi:type="string">uiComponent</item>
+                                    <item name="component" xsi:type="string">Magento_Checkout/js/view/cart-item-renderer</item>
                                     <item name="config" xsi:type="array">
                                         <item name="displayArea" xsi:type="string">defaultRenderer</item>
                                         <item name="template" xsi:type="string">Magento_Checkout/minicart/item/default</item>

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/cart-item-renderer.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/cart-item-renderer.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define([
+    'uiComponent'
+], function (Component) {
+    'use strict';
+
+    return Component.extend({
+        /**
+         * Prepare the product name value to be rendered as HTML
+         *
+         * @param {String} productName
+         * @return {String}
+         */
+        getProductNameUnsanitizedHtml: function (productName) {
+            // product name has already escaped on backend
+            return productName;
+        },
+
+        /**
+         * Prepare the given option value to be rendered as HTML
+         *
+         * @param {String} optionValue
+         * @return {String}
+         */
+        getOptionValueUnsanitizedHtml: function (optionValue) {
+            // option value has already escaped on backend
+            return optionValue;
+        }
+    });
+});

--- a/app/code/Magento/Checkout/view/frontend/web/template/minicart/item/default.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/minicart/item/default.html
@@ -24,10 +24,10 @@
         <div class="product-item-details">
             <strong class="product-item-name">
                 <!-- ko if: product_has_url -->
-                <a data-bind="attr: {href: product_url}, html: product_name"></a>
+                <a data-bind="attr: {href: product_url}, html: $parent.getProductNameUnsanitizedHtml(product_name)"></a>
                 <!-- /ko -->
                 <!-- ko ifnot: product_has_url -->
-                    <!-- ko text: product_name --><!-- /ko -->
+                    <span data-bind="html: $parent.getProductNameUnsanitizedHtml(product_name)"></span>
                 <!-- /ko -->
             </strong>
 
@@ -42,10 +42,10 @@
                         <dt class="label"><!-- ko text: option.label --><!-- /ko --></dt>
                         <dd class="values">
                             <!-- ko if: Array.isArray(option.value) -->
-                                <span data-bind="html: option.value.join('<br>')"></span>
+                                <span data-bind="html: $parents[1].getOptionValueUnsanitizedHtml(option.value.join('<br/>'))"></span>
                             <!-- /ko -->
                             <!-- ko if: (!Array.isArray(option.value) && ['file', 'html'].includes(option.option_type)) -->
-                                <span data-bind="html: option.value"></span>
+                                <span data-bind="html: $parents[1].getOptionValueUnsanitizedHtml(option.value)"></span>
                             <!-- /ko -->
                             <!-- ko if: (!Array.isArray(option.value) && !['file', 'html'].includes(option.option_type)) -->
                             <span data-bind="text: option.value"></span>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
With product has url magento render name without problem. But in the case product without url will render product name in cart incorrectly. Ex: product with special characters like double quotes
This fix will cover the case products don't have url and render name correctly


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#29075

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. From backend admin create new product with name contain special character such as double quote, &, -, /
2. Clear cache go to frontend view new product

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
I have one question need clarify about knockout 
In template inside foreach loop when use $parent for reference to component i can't call to method that i have defined But if i used $parents[1] its work to call method! Any reason behind this ? i don't see any doc mention in magento official devdocs
Is that knockout context changed inside loop foreach ?
CC: @ihor-sviziev @omiroshnichenko @guz-anton

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
