### PR TITLE
Fixed Unable to apply data patch issue after upgrade in 2.4 #29365

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Setup/Patch/Data/UpdateUrlKeyForProducts.php
+++ b/app/code/Magento/CatalogUrlRewrite/Setup/Patch/Data/UpdateUrlKeyForProducts.php
@@ -35,18 +35,26 @@ class UpdateUrlKeyForProducts implements DataPatchInterface, PatchVersionInterfa
     private $urlProduct;
 
     /**
+     * @var \Magento\Framework\EntityManager\MetadataPool
+     */
+    private $metadataPool;
+
+    /**
      * @param ModuleDataSetupInterface $moduleDataSetup
      * @param EavSetupFactory $eavSetupFactory
      * @param Url $urlProduct
+     * @param \Magento\Framework\EntityManager\MetadataPool $metadataPool
      */
     public function __construct(
         ModuleDataSetupInterface $moduleDataSetup,
         EavSetupFactory $eavSetupFactory,
-        Url $urlProduct
+        Url $urlProduct,
+        \Magento\Framework\EntityManager\MetadataPool $metadataPool
     ) {
         $this->moduleDataSetup = $moduleDataSetup;
         $this->eavSetup = $eavSetupFactory->create(['setup' => $moduleDataSetup]);
         $this->urlProduct = $urlProduct;
+        $this->metadataPool = $metadataPool;
     }
 
     /**
@@ -58,7 +66,7 @@ class UpdateUrlKeyForProducts implements DataPatchInterface, PatchVersionInterfa
         $table = $this->moduleDataSetup->getTable('catalog_product_entity_varchar');
         $select = $this->moduleDataSetup->getConnection()->select()->from(
             $table,
-            ['entity_id', 'attribute_id', 'store_id', 'value_id', 'value']
+            [$this->getProductLinkField(), 'attribute_id', 'store_id', 'value_id', 'value']
         )->where(
             'attribute_id = ?',
             $this->eavSetup->getAttributeId($productTypeId, 'url_key')
@@ -98,5 +106,18 @@ class UpdateUrlKeyForProducts implements DataPatchInterface, PatchVersionInterfa
     public function getAliases()
     {
         return [];
+    }
+
+    /**
+     * Return product id field name - entity_id|row_id
+     *
+     * @return string
+     * @throws \Exception
+     */
+    private function getProductLinkField()
+    {
+        return $this->metadataPool
+            ->getMetadata(\Magento\Catalog\Api\Data\ProductInterface::class)
+            ->getLinkField();
     }
 }

--- a/app/code/Magento/CatalogUrlRewrite/Setup/Patch/Data/UpdateUrlKeyForProducts.php
+++ b/app/code/Magento/CatalogUrlRewrite/Setup/Patch/Data/UpdateUrlKeyForProducts.php
@@ -58,7 +58,7 @@ class UpdateUrlKeyForProducts implements DataPatchInterface, PatchVersionInterfa
         $table = $this->moduleDataSetup->getTable('catalog_product_entity_varchar');
         $select = $this->moduleDataSetup->getConnection()->select()->from(
             $table,
-            ['value_id', 'value']
+            ['entity_id', 'attribute_id', 'store_id', 'value_id', 'value']
         )->where(
             'attribute_id = ?',
             $this->eavSetup->getAttributeId($productTypeId, 'url_key')


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixed Unable to apply data patch issue #29365
### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#29365
2. Fixes https://github.com/magento/magento2/issues/29805

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Composer upgrade from 2.3.5-p1 to 2.4.0
2. php bin/magento setup:upgrade

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
