### PR TITLE
Fix URL generation for new store when it created with setup:config:import

### DIFF
--- a/app/code/Magento/Deploy/Console/Command/App/ConfigImportCommand.php
+++ b/app/code/Magento/Deploy/Console/Command/App/ConfigImportCommand.php
@@ -3,14 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Deploy\Console\Command\App;
 
+use Magento\Config\Console\Command\EmulatedAdminhtmlAreaProcessor;
+use Magento\Deploy\Console\Command\App\ConfigImport\Processor;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\AreaList;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Console\Cli;
+use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Exception\RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Magento\Framework\Console\Cli;
-use Magento\Deploy\Console\Command\App\ConfigImport\Processor;
 
 /**
  * Runs the process of importing configuration data from shared source to appropriate application sources
@@ -21,9 +28,6 @@ use Magento\Deploy\Console\Command\App\ConfigImport\Processor;
  */
 class ConfigImportCommand extends Command
 {
-    /**
-     * Command name.
-     */
     const COMMAND_NAME = 'app:config:import';
 
     /**
@@ -34,11 +38,39 @@ class ConfigImportCommand extends Command
     private $processor;
 
     /**
-     * @param Processor $processor the configuration importer
+     * @var EmulatedAdminhtmlAreaProcessor
      */
-    public function __construct(Processor $processor)
-    {
+    private $adminhtmlAreaProcessor;
+
+    /**
+     * @var DeploymentConfig
+     */
+    private $deploymentConfig;
+
+    /**
+     * @var AreaList
+     */
+    private $areaList;
+
+    /**
+     * @param Processor $processor the configuration importer
+     * @param DeploymentConfig|null $deploymentConfig
+     * @param EmulatedAdminhtmlAreaProcessor|null $adminhtmlAreaProcessor
+     * @param AreaList|null $areaList
+     */
+    public function __construct(
+        Processor $processor,
+        DeploymentConfig $deploymentConfig = null,
+        EmulatedAdminhtmlAreaProcessor $adminhtmlAreaProcessor = null,
+        AreaList $areaList = null
+    ) {
         $this->processor = $processor;
+        $this->deploymentConfig = $deploymentConfig
+            ?? ObjectManager::getInstance()->get(DeploymentConfig::class);
+        $this->adminhtmlAreaProcessor = $adminhtmlAreaProcessor
+            ?? ObjectManager::getInstance()->get(EmulatedAdminhtmlAreaProcessor::class);
+        $this->areaList = $areaList
+            ?? ObjectManager::getInstance()->get(AreaList::class);
 
         parent::__construct();
     }
@@ -55,12 +87,26 @@ class ConfigImportCommand extends Command
     }
 
     /**
-     * Imports data from deployment configuration files to the DB. {@inheritdoc}
+     * Imports data from deployment configuration files to the DB.
+     * {@inheritdoc}
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     * @throws \Exception
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         try {
-            $this->processor->execute($input, $output);
+            if ($this->canEmulateAdminhtmlArea()) {
+                // Emulate adminhtml area in order to execute all needed plugins declared only for this area
+                // For instance URL rewrite generation during creating store view
+                $this->adminhtmlAreaProcessor->process(function () use ($input, $output) {
+                    $this->processor->execute($input, $output);
+                });
+            } else {
+                $this->processor->execute($input, $output);
+            }
         } catch (RuntimeException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');
 
@@ -68,5 +114,20 @@ class ConfigImportCommand extends Command
         }
 
         return Cli::RETURN_SUCCESS;
+    }
+
+    /**
+     * Detects if we can emulate adminhtml area
+     *
+     * This area could be not available for instance during setup:install
+     *
+     * @return bool
+     * @throws RuntimeException
+     * @throws FileSystemException
+     */
+    private function canEmulateAdminhtmlArea(): bool
+    {
+        return $this->deploymentConfig->isAvailable()
+            && in_array(Area::AREA_ADMINHTML, $this->areaList->getCodes());
     }
 }

--- a/app/code/Magento/Deploy/Test/Unit/Console/Command/App/ConfigImportCommandTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Console/Command/App/ConfigImportCommandTest.php
@@ -7,8 +7,11 @@ declare(strict_types=1);
 
 namespace Magento\Deploy\Test\Unit\Console\Command\App;
 
+use Magento\Config\Console\Command\EmulatedAdminhtmlAreaProcessor;
 use Magento\Deploy\Console\Command\App\ConfigImport\Processor;
 use Magento\Deploy\Console\Command\App\ConfigImportCommand;
