### PR TITLE
Fix missing escape less calc

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Sales/web/css/source/module/order/_payment-shipping.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Sales/web/css/source/module/order/_payment-shipping.less
@@ -9,13 +9,15 @@
 
 .admin__payment-method-wrapper {
     margin: 0;
-    width: calc(50% - @indent__l);
+    width: ~'calc(50% - @{indent__l})';
+
     .admin__field {
         margin-left: 0;
         &:first-child {
             margin-top: 1.5rem;
         }
     }
+
     .admin__payment-methods {
         margin: 0;
     }
@@ -62,6 +64,7 @@
     position: absolute;
     right: 0;
     top: 0;
+
     span {
         background-color: @color-white;
         display: block;
@@ -71,6 +74,7 @@
         position: absolute;
         top: 43px;
     }
+
     .order-shipping-address & {
         span {
             top: 0;
@@ -102,6 +106,7 @@
     + .order-payment-currency {
         margin-top: @indent__s;
     }
+    
     .admin__table-secondary {
         margin-top: @indent__s;
         &:extend(.abs-admin__table-secondary-edit-order all);

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -163,6 +163,7 @@
         .admin__field-control {
             padding-top: 7px;
         }
+        
         .admin__field-option {
             padding-top: 0;
         }
@@ -361,6 +362,7 @@
         cursor: inherit;
         opacity: 1;
         outline: inherit;
+
         .admin__action-multiselect-wrap {
             .admin__action-multiselect {
                 .__form-control-pattern__disabled();
@@ -433,7 +435,7 @@
             font-size: 1.7rem;
             font-weight: @font-weight__bold;
             padding: 1.7rem 0;
-            width: calc(100% - @indent__l);
+            width: ~'calc(100% - @{indent__l})';
         }
 
         .admin__field-option {
@@ -704,6 +706,7 @@
                 width: 100%;
             }
         }
+
         & > .admin__field-label {
             text-align: left;
         }
@@ -819,4 +822,3 @@
         overflow: hidden;
     }
 }
-

--- a/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Sales/web/css/source/_module.less
@@ -210,6 +210,7 @@
 
         .items-qty {
             &:extend(.abs-reset-list all);
+            
             .item {
                 white-space: nowrap;
             }
@@ -347,13 +348,15 @@
 
         .product-item-name {
             float: left;
-            width: calc(100% - 20px);
+            width: calc(~'100% - 20px');
         }
+
         .product-item::after {
             clear: both;
             content: '';
             display: table;
         }
+
         .product-item {
             .label {
                 &:extend(.abs-visually-hidden all);
@@ -491,6 +494,7 @@
 
         .data.table .col.options {
             padding: 0 10px 15px;
+
             &:before {
                 display: none;
             }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
We've escaped the content in the calc, this way the calc in the css output file will be correctly. Previously magento will return wrong calc value

Less: width: calc(100% - 20px);
Before fix
`.block-reorder .product-item-name {
  float: left;
  width: calc(80%);
}`

Less: width: calc(~'100% - 20px');
After fix
`.block-reorder .product-item-name {
  float: left;
  width: calc(100% - 20px);
}`

If less code contain variable escape will a little bit difference
Instead write like this: width: calc(100% - @indent__l);
We should write like this 
`width: ~'calc(100% - @{indent__l})';`
or `width: calc(~'100% -' @{indent__l});`

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Scenario 1
Backend theme change
1. Check file css output styles-m.css
2. Find class admin__payment-method-wrapper , admin__field-control (theme backend)
3. Make sure the final calc show correct value in output css

Scenario 2
Luma theme change
1. Check file css output styles-m.css
2. Find class .block-reorder .product-item-name  (theme luma)
3. Make sure the final calc show correct value in output css


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30542: Fix missing escape less calc