### PR TITLE
Fixed Redirect to the store view when trying to save attribute on product creation page

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminCreateNewProductAttributeSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminCreateNewProductAttributeSection.xml
@@ -10,6 +10,7 @@
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="AdminCreateNewProductAttributeSection">
         <element name="saveAttribute" type="button" selector="#save" timeout="30"/>
+        <element name="closeAttribute" type="button" selector="#cancel" timeout="30"/>
         <element name="defaultLabel" type="input" selector="input[name='frontend_label[0]']"/>
         <element name="inputType" type="select" selector="select[name='frontend_input']" timeout="30"/>
         <element name="addValue" type="button" selector="//button[contains(@data-action,'add_new_row')]" timeout="30"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminVerifyCreateCloseCreateCustomProductAttributeTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminVerifyCreateCloseCreateCustomProductAttributeTest.xml
@@ -11,10 +11,10 @@
     <test name="AdminVerifyCreateCloseCreateCustomProductAttributeTest">
         <annotations>
             <features value="Catalog"/>
-            <stories value="Create product Attribute"/>
-            <title value="Create Custom Product Attribute Dropdown Field (Not Required) from Product Page"/>
+            <stories value="Create product Attribute after closing the new attribute window multiple times"/>
+            <title value="Create Custom Product Attribute Dropdown Field (Not Required) from Product Page after closing the new attribute window multiple times"/>
             <description
-                value="login as admin and create simple product attribute Dropdown field after closing the new attribute window"/>
+                value="login as admin and create simple product attribute Dropdown field after closing the new attribute window multiple times"/>
             <severity value="MAJOR"/>
             <testCaseId value="MC-30362"/>
             <group value="catalog"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminVerifyCreateCloseCreateCustomProductAttributeTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminVerifyCreateCloseCreateCustomProductAttributeTest.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminVerifyCreateCloseCreateCustomProductAttributeTest">
