### PR TITLE
[WIP] #1770: Preview is not expanded on applying bookmark if the same rowIndex preview was expanded

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/image-preview.js
@@ -18,13 +18,15 @@ define([
             height: 0,
             displayedRecord: {},
             lastOpenedImage: false,
+            bookmarksProvider: 'componentType = bookmark, ns = ${ $.ns }',
             fields: {
                 previewUrl: 'preview_url',
                 title: 'title'
             },
             modules: {
                 masonry: '${ $.parentName }',
-                thumbnailComponent: '${ $.parentName }.thumbnail_url'
+                thumbnailComponent: '${ $.parentName }.thumbnail_url',
+                bookmarks: '${ $.bookmarksProvider }'
             },
             statefull: {
                 sorting: true,
@@ -34,7 +36,11 @@ define([
                 '${ $.provider }:params.filters': 'hide',
                 '${ $.provider }:params.search': 'hide',
                 '${ $.provider }:params.paging': 'hide',
+                '${ $.bookmarksProvider }:activeIndex': 'hide',
                 '${ $.provider }:data.items': 'updateDisplayedRecord'
+            },
+            imports: {
+                current: '${ $.provider }:params.paging.current'
             },
             exports: {
                 height: '${ $.parentName }.thumbnail_url:previewHeight'
@@ -207,6 +213,16 @@ define([
          * Close image preview
          */
         hide: function () {
+            var bookmarksLastOpenedImage = this.bookmarks().getActiveView().data.columns.preview.lastOpenedImage,
+                bookmarksActiveViewIndex = this.bookmarks().getActiveView().index,
+                bookmarksActiveViewCurrentPage = this.bookmarks().getActiveView().data.paging.current,
+                currentPage = this.current;
+            if (bookmarksLastOpenedImage && bookmarksActiveViewIndex !== 'default'
+                && bookmarksActiveViewCurrentPage === currentPage) {
+                this.lastOpenedImage(bookmarksLastOpenedImage);
+                return;
+            }
+
             this.lastOpenedImage(false);
             this.visibleRecord(null);
             this.height(0);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR will introduce the fix to preview not expanded when applying bookmark if the same row index preview is expanded.
### Related Pull Requests
<!-- related pull request placeholder -->
1. https://github.com/magento/adobe-stock-integration/pull/1842
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes https://github.com/magento/adobe-stock-integration/issues/1770

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
