### PR TITLE
Allow to cache search results

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish4.vcl
+++ b/app/code/Magento/PageCache/etc/varnish4.vcl
@@ -57,8 +57,8 @@ sub vcl_recv {
         return (pass);
     }
 
-    # Bypass shopping cart, checkout and search requests
-    if (req.url ~ "/checkout" || req.url ~ "/catalogsearch") {
+    # Bypass shopping cart and checkout
+    if (req.url ~ "/checkout") {
         return (pass);
     }
 

--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -58,8 +58,8 @@ sub vcl_recv {
         return (pass);
     }
 
-    # Bypass shopping cart, checkout and search requests
-    if (req.url ~ "/checkout" || req.url ~ "/catalogsearch") {
+    # Bypass shopping cart and checkout
+    if (req.url ~ "/checkout") {
         return (pass);
     }
 

--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -62,8 +62,8 @@ sub vcl_recv {
         return (pass);
     }
 
-    # Bypass shopping cart, checkout and search requests
-    if (req.url ~ "/checkout" || req.url ~ "/catalogsearch") {
+    # Bypass shopping cart and checkout
+    if (req.url ~ "/checkout") {
         return (pass);
     }
 


### PR DESCRIPTION
### Description (*)
Starting version 2.2.4, search result page can be cached, but varnish vcl has a rule to not cache the page.

### Manual testing scenarios (*)
1. Configure magento to use varnish for FPC
2. Do a search with one of the top 100 searches (default value), or go to Go to Admin -> Stores -> Configuration -> Catalog -> Catalog -> Catalog Search and set `Number of top search results to cache` to 0 (this will set to cache all the results)
3. Do the same query, to see if you hit the cache.

Actual result:
- The search page is not cached.

Expected result:
- The search page should be delivered from cache

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30508: Allow to cache search results