### PR TITLE
fix #30094 function call on array

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/order/totals/tax.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/totals/tax.phtml
@@ -59,7 +59,10 @@ $randomHelper = $block->getData('randomHelper');
             ?>
 
             <?php foreach ($rates as $rate): ?>
-                <tr id="rate-<?= /* @noEscape */ $rate->getId() ?>"
+                <?php
+                    $rateId = $randomHelper->getRandomString(20);
+                ?>
+                <tr id="rate-<?= /* @noEscape */ $rateId ?>"
                     class="summary-details<?= ($isTop ? ' summary-details-first' : '') ?>">
                     <?php if ($rate['percent'] !== null): ?>
                         <td class="admin__total-mark">
@@ -74,7 +77,7 @@ $randomHelper = $block->getData('randomHelper');
                         </td>
                     <?php endif; ?>
                 </tr>
-                <?= /* @noEscape */ $secureRenderer->renderStyleAsTag("display:none;", 'tr#rate-' . $rate->getId()) ?>
+                <?= /* @noEscape */ $secureRenderer->renderStyleAsTag("display:none;", 'tr#rate-' . $rateId) ?>
                 <?php
                 $isFirst = 0;
                 $isTop = 0;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixes #30094:
`Call to a member function getId() on array in module-sales/view/adminhtml/templates/order/totals/tax.phtml:62`

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#30094

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Set config `sales_display/fields/full_summary` to `1`
2. Open any invoice (e.g. `/admin/sales/invoice/view/invoice_id/1/`)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
Issue is introduced here https://github.com/magento/magento2/commit/70ede03e5c2dc9e2c3bb23d0fc5c29cb03cbe7dd
Using the same rather "workaround" as below for `$infoId`: https://github.com/magento/magento2/blob/2.4.1/app/code/Magento/Sales/view/adminhtml/templates/order/totals/tax.phtml#L91


### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