+        <annotations>
+            <features value="Catalog"/>
+            <stories value="Create product Attribute"/>
+            <title value="Create Custom Product Attribute Dropdown Field (Not Required) from Product Page"/>
+            <description
+                value="login as admin and create simple product attribute Dropdown field after closing the new attribute window"/>
+            <severity value="MAJOR"/>
+            <testCaseId value="MC-30362"/>
+            <group value="catalog"/>
+        </annotations>
+        <before>
+            <createData entity="SimpleSubCategory" stepKey="createCategory"/>
+            <createData entity="SimpleProduct" stepKey="createProduct">
+                <requiredEntity createDataKey="createCategory"/>
+            </createData>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginToAdminPanel"/>
+        </before>
+        <after>
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
+            <actionGroup ref="AdminDeleteProductAttributeByLabelActionGroup" stepKey="deleteCreatedAttribute">
+                <argument name="productAttributeLabel" value="{{ProductAttributeFrontendLabel.label}}"/>
+            </actionGroup>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logoutFromAdminPanel"/>
+        </after>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="navigateToProductPage">
+            <argument name="productId" value="$createProduct.id$"/>
+        </actionGroup>
+        <!-- Attribute creation -->
+        <click selector="{{AdminProductFormSection.addAttributeBtn}}" stepKey="clickOnAddAttribute"/>
+        <waitForElementVisible selector="{{AdminProductFormSection.createNewAttributeBtn}}" stepKey="waitForCreateBtn"/>
+        <click selector="{{AdminProductFormSection.createNewAttributeBtn}}" stepKey="clickCreateNewAttributeButton"/>
+        <waitForElementVisible selector="{{AdminCreateNewProductAttributeSection.defaultLabel}}"
+                               stepKey="waitForLabelInput"/>
+        <!-- Close creation window few times -->
+        <click selector="{{AdminCreateNewProductAttributeSection.closeAttribute}}"
+               stepKey="clickCloseNewAttributeWindowButton"/>
+        <waitForElementVisible selector="{{AdminProductFormSection.createNewAttributeBtn}}"
+                               stepKey="waitForCreateBtn2"/>
+        <click selector="{{AdminProductFormSection.createNewAttributeBtn}}" stepKey="clickCreateNewAttributeButton2"/>
+        <waitForElementVisible selector="{{AdminCreateNewProductAttributeSection.defaultLabel}}"
+                               stepKey="waitForLabelInput2"/>
+        <click selector="{{AdminCreateNewProductAttributeSection.closeAttribute}}"
+               stepKey="clickCloseNewAttributeWindowButton2"/>
+        <waitForElementVisible selector="{{AdminProductFormSection.createNewAttributeBtn}}"
+                               stepKey="waitForCreateBtn3"/>
+        <click selector="{{AdminProductFormSection.createNewAttributeBtn}}" stepKey="clickCreateNewAttributeButton3"/>
+        <waitForElementVisible selector="{{AdminCreateNewProductAttributeSection.defaultLabel}}"
+                               stepKey="waitForLabelInput3"/>
+        <!-- Fill attribute data and save -->
+        <fillField selector="{{AdminCreateNewProductAttributeSection.defaultLabel}}"
+                   userInput="{{ProductAttributeFrontendLabel.label}}" stepKey="fillAttributeLabel"/>
+        <selectOption selector="{{AdminCreateNewProductAttributeSection.inputType}}" userInput="Dropdown"
+                      stepKey="setInputType"/>
+        <click selector="{{AdminCreateNewProductAttributeSection.advancedAttributeProperties}}"
+               stepKey="clickOnAdvancedAttributeProperties"/>
+        <waitForElementVisible selector="{{AdminCreateNewProductAttributeSection.attributeCode}}"
+                               stepKey="waitForAttributeCodeToVisible"/>
+        <fillField selector="{{AdminCreateNewProductAttributeSection.attributeCode}}"
+                   userInput="{{newProductAttribute.attribute_code}}" stepKey="fillAttributeCode"/>
+        <scrollTo selector="{{AdminCreateNewProductAttributeSection.storefrontProperties}}"
+                  stepKey="scrollToStorefrontProperties"/>
+        <click selector="{{AdminCreateNewProductAttributeSection.storefrontProperties}}"
+               stepKey="clickOnStorefrontProperties"/>
+        <waitForElementVisible selector="{{AdminCreateNewProductAttributeSection.inSearch}}"
+                               stepKey="waitForStoreFrontProperties"/>
+        <checkOption selector="{{AdminCreateNewProductAttributeSection.inSearch}}" stepKey="enableInSearchOption"/>
+        <checkOption selector="{{AdminCreateNewProductAttributeSection.advancedSearch}}"
+                     stepKey="enableAdvancedSearch"/>
+        <checkOption selector="{{AdminCreateNewProductAttributeSection.visibleOnStorefront}}"
+                     stepKey="enableVisibleOnStorefront"/>
+        <checkOption selector="{{AdminCreateNewProductAttributeSection.sortProductListing}}"
+                     stepKey="enableSortProductListing"/>
+        <actionGroup ref="AdminAddOptionForDropdownAttributeActionGroup" stepKey="createDropdownOption">
+            <argument name="storefrontViewAttributeValue" value="{{ProductAttributeOption8.label}}"/>
+            <argument name="adminAttributeLabel" value="{{ProductAttributeOption8.label}}"/>
+        </actionGroup>
+        <checkOption selector="{{AdminCreateNewProductAttributeSection.defaultRadioButton('1')}}"
+                     stepKey="selectRadioButton"/>
+        <click selector="{{AdminCreateNewProductAttributeSection.saveAttribute}}" stepKey="clickOnSaveAttribute"/>
+        <!-- Check if the product page after attribute save-->
+        <seeInCurrentUrl url="{{AdminProductEditPage.url($createProduct.id$)}}" stepKey="seeRedirectToProductPage"/>
+    </test>
+</tests>

--- a/app/code/Magento/Ui/view/base/web/js/form/components/insert.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/components/insert.js
@@ -201,7 +201,7 @@ define([
             var links  = {};
 
             _.each(data, function (value, key) {
-                if (value.split('.')[0] === ns) {
+                if (typeof value === 'string' && value.split('.')[0] === ns) {
                     links[key] = value;
                 }
             });


### PR DESCRIPTION
#30362: Fixed Redirect to the store view when trying to save attribute on product creation page
also fixes #30361

Preconditions (*)

Magento 2.4-develop
Steps to reproduce (*)

    Go to Catalog -> Products -> Add New Product
    Click on the "Add Attribute" button (Upper right corner)
    Click on the "Create New Attribute" button
    Close the opened window
    Click on the "Create New Attribute" button again
    Close the opened window
    Click on the "Create New Attribute" button again
    Enter "Attribute Label", set type to drop-down and add two values -> Save

Expected result (*)

No redirect. Attribute is saved.
Actual result (*)
https://user-images.githubusercontent.com/30689417/95333312-48e4f780-08b5-11eb-884d-a2100962d1e7.gif
Redirect to the Home Page if trying to save a attribute on product creation page. Attribute isn`t saved

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
