### PR TITLE
add --no-tablespaces parameters to mysqldump

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
@@ -125,7 +125,7 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
         $format = sprintf(
             '%s %s %s %s',
             'mysqldump --defaults-file=%s --host=%s --port=%s',
-            '--no-tablespaces'
+            '--no-tablespaces',
             $additionalArguments,
             '%s > %s'
         );

--- a/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Db/Mysql.php
@@ -123,8 +123,9 @@ class Mysql extends \Magento\TestFramework\Db\AbstractDb
         }
 
         $format = sprintf(
-            '%s %s %s',
+            '%s %s %s %s',
             'mysqldump --defaults-file=%s --host=%s --port=%s',
+            '--no-tablespaces'
             $additionalArguments,
             '%s > %s'
         );

--- a/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
+++ b/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
@@ -375,13 +375,13 @@ class CrontabManagerTest extends TestCase
             ],
             [
                 'tasks' => [
-                    ['command' => '{magentoRoot}run.php mysqldump db > db-$(date +%F).sql']
+                    ['command' => '{magentoRoot}run.php mysqldump --no-tablespaces db > db-$(date +%F).sql']
                 ],
                 'content' => '* * * * * /bin/php /var/www/cron.php',
                 'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
                     . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . hash("sha256", BP) . PHP_EOL
                     . '* * * * * ' . PHP_BINARY . ' /var/www/magento2/run.php'
-                    . ' mysqldump db > db-\$(date +%%F).sql' . PHP_EOL
+                    . ' mysqldump --no-tablespaces db > db-\$(date +%%F).sql' . PHP_EOL
                     . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL,
             ],
         ];


### PR DESCRIPTION
### Description (*)

adds --no-tablespaces to all occurrences of mysqldump. With this PR integration tests can run without the PROCESS privilege which is required since MySQL 5.7.31 / 8.0.21 to run mysqldump by default. See also https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-31.html#mysqld-5-7-31-security or https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-21.html for details

### Related Pull Requests
/

### Fixed Issues (if relevant)
/
### Manual testing scenarios (*)
this only affects the integration tests. 

With this PR integration tests can run without the PROCESS privilege which is required since MySQL 5.7.31 to run mysqldump by default.

### Questions or comments
/

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30566: add --no-tablespaces parameters to mysqldump