### PR TITLE
design issue #30414 fixed

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
@@ -125,7 +125,7 @@
         float: right;
 
         .block-minicart {
-            .lib-css(padding, 25px @minicart__padding-horizontal);
+            .lib-css(padding, 25px 20px 10px 20px);
 
             .block-title {
                 display: none;
@@ -200,7 +200,7 @@
         }
 
         .minicart-widgets {
-            margin-top: 15px;
+            margin-top: 8px;
         }
     }
 


### PR DESCRIPTION
Extra spacing issue fixed from bottom in minicart.


### Description (*)
Extra spacing below View and Edit Cart link in minicart issue fixed.

before :
https://user-images.githubusercontent.com/50991251/95651979-74f9b600-0b0b-11eb-935e-36ceb1296af0.png

after :  
https://user-images.githubusercontent.com/50991251/95651984-804ce180-0b0b-11eb-9e49-d7250a12a42c.png


### Related Pull Requests

### Fixed Issues (if relevant)
1. Fixes magento/magento2#30414

### Manual testing scenarios (*)
1) open magento base url.
2) open product page
3) add product to your cart.
4) opne minicart in header.
5) check spacing below View and Edit Cart link.

### Questions or comments


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
