### PR TITLE
Fix webapi returns variables in JSON using snake case and I need came…

### DIFF
--- a/lib/internal/Magento/Framework/Reflection/DataObjectProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/DataObjectProcessor.php
@@ -47,12 +47,18 @@ class DataObjectProcessor
     private $processors;
 
     /**
+     * @var array
+     */
+    private $objectKeyMap;
+
+    /**
      * @param MethodsMap $methodsMapProcessor
      * @param TypeCaster $typeCaster
      * @param FieldNamer $fieldNamer
      * @param CustomAttributesProcessor $customAttributesProcessor
      * @param ExtensionAttributesProcessor $extensionAttributesProcessor
      * @param array $processors
+     * @param array $objectKeyMap
      */
     public function __construct(
         MethodsMap $methodsMapProcessor,
@@ -60,7 +66,8 @@ class DataObjectProcessor
         FieldNamer $fieldNamer,
         CustomAttributesProcessor $customAttributesProcessor,
         ExtensionAttributesProcessor $extensionAttributesProcessor,
-        array $processors = []
+        array $processors = [],
+        array $objectKeyMap = []
     ) {
         $this->methodsMapProcessor = $methodsMapProcessor;
         $this->typeCaster = $typeCaster;
@@ -68,6 +75,7 @@ class DataObjectProcessor
         $this->extensionAttributesProcessor = $extensionAttributesProcessor;
         $this->customAttributesProcessor = $customAttributesProcessor;
         $this->processors = $processors;
+        $this->objectKeyMap = $objectKeyMap;
     }
 
     /**
@@ -128,7 +136,7 @@ class DataObjectProcessor
                 }
             }
 
-            $outputData[$key] = $value;
+            $outputData[$this->mapObjectKey($key, ltrim($dataObjectType, '\\'))] = $value;
         }
 
         $outputData = $this->changeOutputArray($dataObject, $outputData);
@@ -152,5 +160,21 @@ class DataObjectProcessor
         }
 
         return $outputData;
+    }
+
+    /**
+     * @param string $key
+     * @param string $dataObjectType
+     * @return string
+     */
+    protected function mapObjectKey(string $key, string $dataObjectType): string
+    {
+        if (
+            array_key_exists($dataObjectType, $this->objectKeyMap) &&
+            array_key_exists($key, $this->objectKeyMap[$dataObjectType])
+        ) {
+            $key = $this->objectKeyMap[$dataObjectType][$key];
+        }
+        return $key;
     }
 }

--- a/lib/internal/Magento/Framework/Reflection/DataObjectProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/DataObjectProcessor.php
@@ -167,7 +167,7 @@ class DataObjectProcessor
      * @param string $dataObjectType
      * @return string
      */
-    protected function mapObjectKey(string $key, string $dataObjectType): string
+    private function mapObjectKey(string $key, string $dataObjectType): string
     {
         if (
             array_key_exists($dataObjectType, $this->objectKeyMap) &&

--- a/lib/internal/Magento/Framework/Reflection/DataObjectProcessor.php
+++ b/lib/internal/Magento/Framework/Reflection/DataObjectProcessor.php
@@ -136,7 +136,7 @@ class DataObjectProcessor
                 }
             }
 
-            $outputData[$this->mapObjectKey($key, ltrim($dataObjectType, '\\'))] = $value;
+            $outputData[$this->getKeyByObjectType($key, $dataObjectType)] = $value;
         }
 
         $outputData = $this->changeOutputArray($dataObject, $outputData);
@@ -167,8 +167,9 @@ class DataObjectProcessor
      * @param string $dataObjectType
      * @return string
      */
-    protected function mapObjectKey(string $key, string $dataObjectType): string
+    protected function getKeyByObjectType(string $key, string $dataObjectType): string
     {
+        $dataObjectType = ltrim($dataObjectType, '\\');
         if (
             array_key_exists($dataObjectType, $this->objectKeyMap) &&
             array_key_exists($key, $this->objectKeyMap[$dataObjectType])


### PR DESCRIPTION
### Description (*)
Added objectKeyMap which accepts parameters from di.xml to modify data object keys
We can now modify the keys of any accessor on any class used in the rendering of the REST API, using the following (or similar) snippet in the `di.xml` of the `webapi_rest` directory. 
````
<type name="Magento\Framework\Reflection\DataObjectProcessor">
        <arguments>
            <argument name="objectKeyMap" xsi:type="array">
                <item name="Magento\Cms\Api\Data\PageInterface" xsi:type="array"> <!-- Change the accessors keys of this class -->
                    <item name="page_layout" xsi:type="string">PageLayout</item> <!-- page_layout should be shown as PageLayout in the ouput -->
                </item>
            </argument>
        </arguments>
    </type>
````

### Fixed Issues (if relevant)

1. Fixes magento/magento2#24681 : webapi returns variables in JSON using snake case and I need camelCase

### Manual testing scenarios (*)
1. Add a `di.xml` inside `webapi_rest` directory of any module and inject object key names to it, similar to the following
````
<type name="Magento\Framework\Reflection\DataObjectProcessor">
        <arguments>
            <argument name="objectKeyMap" xsi:type="array">
                <item name="Magento\Cms\Api\Data\PageInterface" xsi:type="array">
                    <item name="page_layout" xsi:type="string">PageLayout</item>
                </item>
            </argument>
        </arguments>
    </type>
````
2. Call the REST API and observe the new keys reflecting.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
