### PR TITLE
#30199 Fixed "Learn More should be See details/More Details as Customer see the product details not learn anything"

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list.phtml
@@ -138,7 +138,7 @@ $_helper = $block->getData('outputHelper');
                                     ) ?>
                                     <a href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>"
                                        title="<?= /* @noEscape */ $_productNameStripped ?>"
-                                       class="action more"><?= $escaper->escapeHtml(__('Learn More')) ?></a>
+                                       class="action more"><?= $escaper->escapeHtml(__('More Details')) ?></a>
                                 </div>
                             <?php endif; ?>
                         </div>


### PR DESCRIPTION
Fixed #30199  "Learn More should be See details/More Details as Customer see the product details not learn anything"

### Description (*)
Learn More should be See details/More Details as Customer see the product details not learn anything
![94336072-d09d4d00-fffd-11ea-99ab-9a6a67206c9a](https://user-images.githubusercontent.com/25526119/95646143-1d475480-0ae3-11eb-9c0f-be63c241f501.png)

(/) Expected result
Learn More should be See details/More Details as Customer see the product details not learn anything

Benefits (*)
User should see clear message label like More Details/See Details

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
