### PR TITLE
Fix stateful object TransportBuilder being shared by DI

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -1809,6 +1809,7 @@
                 type="Magento\Framework\Mail\MimeMessage" />
     <preference for="Magento\Framework\Mail\MimePartInterface"
                 type="Magento\Framework\Mail\MimePart" />
+    <type name="Magento\Framework\Mail\Template\TransportBuilder" shared="false"/>
     <type name="Magento\Framework\DB\Adapter\AdapterInterface">
         <plugin name="execute_commit_callbacks" type="Magento\Framework\Model\ExecuteCommitCallbacks" />
     </type>


### PR DESCRIPTION
### Description (*)
Fix stateful object `TransportBuilder` being shared by DI, allowing for major production bugs to happen.

If, for some reason, the inner state of `TransportBuilder` is not reset, it will be dirty when it is used by the next client (`Magento\Sales\Model\Order\Email\SenderBuilder` is a client). Currently the `TransportBuilder` is being reused when sending e-mails asynchronously in the background (`sales_email/general/async_sending`), which can lead to mails being sent to additional e-mail adresses added by previous clients, which is **_very_** undesirable!

This comes down to a qualitative risk analysis:
**Likelihood of it happening**: Unlikely
**Impact when it happens**: High

We should prevent this risk by setting the DI `shared` property to **false** for the class `Magento\Framework\Mail\Template\TransportBuilder`.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
- Fixes #30105: Risk: statefulness of TransportBuilder

### Manual testing scenarios (*)
1. Enable asynchronous sending
2. Create 2 or 3 orders
3. Run cron
4. All order confirmations e-mails should be sent

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
