### PR TITLE
Input type datetime is used in lib styles

### DIFF
--- a/lib/web/css/source/lib/_forms.less
+++ b/lib/web/css/source/lib/_forms.less
@@ -271,7 +271,7 @@
     input[type="tel"],
     input[type="search"],
     input[type="number"],
-    input[type="datetime"],
+    input[type*="date"],
     input[type="email"] {
         .lib-form-element-input(@_type: input-text);
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
By replacing the attribute selector `input[type=datetime]` for a less specific input type selector.
It will it not force us to override the lib styles for using a deprecated html input type.

This change will keep the old situation intact.
And adds support `input[type=date]` and `input[type=datetime-local]`, for the form styling.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes #30064 

### Manual testing scenarios (*)
None.
Magento 2 does not use this input type on the front-end.
The only place this attribute is found in, is in the `lib/web/css/docs`.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
