### PR TITLE
Change isDeferEnabled() to public function

### DIFF
--- a/app/code/Magento/Theme/Controller/Result/JsFooterPlugin.php
+++ b/app/code/Magento/Theme/Controller/Result/JsFooterPlugin.php
@@ -100,7 +100,7 @@ class JsFooterPlugin
      *
      * @return bool
      */
-    private function isDeferEnabled(): bool
+    public function isDeferEnabled(): bool
     {
         return $this->scopeConfig->isSetFlag(
             self::XML_PATH_DEV_MOVE_JS_TO_BOTTOM,


### PR DESCRIPTION
### Description (*)
It would be nice it `\Magento\Theme\Controller\Result\JsFooterPlugin::isDeferEnabled` was a public method, so we can use plugins to modify the outcome. 

A use case for this would be to maybe disable defer JS on specific pages, this could be easily done then with an after plugin on `\Magento\Theme\Controller\Result\JsFooterPlugin::isDeferEnabled`

### Fixed Issues (if relevant)
None 

### Manual testing scenarios (*)
None

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31155: Change isDeferEnabled() to public function