### PR TITLE
MessageValidator fails on hash arrays that dont have 0 element

### DIFF
--- a/lib/internal/Magento/Framework/MessageQueue/MessageValidator.php
+++ b/lib/internal/Magento/Framework/MessageQueue/MessageValidator.php
@@ -119,7 +119,7 @@ class MessageValidator
         $realType = $this->getRealType($message);
         if ($realType == 'array' && count($message) == 0) {
             return;
-        } elseif ($realType == 'array' && count($message) > 0) {
+        } elseif ($realType == 'array' && isset($message[0])) {
             $realType = $this->getRealType($message[0]);
             $compareType = preg_replace('/\[\]/', '', $messageType);
         }
@@ -153,7 +153,7 @@ class MessageValidator
         $realType = $this->getRealType($message);
         if ($realType == 'array' && count($message) == 0) {
             return;
-        } elseif ($realType == 'array' && count($message) > 0) {
+        } elseif ($realType == 'array' && isset($message[0])) {
             $message = $message[0];
             $compareType = preg_replace('/\[\]/', '', $messageType);
         }

--- a/lib/internal/Magento/Framework/MessageQueue/Test/Unit/MessageValidatorTest.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Test/Unit/MessageValidatorTest.php
@@ -255,6 +255,14 @@ class MessageValidatorTest extends TestCase
                 $customerMock,
                 'Data in topic "topic" must be of type "Magento\Customer\Api\Data\CustomerInterface[]". '
             ],
+            [
+                [
+                    CommunicationConfig::TOPIC_REQUEST_TYPE => CommunicationConfig::TOPIC_REQUEST_TYPE_CLASS,
+                    CommunicationConfig::TOPIC_REQUEST => 'Magento\Customer\Api\Data\CustomerInterface[]'
+                ],
+                [1=>23, 3=>545],
+                'Data in topic "topic" must be of type "Magento\Customer\Api\Data\CustomerInterface[]". '
+            ],
         ];
     }
 }


### PR DESCRIPTION
Magento\Framework\MessageQueue\Test\Unit\MessageValidatorTest::testInvalidMessageType with data set #11 (array('object_interface', 'Magento\Customer\Api\Data\Cus...face[]'), array(23, 545), 'Data in topic "topic" must be...e[]". ')
PHPUnit\Framework\Exception: Notice: Undefined offset: 0 in /magento/lib/internal/Magento/Framework/MessageQueue/MessageValidator.php:157.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30563: MessageValidator fails on hash arrays that dont have 0 element