### PR TITLE
30349: Product filter with category_id does not work as expected - fi…

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/ProductSearch.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/DataProvider/ProductSearch.php
@@ -113,7 +113,7 @@ class ProductSearch
         $searchResults = $this->searchResultsFactory->create();
         $searchResults->setSearchCriteria($searchCriteriaForCollection);
         $searchResults->setItems($collection->getItems());
-        $searchResults->setTotalCount($searchResult->getTotalCount());
+        $searchResults->setTotalCount($collection->getSize());
         return $searchResults;
     }
 

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor/CategoryFilter.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor/CategoryFilter.php
@@ -51,6 +51,11 @@ class CategoryFilter implements CustomFilterInterface
      */
     public function apply(Filter $filter, AbstractDb $collection)
     {
+        $conditionType = $filter->getConditionType();
+        if ($conditionType !== 'eq') {
+            return true;
+        }
+
         $categoryIds = $filter->getValue();
         if (!is_array($categoryIds)) {
             $categoryIds = [$categoryIds];
@@ -61,6 +66,7 @@ class CategoryFilter implements CustomFilterInterface
             $category = $this->categoryFactory->create();
             $this->categoryResourceModel->load($category, $categoryId);
             $categoryProducts[$categoryId] = $category->getProductCollection()->getAllIds();
+            $collection->addCategoryFilter($category);
         }
 
         $categoryProductIds = array_unique(array_merge(...$categoryProducts));

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor/CategoryFilter.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor/CategoryFilter.php
@@ -61,7 +61,6 @@ class CategoryFilter implements CustomFilterInterface
             $category = $this->categoryFactory->create();
             $this->categoryResourceModel->load($category, $categoryId);
             $categoryProducts[$categoryId] = $category->getProductCollection()->getAllIds();
-            $collection->addCategoryFilter($category);
         }
 
         $categoryProductIds = array_unique(array_merge(...$categoryProducts));

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductSearchTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductSearchTest.php
@@ -1492,7 +1492,8 @@ QUERY;
                 $actualProducts[$linkProduct->getSku()] = $product->getName();
             }
         }
-        $this->assertEquals(array_column($response['products']['items'],"name","sku"), $actualProducts);
+        $expectedProducts = array_column($response['products']['items'],"name","sku");
+        $this->assertEquals($expectedProducts, $actualProducts);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductSearchTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductSearchTest.php
@@ -1448,11 +1448,12 @@ QUERY;
      */
     public function testFilteringForProductsFromMultipleCategories()
     {
+        $categoriesIds = ["4","5","12"];
         $query
             = <<<QUERY
 {
    products(filter:{
-          category_id :{in:["4","5","12"]}
+          category_id :{in:["{$categoriesIds[0]}","{$categoriesIds[1]}","{$categoriesIds[2]}"]}
          })
  {
     items
@@ -1478,6 +1479,20 @@ QUERY;
         $response = $this->graphQlQuery($query);
         /** @var ProductRepositoryInterface $productRepository */
         $this->assertEquals(3, $response['products']['total_count']);
+        $actualProducts = [];
+        foreach ($categoriesIds as $categoriesId) {
+            /** @var CategoryLinkManagement $productLinks */
+            $productLinks = ObjectManager::getInstance()->get(CategoryLinkManagement::class);
+            $links = $productLinks->getAssignedProducts($categoriesId);
+            $links = array_reverse($links);
+            foreach ($links as $linkProduct) {
+                $productRepository = ObjectManager::getInstance()->get(ProductRepositoryInterface::class);
+                /** @var ProductInterface $product */
+                $product = $productRepository->get($linkProduct->getSku());
+                $actualProducts[$linkProduct->getSku()] = $product->getName();
+            }
+        }
+        $this->assertEquals(array_column($response['products']['items'],"name","sku"), $actualProducts);
     }
 
     /**

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductSearchTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductSearchTest.php
@@ -1492,7 +1492,7 @@ QUERY;
                 $actualProducts[$linkProduct->getSku()] = $product->getName();
             }
         }
-        $expectedProducts = array_column($response['products']['items'],"name","sku");
+        $expectedProducts = array_column($response['products']['items'], "name", "sku");
         $this->assertEquals($expectedProducts, $actualProducts);
     }
 


### PR DESCRIPTION
Product filter with category_id does not work as expected

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
1. Create 2 categories with 1 product each
2. run query to fetch products in those categories
`{
  products(filter: {category_id: {in: ["<cat1>", "<cat2>"]}}) {
    items {
      sku
      name
    }
    total_count
  }
}`
3. Should display total_count should be 2, and items should contain 2 products
### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#30349

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
