### PR TITLE
Reduced html content of image details templates

### DIFF
--- a/app/code/Magento/MediaGalleryUi/view/adminhtml/templates/image_details.phtml
+++ b/app/code/Magento/MediaGalleryUi/view/adminhtml/templates/image_details.phtml
@@ -22,15 +22,8 @@ use Magento\Framework\Escaper;
             title: '<?= $escaper->escapeHtmlAttr(__('Image Details')); ?>'
         }
      }">
-    <div class="page-main-actions">
-        <div class="page-actions">
-            <div class="page-actions-inner">
-                <div class="page-action-buttons" id="media-gallery-image-actions"
-                     data-bind="scope: 'mediaGalleryImageActions'">
-                    <!-- ko template: getTemplate() --><!-- /ko -->
-                </div>
-            </div>
-        </div>
+    <div class="page-main-actions" data-bind="scope: 'mediaGalleryImageActions'">
+        <!-- ko template: getTemplate() --><!-- /ko -->
     </div>
     <div id="media-gallery-image-details-messages" data-bind="scope: 'mediaGalleryImageDetailsMessages'">
         <!-- ko template: getTemplate() --><!-- /ko -->
@@ -51,22 +44,10 @@ use Magento\Framework\Escaper;
                         "modalSelector": ".media-gallery-image-details-modal",
                         "modalWindowSelector": ".media-gallery-image-details",
                         "mediaGridMessages": "media_gallery_listing.media_gallery_listing.messages"
-                    }
-                }
-            }
-        },
-        "#media-gallery-image-details-messages": {
-            "Magento_Ui/js/core/app": {
-                "components": {
+                    },
                     "mediaGalleryImageDetailsMessages": {
                         "component": "Magento_MediaGalleryUi/js/grid/messages"
-                    }
-                }
-            }
-        },
-        "#media-gallery-image-actions": {
-            "Magento_Ui/js/core/app": {
-                "components": {
+                    },
                     "mediaGalleryImageActions": {
                         "component": "Magento_MediaGalleryUi/js/image/image-actions",
                         "modalSelector": ".media-gallery-image-details-modal",

--- a/app/code/Magento/MediaGalleryUi/view/adminhtml/templates/image_details_standalone.phtml
+++ b/app/code/Magento/MediaGalleryUi/view/adminhtml/templates/image_details_standalone.phtml
@@ -18,15 +18,8 @@
             title: '<?= $escaper->escapeHtmlAttr(__('Image Details')); ?>'
         }
      }">
-    <div class="page-main-actions">
-        <div class="page-actions">
-            <div class="page-actions-inner">
-                <div class="page-action-buttons" id="media-gallery-image-actions"
-                     data-bind="scope: 'mediaGalleryImageActions'">
-                    <!-- ko template: getTemplate() --><!-- /ko -->
-                </div>
-            </div>
-        </div>
+    <div class="page-main-actions" data-bind="scope: 'mediaGalleryImageActions'">
+        <!-- ko template: getTemplate() --><!-- /ko -->
     </div>
     <div id="media-gallery-image-details-messages" data-bind="scope: 'mediaGalleryImageDetailsMessages'">
         <!-- ko template: getTemplate() --><!-- /ko -->
@@ -47,22 +40,7 @@
                         "modalSelector": ".media-gallery-image-details-modal",
                         "modalWindowSelector": ".media-gallery-image-details",
                         "mediaGridMessages": "standalone_media_gallery_listing.standalone_media_gallery_listing.messages"
-                    }
-                }
-            }
-        },
-        "#media-gallery-image-details-messages": {
-            "Magento_Ui/js/core/app": {
-                "components": {
-                    "mediaGalleryImageDetailsMessages": {
-                        "component": "Magento_MediaGalleryUi/js/grid/messages"
-                    }
-                }
-            }
-        },
-        "#media-gallery-image-actions": {
-            "Magento_Ui/js/core/app": {
-                "components": {
+                    },
                     "mediaGalleryImageActions": {
                         "component": "Magento_MediaGalleryUi/js/image/image-actions",
                         "modalSelector": ".media-gallery-image-details-modal",
@@ -70,6 +48,9 @@
                         "mediaGalleryImageDetailsName": "mediaGalleryImageDetails",
                         "imageModelName" : "standalone_media_gallery_listing.standalone_media_gallery_listing.media_gallery_columns.thumbnail_url",
                         "actionsList": <?= /* @noEscape */ $block->getActionsJson() ?>
+                    },
+                    "mediaGalleryImageDetailsMessages": {
+                        "component": "Magento_MediaGalleryUi/js/grid/messages"
                     }
                 }
             }

