### PR TITLE
Fix compatibility with phpunit 9.3 in integration and api functional tests

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/WebApiTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/WebApiTest.php
@@ -11,9 +11,16 @@ use Magento\TestFramework\SkippableInterface;
 use Magento\TestFramework\Workaround\Override\Config;
 use Magento\TestFramework\Workaround\Override\WrapperGenerator;
 use PHPUnit\Framework\TestSuite;
+use PHPUnit\TextUI\Configuration\Configuration as LegacyConfiguration;
 use PHPUnit\TextUI\Configuration\Registry;
-use PHPUnit\TextUI\Configuration\TestSuiteCollection;
-use PHPUnit\TextUI\Configuration\TestSuiteMapper;
+use PHPUnit\TextUI\Configuration\TestSuite as LegacyTestSuiteConfiguration;
+use PHPUnit\TextUI\Configuration\TestSuiteCollection as LegacyTestSuiteCollection;
+use PHPUnit\TextUI\Configuration\TestSuiteMapper as LegacyTestSuiteMapper;
+use PHPUnit\TextUI\XmlConfiguration\Configuration;
+use PHPUnit\TextUI\XmlConfiguration\Loader;
+use PHPUnit\TextUI\XmlConfiguration\TestSuite as TestSuiteConfiguration;
+use PHPUnit\TextUI\XmlConfiguration\TestSuiteCollection;
+use PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper;
 
 /**
  * Web API tests wrapper.
@@ -24,17 +31,17 @@ class WebApiTest extends TestSuite
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @param string $className
      * @return TestSuite
+     * @throws \ReflectionException
      */
     public static function suite($className)
     {
         $generator = new WrapperGenerator();
         $overrideConfig = Config::getInstance();
-        $configuration = Registry::getInstance()->get(self::getConfigurationFile());
+        $configuration = self::getConfiguration();
         $suitesConfig = $configuration->testSuite();
         $suite = new TestSuite();
-        /** @var \PHPUnit\TextUI\Configuration\TestSuite $suiteConfig */
         foreach ($suitesConfig as $suiteConfig) {
-            $suites = (new TestSuiteMapper())->map(TestSuiteCollection::fromArray([$suiteConfig]), '');
+            $suites = self::getSuites($suiteConfig);
             /** @var TestSuite $testSuite */
             foreach ($suites as $testSuite) {
                 /** @var TestSuite $test */
@@ -67,5 +74,40 @@ class WebApiTest extends TestSuite
         $shortConfig = $params['c'] ?? '';
 
         return $shortConfig ? $shortConfig : $longConfig;
+    }
+
+    /**
+     * Retrieve configuration depends on used phpunit version
+     *
+     * @return Configuration|LegacyConfiguration
+     */
+    private static function getConfiguration()
+    {
+        // Compatibility with phpunit < 9.3
+        if (!class_exists(Configuration::class)) {
+            // @phpstan-ignore-next-line
+            return Registry::getInstance()->get(self::getConfigurationFile());
+        }
+
+        // @phpstan-ignore-next-line
+        return (new Loader())->load(self::getConfigurationFile());
+    }
+
+    /**
+     * Retrieve test suites by suite config depends on used phpunit version
+     *
+     * @param TestSuiteConfiguration|LegacyTestSuiteConfiguration $suiteConfig
+     * @return TestSuite
+     */
+    private static function getSuites($suiteConfig)
+    {
+        // Compatibility with phpunit < 9.3
+        if (!class_exists(Configuration::class)) {
+            // @phpstan-ignore-next-line
+            return (new LegacyTestSuiteMapper())->map(LegacyTestSuiteCollection::fromArray([$suiteConfig]), '');
+        }
+
+        // @phpstan-ignore-next-line
+        return (new TestSuiteMapper())->map(TestSuiteCollection::fromArray([$suiteConfig]), '');
     }
 }

--- a/dev/tests/integration/testsuite/Magento/IntegrationTest.php
+++ b/dev/tests/integration/testsuite/Magento/IntegrationTest.php
@@ -11,9 +11,16 @@ use Magento\TestFramework\SkippableInterface;
 use Magento\TestFramework\Workaround\Override\Config;
 use Magento\TestFramework\Workaround\Override\WrapperGenerator;
 use PHPUnit\Framework\TestSuite;
+use PHPUnit\TextUI\Configuration\Configuration as LegacyConfiguration;
 use PHPUnit\TextUI\Configuration\Registry;
-use PHPUnit\TextUI\Configuration\TestSuiteCollection;
-use PHPUnit\TextUI\Configuration\TestSuiteMapper;
+use PHPUnit\TextUI\Configuration\TestSuite as LegacyTestSuiteConfiguration;
+use PHPUnit\TextUI\Configuration\TestSuiteCollection as LegacyTestSuiteCollection;
+use PHPUnit\TextUI\Configuration\TestSuiteMapper as LegacyTestSuiteMapper;
+use PHPUnit\TextUI\XmlConfiguration\Configuration;
+use PHPUnit\TextUI\XmlConfiguration\Loader;
+use PHPUnit\TextUI\XmlConfiguration\TestSuite as TestSuiteConfiguration;
+use PHPUnit\TextUI\XmlConfiguration\TestSuiteCollection;
+use PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper;
 
 /**
  * Integration tests wrapper.
@@ -24,20 +31,20 @@ class IntegrationTest extends TestSuite
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      * @param string $className
      * @return TestSuite
+     * @throws \ReflectionException
      */
     public static function suite($className)
     {
         $generator = new WrapperGenerator();
         $overrideConfig = Config::getInstance();
-        $configuration = Registry::getInstance()->get(self::getConfigurationFile());
+        $configuration = self::getConfiguration();
         $suitesConfig = $configuration->testSuite();
         $suite = new TestSuite();
-        /** @var \PHPUnit\TextUI\Configuration\TestSuite $suiteConfig */
         foreach ($suitesConfig as $suiteConfig) {
             if ($suiteConfig->name() === 'Magento Integration Tests') {
                 continue;
             }
-            $suites = (new TestSuiteMapper())->map(TestSuiteCollection::fromArray([$suiteConfig]), '');
+            $suites = self::getSuites($suiteConfig);
             /** @var TestSuite $testSuite */
             foreach ($suites as $testSuite) {
                 /** @var TestSuite $test */
@@ -70,5 +77,40 @@ class IntegrationTest extends TestSuite
         $shortConfig = $params['c'] ?? '';
 
         return $shortConfig ? $shortConfig : $longConfig;
+    }
+
+    /**
+     * Retrieve configuration depends on used phpunit version
+     *
+     * @return Configuration|LegacyConfiguration
+     */
+    private static function getConfiguration()
+    {
+        // Compatibility with phpunit < 9.3
+        if (!class_exists(Configuration::class)) {
+            // @phpstan-ignore-next-line
+            return Registry::getInstance()->get(self::getConfigurationFile());
+        }
+
+        // @phpstan-ignore-next-line
+        return (new Loader())->load(self::getConfigurationFile());
+    }
+
+    /**
+     * Retrieve test suites by suite config depends on used phpunit version
+     *
+     * @param TestSuiteConfiguration|LegacyTestSuiteConfiguration $suiteConfig
+     * @return TestSuite
+     */
+    private static function getSuites($suiteConfig)
+    {
+        // Compatibility with phpunit < 9.3
+        if (!class_exists(Configuration::class)) {
+            // @phpstan-ignore-next-line
+            return (new LegacyTestSuiteMapper())->map(LegacyTestSuiteCollection::fromArray([$suiteConfig]), '');
+        }
+
+        // @phpstan-ignore-next-line
+        return (new TestSuiteMapper())->map(TestSuiteCollection::fromArray([$suiteConfig]), '');
     }
 }


### PR DESCRIPTION
### Description (*)
Fixes compatibility with phpunit 9.3 and keeping backward compatibility with phpunit <9.3, similar what was done in symfony https://github.com/symfony/phpunit-bridge/commit/9a87dd7e6074107ebc36ae96c231f79e8eb3fa59

✔ Before my changes on phpunit 9.1:
❌ Before my changes on phpunit 9.3:
![image](https://user-images.githubusercontent.com/1873745/94028646-b0cf1480-fdc4-11ea-8555-12b50242423b.png)


✔ After my changes on phpunit 9.1:
![image](https://user-images.githubusercontent.com/1873745/94028553-98f79080-fdc4-11ea-87bc-0178c4840b47.png)
✔ After my changes on phpunit 9.3:
![image](https://user-images.githubusercontent.com/1873745/94028599-a3198f00-fdc4-11ea-9666-812a28a62cd9.png)


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes https://github.com/magento/magento2/issues/30146

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Try to run integration tests
2. Try to run api functional tests
3. Upgrade to phpunit 9.3
4. Try to run integration tests again
5. Try to run api functional tests


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
