### PR TITLE
Fix issue with logging each cookie as separate context

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
+++ b/lib/internal/Magento/Framework/Stdlib/Cookie/PhpCookieManager.php
@@ -212,7 +212,10 @@ class PhpCookieManager implements CookieManagerInterface
         if ($numCookies > static::MAX_NUM_COOKIES) {
             $this->logger->warning(
                 new Phrase('Unable to send the cookie. Maximum number of cookies would be exceeded.'),
-                array_merge($_COOKIE, ['user-agent' => $this->httpHeader->getHttpUserAgent()])
+                [
+                    'cookies' => $_COOKIE,
+                    'user-agent' => $this->httpHeader->getHttpUserAgent()
+                ]
             );
         }
 

--- a/lib/internal/Magento/Framework/Stdlib/Test/Unit/Cookie/PhpCookieManagerTest.php
+++ b/lib/internal/Magento/Framework/Stdlib/Test/Unit/Cookie/PhpCookieManagerTest.php
@@ -565,7 +565,10 @@ namespace Magento\Framework\Stdlib\Test\Unit\Cookie
                 ->method('warning')
                 ->with(
                     new Phrase('Unable to send the cookie. Maximum number of cookies would be exceeded.'),
-                    array_merge($_COOKIE, ['user-agent' => $userAgent])
+                    [
+                        'cookies' => $_COOKIE,
+                        'user-agent' => $userAgent
+                    ]
                 );
 
             $this->cookieManager->setPublicCookie(


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When the number of cookies becomes more than 50 the warning log is written: "Unable to send the cookie. Maximum number of cookies would be exceeded." And each cookie is converting to a separate log context. And in the case of using the Graylog app, it is converting to a separate field.
By this pull request, the $_COOKIE array is converting to a string and writing as 'cookie' context while writing the log

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Exceed the number of cookies > 50
2. Watch the log

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31471: Fix issue with logging each cookie as separate context