### PR TITLE
Only addresses that have the flag "save in address book" should be saved on the customer

### DIFF
--- a/app/code/Magento/Sales/Model/Order/OrderCustomerExtractor.php
+++ b/app/code/Magento/Sales/Model/Order/OrderCustomerExtractor.php
@@ -17,6 +17,7 @@ use Magento\Customer\Api\Data\RegionInterfaceFactory as RegionFactory;
 use Magento\Customer\Api\Data\CustomerInterfaceFactory as CustomerFactory;
 use Magento\Quote\Api\Data\AddressInterfaceFactory as QuoteAddressFactory;
 use Magento\Sales\Model\Order\Address as OrderAddress;
+use Magento\Quote\Model\Quote\Address as QuoteAddress;
 
 /**
  * Extract customer data from an order.
@@ -54,9 +55,9 @@ class OrderCustomerExtractor
     private $customerFactory;
 
     /**
-     * @var QuoteAddressFactory
+     * @var QuoteAddressCollectionFactory
      */
-    private $quoteAddressFactory;
+    private $quoteAddressCollectionFactory;
 
     /**
      * @param OrderRepositoryInterface $orderRepository
@@ -74,15 +75,17 @@ class OrderCustomerExtractor
         AddressFactory $addressFactory,
         RegionFactory $regionFactory,
         CustomerFactory $customerFactory,
-        QuoteAddressFactory $quoteAddressFactory
-    ) {
+        QuoteAddressCollectionFactory $quoteAddressCollectionFactory
+
+    )
+    {
         $this->orderRepository = $orderRepository;
         $this->customerRepository = $customerRepository;
         $this->objectCopyService = $objectCopyService;
         $this->addressFactory = $addressFactory;
         $this->regionFactory = $regionFactory;
         $this->customerFactory = $customerFactory;
-        $this->quoteAddressFactory = $quoteAddressFactory;
+        $this->quoteAddressCollectionFactory = $quoteAddressCollectionFactory;
     }
 
     /**
@@ -111,36 +114,46 @@ class OrderCustomerExtractor
         $processedAddressData = [];
         $customerAddresses = [];
         foreach ($order->getAddresses() as $orderAddress) {
-            $addressData = $this->objectCopyService
-                ->copyFieldsetToTarget('order_address', 'to_customer_address', $orderAddress, []);
+            $quoteAddressId = $orderAddress->getQuoteAddressId();
 
-            $index = array_search($addressData, $processedAddressData);
-            if ($index === false) {
-                // create new customer address only if it is unique
-                $customerAddress = $this->addressFactory->create(['data' => $addressData]);
-                $customerAddress->setIsDefaultBilling(false);
-                $customerAddress->setIsDefaultShipping(false);
-                if (is_string($orderAddress->getRegion())) {
-                    /** @var RegionInterface $region */
-                    $region = $this->regionFactory->create();
-                    $region->setRegion($orderAddress->getRegion());
-                    $region->setRegionCode($orderAddress->getRegionCode());
-                    $region->setRegionId($orderAddress->getRegionId());
-                    $customerAddress->setRegion($region);
+            /* @var QuoteAddress $quoteAddress */
+            $quoteAddress = $this->quoteAddressCollectionFactory->create()
+                ->addFieldToSelect(QuoteAddress::SAVE_IN_ADDRESS_BOOK)
+                ->addFieldToFilter("address_id", $quoteAddressId)
+                ->getFirstItem();
+
+            if ($quoteAddress && (int)$quoteAddress->getSaveInAddressBook() === 1) {
+                $addressData = $this->objectCopyService
+                    ->copyFieldsetToTarget('order_address', 'to_customer_address', $orderAddress, []);
+
+                $index = array_search($addressData, $processedAddressData);
+                if ($index === false) {
+                    // create new customer address only if it is unique
+                    $customerAddress = $this->addressFactory->create(['data' => $addressData]);
+                    $customerAddress->setIsDefaultBilling(false);
+                    $customerAddress->setIsDefaultShipping(false);
+                    if (is_string($orderAddress->getRegion())) {
+                        /** @var RegionInterface $region */
+                        $region = $this->regionFactory->create();
+                        $region->setRegion($orderAddress->getRegion());
+                        $region->setRegionCode($orderAddress->getRegionCode());
+                        $region->setRegionId($orderAddress->getRegionId());
+                        $customerAddress->setRegion($region);
+                    }
+
+                    $processedAddressData[] = $addressData;
+                    $customerAddresses[] = $customerAddress;
+                    $index = count($processedAddressData) - 1;
                 }
 
-                $processedAddressData[] = $addressData;
-                $customerAddresses[] = $customerAddress;
-                $index = count($processedAddressData) - 1;
-            }
-
-            $customerAddress = $customerAddresses[$index];
-            // make sure that address type flags from equal addresses are stored in one resulted address
-            if ($orderAddress->getAddressType() == OrderAddress::TYPE_BILLING) {
-                $customerAddress->setIsDefaultBilling(true);
-            }
-            if ($orderAddress->getAddressType() == OrderAddress::TYPE_SHIPPING) {
-                $customerAddress->setIsDefaultShipping(true);
+                $customerAddress = $customerAddresses[$index];
+                // make sure that address type flags from equal addresses are stored in one resulted address
+                if ($orderAddress->getAddressType() == OrderAddress::TYPE_BILLING) {
+                    $customerAddress->setIsDefaultBilling(true);
+                }
+                if ($orderAddress->getAddressType() == OrderAddress::TYPE_SHIPPING) {
+                    $customerAddress->setIsDefaultShipping(true);
+                }
             }
         }
 

