### PR TITLE
free-payemnt-method-virtual-product-order-status

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
@@ -7,6 +7,7 @@
 namespace Magento\Sales\Model\ResourceModel\Order\Handler;
 
 use Magento\Sales\Model\Order;
+use Magento\Payment\Model\Method\Free;
 
 /**
  * Class State
@@ -35,13 +36,29 @@ class State
                 && !$order->canCreditmemo()
                 && !$order->canShip()
             ) {
-                $order->setState(Order::STATE_CLOSED)
-                    ->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CLOSED));
+                if ($order->getPayment()->getMethodInstance()->getCode() === Free::PAYMENT_METHOD_FREE_CODE) {
+                    $this->setOrderStateAndStatus($order, Order::STATE_COMPLETE, Order::STATE_COMPLETE);
+                } else {
+                    $this->setOrderStateAndStatus($order, Order::STATE_CLOSED, Order::STATE_CLOSED);
+                }
             } elseif ($currentState === Order::STATE_PROCESSING && !$order->canShip()) {
-                $order->setState(Order::STATE_COMPLETE)
-                    ->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_COMPLETE));
+                $this->setOrderStateAndStatus($order, Order::STATE_COMPLETE, Order::STATE_COMPLETE);
             }
         }
         return $this;
+    }
+
+    /**
+     * Set Order status
+     *
+     * @param Order $order
+     * @param string $state
+     * @param string $status
+     * @return void
+     */
+    private function setOrderStateAndStatus(Order $order, $state, $status)
+    {
+        $order->setState($state)
+            ->setStatus($order->getConfig()->getStateDefaultStatus($status));
     }
 }


### PR DESCRIPTION
**Step To Reproduce**

1 Please Set Zero Subtotal checkout new order status to Processing ( https://imgur.com/a/mrJQyTN )
2.create a virtual Product with Price 0
3.then add to cart that product and place an order with a total of 0
4. then check order status in admin orders grid ( https://imgur.com/a/syfqkkX )

Original Issue: https://github.com/magento/magento2/issues/31046

This PR Resolved the issue of Order status and state to complete when User place an order with 0 amount for the Virtual products.

Earlier When Trying to place order for the Virtual amount with 0 value, Order will be closed automatically.