### PR TITLE
Added fix for wrong product ratings issue #30196

### DIFF
--- a/app/code/Magento/Review/view/frontend/templates/customer/view.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/customer/view.phtml
@@ -42,14 +42,14 @@ $product = $block->getProductData();
                             <span class="rating-label">
                                 <span><?= $block->escapeHtml($_rating->getRatingCode()) ?></span>
                             </span>
-                            <div class="rating-result" title="<?= /* @noEscape */ $rating ?>%">
+                            <div class="rating-result" id="rating-result_<?= /* @noEscape */ $_rating->getRatingId() ?>" title="<?= $block->escapeHtmlAttr($rating); ?>%">
                                 <span>
                                     <span><?= /* @noEscape */ $rating ?>%</span>
                                 </span>
                             </div>
                             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-                                "width:" . /* @noEscape */ $rating . "%",
-                                'div.rating-result>span:first-child'
+                            'width:' . $block->escapeHtmlAttr($rating) . '%',
+                            '#rating-result_' . $_rating->getRatingId() . ' span'
                             ) ?>
                         </div>
                     <?php endif; ?>


### PR DESCRIPTION
#30196 : Added fix for wrong product ratings issue in Customer Panel "My Product Reviews.

Preconditions (*)

    1. Magento 2.4 with sample data

Steps to reproduce (*)

   1. Submit a review on any Product.
   2. After Admin approve the review, Login to Customer panel.
   3. Navigate to "My Product Reviews" menu and click on "see Details" for the submitted review.
   4. It shows the wrong ratings stars there.

Expected result (*)

Correct rating star should be display at list view

Actual result (*)

![wrong review](https://user-images.githubusercontent.com/25526099/95647962-58e91b00-0af1-11eb-9b59-d936232d095a.png)


### Contribution checklist (*)
 - [ *] Pull request has a meaningful description of its purpose
 - [* ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30403: Added fix for wrong product ratings issue #30196