### PR TITLE
Use oauth_nonce, oauth_version and oauth_timestamp in signature gener…

### DIFF
--- a/lib/internal/Magento/Framework/Oauth/Oauth.php
+++ b/lib/internal/Magento/Framework/Oauth/Oauth.php
@@ -154,7 +154,7 @@ class Oauth implements OauthInterface
         ];
         $headerParameters = array_merge($headerParameters, $params);
         $headerParameters['oauth_signature'] = $this->_httpUtility->sign(
-            $params,
+            $headerParameters,
             $signatureMethod,
             $headerParameters['oauth_consumer_secret'],
             $headerParameters['oauth_token_secret'],


### PR DESCRIPTION
## Summary
Use oauth_nonce, oauth_version and oauth_timestamp in signature generation

## Current Issue
Using \Magento\Framework\Oauth\Oauth class for Oauth header generation causes "This signature is Invalid error." 

## Description
Using \Magento\Framework\Oauth\Oauth class for Oauth header generation causes "This signature is Invalid error." 
That happens because _validateSignature uses  oauth_nonce, oauth_version and oauth_timestamp in signature generation but buildAuthorizationHeader does not use them in signature generation. Hence signatures don't match.
 This pull request fixes that by using oauth_nonce, oauth_version and oauth_timestamp  in oauth signature generation.





