### PR TITLE
Set cartItem errors relative to the cart item

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/CartItems.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/CartItems.php
@@ -51,7 +51,9 @@ class CartItems implements ResolverInterface
         /** @var QuoteItem $cartItem */
         foreach ($cartItems as $cartItem) {
             if ($cartItem->getHasError()) {
-                $itemsData[] = new GraphQlInputException(__($cartItem->getErrorInfos()[0]['message']));
+                foreach ($cartItem->getErrorInfos() as $error) {
+                    $itemsData[] = new GraphQlInputException(__($error['message']));
+                }
             }
             
             $productId = $cartItem->getProduct()->getId();

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/CartItems.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/CartItems.php
@@ -46,17 +46,14 @@ class CartItems implements ResolverInterface
         $cart = $value['model'];
 
         $itemsData = [];
-        if ($cart->getData('has_error')) {
-            $errors = $cart->getErrors();
-            foreach ($errors as $error) {
-                $itemsData[] = new GraphQlInputException(__($error->getText()));
-            }
-        }
-
         $cartProductsData = $this->getCartProductsData($cart);
         $cartItems = $cart->getAllVisibleItems();
         /** @var QuoteItem $cartItem */
         foreach ($cartItems as $cartItem) {
+            if ($cartItem->getHasError()) {
+                $itemsData[] = new GraphQlInputException(__($cartItem->getErrorInfos()[0]['message']));
+            }
+            
             $productId = $cartItem->getProduct()->getId();
             if (!isset($cartProductsData[$productId])) {
                 $itemsData[] = new GraphQlNoSuchEntityException(
@@ -64,6 +61,7 @@ class CartItems implements ResolverInterface
                 );
                 continue;
             }
+            
             $productData = $cartProductsData[$productId];
 
             $itemsData[] = [


### PR DESCRIPTION


### Description (*)
Currently the errors are always returned at the beginning of the cart items array. 
This makes it impossible for the frontend to know error is associated with a cart item because the error paths are returned incorrectly.

It would be best to fix the cart so it won't return additional `null` items. If an error is thrown

### Manual testing scenarios (*)
1. Add a product to your cart
2. Make the product out of stock
3. Request the cart
4. The errors are added to the top of the cartItems array and null cart items are added.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30861: Set cartItem errors relative to the cart item