### PR TITLE
reset count flag is not taken to account when setting qty

### DIFF
--- a/app/code/Magento/Quote/Api/Data/CartItemInterface.php
+++ b/app/code/Magento/Quote/Api/Data/CartItemInterface.php
@@ -30,6 +30,8 @@ interface CartItemInterface extends \Magento\Framework\Api\ExtensibleDataInterfa
     const KEY_QUOTE_ID = 'quote_id';
 
     const KEY_PRODUCT_OPTION = 'product_option';
+    
+    const KEY_RESET_COUNT = 'reset_count';
 
     /**#@-*/
 

--- a/app/code/Magento/Quote/Model/Quote/Item/Processor.php
+++ b/app/code/Magento/Quote/Model/Quote/Item/Processor.php
@@ -94,7 +94,11 @@ class Processor
         if ($request->getResetCount() && !$candidate->getStickWithinParent() && $item->getId() == $request->getId()) {
             $item->setData(CartItemInterface::KEY_QTY, 0);
         }
-        $item->addQty($candidate->getCartQty());
+        if ($request->getData(CartItemInterface::KEY_RESET_COUNT) === true) {
+            $item->setQty($candidate->getCartQty());
+        } else {
+            $item->addQty($candidate->getCartQty());
+        }
 
         if (!$item->getParentItem() || $item->getParentItem()->isChildrenCalculated()) {
             $item->setPrice($candidate->getFinalPrice());


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

### Description (*)
when using the rest api and updating an item in the cart with a new qty the qty in cart is + to qty in the candidate even when the reset count flag is set to true. 


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31139: reset count flag is not taken to account when setting qty