### PR TITLE
MFTF: Admin Delete CMS Block Test

### DIFF
--- a/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminDeleteCMSBlockFromGridActionGroup.xml
+++ b/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminDeleteCMSBlockFromGridActionGroup.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminDeleteCMSBlockFromGridActionGroup">
+        <arguments>
+            <argument name="identifier" type="entity"/>
+        </arguments>
+        <click selector="{{BlockPageActionsSection.select(identifier)}}" stepKey="clickSelect"/>
+        <click selector="{{BlockPageActionsSection.delete(identifier)}}" stepKey="clickDelete"/>
+        <waitForElementVisible selector="{{BlockPageActionsSection.deleteConfirm}}" stepKey="waitForOkButtonToBeVisible"/>
+        <click selector="{{BlockPageActionsSection.deleteConfirm}}" stepKey="clickOkButton"/>
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminOpenCMSBlocksGridActionGroup.xml
+++ b/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminOpenCMSBlocksGridActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminOpenCMSBlocksGridActionGroup">
+        <annotations>
+            <description>Navigate to the Admin Blocks Grid page.</description>
+        </annotations>
+
+        <amOnPage url="{{CmsBlocksPage.url}}" stepKey="navigateToCMSBlocksGrid"/>
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminSearchCMSBlockInGridByIdentifierActionGroup.xml
+++ b/app/code/Magento/Cms/Test/Mftf/ActionGroup/AdminSearchCMSBlockInGridByIdentifierActionGroup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminSearchCMSBlockInGridByIdentifierActionGroup">
+        <arguments>
+            <argument name="identifier" type="string"/>
+        </arguments>
+        <click selector="{{BlockPageActionsSection.FilterBtn}}" stepKey="clickFilterButton"/>
+        <fillField selector="{{BlockPageActionsSection.URLKey}}" userInput="{{identifier}}" stepKey="fillIdentifierField"/>
+        <click selector="{{BlockPageActionsSection.ApplyFiltersBtn}}" stepKey="clickApplyFiltersButton"/>
+        <waitForPageLoad stepKey="waitForPageLoading"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertAdminCMSBlockIsNotInGridActionGroup.xml
+++ b/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertAdminCMSBlockIsNotInGridActionGroup.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertAdminCMSBlockIsNotInGridActionGroup">
+        <arguments>
+            <argument name="identifier" type="entity"/>
+        </arguments>
+        <dontSee userInput="{{identifier}}" selector="{{AdminBlockGridSection.gridDataRow}}" stepKey="dontSeeCmsBlockInGrid"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Cms/Test/Mftf/Section/AdminBlockGridSection.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Section/AdminBlockGridSection.xml
@@ -14,6 +14,6 @@
         <element name="checkbox" type="checkbox" selector="//label[@class='data-grid-checkbox-cell-inner']//input[@class='admin__control-checkbox']"/>
         <element name="select" type="select" selector="//tr[@class='data-row']//button[@class='action-select']"/>
         <element name="editInSelect" type="text" selector="//a[contains(text(), 'Edit')]"/>
-        <element name="gridDataRow" type="input" selector=".data-row .data-grid-cell-content"/>
+        <element name="gridDataRow" type="input" selector="//table[@data-role='grid']//tr/td"/>
     </section>
 </sections>

--- a/app/code/Magento/Cms/Test/Mftf/Section/AdminBlockGridSection.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Section/AdminBlockGridSection.xml
@@ -14,5 +14,6 @@
         <element name="checkbox" type="checkbox" selector="//label[@class='data-grid-checkbox-cell-inner']//input[@class='admin__control-checkbox']"/>
         <element name="select" type="select" selector="//tr[@class='data-row']//button[@class='action-select']"/>
         <element name="editInSelect" type="text" selector="//a[contains(text(), 'Edit')]"/>
+        <element name="gridDataRow" type="input" selector=".data-row .data-grid-cell-content"/>
     </section>
 </sections>

--- a/app/code/Magento/Cms/Test/Mftf/Section/BlockPageActionsSection.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Section/BlockPageActionsSection.xml
@@ -20,7 +20,7 @@
         <element name="URLKey" type="input" selector="//div[@class='admin__form-field-control']/input[@name='identifier']"/>
         <element name="ApplyFiltersBtn" type="button" selector="//span[text()='Apply Filters']"/>
         <element name="blockGridRowByTitle" type="input" selector="//tbody//tr//td//div[contains(., '{{var1}}')]" parameterized="true" timeout="30"/>
