### PR TITLE
[MessageQueue]: add support for first class queue configuration.

### DIFF
--- a/app/code/Magento/Ui/etc/di.xml
+++ b/app/code/Magento/Ui/etc/di.xml
@@ -256,6 +256,7 @@
                 <item name="array" xsi:type="object">arrayArgumentInterpreterProxy</item>
                 <item name="boolean" xsi:type="object">Magento\Framework\Data\Argument\Interpreter\Boolean</item>
                 <item name="number" xsi:type="object">Magento\Framework\Data\Argument\Interpreter\Number</item>
+                <item name="int" xsi:type="object">Magento\Framework\Data\Argument\Interpreter\Integer</item>
                 <item name="string" xsi:type="object">Magento\Framework\Data\Argument\Interpreter\StringUtils</item>
                 <item name="null" xsi:type="object">Magento\Framework\Data\Argument\Interpreter\NullType</item>
                 <item name="url" xsi:type="object">Magento\Ui\Config\Argument\Parser\Url</item>

--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -479,6 +479,7 @@
                 <item name="array" xsi:type="object">layoutArrayArgumentReaderInterpreterProxy</item>
                 <item name="boolean" xsi:type="object">Magento\Framework\Data\Argument\Interpreter\Boolean</item>
                 <item name="number" xsi:type="object">Magento\Framework\Data\Argument\Interpreter\Number</item>
+                <item name="int" xsi:type="object">Magento\Framework\Data\Argument\Interpreter\Integer</item>
                 <item name="string" xsi:type="object">Magento\Framework\Data\Argument\Interpreter\StringUtils</item>
                 <item name="null" xsi:type="object">Magento\Framework\Data\Argument\Interpreter\NullType</item>
                 <item name="object" xsi:type="object">Magento\Framework\View\Layout\Argument\Interpreter\Passthrough</item>

--- a/lib/internal/Magento/Framework/App/ObjectManagerFactory.php
+++ b/lib/internal/Magento/Framework/App/ObjectManagerFactory.php
@@ -231,6 +231,7 @@ class ObjectManagerFactory
                 'boolean' => new \Magento\Framework\Data\Argument\Interpreter\Boolean($booleanUtils),
                 'string' => new \Magento\Framework\Data\Argument\Interpreter\BaseStringUtils($booleanUtils),
                 'number' => new \Magento\Framework\Data\Argument\Interpreter\Number(),
+                'int' => new \Magento\Framework\Data\Argument\Interpreter\Integer(),
                 'null' => new \Magento\Framework\Data\Argument\Interpreter\NullType(),
                 'object' => new \Magento\Framework\Data\Argument\Interpreter\DataObject($booleanUtils),
                 'const' => $constInterpreter,

--- a/lib/internal/Magento/Framework/Data/Argument/Interpreter/Integer.php
+++ b/lib/internal/Magento/Framework/Data/Argument/Interpreter/Integer.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Framework\Data\Argument\Interpreter;
+
+use Magento\Framework\Data\Argument\InterpreterInterface;
+
+/**
+ * Interpreter of numeric data, such as integer or float
+ */
+class Integer implements InterpreterInterface
+{
+    /**
+     * {@inheritdoc}
+     * @return int|float
+     * @throws \InvalidArgumentException
+     */
+    public function evaluate(array $data)
+    {
+        if (!isset($data['value']) || !is_numeric($data['value'])) {
+            throw new \InvalidArgumentException('Numeric value is expected.');
+        }
+        $result = $data['value'];
+        return (int)$result;
+    }
+}

--- a/lib/internal/Magento/Framework/Data/etc/argument/types.xsd
+++ b/lib/internal/Magento/Framework/Data/etc/argument/types.xsd
@@ -73,6 +73,12 @@
         </xs:complexContent>
     </xs:complexType>
 
+    <xs:complexType name="int">
+        <xs:complexContent>
+            <xs:extension base="argumentType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
     <xs:complexType name="null">
         <xs:complexContent>
             <xs:restriction base="argumentType"/>