--- a/app/code/Magento/Sales/Model/Order/OrderCustomerExtractor.php
+++ b/app/code/Magento/Sales/Model/Order/OrderCustomerExtractor.php
@@ -18,6 +18,8 @@ use Magento\Customer\Api\Data\CustomerInterfaceFactory as CustomerFactory;
 use Magento\Quote\Api\Data\AddressInterfaceFactory as QuoteAddressFactory;
 use Magento\Sales\Model\Order\Address as OrderAddress;
 use Magento\Quote\Model\Quote\Address as QuoteAddress;
+use Magento\Quote\Model\ResourceModel\Quote\Address\CollectionFactory as QuoteAddressCollectionFactory;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Extract customer data from an order.
@@ -55,6 +57,11 @@ class OrderCustomerExtractor
     private $customerFactory;
 
     /**
+     * @var QuoteAddressFactory
+     */
+    private $quoteAddressFactory;
+
+    /**
      * @var QuoteAddressCollectionFactory
      */
     private $quoteAddressCollectionFactory;
@@ -75,18 +82,20 @@ class OrderCustomerExtractor
         AddressFactory $addressFactory,
         RegionFactory $regionFactory,
         CustomerFactory $customerFactory,
-        QuoteAddressCollectionFactory $quoteAddressCollectionFactory
-
-    )
-    {
+        QuoteAddressFactory $quoteAddressFactory,
+        QuoteAddressCollectionFactory $quoteAddressCollectionFactory = null
+    ) {
         $this->orderRepository = $orderRepository;
         $this->customerRepository = $customerRepository;
         $this->objectCopyService = $objectCopyService;
         $this->addressFactory = $addressFactory;
         $this->regionFactory = $regionFactory;
         $this->customerFactory = $customerFactory;
-        $this->quoteAddressCollectionFactory = $quoteAddressCollectionFactory;
+        $this->quoteAddressFactory = $quoteAddressFactory;
+        $this->quoteAddressCollectionFactory = $quoteAddressCollectionFactory ?: ObjectManager::getInstance()
+            ->get(QuoteAddressCollectionFactory::class);
     }
+
 
     /**
      * Extract customer data from order.


### PR DESCRIPTION
### Description (*)

When registering as a new customer on the success page after placing an order, the \Magento\Sales\Model\Order\OrderCustomerExtractor class copies all addresses from the order to the customer data.
This however is incorrect if 1 or more addresses have the save_in_address_book variable set to false in the quote_address table. This PR fixes it.

### Fixed Issues (if relevant)

1. Fixes  https://github.com/magento/magento2/issues/31113

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add product to cart as guest
2. Programatically change the shipping address to not be saved in the address book 
3. Finish the checkout process
4. Create a customer account on the order success page. 
5. Only the addresses that have "save in address book = 1" will be saved to the customer. 