### PR TITLE
Update `data-price-amount` on reload price

### DIFF
--- a/app/code/Magento/Catalog/view/base/web/js/price-box.js
+++ b/app/code/Magento/Catalog/view/base/web/js/price-box.js
@@ -151,7 +151,7 @@ define([
 
                 $('[data-price-type="' + priceCode + '"]', this.element).html(priceTemplate({
                     data: price
-                }));
+                })).attr('data-price-amount', price.amount);
             }, this);
         },
 


### PR DESCRIPTION
This resolved the issue reported in #31199 and updates the `data-price-amount` correctly on configurable product changes.

### Description (*)
Update the `data-price-amount` in the `reloadPrice` function that is used to render the updated prices on the configurable product page.

### Related Pull Requests
None

### Fixed Issues (if relevant)
1. Fixes magento/magento2#31199

### Manual testing scenarios (*)
1. Go to a configurable product where the price changes when options are changed
2. On page load the data-price-amount on the span's with class price-wrapper are set correctly
3. Change the options so the price(s) change on the page
4. The `data-price-amount` should be updated correctly.

### Questions or comments
None

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
