### PR TITLE
26343 : Bundle product options deleted incorrectly

### DIFF
--- a/app/code/Magento/Bundle/view/adminhtml/web/js/components/bundle-dynamic-rows.js
+++ b/app/code/Magento/Bundle/view/adminhtml/web/js/components/bundle-dynamic-rows.js
@@ -72,7 +72,7 @@ define([
          */
         removeBundleItemsFromOption: function (index) {
             var bundleSelections = registry.get(this.name + '.' + index + '.' + this.bundleSelectionsName),
-                bundleSelectionsLength = (bundleSelections.elems() || []).length,
+                bundleSelectionsLength = bundleSelections ? (bundleSelections.elems() || []).length:[],
                 i;
 
             if (bundleSelectionsLength) {


### PR DESCRIPTION
Fix issue :- https://github.com/magento/magento2/issues/30347