+use Magento\Framework\App\AreaList;
+use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Console\Cli;
 use Magento\Framework\Exception\RuntimeException;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -28,15 +31,36 @@ class ConfigImportCommandTest extends TestCase
     private $commandTester;
 
     /**
+     * @var DeploymentConfig|MockObject
+     */
+    private $deploymentConfigMock;
+
+    /**
+     * @var EmulatedAdminhtmlAreaProcessor|MockObject
+     */
+    private $adminhtmlAreaProcessorMock;
+
+    /**
+     * @var AreaList|MockObject
+     */
+    private $areaListMock;
+
+    /**
      * @return void
      */
     protected function setUp(): void
     {
-        $this->processorMock = $this->getMockBuilder(Processor::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->processorMock = $this->createMock(Processor::class);
+        $this->deploymentConfigMock = $this->createMock(DeploymentConfig::class);
+        $this->adminhtmlAreaProcessorMock = $this->createMock(EmulatedAdminhtmlAreaProcessor::class);
+        $this->areaListMock = $this->createMock(AreaList::class);
 
-        $configImportCommand = new ConfigImportCommand($this->processorMock);
+        $configImportCommand = new ConfigImportCommand(
+            $this->processorMock,
+            $this->deploymentConfigMock,
+            $this->adminhtmlAreaProcessorMock,
+            $this->areaListMock
+        );
 
         $this->commandTester = new CommandTester($configImportCommand);
     }
@@ -46,6 +70,13 @@ class ConfigImportCommandTest extends TestCase
      */
     public function testExecute()
     {
+        $this->deploymentConfigMock->expects($this->once())->method('isAvailable')->willReturn(true);
+        $this->adminhtmlAreaProcessorMock->expects($this->once())
+            ->method('process')->willReturnCallback(function (callable $callback, array $params = []) {
+                return $callback(...$params);
+            });
+        $this->areaListMock->expects($this->once())->method('getCodes')->willReturn(['adminhtml']);
+
         $this->processorMock->expects($this->once())
             ->method('execute');
 
@@ -57,11 +88,48 @@ class ConfigImportCommandTest extends TestCase
      */
     public function testExecuteWithException()
     {
+        $this->deploymentConfigMock->expects($this->once())->method('isAvailable')->willReturn(true);
+        $this->adminhtmlAreaProcessorMock->expects($this->once())
+            ->method('process')->willReturnCallback(function (callable $callback, array $params = []) {
+                return $callback(...$params);
+            });
+        $this->areaListMock->expects($this->once())->method('getCodes')->willReturn(['adminhtml']);
+
         $this->processorMock->expects($this->once())
             ->method('execute')
             ->willThrowException(new RuntimeException(__('Some error')));
 
         $this->assertSame(Cli::RETURN_FAILURE, $this->commandTester->execute([]));
         $this->assertStringContainsString('Some error', $this->commandTester->getDisplay());
+    }
+
+    /**
+     * @return void
+     */
+    public function testExecuteWithDeploymentConfigNotAvailable()
+    {
+        $this->deploymentConfigMock->expects($this->once())->method('isAvailable')->willReturn(false);
+        $this->adminhtmlAreaProcessorMock->expects($this->never())->method('process');
+        $this->areaListMock->expects($this->never())->method('getCodes');
+
+        $this->processorMock->expects($this->once())
+            ->method('execute');
+
+        $this->assertSame(Cli::RETURN_SUCCESS, $this->commandTester->execute([]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testExecuteWithMissingAdminhtmlLocale()
+    {
+        $this->deploymentConfigMock->expects($this->once())->method('isAvailable')->willReturn(true);
+        $this->adminhtmlAreaProcessorMock->expects($this->never())->method('process');
+        $this->areaListMock->expects($this->once())->method('getCodes')->willReturn([]);
+
+        $this->processorMock->expects($this->once())
+            ->method('execute');
+
+        $this->assertSame(Cli::RETURN_SUCCESS, $this->commandTester->execute([]));
     }
 }

--- a/app/code/Magento/Deploy/etc/di.xml
+++ b/app/code/Magento/Deploy/etc/di.xml
@@ -35,6 +35,12 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Deploy\Console\Command\App\ConfigImportCommand">
+        <arguments>
+            <argument name="adminhtmlAreaProcessor" xsi:type="object">Magento\Config\Console\Command\EmulatedAdminhtmlAreaProcessor\Proxy</argument>
+            <argument name="areaList" xsi:type="object">Magento\Framework\App\AreaList\Proxy</argument>
+        </arguments>
+    </type>
     <type name="Magento\Deploy\Model\Filesystem">
         <arguments>
             <argument name="shell" xsi:type="object">Magento\Framework\App\Shell</argument>


### PR DESCRIPTION
### Description (*)
Emulate adminhtml area where url rewrites are created

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. N/A

### Manual testing scenarios (*)
1. On Dev. env setup only one store view with few categories and products
2. dump stores info to config.php with [php bin/magento app:config:dump](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-config-mgmt-export.html) and commit it
3. Deploy to production (run `php bin/magento setup:upgrade --keep-generated` on production env)
4. On dev. env create second store view in the same Store Group and Website
5. dump stores info to config.php with [php bin/magento app:config:dump](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-config-mgmt-export.html) and commit it
6. Deploy to production (run `php bin/magento setup:upgrade --keep-generated` on production env)

**Expected result:**
On second store view on dev and production environments were generated URL rewrites for categories and products.

**Actual result:**
On second store view URL rewrites were generated only on dev env (it was created via admin), but they weren't generated on production env (it was created during `setup:upgrade` command)

### Questions or comments
My investigation shown that only in adminhtml area URL rewrites are generated when store view is created:
https://github.com/magento/magento2/blob/a31f4a35c018ad09654e5bd5871086b73fbd3d2d/app/code/Magento/CatalogUrlRewrite/etc/adminhtml/di.xml#L9-L14

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30025: Fix URL generation for new store when it created with setup:config:import