### PR TITLE
CartItemInterface should include customizable_options

### DIFF
--- a/app/code/Magento/ConfigurableProductGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/ConfigurableProductGraphQl/etc/schema.graphqls
@@ -59,7 +59,7 @@ input ConfigurableProductCartItemInput {
 }
 
 type ConfigurableCartItem implements CartItemInterface {
-    customizable_options: [SelectedCustomizableOption] @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\CustomizableOptions")
+    customizable_options: [SelectedCustomizableOption]! @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\CustomizableOptions")
     configurable_options: [SelectedConfigurableOption!]! @resolver(class: "Magento\\ConfigurableProductGraphQl\\Model\\Resolver\\ConfigurableCartItemOptions")
 }
 

--- a/app/code/Magento/DownloadableGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/DownloadableGraphQl/etc/schema.graphqls
@@ -25,7 +25,7 @@ type AddDownloadableProductsToCartOutput {
 }
 
 type DownloadableCartItem implements CartItemInterface @doc(description: "Downloadable Cart Item") {
-    customizable_options: [SelectedCustomizableOption] @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\CustomizableOptions")
+    customizable_options: [SelectedCustomizableOption]! @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\CustomizableOptions")
     links: [DownloadableProductLinks] @resolver(class: "Magento\\DownloadableGraphQl\\Resolver\\DownloadableCartItem\\Links") @doc(description: "An array containing information about the links for the added to cart downloadable product")
     samples: [DownloadableProductSamples] @resolver(class: "Magento\\DownloadableGraphQl\\Resolver\\DownloadableCartItem\\Samples") @doc(description: "DownloadableProductSamples defines characteristics of a downloadable product")
 }

--- a/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/QuoteGraphQl/etc/schema.graphqls
@@ -320,11 +320,11 @@ type SetGuestEmailOnCartOutput {
 }
 
 type SimpleCartItem implements CartItemInterface @doc(description: "Simple Cart Item") {
-    customizable_options: [SelectedCustomizableOption] @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\CustomizableOptions")
+    customizable_options: [SelectedCustomizableOption]! @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\CustomizableOptions")
 }
 
 type VirtualCartItem implements CartItemInterface @doc(description: "Virtual Cart Item") {
-    customizable_options: [SelectedCustomizableOption] @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\CustomizableOptions")
+    customizable_options: [SelectedCustomizableOption]! @resolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\CustomizableOptions")
 }
 
 interface CartItemInterface @typeResolver(class: "Magento\\QuoteGraphQl\\Model\\Resolver\\CartItemTypeResolver") {


### PR DESCRIPTION
Fix all nullable customizable_options
Fixes issue: #31180
customizable_options: <SelectedCustomizableOption]

to be non nullable
customizable_options: [SelectedCustomizableOption]!



    I need to query a user's cart via graphQL and include customizable_options for each cart item.
    In order to do that now I need to use a fragment for each type implementing CartItemInterface
    Problem is that BundleCartItem has customizable*options: [SelectedCustomizableOption]! ( not nullable ) while all the other cart item types have customizable*options: [SelectedCustomizableOption] (nullable)

**Expected result (*)**

    The customizable_options field should be part of CartItemInterface since all implementing types include it.
    The customizable_options field should at least use the same type declaration in all implementing types in order to be able to fetch it in the cart query.

**Actual result (*)**

    The cart query validation error

![101203436-52030280-3673-11eb-986f-810b4216a658](https://user-images.githubusercontent.com/25526037/101890979-73aa3f80-3bc7-11eb-84ff-bb96c4f271be.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
