### PR TITLE
[GRAPHQL] Made the attribute `destination_cart_id` for mergeCarts mutation not required.

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/MergeCarts.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/MergeCarts.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\QuoteGraphQl\Model\Resolver;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
@@ -50,19 +51,21 @@ class MergeCarts implements ResolverInterface
     /**
      * @param GetCartForUser $getCartForUser
      * @param CartRepositoryInterface $cartRepository
-     * @param CustomerCartResolver $customerCartResolver
-     * @param QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId
+     * @param CustomerCartResolver|null $customerCartResolver
+     * @param QuoteIdToMaskedQuoteIdInterface|null $quoteIdToMaskedQuoteId
      */
     public function __construct(
         GetCartForUser $getCartForUser,
         CartRepositoryInterface $cartRepository,
-        CustomerCartResolver $customerCartResolver,
-        QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId
+        CustomerCartResolver $customerCartResolver = null,
+        QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId = null
     ) {
         $this->getCartForUser = $getCartForUser;
         $this->cartRepository = $cartRepository;
-        $this->customerCartResolver = $customerCartResolver;
-        $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId;
+        $this->customerCartResolver = $customerCartResolver
+            ?: ObjectManager::getInstance()->get(CustomerCartResolver::class);
+        $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId
+            ?: ObjectManager::getInstance()->get(QuoteIdToMaskedQuoteIdInterface::class);
     }
 
     /**

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/MergeCarts.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/MergeCarts.php
@@ -7,17 +7,23 @@ declare(strict_types=1);
 
 namespace Magento\QuoteGraphQl\Model\Resolver;
 
+use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
-use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
-use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\GraphQl\Model\Query\ContextInterface;
-use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Cart\CustomerCartResolver;
+use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
+use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
 
 /**
  * Merge Carts Resolver
+ *
+ * @SuppressWarnings(PHPMD.LongVariable)
  */
 class MergeCarts implements ResolverInterface
 {
@@ -32,43 +38,86 @@ class MergeCarts implements ResolverInterface
     private $cartRepository;
 
     /**
+     * @var CustomerCartResolver
+     */
+    private $customerCartResolver;
+
+    /**
+     * @var QuoteIdToMaskedQuoteIdInterface
+     */
+    private $quoteIdToMaskedQuoteId;
+
+    /**
      * @param GetCartForUser $getCartForUser
      * @param CartRepositoryInterface $cartRepository
+     * @param CustomerCartResolver $customerCartResolver
+     * @param QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId
      */
     public function __construct(
         GetCartForUser $getCartForUser,
-        CartRepositoryInterface $cartRepository
+        CartRepositoryInterface $cartRepository,
+        CustomerCartResolver $customerCartResolver,
+        QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId
     ) {
         $this->getCartForUser = $getCartForUser;
         $this->cartRepository = $cartRepository;
+        $this->customerCartResolver = $customerCartResolver;
+        $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId;
     }
 
     /**
      * @inheritdoc
      */
-    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
-    {
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
         if (empty($args['source_cart_id'])) {
-            throw new GraphQlInputException(__('Required parameter "source_cart_id" is missing'));
-        }
-
-        if (empty($args['destination_cart_id'])) {
-            throw new GraphQlInputException(__('Required parameter "destination_cart_id" is missing'));
+            throw new GraphQlInputException(__(
+                'Required parameter "source_cart_id" is missing'
+            ));
         }
 
         /** @var ContextInterface $context */
         if (false === $context->getExtensionAttributes()->getIsCustomer()) {
-            throw new GraphQlAuthorizationException(__('The current customer isn\'t authorized.'));
+            throw new GraphQlAuthorizationException(__(
+                'The current customer isn\'t authorized.'
+            ));
+        }
+        $currentUserId = $context->getUserId();
+
+        if (empty($args['destination_cart_id'])) {
+            try {
+                $cart = $this->customerCartResolver->resolve($currentUserId);
+            } catch (CouldNotSaveException $exception) {
+                throw new GraphQlNoSuchEntityException(
+                    __('Could not create empty cart for customer'),
+                    $exception
+                );
+            }
+            $customerMaskedCartId = $this->quoteIdToMaskedQuoteId->execute(
+                (int) $cart->getId()
+            );
         }
 
         $guestMaskedCartId = $args['source_cart_id'];
-        $customerMaskedCartId = $args['destination_cart_id'];
+        $customerMaskedCartId = $customerMaskedCartId ?? $args['destination_cart_id'];
 
-        $currentUserId = $context->getUserId();
         $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
         // passing customerId as null enforces source cart should always be a guestcart
-        $guestCart = $this->getCartForUser->execute($guestMaskedCartId, null, $storeId);
-        $customerCart = $this->getCartForUser->execute($customerMaskedCartId, $currentUserId, $storeId);
+        $guestCart = $this->getCartForUser->execute(
+            $guestMaskedCartId,
+            null,
+            $storeId
+        );
+        $customerCart = $this->getCartForUser->execute(
+            $customerMaskedCartId,
+            $currentUserId,
+            $storeId
+        );
         $customerCart->merge($guestCart);
         $guestCart->setIsActive(false);
         $this->cartRepository->save($customerCart);

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/MergeCarts.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/MergeCarts.php
@@ -89,7 +89,7 @@ class MergeCarts implements ResolverInterface
         }
         $currentUserId = $context->getUserId();
 
-        if (empty($args['destination_cart_id'])) {
+        if (!isset($args['destination_cart_id'])) {
             try {
                 $cart = $this->customerCartResolver->resolve($currentUserId);
             } catch (CouldNotSaveException $exception) {
@@ -101,6 +101,12 @@ class MergeCarts implements ResolverInterface
             $customerMaskedCartId = $this->quoteIdToMaskedQuoteId->execute(
                 (int) $cart->getId()
             );
+        } else {
+            if (empty($args['destination_cart_id'])) {
+                throw new GraphQlInputException(__(
+                    'The parameter "destination_cart_id" cannot be empty'
+                ));
+            }
         }
 
         $guestMaskedCartId = $args['source_cart_id'];

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -20,7 +20,7 @@ type Mutation {
     setPaymentMethodOnCart(input: SetPaymentMethodOnCartInput): SetPaymentMethodOnCartOutput @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\SetPaymentMethodOnCart")
     setGuestEmailOnCart(input: SetGuestEmailOnCartInput): SetGuestEmailOnCartOutput @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\SetGuestEmailOnCart")
     setPaymentMethodAndPlaceOrder(input: SetPaymentMethodAndPlaceOrderInput): PlaceOrderOutput @deprecated(reason: "Should use setPaymentMethodOnCart and placeOrder mutations in single request.") @resolver(class: "\\Magento\\QuoteGraphQl\\Model\\Resolver\\SetPaymentAndPlaceOrder")
-    mergeCarts(source_cart_id: String!, destination_cart_id: String!): Cart! @doc(description:"Merges the source cart into the destination cart") @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\MergeCarts")
+    mergeCarts(source_cart_id: String!, destination_cart_id: String): Cart! @doc(description:"Merges the source cart into the destination cart") @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\MergeCarts")
     placeOrder(input: PlaceOrderInput): PlaceOrderOutput @resolver(class: "\\Magento\\QuoteGraphQl\\Model\\Resolver\\PlaceOrder")
     addProductsToCart(cartId: String!, cartItems: [CartItemInput!]!): AddProductsToCartOutput @doc(description:"Add any type of product to the cart") @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\AddProductsToCart")
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/MergeCartsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/MergeCartsTest.php
@@ -192,9 +192,6 @@ class MergeCartsTest extends GraphQlAbstract
      */
     public function testMergeCartsWithEmptyDestinationCartId()
     {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Required parameter "destination_cart_id" is missing');
-
         $guestQuote = $this->quoteFactory->create();
         $this->quoteResource->load(
             $guestQuote,

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/MergeCartsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/MergeCartsTest.php
@@ -192,6 +192,9 @@ class MergeCartsTest extends GraphQlAbstract
      */
     public function testMergeCartsWithEmptyDestinationCartId()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The parameter "destination_cart_id" cannot be empty');
+
         $guestQuote = $this->quoteFactory->create();
         $this->quoteResource->load(
             $guestQuote,
@@ -204,6 +207,54 @@ class MergeCartsTest extends GraphQlAbstract
 
         $query = $this->getCartMergeMutation($guestQuoteMaskedId, $customerQuoteMaskedId);
         $this->graphQlMutation($query, [], '', $this->getHeaderMap());
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Checkout/_files/quote_with_virtual_product_saved.php
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     */
+    public function testMergeCartsWithoutDestinationCartId()
+    {
+        $guestQuote = $this->quoteFactory->create();
+        $this->quoteResource->load(
+            $guestQuote,
+            'test_order_with_virtual_product_without_address',
+            'reserved_order_id'
+        );
+        $guestQuoteMaskedId = $this->quoteIdToMaskedId->execute((int)$guestQuote->getId());
+        $query = $this->getCartMergeMutationWithoutDestinationCartId(
+            $guestQuoteMaskedId
+        );
+        $mergeResponse = $this->graphQlMutation($query, [], '', $this->getHeaderMap());
+
+        self::assertArrayHasKey('mergeCarts', $mergeResponse);
+        $cartResponse = $mergeResponse['mergeCarts'];
+        self::assertArrayHasKey('items', $cartResponse);
+        self::assertCount(2, $cartResponse['items']);
+
+        $customerQuote = $this->quoteFactory->create();
+        $this->quoteResource->load($customerQuote, 'test_quote', 'reserved_order_id');
+        $customerQuoteMaskedId = $this->quoteIdToMaskedId->execute((int)$customerQuote->getId());
+
+        $cartResponse = $this->graphQlMutation(
+            $this->getCartQuery($customerQuoteMaskedId),
+            [],
+            '',
+            $this->getHeaderMap()
+        );
+
+        self::assertArrayHasKey('cart', $cartResponse);
+        self::assertArrayHasKey('items', $cartResponse['cart']);
+        self::assertCount(2, $cartResponse['cart']['items']);
+        $item1 = $cartResponse['cart']['items'][0];
+        self::assertArrayHasKey('quantity', $item1);
+        self::assertEquals(2, $item1['quantity']);
+        $item2 = $cartResponse['cart']['items'][1];
+        self::assertArrayHasKey('quantity', $item2);
+        self::assertEquals(1, $item2['quantity']);
     }
 
     /**
@@ -241,6 +292,31 @@ mutation {
   mergeCarts(
     source_cart_id: "{$guestQuoteMaskedId}"
     destination_cart_id: "{$customerQuoteMaskedId}"
+  ){
+  items {
+      quantity
+      product {
+        sku
+      }
+    }
+  }
+}
+QUERY;
+    }
+
+    /**
+     * Create the mergeCart mutation
+     *
+     * @param string $guestQuoteMaskedId
+     * @return string
+     */
+    private function getCartMergeMutationWithoutDestinationCartId(
+        string $guestQuoteMaskedId
+    ): string {
+        return <<<QUERY
+mutation {
+  mergeCarts(
+    source_cart_id: "{$guestQuoteMaskedId}"
   ){
   items {
       quantity


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR makes the attribute `destination_cart_id` for mergeCarts mutation not required.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#30469: [Atwix] Make the destination_cart_id argument optional in the mergeCarts mutation

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
**Scenario 1.**

1. Create an empty cart using GraphQl mutation `createEmptyCart` (keep the cart ID);
2. Add product to cart;
3. Generate customer token and write it to headers;
4. Merge guest cart (with ID kept above) with the current logged in customer's cart (don't use `destination_cart_id`)
```
mutation {
  mergeCarts(
    source_cart_id: "<YOUR-GUEST-CART-ID>"
  ) {
    items {
      id
      product {
        name
        sku
      }
      quantity
    }
  }
}
```
5. Check the response. The added product should be in the customer cart.

**Scenario 2.**

1. Generate customer token and write it to headers;
2. Get the cart ID using `customerCart` query;
3. Add the product(s) to cart;
4. Revoke customer token;
5. Create an empty cart using GraphQl mutation `createEmptyCart` (keep the cart ID);
6. Add product to cart;
7. Generate customer token and write it to headers (for the customer from p.1);
8. Merge guest cart (with ID kept in p.5) with the current logged in customer's cart (don't use `destination_cart_id`)
```
mutation {
  mergeCarts(
    source_cart_id: "<YOUR-GUEST-CART-ID>"
  ) {
    items {
      id
      product {
        name
        sku
      }
      quantity
    }
  }
}
```
9. Check the response. All added products should be in the customer cart.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
