### PR TITLE
Design Issue on view bundle order over customer Dashboard #30420 Fixed

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
@@ -96,8 +96,6 @@
                 .col {
                     &.label {
                         font-weight: @font-weight__bold;
-                        padding-bottom: 5px;
-                        padding-top: 0;
                     }
 
                     &.options {
@@ -117,7 +115,6 @@
 
                 .item-options-container td {
                     padding-bottom: 15px;
-                    padding-top: 0;
                 }
             }
 
@@ -681,7 +678,7 @@
             .col {
                 &.label,
                 &.value {
-                    padding-left: 0;
+                    padding-left: 10px;
                 }
             }
         }


### PR DESCRIPTION
### Description (*)
Design Issue on view bundle order header over customer Dashboard

### Preconditions (*)

    PHP Version: 7.3.23
    Magento Version: Magento 2.4.0
    Viewport : Desktop

### Steps to reproduce (*)

    Login as customer
    Order Bundle product
    Goto Customer Dashboard
    Click on my Orders
    Click on view order over bundle product
    Issue on Items Ordered tab

### Expected result (*)
![bundle_header_solved](https://user-images.githubusercontent.com/53182467/95653225-bd69a180-0b14-11eb-8b88-1db5e4969020.png)
### Actual Result (*)
![bundle_header](https://user-images.githubusercontent.com/53182467/95653235-cf4b4480-0b14-11eb-8841-12d245ce747f.png)


### Resolved issues:
1. [x] resolves magento/magento2#30420