### PR TITLE
Remove wrong tags in AdminNotification module

### DIFF
--- a/app/code/Magento/AdminNotification/Block/ToolbarEntry.php
+++ b/app/code/Magento/AdminNotification/Block/ToolbarEntry.php
@@ -10,7 +10,6 @@ namespace Magento\AdminNotification\Block;
  * Toolbar entry that shows latest notifications
  *
  * @api
- * @author      Magento Core Team <core@magentocommerce.com>
  * @since 100.0.2
  */
 class ToolbarEntry extends \Magento\Backend\Block\Template

--- a/app/code/Magento/AdminNotification/Model/Feed.php
+++ b/app/code/Magento/AdminNotification/Model/Feed.php
@@ -12,7 +12,6 @@ use Magento\Framework\Config\ConfigOptionsListConstants;
 /**
  * AdminNotification Feed model
  *
- * @author      Magento Core Team <core@magentocommerce.com>
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @api
  * @since 100.0.2

--- a/app/code/Magento/AdminNotification/Model/InboxInterface.php
+++ b/app/code/Magento/AdminNotification/Model/InboxInterface.php
@@ -8,7 +8,6 @@ namespace Magento\AdminNotification\Model;
 /**
  * AdminNotification Inbox interface
  *
- * @author Magento Core Team <core@magentocommerce.com>
  * @api
  * @since 100.0.2
  */

--- a/app/code/Magento/AdminNotification/Model/NotificationService.php
+++ b/app/code/Magento/AdminNotification/Model/NotificationService.php
@@ -8,7 +8,6 @@ namespace Magento\AdminNotification\Model;
 /**
  * Notification service model
  *
- * @author      Magento Core Team <core@magentocommerce.com>
  * @api
  * @since 100.0.2
  */

--- a/app/code/Magento/AdminNotification/Model/ResourceModel/Grid/Collection.php
+++ b/app/code/Magento/AdminNotification/Model/ResourceModel/Grid/Collection.php
@@ -6,8 +6,6 @@
 
 /**
  * AdminNotification Inbox model
- *
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 namespace Magento\AdminNotification\Model\ResourceModel\Grid;
 

--- a/app/code/Magento/AdminNotification/Model/ResourceModel/Inbox/Collection.php
+++ b/app/code/Magento/AdminNotification/Model/ResourceModel/Inbox/Collection.php
@@ -9,8 +9,6 @@ namespace Magento\AdminNotification\Model\ResourceModel\Inbox;
  * AdminNotification Inbox model
  *
  * @api
- * @author      Magento Core Team <core@magentocommerce.com>
- * @api
  * @since 100.0.2
  */
 class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection

--- a/app/code/Magento/AdminNotification/Model/ResourceModel/Inbox/Collection/Unread.php
+++ b/app/code/Magento/AdminNotification/Model/ResourceModel/Inbox/Collection/Unread.php
@@ -6,8 +6,6 @@
 
 /**
  * Collection of unread notifications
- *
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 namespace Magento\AdminNotification\Model\ResourceModel\Inbox\Collection;
 

--- a/app/code/Magento/AdminNotification/Observer/PredispatchAdminActionControllerObserver.php
+++ b/app/code/Magento/AdminNotification/Observer/PredispatchAdminActionControllerObserver.php
@@ -9,8 +9,6 @@ use Magento\Framework\Event\ObserverInterface;
 
 /**
  * AdminNotification observer
- *
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 class PredispatchAdminActionControllerObserver implements ObserverInterface
 {


### PR DESCRIPTION
This PR removes wrong tags in `AdminNotification` module
<pre>
Structure of documentation space
@author ,@category, @package, and @subpackage MUST NOT be used. Documentation is organized with the use of namespaces.
</pre>
Regarding https://devdocs.magento.com/guides/v2.4/coding-standards/docblock-standard-general.html#documentation-space