### PR TITLE
Fix #29879 Breadcrump Undefined class constant 'XML_PATH_CATEGORY_URL_SUFFIX'

### DIFF
--- a/app/code/Magento/Catalog/ViewModel/Product/Breadcrumbs.php
+++ b/app/code/Magento/Catalog/ViewModel/Product/Breadcrumbs.php
@@ -71,7 +71,7 @@ class Breadcrumbs extends DataObject implements ArgumentInterface
     public function getCategoryUrlSuffix()
     {
         return $this->scopeConfig->getValue(
-            static::XML_PATH_CATEGORY_URL_SUFFIX,
+            self::XML_PATH_CATEGORY_URL_SUFFIX,
             ScopeInterface::SCOPE_STORE
         );
     }
@@ -84,7 +84,7 @@ class Breadcrumbs extends DataObject implements ArgumentInterface
     public function isCategoryUsedInProductUrl(): bool
     {
         return $this->scopeConfig->isSetFlag(
-            static::XML_PATH_PRODUCT_USE_CATEGORIES,
+            self::XML_PATH_PRODUCT_USE_CATEGORIES,
             ScopeInterface::SCOPE_STORE
         );
     }


### PR DESCRIPTION
When creating a plugin, that is calling the public functions for the
product breadcrump they ending up throwing an error message, because
this constants has been marked as private recently.

This is fixing it with referencing to the current instance and all is
working again. This fix is analog to another bug of the same type:

https://github.com/magento/magento2/issues/28981
https://github.com/magento/magento2/pull/28797

This should resolve:
Resolves https://github.com/magento/magento2/issues/29879
