### PR TITLE
Cart item Price should be the converted (with quote currency) value (…

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/CartItemPrices.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/CartItemPrices.php
@@ -60,7 +60,7 @@ class CartItemPrices implements ResolverInterface
         return [
             'price' => [
                 'currency' => $currencyCode,
-                'value' => $cartItem->getPrice(),
+                'value' => $cartItem->getConvertedPrice(),
             ],
             'row_total' => [
                 'currency' => $currencyCode,

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
@@ -232,6 +232,30 @@ class CartTotalsTest extends GraphQlAbstract
     }
 
     /**
+     * The totals calculation with second currency.
+     *
+     * @magentoApiDataFixture Magento/Store/_files/second_store_with_second_currency.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     */
+    public function testGetCartTotalsWithDifferentCurrency()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $storeCodeFromFixture = 'fixture_second_store';
+        $headerMap = ['Store' => $storeCodeFromFixture, 'Content-Currency' => 'EUR'];
+        $response = $this->graphQlQuery($query, [], '', $headerMap);
+
+        $cartItem = $response['cart']['items'][0];
+        self::assertEquals(20, $cartItem['prices']['price']['value']);
+        self::assertEquals(40, $cartItem['prices']['row_total']['value']);
+        self::assertEquals(40, $cartItem['prices']['row_total_including_tax']['value']);
+        self::assertEquals('EUR', $cartItem['prices']['price']['currency']);
+        self::assertEquals('EUR', $cartItem['prices']['row_total']['currency']);
+    }
+
+    /**
      * _security
      * @magentoApiDataFixture Magento/Customer/_files/customer.php
      * @magentoApiDataFixture Magento/GraphQl/Tax/_files/tax_rule_for_region_1.php

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
@@ -234,7 +234,7 @@ class CartTotalsTest extends GraphQlAbstract
     /**
      * The totals calculation with second currency.
      *
-     * @magentoApiDataFixture Magento/Store/_files/second_store_with_second_currency.php
+     * @magentoApiDataFixture Magento/CurrencySymbol/_files/second_currency.php
      * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
@@ -243,8 +243,7 @@ class CartTotalsTest extends GraphQlAbstract
     {
         $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
         $query = $this->getQuery($maskedQuoteId);
-        $storeCodeFromFixture = 'fixture_second_store';
-        $headerMap = ['Store' => $storeCodeFromFixture, 'Content-Currency' => 'EUR'];
+        $headerMap = ['Content-Currency' => 'EUR'];
         $response = $this->graphQlQuery($query, [], '', $headerMap);
 
         $cartItem = $response['cart']['items'][0];

--- a/dev/tests/integration/testsuite/Magento/CurrencySymbol/_files/second_currency.php
+++ b/dev/tests/integration/testsuite/Magento/CurrencySymbol/_files/second_currency.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+use Magento\TestFramework\Workaround\Override\Fixture\Resolver;
+
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+$store = $objectManager->create(\Magento\Store\Model\Store::class);
+if ($storeId = $store->load('default', 'code')->getId()) {
+    /** @var \Magento\Config\Model\ResourceModel\Config $configResource */
+    $configResource = $objectManager->get(\Magento\Config\Model\ResourceModel\Config::class);
+    $configResource->saveConfig(
+        \Magento\Directory\Model\Currency::XML_PATH_CURRENCY_DEFAULT,
+        'EUR',
+        \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+        $storeId
+    );
+    $configResource->saveConfig(
+        \Magento\Directory\Model\Currency::XML_PATH_CURRENCY_ALLOW,
+        'EUR',
+        \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+        $storeId
+    );
+    /**
+     * Configuration cache clean is required to reload currency setting
+     */
+    /** @var Magento\Config\App\Config\Type\System $config */
+    $config = $objectManager->get(\Magento\Config\App\Config\Type\System::class);
+    $config->clean();
+}
+
+
+/** @var \Magento\Directory\Model\ResourceModel\Currency $rate */
+$rate = $objectManager->create(\Magento\Directory\Model\ResourceModel\Currency::class);
+$rate->saveRates(
+    [
+        'USD' => ['EUR' => 2],
+        'EUR' => ['USD' => 0.5]
+    ]
+);

--- a/dev/tests/integration/testsuite/Magento/CurrencySymbol/_files/second_currency_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/CurrencySymbol/_files/second_currency_rollback.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+use Magento\TestFramework\Workaround\Override\Fixture\Resolver;
+
+$objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+$store = $objectManager->create(\Magento\Store\Model\Store::class);
+$storeId = $store->load('default', 'code')->getId();
+
+if ($storeId) {
+    $configResource = $objectManager->get(\Magento\Config\Model\ResourceModel\Config::class);
+    $configResource->deleteConfig(
+        \Magento\Directory\Model\Currency::XML_PATH_CURRENCY_DEFAULT,
+        \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+        $storeId
+    );
+    $configResource->deleteConfig(
+        \Magento\Directory\Model\Currency::XML_PATH_CURRENCY_ALLOW,
+        \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+        $storeId
+    );
+}


### PR DESCRIPTION
Cart item Price should be the converted (with quote currency) value (like row_total, row_total_including_tax, and total_item_discount that's already the right value).

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#29994

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Send the "Content-Currency" header with a value that's different from the default currency.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [v] Pull request has a meaningful description of its purpose
 - [v] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
