### PR TITLE
Return correct type

### DIFF
--- a/lib/internal/Magento/Framework/Logger/Monolog.php
+++ b/lib/internal/Magento/Framework/Logger/Monolog.php
@@ -11,7 +11,7 @@ use Monolog\Logger;
 class Monolog extends Logger
 {
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function __construct($name, array $handlers = [], array $processors = [])
     {

--- a/lib/internal/Magento/Framework/Logger/Monolog.php
+++ b/lib/internal/Magento/Framework/Logger/Monolog.php
@@ -29,7 +29,7 @@ class Monolog extends Logger
      * @param integer $level The logging level
      * @param string $message The log message
      * @param array $context The log context
-     * @return Boolean Whether the record has been processed
+     * @return bool Whether the record has been processed
      */
     public function addRecord($level, $message, array $context = [])
     {


### PR DESCRIPTION
### Description

`Boolean` and `bool` aren't the same thing for static analysis tools.

### Manual testing scenarios

1. Overwrite `\Magento\Framework\Logger\Monolog` with a class that you own;
2. Run `psalm` against your class;
3.
```
ERROR: UndefinedDocblockClass - app/code/Vendor/Module/Model/Logger.php:15:16 - Docblock-defined class or interface Magento\Framework\Logger\Boolean does not exist (see https://psalm.dev/200)
        return parent::addRecord($level, $message, $context);
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