--- a/app/code/Magento/MediaGalleryUi/view/adminhtml/templates/image_edit_details.phtml
+++ b/app/code/Magento/MediaGalleryUi/view/adminhtml/templates/image_edit_details.phtml
@@ -20,15 +20,8 @@ use Magento\Backend\Block\Template;
             title: '<?= $escaper->escapeHtmlAttr(__('Edit Image')); ?>'
         }
      }">
-    <div class="page-main-actions">
-        <div class="page-actions">
-            <div class="page-actions-inner">
-                <div class="page-action-buttons" id="media-gallery-edit-image-actions"
-                     data-bind="scope: 'mediaGalleryImageEditActions'">
-                    <!-- ko template: getTemplate() --><!-- /ko -->
-                </div>
-            </div>
-        </div>
+    <div class="page-main-actions" data-bind="scope: 'mediaGalleryImageEditActions'">
+        <!-- ko template: getTemplate() --><!-- /ko -->
     </div>
     <div id="media-gallery-image-edit-details-messages" data-bind="scope: 'mediaGalleryEditDetailsMessages'">
         <!-- ko template: getTemplate() --><!-- /ko -->
@@ -50,25 +43,10 @@ use Magento\Backend\Block\Template;
                         "imageEditDetailsUrl": "<?= $escaper->escapeJs($block->getData('imageEditDetailsUrl')); ?>",
                         "saveDetailsUrl": "<?= $escaper->escapeJs($block->getData('saveDetailsUrl')); ?>",
                         "mediaGridMessages": "standalone_media_gallery_listing.standalone_media_gallery_listing.messages"
-                    }
-                }
-            },
-            "Magento_MediaGalleryUi/js/validation/validate-image-title": {},
-            "Magento_MediaGalleryUi/js/validation/validate-image-description": {},
-            "Magento_MediaGalleryUi/js/validation/validate-image-keyword": {}
-        },
-        "#media-gallery-image-edit-details-messages": {
-            "Magento_Ui/js/core/app": {
-                "components": {
+                    },
                     "mediaGalleryEditDetailsMessages": {
                         "component": "Magento_MediaGalleryUi/js/grid/messages"
-                    }
-                }
-            }
-        },
-        "#media-gallery-edit-image-actions": {
-            "Magento_Ui/js/core/app": {
-                "components": {
+                    },
                     "mediaGalleryImageEditActions": {
                         "component": "Magento_MediaGalleryUi/js/image/image-actions",
                         "modalSelector": ".media-gallery-edit-image-details-modal",
@@ -91,7 +69,10 @@ use Magento\Backend\Block\Template;
                         ]
                     }
                 }
-            }
+            },
+            "Magento_MediaGalleryUi/js/validation/validate-image-title": {},
+            "Magento_MediaGalleryUi/js/validation/validate-image-description": {},
+            "Magento_MediaGalleryUi/js/validation/validate-image-keyword": {}
         }
     }
 </script>

--- a/app/code/Magento/MediaGalleryUi/view/adminhtml/templates/image_edit_details_standalone.phtml
+++ b/app/code/Magento/MediaGalleryUi/view/adminhtml/templates/image_edit_details_standalone.phtml
@@ -20,15 +20,8 @@ use Magento\Backend\Block\Template;
             title: '<?= $escaper->escapeHtmlAttr(__('Edit Image')); ?>'
         }
      }">
