### PR TITLE
Fixed placeholder translation in Magento UI grid search component

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/search/search.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/search/search.js
@@ -19,7 +19,7 @@ define([
     return Element.extend({
         defaults: {
             template: 'ui/grid/search/search',
-            placeholder: 'Search by keyword',
+            placeholder: $t('Search by keyword'),
             label: $t('Keyword'),
             value: '',
             previews: [],


### PR DESCRIPTION
Fixed translations in Magento UI grid search component

### Description (*)
Grid search input placeholder is not translated. Even if a phrase exists in translations csv file, translation will not be shown in UI since in js component function `$t()` are not used. 

### Manual testing scenarios (*)
1. Install any language pack, which contains translation of phrase 'Search by keyword'.
2. Turn on appropriate language
3. Look at any grid in backend. Phrase 'Search by keyword' is not translated.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages



### Resolved issues:
1. [x] resolves magento/magento2#30510: Fixed placeholder translation in Magento UI grid search component