### PR TITLE
Adjust .editorconfig to correct the automatic formatting of db_schema_whitelist.json files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,7 @@ indent_size = 2
 
 [{composer, auth}.json]
 indent_size = 4
+
+[db_schema_whitelist.json]
+indent_size = 4
+trim_trailing_whitespace = false


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Since the [.editorconfig](https://github.com/magento/magento2/blob/2.4.1/.editorconfig) file was changed to use two spaces for json files, this leads to problems with **db_schema_whitelist.json** files. All schemas are generated by the cli [setup:db-declaration:generate-whitelist](https://github.com/magento/magento2/blob/2.4.1/app/code/Magento/Developer/Console/Command/TablesWhitelistGenerateCommand.php#L55) command and [put json content](https://github.com/magento/magento2/blob/2.4.1/app/code/Magento/Developer/Model/Setup/Declaration/Schema/WhitelistGenerator.php#L158) formatted by the [json_decode](https://github.com/magento/magento2/blob/2.4.1/lib/internal/Magento/Framework/Setup/JsonPersistor.php#L22) function with [JSON_PRETTY_PRINT](https://www.php.net/manual/en/json.constants.php#constant.json-pretty-print) constant. This mechanism displays an indent of 4 spaces and does not add a new line at the bottom of the file. But when we change our file **db_schema.xml** and run [setup:db-declaration:generate-whitelist](https://github.com/magento/magento2/blob/2.4.1/app/code/Magento/Developer/Console/Command/TablesWhitelistGenerateCommand.php#L55) cli command, it updates the contents of the **db_schema_whitelist.json** file, and when we opened it in the IDE, the **.editorconfig** add a new line at the bottom and we can't delete it, because it is always adding at the end on saving the file.

![image](https://user-images.githubusercontent.com/1055999/101159721-e1da8980-363e-11eb-870d-417792b10cb4.png)


### Related Pull Requests
<!-- related pull request placeholder -->

https://github.com/magento/magento2/pull/30062


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open any **db_schema_whitelist.json** file in PhpStorm
2. And run **Reformat Code**
3. Press **Ctrl+S** to save file

![image](https://user-images.githubusercontent.com/1055999/101159935-40a00300-363f-11eb-9313-0579ad90348a.png)
![image](https://user-images.githubusercontent.com/1055999/101160100-81981780-363f-11eb-8d6a-87eed530b382.png)


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31171: Adjust .editorconfig to correct the automatic formatting of db_schema_whitelist.json files