### PR TITLE
Fix PHPDoc param attribute is not always a string

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/EntityAbstract.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/EntityAbstract.php
@@ -87,7 +87,7 @@ abstract class EntityAbstract extends AbstractDb
      * Perform actions after object save
      *
      * @param \Magento\Framework\Model\AbstractModel $object
-     * @param string $attribute
+     * @param AbstractAttribute|string[]|string $attribute
      * @return $this
      * @throws \Exception
      */


### PR DESCRIPTION
# Description (*)
Fix PHPDoc param attribute is not always a string

In the implementation:

```
if ($attribute instanceof AbstractAttribute) {
    $attributes = $attribute->getAttributeCode();
} elseif (is_string($attribute)) {
    $attributes = [$attribute];
} else {
    $attributes = $attribute;
}
```

# Manual testing scenarios (*)

N/A

Contribution checklist (*)
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable) / N/A
- [x] All automated tests passed successfully (all builds are green) / N/A

### Resolved issues:
1. [x] resolves magento/magento2#30191: Fix PHPDoc param attribute is not always a string