### PR TITLE
[GraphQL] Added module  Product Alerts GraphQL

### DIFF
--- a/app/code/Magento/ProductAlertGraphQl/Model/DataProvider/Product/CollectionProcessor/PriceProcessor.php
+++ b/app/code/Magento/ProductAlertGraphQl/Model/DataProvider/Product/CollectionProcessor/PriceProcessor.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductAlertGraphQl\Model\DataProvider\Product\CollectionProcessor;
+
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
+use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessorInterface;
+use Magento\GraphQl\Model\Query\ContextInterface;
+use Magento\ProductAlert\Helper\Data as AlertsHelper;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\App\ResourceConnection;
+
+/**
+ * Add price alert field for product collection
+ */
+class PriceProcessor implements CollectionProcessorInterface
+{
+    /**
+     * @var AlertsHelper
+     */
+    private $helper;
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @param AlertsHelper $helper
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        AlertsHelper $helper,
+        ResourceConnection $resourceConnection
+    ) {
+        $this->helper = $helper;
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * Process collection to add additional joins, attributes, and clauses to a product collection.
+     *
+     * @param Collection $collection
+     * @param SearchCriteriaInterface $searchCriteria
+     * @param array $attributeNames
+     * @param ContextInterface|null $context
+     * @return Collection
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function process(
+        Collection $collection,
+        SearchCriteriaInterface $searchCriteria,
+        array $attributeNames,
+        ContextInterface $context = null
+    ): Collection {
+        $connection = $this->resourceConnection->getConnection();
+        
+        if ($this->helper->isStockAlertAllowed() && 
+            $context !== null &&
+            $context->getUserId() &&
+            in_array('productalert_price_subcribed', $attributeNames)) {
+            $store = $context->getExtensionAttributes()->getStore();
+            $joinCondition = $connection->quoteInto(
+                'alert_price.product_id = e.entity_id AND alert_price.customer_id = ? AND alert_price.store_id = ?', $context->getUserId(), $store->getId());
+            $collection->getSelect()->joinLeft(
+                ['alert_price' => $connection->getTableName('product_alert_price')],
+                $joinCondition,
+                ['productalert_price_subcribed' => 'alert_price.alert_price_id']
+            );
+        }
+
+        return $collection;
+    }
+}

--- a/app/code/Magento/ProductAlertGraphQl/Model/DataProvider/Product/CollectionProcessor/StockProcessor.php
+++ b/app/code/Magento/ProductAlertGraphQl/Model/DataProvider/Product/CollectionProcessor/StockProcessor.php
@@ -5,7 +5,7 @@
  */
 declare(strict_types=1);
 
-namespace Magento\ProductAlertGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessor;
+namespace Magento\ProductAlertGraphQl\Model\DataProvider\Product\CollectionProcessor;
 
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessorInterface;

--- a/app/code/Magento/ProductAlertGraphQl/Model/DataProvider/Product/CollectionProcessor/StockProcessor.php
+++ b/app/code/Magento/ProductAlertGraphQl/Model/DataProvider/Product/CollectionProcessor/StockProcessor.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductAlertGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessor;
+
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
+use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessorInterface;
+use Magento\GraphQl\Model\Query\ContextInterface;
+use Magento\ProductAlert\Helper\Data as AlertsHelper;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\App\ResourceConnection;
+
+/**
+ * Add stock alert field for product collection
+ */
+class StockProcessor implements CollectionProcessorInterface
+{
+    /**
+     * @var AlertsHelper
+     */
+    private $helper;
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @param AlertsHelper $helper
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        AlertsHelper $helper,
+        ResourceConnection $resourceConnection
+    ) {
+        $this->helper = $helper;
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * Process collection to add additional joins, attributes, and clauses to a product collection.
+     *
+     * @param Collection $collection
+     * @param SearchCriteriaInterface $searchCriteria
+     * @param array $attributeNames
+     * @param ContextInterface|null $context
+     * @return Collection
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function process(
+        Collection $collection,
+        SearchCriteriaInterface $searchCriteria,
+        array $attributeNames,
+        ContextInterface $context = null
+    ): Collection {
+        $connection = $this->resourceConnection->getConnection();
+
+        if ($this->helper->isStockAlertAllowed() && 
+            $context !== null &&
+            $context->getUserId() &&
+            in_array('productalert_stock_subcribed', $attributeNames)) {
+            $store = $context->getExtensionAttributes()->getStore();
+            $joinCondition = $connection->quoteInto(
+                'alert_stock.product_id = e.entity_id AND alert_stock.customer_id = ? AND alert_stock.store_id = ?', $context->getUserId(), $store->getId());
+            $collection->getSelect()->joinLeft(
+                ['alert_stock' => $connection->getTableName('product_alert_stock')],
+                $joinCondition,
+                ['productalert_stock_subcribed' => 'alert_stock.alert_stock_id']
+            );
+        }
+
+        return $collection;
+    }
+}

