### PR TITLE
Fix array to string conversion error when saving row system config with defaults

### DIFF
--- a/app/code/Magento/Config/Model/Config/Backend/Serialized.php
+++ b/app/code/Magento/Config/Model/Config/Backend/Serialized.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Config\Model\Config\Backend;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Serialize\Serializer\Json;
 
@@ -83,5 +84,27 @@ class Serialized extends \Magento\Framework\App\Config\Value
         }
         parent::beforeSave();
         return $this;
+    }
+
+    /**
+     * Get old value from existing config
+     *
+     * @return string
+     */
+    public function getOldValue()
+    {
+        // If the value is retrieved from defaults defined in config.xml
+        // it may be returned as an array.
+        $value = $this->_config->getValue(
+            $this->getPath(),
+            $this->getScope() ?: ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
+            $this->getScopeCode()
+        );
+
+        if (is_array($value)) {
+            return $this->serializer->serialize($value);
+        }
+
+        return (string)$value;
     }
 }


### PR DESCRIPTION
### Description (*)

This PR solves issue #30314. The backend model `Magento\Config\Model\Config\Backend\Serialized` that is designed to handle complex values, serializes non-scalar values before they are persisted to database. But when the "old value" is loaded from config defaults (defined in config.xml) for comparison, the default value is received as array. When the array is casted to string it results in an array to string conversion error.

This issue is fixed by overriding the `getOldValue` function of `Magento\Framework\App\Config\Value` and serializing the default value coming from the config.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#30314

### Manual testing scenarios (*)

The above mentioned issue describes what to do, to reproduce the issue.

### Questions or comments

Does it make sense to merge this fix into Magento 2.3 branch?

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
