### PR TITLE
Create New Order in Default Store View on Admin #30442 Fixed

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Sales/web/css/source/module/_order.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Sales/web/css/source/module/_order.less
@@ -48,7 +48,14 @@
         #mix-grid .width(9,12);
         margin-left: 0;
     }
-
+    
+    .page-create-order{
+        .order-details 
+        {
+            width: 100%;
+        }
+    }
+    
     .order-sidebar {
         #mix-grid .column(3,12);
         margin-left: 0;


### PR DESCRIPTION
Blank space on left side

### Preconditions (*)

    Magento version : Magento 2.4
    Php version : 7.3.23
    Viewport : Desktop

### Steps to reproduce (*)

    Login to Magento Admin
    Goto Sales > Orders > Create New Order > Create New Customer

### Expected result (*)

![neworder_solved](https://user-images.githubusercontent.com/53182467/95675654-7512b800-0bd6-11eb-92b4-9bd55d836503.png)

### Actual result (*)
![neworder](https://user-images.githubusercontent.com/53182467/95675668-8360d400-0bd6-11eb-9e33-726ec43bacc2.png)



### Resolved issues:
1. [x] resolves magento/magento2#30460: Create New Order in Default Store View on Admin #30442 Fixed