### PR TITLE
Added configuration for Stale Issue bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,68 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+ daysUntilStale: 76
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 14
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - "Priority: P0"
+  - "Priority: P1"
+  - "Priority: P2"
+  - "Progress: dev in progress"
+  - "Progress: PR in progress"
+  - "Progress: done"
+  - "B2B: GraphQL"   
+  - "Progress: PR Created"
+  - "PAP"
+  - "Project: Login as Customer"
+  - "Project: GraphQL"
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: "stale issue"
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed after 14 days if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
### Description 

This PR adds configuration for the GitHub application https://probot.github.io/apps/stale/

This application will label stale issues, comment, and close if no further activities occur.
Please see the official [README.md](https://github.com/probot/stale/blob/master/README.md) of the application owner for more details.

The Goal is _Keep [the Issue Backlog](https://github.com/magento/magento2/issues) healthy and up to date_

- it will be applied on the Issue only, PRs will not be commented and processed as stale


### Example of work 
1. An Issue was reported and [does not have activity](https://github.com/probot/stale/blob/master/README.md#how-are-issues-and-pull-requests-considered-stale) for XX days defined in [`daysUntilStale`](https://github.com/magento/magento2/pull/30095/files#diff-0582c54ce27332bb1bf68e65f7b91d0dR4) configuration. 
-- ` daysUntilStale: 76`
2. **Stale-bot** is starting processing this issue.
3. **Stale-bot** checks if an Issue has any label from the exclude list defined in [`exemptLabels`](https://github.com/magento/magento2/pull/30095/files#diff-0582c54ce27332bb1bf68e65f7b91d0dR14) configuration. 
If Yes, the issue will NOT be processed as stale:
-- If Issue is critical (P0, P1, P2) 
-- If Issue is in progress or has opened Pull Request
-- if Issue related to an additional or special project 
```
exemptLabels:
  - "Priority: P0"
  - "Priority: P1"
  - "Priority: P2"
  - "Progress: dev in progress"
  - "Progress: PR in progress"
  - "Progress: done"
  - "B2B: GraphQL"   
  - "Progress: PR Created"
  - "PAP"
  - "Project: Login as Customer"
  - "Project: GraphQL"
```
4. **Stale-bot** marks Issue with lable defined in [`staleLabel`](https://github.com/magento/magento2/pull/30095/files#diff-0582c54ce27332bb1bf68e65f7b91d0dR37) config
--  `staleLabel: "stale issue"`

5. **Stale-bot** posts a comment defined in [`markComment`](https://github.com/magento/magento2/pull/30095/files#diff-0582c54ce27332bb1bf68e65f7b91d0dR40) config
-- ```This issue has been automatically marked as stale because it has not had
  recent activity. It will be closed after 14 days if no further activity occurs. Thank you
  for your contributions.```

6.  Issue will be labeled and commented as stale during the next XX days defined in [`daysUntilClose`](https://github.com/magento/magento2/pull/30095/files#diff-0582c54ce27332bb1bf68e65f7b91d0dR8). 
If no new activities appear,  **Stale-bot** will close this Issue.
-- `daysUntilClose: 14`


