### PR TITLE
Pass string value to PHP functions which expect a string parameter.

### DIFF
--- a/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
@@ -532,9 +532,9 @@ abstract class AbstractEntity
                 foreach ($attribute->getSource()->getAllOptions(false) as $option) {
                     $value = is_array($option['value']) ? $option['value'] : [$option];
                     foreach ($value as $innerOption) {
-                        if (strlen($innerOption['value'])) {
+                        if (strlen((string) $innerOption['value'])) {
                             // skip ' -- Please Select -- ' option
-                            $options[strtolower($innerOption[$index])] = $innerOption['value'];
+                            $options[strtolower((string) $innerOption[$index])] = $innerOption['value'];
                         }
                     }
                 }

--- a/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\ImportExport\Model\Import\Entity;
 
 use Magento\Framework\App\ObjectManager;


### PR DESCRIPTION
### Description (*)

Helps prepare file for `declare(strict_types=1);`. 

When the source for a `Magento\Eav\Model\Entity\Attribute\Source\Boolean` attribute was being processed, the following would occur if strict_types was turned on:

- Line 535 would throw: `strlen() expects parameter 1 to be string, int given` (since values are int values `0` and `1`)
- Line 537 would throw: `strtolower() expects parameter 1 to be string, object given` (since it was passing it an object of `\Magento\Framework\Phrase`)

### Manual testing scenarios (*)

None performed. Given the nature of the logic though we know that [strlen()](https://www.php.net/strlen) expects a string value as does [strtolower()](https://www.php.net/strtolower). Without `declare(strict_types=1)` turned on, this casting occurs automatically. With it on, a `\TypeError` is thrown. Explicitly casting to string prior to passing values to these two functions resolves this.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30785: Pass string value to PHP functions which expect a string parameter.