### PR TITLE
Remove wrong tags in AdvancedPricingImportExport module

### DIFF
--- a/app/code/Magento/AdvancedPricingImportExport/Model/Export/AdvancedPricing.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Export/AdvancedPricing.php
@@ -14,7 +14,6 @@ use Magento\Store\Model\Store;
 /**
  * Export Advanced Pricing
  *
- * @author      Magento Core Team <core@magentocommerce.com>
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)


### PR DESCRIPTION
This PR removes wrong tag in `AdvancedPricingImportExport` module
<pre>
Structure of documentation space
@author ,@category, @package, and @subpackage MUST NOT be used. Documentation is organized with the use of namespaces.
</pre>
Regarding https://devdocs.magento.com/guides/v2.4/coding-standards/docblock-standard-general.html#documentation-space