### PR TITLE
#1801: User is not scrolled up to the "Login failed. Please check if the Secret Key..." error, and can miss the message

### DIFF
--- a/app/code/Magento/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image.js
+++ b/app/code/Magento/MediaGalleryUi/view/adminhtml/web/js/grid/columns/image.js
@@ -13,6 +13,8 @@ define([
     return Column.extend({
         defaults: {
             bodyTmpl: 'Magento_MediaGalleryUi/grid/columns/image',
+            messageContentSelector: 'ul.messages',
+            mediaGalleryContainerSelector: '.media-gallery-container',
             deleteImageUrl: 'media_gallery/image/delete',
             addSelectedBtnSelector: '#add_selected',
             deleteSelectedBtnSelector: '#delete_selected',
@@ -270,6 +272,7 @@ define([
          */
         addMessage: function (code, message) {
             this.messages().add(code, message);
+            this.scrollToMessageContent();
             this.messages().scheduleCleanup();
         },
 
@@ -284,6 +287,20 @@ define([
                 !this.massaction().massActionMode()) {
                 this.deselectImage();
             }
+        },
+
+        /**
+         * Scroll to the top of media gallery page
+         */
+        scrollToMessageContent: function () {
+            var scrollTargetElement = $(this.messageContentSelector),
+                scrollTargetContainer = $(this.mediaGalleryContainerSelector);
+
+            scrollTargetContainer.find(scrollTargetElement).get(0).scrollIntoView({
+                behavior: 'smooth',
+                block: 'center',
+                inline: 'nearest'
+            });
         }
     });
 });


### PR DESCRIPTION
### Description (*)
Added a modification to scroll to the top of the modal to show the error message after unsuccessful licensing from Media Gallery

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/adobe-stock-integration/issues/1801

### Manual testing scenarios (*)
**Preconditions**
1. Install Magento with Adobe Stock Integration
2. Configured integration in Stores -> Configuration -> Advanced-> System -> Adobe Stock Integration fieldset
3. Old Media Gallery enabled in Stores -> Configuration -> Advanced-> System -> Media Gallery -> Enable Old Media Gallery - No
4. Provided _API Key (Client ID)_ . **Not** provided _Client Secret_
5. Multiple images saved to Media Gallery, (four rows of images in my case)
6. Unlicensed image preview saved to Media Gallery being at the bottom of images

**Testing Steps**
1. Go to **Content - Media Gallery**, click **Search Adobe Stock**
2. Scroll to the bottom of the page
3. Select the previously saved Unlicensed image
4. Click "three dots" and select **License**

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)