--- a/app/code/Magento/ProductAlertGraphQl/Model/Resolver/Price/Subscribe.php
+++ b/app/code/Magento/ProductAlertGraphQl/Model/Resolver/Price/Subscribe.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductAlertGraphQl\Model\Resolver\Price;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\ProductAlert\Helper\Data as AlertsHelper;
+use Magento\ProductAlert\Model\PriceFactory;
+
+/**
+ * Subscribe to product price alert
+ */
+class Subscribe implements ResolverInterface
+{
+    /**
+     * @var AlertsHelper
+     */
+    private $helper;
+
+    /**
+     * @var PriceFactory
+     */
+    private $priceFactory;
+
+    /**
+     * @param AlertsHelper $helper
+     */
+    public function __construct(
+        AlertsHelper $helper,
+        PriceFactory $priceFactory
+    ) {
+        $this->helper = $helper;
+        $this->priceFactory = $priceFactory;
+    }
+
+   /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!$this->helper->isPriceAlertAllowed()) {
+            throw new GraphQlInputException(__('The product price alerts is currently disabled.'));
+        }
+
+        $customerId = $context->getUserId();
+        $store = $context->getExtensionAttributes()->getStore();
+
+        /* Guest checking */
+        if (null === $customerId || 0 === $customerId) {
+            throw new GraphQlAuthorizationException(__('The current user cannot perform operations on product alerts'));
+        }
+
+        $productId = ((int) $args['productId']) ?: null;
+
+        $model = $this->priceFactory->create()
+                ->setCustomerId($customerId)
+                ->setProductId($productId)
+                ->setWebsiteId($store->getWebsiteId())
+                ->setStoreId($store->getId())
+                ->loadByParam();
+
+        if ($model->getId()) {
+            throw new GraphQlInputException(__('The current user is currently subscribed to price alert.'));
+        }
+
+        $model->save();
+
+        return [
+            'id' => $model->getId()
+        ];
+    }
+}

--- a/app/code/Magento/ProductAlertGraphQl/Model/Resolver/Price/Unsubscribe.php
+++ b/app/code/Magento/ProductAlertGraphQl/Model/Resolver/Price/Unsubscribe.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductAlertGraphQl\Model\Resolver\Price;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\ProductAlert\Helper\Data as AlertsHelper;
+use Magento\ProductAlert\Model\PriceFactory;
+
+/**
+ * Unsubscribe to product price alert
+ */
+class Unsubscribe implements ResolverInterface
+{
+    /**
+     * @var AlertsHelper
+     */
+    private $helper;
+
+    /**
+     * @var PriceFactory
+     */
+    private $priceFactory;
+
+    /**
+     * @param AlertsHelper $helper
+     */
+    public function __construct(
+        AlertsHelper $helper,
+        PriceFactory $priceFactory
+    ) {
+        $this->helper = $helper;
+        $this->priceFactory = $priceFactory;
+    }
+
+   /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!$this->helper->isPriceAlertAllowed()) {
+            throw new GraphQlInputException(__('The product price alerts is currently disabled.'));
+        }
+
+        $customerId = $context->getUserId();
+        $store = $context->getExtensionAttributes()->getStore();
+
+        /* Guest checking */
+        if (null === $customerId || 0 === $customerId) {
+            throw new GraphQlAuthorizationException(__('The current user cannot perform operations on product alerts'));
+        }
+
+        $productId = ((int) $args['productId']) ?: null;
+
+        $model = $this->priceFactory->create()
+                ->setCustomerId($customerId)
+                ->setProductId($productId)
+                ->setWebsiteId($store->getWebsiteId())
+                ->setStoreId($store->getId())
+                ->loadByParam();
+        
+        if (!$model->getId()) {
+            throw new GraphQlInputException(__('The current user isn\'t subscribed to price alert.'));
+        }
+
+        $model->delete();
+
+        return true;
+    }
+}

