### PR TITLE
Validator Image: remove ico validation

### DIFF
--- a/app/code/Magento/MediaStorage/Model/File/Validator/Image.php
+++ b/app/code/Magento/MediaStorage/Model/File/Validator/Image.php
@@ -25,7 +25,6 @@ class Image extends \Zend_Validate_Abstract
         'jpg'  => 'image/jpeg',
         'gif'  => 'image/gif',
         'bmp'  => 'image/bmp',
-        'ico'  => 'image/vnd.microsoft.icon',
     ];
 
     /**


### PR DESCRIPTION
Validator Image: remove ico validation because imagecreatefromstring does not support ico file

Source: https://www.php.net/manual/en/function.imagecreatefromstring.php

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
In Design configuration it's not possible to upload an ico file


### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Go to admin panel
2. Go to Content > Design  > Configuration
3. Try to upload an ico file in HTML Head > Favicon icon

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31035: Validator Image: remove ico validation