### PR TITLE
Invalid combination of tabs and spaces in phpstan.neon

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon
@@ -1,41 +1,41 @@
 parameters:
-	checkExplicitMixedMissingReturn: true
-	checkPhpDocMissingReturn: true
-	reportUnmatchedIgnoredErrors: false
-	excludes_analyse:
-		- %rootDir%/../../../lib/internal/Magento/Framework/ObjectManager/Test/Unit/*
-		- %rootDir%/../../../*/_files/*
-		- %rootDir%/../../../dev/tests/*/Fixtures/*
-		- %rootDir%/../../../dev/tests/*/tmp/*
-		- %rootDir%/../../../dev/tests/*/_generated/*
-		- %rootDir%/../../../pub/*
-	autoload_directories:
-		- %rootDir%/../../../dev/tests/static/framework/tests/unit/testsuite/Magento
-		- %rootDir%/../../../dev/tests/integration/framework/tests/unit/testsuite/Magento
-		- %rootDir%/../../../dev/tests/api-functional/_files/Magento
-	autoload_files:
-			- %rootDir%/../../../dev/tests/static/framework/autoload.php
-			- %rootDir%/../../../dev/tests/integration/framework/autoload.php
-			- %rootDir%/../../../dev/tests/api-functional/framework/autoload.php
-			- %rootDir%/../../../dev/tests/setup-integration/framework/autoload.php
-			- %rootDir%/../../../dev/tests/static/framework/Magento/PhpStan/autoload.php
-	ignoreErrors:
-	    # Ignore PHPStan\Rules\Classes\UnusedConstructorParametersRule
-		- '#Constructor of class [a-zA-Z0-9\\_]+ has an unused parameter#'
-		# Ignore setCustomErrorHandler function not found in bootstrap files
-		- '#Function setCustomErrorHandler not found#'
-		# Ignore 'return statement is missing' error when 'void' is present in return type list
-		- '#Method (?:.*?) should return (?:.*?)void(?:.*?) but return statement is missing.#'
-		# Ignore constants, defined dynamically.
-		- '#Constant TESTS_WEB_API_ADAPTER not found.#'
-		- '#Constant TESTS_BASE_URL not found.#'
-		- '#Constant TESTS_XDEBUG_ENABLED not found.#'
-		- '#Constant TESTS_XDEBUG_SESSION not found.#'
-		- '#Constant INTEGRATION_TESTS_DIR not found.#'
-		- '#Constant MAGENTO_MODULES_PATH not found.#'
-		- '#Constant TESTS_MODULES_PATH not found.#'
-		- '#Constant TESTS_INSTALLATION_DB_CONFIG_FILE not found.#'
-		- '#Constant T_[A-Z_]+ not found.#'
+    checkExplicitMixedMissingReturn: true
+    checkPhpDocMissingReturn: true
+    reportUnmatchedIgnoredErrors: false
+    excludes_analyse:
+        - %rootDir%/../../../lib/internal/Magento/Framework/ObjectManager/Test/Unit/*
+        - %rootDir%/../../../*/_files/*
+        - %rootDir%/../../../dev/tests/*/Fixtures/*
+        - %rootDir%/../../../dev/tests/*/tmp/*
+        - %rootDir%/../../../dev/tests/*/_generated/*
+        - %rootDir%/../../../pub/*
+    autoload_directories:
+        - %rootDir%/../../../dev/tests/static/framework/tests/unit/testsuite/Magento
+        - %rootDir%/../../../dev/tests/integration/framework/tests/unit/testsuite/Magento
+        - %rootDir%/../../../dev/tests/api-functional/_files/Magento
+    autoload_files:
+            - %rootDir%/../../../dev/tests/static/framework/autoload.php
+            - %rootDir%/../../../dev/tests/integration/framework/autoload.php
+            - %rootDir%/../../../dev/tests/api-functional/framework/autoload.php
+            - %rootDir%/../../../dev/tests/setup-integration/framework/autoload.php
+            - %rootDir%/../../../dev/tests/static/framework/Magento/PhpStan/autoload.php
+    ignoreErrors:
+        # Ignore PHPStan\Rules\Classes\UnusedConstructorParametersRule
+        - '#Constructor of class [a-zA-Z0-9\\_]+ has an unused parameter#'
+        # Ignore setCustomErrorHandler function not found in bootstrap files
+        - '#Function setCustomErrorHandler not found#'
+        # Ignore 'return statement is missing' error when 'void' is present in return type list
+        - '#Method (?:.*?) should return (?:.*?)void(?:.*?) but return statement is missing.#'
+        # Ignore constants, defined dynamically.
+        - '#Constant TESTS_WEB_API_ADAPTER not found.#'
+        - '#Constant TESTS_BASE_URL not found.#'
+        - '#Constant TESTS_XDEBUG_ENABLED not found.#'
+        - '#Constant TESTS_XDEBUG_SESSION not found.#'
+        - '#Constant INTEGRATION_TESTS_DIR not found.#'
+        - '#Constant MAGENTO_MODULES_PATH not found.#'
+        - '#Constant TESTS_MODULES_PATH not found.#'
+        - '#Constant TESTS_INSTALLATION_DB_CONFIG_FILE not found.#'
+        - '#Constant T_[A-Z_]+ not found.#'
 
 
 services:


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

The [phpstan.neon](https://github.com/magento/magento2/blob/2.4.1/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon) file contains both spaces and tabs for different lines. But [one line](https://github.com/magento/magento2/blob/2.4.1/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon#L23) contains both characters. In our case, this line is a comment, and it is ignored during parsing, but this is denied by [nette/neon](https://github.com/nette/neon/blob/v3.2.1/src/Neon/Decoder.php#L229) parser. In addition, for code consistency, it must be brought to a common style.

### Related Pull Requests
<!-- related pull request placeholder -->
https://github.com/magento/magento2/commit/4e045c7c291658e4843aca93077d00791ed8b9ea#diff-b47a177d03a63c60ce971880ec7d61c2ba5bb7126f3ec0357f97059e4db4f859
https://github.com/magento/magento2/commit/19b636e90432066692b3ad9f9a27d2eca4879d45#diff-b47a177d03a63c60ce971880ec7d61c2ba5bb7126f3ec0357f97059e4db4f859

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open [phpstan.neon](https://github.com/magento/magento2/blob/2.4.1/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon) file in PhpStorm with [NEON support](https://plugins.jetbrains.com/plugin/7060-neon-support) plugin
2. It is highlighted with errors
![image](https://user-images.githubusercontent.com/1055999/101156294-70e4a300-3639-11eb-99f1-947be58fddd2.png)



### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31239: Invalid combination of tabs and spaces in phpstan.neon