### PR TITLE
Change to uploadMediaFiles to check if image currently exists

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1753,7 +1753,6 @@ class Product extends AbstractEntity
                         $uploadedFile = $this->getAlreadyExistedImage($rowExistingImages, $columnImage, $importDir);
                         if (!$uploadedFile && !isset($uploadedImages[$columnImage])) {
                             $uploadedFile = $this->uploadMediaFiles($columnImage);
-                            $uploadedFile = $uploadedFile ?: $this->getSystemFile($columnImage);
                             if ($uploadedFile) {
                                 $uploadedImages[$columnImage] = $uploadedFile;
                             } else {
@@ -2262,8 +2261,11 @@ class Product extends AbstractEntity
             $res = $this->_getUploader()->move($fileName, $renameFileOff);
             return $res['file'];
         } catch (\Exception $e) {
-            $this->_logger->critical($e);
-            return '';
+            $systemFile = $this->getSystemFile($fileName);
+            if (!$systemFile) {
+                $this->_logger->critical($e);
+            }
+            return $systemFile;
         }
     }
 


### PR DESCRIPTION
### Description (*)
Refactors CatalogImportExport/Model/Import/Product->uploadMediaFiles to check if the file that was _was not_ moved already exists on the filesystem. If the file does exist on the filesystem, no critical log entry is created, during the exception catch, since no error has actually occurred.

### Related Pull Requests

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/30978

### Manual testing scenarios (*)
1. Create Simple product with image
2. Go to Admin -> System -> Export
3. Select "Products" from the "Entity Type" dropdown and click on the Continue button
4. Run php bin/magento cron:run and download the exported file
6. Go to Admin -> System -> Import
7. Select "Products" from the "Entity Type" dropdown
8. Select "Add/Update" from the "Import Behavior" dropdown
9. Click on the "Choose File" button
10. Select the file saved in step 4
11. Click on the "Check Data" button
12. Assert that 'File is valid! To start import process press "Import" button' text appears, and click the "Import" button
13. Assert that no error is shown on the response page
14. Assert that var/log/exception.log does not contain an entry stating that the existing image failed to be found
15. Open the file in step 4
16. Change the filename of the "base_image column", by adding some text before the '.' and the extension
17. Save the file
18. Go to Admin -> System -> Import
19. Select "Products" from the "Entity Type" dropdown
20. Select "Add/Update" from the "Import Behavior" dropdown
21. Click on the "Choose File" button
22. Select the file saved in step 4
23. Click on the "Check Data" button
24. Assert that 'File is valid! To start import process press "Import" button' text appears, and click the "Import" button
25. Assert that the error "Imported resource (image) could not be downloaded from external resource due to timeout or access permissions in row(s): 1" appears on the result page
26. Assert that var/log/exception.log contains an entry stating that the non-existing image failed to be found

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
