### PR TITLE
Toolbar is not align proper in mywishlist page in mobile view #30432  fixed

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Wishlist/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Wishlist/web/css/source/_module.less
@@ -200,6 +200,21 @@
             }
         }
     }
+    
+    .toolbar {
+        &.wishlist-toolbar {
+            .limiter {
+                float: none;
+            }
+            
+            .toolbar-amount,
+            .limiter {
+                display: block;
+                z-index: 1;
+                text-align: center;
+            }
+        }
+    }
 }
 
 .media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {


### PR DESCRIPTION
Fixes https://github.com/magento/magento2/issues/30432

Toolbar is not align proper in mywishlist page in mobile view #30432 fixed
**Description**
Toolbar is not align proper in MyWishlist page in mobile view
Preconditions (*)

    Magento2.4
    php7.4

###Steps to reproduce (*)

    open magento base url.
    tab sign in on top right of screen.
    enter email id and password to sign in your account.
    go to my wishlist page and open mobile view.
    check toolbar-amount and limiter design in mobile view (and compare with my orders page in mobiel view)

**Expected result (*)**
![wishlist_solution_1](https://user-images.githubusercontent.com/26018716/95653819-150a0c00-0b19-11eb-93c9-3362ab682bf4.png)



**Actual result (*)**
![wishlist_issue_1](https://user-images.githubusercontent.com/26018716/95653808-0b80a400-0b19-11eb-8316-aad1ed3f672c.png)
