### PR TITLE
Improve render minicart content by native binding knockoutJs

### DIFF
--- a/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontAddProductWithAllTypesOfCustomOptionToTheShoppingCartTest.xml
@@ -105,7 +105,7 @@
         <!-- Assert Product Count in Mini Cart -->
         <actionGroup ref="StorefrontAssertMiniCartItemCountActionGroup" stepKey="assertProductCountAndTextInMiniCart">
             <argument name="productCount" value="2"/>
-            <argument name="productCountText" value="2 Item in Cart"/>
+            <argument name="productCountText" value="2 Items in Cart"/>
         </actionGroup>
 
         <!--Assert Product Items in Mini cart-->

--- a/app/code/Magento/Checkout/view/frontend/web/template/minicart/content.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/minicart/content.html
@@ -6,12 +6,18 @@
 -->
 <div class="block-title">
     <strong>
-        <span class="text" translate="'My Cart'"/>
+        <span class="text" data-bind="i18n: 'My Cart'"/>
         <span
             class="qty empty"
-            text="getCartParam('summary_count')"
-            data-bind="css: { empty: !!getCartParam('summary_count') == false },
-                       attr: { title: $t('Items in Cart') }">
+            data-bind="
+                css: {
+                    empty: !!getCartParam('summary_count') == false
+                },
+                attr: {
+                    title: $t('Items in Cart')
+                },
+                text: getCartParam('summary_count')
+            ">
         </span>
     </strong>
 </div>
@@ -27,26 +33,29 @@
                 },
                 click: closeMinicart()
             ">
-        <span translate="'Close'"/>
+        <span data-bind="i18n: 'Close'"/>
     </button>
 
-    <if args="getCartParam('summary_count')">
+    <!-- ko if: getCartParam('summary_count') -->
         <div class="items-total">
-            <span class="count" if="maxItemsToDisplay < getCartLineItemsCount()" text="maxItemsToDisplay"/>
-            <translate args="'of'" if="maxItemsToDisplay < getCartLineItemsCount()"/>
-            <span class="count" text="getCartParam('summary_count')"/>
-                <!-- ko if: (getCartLineItemsCount() === 1) -->
-                    <span translate="'Item in Cart'"/>
-                <!--/ko-->
-                <!-- ko if: (getCartLineItemsCount() > 1) -->
-                    <span translate="'Items in Cart'"/>
-                <!--/ko-->
+            <!-- ko if: maxItemsToDisplay < getCartLineItemsCount() -->
+            <span class="count" data-bind="text: maxItemsToDisplay"/>
+            <!-- /ko -->
+            <!-- ko if: maxItemsToDisplay < getCartLineItemsCount() --><!-- ko i18n: 'of' --><!-- /ko --><!-- /ko -->
+            <span class="count" data-bind="text: getCartParam('summary_count')"/>
+            <!-- ko if: (getCartParam('summary_count') === 1) -->
+                <span data-bind="i18n: 'Item in Cart'"/>
+            <!-- /ko -->
+            <!-- ko if: (getCartParam('summary_count') > 1) -->
+                <span data-bind="i18n: 'Items in Cart'"/>
+            <!-- /ko -->
         </div>
 
-        <each args="getRegion('subtotalContainer')" render=""/>
-        <each args="getRegion('extraInfo')" render=""/>
+        <!-- ko foreach: getRegion('subtotalContainer') --><!-- ko template: getTemplate() --><!-- /ko --><!-- /ko -->
+        <!-- ko foreach: getRegion('extraInfo') --><!-- ko template: getTemplate() --><!-- /ko --><!-- /ko -->
 
-        <div class="actions" if="getCartParam('possible_onepage_checkout')">
+        <!-- ko if: getCartParam('possible_onepage_checkout') -->
+        <div class="actions">
             <div class="primary">
                 <button
                         id="top-cart-btn-checkout"
@@ -57,52 +66,57 @@
                             attr: {
                                 title: $t('Proceed to Checkout')
                             },
-                            click: closeMinicart()
+                            click: closeMinicart(),
+                            i18n: 'Proceed to Checkout'
                         "
-                        translate="'Proceed to Checkout'"
                 />
                 <div data-bind="html: getCartParamUnsanitizedHtml('extra_actions')"></div>
             </div>
         </div>
-    </if>
+        <!-- /ko -->
+    <!-- /ko -->
 
