### PR TITLE
Deny access to vendor folder in nginx.conf.sample

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -177,6 +177,10 @@ location /errors/ {
     }
 }
 
+location /vendor/ {
+    deny all;
+}
+
 # PHP entry point for main application
 location ~ ^/(index|get|static|errors/report|errors/404|errors/503|health_check)\.php$ {
     try_files $uri =404;


### PR DESCRIPTION
The .htaccess file in the vendor folder denies acccess for all requests, in the nginx.conf.sample file a similar rule is missing.

### Description (*)
Added a rule to deny access to the vendor folder.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Apply changes to nginx config
2. Try to access folder


### Contribution checklist (*)
 - [x] All commits are accompanied by meaningful commit messages
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
