### PR TITLE
Avoid notice on PHP 7.4 of using an array accesser on type null.

### DIFF
--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -1047,7 +1047,7 @@ class Installer
             }
             $schemaListener->setModuleName($moduleName);
             $this->log->log("Module '{$moduleName}':");
-            $configVer = $this->moduleList->getOne($moduleName)['setup_version'];
+            $configVer = ($moduleConfig = $this->moduleList->getOne($moduleName)) ? $moduleConfig['setup_version'] : null;
             $currentVersion = $moduleContextList[$moduleName]->getVersion();
             // Schema/Data is installed
             if ($currentVersion !== '') {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixes Notice: Trying to access array offset on value of type null when running `bin/magento setup:db-schema:upgrade` on Magento 2.6 and PHP 7.4


### Fixed Issues (if relevant)
 No reported issues that I could find

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Try upgrading M 2.3 site to 2.4 when using PHP 7.4. When new modules are found which do not have an existing db schema version this error will occur. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
