### PR TITLE
Added 'UnavailableQuantity' test case for updateCartItems mutation

### DIFF
--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/CatalogInventory/UpdateCartItemsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/CatalogInventory/UpdateCartItemsTest.php
@@ -55,6 +55,24 @@ class UpdateCartItemsTest extends GraphQlAbstract
     }
 
     /**
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     */
+    public function testUpdateCartItemSetUnavailableQuantity()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $itemId = $this->getQuoteItemIdByReservedQuoteIdAndSku->execute('test_quote', 'simple_product');
+
+        $quantity = 100;
+        $this->expectExceptionMessage(
+            "Could not update the product with SKU simple_product: The requested qty is not available"
+        );
+        $query = $this->getQuery($maskedQuoteId, $itemId, $quantity);
+        $this->graphQlMutation($query);
+    }
+
+    /**
      * @param string $maskedQuoteId
      * @param int $itemId
      * @param float $quantity


### PR DESCRIPTION
### Description
Could not reproduce reported bug, looks like the mentioned logic (see path below) has been refactored.
`vendor/magento/module-quote-graph-ql/Model/Resolver/UpdateCartItems.php:92`
Because of that added the test to cover 'UnavailableQuantity' case (similar to reported case).

### Fixed Issues
#30220