### PR TITLE
Add CartItemOptionsProcessor to Magento_Quote's API

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Item/CartItemOptionsProcessor.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/CartItemOptionsProcessor.php
@@ -9,6 +9,7 @@ use Magento\Quote\Api\Data\CartItemInterface;
 
 /**
  * @api
+ * @since 100.1.0
  */
 class CartItemOptionsProcessor
 {

--- a/app/code/Magento/Quote/Model/Quote/Item/CartItemOptionsProcessor.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/CartItemOptionsProcessor.php
@@ -7,6 +7,9 @@ namespace Magento\Quote\Model\Quote\Item;
 
 use Magento\Quote\Api\Data\CartItemInterface;
 
+/**
+ * @api
+ */
 class CartItemOptionsProcessor
 {
     /**

--- a/app/code/Magento/Quote/Model/Quote/Item/CartItemOptionsProcessor.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/CartItemOptionsProcessor.php
@@ -9,7 +9,6 @@ use Magento\Quote\Api\Data\CartItemInterface;
 
 /**
  * @api
- * @since 100.1.0
  */
 class CartItemOptionsProcessor
 {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This class is used by at least one VBE and is necessary for loading Cart Item Options for quotes that are not "active" (for example, when wanting to retrieve option information for an order that has already been placed)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#30831: Add CartItemOptionsProcessor to Magento_Quote's API