### PR TITLE
Make sure the depends definition works for custom widgets. Also conve…

### DIFF
--- a/lib/web/mage/adminhtml/form.js
+++ b/lib/web/mage/adminhtml/form.js
@@ -496,9 +496,14 @@ define([
             }
 
             // toggle target row
-            headElement = $(idTo + '-head');
+            headElement = jQuery('#' + idTo + '-head');
             isInheritCheckboxChecked = $(idTo + '_inherit') && $(idTo + '_inherit').checked;
             target = $(idTo);
+
+            // Account for the chooser style parameters.
+            if (target === null && headElement.length === 0 && idTo.substring(0, 16) === 'options_fieldset') {
+                headElement = jQuery('.field-' + idTo).add('.field-chooser' + idTo);
+            }
 
             // Target won't always exist (for example, if field type is "label")
             if (target) {
@@ -529,10 +534,10 @@ define([
                     });
                 }
 
-                if (headElement) {
+                if (headElement.length > 0) {
                     headElement.show();
 
-                    if (headElement.hasClassName('open') && target) {
+                    if (headElement.hasClass('open') && target) {
                         target.show();
                     } else if (target) {
                         target.hide();
@@ -567,7 +572,7 @@ define([
                     });
                 }
 
-                if (headElement) {
+                if (headElement.length > 0) {
                     headElement.hide();
                 }
 


### PR DESCRIPTION
…rted code from PrototypeJS to jQuery.

### Description (*)
This fixes https://github.com/magento/magento2/issues/6868 and basically implements the solution proposed on [stackexchange](https://magento.stackexchange.com/a/176465/2911).

The solution from stackexchange is a bit strange though, since they use jQuery while the original code used Prototype and this caused them to have to swap the following if around, since the headElement could either be a jQuery or Prototype element and it would crash if it was a jQuery object:
```js
 if (headElement.hasClassName('open') && target) {

vs

 if (target && headElement.hasClassName('open')) {
```

So instead of taking over the proposed code, I've converted all code touching `headElement` to now use jQuery so we no longer have this strange hybrid solution.

### Related Pull Requests
None

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/magento2/issues/6868: Widget parameter depends does not work on specified block
2. Fixes https://github.com/magento/magento2/issues/7252: Widget node depends with block parameter
3. Fixes https://github.com/magento/magento2/issues/13316: Widget field depends with type block KO
4. MAGETWO-82054

### Manual testing scenarios (*)
1. See https://github.com/magento/magento2/issues/6868 (didn't really test it with that, but with a custom widget from our own collection)

### Questions or comments
Before somebody asks, I'm not interested in writing tests for this, so if this is required, feel free to pick this up yourselves 🙂 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
