### PR TITLE
MC-37807: Link to a file of a Product with Customizable Option(File) is not available throughout a multishipping checkout process

### DIFF
--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/item/default.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/item/default.phtml
@@ -13,7 +13,7 @@
             <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
             <dt><?= $block->escapeHtml($_option['label']) ?></dt>
             <dd<?= (isset($_formatedOptionValue['full_view']) ? ' class="tooltip wrapper"' : '') ?>>
-                <?= $block->escapeHtml($_formatedOptionValue['value'], ['span']) ?>
+                <?= $block->escapeHtml($_formatedOptionValue['value'], ['span', 'a']) ?>
                 <?php if (isset($_formatedOptionValue['full_view'])) : ?>
                     <dl class="item options tooltip content">
                         <dt><?= $block->escapeHtml($_option['label']) ?></dt>

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/item/default.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/item/default.phtml
@@ -6,18 +6,23 @@
 
 // phpcs:disable Magento2.Files.LineLength
 ?>
-<strong class="product name product-item-name"><a href="<?= $block->escapeUrl($block->getProductUrl()) ?>"><?= $block->escapeHtml($block->getProductName()) ?></a></strong>
+<?php
+/** @var \Magento\Checkout\Block\Cart\Item\Renderer\ $block */
+/** @var \Magento\Framework\Escaper $escaper */
+?>
+
+<strong class="product name product-item-name"><a href="<?= $escaper->escapeUrl($block->getProductUrl()) ?>"><?= $escaper->escapeHtml($block->getProductName()) ?></a></strong>
 <?php if ($_options = $block->getOptionList()) : ?>
     <dl class="item-options">
         <?php foreach ($_options as $_option) : ?>
             <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
-            <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+            <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
             <dd<?= (isset($_formatedOptionValue['full_view']) ? ' class="tooltip wrapper"' : '') ?>>
-                <?= $block->escapeHtml($_formatedOptionValue['value'], ['span', 'a']) ?>
+                <?= $escaper->escapeHtml($_formatedOptionValue['value'], ['span', 'a']) ?>
                 <?php if (isset($_formatedOptionValue['full_view'])) : ?>
                     <dl class="item options tooltip content">
-                        <dt><?= $block->escapeHtml($_option['label']) ?></dt>
-                        <dd><?= $block->escapeHtml($_formatedOptionValue['full_view'], ['span']) ?></dd>
+                        <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
+                        <dd><?= $escaper->escapeHtml($_formatedOptionValue['full_view'], ['span']) ?></dd>
                     </dl>
                 <?php endif; ?>
             </dd>

--- a/dev/tests/integration/testsuite/Magento/Multishipping/Block/Checkout/OverviewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Multishipping/Block/Checkout/OverviewTest.php
@@ -6,7 +6,7 @@
 
 namespace Magento\Multishipping\Block\Checkout;
 
-use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ProductRepository;
 use Magento\Checkout\Block\Cart\Item\Renderer;
 use Magento\Framework\App\Area;
 use Magento\Framework\ObjectManagerInterface;
@@ -26,12 +26,12 @@ class OverviewTest extends TestCase
     /**
      * @var Overview
      */
-    protected $block;
+    private $block;
 
     /**
      * @var ObjectManagerInterface
      */
-    protected $objectManager;
+    private $objectManager;
 
     /**
      * @var Quote
@@ -39,7 +39,7 @@ class OverviewTest extends TestCase
     private $quote;
 
     /**
-     * @var Product
+     * @var ProductRepository
      */
     private $product;
 
@@ -48,6 +48,9 @@ class OverviewTest extends TestCase
      */
     private $item;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp(): void
     {
         Bootstrap::getInstance()->loadArea(Area::AREA_FRONTEND);
@@ -72,9 +75,9 @@ class OverviewTest extends TestCase
             Renderer::class,
             ['template' => 'cart/item/default.phtml']
         );
