### PR TITLE
Fix exception which is thrown on search results page

### DIFF
--- a/app/code/Magento/Search/Model/SynonymAnalyzer.php
+++ b/app/code/Magento/Search/Model/SynonymAnalyzer.php
@@ -138,7 +138,7 @@ class SynonymAnalyzer implements SynonymAnalyzerInterface
         $patterns = [];
         for ($lastItem = count($words); $lastItem > 0; $lastItem--) {
             $words = array_map(function ($word) {
-               return preg_quote($word, '/');
+                return preg_quote($word, '/');
             }, $words);
             $phrase = implode("\s+", \array_slice($words, 0, $lastItem));
             $patterns[] = '^' . $phrase . ',';

--- a/app/code/Magento/Search/Model/SynonymAnalyzer.php
+++ b/app/code/Magento/Search/Model/SynonymAnalyzer.php
@@ -137,6 +137,7 @@ class SynonymAnalyzer implements SynonymAnalyzerInterface
         $patterns = [];
         for ($lastItem = count($words); $lastItem > 0; $lastItem--) {
             $phrase = implode("\s+", \array_slice($words, 0, $lastItem));
+            $phrase = preg_quote($phrase, '/');
             $patterns[] = '^' . $phrase . ',';
             $patterns[] = ',' . $phrase . ',';
             $patterns[] = ',' . $phrase . '$';

--- a/app/code/Magento/Search/Model/SynonymAnalyzer.php
+++ b/app/code/Magento/Search/Model/SynonymAnalyzer.php
@@ -137,8 +137,10 @@ class SynonymAnalyzer implements SynonymAnalyzerInterface
     {
         $patterns = [];
         for ($lastItem = count($words); $lastItem > 0; $lastItem--) {
+            $words = array_map(function ($word) {
+               return preg_quote($word, '/');
+            }, $words);
             $phrase = implode("\s+", \array_slice($words, 0, $lastItem));
-            $phrase = preg_quote($phrase, '/');
             $patterns[] = '^' . $phrase . ',';
             $patterns[] = ',' . $phrase . ',';
             $patterns[] = ',' . $phrase . '$';

--- a/app/code/Magento/Search/Model/SynonymAnalyzer.php
+++ b/app/code/Magento/Search/Model/SynonymAnalyzer.php
@@ -42,6 +42,7 @@ class SynonymAnalyzer implements SynonymAnalyzerInterface
      *   3 => [ 0 => "british", 1 => "english" ],
      *   4 => [ 0 => "queen", 1 => "monarch" ]
      * ]
+     *
      * @param string $phrase
      * @return array
      * @throws \Magento\Framework\Exception\LocalizedException

--- a/app/code/Magento/Search/Test/Unit/Model/SynonymAnalyzerTest.php
+++ b/app/code/Magento/Search/Test/Unit/Model/SynonymAnalyzerTest.php
@@ -49,9 +49,9 @@ class SynonymAnalyzerTest extends TestCase
      */
     public function testGetSynonymsForPhrase()
     {
-        $phrase = 'Elizabeth is the british queen';
+        $phrase = 'Elizabeth/Angela is the british queen';
         $expected = [
-            0 => [ 0 => "Elizabeth" ],
+            0 => [ 0 => "Elizabeth/Angela" ],
             1 => [ 0 => "is" ],
             2 => [ 0 => "the" ],
             3 => [ 0 => "british", 1 => "english" ],

--- a/dev/tests/integration/testsuite/Magento/Search/Model/SynonymAnalyzerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Search/Model/SynonymAnalyzerTest.php
@@ -78,6 +78,10 @@ class SynonymAnalyzerTest extends \PHPUnit\Framework\TestCase
                 'phrase' => 'schlicht',
                 'expectedResult' => [['schlicht', 'natürlich']]
             ],
+            'withSlashInSearchPhrase' => [
+                'phrase' => 'orange hill/peak',
+                'expectedResult' => [['orange', 'magento'], ['hill/peak']]
+            ],
         ];
     }
 


### PR DESCRIPTION
### Description

PR fixes issue which results with throwing exception on search page when phrase contains slash (/).

### Related Pull Requests
n/a

### Fixed Issues (if relevant)

1. Fixes magento/magento2#25886
2. Fixes magento/magento2#25110
3. Fixes magento/magento2#28286

### Manual testing scenarios

1. Install clean Magento
2. Ensure that Elasticsearch is enabled as search backend
3. Ensure the synonym exists in SEO & Search -> Search Synonyms:
foo,bar"foobar",
2. Search for "Foo/Bar" in frontend

Without fix, the exception is thrown. PR ensures that generated phrases have preg modifiers escaped so exception won't be thrown.

### Questions or comments

Fix was made inside private method. I'm not sure if any tests should be changed for that? Or regression test should be added?

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
