### PR TITLE
Design Issue of select box (text is cutting from bottom) on Admin

### DIFF
--- a/app/design/adminhtml/Magento/backend/web/css/styles-old.less
+++ b/app/design/adminhtml/Magento/backend/web/css/styles-old.less
@@ -802,7 +802,7 @@
             .lib-css(appearance, none, 1);
 
             display: inline-block;
-            line-height: normal;
+            line-height: inherit;
             min-width: 80px;
 
             background-repeat: no-repeat;


### PR DESCRIPTION
Design Issue of select box (text is cutting from bottom) on Admin Fixed #30440

### Preconditions (*)

    Magento version : Magento 2.4
    Php version : 7.3.23
    Viewport : Desktop

### Steps to reproduce (*)

    Login to Magento Admin
    Goto Stores > Configuration > Advanced > Admin

### Expected result (*)

![field_solved](https://user-images.githubusercontent.com/53182467/95674988-860cfa80-0bd1-11eb-875d-dbfbb1f8432f.png)

### Actual result (*)

![field](https://user-images.githubusercontent.com/53182467/95674999-9d4be800-0bd1-11eb-893d-399289eea438.png)


### Resolved issues:
1. [x] resolves magento/magento2#30459: Design Issue of select box (text is cutting from bottom) on Admin