### PR TITLE
[MFTF] Adding AdminClickRefundOfflineOnNewMemoPageActionGroup

### DIFF
--- a/app/code/Magento/Downloadable/Test/Mftf/Test/StorefrontAccountDownloadableProductLinkAfterPartialRefundTest.xml
+++ b/app/code/Magento/Downloadable/Test/Mftf/Test/StorefrontAccountDownloadableProductLinkAfterPartialRefundTest.xml
@@ -98,8 +98,8 @@
             <argument name="rowNumber" value="1"/>
         </actionGroup>
 
-        <click selector="{{AdminCreditMemoTotalSection.submitRefundOffline}}" stepKey="clickRefundOffline"/>
-        <waitForPageLoad stepKey="waitForResultPage"/>
+        <actionGroup ref="AdminClickRefundOfflineOnNewMemoPageActionGroup" stepKey="clickRefundOffline"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="waitForResultPage"/>
 
         <actionGroup ref="StorefrontNotAssertDownloadableProductLinkInCustomerAccountActionGroup" stepKey="dontSeeStorefrontMyAccountDownloadableProductsLink">
             <argument name="product" value="$$createDownloadableProduct$$"/>

--- a/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminClickRefundOfflineOnNewMemoPageActionGroup.xml
+++ b/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminClickRefundOfflineOnNewMemoPageActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminClickRefundOfflineOnNewMemoPageActionGroup">
+        <annotations>
+            <description>Click the Refund Offline button on the New Memo page</description>
+        </annotations> 
+        <click selector="{{AdminCreditMemoTotalSection.submitRefundOffline}}" stepKey="clickRefundOffline"/>
+        <waitForElementVisible selector="{{AdminMessagesSection.success}}" stepKey="waitForSuccesMessage"/>
+        <see selector="{{AdminMessagesSection.success}}" userInput="You created the credit memo." stepKey="seeSuccessMessage"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoBankTransferPaymentTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoBankTransferPaymentTest.xml
@@ -85,8 +85,8 @@
         </actionGroup>
 
         <!-- On order's page click 'Refund offline' button -->
-        <click selector="{{AdminCreditMemoTotalSection.submitRefundOffline}}" stepKey="clickRefundOffline"/>
-        <waitForPageLoad stepKey="waitForResultPage"/>
+        <actionGroup ref="AdminClickRefundOfflineOnNewMemoPageActionGroup" stepKey="clickRefundOffline"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="waitForResultPage"/>
 
         <!-- Perform all assertions: assert refund success create message -->
         <see selector="{{AdminIndexManagementSection.successMessage}}" userInput="You created the credit memo." stepKey="assertRefundSuccessCreateMessage"/>

--- a/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoPartialRefundTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoPartialRefundTest.xml
@@ -78,8 +78,8 @@
         </actionGroup>
 
         <!-- On order's page click 'Refund offline' button -->
-        <click selector="{{AdminCreditMemoTotalSection.submitRefundOffline}}" stepKey="clickRefundOffline"/>
-        <waitForPageLoad stepKey="waitForResultPage"/>
+        <actionGroup ref="AdminClickRefundOfflineOnNewMemoPageActionGroup" stepKey="clickRefundOffline"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="waitForResultPage"/>
 
         <!-- Perform all assertions: assert refund success create message -->
         <waitForElementVisible selector="{{AdminIndexManagementSection.successMessage}}" stepKey="waitForSuccessMessage"/>

--- a/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoWithPurchaseOrderTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateCreditMemoWithPurchaseOrderTest.xml
@@ -88,8 +88,8 @@
         </actionGroup>
 
         <!-- On order's page click 'Refund offline' button -->
-        <click selector="{{AdminCreditMemoTotalSection.submitRefundOffline}}" stepKey="clickRefundOffline"/>
-        <waitForPageLoad stepKey="waitForResultPage"/>
+        <actionGroup ref="AdminClickRefundOfflineOnNewMemoPageActionGroup" stepKey="clickRefundOffline"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="waitForResultPage"/>
 
         <!-- Perform all assertions: assert refund success create message -->
         <see selector="{{AdminIndexManagementSection.successMessage}}" userInput="You created the credit memo." stepKey="assertRefundSuccessCreateMessage"/>

--- a/app/code/Magento/Sales/Test/Mftf/Test/EndToEndB2CAdminTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/EndToEndB2CAdminTest.xml
@@ -140,8 +140,8 @@
             <argument name="billingAddress" value="US_Address_TX"/>
         </actionGroup>
         <!--Submit credit memo-->
-        <click selector="{{AdminCreditMemoTotalSection.submitRefundOffline}}" stepKey="clickRefundOffline" after="verifyOrderCreditMemoInformation"/>
-        <see selector="{{AdminOrderDetailsMessagesSection.successMessage}}" userInput="You created the credit memo." stepKey="seeCreditMemoSuccess" after="clickRefundOffline"/>
+        <actionGroup ref="AdminClickRefundOfflineOnNewMemoPageActionGroup" stepKey="clickRefundOffline" after="verifyOrderCreditMemoInformation"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="seeCreditMemoSuccess" after="clickRefundOffline"/>
         <click selector="{{AdminOrderDetailsOrderViewSection.creditMemos}}" stepKey="clickOrderCreditMemosTab" after="seeCreditMemoSuccess"/>
         <waitForLoadingMaskToDisappear stepKey="waitForCreditMemoTabLoadingMask" after="clickOrderCreditMemosTab"/>
         <see selector="{{AdminOrderCreditMemosTabSection.gridRow('1')}}" userInput="{{Simple_US_Customer.firstname}}" stepKey="seeOrderCreditMemoInTabGrid" after="waitForCreditMemoTabLoadingMask"/>


### PR DESCRIPTION
### Description (*)
Adding AdminClickRefundOfflineOnNewMemoPageActionGroup

### Resolved issues:
1. [x] resolves magento/magento2#31325: [MFTF] Adding AdminClickRefundOfflineOnNewMemoPageActionGroup