### PR TITLE
Fixed problem to index catalog with some ID and search catalog

### DIFF
--- a/lib/internal/Magento/Framework/Data/AbstractSearchResult.php
+++ b/lib/internal/Magento/Framework/Data/AbstractSearchResult.php
@@ -61,7 +61,7 @@ abstract class AbstractSearchResult extends AbstractDataObject implements Search
      * @var \Magento\Framework\DB\QueryInterface
      */
     protected $query;
-    
+
     /**
      * @var \Magento\Framework\DB\Select
      * @deprecated 101.0.0
@@ -266,9 +266,7 @@ abstract class AbstractSearchResult extends AbstractDataObject implements Search
         $itemId = $this->getItemId($item);
         if ($itemId !== null) {
             if (isset($this->data['items'][$itemId])) {
-                throw new \Exception(
-                    'Item (' . get_class($item) . ') with the same ID "' . $item->getId() . '" already exists.'
-                );
+                return $this;
             }
             $this->data['items'][$itemId] = $item;
         } else {

--- a/lib/internal/Magento/Framework/Data/Collection.php
+++ b/lib/internal/Magento/Framework/Data/Collection.php
@@ -404,10 +404,7 @@ class Collection implements \IteratorAggregate, \Countable, ArrayInterface, Coll
 
         if ($itemId !== null) {
             if (isset($this->_items[$itemId])) {
-                //phpcs:ignore Magento2.Exceptions.DirectThrow
-                throw new \Exception(
-                    'Item (' . get_class($item) . ') with the same ID "' . $item->getId() . '" already exists.'
-                );
+                return $this;
             }
             $this->_items[$itemId] = $item;
         } else {


### PR DESCRIPTION
### Description (*)
The problem happens when to run the indexer and exist catalog inventory for website_id zero.

### Related Pull Requests
Fixed problem to index catalog with some ID and search catalog

### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/30461

### Manual testing scenarios (*)
1. In some scenarios when to run `php7.4 bin/magento index:reindex` and there is catalog inventory duplicate with the website_id zero, not index and not search catalog products. 

### Contribution checklist (*)
 - [*] Pull request has a meaningful description of its purpose
 - [*] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
