### PR TITLE
Fixed #30388 Uncaught TypeError: Event.observe is not a function in admin review edit page

### DIFF
--- a/app/code/Magento/Review/Block/Adminhtml/Edit.php
+++ b/app/code/Magento/Review/Block/Adminhtml/Edit.php
@@ -220,8 +220,10 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
                         );
                     }
            }
+            require(["jquery","prototype"], function(jQuery){
            Event.observe(window, \'load\', function(){
                  Event.observe($("select_stores"), \'change\', review.updateRating);
+           });
            });
         ';
     }


### PR DESCRIPTION
Fixed #30388 
Preconditions

    Magento 2.4.0
    Mac OS High Sierra Environment

Steps to reproduce

    Login to admin
    Go to menu Marketing -> All Reivews
    Try to edit any order

Expected result

    Working review edit

Actual result

    JS console error - Uncaught TypeError: Event.observe is not a function
    Styles are broken
    Changing status and saving is working though
