### PR TITLE
Allows configuring the setting 'Add Store Code to Urls' in website scope

### DIFF
--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -455,7 +455,7 @@
             <resource>Magento_Config::web</resource>
             <group id="url" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Url Options</label>
-                <field id="use_store" translate="label comment" type="select" sortOrder="10" showInDefault="1" canRestore="1">
+                <field id="use_store" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" canRestore="1">
                     <label>Add Store Code to Urls</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <backend_model>Magento\Config\Model\Config\Backend\Store</backend_model>


### PR DESCRIPTION
### Description (*)
We sometimes have to setup a url structure like this when working with multiple websites:

| Website       | Storeview    | Url          |
| ------------ | ---------- | ----------- |
| Example 1     | English      | https://www.example1.co.uk/    |
| Example 2     | French       | https://www.example2.be/fr/ |
| Example 2     | Dutch        | https://www.example2.be/nl/ |

Currently this isn't easily possible in Magento, because the configuration flag to add storeview codes to the url is global.

This PR changes this and makes it configurable in website scope, so we can choose to add storeview codes to the url for one website but not for another one.

We have this configuration setup on 2 Magento instances in development and it looks like this works perfectly fine, we haven't seen strange bugs with this so far.

### Related Pull Requests
None

### Fixed Issues (if relevant)
1. None that I could find

### Manual testing scenarios (*)
1. Create at least 2 websites, each having at least 1 storeview
2. Give the 2 websites a different base url (different domain name)
3. Enable the setting General > Web > Url Options > Add Store Code to Urls for one website but not for the other
4. On the frontend, verify that the url's for both websites are as expected: one website should not have a storeview code in the url and the other one should have one.

### Questions or comments
I haven't tested how this behaves if the websites have the exact same base url. That might give troubles, so we'd best test this and if it gives issues, we might need to add a warning to the setting explaining that you need to use different base url's if you want to use this setting in website scope.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
