### PR TITLE
Fix docblock annotation for PublisherInterface message

### DIFF
--- a/lib/internal/Magento/Framework/MessageQueue/PublisherInterface.php
+++ b/lib/internal/Magento/Framework/MessageQueue/PublisherInterface.php
@@ -18,7 +18,7 @@ interface PublisherInterface
      * Publishes a message to a specific queue or exchange.
      *
      * @param string $topicName
-     * @param array|object $data
+     * @param $data
      * @return null|mixed
      * @throws \InvalidArgumentException If message is not formed properly
      * @since 103.0.0

--- a/lib/internal/Magento/Framework/MessageQueue/PublisherInterface.php
+++ b/lib/internal/Magento/Framework/MessageQueue/PublisherInterface.php
@@ -18,7 +18,7 @@ interface PublisherInterface
      * Publishes a message to a specific queue or exchange.
      *
      * @param string $topicName
-     * @param $data
+     * @param mixed $data
      * @return null|mixed
      * @throws \InvalidArgumentException If message is not formed properly
      * @since 103.0.0


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

The message on the publisher interface's `publish` method currently has a docblock annotation of `array|object`. However, since this type can be anything other than array or object as long as it's defined in the `communication.xml` this docblock annotation creates confusion. The docblock annotation is therefore wrong. This PR fixes that.

### Related Pull Requests
<!-- related pull request placeholder -->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Since this is a doc change, I'm not sure if there's any manual testing scenarios? Please tell me if I'm wrong.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30190: Fix docblock annotation for PublisherInterface message