### PR TITLE
fixing arguments for method in getStatusByState

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Status.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Status.php
@@ -257,7 +257,7 @@ class Status extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     {
         return (string)$this->getConnection()->fetchOne(
             $select = $this->getConnection()->select()
-                ->from(['sss' => $this->stateTable, []])
+                ->from(['sss' => $this->stateTable], [])
                 ->where('state = ?', $state)
                 ->limit(1)
                 ->columns(['status'])


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
if you will checking this condition 
`echo $select = $this->getConnection()->select()
            ->from(['sss' => $this->stateTable, []])
            ->where('state = ?', $state)
            ->limit(1)
            ->columns(['status']);` 
then you see
`SELECT 
    `sss`.*, `sss`.`status`
FROM
    `sales_order_status_state` AS `sss`
WHERE
    (state = 'complete')
LIMIT 1`
but method getStatusByState return is correct value - because the status of a certain state should return. But if this code is rewritten to get the state, then we will also get the status, this is all due to the incorrect parameter in the from method

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. echo $select in getStatusByState method should return sql like this
`SELECT `sss`.`status` FROM `sales_order_status_state` AS `sss` WHERE (state = 'complete') LIMIT 1`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30173: fixing arguments for method in getStatusByState