### PR TITLE
[MFTF] deprecated GoToAttributeGridPageActionGroup

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenAttributeSetGridPageActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminOpenAttributeSetGridPageActionGroup.xml
@@ -8,6 +8,10 @@
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="AdminOpenAttributeSetGridPageActionGroup">
+        <annotations>
+            <description>Open the Attribute Sets grid page.</description>
+        </annotations>
+
         <amOnPage url="{{AdminProductAttributeSetGridPage.url}}" stepKey="goToAttributeSetPage"/>
         <waitForPageLoad stepKey="waitForAttributeSetPageLoad"/>
     </actionGroup>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/GoToAttributeGridPageActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/GoToAttributeGridPageActionGroup.xml
@@ -8,7 +8,7 @@
 
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
-    <actionGroup name="GoToAttributeGridPageActionGroup">
+    <actionGroup name="GoToAttributeGridPageActionGroup" deprecated="Use AdminOpenAttributeSetGridPageActionGroup instead.">
         <annotations>
             <description>Goes to the Attribute Sets grid page.</description>
         </annotations>

--- a/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontQuickSearchConfigurableChildrenTest.xml
+++ b/app/code/Magento/CatalogSearch/Test/Mftf/Test/StorefrontQuickSearchConfigurableChildrenTest.xml
@@ -32,7 +32,7 @@
 
             <!-- Assign attribute to set -->
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
-            <actionGroup ref="GoToAttributeGridPageActionGroup" stepKey="goToAttributeSetPage"/>
+            <actionGroup ref="AdminOpenAttributeSetGridPageActionGroup" stepKey="goToAttributeSetPage"/>
             <actionGroup ref="GoToAttributeSetByNameActionGroup" stepKey="openAttributeSetByName">
                 <argument name="name" value="$createAttributeSet.attribute_set_name$"/>
             </actionGroup>


### PR DESCRIPTION
This PR deprecated `GoToAttributeGridPageActionGroup`

### Resolved issues:
1. [x] resolves magento/magento2#30103: [MFTF] deprecated GoToAttributeGridPageActionGroup