### PR TITLE
31075-added type to CustomizableDateValue for detect from one of three

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Product/CustomizableDateTypeOptionValue.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Product/CustomizableDateTypeOptionValue.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogGraphQl\Model\Resolver\Product;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+/**
+ * Format the option type value.
+ */
+class CustomizableDateTypeOptionValue implements ResolverInterface
+{
+    /**
+     * Resolver option code.
+     */
+    private const OPTION_CODE = 'type';
+
+    /**
+     * Resolver enum type options to up case format.
+     *
+     * @param Field $field
+     * @param ContextInterface $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     *
+     * @return string
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null): string
+    {
+        $dteType = $value[self::OPTION_CODE] ?? '';
+
+        return strtoupper($dteType);
+    }
+}

--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -49,6 +49,12 @@ enum PriceTypeEnum @doc(description: "This enumeration the price type.") {
     DYNAMIC
 }
 
+enum CustomizableDateTypeEnum @doc(description: "This enumeration customizable date type.") {
+    date
+    date_time
+    time
+}
+
 type ProductPrices @doc(description: "ProductPrices is deprecated, replaced by PriceRange. The ProductPrices object contains the regular price of an item, as well as its minimum and maximum prices. Only composite products, which include bundle, configurable, and grouped products, can contain a minimum and maximum price.") {
     minimalPrice: Price @deprecated(reason: "Use PriceRange.minimum_price.") @doc(description: "The lowest possible final price for all the options defined within a composite product. If you are specifying a price range, this would be the from value.")
     maximalPrice: Price @deprecated(reason: "Use PriceRange.maximum_price.") @doc(description: "The highest possible final price for all the options defined within a composite product. If you are specifying a price range, this would be the to value.")
@@ -153,7 +159,7 @@ type CustomizableDateOption implements CustomizableOptionInterface @doc(descript
 type CustomizableDateValue @doc(description: "CustomizableDateValue defines the price and sku of a product whose page contains a customized date picker.") {
     price: Float @doc(description: "The price assigned to this option.")
     price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC.")
-    type: String @doc(description: "date, date_time or time")
+    type: CustomizableDateTypeEnum @doc(description: "date, date_time or time")
     sku: String @doc(description: "The Stock Keeping Unit for this option.")
     uid: ID! @doc(description: "A string that encodes option details.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\CustomizableEnteredOptionValueUid") # A Base64 string that encodes option details.
 }

--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -50,9 +50,9 @@ enum PriceTypeEnum @doc(description: "This enumeration the price type.") {
 }
 
 enum CustomizableDateTypeEnum @doc(description: "This enumeration customizable date type.") {
-    date
-    date_time
-    time
+    DATE
+    DATE_TIME
+    TIME
 }
 
 type ProductPrices @doc(description: "ProductPrices is deprecated, replaced by PriceRange. The ProductPrices object contains the regular price of an item, as well as its minimum and maximum prices. Only composite products, which include bundle, configurable, and grouped products, can contain a minimum and maximum price.") {
@@ -159,7 +159,7 @@ type CustomizableDateOption implements CustomizableOptionInterface @doc(descript
 type CustomizableDateValue @doc(description: "CustomizableDateValue defines the price and sku of a product whose page contains a customized date picker.") {
     price: Float @doc(description: "The price assigned to this option.")
     price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC.")
-    type: CustomizableDateTypeEnum @doc(description: "date, date_time or time")
+    type: CustomizableDateTypeEnum @doc(description: "DATE, DATE_TIME or TIME") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\CustomizableDateTypeOptionValue")
     sku: String @doc(description: "The Stock Keeping Unit for this option.")
     uid: ID! @doc(description: "A string that encodes option details.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\CustomizableEnteredOptionValueUid") # A Base64 string that encodes option details.
 }

--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -153,6 +153,7 @@ type CustomizableDateOption implements CustomizableOptionInterface @doc(descript
 type CustomizableDateValue @doc(description: "CustomizableDateValue defines the price and sku of a product whose page contains a customized date picker.") {
     price: Float @doc(description: "The price assigned to this option.")
     price_type: PriceTypeEnum @doc(description: "FIXED, PERCENT, or DYNAMIC.")
+    type: String @doc(description: "date, date_time or time")
     sku: String @doc(description: "The Stock Keeping Unit for this option.")
     uid: ID! @doc(description: "A string that encodes option details.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\CustomizableEnteredOptionValueUid") # A Base64 string that encodes option details.
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/Options/CustomizableOptionsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/Options/CustomizableOptionsTest.php
@@ -111,19 +111,19 @@ QUERY;
                         [
                             'title' => 'date option',
                             'values' => [
-                                'type' => 'date'
+                                'type' => 'DATE'
                             ]
                         ],
                         [
                             'title' => 'date_time option',
                             'values' => [
-                                'type' => 'date_time'
+                                'type' => 'DATE_TIME'
                             ]
                         ],
                         [
                             'title' => 'time option',
                             'values' => [
-                                'type' => 'time'
+                                'type' => 'TIME'
                             ]
                         ]
                     ]

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/Options/CustomizableOptionsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/Options/CustomizableOptionsTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Catalog\Options\Uid;
+
+use Exception;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\Helper\CompareArraysRecursively;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+/**
+ * Test for customizable product options.
+ */
+class CustomizableOptionsTest extends GraphQlAbstract
+{
+    /**
+     * @var CompareArraysRecursively
+     */
+    private $compareArraysRecursively;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->compareArraysRecursively = $objectManager->create(CompareArraysRecursively::class);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Catalog/_files/product_with_options.php
+     *
+     * @param array $optionDataProvider
+     *
+     * @dataProvider getProductCustomizableOptionsProvider
+     * @throws Exception
+     */
+    public function testQueryCustomizableOptions(array $optionDataProvider): void
+    {
+        $productSku = 'simple';
+        $query = $this->getQuery($productSku);
+        $response = $this->graphQlQuery($query);
+        $responseProduct = reset($response['products']['items']);
+        self::assertNotEmpty($responseProduct['options']);
+
+        foreach ($optionDataProvider as $key => $data) {
+            $this->compareArraysRecursively->execute($data, $responseProduct[$key]);
+        }
+    }
+
+    /**
+     * Get query.
+     *
+     * @param string $sku
+     *
+     * @return string
+     */
+    private function getQuery(string $sku): string
+    {
+        return <<<QUERY
+query {
+  products(filter: { sku: { eq: "$sku" } }) {
+    items {
+      ... on CustomizableProductInterface {
+        options {
+          option_id
+          title
+          ... on CustomizableDateOption {
+               value {
+                  type
+               }
+          }
+        }
+      }
+    }
+  }
+}
+QUERY;
+    }
+
+    /**
+     * Get product customizable options provider.
+     *
+     * @return array
+     */
+    public function getProductCustomizableOptionsProvider(): array
+    {
+        return [
+            'products' => [
+                'items' => [
+                    'options' => [
+                        [
+                            'title' => 'test_option_code_1'
+                        ],
+                        [
+                            'title' => 'area option'
+                        ],
+                        [
+                            'title' => 'file option'
+                        ],
+                        [
+                            'title' => 'radio option'
+                        ],
+                        [
+                            'title' => 'multiple option'
+                        ],
+                        [
+                            'title' => 'date option',
+                            'values' => [
+                                'type' => 'date'
+                            ]
+                        ],
+                        [
+                            'title' => 'date_time option',
+                            'values' => [
+                                'type' => 'date_time'
+                            ]
+                        ],
+                        [
+                            'title' => 'time option',
+                            'values' => [
+                                'type' => 'time'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/Options/CustomizableOptionsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/Options/CustomizableOptionsTest.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-namespace Magento\GraphQl\Catalog\Options\Uid;
+namespace Magento\GraphQl\Catalog\Options;
 
 use Exception;
 use Magento\TestFramework\Helper\Bootstrap;


### PR DESCRIPTION
### Description (*)

Fixed the issue `GraphQL: CustomizableDateOption or CustomizableDateValue should indicate the precise Date option type`.
Was added `type` option to detect one of three CustomizableDateOption types:  **date**, **date_time** or **time**.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#31075

### Manual testing scenarios (*)

1. Add multiple Date customizable options to a product. Use different date types: Date, Date & Time, Time
2. Query the previous product via graphQL and display the customizable options. Use sample query below:
```
{
  products(filter: {sku: {eq: "test-sku"}}) {
    items {
      sku
      __typename
      id
      name
      ... on SimpleProduct {
         options {
          __typename
          option_id
          required
          sort_order
          title
          ... on CustomizableDateOption {
            value {
              uid
              price
              price_type
              __typename
            }
            __typename
          }
        }
      }
    }
  }
}
```
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
