### PR TITLE
Do not stale "Progress: ready for dev" issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,6 +15,7 @@ exemptLabels:
   - "Priority: P0"
   - "Priority: P1"
   - "Priority: P2"
+  - "Progress: ready for dev"
   - "Progress: dev in progress"
   - "Progress: PR in progress"
   - "Progress: done"


### PR DESCRIPTION
### Description

`Progress: ready for dev` issues were already confirmed, so we're not waiting for additional input from anyone, but rather from development capacity. Closing a confirmed issue should only happen if 1) it's not reproducible anymore (wontfix) or 2) by a decision of product management. Time alone isn't an indication of neither of those scenarios.

### Manual testing scenarios

1. Create a bug report;
2. Magento team confirms it by assigning the `Progress: ready for dev` label;
3. The issue won't be closed by the stale bot.