-    <if args="getCartParam('summary_count')">
-        <strong class="subtitle" translate="'Recently added item(s)'"/>
+    <!-- ko if: getCartParam('summary_count') -->
+        <strong class="subtitle" data-bind="i18n: 'Recently added item(s)'"/>
         <div data-action="scroll" class="minicart-items-wrapper">
             <ol id="mini-cart" class="minicart-items" data-bind="foreach: { data: getCartItems(), as: 'item' }">
-                <each args="$parent.getRegion($parent.getItemRenderer(item.product_type))"
-                      render="{name: getTemplate(), data: item, afterRender: function() {$parents[1].initSidebar()}}"
-                />
+                <!-- ko foreach: $parent.getRegion($parent.getItemRenderer(item.product_type)) -->
+                    <!-- ko template: {name: getTemplate(), data: item, afterRender: function() {$parents[1].initSidebar()}} --><!-- /ko -->
+                <!-- /ko -->
             </ol>
         </div>
-    </if>
+    <!-- /ko -->
 
-    <ifnot args="getCartParam('summary_count')">
+    <!-- ko ifnot: getCartParam('summary_count') -->
         <strong class="subtitle empty"
-                translate="'You have no items in your shopping cart.'"
+                data-bind="i18n: 'You have no items in your shopping cart.'"
         />
-        <if args="getCartParam('cart_empty_message')">
-            <p class="minicart empty text" text="getCartParam('cart_empty_message')"/>
+        <!-- ko if: getCartParam('cart_empty_message') -->
+            <p class="minicart empty text" data-bind="text: getCartParam('cart_empty_message')"/>
             <div class="actions">
                 <div class="secondary">
                     <a class="action viewcart" data-bind="attr: {href: shoppingCartUrl}">
-                        <span translate="'View and Edit Cart'"/>
+                        <span data-bind="i18n: 'View and Edit Cart'"/>
                     </a>
                 </div>
             </div>
-        </if>
-    </ifnot>
+        <!-- /ko -->
+    <!-- /ko -->
 
-    <div class="actions" if="getCartParam('summary_count')">
+    <!-- ko if: getCartParam('summary_count') -->
+    <div class="actions">
         <div class="secondary">
             <a class="action viewcart" data-bind="attr: {href: shoppingCartUrl}">
-                <span translate="'View and Edit Cart'"/>
+                <span data-bind="i18n: 'View and Edit Cart'"/>
             </a>
         </div>
     </div>
+    <!-- /ko -->
 
-    <div id="minicart-widgets" class="minicart-widgets" if="regionHasElements('promotion')">
-        <each args="getRegion('promotion')" render=""/>
+    <!-- ko if: regionHasElements('promotion') -->
+    <div id="minicart-widgets" class="minicart-widgets">
+        <!-- ko foreach: getRegion('promotion') --><!-- ko template: getTemplate() --><!-- /ko --><!-- /ko -->
     </div>
+    <!-- /ko -->
 </div>
-<each args="getRegion('sign-in-popup')" render=""/>
+<!-- ko foreach: getRegion('sign-in-popup') --><!-- ko template: getTemplate() --><!-- /ko --><!-- /ko -->


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR aim to bring improvement for render minicart content by default knockout binding instead use magento binding. Default magento provide it own custom binding and used widely across core base
More details here: https://devdocs.magento.com/guides/v2.4/ui_comp_guide/concepts/magento-bindings.html
With new patch minicart content will render faster
We should delivery content as fast as possible for user at first load. Improve user experiences

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
No issue available related 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Test in some main page such as : Home , Category, Details Page
2. Add product to cart
3. Verify minicart content update and render without break
For profiler deep check we need open "Performance" tab in google chrome dev tools
Reload from start record for profiling
Zoom in graph profile > See Network section and find and indicate
Magento/Checkout/view/frontend/web/template/minicart/content.html rendered
See Main section to view how much time  parseTemplate called

Test check qty visual in minicart
when use config Display Cart Summary: Display item quantities <=Default option
Admin > Configuration > Sales > Checkout > My Cart Link

Test case 1: Add only one product and update qty to above a least 2
Expected result: show correct item qty 
Test case 2: Add 2 products and update qty
Expected result show correct item qty 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
Why choose minicart? Because it's show in almost page and render while user interactive to ui

Before change results
![before_update](https://user-images.githubusercontent.com/1908873/94830107-66d5d680-0435-11eb-9efc-7fbe27b13378.png)
Time parse: ~7ms

After change results
![after_update](https://user-images.githubusercontent.com/1908873/94830114-6b01f400-0435-11eb-8b9c-5b5c7b6cc1ac.png)
Time parse: ~2ms

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30564: Improve render minicart content by native binding knockoutJs