### PR TITLE
Invoice for an order that contains only one configurable product is not generated correctly

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Invoice.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice.php
@@ -679,6 +679,11 @@ class Invoice extends AbstractModel implements EntityInterface, InvoiceInterface
     public function isLast()
     {
         foreach ($this->getAllItems() as $item) {
+            $orderItem = $item->getOrderItem();
+            if ($orderItem->isDummy()) {
+                continue;
+            }
+
             if (!$item->isLast()) {
                 return false;
             }

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/InvoiceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/InvoiceTest.php
@@ -3,20 +3,57 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Sales\Model\Order;
 
-class InvoiceTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Sales\Model\ResourceModel\Order\Collection as OrderCollection;
+use Magento\Sales\Api\InvoiceManagementInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+
+/**
+ * Invoice model test.
+ */
+class InvoiceTest extends TestCase
 {
     /**
-     * @var \Magento\Sales\Model\ResourceModel\Order\Collection
+     * @var \Magento\Framework\ObjectManagerInterface
      */
-    private $_collection;
+    private $objectManager;
 
+    /**
+     * @var OrderCollection
+     */
+    private $collection;
+
+    /**
+     * @var InvoiceManagementInterface
+     */
+    private $invoiceManagement;
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
-        $this->_collection = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-            \Magento\Sales\Model\ResourceModel\Order\Collection::class
-        );
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->collection = $this->objectManager->create(OrderCollection::class);
+        $this->invoiceManagement = $this->objectManager->get(InvoiceManagementInterface::class);
+        $this->orderRepository = $this->objectManager->get(OrderRepositoryInterface::class);
+        $this->searchCriteriaBuilder = $this->objectManager->get(SearchCriteriaBuilder::class);
     }
 
     /**
@@ -27,9 +64,27 @@ class InvoiceTest extends \PHPUnit\Framework\TestCase
         $expectedResult = [['total_item_count' => 1]];
         $actualResult = [];
         /** @var \Magento\Sales\Model\Order $order */
-        foreach ($this->_collection->getItems() as $order) {
+        foreach ($this->collection->getItems() as $order) {
             $actualResult[] = ['total_item_count' => $order->getData('total_item_count')];
         }
         $this->assertEquals($expectedResult, $actualResult);
+    }
+
+    /**
+     * Test order with exactly one configurable.
+     *
+     * @return void
+     * @magentoDataFixture Magento/Sales/_files/order_configurable_product.php
+     */
+    public function testLastInvoiceWithConfigurable(): void
+    {
+        $searchCriteria = $this->searchCriteriaBuilder->addFilter('increment_id', '100000001')
+            ->create();
+        $orders = $this->orderRepository->getList($searchCriteria);
+        $orders = $orders->getItems();
+        $order = array_shift($orders);
+        $invoice = $this->invoiceManagement->prepareInvoice($order);
+
+        self::assertEquals($invoice->isLast(), true);
     }
 }


### PR DESCRIPTION
### Description (*)
When you placing exactly one configurable option two order items appears in order model - one of them is dummy, that just provides useful information about the order. Such kind of dummy items are defined as not the last in invoice model that brings us wrong flow of a total calculation.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#31143

### Manual testing scenarios (*)
**Preconditions**
1. CE 2.4-develop version
2. Install extension module with feature which can add extra fee on order, for example - https://github.com/mageprince/magento2-paymentfee
3. Add a tax rule
4. Create configurable product
5. Add extra fee on orders, for example - Price type : fixed price, Payment method fee:
payment method code: "checkmo", fee amount: "30"
Calculate tax: yes
**Steps**
1. Place order with one of options of configurable product, so that the Tax Rule will apply
2. As Admin try create an Invoice

 **Expected result**
Extra payment fee created by the module includes the Tax from the Tax Rule.

 **Actual result**
Extra payment fee created by the module doesn't include the Tax from the Tax Rule

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
