### PR TITLE
Add uid field to the DownloadableProductsSample type

### DIFF
--- a/app/code/Magento/DownloadableGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/DownloadableGraphQl/etc/schema.graphqls
@@ -63,6 +63,7 @@ type DownloadableProductSamples @doc(description: "DownloadableProductSamples de
     sample_url: String @doc(description: "URL to the downloadable sample")
     sample_type: DownloadableFileTypeEnum @deprecated(reason: "`sample_url` serves to get the downloadable sample")
     sample_file: String @deprecated(reason: "`sample_url` serves to get the downloadable sample")
+    uid: ID! @doc(description: "The unique ID for a `DownloadableProductLinks` object.") @resolver(class: "Magento\\DownloadableGraphQl\\Resolver\\Product\\DownloadableLinksValueUid")
 }
 
 type DownloadableOrderItem implements OrderItemInterface {


### PR DESCRIPTION
For the Downloadable Product GraphQL schema file contains the DownloadableProductSamples type. In this type, We have already deprecated id field and we will replace it with uid changes. 

Only changes of UID will automatically gets the latest changes as per unique identifier.

### Resolved issues:
1. [x] resolves magento/magento2#31194: Add uid field to the DownloadableProductsSample type