### PR TITLE
Fix invalid country json on registration form

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
@@ -335,9 +335,9 @@ script;
                 "regionInputId": "#region",
                 "postcodeId": "#zip",
                 "form": "#form-validate",
-                "regionJson": {$regionJson},
-                "defaultRegion": "{$regionId}",
-                "countriesWithOptionalZip": {$countriesWithOptionalZip}
+                "regionJson": <?= $regionJson ?>,
+                "defaultRegion": "<?= $regionId ?>",
+                "countriesWithOptionalZip": <?= $countriesWithOptionalZip ?>
             }
         }
     }


### PR DESCRIPTION
PHP variables weren't being evaluated properly inside the javascript block

### Description (*)
The PHP variables that were being created were going unused and throwing an error for `apply.js getNodeData()`

### Fixed Issues (if relevant)

1. fixes magento/magento2#30099

### Manual testing scenarios (*)
1. Set `show_address_fields` to true
2. Visit /customer/account/create/
3. View js error console
4. Look for the "getNodeData expecting }" error

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31004: Fix invalid country json on registration form