### PR TITLE
REFACTOR: Remove ugly `false !=` constructs

### DIFF
--- a/lib/internal/Magento/Framework/View/Element/Html/Link.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Link.php
@@ -136,7 +136,7 @@ class Link extends \Magento\Framework\View\Element\Template
      */
     protected function _toHtml()
     {
-        if (false != $this->getTemplate()) {
+        if ($this->getTemplate()) {
             return parent::_toHtml();
         }
 

--- a/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
@@ -127,7 +127,7 @@ class Current extends Template
      */
     protected function _toHtml()
     {
-        if (false != $this->getTemplate()) {
+        if ($this->getTemplate()) {
             return parent::_toHtml();
         }
 

--- a/lib/internal/Magento/Framework/View/Element/Html/Links.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Links.php
@@ -70,7 +70,7 @@ class Links extends \Magento\Framework\View\Element\Template
      */
     protected function _toHtml()
     {
-        if (false != $this->getTemplate()) {
+        if ($this->getTemplate()) {
             return parent::_toHtml();
         }
 


### PR DESCRIPTION
### Description (*)
This might be surprising but `false != $x` is the same as `$x`.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31372: REFACTOR: Remove ugly `false !=` constructs