### PR TITLE
Add exception to log context in Ui\TemplateEngine

### DIFF
--- a/app/code/Magento/Ui/TemplateEngine/Xhtml/Result.php
+++ b/app/code/Magento/Ui/TemplateEngine/Xhtml/Result.php
@@ -124,7 +124,10 @@ class Result implements ResultInterface
             $this->appendLayoutConfiguration();
             $result = $this->compiler->postprocessing($this->template->__toString());
         } catch (\Throwable $e) {
-            $this->logger->critical($e);
+            $this->logger->critical("Error while rendering template: {message}", [
+                "exception" => $e,
+                "message" => $e->getMessage()
+            ]);
             $result = $e->getMessage();
             if ($this->state->getMode() === State::MODE_DEVELOPER) {
                 $result .= "<pre><code>Exception in {$e->getFile()}:{$e->getLine()}</code></pre>";


### PR DESCRIPTION
### Description (*)
This pull request adds the exception to the context array in the log message when template rendering fails. Especially useful when working with UI components, which seem to throw errors left and right. 😉 

### Manual testing scenarios (*)
Throw an exception in a data provider, and watch the logs

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#29874: Add exception to log context in Ui\TemplateEngine