### PR TITLE
Fixed issue #30251   Html tag <br> visible in message

### DIFF
--- a/app/code/Magento/ImportExport/Controller/Adminhtml/ImportResult.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/ImportResult.php
@@ -68,7 +68,7 @@ abstract class ImportResult extends Import
             $message = '';
             $counter = 0;
             foreach ($this->getErrorMessages($errorAggregator) as $error) {
-                $message .= ++$counter . '. ' . $error . '<br>';
+                $message .= ++$counter . '. ' . $error . '</br>';
                 if ($counter >= self::LIMIT_ERRORS_MESSAGE) {
                     break;
                 }
@@ -83,11 +83,11 @@ abstract class ImportResult extends Import
             }
             try {
                 $resultBlock->addNotice(
-                    '<strong>' . __('Following Error(s) has been occurred during importing process:') . '</strong><br>'
+                    '<strong>' . __('Following Error(s) has been occurred during importing process:') . '</strong></br>'
                     . '<div class="import-error-wrapper">' . __('Only the first 100 errors are shown. ')
                     . '<a href="'
                     . $this->createDownloadUrlImportHistoryFile($this->createErrorReport($errorAggregator))
-                    . '">' . __('Download full report') . '</a><br>'
+                    . '">' . __('Download full report') . '</a></br>'
                     . '<div class="import-error-list">' . $message . '</div></div>'
                 );
             } catch (\Exception $e) {


### PR DESCRIPTION


### Description (*)
Html tag <br> visible in message #30251

### Fixed Issues (if relevant)

1. Fixes magento/magento2#30251

### Manual testing scenarios (*)
Open the file with exported product and delete it's SKU. Save it

Go to System -> Import

Fill required fields and select exported file to import.

    Entity Type: Products;
    Import Behavior: Add/Update

Click on Check Data

(/) Expected Result:

Html tag
not visible

(x) Actual Result:

Html tag
 visible in message



### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
