### PR TITLE
fix conflict for logo_height argument by default.xml

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Theme/web/css/source/_module.less
@@ -91,7 +91,6 @@
 
         img {
             display: block;
-            height: auto;
         }
 
         .page-print & {

--- a/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Theme/web/css/source/_module.less
@@ -148,7 +148,6 @@
 
         img {
             display: block;
-            height: auto;
         }
 
         .page-print & {

--- a/lib/web/css/source/lib/_resets.less
+++ b/lib/web/css/source/lib/_resets.less
@@ -49,7 +49,6 @@
 
     img {
         max-width: 100%;
-        height: auto;
         border: 0;
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

For a new theme, for example child of luma, if you want change the logo by default.xml and set also **his size by the height**, you should write this:

`
        <referenceBlock name="logo">
            <arguments>
                <argument name="logo_file" xsi:type="string">images/logo.png</argument>
                <argument name="logo_height" xsi:type="number">300</argument>
            </arguments>
        </referenceBlock>
`

Now the problem is that it doesn't works, because there is a conflict with the line **151** of **_module.less**:
<img width="686" alt="Schermata 2020-10-07 alle 19 56 30" src="https://user-images.githubusercontent.com/6259010/95432179-982b3680-094e-11eb-9969-6f8df7628734.png">
<img width="498" alt="Schermata 2020-10-07 alle 19 56 42" src="https://user-images.githubusercontent.com/6259010/95432303-c6107b00-094e-11eb-9358-d03bd5c97226.png">

The result is that our rule is overwritten:
<img width="367" alt="Schermata 2020-10-07 alle 19 22 14" src="https://user-images.githubusercontent.com/6259010/95432668-42a35980-094f-11eb-9585-31dba5da1cbc.png">

It doesn't happen with **Width**.
Sometime we want set the image by height and not by the width... or maybe with both... why not? It's your choice.
So for now the _logo_height_ have no sense to exist.

The height: auto should be deleted and all will work fine.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Magento 2.4-develop
2. Create a new theme child of Luma
3. Create the **default.xml** and copy this:

        <referenceBlock name="logo">
         <arguments>
                <argument name="logo_file" xsi:type="string">images/logo.png</argument>
                <argument name="logo_height" xsi:type="number">300</argument>
          </arguments>
        </referenceBlock>
4. Put your custom logo.png inside the images folder.
5. Save and delete the cache
6. Refresh the page

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30377: fix conflict for logo_height argument by default.xml