-        $this->quote = $this->objectManager->get(Quote::class);
-        $this->product = $this->objectManager->get(Product::class);
-        $this->item = $this->objectManager->get(Item::class);
+        $this->quote = $this->objectManager->create(Quote::class);
+        $this->product = $this->objectManager->create(ProductRepository::class);
+        $this->item = $this->objectManager->create(Item::class);
     }
 
     /**
@@ -82,7 +85,7 @@ class OverviewTest extends TestCase
      */
     public function testGetRowItemHtml()
     {
-        $product = $this->product->load('1');
+        $product = $this->product->get('simple');
         $item = $this->item->setProduct($product);
         $item->setQuote($this->quote);
         // assure that default renderer was obtained

--- a/dev/tests/integration/testsuite/Magento/Multishipping/Block/Checkout/OverviewTest.php
+++ b/dev/tests/integration/testsuite/Magento/Multishipping/Block/Checkout/OverviewTest.php
@@ -6,28 +6,55 @@
 
 namespace Magento\Multishipping\Block\Checkout;
 
+use Magento\Catalog\Model\Product;
+use Magento\Checkout\Block\Cart\Item\Renderer;
+use Magento\Framework\App\Area;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\View\Element\RendererList;
+use Magento\Framework\View\LayoutInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Item;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\Helper\Xpath;
+use PHPUnit\Framework\TestCase;
+
 /**
- * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+ * Verify default items template
  */
-class OverviewTest extends \PHPUnit\Framework\TestCase
+class OverviewTest extends TestCase
 {
     /**
-     * @var \Magento\Multishipping\Block\Checkout\Overview
+     * @var Overview
      */
-    protected $_block;
+    protected $block;
 
     /**
-     * @var \Magento\Framework\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
-    protected $_objectManager;
+    protected $objectManager;
+
+    /**
+     * @var Quote
+     */
+    private $quote;
+
+    /**
+     * @var Product
+     */
+    private $product;
+
+    /**
+     * @var Item
+     */
+    private $item;
 
     protected function setUp(): void
     {
-        \Magento\TestFramework\Helper\Bootstrap::getInstance()->loadArea(\Magento\Framework\App\Area::AREA_FRONTEND);
-        $this->_objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $this->_block = $this->_objectManager->get(\Magento\Framework\View\LayoutInterface::class)
+        Bootstrap::getInstance()->loadArea(Area::AREA_FRONTEND);
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->block = $this->objectManager->get(LayoutInterface::class)
             ->createBlock(
-                \Magento\Multishipping\Block\Checkout\Overview::class,
+                Overview::class,
                 'checkout_overview',
                 [
                     'data' => [
@@ -37,33 +64,49 @@ class OverviewTest extends \PHPUnit\Framework\TestCase
                 ]
             );
 
-        $this->_block->addChild('renderer.list', \Magento\Framework\View\Element\RendererList::class);
-        $this->_block->getChildBlock(
+        $this->block->addChild('renderer.list', RendererList::class);
+        $this->block->getChildBlock(
             'renderer.list'
         )->addChild(
             'default',
-            \Magento\Checkout\Block\Cart\Item\Renderer::class,
+            Renderer::class,
             ['template' => 'cart/item/default.phtml']
         );
+        $this->quote = $this->objectManager->get(Quote::class);
+        $this->product = $this->objectManager->get(Product::class);
+        $this->item = $this->objectManager->get(Item::class);
     }
 
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     */
     public function testGetRowItemHtml()
     {
-        /** @var $item \Magento\Quote\Model\Quote\Item */
-        $item = $this->_objectManager->create(\Magento\Quote\Model\Quote\Item::class);
-        /** @var $product \Magento\Catalog\Model\Product */
-        $product = $this->_objectManager->create(\Magento\Catalog\Model\Product::class);
-        $product->load(1);
-        $item->setProduct($product);
-        /** @var $quote \Magento\Quote\Model\Quote */
-        $quote = $this->_objectManager->create(\Magento\Quote\Model\Quote::class);
-        $item->setQuote($quote);
+        $product = $this->product->load('1');
+        $item = $this->item->setProduct($product);
+        $item->setQuote($this->quote);
         // assure that default renderer was obtained
         $this->assertEquals(
             1,
-            \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+            Xpath::getElementsCountForXpath(
                 '//*[contains(@class,"product") and contains(@class,"name")]/a',
-                $this->_block->getRowItemHtml($item)
+                $this->block->getRowItemHtml($item)
+            )
+        );
+    }
+
+    /**
+     * @magentoDataFixture Magento/Checkout/_files/customer_quote_with_items_simple_product_options.php
+     */
+    public function testLinkOptionalProductFileItemHtml()
+    {
+        $quote = $this->quote->load('customer_quote_product_custom_options', 'reserved_order_id');
+        $item = current($quote->getAllItems());
+        $this->assertEquals(
+            1,
+            Xpath::getElementsCountForXpath(
+                '//dd/a[contains(text(), "test.jpg")]',
+                $this->block->getRowItemHtml($item)
             )
         );
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Steps to Reproduce:

1. Go to the Storefront as the created Customer
2. Add the created Product to the Shopping Cart (Qty = 2), uploading a valid file
3. Open the mini-cart
4. Click the “View and Edit Cart” link
5. Click the “Check Out with Multiple Addresses” link
6. Select shipping addresses on the “Ship to Multiple Addresses”
7. Click the “Go to Shipping Information” button
8. Select Flat Rate - Fixed Shipping Method for the each address
9. Click the “Continue to Billing Information” button
10. Select “Check / Money order” Payment Method
11. Click the “Go to Review Your Order” button

**Expected results:**
There should be a link, enabling file downloading, throughout entire multishipping checkout process (name of the file)

 **Actual results:**
There is no link enabling file downloading throughout entire multishipping checkout process (name of the file)


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31095: MC-37807: Link to a file of a Product with Customizable Option(File) is not available throughout a multishipping checkout process