### PR TITLE
MC-30104: When using MysqlMQ messages are always set to complete even if exception occurs

### DIFF
--- a/dev/tests/integration/_files/Magento/TestModuleMysqlMq/Model/Processor.php
+++ b/dev/tests/integration/_files/Magento/TestModuleMysqlMq/Model/Processor.php
@@ -5,13 +5,16 @@
  */
 namespace Magento\TestModuleMysqlMq\Model;
 
+use LogicException;
+use Magento\Framework\MessageQueue\ConnectionLostException;
+
 /**
  * Test message processor is used by \Magento\MysqlMq\Model\PublisherConsumerTest
  */
 class Processor
 {
     /**
-     * @param \Magento\TestModuleMysqlMq\Model\DataObject $message
+     * @param DataObject $message
      */
     public function processMessage($message)
     {
@@ -23,7 +26,7 @@ class Processor
     }
 
     /**
-     * @param \Magento\TestModuleMysqlMq\Model\DataObject $message
+     * @param DataObject $message
      */
     public function processObjectCreated($message)
     {
@@ -35,7 +38,7 @@ class Processor
     }
 
     /**
-     * @param \Magento\TestModuleMysqlMq\Model\DataObject $message
+     * @param DataObject $message
      */
     public function processCustomObjectCreated($message)
     {
@@ -47,7 +50,7 @@ class Processor
     }
 
     /**
-     * @param \Magento\TestModuleMysqlMq\Model\DataObject $message
+     * @param DataObject $message
      */
     public function processObjectUpdated($message)
     {
@@ -59,13 +62,23 @@ class Processor
     }
 
     /**
-     * @param \Magento\TestModuleMysqlMq\Model\DataObject $message
+     * @param DataObject $message
      */
     public function processMessageWithException($message)
     {
         file_put_contents($message->getOutputPath(), "Exception processing {$message->getEntityId()}");
-        throw new \LogicException(
+        throw new LogicException(
             "Exception during message processing happened. Entity: {{$message->getEntityId()}}"
+        );
+    }
+
+    /**
+     * @throws ConnectionLostException
+     */
+    public function processMessageWithConnectionException()
+    {
+        throw new ConnectionLostException(
+            "Connection exception during message processing happened."
         );
     }
 }

--- a/dev/tests/integration/_files/Magento/TestModuleMysqlMq/etc/communication.xml
+++ b/dev/tests/integration/_files/Magento/TestModuleMysqlMq/etc/communication.xml
@@ -7,6 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Communication/etc/communication.xsd">
     <topic name="demo.exception" request="Magento\TestModuleMysqlMq\Model\DataObject"/>
+    <topic name="demo.connection.exception" request="Magento\TestModuleMysqlMq\Model\DataObject"/>
     <topic name="test.schema.defined.by.method" schema="Magento\TestModuleMysqlMq\Model\DataObjectRepository::delayedOperation" is_synchronous="false"/>
     <topic name="demo.object.created" request="Magento\TestModuleMysqlMq\Model\DataObject"/>
     <topic name="demo.object.updated" request="Magento\TestModuleMysqlMq\Model\DataObject"/>

--- a/dev/tests/integration/_files/Magento/TestModuleMysqlMq/etc/queue.xml
+++ b/dev/tests/integration/_files/Magento/TestModuleMysqlMq/etc/queue.xml
@@ -9,6 +9,9 @@
     <broker topic="demo.exception" type="db" exchange="magento">
         <queue consumer="demoConsumerWithException" name="queue-exception" handler="Magento\TestModuleMysqlMq\Model\Processor::processMessageWithException"/>
     </broker>
+    <broker topic="demo.connection.exception" type="db" exchange="magento">
+        <queue consumer="demoConsumerWithConnectionException" name="queue-connection-exception" handler="Magento\TestModuleMysqlMq\Model\Processor::processMessageWithConnectionException"/>
+    </broker>
     <broker topic="test.schema.defined.by.method" type="db" exchange="magento">
         <queue consumer="delayedOperationConsumer" name="demo-queue-6" handler="Magento\TestModuleMysqlMq\Model\DataObjectRepository::delayedOperation"/>
     </broker>

--- a/dev/tests/integration/_files/Magento/TestModuleMysqlMq/etc/queue_consumer.xml
+++ b/dev/tests/integration/_files/Magento/TestModuleMysqlMq/etc/queue_consumer.xml
@@ -10,5 +10,6 @@
     <consumer name="demoConsumerQueueTwo" queue="queue-updated" connection="db" handler="Magento\TestModuleMysqlMq\Model\Processor::processObjectUpdated"/>
     <consumer name="demoConsumerQueueThree" queue="queue-custom-created" connection="db" handler="Magento\TestModuleMysqlMq\Model\Processor::processCustomObjectCreated"/>
     <consumer name="demoConsumerWithException" queue="queue-exception" connection="db" handler="Magento\TestModuleMysqlMq\Model\Processor::processMessageWithException"/>
+    <consumer name="demoConsumerWithConnectionException" queue="queue-connection-exception" connection="db" handler="Magento\TestModuleMysqlMq\Model\Processor::processMessageWithConnectionException"/>
     <consumer name="delayedOperationConsumer" queue="demo-queue-6" connection="db" handler="Magento\TestModuleMysqlMq\Model\DataObjectRepository::delayedOperation"/>
 </config>

--- a/dev/tests/integration/_files/Magento/TestModuleMysqlMq/etc/queue_publisher.xml
+++ b/dev/tests/integration/_files/Magento/TestModuleMysqlMq/etc/queue_publisher.xml
@@ -9,6 +9,9 @@
     <publisher topic="demo.exception">
         <connection name="db" exchange="magento"/>
     </publisher>
+    <publisher topic="demo.connection.exception">
+        <connection name="db" exchange="magento"/>
+    </publisher>
     <publisher topic="test.schema.defined.by.method">
         <connection name="db" exchange="magento"/>
     </publisher>

--- a/dev/tests/integration/_files/Magento/TestModuleMysqlMq/etc/queue_topology.xml
+++ b/dev/tests/integration/_files/Magento/TestModuleMysqlMq/etc/queue_topology.xml
@@ -9,6 +9,7 @@
 
     <exchange name="magento" type="topic" connection="db">
         <binding id="demo.exception.consumer" topic="demo.exception" destination="queue-exception" destinationType="queue"/>
+        <binding id="demo.connection.exception.consumer" topic="demo.connection.exception" destination="queue-connection-exception" destinationType="queue"/>
         <binding id="test.schema.defined.by.method" topic="test.schema.defined.by.method" destination="demo-queue-6" destinationType="queue"/>
         <binding id="demo.object.created" topic="demo.object.created" destination="queue-created" destinationType="queue"/>
         <binding id="demo.object.updated" topic="demo.object.updated" destination="queue-updated" destinationType="queue"/>

--- a/dev/tests/integration/testsuite/Magento/MessageQueue/Model/ConsumerTest.php
+++ b/dev/tests/integration/testsuite/Magento/MessageQueue/Model/ConsumerTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MessageQueue\Model;
+
+use Magento\Framework\MessageQueue\Consumer;
+use Magento\Framework\MessageQueue\ConsumerFactory;
+use Magento\Framework\MessageQueue\EnvelopeFactory;
+use Magento\Framework\MessageQueue\QueueInterface;
+use Magento\MysqlMq\Model\QueueManagement;
+use Magento\MysqlMq\Model\ResourceModel\Queue;
+use Magento\TestFramework\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the different cases of consumers running by Consumer processor
+ */
+class ConsumerTest extends TestCase
+{
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var Consumer
+     */
+    private $model;
+
+    /**
+     * @var Queue
+     */
+    private $queueResource;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->objectManager = ObjectManager::getInstance();
+        /** @var ConsumerFactory $factory */
+        $factory = $this->objectManager->get(ConsumerFactory::class);
+        $this->model = $factory->get('demoConsumerWithConnectionException');
+        $this->queueResource = $this->objectManager->get(Queue::class);
+    }
+
+    /**
+     * Test if after connection exception and retry
+     * message doesn't have success status but still has status in progress
+     *
+     * @return void
+     */
+    public function testRunWithException(): void
+    {
+        /** @var EnvelopeFactory $envelopFactory */
+        $envelopFactory = $this->objectManager->get(EnvelopeFactory::class);
+        $messageBody = '{"name":"test"}';
+        $topicName = 'demo.connection.exception';
+        $queueName = 'queue-connection-exception';
+        $envelope = $envelopFactory->create(['body' => $messageBody, 'properties' => ['topic_name' => $topicName]]);
+        /** @var QueueInterface $queue */
+        $queue = $this->objectManager->create(
+            \Magento\MysqlMq\Model\Driver\Queue::class,
+            ['queueName' => $queueName]
+        );
+        $queue->push($envelope);
+        $messages = $this->queueResource->getMessages($queueName, 1);
+        $envelope = $envelopFactory->create(['body' => $messageBody, 'properties' => $messages[0]]);
+        $this->model->process(1);
+        $queue->reject($envelope);
+        $this->model->process(1);
+        $message = $this->getLastMessage($queueName);
+        $this->assertEquals(QueueManagement::MESSAGE_STATUS_IN_PROGRESS, $message['status']);
+    }
+
+    /**
+     * Return last message by queue name
+     *
+     * @param string $queueName
+     * @return array
+     */
+    private function getLastMessage(string $queueName)
+    {
+        $connection = $this->queueResource->getConnection();
+        $select = $connection->select()
+            ->from(
+                ['queue_message' => $this->queueResource->getTable('queue_message')],
+                []
+            )->join(
+                ['queue_message_status' => $this->queueResource->getTable('queue_message_status')],
+                'queue_message.id = queue_message_status.message_id',
+                [
+                    QueueManagement::MESSAGE_QUEUE_RELATION_ID => 'id',
+                    QueueManagement::MESSAGE_STATUS => 'status',
+                ]
+            )->join(
+                ['queue' => $this->queueResource->getTable('queue')],
+                'queue.id = queue_message_status.queue_id',
+                [QueueManagement::MESSAGE_QUEUE_NAME => 'name']
+            )->where('queue.name = ?', $queueName)
+            ->order(['queue_message_status.id DESC']);
+
+        return $connection->fetchRow($select);
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/MessageQueue/Model/ResourceModel/LockTest.php
+++ b/dev/tests/integration/testsuite/Magento/MessageQueue/Model/ResourceModel/LockTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\MessageQueue\Model\ResourceModel;
+
+use Magento\Framework\MessageQueue\LockInterface;
+use Magento\TestFramework\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers Lock resource model test cases
+ */
+class LockTest extends TestCase
+{
+    public function testSaveLock()
+    {
+        $objectManager = ObjectManager::getInstance();
+        /** @var Lock $resourceModel */
+        $resourceModel = $objectManager->get(Lock::class);
+        $lock = $objectManager->create(LockInterface::class);
+        $resourceModel->saveLock($lock);
+        self::assertNotEquals(null, $lock->getId());
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Stores lock id in lock object after creation
### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#18140

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add to \Magento\Catalog\Model\Attribute\Backend\Consumer::process exception throw
2. Create product
3. Update attribute by massaction
4. perform cron:run 3 times command in case if cron is not installed
#### Expected result:
Status of message in queue_message_status table = 6 (error)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
