### PR TITLE
[MFTF] Refactoring AdminSortingByWebsitesTest

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminChangeWebSiteAssignedToProductActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminChangeWebSiteAssignedToProductActionGroup.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminChangeWebSiteAssignedToProductActionGroup" extends="AddWebsiteToProductActionGroup">
+        <annotations>
+            <description>Extends AddWebsiteToProductActionGroup. Changes website assigned to product from websiteToDeselect to website</description>
+        </annotations>
+        <arguments>
+            <argument name="websiteToDeselect" type="string"/>
+        </arguments>
+
+        <uncheckOption selector="{{ProductInWebsitesSection.website(websiteToDeselect)}}" stepKey="uncheckWebsite" after="checkWebsite"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSortProductsGridByActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSortProductsGridByActionGroup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminSortProductsGridByActionGroup">
+        <annotations>
+            <description>Sorts the Product Grid by field</description>
+        </annotations>
+        <arguments>
+            <argument name="field" type="string"/>
+        </arguments>
+
+        <click selector="{{AdminProductGridSection.columnHeader(field)}}" stepKey="clickWebsitesHeaderToSort"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForApplyingChanges"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminSortingByWebsitesTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminSortingByWebsitesTest.xml
@@ -25,7 +25,7 @@
             </createData>
 
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
-            <!--Create new website -->
+
             <actionGroup ref="AdminCreateWebsiteActionGroup" stepKey="createAdditionalWebsite">
                 <argument name="newWebsiteName" value="{{customWebsite.name}}"/>
                 <argument name="websiteCode" value="{{customWebsite.code}}"/>
@@ -54,31 +54,30 @@
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
 
-        <!--Assign Custom Website to Simple Product -->
-        <actionGroup ref="AdminOpenProductIndexPageActionGroup" stepKey="navigateToCatalogProductGrid"/>
-
-        <conditionalClick selector="{{AdminProductGridFilterSection.clearFilters}}" dependentSelector="{{AdminProductGridFilterSection.clearFilters}}" visible="true" stepKey="clickClearFiltersInitial"/>
+        <actionGroup ref="AdminClearFiltersActionGroup" stepKey="navigateToCatalogProductGrid"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="clickClearFiltersInitial"/>
         <actionGroup ref="OpenEditProductOnBackendActionGroup" stepKey="assignCustomWebsiteToProduct">
             <argument name="product" value="$$productAssignedToCustomWebsite$$"/>
         </actionGroup>
-        <scrollTo selector="{{ProductInWebsitesSection.sectionHeader}}" stepKey="scrollToWebsites"/>
-        <conditionalClick selector="{{ProductInWebsitesSection.sectionHeader}}" dependentSelector="{{AdminProductContentSection.sectionHeaderShow}}" visible="false" stepKey="expandSection"/>
-        <waitForPageLoad stepKey="waitForPageOpened"/>
-        <uncheckOption selector="{{ProductInWebsitesSection.website(_defaultWebsite.name)}}" stepKey="deselectMainWebsite"/>
-        <checkOption selector="{{ProductInWebsitesSection.website(customWebsite.name)}}" stepKey="selectWebsite"/>
+        <actionGroup ref="AdminChangeWebSiteAssignedToProductActionGroup" stepKey="scrollToWebsites">
+            <argument name="website" value="{{customWebsite.name}}"/>
+            <argument name="websiteToDeselect" value="{{_defaultWebsite.name}}"/>
+        </actionGroup>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="expandSection"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="waitForPageOpened"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="deselectMainWebsite"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="selectWebsite"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="clickSave"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="seeSaveProductMessageAgain"/>
 
-        <actionGroup ref="AdminProductFormSaveActionGroup" stepKey="clickSave"/>
-        <seeElement selector="{{AdminProductMessagesSection.successMessage}}" stepKey="seeSaveProductMessageAgain"/>
-
-        <!--Navigate To Product Grid To Check Website Sorting-->
         <actionGroup ref="AdminOpenProductIndexPageActionGroup" stepKey="navigateToCatalogProductGridToSortByWebsite"/>
-
-        <!--Sorting works (By Websites) ASC-->
-        <click selector="{{AdminProductGridSection.columnHeader('Websites')}}" stepKey="clickWebsitesHeaderToSortAsc"/>
+        <actionGroup ref="AdminSortProductsGridByActionGroup" stepKey="clickWebsitesHeaderToSortAsc">
+            <argument name="field" value="Websites"/>
+        </actionGroup>
         <see selector="{{AdminProductGridSection.productGridContentsOnRow('1')}}" userInput="Main Website" stepKey="checkIfProduct1WebsitesAsc"/>
-
-        <!--Sorting works (By Websites) DESC-->
-        <click selector="{{AdminProductGridSection.columnHeader('Websites')}}" stepKey="clickWebsitesHeaderToSortDesc"/>
+        <actionGroup ref="AdminSortProductsGridByActionGroup" stepKey="clickWebsitesHeaderToSortDesc">
+            <argument name="field" value="Websites"/>
+        </actionGroup>
         <see selector="{{AdminProductGridSection.productGridContentsOnRow('1')}}" userInput="{{customWebsite.name}}" stepKey="checkIfProduct1WebsitesDesc"/>
     </test>
 </tests>


### PR DESCRIPTION
### Description (*)
The test is refactored according to the best practices followed by MFTF.

### Manual testing scenarios (*)
1. Create a custom website
2. Assign the created website to a product
3. Go to Catalog->Products
4. Sort the Products grid by the "Website" column asc
5. Check if the product in the first row is assigned to Main Website
6. Sort the Products grid by the "Website" column desc
7.  Check if the product in the first row the created custom website


### Resolved issues:
1. [x] resolves magento/magento2#31442: [MFTF] Refactoring AdminSortingByWebsitesTest