--- a/app/code/Magento/ProductAlertGraphQl/Model/Resolver/Product/Price.php
+++ b/app/code/Magento/ProductAlertGraphQl/Model/Resolver/Product/Price.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductAlertGraphQl\Model\Resolver\Product;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
+
+/**
+ * Check product in subscription price list 
+ */
+class Price implements ResolverInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        /** @var ProductInterface $product */
+        $product = $value['model'];
+
+        return $product->getData('productalert_price_subcribed') !== null;
+    }
+}

--- a/app/code/Magento/ProductAlertGraphQl/Model/Resolver/Product/Stock.php
+++ b/app/code/Magento/ProductAlertGraphQl/Model/Resolver/Product/Stock.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductAlertGraphQl\Model\Resolver\Product;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
+
+/**
+ * Check product in subscription stock list 
+ */
+class Stock implements ResolverInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        /** @var ProductInterface $product */
+        $product = $value['model'];
+
+        return $product->getData('productalert_stock_subcribed') !== null;
+    }
+}

--- a/app/code/Magento/ProductAlertGraphQl/Model/Resolver/Stock/Subscribe.php
+++ b/app/code/Magento/ProductAlertGraphQl/Model/Resolver/Stock/Subscribe.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductAlertGraphQl\Model\Resolver\Stock;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\ProductAlert\Helper\Data as AlertsHelper;
+use Magento\ProductAlert\Model\StockFactory;
+
+/**
+ * Subscribe to product stock alert
+ */
+class Subscribe implements ResolverInterface
+{
+    /**
+     * @var AlertsHelper
+     */
+    private $helper;
+
+    /**
+     * @var StockFactory
+     */
+    private $stockFactory;
+
+    /**
+     * @param AlertsHelper $helper
+     * @param StockFactory $stockFactory
+     */
+    public function __construct(
+        AlertsHelper $helper,
+        StockFactory $stockFactory
+    ) {
+        $this->helper = $helper;
+        $this->stockFactory = $stockFactory;
+    }
+
+   /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!$this->helper->isStockAlertAllowed()) {
+            throw new GraphQlInputException(__('The product stock alerts is currently disabled.'));
+        }
+
+        $customerId = $context->getUserId();
+        $store = $context->getExtensionAttributes()->getStore();
+
+        /* Guest checking */
+        if (null === $customerId || 0 === $customerId) {
+            throw new GraphQlAuthorizationException(__('The current user cannot perform operations on product alerts'));
+        }
+
+        $productId = ((int) $args['productId']) ?: null;
+
+        $model = $this->stockFactory->create()
+                ->setCustomerId($customerId)
+                ->setProductId($productId)
+                ->setWebsiteId($store->getWebsiteId())
+                ->setStoreId($store->getId())
+                ->loadByParam();
+
+        if ($model->getId()) {
+            throw new GraphQlInputException(__('The current user is currently subscribed to stock alert.'));
+        }
+
+        $model->save();
+
+        return [
+            'id' => $model->getId()
+        ];
+    }
+}

