### PR TITLE
Replace 'static::' with 'self::' when accessing private const.

### DIFF
--- a/app/code/Magento/Backend/Model/Dashboard/Period.php
+++ b/app/code/Magento/Backend/Model/Dashboard/Period.php
@@ -46,11 +46,11 @@ class Period
     public function getPeriodChartUnits(): array
     {
         return [
-            static::PERIOD_24_HOURS => static::PERIOD_UNIT_HOUR,
-            static::PERIOD_7_DAYS => static::PERIOD_UNIT_DAY,
-            static::PERIOD_1_MONTH => static::PERIOD_UNIT_DAY,
-            static::PERIOD_1_YEAR => static::PERIOD_UNIT_MONTH,
-            static::PERIOD_2_YEARS => static::PERIOD_UNIT_MONTH
+            static::PERIOD_24_HOURS => self::PERIOD_UNIT_HOUR,
+            static::PERIOD_7_DAYS => self::PERIOD_UNIT_DAY,
+            static::PERIOD_1_MONTH => self::PERIOD_UNIT_DAY,
+            static::PERIOD_1_YEAR => self::PERIOD_UNIT_MONTH,
+            static::PERIOD_2_YEARS => self::PERIOD_UNIT_MONTH
         ];
     }
 }

--- a/app/code/Magento/Backend/ViewModel/ChartDisabled.php
+++ b/app/code/Magento/Backend/ViewModel/ChartDisabled.php
@@ -57,7 +57,7 @@ class ChartDisabled implements ArgumentInterface
     public function getConfigUrl(): string
     {
         return $this->urlBuilder->getUrl(
-            static::ROUTE_SYSTEM_CONFIG,
+            self::ROUTE_SYSTEM_CONFIG,
             ['section' => 'admin', '_fragment' => 'admin_dashboard-link']
         );
     }
@@ -70,7 +70,7 @@ class ChartDisabled implements ArgumentInterface
     public function isChartEnabled(): bool
     {
         return $this->scopeConfig->isSetFlag(
-            static::XML_PATH_ENABLE_CHARTS,
+            self::XML_PATH_ENABLE_CHARTS,
             ScopeInterface::SCOPE_STORE
         );
     }

--- a/app/code/Magento/Catalog/Model/Config/LayerCategoryConfig.php
+++ b/app/code/Magento/Catalog/Model/Config/LayerCategoryConfig.php
@@ -60,7 +60,7 @@ class LayerCategoryConfig
         }
 
         return $this->scopeConfig->isSetFlag(
-            static::XML_PATH_CATALOG_LAYERED_NAVIGATION_DISPLAY_CATEGORY,
+            self::XML_PATH_CATALOG_LAYERED_NAVIGATION_DISPLAY_CATEGORY,
             $scopeType,
             $scopeCode
         );

--- a/app/code/Magento/DownloadableImportExport/Model/Import/Product/Type/Downloadable.php
+++ b/app/code/Magento/DownloadableImportExport/Model/Import/Product/Type/Downloadable.php
@@ -370,12 +370,12 @@ class Downloadable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
 
         foreach ($sampleData as $link) {
             if ($this->hasDomainNotInWhitelist($link, 'link_type', 'link_url')) {
-                $this->_entityModel->addRowError(static::ERROR_LINK_URL_NOT_IN_DOMAIN_WHITELIST, $this->rowNum);
+                $this->_entityModel->addRowError(self::ERROR_LINK_URL_NOT_IN_DOMAIN_WHITELIST, $this->rowNum);
                 $result = true;
             }
 
             if ($this->hasDomainNotInWhitelist($link, 'sample_type', 'sample_url')) {
-                $this->_entityModel->addRowError(static::ERROR_SAMPLE_URL_NOT_IN_DOMAIN_WHITELIST, $this->rowNum);
+                $this->_entityModel->addRowError(self::ERROR_SAMPLE_URL_NOT_IN_DOMAIN_WHITELIST, $this->rowNum);
                 $result = true;
             }
         }
@@ -406,12 +406,12 @@ class Downloadable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
 
         foreach ($linkData as $link) {
             if ($this->hasDomainNotInWhitelist($link, 'link_type', 'link_url')) {
-                $this->_entityModel->addRowError(static::ERROR_LINK_URL_NOT_IN_DOMAIN_WHITELIST, $this->rowNum);
+                $this->_entityModel->addRowError(self::ERROR_LINK_URL_NOT_IN_DOMAIN_WHITELIST, $this->rowNum);
                 $result = true;
             }
 
             if ($this->hasDomainNotInWhitelist($link, 'sample_type', 'sample_url')) {
-                $this->_entityModel->addRowError(static::ERROR_SAMPLE_URL_NOT_IN_DOMAIN_WHITELIST, $this->rowNum);
+                $this->_entityModel->addRowError(self::ERROR_SAMPLE_URL_NOT_IN_DOMAIN_WHITELIST, $this->rowNum);
                 $result = true;
             }
         }


### PR DESCRIPTION
# Description

This PR prevents 'Undefined class constant' error if a plugin will be added for one of these classes. Example: 

### Related Pull Requests
https://github.com/magento/magento2/pull/28797
https://github.com/magento/magento2/pull/29925

### Related Issues
1. https://github.com/magento/magento-coding-standard/issues/197

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30781: Replace 'static::' with 'self::' when accessing private const.