### PR TITLE
Cleaned up duplicate variable assignments in the same line

### DIFF
--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/CategoryTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/CategoryTest.php
@@ -94,7 +94,7 @@ class CategoryTest extends TestCase
             ->setMethods(['getState', 'getProductCollection'])
             ->getMock();
 
-        $this->fulltextCollection = $this->fulltextCollection = $this->getMockBuilder(
+        $this->fulltextCollection = $this->getMockBuilder(
             Collection::class
         )
             ->disableOriginalConstructor()

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/DecimalTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/DecimalTest.php
@@ -84,7 +84,7 @@ class DecimalTest extends TestCase
             ->method('create')
             ->willReturn($this->filterItem);
 
-        $this->fulltextCollection = $this->fulltextCollection = $this->getMockBuilder(
+        $this->fulltextCollection = $this->getMockBuilder(
             Collection::class
         )
             ->disableOriginalConstructor()

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/PriceTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/PriceTest.php
@@ -99,7 +99,7 @@ class PriceTest extends TestCase
             ->method('getState')
             ->willReturn($this->state);
 
-        $this->fulltextCollection = $this->fulltextCollection = $this->getMockBuilder(
+        $this->fulltextCollection = $this->getMockBuilder(
             Collection::class
         )
             ->disableOriginalConstructor()

--- a/app/code/Magento/Reports/Block/Adminhtml/Grid.php
+++ b/app/code/Magento/Reports/Block/Adminhtml/Grid.php
@@ -209,7 +209,7 @@ class Grid extends \Magento\Backend\Block\Widget\Grid
         } elseif ($this->getRequest()->getParam('website')) {
             $storeIds = $this->_storeManager->getWebsite($this->getRequest()->getParam('website'))->getStoreIds();
         } elseif ($this->getRequest()->getParam('group')) {
-            $storeIds = $storeIds = $this->_storeManager->getGroup(
+            $storeIds = $this->_storeManager->getGroup(
                 $this->getRequest()->getParam('group')
             )->getStoreIds();
         }

--- a/app/code/Magento/Sales/Model/Order/Payment.php
+++ b/app/code/Magento/Sales/Model/Order/Payment.php
@@ -742,7 +742,7 @@ class Payment extends Info implements OrderPaymentInterface
                 $this->formatPrice($baseAmountToRefund)
             );
         }
-        $message = $message = $this->prependMessage($message);
+        $message = $this->prependMessage($message);
         $message = $this->_appendTransactionToMessage($transaction, $message);
         $orderState = $this->getOrderStateResolver()->getStateForOrder($this->getOrder());
         $statuses = $this->getOrder()->getConfig()->getStateStatuses($orderState, false);

--- a/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/AbstractAggregateCalculator.php
@@ -21,7 +21,7 @@ abstract class AbstractAggregateCalculator extends AbstractCalculator
             $this->taxClassManagement->getTaxClassId($item->getTaxClassKey())
         );
         $rate = $this->calculationTool->getRate($taxRateRequest);
-        $storeRate = $storeRate = $this->calculationTool->getStoreRate($taxRateRequest, $this->storeId);
+        $storeRate = $this->calculationTool->getStoreRate($taxRateRequest, $this->storeId);
 
         $discountTaxCompensationAmount = 0;
         $applyTaxAfterDiscount = $this->config->applyTaxAfterDiscount($this->storeId);

--- a/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
@@ -39,7 +39,7 @@ class UnitBaseCalculator extends AbstractCalculator
             $this->taxClassManagement->getTaxClassId($item->getTaxClassKey())
         );
         $rate = $this->calculationTool->getRate($taxRateRequest);
-        $storeRate = $storeRate = $this->calculationTool->getStoreRate($taxRateRequest, $this->storeId);
+        $storeRate = $this->calculationTool->getStoreRate($taxRateRequest, $this->storeId);
 
         // Calculate $priceInclTax
         $applyTaxAfterDiscount = $this->config->applyTaxAfterDiscount($this->storeId);