-        <element name="delete" type="button" selector="//div[text()='{{var1}}']/parent::td//following-sibling::td[@class='data-grid-actions-cell']//a[text()='Delete']" parameterized="true"/>
-        <element name="deleteConfirm" type="button" selector=".action-primary.action-accept" timeout="60"/>
+        <element name="delete" type="button" selector="//a[@data-action='item-delete']"/>
+        <element name="deleteConfirm" type="button" selector="//button[@data-role='action']//span[text()='OK']" timeout="60"/>
     </section>
 </sections>

--- a/app/code/Magento/Cms/Test/Mftf/Section/BlockPageActionsSection.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Section/BlockPageActionsSection.xml
@@ -20,5 +20,7 @@
         <element name="URLKey" type="input" selector="//div[@class='admin__form-field-control']/input[@name='identifier']"/>
         <element name="ApplyFiltersBtn" type="button" selector="//span[text()='Apply Filters']"/>
         <element name="blockGridRowByTitle" type="input" selector="//tbody//tr//td//div[contains(., '{{var1}}')]" parameterized="true" timeout="30"/>
+        <element name="delete" type="button" selector="//div[text()='{{var1}}']/parent::td//following-sibling::td[@class='data-grid-actions-cell']//a[text()='Delete']" parameterized="true"/>
+        <element name="deleteConfirm" type="button" selector=".action-primary.action-accept" timeout="60"/>
     </section>
 </sections>

--- a/app/code/Magento/Cms/Test/Mftf/Test/AdminDeleteCmsBlockTest.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Test/AdminDeleteCmsBlockTest.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminDeleteCmsBlockTest">
+        <annotations>
+            <features value="Cms"/>
+            <stories value="CMS Blocks Deleting"/>
+            <title value="Admin should be able to delete CMS block from grid"/>
+            <description value="Admin should be able to delete CMS block from grid"/>
+            <group value="Cms"/>
+            <severity value="MINOR"/>
+        </annotations>
+        <before>
+            <createData entity="_defaultBlock" stepKey="createCMSBlock"/>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
+        </after>
+
+        <actionGroup ref="AdminOpenCMSBlocksGridActionGroup" stepKey="navigateToCmsBlocksGrid"/>
+        <actionGroup ref="ClearFiltersAdminDataGridActionGroup" stepKey="clearGridSearchFilters"/>
+        <actionGroup ref="AdminSearchCMSBlockInGridByIdentifierActionGroup" stepKey="findCreatedCmsBlock">
+            <argument name="identifier" value="$$createCMSBlock.identifier$$"/>
+        </actionGroup>
+        <actionGroup ref="AdminDeleteCMSBlockFromGridActionGroup" stepKey="deleteCmsBlockFromGrid">
+            <argument name="identifier" value="$$createCMSBlock.identifier$$"/>
+        </actionGroup>
+        <actionGroup ref="AssertMessageInAdminPanelActionGroup" stepKey="assertSuccessMessage">
+            <argument name="message" value="You deleted the block."/>
+        </actionGroup>
+        <actionGroup ref="ClearFiltersAdminDataGridActionGroup" stepKey="clearGridSearchFiltersAfterBlockDeleting"/>
+        <actionGroup ref="AdminSearchCMSBlockInGridByIdentifierActionGroup" stepKey="searchDeletedCmsBlock">
+            <argument name="identifier" value="$$createCMSBlock.identifier$$"/>
+        </actionGroup>
+        <actionGroup ref="AssertAdminCMSBlockIsNotInGridActionGroup" stepKey="assertDeletedCMSBlockIsNotInGrid">
+            <argument name="identifier" value="$$createCMSBlock.identifier$$"/>
+        </actionGroup>
+    </test>
+</tests>


### PR DESCRIPTION
**Description**
This PR contains a test for deleting CMS block from grid by Admin User

**Steps To reproduce:**

1 - Create CMS block
2 - Login as Admin User
3 - Navigate to Content->Blocks
4 - Find Created CMS Block
5 - Delete Created CMS Block
6 - Perform Assertions

### Resolved issues:
1. [x] resolves magento/magento2#30372: MFTF: Admin Delete CMS Block Test