### PR TITLE
ISSUE-30265 - Fix product add / remove in Safari when creating an order in admin

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/configure.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/configure.phtml
@@ -10,11 +10,6 @@ $blockId = $block->getId();
 <div id="product_composite_configure"
      class="product-configure-popup product-configure-popup-<?= $block->escapeHtmlAttr($blockId) ?>">
     <iframe name="product_composite_configure_iframe" id="product_composite_configure_iframe"></iframe>
-    <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
-        'onload',
-        "window.productConfigure && productConfigure.onLoadIFrame()",
-        'iframe[name=\'product_composite_configure_iframe\']:last-of-type'
-    ) ?>
 
     <form action="" method="post" id="product_composite_configure_form" enctype="multipart/form-data"
           target="product_composite_configure_iframe" class="product_composite_configure_form">
@@ -85,3 +80,8 @@ script;
     ?>
     <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false); ?>
 </div>
+<?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
+    'onload',
+    "window.productConfigure && productConfigure.onLoadIFrame()",
+    'iframe[name=\'product_composite_configure_iframe\']:last-of-type'
+) ?>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When creating an order in admin in Safari, adding a product to the order results in an endless load spinner. The page has to be refreshed (and then reflects the added product). Same when removing a product. This PR fixes this behavior in Safari.

Product management works by submitting a form to an iframe. An onload listener is attached to the iframe, and this is what removes the loading spinner and updates the order contents to reflect added or removed products. Commit 499d43d3b52 changed the iframe selector in the js to use :last-of-type. This is the underlying problem. Safari fails to find the iframe and attach the onload listener. Removing :last-of-type from the selector, or even wrapping the js in setTimeout with a 1 ms delay fixes the problem.

It looks like this is a timing / sequence issue specific to Safari with regard to DOM render and the use of :last-of-type. I theorize that, because last-of-type examines siblings of the same parent, a query with last-of-type will not properly match elements until the DOM for the parent is complete. Because the js is right after the iframe (within the parent div), the parent DOM is not complete when the js runs.

To solve this, I simply moved the javascript to the bottom of the template, outside the div that wraps the iframe. Safari now locates the iframe on page load and attaches the onload listener as expected.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#30265

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Using Safari:
1. Go admin - Sales - Create New Order
2. Select any customer from grid
3. Click Add Products
4. Select any Product, enter quantity
5. Click add "selected products to order" button 
6. Confirm that the loading spinner only appears for a moment before disappearing, and the product is then reflected in the order.
7. Remove the product and confirm the same result.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
