### PR TITLE
MFTF: Replace repetitive actions with Action Groups in AdminUpdateStoreGroupAcceptAlertAndVerifyStoreViewFormTest, AdminUpdateStoreGroupAndVerifyStoreViewFormTest and AdminUpdateStoreViewTest

### DIFF
--- a/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminOpenFirstRowInStoresGridActionGroup.xml
+++ b/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminOpenFirstRowInStoresGridActionGroup.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminOpenFirstRowInStoresGridActionGroup">
+
+        <click selector="{{AdminStoresGridSection.firstRow}}" stepKey="clickFirstRow"/>
+        <waitForPageLoad stepKey="AdminSystemStoreGroupPageToOpen"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminOpenStoreInFirstRowInStoresGridActionGroup.xml
+++ b/app/code/Magento/Store/Test/Mftf/ActionGroup/AdminOpenStoreInFirstRowInStoresGridActionGroup.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminOpenStoreInFirstRowInStoresGridActionGroup">
+
+        <click selector="{{AdminStoresGridSection.storeNameInFirstRow}}" stepKey="clickStoreViewFirstRowInGrid"/>
+        <waitForPageLoad stepKey="waitForAdminSystemStoreViewPageLoad"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateStoreGroupAcceptAlertAndVerifyStoreViewFormTest.xml
+++ b/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateStoreGroupAcceptAlertAndVerifyStoreViewFormTest.xml
@@ -51,8 +51,8 @@
         <actionGroup ref="AssertStoreGroupInGridActionGroup" stepKey="openCreatedStoreGroupInGrid">
             <argument name="storeGroupName" value="{{staticStoreGroup.name}}"/>
         </actionGroup>
-        <click selector="{{AdminStoresGridSection.firstRow}}" stepKey="clickFirstRow"/>
-        <waitForPageLoad stepKey="AdminSystemStoreGroupPageToOpen"/>
+        <actionGroup ref="AdminOpenFirstRowInStoresGridActionGroup" stepKey="clickFirstRow"/>
+
         <!--Update created Store group as per requirement and accept alert message-->
         <actionGroup ref="EditCustomStoreGroupAcceptWarningMessageActionGroup" stepKey="updateCustomStoreGroup">
             <argument name="website" value="{{customWebsite.name}}"/>

--- a/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateStoreGroupAndVerifyStoreViewFormTest.xml
+++ b/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateStoreGroupAndVerifyStoreViewFormTest.xml
@@ -41,8 +41,8 @@
         <actionGroup ref="AssertStoreGroupInGridActionGroup" stepKey="openCreatedStoreGroupInGrid">
             <argument name="storeGroupName" value="{{SecondStoreGroupUnique.name}}"/>
         </actionGroup>
-        <click selector="{{AdminStoresGridSection.firstRow}}" stepKey="clickFirstRow"/>
-        <waitForPageLoad stepKey="AdminSystemStoreGroupPageToOpen"/>
+        <actionGroup ref="AdminOpenFirstRowInStoresGridActionGroup" stepKey="clickFirstRow"/>
+
         <!--Update created Store group as per requirement-->
         <actionGroup ref="CreateCustomStoreActionGroup" stepKey="createNewCustomStoreGroup">
             <argument name="website" value="{{_defaultWebsite.name}}"/>

--- a/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateStoreViewTest.xml
+++ b/app/code/Magento/Store/Test/Mftf/Test/AdminUpdateStoreViewTest.xml
@@ -39,8 +39,8 @@
             <actionGroup ref="AssertStoreViewInGridActionGroup" stepKey="searchCreatedStoreViewInGrid">
                 <argument name="storeViewName" value="{{storeViewData.name}}"/>
             </actionGroup>
-            <click selector="{{AdminStoresGridSection.storeNameInFirstRow}}" stepKey="clickStoreViewFirstRowInGrid"/>
-            <waitForPageLoad stepKey="waitForAdminSystemStoreViewPageLoad"/>
+            <actionGroup ref="AdminOpenStoreInFirstRowInStoresGridActionGroup" stepKey="clickStoreViewFirstRowInGrid"/>
+
             <!--Update created store view as per requirements-->
             <actionGroup ref="AdminCreateStoreViewActionGroup" stepKey="updateStoreView">
                 <argument name="StoreGroup" value="_defaultStoreGroup"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
AdminUpdateStoreGroupAcceptAlertAndVerifyStoreViewFormTest, AdminUpdateStoreGroupAndVerifyStoreViewFormTest and AdminUpdateStoreViewTest are refactored according to the best practices followed by MFTF.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
Run tests in the local environment and verified the tests run successfully.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
