### PR TITLE
Fixed "Email Copy of Invoice", "Email Copy of Shipment" and "Email Copy of Creditmemo" Issues

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Save.php
@@ -7,6 +7,7 @@ namespace Magento\Sales\Controller\Adminhtml\Order\Creditmemo;
 
 use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
 use Magento\Backend\App\Action;
+use Magento\Sales\Helper\Data as SalesData;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Email\Sender\CreditmemoSender;
 
@@ -35,20 +36,29 @@ class Save extends \Magento\Backend\App\Action implements HttpPostActionInterfac
     protected $resultForwardFactory;
 
     /**
+     * @var SalesData
+     */
+    private $salesData;
+
+    /**
      * @param Action\Context $context
      * @param \Magento\Sales\Controller\Adminhtml\Order\CreditmemoLoader $creditmemoLoader
      * @param CreditmemoSender $creditmemoSender
      * @param \Magento\Backend\Model\View\Result\ForwardFactory $resultForwardFactory
+     * @param SalesData $salesData
      */
     public function __construct(
         Action\Context $context,
         \Magento\Sales\Controller\Adminhtml\Order\CreditmemoLoader $creditmemoLoader,
         CreditmemoSender $creditmemoSender,
-        \Magento\Backend\Model\View\Result\ForwardFactory $resultForwardFactory
+        \Magento\Backend\Model\View\Result\ForwardFactory $resultForwardFactory,
+        SalesData $salesData = null
     ) {
         $this->creditmemoLoader = $creditmemoLoader;
         $this->creditmemoSender = $creditmemoSender;
         $this->resultForwardFactory = $resultForwardFactory;
+        $this->salesData = $salesData ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(SalesData::class);
         parent::__construct($context);
     }
 
@@ -108,7 +118,7 @@ class Save extends \Magento\Backend\App\Action implements HttpPostActionInterfac
                 $doOffline = isset($data['do_offline']) ? (bool)$data['do_offline'] : false;
                 $creditmemoManagement->refund($creditmemo, $doOffline);
 
-                if (!empty($data['send_email'])) {
+                if (!empty($data['send_email']) && $this->salesData->canSendNewCreditMemoEmail()) {
                     $this->creditmemoSender->send($creditmemo);
                 }
 

--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Invoice/Save.php
@@ -86,7 +86,8 @@ class Save extends \Magento\Backend\App\Action implements HttpPostActionInterfac
         $this->shipmentFactory = $shipmentFactory;
         $this->invoiceService = $invoiceService;
         parent::__construct($context);
-        $this->salesData = $salesData ?? $this->_objectManager->get(SalesData::class);
+        $this->salesData = $salesData ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(SalesData::class);
     }
 
     /**
@@ -213,7 +214,7 @@ class Save extends \Magento\Backend\App\Action implements HttpPostActionInterfac
 
             // send invoice/shipment emails
             try {
-                if (!empty($data['send_email']) || $this->salesData->canSendNewInvoiceEmail()) {
+                if (!empty($data['send_email']) && $this->salesData->canSendNewInvoiceEmail()) {
                     $this->invoiceSender->send($invoice);
                 }
             } catch (\Exception $e) {
@@ -222,7 +223,7 @@ class Save extends \Magento\Backend\App\Action implements HttpPostActionInterfac
             }
             if ($shipment) {
                 try {
-                    if (!empty($data['send_email']) || $this->salesData->canSendNewShipmentEmail()) {
+                    if (!empty($data['send_email']) && $this->salesData->canSendNewShipmentEmail()) {
                         $this->shipmentSender->send($shipment);
                     }
                 } catch (\Exception $e) {

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/SaveTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/SaveTest.php
@@ -21,9 +21,13 @@ use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Registry;
 use Magento\Framework\Session\Storage;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Sales\Api\CreditmemoManagementInterface;
 use Magento\Sales\Controller\Adminhtml\Order\Creditmemo\Save;
 use Magento\Sales\Controller\Adminhtml\Order\CreditmemoLoader;
+use Magento\Sales\Helper\Data as SalesData;
+use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Creditmemo;
+use Magento\Sales\Model\Order\Email\Sender\CreditmemoSender;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -88,6 +92,16 @@ class SaveTest extends TestCase
     protected $resultRedirectMock;
 
     /**
+     * @var CreditmemoSender|MockObject
+     */
+    private $creditmemoSender;
+
+    /**
+     * @var SalesData|MockObject
+     */
+    private $salesData;
+
+    /**
      * Init model for future tests
      */
     protected function setUp(): void
@@ -147,12 +161,32 @@ class SaveTest extends TestCase
 
         $context = $helper->getObject(Context::class, $arguments);
 