--- a/lib/internal/Magento/Framework/MessageQueue/Topology/Config/Data.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Topology/Config/Data.php
@@ -23,4 +23,20 @@ class Data extends \Magento\Framework\Config\Data
     ) {
         parent::__construct($reader, $cache, $cacheId, $serializer);
     }
+
+    public function getQueues(): array {
+        return array_filter($this->get(),function($item){
+            if($item['type'] == 'queue'){
+                return $item;
+            }
+        });
+    }
+
+    public function getExchanges(): array {
+        return array_filter($this->get(),function($item){
+            if($item['type'] != 'queue'){
+                return $item;
+            }
+        });
+    }
 }

--- a/lib/internal/Magento/Framework/MessageQueue/Topology/Config/ExchangeConfigItem.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Topology/Config/ExchangeConfigItem.php
@@ -7,6 +7,8 @@ namespace Magento\Framework\MessageQueue\Topology\Config;
 
 use Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItem\BindingInterface;
 use Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItem\Binding\IteratorFactory;
+use Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItem\Binding\Iterator;
+use Magento\Framework\MessageQueue\Topology\Config\ExchangeConfigItem\BindingFactory;
 
 /**
  * {@inheritdoc}
@@ -37,7 +39,7 @@ class ExchangeConfigItem implements ExchangeConfigItemInterface
     /**
      * Exchange bindings.
      *
-     * @var BindingInterface[]
+     * @var Iterator
      */
     private $bindings;
 
@@ -68,6 +70,11 @@ class ExchangeConfigItem implements ExchangeConfigItemInterface
      * @var bool
      */
     private $isInternal;
+
+    /**
+     * @var BindingFactory
+     */
+    public $bindingFactory;
 
     /**
      * Initialize dependencies.
@@ -158,6 +165,11 @@ class ExchangeConfigItem implements ExchangeConfigItemInterface
         $this->isDurable = $data['durable'];
         $this->isAutoDelete = $data['autoDelete'];
         $this->arguments = $data['arguments'];
-        $this->bindings->setData($data['bindings']);
+        if( $this->type != 'queue'){
+            $this->bindings->setData($data['bindings']);
+        }
+        else{
+            $this->bindings->setData([]);
+        }
     }
 }

--- a/lib/internal/Magento/Framework/MessageQueue/Topology/Config/ExchangeConfigItem/Iterator.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Topology/Config/ExchangeConfigItem/Iterator.php
@@ -36,7 +36,7 @@ class Iterator implements \Iterator, \ArrayAccess
      */
     public function __construct(Data $configData, ExchangeConfigItemFactory $itemFactory)
     {
-        $this->data = $configData->get();
+        $this->data = $configData->getExchanges();
         $this->object = $itemFactory->create();
         $this->rewind();
     }

--- a/lib/internal/Magento/Framework/MessageQueue/Topology/Config/Validator/DependentFields.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Topology/Config/Validator/DependentFields.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Framework\MessageQueue\Topology\Config\Validator;
 
 use Magento\Framework\MessageQueue\Topology\Config\ValidatorInterface;
@@ -19,9 +21,11 @@ class DependentFields implements ValidatorInterface
     {
         $errors = [];
         foreach ($configData as $name => $data) {
-            foreach ((array)$data['bindings'] as $binding) {
-                if (isset($data['type']) && $data['type'] == 'topic' && !isset($binding['topic'])) {
-                    $errors[] = 'Topic name is required for topic based exchange: ' . $name;
+            if ($data['type'] != 'queue') {
+                foreach ((array)$data['bindings'] as $binding) {
+                    if (isset($data['type']) && $data['type'] == 'topic' && !isset($binding['topic'])) {
+                        $errors[] = 'Topic name is required for topic based exchange: ' . $name;
+                    }
                 }
             }
         }

--- a/lib/internal/Magento/Framework/MessageQueue/Topology/Config/Validator/FieldsTypes.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Topology/Config/Validator/FieldsTypes.php
@@ -18,7 +18,8 @@ class FieldsTypes implements ValidatorInterface
     public function validate($configData)
     {
         foreach ($configData as $exchangeName => $exchangeConfig) {
-            $this->validateFieldsTypes($exchangeName, $exchangeConfig);
+            $exchangeConfig['type'] != 'queue' ? 
+            $this->validateFieldsTypes($exchangeName, $exchangeConfig) : $this->validateQueueTypes($exchangeName, $exchangeConfig);
         }
     }
 
@@ -127,5 +128,17 @@ class FieldsTypes implements ValidatorInterface
                 }
             }
         }