--- a/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
@@ -10,12 +10,14 @@ use Magento\Tax\Api\Data\QuoteDetailsItemInterface;
 class UnitBaseCalculator extends AbstractCalculator
 {
     /**
-     * @param $amount
-     * @param null $rate
-     * @param null $direction
+     * Determines the rounding operation type and rounds the amount
+     *
+     * @param float $amount
+     * @param string $rate
+     * @param bool $direction
      * @param string $type
      * @param bool $round
-     * @param null $item
+     * @param QuoteDetailsItemInterface $item
      * @return float|string
      */
     protected function roundAmount(
@@ -37,8 +39,10 @@ class UnitBaseCalculator extends AbstractCalculator
     }
 
     /**
-     * @inheridoc
-     * @param QuoteDetailsItemInterface $item
+     * Calculate tax details for quote item with tax in price with given quantity
+     *
+     * @param QuoteDetai
+     * lsItemInterface $item
      * @param int $quantity
      * @param bool $round
      * @return \Magento\Tax\Api\Data\TaxDetailsItemInterface
@@ -114,7 +118,8 @@ class UnitBaseCalculator extends AbstractCalculator
     }
 
     /**
-     * @inheridoc
+     * Calculate tax details for quote item with tax not in price with given quantity
+     *
      * @param QuoteDetailsItemInterface $item
      * @param int $quantity
      * @param bool $round

--- a/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
@@ -41,8 +41,7 @@ class UnitBaseCalculator extends AbstractCalculator
     /**
      * Calculate tax details for quote item with tax in price with given quantity
      *
-     * @param QuoteDetai
-     * lsItemInterface $item
+     * @param QuoteDetailsItemInterface $item
      * @param int $quantity
      * @param bool $round
      * @return \Magento\Tax\Api\Data\TaxDetailsItemInterface

--- a/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
@@ -10,7 +10,13 @@ use Magento\Tax\Api\Data\QuoteDetailsItemInterface;
 class UnitBaseCalculator extends AbstractCalculator
 {
     /**
-     * {@inheritdoc}
+     * @param $amount
+     * @param null $rate
+     * @param null $direction
+     * @param string $type
+     * @param bool $round
+     * @param null $item
+     * @return float|string
      */
     protected function roundAmount(
         $amount,
@@ -31,7 +37,11 @@ class UnitBaseCalculator extends AbstractCalculator
     }
 
     /**
-     * {@inheritdoc}
+     * @inheridoc
+     * @param QuoteDetailsItemInterface $item
+     * @param int $quantity
+     * @param bool $round
+     * @return \Magento\Tax\Api\Data\TaxDetailsItemInterface
      */
     protected function calculateWithTaxInPrice(QuoteDetailsItemInterface $item, $quantity, $round = true)
     {
@@ -104,7 +114,11 @@ class UnitBaseCalculator extends AbstractCalculator
     }
 
     /**
-     * {@inheritdoc}
+     * @inheridoc
+     * @param QuoteDetailsItemInterface $item
+     * @param int $quantity
+     * @param bool $round
+     * @return \Magento\Tax\Api\Data\TaxDetailsItemInterface
      */
     protected function calculateWithTaxNotInPrice(QuoteDetailsItemInterface $item, $quantity, $round = true)
     {


### PR DESCRIPTION
### Description (*)
Re-apply changes from https://github.com/magento/magento2/pull/28085
This is a simple cleanup of two assignments to the same variable occurring in the same line.
Created by using the following regex:
 (\$.*) \= \1 = (with space before to exclude things like self::$loader = $loader = new \Composer\Autoload\ClassLoader(); and with space after to make sure it's an assignment and not anything else like ===)
And replacing with:
 $1 = (also with space before and after to keep the formatting right)

### Related Pull Requests


### Fixed Issues (if relevant)
-

### Manual testing scenarios (*)
none required

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30133: Cleaned up duplicate variable assignments in the same line