+        $creditmemoManagement =  $this->getMockBuilder(CreditmemoManagementInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->_objectManager->expects($this->any())
+            ->method('create')
+            ->with(CreditmemoManagementInterface::class)
+            ->willReturn($creditmemoManagement);
+        $this->creditmemoSender = $this->getMockBuilder(CreditMemoSender::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['send'])
+            ->getMock();
+        $this->creditmemoSender->expects($this->any())
+            ->method('send')
+            ->willReturn(true);
+        $this->salesData = $this->getMockBuilder(SalesData::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['canSendNewCreditmemoEmail'])
+            ->getMock();
         $this->memoLoaderMock = $this->createMock(CreditmemoLoader::class);
         $this->_controller = $helper->getObject(
             Save::class,
             [
                 'context' => $context,
                 'creditmemoLoader' => $this->memoLoaderMock,
+                'creditmemoSender' => $this->creditmemoSender,
+                'salesData' => $this->salesData
             ]
         );
     }
@@ -257,5 +291,95 @@ class SaveTest extends TestCase
     {
         $this->_messageManager->expects($this->once())->method('addErrorMessage')->with($errorMessage);
         $this->_sessionMock->expects($this->once())->method('setFormData')->with($data);
+    }
+
+    /**
+     * @return array
+     */
+    public function testExecuteEmailsDataProvider()
+    {
+        /**
+        * string $sendEmail
+        * bool $emailEnabled
+        * bool $shouldEmailBeSent
+        */
+        return [
+            ['', false, false],
+            ['', true, false],
+            ['on', false, false],
+            ['on', true, true]
+        ];
+    }
+
+    /**
+     * @param string $sendEmail
+     * @param bool $emailEnabled
+     * @param bool $shouldEmailBeSent
+     * @dataProvider testExecuteEmailsDataProvider
+     */
+    public function testExecuteEmails(
+        $sendEmail,
+        $emailEnabled,
+        $shouldEmailBeSent
+    ) {
+        $orderId = 1;
+        $creditmemoId = 2;
+        $invoiceId = 3;
+        $creditmemoData = ['items' => [], 'send_email' => $sendEmail];
+
+        $this->resultRedirectFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($this->resultRedirectMock);
+        $this->resultRedirectMock->expects($this->once())
+            ->method('setPath')
+            ->with('sales/order/view', ['order_id' => $orderId])
+            ->willReturnSelf();
+
+        $order = $this->createPartialMock(
+            Order::class,
+            []
+        );
+
+        $creditmemo = $this->createPartialMock(
+            Creditmemo::class,
+            ['isValidGrandTotal', 'getOrder', 'getOrderId']
+        );
+        $creditmemo->expects($this->once())
+            ->method('isValidGrandTotal')
+            ->willReturn(true);
+        $creditmemo->expects($this->once())
+            ->method('getOrder')
+            ->willReturn($order);
+        $creditmemo->expects($this->once())
+            ->method('getOrderId')
+            ->willReturn($orderId);
+
+        $this->_requestMock->expects($this->any())
+            ->method('getParam')
+            ->willReturnMap(
+                [
+                    ['order_id', null, $orderId],
+                    ['creditmemo_id', null, $creditmemoId],
+                    ['creditmemo', null, $creditmemoData],
+                    ['invoice_id', null, $invoiceId]
+                ]
+            );
+
+        $this->_requestMock->expects($this->any())
+            ->method('getPost')
+            ->willReturn($creditmemoData);
+
+        $this->memoLoaderMock->expects($this->once())
+            ->method('load')
+            ->willReturn($creditmemo);
+
+        $this->salesData->expects($this->any())
+            ->method('canSendNewCreditmemoEmail')
+            ->willReturn($emailEnabled);
+        if ($shouldEmailBeSent) {
+            $this->creditmemoSender->expects($this->once())
+                ->method('send');
+        }
+        $this->assertEquals($this->resultRedirectMock, $this->_controller->execute());
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/SaveTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/SaveTest.php
@@ -8,16 +8,27 @@ declare(strict_types=1);
 namespace Magento\Sales\Test\Unit\Controller\Adminhtml\Order\Invoice;
 
 use Magento\Backend\App\Action\Context;
+use Magento\Backend\Model\Session;
 use Magento\Backend\Model\View\Result\Redirect;
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\Data\Form\FormKey\Validator;
+use Magento\Framework\DB\Transaction;
 use Magento\Framework\Message\ManagerInterface;
+use Magento\Framework\ObjectManager\ObjectManager as FrameworkObjectManager;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\View\Result\PageFactory;
 use Magento\Sales\Controller\Adminhtml\Order\Invoice\Save;
+use Magento\Sales\Helper\Data as SalesData;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
+use Magento\Sales\Model\Order\Invoice;
+use Magento\Sales\Model\Service\InvoiceService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class SaveTest extends TestCase
 {
     /**
@@ -49,6 +60,26 @@ class SaveTest extends TestCase
      * @var Save
      */
     protected $controller;
+
+    /**
+     * @var SalesData|MockObject
+     */
+    private $salesData;
+
+    /**
+     * @var InvoiceSender|MockObject
+     */
+    private $invoiceSender;
+
+    /**
+     * @var FrameworkObjectManager|MockObject
+     */
+    private $objectManager;
+
+    /**
+     * @var InvoiceService|MockObject
+     */
+    private $invoiceService;
 
     /**
      * SetUp method
@@ -98,11 +129,36 @@ class SaveTest extends TestCase
         $contextMock->expects($this->any())
             ->method('getMessageManager')
             ->willReturn($this->messageManagerMock);
+        $this->objectManager = $this->createPartialMock(
+            FrameworkObjectManager::class,
+            ['create','get']
+        );
+        $contextMock->expects($this->any())
+            ->method('getObjectManager')
+            ->willReturn($this->objectManager);
+        $this->invoiceSender = $this->getMockBuilder(InvoiceSender::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['send'])
+            ->getMock();
+        $this->invoiceSender->expects($this->any())
+            ->method('send')
+            ->willReturn(true);
+        $this->salesData = $this->getMockBuilder(SalesData::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['canSendNewInvoiceEmail'])
+            ->getMock();
+        $this->invoiceService = $this->getMockBuilder(InvoiceService::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['prepareInvoice'])
+            ->getMock();
 
         $this->controller = $objectManager->getObject(
             Save::class,
             [
                 'context' => $contextMock,
+                'invoiceSender' => $this->invoiceSender,
+                'invoiceService' => $this->invoiceService,
+                'salesData' => $this->salesData
             ]
         );
     }
@@ -134,6 +190,150 @@ class SaveTest extends TestCase
             ->method('setPath')
             ->with('sales/order/index')
             ->willReturnSelf();
+
+        $this->assertEquals($redirectMock, $this->controller->execute());
+    }
+
+    /**
+     * @return array
+     */
+    public function testExecuteEmailsDataProvider()
+    {
+        /**
+        * string $sendEmail
+        * bool $emailEnabled
+        * bool $shouldEmailBeSent
+        */
+        return [
+            ['', false, false],
+            ['', true, false],
+            ['on', false, false],
+            ['on', true, true]
+        ];
+    }
+
+    /**
+     * @param string $sendEmail
+     * @param bool $emailEnabled
+     * @param bool $shouldEmailBeSent
+     * @dataProvider testExecuteEmailsDataProvider
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public function testExecuteEmails(
+        $sendEmail,
+        $emailEnabled,
+        $shouldEmailBeSent
+    ) {
+        $redirectMock = $this->getMockBuilder(Redirect::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $redirectMock->expects($this->once())
+            ->method('setPath')
+            ->with('sales/order/view')
+            ->willReturnSelf();
+
+        $this->resultPageFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($redirectMock);
+        $this->formKeyValidatorMock->expects($this->once())
+            ->method('validate')
+            ->with($this->requestMock)
+            ->willReturn(true);
+        $this->requestMock->expects($this->once())
+            ->method('isPost')
+            ->willReturn(true);
+
+        $invoiceData = ['items' => [], 'send_email' => $sendEmail];
+
+        $orderId = 2;
+        $order = $this->createPartialMock(
+            Order::class,
+            ['load','getId','canInvoice']
+        );
+        $order->expects($this->once())
+            ->method('load')
+            ->willReturn($order);
+        $order->expects($this->once())
+            ->method('getId')
+            ->willReturn($orderId);
+        $order->expects($this->once())
+            ->method('canInvoice')
+            ->willReturn(true);
+
+        $invoice = $this->getMockBuilder(Invoice::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getTotalQty','getOrder','register'])
+            ->getMock();
+        $invoice->expects($this->any())
+            ->method('getTotalQty')
+            ->willReturn(1);
+        $invoice->expects($this->any())
+            ->method('getOrder')
+            ->willReturn($order);
+        $invoice->expects($this->once())
+            ->method('register')
+            ->willReturn($order);
+
+        $this->invoiceService->expects($this->any())
+            ->method('prepareInvoice')
+            ->willReturn($invoice);
+
+        $saveTransaction = $this->getMockBuilder(Transaction::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['addObject','save'])
+            ->getMock();
+        $saveTransaction->expects($this->at(0))
+            ->method('addObject')
+            ->with($invoice)->willReturnSelf();
+        $saveTransaction->expects($this->at(1))
+            ->method('addObject')
+            ->with($order)->willReturnSelf();
+        $saveTransaction->expects($this->at(2))
+            ->method('save');
+
+        $session = $this->getMockBuilder(Session::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCommentText'])
+            ->getMock();
+        $session->expects($this->once())
+            ->method('getCommentText')
+            ->with(true);
+
+        $this->objectManager->expects($this->any())
+            ->method('create')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        [Transaction::class, [], $saveTransaction],
+                        [Order::class, [], $order],
+                        [Session::class, [], $session]
+                    ]
+                )
+            );
+        $this->objectManager->expects($this->any())
+            ->method('get')
+            ->with(Session::class)
+            ->willReturn($session);
+
+        $this->requestMock->expects($this->any())
+            ->method('getParam')
+            ->willReturnMap(
+                [
+                    ['order_id', null, $orderId],
+                    ['invoice', null, $invoiceData]
+                ]
+            );
+        $this->requestMock->expects($this->any())
+            ->method('getPost')
+            ->willReturn($invoiceData);
+
+        $this->salesData->expects($this->any())
+            ->method('canSendNewInvoiceEmail')
+            ->willReturn($emailEnabled);
+        if ($shouldEmailBeSent) {
+            $this->invoiceSender->expects($this->once())
+                ->method('send');
+        }
 
         $this->assertEquals($redirectMock, $this->controller->execute());
     }

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Invoice/AbstractInvoiceControllerTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Invoice/AbstractInvoiceControllerTest.php
@@ -97,15 +97,21 @@ abstract class AbstractInvoiceControllerTest extends AbstractBackendController
      * @param array $items
      * @param string $commentText
      * @param bool $doShipment
+     * @param bool $sendEmail
      * @return array
      */
-    protected function hydratePost(array $items, string $commentText = '', $doShipment = false): array
-    {
+    protected function hydratePost(
+        array $items,
+        string $commentText = '',
+        $doShipment = false,
+        $sendEmail = false
+    ): array {
         return [
             'invoice' => [
                 'items' => $items,
                 'comment_text' => $commentText,
-                'do_shipment' => $doShipment
+                'do_shipment' => $doShipment,
+                'send_email' => $sendEmail
             ],
         ];
     }

--- a/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Invoice/SaveTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Controller/Adminhtml/Order/Invoice/SaveTest.php
@@ -58,6 +58,26 @@ class SaveTest extends AbstractInvoiceControllerTest
         $this->dispatch('backend/sales/order_invoice/save');
         $invoice = $this->getInvoiceByOrder($order);
         $this->checkSuccess($invoice, 2);
+        $this->assertNull($this->transportBuilder->getSentMessage());
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     *
+     * @return void
+     */
+    public function testSendEmailOnInvoiceSaveEmailCopyOfInvoice(): void
+    {
+        $order = $this->getOrder('100000001');
+        $itemId = $order->getItemsCollection()->getFirstItem()->getId();
+        $post = $this->hydratePost([$itemId => 2], "", false, "1");
+        $this->prepareRequest(
+            $post,
+            ['order_id' => $order->getEntityId()]
+        );
+        $this->dispatch('backend/sales/order_invoice/save');
+        $invoice = $this->getInvoiceByOrder($order);
+        $this->checkSuccess($invoice, 2);
         $message = $this->transportBuilder->getSentMessage();
         $this->assertNotNull($message);
         $subject = __('Invoice for your %1 order', $order->getStore()->getFrontendName())->render();


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Magento is not consistent with the operation of the "Email Copy of ......" Checkboxes on the Invoice, Creditmemo and Shipment creation screens in admin.

On the invoice screen, if the box is unticked, but the global setting in Sales Emails is set to enabled, the email still gets sent.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#28511

### Manual testing scenarios (*)

- Create test Product
- Purchase Test Product
- Set Config -> Sales -> Sales Emails to Enabled for Invoice, Shipment and Creditmemo
- Create Invoice and do NOT tick "Email copy of Invoice". Verify Email is NOT received
- Create Shipment and do NOT tick "Email copy of Shipment". Verify Email is NOT received
- Create Creditmemo and do NOT tick "Email copy of Creditmemo". Verify Email is NOT received
- Purchase Test Product
- Create Invoice and tick "Email copy of Invoice". Verify Email is received
- Create Shipment and tick "Email copy of Shipment". Verify Email is received
- Create Creditmemo and tick "Email copy of Creditmemo". Verify Email is received
- Purchase Test Product
- Set Config -> Sales -> Sales Emails to Disabled for Invoice, Shipment and Creditmemo
- Create Invoice. Verify Email is NOT received
- Create Shipment. Verify Email is NOT received
- Create Creditmemo. Verify Email is NOT received

### Questions or comments
Unit test covered

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