--- a/app/code/Magento/ProductAlertGraphQl/Model/Resolver/Stock/Unsubscribe.php
+++ b/app/code/Magento/ProductAlertGraphQl/Model/Resolver/Stock/Unsubscribe.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\ProductAlertGraphQl\Model\Resolver\Stock;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\ProductAlert\Helper\Data as AlertsHelper;
+use Magento\ProductAlert\Model\StockFactory;
+
+/**
+ * Unsubscribe to product stock alert
+ */
+class Unsubscribe implements ResolverInterface
+{
+    /**
+     * @var AlertsHelper
+     */
+    private $helper;
+
+    /**
+     * @var StockFactory
+     */
+    private $stockFactory;
+
+    /**
+     * @param AlertsHelper $helper
+     */
+    public function __construct(
+        AlertsHelper $helper,
+        StockFactory $stockFactory
+    ) {
+        $this->helper = $helper;
+        $this->stockFactory = $stockFactory;
+    }
+
+   /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!$this->helper->isStockAlertAllowed()) {
+            throw new GraphQlInputException(__('The product stock alerts is currently disabled.'));
+        }
+
+        $customerId = $context->getUserId();
+        $store = $context->getExtensionAttributes()->getStore();
+
+        /* Guest checking */
+        if (null === $customerId || 0 === $customerId) {
+            throw new GraphQlAuthorizationException(__('The current user cannot perform operations on product alerts'));
+        }
+
+        $productId = ((int) $args['productId']) ?: null;
+
+        $model = $this->stockFactory->create()
+                ->setCustomerId($customerId)
+                ->setProductId($productId)
+                ->setWebsiteId($store->getWebsiteId())
+                ->setStoreId($store->getId())
+                ->loadByParam();
+        
+        if (!$model->getId()) {
+            throw new GraphQlInputException(__('The current user isn\'t subscribed to stocl alert.'));
+        } 
+
+        $model->delete();
+
+        return true;
+    }
+}

--- a/app/code/Magento/ProductAlertGraphQl/README.md
+++ b/app/code/Magento/ProductAlertGraphQl/README.md
@@ -1,0 +1,3 @@
+# ProductAlertGraphQl
+
+**ProductAlertGraphQl** provides resolver information for using Product alerts via GraphQl.

--- a/app/code/Magento/ProductAlertGraphQl/composer.json
+++ b/app/code/Magento/ProductAlertGraphQl/composer.json
@@ -10,6 +10,9 @@
         "magento/module-product-alert":"*",
         "magento/module-store": "*"
     },
+    "suggest": {
+        "magento/module-graph-ql": "*"
+    },    
     "license": [
         "OSL-3.0",
         "AFL-3.0"
@@ -22,5 +25,4 @@
             "Magento\\ProductAlertGraphQl\\": ""
         }
     }
-
 }

--- a/app/code/Magento/ProductAlertGraphQl/composer.json
+++ b/app/code/Magento/ProductAlertGraphQl/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "magento/module-product-alert-graph-ql",
+    "description": "N/A",
+    "type": "magento2-module",
+    "require": {
+        "php": "~7.3.0||~7.4.0",
+        "magento/framework": "*",
+        "magento/module-catalog": "*",
+        "magento/module-catalog-graph-ql": "*",
+        "magento/module-product-alert":"*",
+        "magento/module-store": "*"
+    },
+    "license": [
+        "OSL-3.0",
+        "AFL-3.0"
+    ],
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Magento\\ProductAlertGraphQl\\": ""
+        }
+    }
+
+}

--- a/app/code/Magento/ProductAlertGraphQl/etc/di.xml
+++ b/app/code/Magento/ProductAlertGraphQl/etc/di.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CompositeCollectionProcessor">
+        <arguments>
+            <argument name="collectionProcessors" xsi:type="array">
+                <item name="alert_price" xsi:type="object">Magento\ProductAlertGraphQl\Model\DataProvider\Product\CollectionProcessor\PriceProcessor</item>
+                <item name="alert_stock" xsi:type="object">Magento\ProductAlertGraphQl\Model\DataProvider\Product\CollectionProcessor\StockProcessor</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/app/code/Magento/ProductAlertGraphQl/etc/graphql/di.xml
+++ b/app/code/Magento/ProductAlertGraphQl/etc/graphql/di.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
+        <arguments>
+            <argument name="extendedConfigData" xsi:type="array">
+                <item name="catalog_productalert_allow_stock" xsi:type="string">catalog/productalert/allow_stock</item>
+                <item name="catalog_productalert_allow_price" xsi:type="string">catalog/productalert/allow_price</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/app/code/Magento/ProductAlertGraphQl/etc/module.xml
+++ b/app/code/Magento/ProductAlertGraphQl/etc/module.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Magento_ProductAlertGraphQl">
+        <sequence>
+            <module name="Magento_ProductAlert"/>
+            <module name="Magento_CatalogGraphQl"/>
+        </sequence>
+    </module>
+</config>

