### PR TITLE
add key for returned array for first level in rest api

### DIFF
--- a/lib/internal/Magento/Framework/Webapi/ServiceOutputProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ServiceOutputProcessor.php
@@ -112,13 +112,13 @@ class ServiceOutputProcessor implements ServicePayloadConverterInterface
         if (is_array($data)) {
             $result = [];
             $arrayElementType = substr($type, 0, -2);
-            foreach ($data as $datum) {
+            foreach ($data as $key => $datum) {
                 if (is_object($datum)) {
                     $datum = $this->processDataObject(
                         $this->dataObjectProcessor->buildOutputDataArray($datum, $arrayElementType)
                     );
                 }
-                $result[] = $datum;
+                $result[$key] = $datum;
             }
             return $result;
         } elseif (is_object($data)) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
add key for returned array for first level in api
when you return array in rest api for example
```
/**
 * GET mobile apps link
 * @return array
 */
public function getMobileAppsLink(){
    $data['android']="value";
    $data['ios']="value2";
    return $data;
}
```
expectation : 
```
{
    "android": "value",
    "ios": "value2"
}
```
current result:
```
[
    "value",
    "value2"
]
```


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30676: add key for returned array for first level in rest api