### PR TITLE
Fixed #29698 [2.3.5-p2] Total due is not updated when order is completed with canceled items

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Totals.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Totals.php
@@ -42,16 +42,29 @@ class Totals extends \Magento\Sales\Block\Adminhtml\Totals//\Magento\Sales\Block
                 'area' => 'footer',
             ]
         );
-        $this->_totals['due'] = new \Magento\Framework\DataObject(
-            [
-                'code' => 'due',
-                'strong' => true,
-                'value' => $this->getSource()->getTotalDue(),
-                'base_value' => $this->getSource()->getBaseTotalDue(),
-                'label' => __('Total Due'),
-                'area' => 'footer',
-            ]
-        );
+        if ($this->getSource()->getTotalCanceled() > 0 && $this->getSource()->getBaseTotalCanceled() > 0) {
+                $this->_totals['canceled'] = new \Magento\Framework\DataObject(
+                [
+                    'code' => 'canceled',
+                    'strong' => true,
+                    'value' => $this->getSource()->getTotalCanceled(),
+                    'base_value' => $this->getSource()->getBaseTotalCanceled(),
+                    'label' => __('Total Canceled'),
+                    'area' => 'footer',
+                ]
+            );
+        } else {
+            $this->_totals['due'] = new \Magento\Framework\DataObject(
+                [
+                    'code' => 'due',
+                    'strong' => true,
+                    'value' => $this->getSource()->getTotalDue(),
+                    'base_value' => $this->getSource()->getBaseTotalDue(),
+                    'label' => __('Total Due'),
+                    'area' => 'footer',
+                ]
+            );
+        }
         return $this;
     }
 }

--- a/app/code/Magento/Sales/i18n/en_US.csv
+++ b/app/code/Magento/Sales/i18n/en_US.csv
@@ -799,3 +799,4 @@ Refunds,Refunds
 "Allow Zero GrandTotal","Allow Zero GrandTotal"
 "Could not save the shipment tracking","Could not save the shipment tracking"
 "Please enter a coupon code!","Please enter a coupon code!"
+"Total Canceled", "Total Canceled"


### PR DESCRIPTION
Fixed #29698
### Preconditions (*) 

Magento 2.3.5-p2
Doesn`t reproducible on 2.4-develop


### Steps to reproduce (*)
1.Place an order with items where the quantity is more than 1
2.Create an invoice & shipment for the order partially
3.Cancel the rest of the order items by canceling the order

### Expected result (*)
1.Total due should be 0 since the order status is 'complete'
2.Grand total and other relevant fields should also reflect the price difference



### Actual result (*)
1.Total due shows the remaining unpaid amount even though the order status is 'complete'
2.Grand total remains same


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
