### PR TITLE
Prevent "Overwrite the existing configuration for ...?" question

### DIFF
--- a/setup/src/Magento/Setup/Console/Command/ConfigSetCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ConfigSetCommand.php
@@ -84,11 +84,10 @@ class ConfigSetCommand extends AbstractSetupCommand
             $commandOptions[$option->getName()] = false;
 
             $currentValue = $this->deploymentConfig->get($option->getConfigPath());
-            if (
-                ($currentValue !== null) &&
+            $needOverwrite = ($currentValue !== null) &&
                 ($inputOptions[$option->getName()] !== null) &&
-                ($inputOptions[$option->getName()] !== $currentValue)
-            ) {
+                ($inputOptions[$option->getName()] !== $currentValue);
+            if ($needOverwrite) {
                 $dialog = $this->getHelperSet()->get('question');
                 $question = new Question(
                     '<question>Overwrite the existing configuration for ' . $option->getName() . '?[Y/n]</question>',

--- a/setup/src/Magento/Setup/Console/Command/ConfigSetCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ConfigSetCommand.php
@@ -84,7 +84,11 @@ class ConfigSetCommand extends AbstractSetupCommand
             $commandOptions[$option->getName()] = false;
 
             $currentValue = $this->deploymentConfig->get($option->getConfigPath());
-            if (($currentValue !== null) && ($inputOptions[$option->getName()] !== null)) {
+            if (
+                ($currentValue !== null) &&
+                ($inputOptions[$option->getName()] !== null) &&
+                ($inputOptions[$option->getName()] !== $currentValue)
+            ) {
                 $dialog = $this->getHelperSet()->get('question');
                 $question = new Question(
                     '<question>Overwrite the existing configuration for ' . $option->getName() . '?[Y/n]</question>',

--- a/setup/src/Magento/Setup/Console/Command/ConfigSetCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ConfigSetCommand.php
@@ -69,6 +69,7 @@ class ConfigSetCommand extends AbstractSetupCommand
 
     /**
      * @inheritdoc
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/setup/src/Magento/Setup/Console/Command/ConfigSetCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/ConfigSetCommand.php
@@ -14,9 +14,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 
-/**
- * Config Set Command
- */
 class ConfigSetCommand extends AbstractSetupCommand
 {
     /**


### PR DESCRIPTION
Duplication for PR https://github.com/magento/magento2/pull/26818

This question is occurred [every time](https://github.com/magento/magento2/issues/26762#issuecomment-584698357) I run:
```
$ ./bin/magento setup:config:set
```

after upgrade to 2.3.4

We should ask this question only if new value of configuration option is not equal to the old value,. 

### Resolved issues:
1. [x] resolves magento/magento2#29612: Prevent "Overwrite the existing configuration for db-ssl-verify?" question

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