--- a/app/code/Magento/ProductAlertGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/ProductAlertGraphQl/etc/schema.graphqls
@@ -1,3 +1,6 @@
+# Copyright © Magento, Inc. All rights reserved.
+# See COPYING.txt for license details.
+
 type Mutation {
     subcribeProductAlertStock(productId: Int!): ProductAlert @resolver(class: "Magento\\ProductAlertGraphQl\\Model\\Resolver\\Stock\\Subscribe") @doc(description: "Subscribe customer to Stock Alert")
     unsubcribeProductAlertStock(productId: Int!): Boolean @resolver(class:  "Magento\\ProductAlertGraphQl\\Model\\Resolver\\Stock\\Unsubscribe") @doc(description: "Unsubscribe customer to Stock Alert")

--- a/app/code/Magento/ProductAlertGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/ProductAlertGraphQl/etc/schema.graphqls
@@ -1,0 +1,20 @@
+type Mutation {
+    subcribeProductAlertStock(productId: Int!): ProductAlert @resolver(class: "Magento\\ProductAlertGraphQl\\Model\\Resolver\\Stock\\Subscribe") @doc(description: "Subscribe customer to Stock Alert")
+    unsubcribeProductAlertStock(productId: Int!): Boolean @resolver(class:  "Magento\\ProductAlertGraphQl\\Model\\Resolver\\Stock\\Unsubscribe") @doc(description: "Unsubscribe customer to Stock Alert")
+    subcribeProductAlertPrice(productId: Int!): ProductAlert @resolver(class: "Magento\\ProductAlertGraphQl\\Model\\Resolver\\Price\\Subscribe") @doc(description: "Subscribe customer to Price Alert")
+    unsubcribeProductAlertPrice(productId: Int!): Boolean @resolver(class: "Magento\\ProductAlertGraphQl\\Model\\Resolver\\Price\\Unsubscribe") @doc(description: "Unsubscribe customer to Prce Alert")
+}
+
+type ProductAlert @doc(description: "Product Alert") {
+    id: Int!
+}
+
+type StoreConfig {
+    catalog_productalert_allow_stock: Boolean @doc(description: "Allow Alert When Product Comes Back in Stock")
+    catalog_productalert_allow_price: Boolean @doc(description: "Allow Alert When Product Price Changes")
+}
+
+type ProductInterface {
+    productalert_stock_subcribed: Boolean @resolver(class: "Magento\\ProductAlertGraphQl\\Model\\Resolver\\Product\\Stock") @doc(description: "Is Customer subcribed to Stock Alerts")
+    productalert_price_subcribed: Boolean @resolver(class: "Magento\\ProductAlertGraphQl\\Model\\Resolver\\Product\\Price") @doc(description: "Is Customer subcribed to Price Alerts")
+}

--- a/app/code/Magento/ProductAlertGraphQl/registration.php
+++ b/app/code/Magento/ProductAlertGraphQl/registration.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_ProductAlertGraphQl', __DIR__);


### PR DESCRIPTION
### Description (*)
Added new module with GraphQl for Product Alerts - Price and Stock. I've added mutations:
```
type Mutation {
      subcribeProductAlertStock(productId: Int!): ProductAlert
      unsubcribeProductAlertStock(productId: Int!): Boolean
      subcribeProductAlertPrice(productId: Int!): ProductAlert
      unsubcribeProductAlertPrice(productId: Int!): Boolean
} 
``` 
In addition, Added 2 flags to ProductInterface for get status for logged in user:
```
type ProductInterface {
    productalert_stock_subcribed
    productalert_price_subcribed
}
```

### Fixed Issues (if relevant)
1. Fixes [community-features/315](https://github.com/magento/community-features/issues/315)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
