### PR TITLE
L2 create dir if not exist

### DIFF
--- a/lib/internal/Magento/Framework/Cache/Backend/RemoteSynchronizedCache.php
+++ b/lib/internal/Magento/Framework/Cache/Backend/RemoteSynchronizedCache.php
@@ -101,7 +101,7 @@ class RemoteSynchronizedCache extends \Zend_Cache_Backend implements \Zend_Cache
             $this->remote = $this->_options['remote_backend'];
         } else {
             $dirPath = $this->_options['local_backend_options']['cache_dir'] ?? null;
-            if (!is_dir($dirPath)) {
+            if ($dirPath && !is_dir($dirPath)) {
                 \mkdir($dirPath, 0755, true);
             }
             $this->remote = \Zend_Cache::_makeBackend(

--- a/lib/internal/Magento/Framework/Cache/Backend/RemoteSynchronizedCache.php
+++ b/lib/internal/Magento/Framework/Cache/Backend/RemoteSynchronizedCache.php
@@ -100,6 +100,10 @@ class RemoteSynchronizedCache extends \Zend_Cache_Backend implements \Zend_Cache
         } elseif ($this->_options['remote_backend'] instanceof \Zend_Cache_Backend_ExtendedInterface) {
             $this->remote = $this->_options['remote_backend'];
         } else {
+            $dirPath = $this->_options['local_backend_options']['cache_dir'] ?? null;
+            if (!is_dir($dirPath)) {
+                \mkdir($dirPath, 0755, true);
+            }
             $this->remote = \Zend_Cache::_makeBackend(
                 $this->_options['remote_backend'],
                 array_merge($universalOptions, $this->_options['remote_backend_options']),


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When building magento on sepparate container by pulling files from repo and running `setup:upgrade`  or other commands and using L2 cache configuration with non-default dir, magento throws an error that the dir does not exist.
For example if we put local file caches to the same dir as normal: `{root_magento}/var/cache`

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Configure L2 cache to the dir `{root_magento}/var/cache`
2. Make sure the dir does not exist
3. Try to build magento

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31136: L2 create dir if not exist