### PR TITLE
Fix > Unable to get store URL from admin

### DIFF
--- a/app/code/Magento/Backend/Model/Url.php
+++ b/app/code/Magento/Backend/Model/Url.php
@@ -208,6 +208,11 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
             $cacheSecretKey = true;
         }
         $result = parent::getUrl($routePath, $routeParams);
+
+        if (empty($this->getAreaFrontName())) {
+            $this->turnOffSecretKey();
+        }
+
         if (!$this->useSecretKey()) {
             return $result;
         }
@@ -410,7 +415,7 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
      */
     public function getAreaFrontName()
     {
-        if (!$this->_getData('area_front_name')) {
+        if ($this->_getData('area_front_name') === null) {
             $this->setData('area_front_name', $this->_backendHelper->getAreaFrontName());
         }
         return $this->_getData('area_front_name');
@@ -423,12 +428,9 @@ class Url extends \Magento\Framework\Url implements \Magento\Backend\Model\UrlIn
      */
     protected function _getActionPath()
     {
-
         $path = parent::_getActionPath();
-        if ($path) {
-            if ($this->getAreaFrontName()) {
-                $path = $this->getAreaFrontName() . '/' . $path;
-            }
+        if ($path && $this->getAreaFrontName()) {
+            $path = $this->getAreaFrontName() . DIRECTORY_SEPARATOR . $path;
         }
         return $path;
     }


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
N/A

### Fixed Issues
#5322 

### Manual testing scenarios (*)

By default we have the following scenario related to websites + store + store views:

"Main Website (Code: base)" > "Main Website Store (Code: main_website_store)" > "Default Store View (Code: default)"

1. Create a store and assign to "Main Website (Code: base)" > "Test Store (Code: test)"
2. Create a store view and assign to "Test Store View (Code: test)"
![image](https://user-images.githubusercontent.com/535626/97366382-fe3c1700-1885-11eb-8900-065708767df3.png)

By default on "Stores" > "Settings" > "Configuration" > "General" > "Web":

On "Scope": "Default Config"

"Base URL": http://local.magento2.com/
"Secure Base URL": https://local.magento2.com/

![image](https://user-images.githubusercontent.com/535626/97366465-2166c680-1886-11eb-8b13-bd72d5c883f3.png)

3. Change the "Scope" to "Test Store View"
4. Set "Base URL": http://test.magento2.com/
5. Set "Secure Base URL": https://test.magento2.com/

On backend to create some URL with frontend URL is a little different because backend uses \Magento\Backend\Model\Url, that means your admin backend URL will come along, but you can use the snippet code below to retrieve the frontend URL whatever the store URL you want:

6. For example, add the following snippet code on app/code/Magento/Backend/Controller/Adminhtml/Dashboard/Index.php:36

```php
        /** @var \Magento\Framework\UrlInterface $urlBuilder */
        $urlBuilder = $this->_objectManager->get(\Magento\Backend\Model\UrlInterface::class);

        $url = $urlBuilder->setAreaFrontName('')
            ->setScope(1)
            ->getUrl('myroute');

        echo $url;

        exit;
```

This snippet code above will return: http://local.magento2.com/myroute/

![image](https://user-images.githubusercontent.com/535626/98433286-68ce2d80-20a4-11eb-970a-903e24fdcf27.png)

```php
        /** @var \Magento\Framework\UrlInterface $urlBuilder */
        $urlBuilder = $this->_objectManager->get(\Magento\Backend\Model\UrlInterface::class);

        $url = $urlBuilder->setAreaFrontName('')
            ->setScope(2)
            ->getUrl('myroute');

        echo $url;

        exit;
```

This snippet code above will return: http://test.magento2.com/myroute/

![image](https://user-images.githubusercontent.com/535626/98433293-7e435780-20a4-11eb-9120-609f635416e1.png)


setAreaFrontName('') will remove the admin backend URL string

setScope(N) will set the store ID


### Questions or comments
N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