-    <div class="page-main-actions">
-        <div class="page-actions">
-            <div class="page-actions-inner">
-                <div class="page-action-buttons" id="media-gallery-edit-image-actions"
-                     data-bind="scope: 'mediaGalleryImageEditActions'">
-                    <!-- ko template: getTemplate() --><!-- /ko -->
-                </div>
-            </div>
-        </div>
+    <div class="page-main-actions" data-bind="scope: 'mediaGalleryImageEditActions'">
+        <!-- ko template: getTemplate() --><!-- /ko -->
     </div>
     <div id="media-gallery-image-edit-details-messages" data-bind="scope: 'mediaGalleryEditDetailsMessages'">
         <!-- ko template: getTemplate() --><!-- /ko -->
@@ -50,25 +43,10 @@ use Magento\Backend\Block\Template;
                         "imageEditDetailsUrl": "<?= $escaper->escapeJs($block->getData('imageEditDetailsUrl')); ?>",
                         "saveDetailsUrl": "<?= $escaper->escapeJs($block->getData('saveDetailsUrl')); ?>",
                         "mediaGridMessages": "standalone_media_gallery_listing.standalone_media_gallery_listing.messages"
-                    }
-                }
-            },
-            "Magento_MediaGalleryUi/js/validation/validate-image-title": {},
-            "Magento_MediaGalleryUi/js/validation/validate-image-description": {},
-            "Magento_MediaGalleryUi/js/validation/validate-image-keyword": {}
-        },
-        "#media-gallery-image-edit-details-messages": {
-            "Magento_Ui/js/core/app": {
-                "components": {
+                    },
                     "mediaGalleryEditDetailsMessages": {
                         "component": "Magento_MediaGalleryUi/js/grid/messages"
-                    }
-                }
-            }
-        },
-        "#media-gallery-edit-image-actions": {
-            "Magento_Ui/js/core/app": {
-                "components": {
+                    },
                     "mediaGalleryImageEditActions": {
                         "component": "Magento_MediaGalleryUi/js/image/image-actions",
                         "modalSelector": ".media-gallery-edit-image-details-modal",
@@ -91,7 +69,10 @@ use Magento\Backend\Block\Template;
                         ]
                     }
                 }
-            }
+            },
+            "Magento_MediaGalleryUi/js/validation/validate-image-title": {},
+            "Magento_MediaGalleryUi/js/validation/validate-image-description": {},
+            "Magento_MediaGalleryUi/js/validation/validate-image-keyword": {}
         }
     }
 </script>

--- a/app/code/Magento/MediaGalleryUi/view/adminhtml/web/template/image/actions.html
+++ b/app/code/Magento/MediaGalleryUi/view/adminhtml/web/template/image/actions.html
@@ -4,9 +4,16 @@
  * See COPYING.txt for license details.
  */
 -->
-<each args="{ data: actionsList, as: 'action' }">
-    <button type="button" click="$parent[action.handler].bind($parent)"
-            attr="{class: action.classes, id: 'image-details-action-' + action.name, title: $t(action.title)}">
-        <span translate="action.title"></span>
-    </button>
-</each>
+<div class="page-actions">
+    <div class="page-actions-inner">
+        <div class="page-action-buttons">
+            <each args="{ data: actionsList, as: 'action' }">
+                <button type="button" click="$parent[action.handler].bind($parent)"
+                        attr="{class: action.classes, id: 'image-details-action-' + action.name, title: $t(action.title)}">
+                    <span translate="action.title"></span>
+                </button>
+            </each>
+        </div>
+    </div>
+</div>
+


### PR DESCRIPTION
### Description (*)

Reduced HTML content of image details templates

Media gallery image details and edit slide panels are affected

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

Fixed https://github.com/magento/adobe-stock-integration/issues/1729

### Manual testing scenarios (*)
Test content, actions and error message displaying on the following slide panels in New Media Gallery:
1. Sandalone Media Gallery View Details panel (Admin Panel -> Content -> Media Gallery)
2. Embedded Media Gallery View Details panel (Opened from any wysiwyg editor or image uploader)
3. Sandalone Media Gallery Edit Details panel (Admin Panel -> Content -> Media Gallery)
4. Embedded Media Gallery Edit Details panel (Opened from any wysiwyg editor or image uploader)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