+    }
+
+    /**
+     * Make sure types of all fields in the queue item config are correct.
+     *
+     * @param string $queueName
+     * @param array $queueConfig
+     * @return void
+     * @throws \LogicException
+     */
+    private function validateQueueTypes($queueName, $queueConfig)
+    {
     }
 }

--- a/lib/internal/Magento/Framework/MessageQueue/Topology/Config/Validator/Format.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Topology/Config/Validator/Format.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Framework\MessageQueue\Topology\Config\Validator;
 
 use Magento\Framework\MessageQueue\Topology\Config\ValidatorInterface;
@@ -17,24 +19,34 @@ class Format implements ValidatorInterface
      */
     public function validate($configData)
     {
-        $requiredFields = ['name', 'type', 'connection', 'durable', 'autoDelete', 'internal', 'bindings', 'arguments'];
+        $requiredExchangeFields = ['name', 'type', 'connection', 'durable', 'autoDelete', 'internal', 'bindings', 'arguments'];
+        $requiredQueueFields = ['name', 'type', 'connection', 'durable', 'autoDelete', 'internal', 'arguments'];
+
         $requiredBindingFields = ['id', 'destinationType', 'destination', 'disabled', 'topic', 'arguments'];
         $errors = [];
         foreach ($configData as $name => $data) {
-            $diff = array_diff($requiredFields, array_keys($data));
-            foreach ($diff as $field) {
-                $errors[] = sprintf('Missing [%s] field for exchange %s.', $field, $name);
-            }
-
-            if (!array_key_exists('bindings', $data) || !is_array($data['bindings'])) {
-                $errors[] = sprintf('Invalid bindings format for exchange %s.', $name);
-                continue;
-            }
-
-            foreach ($data['bindings'] as $bindingConfig) {
-                $diff = array_diff($requiredBindingFields, array_keys($bindingConfig));
+            if ($data['type'] != 'queue') {
+                $diff = array_diff($requiredExchangeFields, array_keys($data));
                 foreach ($diff as $field) {
-                    $errors[] = sprintf('Missing [%s] field for binding %s in exchange config.', $field, $name);
+                    $errors[] = sprintf('Missing [%s] field for exchange %s.', $field, $name);
+                }
+
+                if (!array_key_exists('bindings', $data) || !is_array($data['bindings'])) {
+                    $errors[] = sprintf('Invalid bindings format for exchange %s.', $name);
+                    continue;
+                }
+
+                foreach ($data['bindings'] as $bindingConfig) {
+                    $diff = array_diff($requiredBindingFields, array_keys($bindingConfig));
+                    foreach ($diff as $field) {
+                        $errors[] = sprintf('Missing [%s] field for binding %s in exchange config.', $field, $name);
+                    }
+                }
+            }
+            else{
+                $diff = array_diff($requiredQueueFields, array_keys($data));
+                foreach ($diff as $field) {
+                    $errors[] = sprintf('Really Missing [%s] field for queue %s.', $field, $name);
                 }
             }
         }

--- a/lib/internal/Magento/Framework/MessageQueue/Topology/Config/Xml/Reader.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Topology/Config/Xml/Reader.php
@@ -22,6 +22,9 @@ class Reader extends \Magento\Framework\Config\Reader\Filesystem implements Read
         '/config/exchange/binding' => 'id',
         '/config/exchange/binding/arguments/argument' => 'name',
         '/config/exchange/binding/arguments/argument(/item)+' => 'name',
+        '/config/queue' => ['name', 'connection'],
+        '/config/queue/arguments/argument' => 'name',
+        '/config/queue/arguments/argument(/item)+' => 'name'
     ];
 
     /**

--- a/lib/internal/Magento/Framework/MessageQueue/etc/topology.xsd
+++ b/lib/internal/Magento/Framework/MessageQueue/etc/topology.xsd
@@ -42,6 +42,12 @@
         </xs:complexContent>
     </xs:complexType>
 
+    <xs:complexType name="int">
+        <xs:complexContent>
+            <xs:extension base="argumentType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
     <xs:complexType name="boolean">
         <xs:complexContent>
             <xs:extension base="argumentType"/>
@@ -68,6 +74,7 @@
                         <xs:field xpath="@id"/>
                     </xs:unique>
                 </xs:element>
+                <xs:element type="queueConfigType" name="queue" maxOccurs="unbounded" minOccurs="0"/>
             </xs:sequence>
         </xs:complexType>
         <xs:unique name="unique-exchange-name-connection">
@@ -106,6 +113,18 @@
         <xs:attribute type="xs:boolean" name="internal" use="optional"/>
     </xs:complexType>
 
+     <xs:complexType name="queueConfigType">
+        <xs:choice maxOccurs="unbounded">
+            <xs:element type="argumentsType" name="arguments" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:choice>
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="queueType" name="type" use="required"/>
+        <xs:attribute name="connection" type="xs:string" use="required" />
+        <xs:attribute type="xs:boolean" name="durable" use="optional"/>
+        <xs:attribute type="xs:boolean" name="autoDelete" use="optional"/>
+        <xs:attribute type="xs:boolean" name="internal" use="optional"/>
+    </xs:complexType>
+
     <xs:simpleType name="exchangeType">
         <xs:restriction base="xs:string">
             <xs:enumeration value="topic" />
@@ -113,6 +132,12 @@
     </xs:simpleType>
 
     <xs:simpleType name="destinationType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="queue" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="queueType">
         <xs:restriction base="xs:string">
             <xs:enumeration value="queue" />
         </xs:restriction>

--- a/lib/internal/Magento/Framework/MessageQueue/etc/topology_merged.xsd
+++ b/lib/internal/Magento/Framework/MessageQueue/etc/topology_merged.xsd
@@ -24,6 +24,24 @@
     </xs:redefine>
 
     <xs:redefine schemaLocation="urn:magento:framework-message-queue:etc/topology.xsd">
+        <xs:complexType name="queueConfigType">
+            <xs:complexContent>
+                <xs:restriction base="queueConfigType">
+                    <xs:choice maxOccurs="unbounded">
+                        <xs:element type="argumentsType" name="arguments" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:choice>
+                    <xs:attribute type="xs:string" name="name" use="required"/>
+                    <xs:attribute type="queueType" name="type" use="required"/>
+                    <xs:attribute name="connection" type="xs:string" use="required" />
+                    <xs:attribute type="xs:boolean" name="durable" use="optional"/>
+                    <xs:attribute type="xs:boolean" name="autoDelete" use="optional"/>
+                    <xs:attribute type="xs:boolean" name="internal" use="optional"/>
+                </xs:restriction>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:redefine>
+
+    <xs:redefine schemaLocation="urn:magento:framework-message-queue:etc/topology.xsd">
         <xs:complexType name="exchangeConfigType">
             <xs:complexContent>
                 <xs:restriction base="exchangeConfigType">


### PR DESCRIPTION
Co-authored-by: Damien Retzinger <damienwebdev@gmail.com>

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

The Message Broker, RabbitMQ, supports `arguments` that are defined at queue creation time that dictate certain behaviors of the resulting queue. Currently (as of v2.4.0), Magento infers what queues will be created from properties of the `exchange.binding` defined in any given module's `queue_topology.xml`.

Unfortunately, the current implementation of `queue_topology.xml` does not expose a queue object to specify arguments at queue creation time, preventing utilization of the configurable behavior of RabbitMQ queues.


### Related Pull Requests
https://github.com/magento/architecture/pull/432/files

### Manual testing scenarios (*)
https://github.com/magento/architecture/blob/master/design-documents/message-queue/first-class-queue-configuration.md#sample-configurations


### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)

CC: @damienwebdev @nrkapoor @paliarush @nuzil @maghamed 
