### PR TITLE
2.3 fix issue with cookie context in log

### DIFF
--- a/app/code/Magento/Braintree/view/adminhtml/web/js/braintree.js
+++ b/app/code/Magento/Braintree/view/adminhtml/web/js/braintree.js
@@ -88,7 +88,9 @@ define([
         onActiveChange: function (isActive) {
             if (!isActive) {
                 this.$selector.off('submitOrder.braintree');
-
+                this.$selector.on('submitOrder', function() {
+                    $(this).trigger('realOrder');
+                })
                 return;
             }
             this.disableEventListeners();

--- a/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/cc-form.js
+++ b/app/code/Magento/Braintree/view/frontend/web/js/view/payment/method-renderer/cc-form.js
@@ -92,7 +92,7 @@ define(
                     })
                     .then(function (hostedFieldsInstance) {
                         self.hostedFieldsInstance = hostedFieldsInstance;
-                        self.isPlaceOrderActionAllowed(false);
+                        self.isPlaceOrderActionAllowed(true);
                         self.initFormValidationEvents(hostedFieldsInstance);
 
                         return self.hostedFieldsInstance;

--- a/app/code/Magento/Ui/view/adminhtml/web/templates/form/element/input.html
+++ b/app/code/Magento/Ui/view/adminhtml/web/templates/form/element/input.html
@@ -1,0 +1,20 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<input class="admin__control-text" type="text"
+    data-bind="
+        event: {change: userChanges},
+        value: value,
+        hasFocus: focused,
+        valueUpdate: valueUpdate,
+        attr: {
+            name: inputName,
+            placeholder: placeholder,
+            'aria-describedby': noticeId,
+            id: uid,
+            disabled: disabled,
+            maxlength: 4000
+    }"/>

--- a/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
+++ b/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
@@ -207,21 +207,7 @@ class PhpCookieManager implements CookieManagerInterface
         if ($numCookies > static::MAX_NUM_COOKIES) {
             $this->logger->warning(
                 new Phrase('Unable to send the cookie. Maximum number of cookies would be exceeded.'),
-                array_merge(
-                    ['user-agent' => $this->httpHeader->getHttpUserAgent()],
-                    [
-                        'cookies' => implode(
-                            ', ',
-                            array_map(
-                                function ($v, $k) {
-                                    return sprintf("%s='%s'", $k, $v);
-                                },
-                                $_COOKIE,
-                                array_keys($_COOKIE)
-                            )
-                        )
-                    ]
-                )
+                array_merge($_COOKIE, ['user-agent' => $this->httpHeader->getHttpUserAgent()])
             );
         }
 

--- a/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
+++ b/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
@@ -207,7 +207,21 @@ class PhpCookieManager implements CookieManagerInterface
         if ($numCookies > static::MAX_NUM_COOKIES) {
             $this->logger->warning(
                 new Phrase('Unable to send the cookie. Maximum number of cookies would be exceeded.'),
-                array_merge($_COOKIE, ['user-agent' => $this->httpHeader->getHttpUserAgent()])
+                array_merge(
+                    ['user-agent' => $this->httpHeader->getHttpUserAgent()],
+                    [
+                        'cookies' => implode(
+                            ', ',
+                            array_map(
+                                function ($v, $k) {
+                                    return sprintf("%s='%s'", $k, $v);
+                                },
+                                $_COOKIE,
+                                array_keys($_COOKIE)
+                            )
+                        )
+                    ]
+                )
             );
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When the number of cookies becomes more than 50 the warning log is written: "Unable to send the cookie. Maximum number of cookies would be exceeded." And each cookie is converting to a separate log context. And in the case of using the Graylog app, it is converting to a separate field. 
By this pull request, the $_COOKIE array is converting to a string and writing as 'cookie' context while writing the log

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Exceed more than 50 cookies
2. Watch the warning log

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
