### PR TITLE
Typed variadic arguments fail to be injected

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Factory/AbstractFactory.php
@@ -270,7 +270,13 @@ abstract class AbstractFactory implements \Magento\Framework\ObjectManager\Facto
         }
 
         if ($isVariadic) {
-            return is_array($argument) ? $argument : [$argument];
+            $variadicArguments = is_array($argument) ? $argument : [$argument];
+
+            foreach ($variadicArguments as &$variadicArgument) {
+                $this->resolveArgument($variadicArgument, $paramType, $paramDefault, $paramName, $requestedType);
+            };
+
+            return $variadicArguments;
         }
 
         $this->resolveArgument($argument, $paramType, $paramDefault, $paramName, $requestedType);

--- a/lib/internal/Magento/Framework/ObjectManager/Factory/Compiled.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Factory/Compiled.php
@@ -64,6 +64,7 @@ class Compiled extends AbstractFactory
              *
              * Argument key meanings:
              *
+             * _vdic_: variadic argument
              * _i_: shared instance of a class or interface
              * _ins_: non-shared instance of a class or interface
              * _v_: non-array literal value
@@ -73,7 +74,21 @@ class Compiled extends AbstractFactory
              * _d_: default value in case environment variable specified by _a_ does not exist
              */
             foreach ($args as $key => &$argument) {
-                if (isset($arguments[$key])) {
+                if (isset($argument['_vdic_'])) {
+                    // Process variadic
+                    if (isset($arguments[$key])) {
+                        $argument = (array)$arguments[$key];
+                    } else {
+                        $argument = (array)$argument['_vdic_'];
+                        $this->parseArray($argument);
+                    }
+                    unset($args[$key]);
+                    if (count($argument)) {
+                        array_push($args, ...array_values($argument));
+                    }
+                    // Variadic argument is always the last one
+                    break;
+                } elseif (isset($arguments[$key])) {
                     $argument = $arguments[$key];
                 } elseif (isset($argument['_i_'])) {
                     $argument = $this->get($argument['_i_']);

--- a/setup/src/Magento/Setup/Module/Di/Compiler/ArgumentsResolver.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/ArgumentsResolver.php
@@ -60,6 +60,15 @@ class ArgumentsResolver
     ];
 
     /**
+     * Variadic pattern used for configuration
+     *
+     * @var array
+     */
+    private $variadicPattern = [
+        '_vdic_' => [],
+    ];
+
+    /**
      * Configured argument pattern used for configuration
      *
      * @var array
@@ -96,21 +105,14 @@ class ArgumentsResolver
         /** @var ConstructorArgument $constructorArgument */
         foreach ($constructor as $constructorArgument) {
             if ($constructorArgument->isVariadic()) {
+                $argument = $this->variadicPattern;
                 $variadicArguments = $configuredArguments[$constructorArgument->getName()] ?? [];
 
-                if (!is_array($variadicArguments) || !count($variadicArguments)) {
-                    // Variadic argument is always the last one
-                    break;
+                foreach ($variadicArguments as $variadicArgument) {
+                    $argument['_vdic_'][] = $this->getConfiguredArgument($variadicArgument, $constructorArgument);
                 }
 
-                foreach ($variadicArguments as $variadicArgumentKey => $variadicArgument) {
-                    $variadicArguments[$variadicArgumentKey] = $this->getConfiguredArgument(
-                        $variadicArgument,
-                        $constructorArgument
-                    );
-                }
-
-                array_push($arguments, ...array_values($variadicArguments));
+                $arguments[$constructorArgument->getName()] = $argument;
 
                 // Variadic argument is always the last one
                 break;

--- a/setup/src/Magento/Setup/Module/Di/Compiler/ConstructorArgument.php
+++ b/setup/src/Magento/Setup/Module/Di/Compiler/ConstructorArgument.php
@@ -30,6 +30,11 @@ class ConstructorArgument
     private $defaultValue;
 
     /**
+     * @var bool
+     */
+    private $isVariadic;
+
+    /**
      * @param array $configuration
      */
     public function __construct(array $configuration)
@@ -38,6 +43,7 @@ class ConstructorArgument
         $this->type = $configuration[1];
         $this->isRequired = $configuration[2];
         $this->defaultValue = $configuration[3];
+        $this->isVariadic = $configuration[4];
     }
 
     /**
@@ -78,5 +84,15 @@ class ConstructorArgument
     public function getDefaultValue()
     {
         return $this->defaultValue;
+    }
+
+    /**
+     * Returns argument is variadic
+     *
+     * @return bool
+     */
+    public function isVariadic(): bool
+    {
+        return $this->isVariadic;
     }
 }

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/Compiler/ArgumentsResolverTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/Compiler/ArgumentsResolverTest.php
@@ -36,11 +36,11 @@ class ArgumentsResolverTest extends TestCase
         $expectedResultDefault = $this->getResolvedSimpleConfigExpectation();
 
         $constructor = [
-            new ConstructorArgument(['type_dependency', 'Type\Dependency', true, null]),
-            new ConstructorArgument(['type_dependency_shared', 'Type\Dependency\Shared', true, null]),
-            new ConstructorArgument(['value', null, false, 'value']),
-            new ConstructorArgument(['value_array', null, false, ['default_value1', 'default_value2']]),
-            new ConstructorArgument(['value_null', null, false, null]),
+            new ConstructorArgument(['type_dependency', 'Type\Dependency', true, null, false]),
+            new ConstructorArgument(['type_dependency_shared', 'Type\Dependency\Shared', true, null, false]),
+            new ConstructorArgument(['value', null, false, 'value', false]),
+            new ConstructorArgument(['value_array', null, false, ['default_value1', 'default_value2', false]]),
+            new ConstructorArgument(['value_null', null, false, null, false]),
         ];
         $this->diContainerConfig->expects($this->any())
             ->method('isShared')
@@ -68,13 +68,13 @@ class ArgumentsResolverTest extends TestCase
         $expectedResultConfigured = $this->getResolvedConfigurableConfigExpectation();
 
         $constructor = [
-            new ConstructorArgument(['type_dependency_configured', 'Type\Dependency', true, null]),
-            new ConstructorArgument(['type_dependency_shared_configured', 'Type\Dependency\Shared', true, null]),
-            new ConstructorArgument(['global_argument', null, false, null]),
-            new ConstructorArgument(['global_argument_def', null, false, []]),
-            new ConstructorArgument(['value_configured', null, false, 'value']),
-            new ConstructorArgument(['value_array_configured', null, false, []]),
-            new ConstructorArgument(['value_null', null, false, null]),
+            new ConstructorArgument(['type_dependency_configured', 'Type\Dependency', true, null, false]),
+            new ConstructorArgument(['type_dependency_shared_configured', 'Type\Dependency\Shared', true, null, false]),
+            new ConstructorArgument(['global_argument', null, false, null, false]),
+            new ConstructorArgument(['global_argument_def', null, false, [], false]),
+            new ConstructorArgument(['value_configured', null, false, 'value', false]),
+            new ConstructorArgument(['value_array_configured', null, false, [], false]),
+            new ConstructorArgument(['value_null', null, false, null, false]),
         ];
 
         $this->diContainerConfig->expects($this->any())

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/Compiler/ConstructorArgumentTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/Compiler/ConstructorArgumentTest.php
@@ -14,11 +14,12 @@ class ConstructorArgumentTest extends TestCase
 {
     public function testInterface()
     {
-        $argument = ['configuration', 'array', true, null];
+        $argument = ['configuration', 'array', true, null, false];
         $model = new ConstructorArgument($argument);
         $this->assertEquals($argument[0], $model->getName());
         $this->assertEquals($argument[1], $model->getType());
         $this->assertTrue($model->isRequired());
         $this->assertNull($model->getDefaultValue());
+        $this->assertFalse($model->isVariadic());
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Related with https://github.com/magento/magento2/pull/24556.

That PR allowed to inject scalar values as variadic parameters, but **does not work for object injections**. Object definitions don't get instantiated, and target class constructor receives an array of strings instead (with '_instance' key, that should have been transformed into real objects).

```xml
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
  <!-- Declare di arguments injection -->
    <type name="Interactiv4\EmailAttachments\Mail\AttachmentsProcessor">
        <arguments>
            <!-- This argument is a typed variadic one -->
            <argument name="attachmentProviders" xsi:type="array">
                <!-- This argument value is an object implementing variadic argument type -->
                <item name="invoice" xsi:type="object">Interactiv4\SalesEmailAttachments\Mail\AttachmentProvider\InvoiceAttachmentProvider</item>
            </argument>
        </arguments>
    </type>
</config>
```

With proposed changes, variadic arguments are interpreted when needed to be transformed into real objects. Scalar/other variadic arguments will continue working as previously.

Second commit also fixes objects are not being injected into target class constructor when all this conditions are satisfied:
- Target class constructor has a single, variadic, constructor argument.
- A factory is used to inject variadic arguments dynamically.
- Running in compiled mode.

### Related Pull Requests
https://github.com/magento/magento2/pull/24556

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. [x] resolves magento/magento2#30931: Typed variadic arguments fail to be injected

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a class with a typed variadic argument in it:
```php
class Test
{
    public function __construct(SomeInterface ...$interfaceInstances){}
}
```
2. Inject via di.xml instances of given interface, similar as shown in summary.
3. Prior to this proposed change it fails complaining of type error on object construct.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)