### PR TITLE
Fix Wrong Date Format in admin ui grid pt_BR

### DIFF
--- a/lib/web/mage/utils/misc.js
+++ b/lib/web/mage/utils/misc.js
@@ -93,8 +93,12 @@ define([
             var result = mageFormat;
 
             _.each(map, function (moment, mage) {
-                result = result.replace(mage, moment);
+                result = result.replace(
+                    new RegExp(`${mage}(?=([^']*'[^']*')*[^']*$)`),
+                    moment
+                );
             });
+            result = result.replace(/'(.*?)'/g, '[$1]');
 
             return result;
         },


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fix #31020.
Quoted values must not be replaced.
Quotation marks must be replaced with square brackets.

Locale pt_BR date formate is: d 'de' MMM 'de' y HH:mm:ss
The current formatting returns: D 'dd' MMM 'de' YYYY HH:mm:ss
Correct Moment.js format is: D [de] MMM [de] YYYY HH:mm:ss
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#31020

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
