### PR TITLE
Remove incorrect use important in swatches option text

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_module.less
@@ -65,7 +65,6 @@
 //  _____________________________________________
 
 & when (@media-common = true) {
-
     .swatch {
         &-attribute {
             &-label {
@@ -155,7 +154,7 @@
                 padding: 4px 8px;
 
                 &.selected {
-                    .lib-css(background-color, @swatch-option-text__selected__background-color) !important;
+                    .lib-css(background-color, @swatch-option-text__selected__background-color);
                 }
             }
 
@@ -201,6 +200,7 @@
                     top: 0;
                 }
             }
+
             &-disabled {
                 border: 0;
                 cursor: default;
@@ -208,6 +208,7 @@
 
                 &:after {
                     .lib-rotate(-30deg);
+                    .lib-css(background, @swatch-option__disabled__background);
                     content: '';
                     height: 2px;
                     left: -4px;
@@ -215,7 +216,6 @@
                     top: 10px;
                     width: 42px;
                     z-index: 995;
-                    .lib-css(background, @swatch-option__disabled__background);
                 }
             }
 
@@ -226,6 +226,7 @@
             &-tooltip {
                 .lib-css(border, @swatch-option-tooltip__border);
                 .lib-css(color, @swatch-option-tooltip__color);
+                .lib-css(background, @swatch-option-tooltip__background);
                 display: none;
                 max-height: 100%;
                 min-height: 20px;
@@ -234,7 +235,6 @@
                 position: absolute;
                 text-align: center;
                 z-index: 999;
-                .lib-css(background, @swatch-option-tooltip__background);
 
                 &,
                 &-layered {
@@ -278,9 +278,9 @@
                 }
 
                 &-layered {
+                    .lib-css(background, @swatch-option-tooltip-layered__background);
                     .lib-css(border, @swatch-option-tooltip-layered__border);
                     .lib-css(color, @swatch-option-tooltip-layered__color);
-                    .lib-css(background, @swatch-option-tooltip-layered__background);
                     display: none;
                     left: -47px;
                     position: absolute;
@@ -326,7 +326,6 @@
             margin: 2px 0;
             padding: 2px;
             position: static;
-            z-index: 1;
         }
 
         &-visual-tooltip-layered {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Developers will not able re-define styles in swatch option text when core file defined important
Here is example

`body .swatch-attribute .swatch-option.text.selected  {
    background-color: black;
}`

property `background-color` will not able apply when core magento defined important. The last solution is use another important with high css specificity to get higher priority than magento


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Scenario 1
Have customise styles for blank theme
1. Create custom style less file for reproduce approach add style to swatch option text
2. Path file can be app/design/frontend/Magento/blank/Magento_Swatches/web/css/source/_extend.less
3. In file _extend.less add style like description
ex:
`body .swatch-attribute .swatch-option.text.selected { background-color: black; }`
4. Run cache clean and deploy static content
5. Check frontend in details product page. Visit any configurable product have swatch option text to easier see the change
6. If product have swatch option text when user select swatch option the background would change to black
But it's not happen because core define important override define in _extend.less
7. Expected result is the background-color in _extend.less should be applied and have higher priority than default magento 
Default magento is .swatch-option.text.selected {background-color: #ffffff !important} background color white will have high priority than other declare

Before change results: Background-color:  black not apply, still have background color white in swatch-option selected
After change results: Background-color:  black applied

Scenario 2
No customise styles
Swatch text option should show like before change

After results: remain visual same as before
Selected swatch option have background-color white

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30496: Remove incorrect use important in swatches option text