### PR TITLE
ISSUE-29957: Adjusting URL generation for the file attributes type.

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Option/Type/File.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/File.php
@@ -155,13 +155,15 @@ class File extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
      * Return option html
      *
      * @param array $optionInfo
+     * @param array $params
      * @return string|void
      */
-    public function getCustomizedView($optionInfo)
+    public function getCustomizedView($optionInfo, $params = null)
     {
         try {
             if (isset($optionInfo['option_value'])) {
-                return $this->_getOptionHtml($optionInfo['option_value']);
+                $optionValue = $this->parseValue($optionInfo, $params);
+                return $this->_getOptionHtml($optionValue);
             } elseif (isset($optionInfo['value'])) {
                 return $optionInfo['value'];
             }
@@ -375,13 +377,13 @@ class File extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
     /**
      * Format File option html
      *
-     * @param string|array $optionValue Serialized string of option data or its data array
+     * @param array $value option data
+     * @param array $params
      * @return string
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    protected function _getOptionHtml($optionValue)
+    protected function _getOptionHtml($value)
     {
-        $value = $this->_unserializeValue($optionValue);
         try {
             $sizes = $this->prepareSize($value);
 
@@ -559,5 +561,21 @@ class File extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
             $sizes = $value['width'] . ' x ' . $value['height'] . ' ' . __('px.');
         }
         return $sizes;
+    }
+
+    /**
+     * @param array $optionInfo
+     * @param array|null $params
+     * @return array|string
+     */
+    private function parseValue(array $optionInfo, ?array $params)
+    {
+        $optionValue = $optionInfo['option_value'];
+        $value = $this->_unserializeValue($optionValue);
+        if (!isset($params)) {
+            return $value;
+        }
+        $value['url']['params'] = array_merge($value['url']['params'], $params);
+        return $value;
     }
 }

--- a/app/code/Magento/Sales/Block/Adminhtml/Items/Column/DefaultColumn.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Items/Column/DefaultColumn.php
@@ -87,16 +87,17 @@ class DefaultColumn extends \Magento\Sales\Block\Adminhtml\Items\AbstractItems
      * Return custom option html
      *
      * @param array $optionInfo
+     * @param int $itemId
      * @return string
      */
-    public function getCustomizedOptionValue($optionInfo)
+    public function getCustomizedOptionValue($optionInfo, $itemId)
     {
-        // render customized option view
         $_default = $optionInfo['value'];
         if (isset($optionInfo['option_type'])) {
             try {
                 $group = $this->_optionFactory->create()->groupFactory($optionInfo['option_type']);
-                return $group->getCustomizedView($optionInfo);
+                $params =  ['order_item_id' => $itemId, 'option_id' => $optionInfo['option_id']];
+                return $group->getCustomizedView($optionInfo, $params);
             } catch (\Exception $e) {
                 return $_default;
             }

--- a/app/code/Magento/Sales/Block/Order/Item/Renderer/DefaultRenderer.php
+++ b/app/code/Magento/Sales/Block/Order/Item/Renderer/DefaultRenderer.php
@@ -125,6 +125,7 @@ class DefaultRenderer extends \Magento\Framework\View\Element\Template
      * Accept option value and return its formatted view
      *
      * @param mixed $optionValue
+     * @param int $itemId
      * Method works well with these $optionValue format:
      *      1. String
      *      2. Indexed array e.g. array(val1, val2, ...)
@@ -142,7 +143,7 @@ class DefaultRenderer extends \Magento\Framework\View\Element\Template
      * @return array
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    public function getFormatedOptionValue($optionValue)
+    public function getFormatedOptionValue($optionValue, $itemId)
     {
         $optionInfo = [];
 
@@ -164,7 +165,8 @@ class DefaultRenderer extends \Magento\Framework\View\Element\Template
             if (isset($optionInfo['option_type'])) {
                 try {
                     $group = $this->_productOptionFactory->create()->groupFactory($optionInfo['option_type']);
-                    return ['value' => $group->getCustomizedView($optionInfo)];
+                    $params =  ['order_item_id' => $itemId, 'option_id' => $optionInfo['option_id']];
+                    return ['value' => $group->getCustomizedView($optionInfo, $params)];
                 } catch (\Exception $e) {
                     return $_default;
                 }

--- a/app/code/Magento/Sales/Model/Download/CustomOptionInfo.php
+++ b/app/code/Magento/Sales/Model/Download/CustomOptionInfo.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Model\Download;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Sales\Api\OrderItemRepositoryInterface;
+use Magento\Catalog\Model\Product\OptionFactory as ProductOptionFactory;
+use Magento\Quote\Model\Quote\Item\OptionFactory as QuoteItemOptionFactory;
+use Magento\Catalog\Model\Product\Type\AbstractType;
+use Magento\Framework\Serialize\Serializer\Json;
+
+class CustomOptionInfo
+{
+    /**
+     * @var OrderItemRepositoryInterface
+     */
+    private $orderItemRepository;
+
+    /**
+     * @var ProductOptionFactory
+     */
+    private $productOptionFactory;
+
+    /**
+     * @var QuoteItemOptionFactory
+     */
+    private $quoteItemOptionFactory;
+
+    /**
+     * @var Json
+     */
+    private $serializer;
+
+    /**
+     * @param OrderItemRepositoryInterface $orderItemRepository
+     * @param ProductOptionFactory $productOptionFactory
+     * @param QuoteItemOptionFactory $quoteItemOptionFactory
+     * @param Json $serializer
+     */
+    public function __construct(
+        OrderItemRepositoryInterface $orderItemRepository,
+        ProductOptionFactory $productOptionFactory,
+        QuoteItemOptionFactory $quoteItemOptionFactory,
+        Json $serializer
+    ) {
+        $this->orderItemRepository = $orderItemRepository;
+        $this->productOptionFactory = $productOptionFactory;
+        $this->quoteItemOptionFactory = $quoteItemOptionFactory;
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * @param int $quoteItemid
+     * @param int $orderItemId
+     * @param int $optionId
+     * @return array|bool|float|int|mixed|string|null
+     * @throws LocalizedException|NoSuchEntityException
+     */
+    public function search($quoteItemid, $orderItemId, $optionId)
+    {
+        if ($orderItemId && $optionId) {
+            return $this->loadOptionByOrderItemId($orderItemId, $optionId);
+        }
+        return $this->loadOptionByQuoteItemId($quoteItemid);
+    }
+
+    /**
+     * @param int $id
+     * @return array|bool|float|int|mixed|string|null
+     * @throws NoSuchEntityException|LocalizedException
+     */
+    private function loadOptionByQuoteItemId(int $id)
+    {
+        $option = $this->quoteItemOptionFactory->create();
+        $option->load($id);
+
+        if (!$option->getId()) {
+            throw new NoSuchEntityException(__("Quote Item Option %1 not found", $id));
+        }
+
+        $optionId = null;
+        if (strpos($option->getCode(), AbstractType::OPTION_PREFIX) === 0) {
+            $optionId = str_replace(AbstractType::OPTION_PREFIX, '', $option->getCode());
+            if ((int)$optionId != $optionId) {
+                $optionId = null;
+            }
+        }
+
+        $productOption = null;
+        if ($optionId) {
+            $productOption = $this->productOptionFactory->create();
+            $productOption->load($optionId);
+        }
+
+        if (!$productOption->getId()) {
+            throw new NoSuchEntityException(__("Product Option %1 not found", $optionId));
+        }
+
+        if ($productOption->getType() != 'file') {
+            throw new LocalizedException(__("the product option assigned is not type file"));
+        }
+
+        return $info = $this->serializer->unserialize($option->getValue());
+    }
+
+    /**
+     * @param int $orderItemId
+     * @param int $optionId
+     * @return array|bool
+     * @throws LocalizedException
+     */
+    private function loadOptionByOrderItemId(int $orderItemId, int $optionId)
+    {
+        $orderItem = $this->orderItemRepository->get($orderItemId);
+        $orderItemProductOptions = $orderItem->getProductOptions();
+        return $this->loadInfoByOptionData($orderItemProductOptions, $optionId);
+    }
+
+    /**
+     * @param array $orderItemProductOptions
+     * @param string $optionId
+     * @return array
+     * @throws LocalizedException
+     */
+    private function loadInfoByOptionData($orderItemProductOptions, $optionId)
+    {
+        $infoBuyRequest = $this->loadArrayDataByKey($orderItemProductOptions, 'info_buyRequest');
+        if (!isset($infoBuyRequest)) {
+            throw new LocalizedException(__("Order item has not info_buyRequest value assigned"));
+        }
+
+        $options = $this->loadArrayDataByKey($infoBuyRequest, 'options');
+        if (!isset($options)) {
+            throw new LocalizedException(__("InfoBuyRequest has not options value assigned"));
+        }
+
+        $result = $this->loadArrayDataByKey($options, $optionId);
+        if (!isset($result)) {
+            throw new LocalizedException(__("InfoBuyRequest has not option %1", $optionId));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array $data
+     * @param string|int $key
+     * @return bool|mixed
+     */
+    private function loadArrayDataByKey(array $data, $key)
+    {
+        if (!array_key_exists($key, $data)) {
+            return false;
+        }
+
+        return $data[$key];
+    }
+}

--- a/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminDownloadCustomerOptionFileActionGroup.xml
+++ b/app/code/Magento/Sales/Test/Mftf/ActionGroup/AdminDownloadCustomerOptionFileActionGroup.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminDownloadCustomerOptionFileActionGroup">
+        <scrollTo selector="{{AdminOrderItemsOrderedSection.itemProductName('1')}}" x="0" y="-80" stepKey="scrollToOrderItemSection"/>
+        <click selector="{{AdminOrderItemsOrderedSection.itemCustomOptionDownload('1')}}" stepKey="downloadCustomOptionFile"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Sales/Test/Mftf/Section/AdminOrderItemsOrderedSection.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Section/AdminOrderItemsOrderedSection.xml
@@ -10,6 +10,7 @@
         xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="AdminOrderItemsOrderedSection">
         <element name="itemProductName" type="text" selector=".edit-order-table tr:nth-of-type({{row}}) .col-product .product-title" parameterized="true"/>
+        <element name="itemCustomOptionDownload" type="button" selector=".edit-order-table tr:nth-of-type({{row}}) .col-product .item-options dd a" parameterized="true"/>
         <element name="itemProductSku" type="text" selector=".edit-order-table tr:nth-of-type({{row}}) .col-product .product-sku-block" parameterized="true"/>
         <element name="itemStatus" type="text" selector=".edit-order-table tr:nth-of-type({{row}}) .col-status" parameterized="true"/>
         <element name="itemOriginalPrice" type="text" selector=".edit-order-table tr:nth-of-type({{row}}) .col-original-price .price" parameterized="true"/>

--- a/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderWithSimpleProductCustomOptionFileTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderWithSimpleProductCustomOptionFileTest.xml
@@ -51,5 +51,16 @@
         </actionGroup>
         <!--Verify, admin able to change file for custom option.-->
         <actionGroup ref="AdminChangeCustomerOptionFileActionGroup" stepKey="changeFile"/>
+
+        <!-- Select shipping method -->
+        <actionGroup ref="AdminClickGetShippingMethodsAndRatesActionGroup" stepKey="openShippingMethod"/>
+        <comment userInput="Adding the comment to replace action for preserving Backward Compatibility" stepKey="waitForShippingMethods"/>
+        <actionGroup ref="AdminSelectFixedShippingMethodActionGroup" stepKey="chooseShippingMethod"/>
+        <comment userInput="Adding the comment to replace action for preserving Backward Compatibility" stepKey="waitForShippingMethodLoad"/>
+
+        <!--Save Order. -->
+        <actionGroup ref="AdminSubmitOrderActionGroup" stepKey="submitOrder"/>
+        <!--Verify, admin able to download the file for custom option. -->
+        <actionGroup ref="AdminDownloadCustomerOptionFileActionGroup" stepKey="downloadFile" />
     </test>
 </tests>

--- a/app/code/Magento/Sales/Test/Unit/Controller/Download/DownloadCustomOptionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Download/DownloadCustomOptionTest.php
@@ -7,64 +7,30 @@ declare(strict_types=1);
 
 namespace Magento\Sales\Test\Unit\Controller\Download;
 
-use Magento\Backend\App\Action\Context;
-use Magento\Framework\App\Request\Http;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Response\RedirectInterface;
 use Magento\Framework\Controller\Result\Forward;
 use Magento\Framework\Controller\Result\ForwardFactory;
-use Magento\Framework\Serialize\Serializer\Json;
-use Magento\Framework\Unserialize\Unserialize;
-use Magento\Quote\Model\Quote\Item\Option;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Framework\Controller\Result\RedirectFactory;
+use Magento\Sales\Model\Download\CustomOptionInfo;
 use Magento\Sales\Controller\Download\DownloadCustomOption;
 use Magento\Sales\Model\Download;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class DownloadCustomOptionTest extends TestCase
 {
-    /**
-     * Option ID Test Value
-     */
-    const OPTION_ID = '123456';
+    protected const ID = 1;
 
-    /**
-     * Option Code Test Value
-     */
-    const OPTION_CODE = 'option_123456';
+    protected const ORDER_ITEM_ID = 2;
 
-    /**
-     * Option Product ID Value
-     */
-    const OPTION_PRODUCT_ID = 'option_test_product_id';
+    protected const OPTION_ID = 3;
 
-    /**
-     * Option Type Value
-     */
-    const OPTION_TYPE = 'file';
-
-    /**
-     * Option Value Test Value
-     */
-    const OPTION_VALUE = 'option_test_value';
-
-    /**
-     * Option Value Test Value
-     */
-    const SECRET_KEY = 'secret_key';
-
-    /**
-     * @var \Magento\Quote\Model\Quote\Item\Option|MockObject
-     */
-    protected $itemOptionMock;
-
-    /**
-     * @var \Magento\Catalog\Model\Product\Option|MockObject
-     */
-    protected $productOptionMock;
-
-    /**
-     * @var Unserialize|MockObject
-     */
-    protected $serializerMock;
+    protected const SECRET_KEY = 'secret';
 
     /**
      * @var Forward|MockObject
@@ -72,271 +38,196 @@ class DownloadCustomOptionTest extends TestCase
     protected $resultForwardMock;
 
     /**
+     * @var Result|MockObject
+     */
+    protected $resultRedirectMock;
+
+    /**
+     * @var RedirectFactory|MockObject
+     */
+    protected $resultRedirectFactoryMock;
+
+    /**
+     * @var Redirect|MockObject
+     */
+    protected $redirectMock;
+
+    /**
+     * @var RequestInterface|MockObject
+     */
+    protected $requestMock;
+
+    /**
      * @var Download|MockObject
      */
     protected $downloadMock;
+
+    /**
+     * @var MockObject
+     */
+    protected $customOptionInfoMock;
 
     /**
      * @var DownloadCustomOption|MockObject
      */
     protected $objectMock;
 
+    /**
+     * @var ManagerInterface|MockObject
+     */
+    protected $messageManagerMock;
+
     protected function setUp(): void
     {
-        $resultForwardFactoryMock = $this->getMockBuilder(ForwardFactory::class)
+        $this->objectManager = new ObjectManager($this);
+
+        $this->requestMock = $this->getMockBuilder(RequestInterface::class)
+            ->getMock();
+
+        $this->redirectMock = $this->getMockBuilder(RedirectInterface::class)
+            ->getMock();
+
+        $this->resultForwardFactoryMock = $this->getMockBuilder(ForwardFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])
             ->getMock();
-        $this->resultForwardMock = $this->getMockBuilder(Forward::class)
+
+        $this->resultRedirectFactoryMock = $this->getMockBuilder(RedirectFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['forward'])
+            ->onlyMethods(['create'])
             ->getMock();
-        $resultForwardFactoryMock->expects($this->any())->method('create')->willReturn($this->resultForwardMock);
+
+        $this->messageManagerMock = $this->getMockBuilder(ManagerInterface::class)
+            ->getMock();
 
         $this->downloadMock = $this->getMockBuilder(Download::class)
             ->disableOriginalConstructor()
-            ->setMethods(['downloadFile'])
+            ->onlyMethods(['downloadFile'])
             ->getMock();
 
-        $this->serializerMock = $this->getMockBuilder(Json::class)
+        $this->customOptionInfoMock = $this->getMockBuilder(CustomOptionInfo::class)
             ->disableOriginalConstructor()
-            ->setMethods(['serialize', 'unserialize'])
+            ->onlyMethods(['search'])
             ->getMock();
 
-        $requestMock = $this->getMockBuilder(Http::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getParam'])
-            ->getMock();
-        $requestMock->expects($this->any())->method('getParam')
-            ->willReturnMap(
-                [
-                    ['id', null, self::OPTION_ID],
-                    ['key', null, self::SECRET_KEY],
-                ]
-            );
-
-        $this->itemOptionMock = $this->getMockBuilder(Option::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['load', 'getId', 'getCode', 'getProductId', 'getValue'])
-            ->getMock();
-
-        $this->productOptionMock = $this->getMockBuilder(\Magento\Catalog\Model\Product\Option::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['load', 'getId', 'getProductId', 'getType'])
-            ->getMock();
-
-        $objectManagerMock = $this->getMockBuilder(Download::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create'])
-            ->getMock();
-        $objectManagerMock->expects($this->any())->method('create')
-            ->willReturnMap(
-                [
-                    [Option::class, $this->itemOptionMock],
-                    [\Magento\Catalog\Model\Product\Option::class, $this->productOptionMock],
-                ]
-            );
-
-        $contextMock = $this->getMockBuilder(Context::class)
-            ->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    'getRequest',
-                    'getObjectManager',
-                ]
-            )
-            ->getMock();
-        $contextMock->expects($this->once())->method('getObjectManager')->willReturn($objectManagerMock);
-        $contextMock->expects($this->once())->method('getRequest')->willReturn($requestMock);
-
-        $this->objectMock = $this->getMockBuilder(DownloadCustomOption::class)
-            ->setMethods(['endExecute'])
-            ->setConstructorArgs(
-                [
-                    'context'              => $contextMock,
-                    'resultForwardFactory' => $resultForwardFactoryMock,
-                    'download'             => $this->downloadMock,
-                    'unserialize'          => $this->createMock(Unserialize::class),
-                    'serializer'           => $this->serializerMock
-                ]
-            )
-            ->getMock();
+        $this->objectMock = $this->objectManager->getObject(
+            DownloadCustomOption::class,
+            [
+                'request' => $this->requestMock,
+                'redirect' =>  $this->redirectMock,
+                'resultForwardFactory' => $this->resultForwardFactoryMock,
+                'redirectFactory' => $this->resultRedirectFactoryMock,
+                'messageManager' => $this->messageManagerMock,
+                'download' => $this->downloadMock,
+                'searcher' => $this->customOptionInfoMock
+            ]
+        );
     }
 
     /**
-     * @param array $itemOptionValues
-     * @param array $productOptionValues
-     * @param bool $noRouteOccurs
-     * @dataProvider executeDataProvider
+     * @param $orderItemId
+     * @param $optionId
+     * @param $id
+     * @param $secret
+     * @dataProvider getDataProvider
      */
-    public function testExecute($itemOptionValues, $productOptionValues, $noRouteOccurs)
+    public function testExecute($orderItemId, $optionId, $id, $secret)
     {
-        if (!empty($itemOptionValues)) {
-            $this->itemOptionMock->expects($this->once())->method('load')->willReturnSelf();
-            $this->itemOptionMock->expects($this->once())
-                ->method('getId')
-                ->willReturn($itemOptionValues[self::OPTION_ID]);
-            $this->itemOptionMock->expects($this->any())
-                ->method('getCode')
-                ->willReturn($itemOptionValues[self::OPTION_CODE]);
-            $this->itemOptionMock->expects($this->any())
-                ->method('getProductId')
-                ->willReturn($itemOptionValues[self::OPTION_PRODUCT_ID]);
-            $this->itemOptionMock->expects($this->any())
-                ->method('getValue')
-                ->willReturn($itemOptionValues[self::OPTION_VALUE]);
-        }
-        if (!empty($productOptionValues)) {
-            $this->productOptionMock->expects($this->once())->method('load')->willReturnSelf();
-            $this->productOptionMock->expects($this->any())
-                ->method('getId')
-                ->willReturn($productOptionValues[self::OPTION_ID]);
-            $this->productOptionMock->expects($this->any())
-                ->method('getProductId')
-                ->willReturn($productOptionValues[self::OPTION_PRODUCT_ID]);
-            $this->productOptionMock->expects($this->any())
-                ->method('getType')
-                ->willReturn($productOptionValues[self::OPTION_TYPE]);
-        }
-        if ($noRouteOccurs) {
-            $this->resultForwardMock->expects($this->once())->method('forward')->with('noroute')->willReturn(true);
-        } else {
-            $unserializeResult = [self::SECRET_KEY => self::SECRET_KEY];
+        $resultForwardMock = $this->getMockBuilder(Forward::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['forward'])
+            ->getMock();
 
-            $this->serializerMock->expects($this->once())
-                ->method('unserialize')
-                ->with($itemOptionValues[self::OPTION_VALUE])
-                ->willReturn($unserializeResult);
+        $this->resultForwardFactoryMock->expects($this->any())->method('create')->willReturn($resultForwardMock);
 
-            $this->downloadMock->expects($this->once())
-                ->method('downloadFile')
-                ->with($unserializeResult)
-                ->willReturn(true);
+        $resultRedirectMock = $this->getMockBuilder(Redirect::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['setUrl'])
+            ->getMock();
 
-            $this->objectMock->expects($this->once())->method('endExecute')->willReturn(true);
+        $this->resultRedirectFactoryMock->expects($this->any())->method('create')->willReturn($resultRedirectMock);
+
+        $this->requestMock->expects($this->any())
+            ->method('getParam')
+            ->willReturnMap([
+            ['order_item_id', null, $orderItemId ],
+            ['option_id',null, $optionId],
+            ['id', null, $id],
+            ['key', null, $secret]
+        ]);
+
+        $json='
+        {
+            "type": "image\/png",
+            "title": "image.png",
+            "quote_path": "custom_options\/quote\/A\/a\/AAAAA",
+            "order_path": "custom_options\/order\/A\/a\/AAAAA",
+            "fullpath": "\/pub\/media\/custom_options\/quote\/A\/a\/AAAAA",
+            "size": "315404",
+            "width": 400,
+            "height": 532,
+            "secret_key": "secret"
+        }';
+
+        if (!isset($secret)) {
+            $this->customOptionInfoMock->expects($this->once())->method('search')->willReturn(json_decode($json, true));
+            $this->redirectMock->expects($this->once())->method('getRefererUrl')->willReturn('referer_url');
+            $resultRedirectMock->expects($this->once())->method('setUrl')->willReturnSelf();
         }
+
+        if (isset($secret)) {
+            $this->customOptionInfoMock->expects($this->once())->method('search')->willReturn(json_decode($json, true));
+            $this->downloadMock->expects($this->once())->method('downloadFile');
+        }
+
+        if (!isset($id) && (!isset($orderItemId) || !($optionId))) {
+            $this->customOptionInfoMock->expects($this->once())
+                ->method('search')
+                ->willThrowException(new NoSuchEntityException(__("Entity with id 1|2|3 not found")));
+        }
+
         $this->objectMock->execute();
     }
 
-    /**
-     * @return array
-     */
-    public function executeDataProvider()
+    public function getDataProvider()
     {
         return [
-            [ //Good
-                [
-                    self::OPTION_ID => self::OPTION_ID,
-                    self::OPTION_CODE => self::OPTION_CODE,
-                    self::OPTION_PRODUCT_ID => self::OPTION_PRODUCT_ID,
-                    self::OPTION_VALUE => self::OPTION_VALUE
-                ],
-                [
-                    self::OPTION_ID => self::OPTION_ID,
-                    self::OPTION_PRODUCT_ID => self::OPTION_PRODUCT_ID,
-                    self::OPTION_TYPE => self::OPTION_TYPE,
-                ],
-                false
+            [
+                'order_item_id' => self::ORDER_ITEM_ID,
+                'option_id' => self::OPTION_ID,
+                'id' => self::ID,
+                'key' => 'secret'
             ],
-            [ //No Option ID
-                [
-                    self::OPTION_ID => false,
-                    self::OPTION_CODE => self::OPTION_CODE,
-                    self::OPTION_PRODUCT_ID => self::OPTION_PRODUCT_ID,
-                    self::OPTION_VALUE => self::OPTION_VALUE
-                ],
-                [],
-                true
+            [
+                'order_item_id' => null,
+                'option_id' => self::OPTION_ID,
+                'id' => self::ID,
+                'key' => 'secret'
             ],
-            [ //No Product Option
-                [
-                    self::OPTION_ID => self::OPTION_ID,
-                    self::OPTION_CODE => self::OPTION_CODE,
-                    self::OPTION_PRODUCT_ID => self::OPTION_PRODUCT_ID,
-                    self::OPTION_VALUE => self::OPTION_VALUE
-                ],
-                [],
-                true
+            [
+                'order_item_id' => self::ORDER_ITEM_ID,
+                'option_id' => null,
+                'id' => self::ID,
+                'key' => 'secret'
             ],
-            [ //No Product Option ID
-                [
-                    self::OPTION_ID => self::OPTION_ID,
-                    self::OPTION_CODE => self::OPTION_CODE,
-                    self::OPTION_PRODUCT_ID => self::OPTION_PRODUCT_ID,
-                    self::OPTION_VALUE => self::OPTION_VALUE
-                ],
-                [
-                    self::OPTION_ID => null,
-                    self::OPTION_PRODUCT_ID => self::OPTION_PRODUCT_ID,
-                    self::OPTION_TYPE => self::OPTION_TYPE,
-                ],
-                true
+            [
+                'order_item_id' => self::ORDER_ITEM_ID,
+                'option_id' => self::OPTION_ID,
+                'id' => null,
+                'key' => 'secret'
             ],
-            [ //Not Matching Product IDs in Inventory Option
-                [
-                    self::OPTION_ID => self::OPTION_ID,
-                    self::OPTION_CODE => self::OPTION_CODE,
-                    self::OPTION_PRODUCT_ID => 'bad_test_product_ID',
-                    self::OPTION_VALUE => self::OPTION_VALUE
-                ],
-                [
-                    self::OPTION_ID => self::OPTION_ID,
-                    self::OPTION_PRODUCT_ID => self::OPTION_PRODUCT_ID,
-                    self::OPTION_TYPE => self::OPTION_TYPE,
-                ],
-                true
+            [
+                'order_item_id' => self::ORDER_ITEM_ID,
+                'option_id' => self::OPTION_ID,
+                'id' => self::ID,
+                'secret' => null
             ],
-            [ //Not Matching Product IDs in Product Option
-                [
-                    self::OPTION_ID => self::OPTION_ID,
-                    self::OPTION_CODE => self::OPTION_CODE,
-                    self::OPTION_PRODUCT_ID => self::OPTION_PRODUCT_ID,
-                    self::OPTION_VALUE => self::OPTION_VALUE
-                ],
-                [
-                    self::OPTION_ID => self::OPTION_ID,
-                    self::OPTION_PRODUCT_ID => 'bad_test_product_ID',
-                    self::OPTION_TYPE => self::OPTION_TYPE,
-                ],
-                true
-            ],
-            [ //Incorrect Option Type
-                [
-                    self::OPTION_ID => self::OPTION_ID,
-                    self::OPTION_CODE => self::OPTION_CODE,
-                    self::OPTION_PRODUCT_ID => self::OPTION_PRODUCT_ID,
-                    self::OPTION_VALUE => self::OPTION_VALUE
-                ],
-                [
-                    self::OPTION_ID => self::OPTION_ID,
-                    self::OPTION_PRODUCT_ID => self::OPTION_PRODUCT_ID,
-                    self::OPTION_TYPE => 'bad_test_option_type',
-                ],
-                true
-            ],
+            [ //exceptions
+                'order_item_id' => null,
+                'option_id' => null,
+                'id' => null,
+                'secret' => null
+            ]
         ];
-    }
-
-    public function testExecuteBadSecretKey()
-    {
-        $this->itemOptionMock->expects($this->once())->method('load')->willReturnSelf();
-        $this->itemOptionMock->expects($this->once())->method('getId')->willReturn(self::OPTION_ID);
-        $this->itemOptionMock->expects($this->any())->method('getCode')->willReturn(self::OPTION_CODE);
-        $this->itemOptionMock->expects($this->any())->method('getProductId')->willReturn(self::OPTION_PRODUCT_ID);
-        $this->itemOptionMock->expects($this->any())->method('getValue')->willReturn(self::OPTION_VALUE);
-
-        $this->productOptionMock->expects($this->once())->method('load')->willReturnSelf();
-        $this->productOptionMock->expects($this->any())->method('getId')->willReturn(self::OPTION_ID);
-        $this->productOptionMock->expects($this->any())->method('getProductId')->willReturn(self::OPTION_PRODUCT_ID);
-        $this->productOptionMock->expects($this->any())->method('getType')->willReturn(self::OPTION_TYPE);
-
-        $this->serializerMock->expects($this->once())
-            ->method('unserialize')
-            ->with(self::OPTION_VALUE)
-            ->willReturn([self::SECRET_KEY => 'bad_test_secret_key']);
-
-        $this->resultForwardMock->expects($this->once())->method('forward')->with('noroute')->willReturn(true);
-
-        $this->objectMock->execute();
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/Download/CustomOptionInfoTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Download/CustomOptionInfoTest.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Test\Unit\Model\Download;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Sales\Model\Order\ItemRepository;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Catalog\Model\Product\OptionFactory as ProductOptionFactory;
+use Magento\Quote\Model\Quote\Item\OptionFactory as QuoteItemOptionFactory;
+use Magento\Quote\Model\Quote\Item\Option as QuoteItemOption;
+use Magento\Catalog\Model\Product\Option as ProductOption;
+use Magento\Sales\Model\Order\Item as OrderItem;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Sales\Model\Download\CustomOptionInfo;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CustomOptionInfoTest extends TestCase
+{
+    /**
+     * @var MockObject
+     */
+    protected $orderItemRepository;
+
+    /**
+     * @var MockObject
+     */
+    protected $productOptionFactory;
+
+    /**
+     * @var MockObject
+     */
+    protected $quoteItemOptionFactory;
+
+    /**
+     * @var MockObject
+     */
+    protected $serializer;
+
+    /**
+     * @var string
+     */
+    protected $json;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = new ObjectManager($this);
+        $this->orderItemRepository = $this->getMockBuilder(ItemRepository::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['get'])
+            ->getMock();
+        $this->productOptionFactory = $this->getMockBuilder(ProductOptionFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
+            ->getMock();
+        $this->quoteItemOptionFactory = $this->getMockBuilder(QuoteItemOptionFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
+            ->getMock();
+        $this->serializer = $this->getMockBuilder(Json::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testSearchCustomOptionByQuoteItemId() : void
+    {
+        $quoteItemid = 123;
+        $orderItemId = 0;
+        $optionId = 0;
+
+        $customOptionInfoModel = $this->objectManager->getObject(
+            CustomOptionInfo::class,
+            [
+                'orderItemRepository' => $this->orderItemRepository,
+                'productOptionFactory' => $this->productOptionFactory,
+                'quoteItemOptionFactory' => $this->quoteItemOptionFactory,
+                'serializer' => $this->serializer
+            ]
+        );
+
+        $quoteItemOption = $this->getMockBuilder(QuoteItemOption::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['load', 'getId', 'getValue'])
+            ->addMethods(['getCode'])
+            ->getMock();
+
+        $productOption = $this->getMockBuilder(ProductOption::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['load', 'getId', 'getType'])
+            ->getMock();
+
+        $this->quoteItemOptionFactory->expects($this->once())->method('create')->willReturn($quoteItemOption);
+        $quoteItemOption->expects($this->once())->method('load')->willReturn($quoteItemOption);
+        $quoteItemOption->expects($this->once())->method('getId')->willReturn(123);
+        $quoteItemOption->expects($this->any())->method('getCode')->willReturn('option_2');
+
+        $this->productOptionFactory->expects($this->once())->method('create')->willReturn($productOption);
+        $productOption->expects($this->once())->method('load')->willReturn($productOption);
+        $productOption->expects($this->once())->method('getId')->willReturn(1234);
+        $productOption->expects($this->once())->method('getType')->willReturn('file');
+
+        $json='
+        {
+            "type": "image\/jpeg",
+            "title": "image001.jpg",
+            "quote_path": "custom_options\/quote\/A\/A\/AAAAA",
+            "order_path": "custom_options\/order\/A\/A\/AAAAA",
+            "fullpath": "/pub\/media\/custom_options\/quote\/A\/A\/AAAAAA",
+            "size": "14478",
+            "width": 426,
+            "height": 288,
+            "secret_key": "AAAAA"
+        }';
+
+        $quoteItemOption->expects($this->any())->method('getValue')->willReturn($json);
+
+        $this->serializer->expects($this->once())->method('unserialize')->willReturn(json_decode($json));
+
+        $customOptionInfoModel->search($quoteItemid, $orderItemId, $optionId);
+    }
+
+    public function testSearchCustomOptionByOrder() : void
+    {
+
+        $quoteItemid = 0;
+        $orderItemId = 123;
+        $optionId = 1234;
+
+        $customOptionInfoModel = $this->objectManager->getObject(
+            CustomOptionInfo::class,
+            [
+                'orderItemRepository' => $this->orderItemRepository,
+                'productOptionFactory' => $this->productOptionFactory,
+                'quoteItemOptionFactory' => $this->quoteItemOptionFactory,
+                'serializer' => $this->serializer
+            ]
+        );
+
+        $json='
+        {
+            "info_buyRequest": {
+                "uenc": "AAAAA,,",
+                "product": "1",
+                "selected_configurable_option": "",
+                "related_product": "",
+                "item": "1",
+                "qty": "1",
+                "options": {
+                    "2": {
+                        "type": "image\/png",
+                        "title": "image.png",
+                        "quote_path": "custom_options\/quote\/A\/a\/AAAAA",
+                        "order_path": "custom_options\/order\/A\/a\/AAAAA",
+                        "fullpath": "/pub\/media\/custom_options\/quote\/A\/a\/AAAAA",
+                        "size": "315404",
+                        "width": 400,
+                        "height": 532,
+                        "secret_key": "AAAAA"
+                    }
+                }
+            }
+        }';
+
+        $productOption = json_decode($json, true);
+
+        $orderItem = $this->getMockBuilder(OrderItem::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getProductOptions'])
+            ->getMock();
+
+        $this->orderItemRepository->expects($this->once())->method('get')->willReturn($orderItem);
+        $orderItem->expects($this->once())->method('getProductOptions')->willReturn($productOption);
+
+        $customOptionInfoModel->search($quoteItemid, $orderItemId, $optionId);
+    }
+
+    public function testSearchCustomOptionWithNoQuoteItemId() : void
+    {
+        $quoteItemid = 0;
+        $orderItemId = 0;
+        $optionId = 0;
+
+        $customOptionInfoModel = $this->objectManager->getObject(
+            CustomOptionInfo::class,
+            [
+                'orderItemRepository' => $this->orderItemRepository,
+                'productOptionFactory' => $this->productOptionFactory,
+                'quoteItemOptionFactory' => $this->quoteItemOptionFactory,
+                'serializer' => $this->serializer
+            ]
+        );
+
+        $quoteItemOption = $this->getMockBuilder(QuoteItemOption::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['load', 'getId'])
+            ->getMock();
+
+        $this->quoteItemOptionFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($quoteItemOption);
+
+        $quoteItemOption->expects($this->once())->method('load')->willReturn($quoteItemOption);
+        $quoteItemOption->expects($this->once())->method('getId')->willReturn(null);
+        $this->expectException(NoSuchEntityException::class);
+
+        $customOptionInfoModel->search($quoteItemid, $orderItemId, $optionId);
+    }
+
+    public function testSearchCustomOptionWithNoProductOption() : void
+    {
+        $quoteItemid = 123;
+        $orderItemId = 0;
+        $optionId = 0;
+
+        $customOptionInfoModel = $this->objectManager->getObject(
+            CustomOptionInfo::class,
+            [
+                'orderItemRepository' => $this->orderItemRepository,
+                'productOptionFactory' => $this->productOptionFactory,
+                'quoteItemOptionFactory' => $this->quoteItemOptionFactory,
+                'serializer' => $this->serializer
+            ]
+        );
+
+        $quoteItemOption = $this->getMockBuilder(QuoteItemOption::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['load', 'getId', 'getValue'])
+            ->addMethods(['getCode'])
+            ->getMock();
+
+        $productOption = $this->getMockBuilder(ProductOption::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['load', 'getId', 'getType'])
+            ->getMock();
+
+        $this->quoteItemOptionFactory->expects($this->once())->method('create')->willReturn($quoteItemOption);
+        $quoteItemOption->expects($this->once())->method('load')->willReturn($quoteItemOption);
+        $quoteItemOption->expects($this->once())->method('getId')->willReturn(123);
+        $quoteItemOption->expects($this->any())->method('getCode')->willReturn('option_2');
+
+        $this->productOptionFactory->expects($this->once())->method('create')->willReturn($productOption);
+        $productOption->expects($this->once())->method('load')->willReturn($productOption);
+        $productOption->expects($this->once())->method('getId')->willReturn(null);
+        $this->expectException(NoSuchEntityException::class);
+
+        $customOptionInfoModel->search($quoteItemid, $orderItemId, $optionId);
+    }
+
+    public function testSearchCustomOptionWithDifferentType() : void
+    {
+        $quoteItemid = 123;
+        $orderItemId = 0;
+        $optionId = 0;
+
+        $customOptionInfoModel = $this->objectManager->getObject(
+            CustomOptionInfo::class,
+            [
+                'orderItemRepository' => $this->orderItemRepository,
+                'productOptionFactory' => $this->productOptionFactory,
+                'quoteItemOptionFactory' => $this->quoteItemOptionFactory,
+                'serializer' => $this->serializer
+            ]
+        );
+
+        $quoteItemOption = $this->getMockBuilder(QuoteItemOption::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['load', 'getId', 'getValue'])
+            ->addMethods(['getCode'])
+            ->getMock();
+
+        $productOption = $this->getMockBuilder(ProductOption::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['load', 'getId', 'getType'])
+            ->getMock();
+
+        $this->quoteItemOptionFactory->expects($this->once())->method('create')->willReturn($quoteItemOption);
+        $quoteItemOption->expects($this->once())->method('load')->willReturn($quoteItemOption);
+        $quoteItemOption->expects($this->once())->method('getId')->willReturn(123);
+        $quoteItemOption->expects($this->any())->method('getCode')->willReturn('option_2');
+
+        $this->productOptionFactory->expects($this->once())->method('create')->willReturn($productOption);
+        $productOption->expects($this->once())->method('load')->willReturn($productOption);
+        $productOption->expects($this->once())->method('getId')->willReturn(123);
+        $productOption->expects($this->once())->method('getType')->willReturn('int');
+        $this->expectException(LocalizedException::class);
+
+        $customOptionInfoModel->search($quoteItemid, $orderItemId, $optionId);
+    }
+}

--- a/app/code/Magento/Sales/view/adminhtml/templates/items/column/name.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/items/column/name.phtml
@@ -32,7 +32,7 @@ $catalogHelper = $block->getData('catalogHelper');
                 <dt><?= $block->escapeHtml($_option['label']) ?>:</dt>
                 <dd>
                     <?php if (isset($_option['custom_view']) && $_option['custom_view']): ?>
-                        <?= /* @noEscape */ $block->getCustomizedOptionValue($_option) ?>
+                        <?= /* @noEscape */ $block->getCustomizedOptionValue($_option, $_item->getItemId()) ?>
                     <?php else: ?>
                         <?php $_option = $block->getFormattedOption($_option['value']); ?>
                         <?php $dots = 'dots' . uniqid(); ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/items/renderer/default.phtml
@@ -15,7 +15,7 @@ $_item = $block->getItem();
             <?php foreach ($_options as $_option): ?>
                 <dt><?= $block->escapeHtml($_option['label']) ?></dt>
                 <?php if (!$block->getPrintStatus()): ?>
-                    <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
+                    <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option, $_item->getId()) ?>
                     <dd<?= (isset($_formatedOptionValue['full_view']) ? ' class="tooltip wrapper"' : '') ?>>
                         <?= $block->escapeHtml($_formatedOptionValue['value'], ['a']) ?>
                         <?php if (isset($_formatedOptionValue['full_view'])): ?>


### PR DESCRIPTION
### Description (*)
The PR solves the issue for the attributes of the file type that keeps a strong relation with quote data even after the order has been placed. The attribute file URL is saved based on quote data that disappear after the cart has been deleted after his expiration time end up

### Fixed Issues
1. Fixes magento/magento2#29957

### Manual testing scenarios (*)
See #29957 

### Questions or comments
I was able to reproduce and fix the issue in the palliative way. I am writing it because the URL is being saved on the database wrapped in a JSON database field (`product_options`). In my option that URL should not have been saved in the database because that one can be built easily through the data (Option ID, Quote Item ID, Order Item ID).

Therefore I am using that data to build the URL when accessing the URL via order item. I have refactored the controller responsible for the download in order to make it compatible for both the approaches:
1) Static URLs saved on the database when accessing via Quote items, 
2) Dynamic URLs when accessing via the order items

I am not sure if that is the best solution for the issue, maybe change the way like file options are saved should be the best option. But for now, that was the solution that I could provide.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
