### PR TITLE
Fix > Klarna configure button disabled in admin

### DIFF
--- a/app/code/Magento/Paypal/view/adminhtml/web/js/solutions.js
+++ b/app/code/Magento/Paypal/view/adminhtml/web/js/solutions.js
@@ -26,7 +26,7 @@ define([
             /**
              * The selector element responsible for configuration of payment method (CSS class)
              */
-            buttonConfiguration: '.button.action-configure'
+            buttonConfiguration: 'div[class*="paypal"] .button.action-configure'
         },
 
         /**


### PR DESCRIPTION
### Description (*)

Fix > Klarna configure button disabled in admin


### Fixed Issues (if relevant)

Fixes #29421 

### Manual testing scenarios (*)

1. Access magento admin/backend
2. Authenticate/log in
3. Go to : Stotes > Settings > Configuration
4. Click on left sidebar > Sales > Payment Methods
5. Klarna configure button is enabled

### Questions or comments

N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
