### PR TITLE
Directory and filename must be no more than 255 characters in length

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Uploader.php
@@ -112,6 +112,11 @@ class Uploader extends \Magento\MediaStorage\Model\File\Uploader
     private $fileSystem;
 
     /**
+     * Directory and filename must be no more than 255 characters in length
+     */
+    private $maxFilenameLength = 255;
+
+    /**
      * @param \Magento\MediaStorage\Helper\File\Storage\Database $coreFileStorageDb
      * @param \Magento\MediaStorage\Helper\File\Storage $coreFileStorage
      * @param \Magento\Framework\Image\AdapterFactory $imageFactory
@@ -187,6 +192,13 @@ class Uploader extends \Magento\MediaStorage\Model\File\Uploader
         $result = $this->save($destDir);
         unset($result['path']);
         $result['name'] = self::getCorrectFileName($result['name']);
+
+        // Directory and filename must be no more than 255 characters in length
+        if (strlen($result['file']) > $this->maxFilenameLength) {
+            throw new \LengthException(
+                __('Filename is too long; must be %1 characters or less', $this->maxFilenameLength)
+            );
+        }
 
         return $result;
     }

--- a/lib/internal/Magento/Framework/File/Test/Unit/UploaderTest.php
+++ b/lib/internal/Magento/Framework/File/Test/Unit/UploaderTest.php
@@ -26,7 +26,7 @@ class UploaderTest extends TestCase
         $isExceptionExpected = $expectedCorrectedFileName === true;
 
         if ($isExceptionExpected) {
-            $this->expectException(\InvalidArgumentException::class);
+            $this->expectException(\LengthException::class);
         }
 
         $this->assertEquals(
@@ -62,7 +62,7 @@ class UploaderTest extends TestCase
                 'a.' . str_repeat('b', 88)
             ],
             [
-                'a.' . str_repeat('b', 89),
+                'a.' . str_repeat('b', 199), // 201 characters
                 true
             ]
         ];

--- a/lib/internal/Magento/Framework/File/Uploader.php
+++ b/lib/internal/Magento/Framework/File/Uploader.php
@@ -407,8 +407,12 @@ class Uploader
         $fileInfo['extension'] = $fileInfo['extension'] ?? '';
 
         // account for excessively long filenames that cannot be stored completely in database
-        if (strlen($fileInfo['basename']) > 90) {
-            throw new \InvalidArgumentException('Filename is too long; must be 90 characters or less');
+        $maxFilenameLength = 200;
+
+        if (strlen($fileInfo['basename']) > $maxFilenameLength) {
+            throw new \LengthException(
+                __('Filename is too long; must be %1 characters or less', $maxFilenameLength)
+            );
         }
 
         if (preg_match('/^_+$/', $fileInfo['filename'])) {


### PR DESCRIPTION
### Description (*)
According to https://en.wikipedia.org/wiki/Comparison_of_file_systems , I know that wikipedia isn't the best reference to find things related, but most of operation systems the maximum filename length is 255 characters.

https://www.ibm.com/support/knowledgecenter/SSEQVQ_8.1.9/client/c_cmd_filespecsyntax.html 

On this documentation above says:

- On AIX, Solaris, and Mac: The maximum number of characters for a file name is 255.
- On Linux: The maximum length for a file name is 255 bytes.
- The maximum number of bytes for a file name and file path when combined is 6255. However, the file name itself cannot exceed 255 bytes

https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-shares--directories--files--and-metadata

On this documentation above from azure says:

Directory and file component names must be no more than 255 characters in length.

So, the path + filename cannot exceed 255 characters in length.

The current logic is incorrect because it's checking only the basename (filename), not the entire path (directory + filename).

So, I created a pull request fixing it:

### Related Pull Requests

N/A

### Fixed Issues

Fixes #29377 

### Manual testing scenarios (*)

Upload a file where filename is 255 characters length an exception will be thrown.

### Questions or comments

N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
