### PR TITLE
Declare optional argument after required.

### DIFF
--- a/app/code/Magento/MediaGalleryUi/Ui/Component/Listing/Filters/Asset.php
+++ b/app/code/Magento/MediaGalleryUi/Ui/Component/Listing/Filters/Asset.php
@@ -33,8 +33,8 @@ class Asset extends Select
      * @param UiComponentFactory $uiComponentFactory
      * @param FilterBuilder $filterBuilder
      * @param FilterModifier $filterModifier
-     * @param OptionSourceInterface $optionsProvider
      * @param GetContentByAssetIdsInterface $getContentIdentities
+     * @param OptionSourceInterface $optionsProvider
      * @param array $components
      * @param array $data
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -44,8 +44,8 @@ class Asset extends Select
         UiComponentFactory $uiComponentFactory,
         FilterBuilder $filterBuilder,
         FilterModifier $filterModifier,
-        OptionSourceInterface $optionsProvider = null,
         GetContentByAssetIdsInterface $getContentIdentities,
+        OptionSourceInterface $optionsProvider = null,
         array $components = [],
         array $data = []
     ) {


### PR DESCRIPTION
### Description
This prevents PHP fatal error when a plugin is added to the one of parent classes.

### Manual testing scenarios
1. Create a plugin for `\Magento\Framework\View\Element\BlockInterface`.
2. Navigate to _Content > Pages_.
3. A fatal error will be rendered: 'Error: Cannot instantiate interface Magento\Framework\Data\OptionSourceInterface'

### Plugin example

Open `Magento/Cms/etc/di.xml` and add the following code:

```xml
<type name="Magento\Framework\View\Element\BlockInterface">
    <plugin name="cms_plugin" type="Magento\Cms\Plugin\Block" />
</type>
```

Create `Magento\Cms\Plugin\Block` class:

```php
<?php

namespace Magento\Cms\Plugin;

class Block
{
    /**
     * @param mixed $subject
     * @param mixed $result
     * @return mixed
     */
    public function afterToHtml(
        $subject,
        $result
    ) {
        return $result;
    }
}
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31291: Declare optional argument after required.