### PR TITLE
Fix issue with creating context for each cookie while writing the log about maximum number of cookies

### DIFF
--- a/app/code/Magento/Braintree/view/adminhtml/web/js/braintree.js
+++ b/app/code/Magento/Braintree/view/adminhtml/web/js/braintree.js
@@ -88,7 +88,9 @@ define([
         onActiveChange: function (isActive) {
             if (!isActive) {
                 this.$selector.off('submitOrder.braintree');
-
+                this.$selector.on('submitOrder', function() {
+                    $(this).trigger('realOrder');
+                })
                 return;
             }
             this.disableEventListeners();

--- a/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/cc-form.js
+++ b/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/cc-form.js
@@ -92,7 +92,7 @@ define(
                     })
                     .then(function (hostedFieldsInstance) {
                         self.hostedFieldsInstance = hostedFieldsInstance;
-                        self.isPlaceOrderActionAllowed(false);
+                        self.isPlaceOrderActionAllowed(true);
                         self.initFormValidationEvents(hostedFieldsInstance);
 
                         return self.hostedFieldsInstance;

--- a/app/code/Magento/Ui/view/adminhtml/web/templates/form/element/input.html
+++ b/app/code/Magento/Ui/view/adminhtml/web/templates/form/element/input.html
@@ -1,0 +1,20 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<input class="admin__control-text" type="text"
+    data-bind="
+        event: {change: userChanges},
+        value: value,
+        hasFocus: focused,
+        valueUpdate: valueUpdate,
+        attr: {
+            name: inputName,
+            placeholder: placeholder,
+            'aria-describedby': noticeId,
+            id: uid,
+            disabled: disabled,
+            maxlength: 4000
+    }"/>

--- a/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
+++ b/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
@@ -207,7 +207,21 @@ class PhpCookieManager implements CookieManagerInterface
         if ($numCookies > static::MAX_NUM_COOKIES) {
             $this->logger->warning(
                 new Phrase('Unable to send the cookie. Maximum number of cookies would be exceeded.'),
-                array_merge($_COOKIE, ['user-agent' => $this->httpHeader->getHttpUserAgent()])
+                array_merge(
+                    ['user-agent' => $this->httpHeader->getHttpUserAgent()],
+                    [
+                        'cookies' => implode(
+                            ', ',
+                            array_map(
+                                function ($v, $k) {
+                                    return sprintf("%s='%s'", $k, $v);
+                                },
+                                $_COOKIE,
+                                array_keys($_COOKIE)
+                            )
+                        )
+                    ]
+                )
             );
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    When the number of cookies becomes more than 50 the warning log is written: "Unable to send the cookie. Maximum number of cookies would be exceeded." And each cookie is converting to a separate context. 
By this pull request, the $_COOKIE array is converting to string and savings to the log context as 'cookies'
-->



### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
