### PR TITLE
Added unique key on eav_attribute_label table

### DIFF
--- a/app/code/Magento/Eav/etc/db_schema.xml
+++ b/app/code/Magento/Eav/etc/db_schema.xml
@@ -486,6 +486,10 @@
                     referenceColumn="attribute_id" onDelete="CASCADE"/>
         <constraint xsi:type="foreign" referenceId="EAV_ATTRIBUTE_LABEL_STORE_ID_STORE_STORE_ID" table="eav_attribute_label"
                     column="store_id" referenceTable="store" referenceColumn="store_id" onDelete="CASCADE"/>
+        <constraint xsi:type="unique" referenceId="EAV_ATTRIBUTE_LABEL_ATTRIBUTE_ID_STORE_ID_UNIQUE">
+            <column name="store_id"/>
+            <column name="attribute_id"/>
+        </constraint>
         <index referenceId="EAV_ATTRIBUTE_LABEL_STORE_ID" indexType="btree">
             <column name="store_id"/>
         </index>

--- a/app/code/Magento/Eav/etc/db_schema_whitelist.json
+++ b/app/code/Magento/Eav/etc/db_schema_whitelist.json
@@ -307,7 +307,8 @@
         "constraint": {
             "PRIMARY": true,
             "EAV_ATTRIBUTE_LABEL_ATTRIBUTE_ID_EAV_ATTRIBUTE_ATTRIBUTE_ID": true,
-            "EAV_ATTRIBUTE_LABEL_STORE_ID_STORE_STORE_ID": true
+            "EAV_ATTRIBUTE_LABEL_STORE_ID_STORE_STORE_ID": true,
+            "EAV_ATTRIBUTE_LABEL_ATTRIBUTE_ID_STORE_ID_UNIQUE": true
         }
     },
     "eav_form_type": {


### PR DESCRIPTION
**Description (*)**
The table eav_attribute_label should contain a unique key constraint on the (store_id, attribute_id) pair.
This PR add it.

**Contribution checklist (*)**
 Pull request has a meaningful description of its purpose
 All commits are accompanied by meaningful commit messages
 All new or changed code is covered with unit/integration tests (if applicable)
 All automated tests passed successfully (all builds are green)