### PR TITLE
Replaced all escape functions from $block object to $escaper object as a part of Magento coding standards.

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_LayeredNavigation/templates/layer/state.phtml
+++ b/app/design/frontend/Magento/luma/Magento_LayeredNavigation/templates/layer/state.phtml
@@ -11,6 +11,7 @@
  * Category layered navigation state
  *
  * @var $block \Magento\LayeredNavigation\Block\Navigation\State
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <?php $_filters = $block->getActiveFilters() ?>
@@ -20,30 +21,30 @@
             role="heading"
             aria-level="2"
             data-role="title"
-            data-count="<?= /* @noEscape */ count($_filters) ?>"><?= $block->escapeHtml(__('Now Shopping by')) ?></strong>
+            data-count="<?= /* @noEscape */ count($_filters) ?>"><?= $escaper->escapeHtml(__('Now Shopping by')) ?></strong>
     <ol class="items">
         <?php foreach ($_filters as $_filter): ?>
             <li class="item">
-                <span class="filter-label"><?= $block->escapeHtml(__($_filter->getName())) ?></span>
-                <span class="filter-value"><?= $block->escapeHtml($block->stripTags($_filter->getLabel())) ?></span>
+                <span class="filter-label"><?= $escaper->escapeHtml(__($_filter->getName())) ?></span>
+                <span class="filter-value"><?= $escaper->escapeHtml($block->stripTags($_filter->getLabel())) ?></span>
                 <?php
                 $clearLinkUrl = $_filter->getClearLinkUrl();
-                $currentFilterName = $block->escapeHtmlAttr(__($_filter->getName()) . " " . $block->stripTags($_filter->getLabel()));
+                $currentFilterName = $escaper->escapeHtmlAttr(__($_filter->getName()) . " " . $block->stripTags($_filter->getLabel()));
                 if ($clearLinkUrl):
                     ?>
-                    <a class="action previous" href="<?= $block->escapeUrl($_filter->getRemoveUrl()) ?>"
-                       title="<?= $block->escapeHtmlAttr(__('Previous')) ?>">
-                        <span><?= $block->escapeHtml(__('Previous')) ?></span>
+                    <a class="action previous" href="<?= $escaper->escapeUrl($_filter->getRemoveUrl()) ?>"
+                       title="<?= $escaper->escapeHtmlAttr(__('Previous')) ?>">
+                        <span><?= $escaper->escapeHtml(__('Previous')) ?></span>
                     </a>
                     <a class="action remove"
-                       title="<?= $block->escapeHtmlAttr($_filter->getFilter()->getClearLinkText()) ?>"
-                       href="<?= $block->escapeUrl($clearLinkUrl) ?>">
-                        <span><?= $block->escapeHtml($_filter->getFilter()->getClearLinkText()) ?></span>
+                       title="<?= $escaper->escapeHtmlAttr($_filter->getFilter()->getClearLinkText()) ?>"
+                       href="<?= $escaper->escapeUrl($clearLinkUrl) ?>">
+                        <span><?= $escaper->escapeHtml($_filter->getFilter()->getClearLinkText()) ?></span>
                     </a>
                 <?php else: ?>
-                    <a class="action remove" href="<?= $block->escapeUrl($_filter->getRemoveUrl()) ?>"
-                       title="<?= /* @noEscape */ $block->escapeHtmlAttr(__('Remove')) . " " . $currentFilterName ?>">
-                        <span><?= $block->escapeHtml(__('Remove This Item')) ?></span>
+                    <a class="action remove" href="<?= $escaper->escapeUrl($_filter->getRemoveUrl()) ?>"
+                       title="<?= /* @noEscape */ $escaper->escapeHtmlAttr(__('Remove')) . " " . $currentFilterName ?>">
+                        <span><?= $escaper->escapeHtml(__('Remove This Item')) ?></span>
                     </a>
                 <?php endif; ?>
             </li>

--- a/app/design/frontend/Magento/luma/Magento_LayeredNavigation/templates/layer/view.phtml
+++ b/app/design/frontend/Magento/luma/Magento_LayeredNavigation/templates/layer/view.phtml
@@ -9,6 +9,7 @@
  * Category layered navigation
  *
  * @var $block \Magento\LayeredNavigation\Block\Navigation
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 
@@ -29,15 +30,15 @@
     }'>
         <?php $filtered = count($block->getLayer()->getState()->getFilters()) ?>
         <div class="block-title filter-title" data-count="<?= /* @noEscape */ $filtered ?>">
-            <strong data-role="title"><?= $block->escapeHtml(__('Shop By')); ?></strong>
+            <strong data-role="title"><?= $escaper->escapeHtml(__('Shop By')); ?></strong>
         </div>
         <div class="block-content filter-content">
             <?= $block->getChildHtml('state') ?>
 
             <?php if ($block->getLayer()->getState()->getFilters()) : ?>
                 <div class="block-actions filter-actions">
-                    <a href="<?= $block->escapeUrl($block->getClearUrl()) ?>" class="action clear filter-clear">
-                        <span><?= $block->escapeHtml(__('Clear All')) ?></span>
+                    <a href="<?= $escaper->escapeUrl($block->getClearUrl()) ?>" class="action clear filter-clear">
+                        <span><?= $escaper->escapeHtml(__('Clear All')) ?></span>
                     </a>
                 </div>
             <?php endif; ?>
@@ -45,7 +46,7 @@
             <?php foreach ($block->getFilters() as $filter) : ?>
                 <?php if ($filter->getItemsCount()) : ?>
                     <?php if (!$wrapOptions) : ?>
-                        <strong role="heading" aria-level="2" class="block-subtitle filter-subtitle"><?= $block->escapeHtml(__('Shopping Options')) ?></strong>
+                        <strong role="heading" aria-level="2" class="block-subtitle filter-subtitle"><?= $escaper->escapeHtml(__('Shopping Options')) ?></strong>
                         <div class="filter-options" id="narrow-by-list" data-role="content" data-mage-init='
                         {
                             "accordion":
@@ -59,7 +60,7 @@
                         <?php $wrapOptions = true;
                         endif; ?>
                     <div data-role="collapsible" class="filter-options-item">
-                        <div data-role="title" class="filter-options-title"><?= $block->escapeHtml(__($filter->getName())) ?></div>
+                        <div data-role="title" class="filter-options-title"><?= $escaper->escapeHtml(__($filter->getName())) ?></div>
                         <div data-role="content" class="filter-options-content"><?= /* @noEscape */ $block->getChildBlock('renderer')->render($filter) ?></div>
                     </div>
                 <?php endif; ?>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Replaced all escape functions from `$block` object to `$escaper` object as a part of Magento coding standards.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
N/A

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
N/A

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
