### PR TITLE
$product is Product model or DataObject

### DIFF
--- a/app/code/Magento/Catalog/Helper/Image.php
+++ b/app/code/Magento/Catalog/Helper/Image.php
@@ -84,7 +84,7 @@ class Image extends AbstractHelper implements ArgumentInterface
     /**
      * Current Product
      *
-     * @var \Magento\Catalog\Model\Product
+     * @var \Magento\Catalog\Model\Product|\Magento\Framework\DataObject
      */
     protected $_product;
 
@@ -189,7 +189,7 @@ class Image extends AbstractHelper implements ArgumentInterface
     /**
      * Initialize Helper to work with Image
      *
-     * @param \Magento\Catalog\Model\Product $product
+     * @param \Magento\Catalog\Model\Product|\Magento\Framework\DataObject $product
      * @param string $imageId
      * @param array $attributes
      * @return $this
@@ -738,7 +738,7 @@ class Image extends AbstractHelper implements ArgumentInterface
     /**
      * Set current Product
      *
-     * @param \Magento\Catalog\Model\Product $product
+     * @param \Magento\Catalog\Model\Product|\Magento\Framework\DataObject $product
      * @return $this
      */
     protected function setProduct($product)
@@ -750,7 +750,7 @@ class Image extends AbstractHelper implements ArgumentInterface
     /**
      * Get current Product
      *
-     * @return \Magento\Catalog\Model\Product
+     * @return \Magento\Catalog\Model\Product|\Magento\Framework\DataObject
      */
     protected function getProduct()
     {


### PR DESCRIPTION


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Updates the phpdoc to better reflect the potential object type.

\Magento\Catalog\Ui\Component\Listing\Columns\Thumbnail::prepareDataSource() is an example of where the first argument passed to \Magento\Catalog\Helper\Image::init() is not actually an instance of \Magento\Catalog\Model\Product, but rather, just an instance of \Magento\Framework\DataObject.

### Fixed Issues (if relevant)

N/A

### Manual testing scenarios (*)

This is only an update of the PHP doc in (what I believe) is not a class where the PHP Doc is parsed out by any tools. No testing done.

### Questions or comments

In my current project, I had built a `beforeInit()` plugin to `\Magento\Catalog\Helper\Image::init()`. The signature of my `beforeInit()` plugin specified that the second argument to the plugin must be an object of `\Magento\Catalog\Model\Product`. This then broke the product grid page of the admin because [\Magento\Catalog\Ui\Component\Listing\Columns\Thumbnail::prepareDataSource()](https://github.com/magento/magento2/blob/f55f4117d2a87e5a29efd58fbb14fb4c4cd60bee/app/code/Magento/Catalog/Ui/Component/Listing/Columns/Thumbnail.php#L55) does not pass a product model, but rather simply an instance of `\Magento\Framework\DataObject`.

To provide to developers better context into the possible object types passed to this non-type-hinted method, I think an updated phpdoc is appropriate.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31037: $product is Product model or DataObject