### PR TITLE
[GraphQl] Excluding the disabled parent category from the category breadcrumbs

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/DataProvider/Breadcrumbs.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/DataProvider/Breadcrumbs.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\CatalogGraphQl\Model\Resolver\Category\DataProvider;
 
+use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory;
 
 /**
@@ -46,6 +47,7 @@ class Breadcrumbs
             $collection = $this->collectionFactory->create();
             $collection->addAttributeToSelect(['name', 'url_key', 'url_path']);
             $collection->addAttributeToFilter('entity_id', $parentCategoryIds);
+            $collection->addAttributeToFilter(CategoryInterface::KEY_IS_ACTIVE, 1);
 
             foreach ($collection as $category) {
                 $breadcrumbsData[] = [

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryTest.php
@@ -661,6 +661,45 @@ QUERY;
     }
 
     /**
+     * Testing breadcrumbs that shouldn't include disabled parent categories
+     *
+     * @magentoApiDataFixture Magento/Catalog/_files/categories.php
+     */
+    public function testBreadCrumbsWithDisabledParentCategory()
+    {
+        $parentCategoryId = 4;
+        $childCategoryId = 5;
+        $category = $this->categoryRepository->get($parentCategoryId);
+        $category->setIsActive(false);
+        $this->categoryRepository->save($category);
+
+        $query = <<<QUERY
+{
+  category(id: {$childCategoryId}) {
+    name
+    breadcrumbs {
+      category_id
+      category_name
+    }
+  }
+}
+QUERY;
+        $response = $this->graphQlQuery($query);
+        $expectedResponse = [
+            'category' => [
+                'name' => 'Category 1.1.1',
+                'breadcrumbs' => [
+                    [
+                        'category_id' => 3,
+                        'category_name' => "Category 1",
+                    ]
+                ]
+            ]
+        ];
+        $this->assertEquals($expectedResponse, $response);
+    }
+
+    /**
      * @return array
      */
     public function categoryImageDataProvider(): array


### PR DESCRIPTION
### Description (*)
This PR excludes the disabled parent category from the category's breadcrumbs, as the category won't be available on clicking on it. 

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#30468 

### Manual testing scenarios (*)

1. Create the following tree: **Category 1 / Category 1.1 / Category 1.2**
2. Disable the **Category 1.1**
3. Run the following query to get the breadcrumbs for **Category 1.2**

```text
categoryId = Category 1.2 ID

{
  category(id: <categoryId>) {
    name
    breadcrumbs {
        category_name
    }
  }
}
```

### Expected Result

```
{
  "data": {
    "category": {
      "name": "Category 1.2",
      "breadcrumbs": [
        {
          "category_name": "Category 1"
        }
      ]
    }
  }
}
```

### Questions or comments

As an alternative, we may try to add a new attribute for Breadcrumb type , in order to mark the breadcrumb as enabled/disabled.
https://github.com/magento/magento2/blob/a1e5689cc6092e40e1ebb975f4eaae32c4d8d1e5/app/code/Magento/CatalogGraphQl/etc/schema.graphqls#L264-L270

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
