### PR TITLE
show or hide password widget created

### DIFF
--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerEditFormPasswordFieldActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertCustomerEditFormPasswordFieldActionGroup.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertCustomerEditFormPasswordFieldActionGroup">
+        <annotations>
+            <description>Validate the password is visible as plain text in customer account edit form.</description>
+        </annotations>
+        <arguments>
+            <argument name="passwordFieldType" type="string" defaultValue="text"/>
+        </arguments>
+
+        <assertElementContainsAttribute stepKey="assertCurrentPasswordFieldType">
+            <expectedResult selector="{{StorefrontCustomerAccountInformationSection.currentPassword}}" attribute="type" type="string">{{passwordFieldType}}</expectedResult>
+        </assertElementContainsAttribute>
+        <assertElementContainsAttribute stepKey="assertNewPasswordFieldType">
+            <expectedResult selector="{{StorefrontCustomerAccountInformationSection.newPassword}}" attribute="type" type="string">{{passwordFieldType}}</expectedResult>
+        </assertElementContainsAttribute>
+        <assertElementContainsAttribute stepKey="assertConfirmNewPasswordFieldType">
+            <expectedResult selector="{{StorefrontCustomerAccountInformationSection.confirmNewPassword}}" attribute="type" type="string">{{passwordFieldType}}</expectedResult>
+        </assertElementContainsAttribute>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertLoginFormPasswordFieldActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertLoginFormPasswordFieldActionGroup.xml
@@ -8,17 +8,16 @@
 
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
-    <actionGroup name="AssertPasswordFieldActionGroup">
+    <actionGroup name="AssertLoginFormPasswordFieldActionGroup">
         <annotations>
-            <description>Validate the password is visible as plain text.</description>
+            <description>Validate the password is visible as plain text in login form.</description>
         </annotations>
         <arguments>
-            <argument name="fieldSelector" type="string"/>
             <argument name="passwordFieldType" type="string" defaultValue="text"/>
         </arguments>
 
         <assertElementContainsAttribute stepKey="assertPasswordFieldType">
-            <expectedResult selector="{{fieldSelector}}" attribute="type" type="string">{{passwordFieldType}}</expectedResult>
+            <expectedResult selector="{{StorefrontCustomerSignInFormSection.passwordField}}" attribute="type" type="string">{{passwordFieldType}}</expectedResult>
         </assertElementContainsAttribute>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertPasswordFieldActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertPasswordFieldActionGroup.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertPasswordFieldActionGroup">
+        <annotations>
+            <description>Validate the password is visible as plain text.</description>
+        </annotations>
+        <arguments>
+            <argument name="fieldSelector" type="string"/>
+            <argument name="passwordFieldType" type="string" defaultValue="text"/>
+        </arguments>
+
+        <assertElementContainsAttribute stepKey="assertPasswordFieldType">
+            <expectedResult selector="{{fieldSelector}}" attribute="type" type="string">{{passwordFieldType}}</expectedResult>
+        </assertElementContainsAttribute>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertRegistrationFormPasswordFieldActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/AssertRegistrationFormPasswordFieldActionGroup.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertRegistrationFormPasswordFieldActionGroup">
+        <annotations>
+            <description>Validate the password is visible as plain text on customer registration form.</description>
+        </annotations>
+        <arguments>
+            <argument name="passwordFieldType" type="string" defaultValue="text"/>
+        </arguments>
+
+        <assertElementContainsAttribute stepKey="assertPasswordFieldType">
+            <expectedResult selector="{{StorefrontCustomerCreateFormSection.passwordField}}" attribute="type" type="string">{{passwordFieldType}}</expectedResult>
+        </assertElementContainsAttribute>
+        <assertElementContainsAttribute stepKey="assertConfirmPasswordFieldType">
+            <expectedResult selector="{{StorefrontCustomerCreateFormSection.confirmPasswordField}}" attribute="type" type="string">{{passwordFieldType}}</expectedResult>
+        </assertElementContainsAttribute>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickShowPasswordActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickShowPasswordActionGroup.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontClickShowPasswordActionGroup">
+        <annotations>
+            <description>Click on the show password checkbox</description>
+        </annotations>
+        <arguments>
+            <argument name="fieldSelector" type="string"/>
+        </arguments>
+        
+        <click stepKey="clickShowPasswordCheckbox" selector="{{fieldSelector}}"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickShowPasswordActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickShowPasswordActionGroup.xml
@@ -14,8 +14,11 @@
         </annotations>
         <arguments>
             <argument name="fieldSelector" type="string"/>
+            <argument name="passwordFieldSelector" type="string"/>
         </arguments>
         
-        <click stepKey="clickShowPasswordCheckbox" selector="{{fieldSelector}}"/>
+        <conditionalClick stepKey="clickShowPasswordCheckbox" selector="{{fieldSelector}}" dependentSelector="{{fieldSelector}}" visible="true"/>
+        <grabAttributeFrom userInput="type" selector="{{passwordFieldSelector}}" stepKey="grabInputType"/>
+        <return value="{$grabInputType}" stepKey="returnPasswordFieldType"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickShowPasswordActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickShowPasswordActionGroup.xml
@@ -14,11 +14,8 @@
         </annotations>
         <arguments>
             <argument name="fieldSelector" type="string"/>
-            <argument name="passwordFieldSelector" type="string"/>
         </arguments>
         
-        <conditionalClick stepKey="clickShowPasswordCheckbox" selector="{{fieldSelector}}" dependentSelector="{{fieldSelector}}" visible="true"/>
-        <grabAttributeFrom userInput="type" selector="{{passwordFieldSelector}}" stepKey="grabInputType"/>
-        <return value="{$grabInputType}" stepKey="returnPasswordFieldType"/>
+        <click stepKey="clickShowPasswordCheckbox" selector="{{fieldSelector}}"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerEditFormClickShowPasswordActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerEditFormClickShowPasswordActionGroup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontCustomerEditFormClickShowPasswordActionGroup">
+        <annotations>
+            <description>Click on the show password checkbox in customer account information form</description>
+        </annotations>
+
+        <click stepKey="clickShowPasswordCheckbox" selector="{{StorefrontCustomerAccountInformationSection.showPasswordCheckbox}}"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontFillChangePasswordFormActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontFillChangePasswordFormActionGroup.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontFillChangePasswordFormActionGroup">
+        <annotations>
+            <description>Fills in the provided Customer details on the Storefront Customer change password form.</description>
+        </annotations>
+        <arguments>
+            <argument name="customer" type="entity"/>
+        </arguments>
+
+        <fillField  stepKey="fillCurrentPassword" userInput="{{customer.password}}" selector="{{StorefrontCustomerAccountInformationSection.currentPassword}}"/>
+        <fillField  stepKey="fillNewPassword" userInput="{{customer.password}}" selector="{{StorefrontCustomerAccountInformationSection.newPassword}}"/>
+        <fillField  stepKey="fillNewConfirmPassword" userInput="{{customer.password}}" selector="{{StorefrontCustomerAccountInformationSection.confirmNewPassword}}"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontLoginFormClickShowPasswordActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontLoginFormClickShowPasswordActionGroup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontLoginFormClickShowPasswordActionGroup">
+        <annotations>
+            <description>Click on the show password checkbox in login form</description>
+        </annotations>
+
+        <click stepKey="clickShowPasswordCheckbox" selector="{{StorefrontCustomerSignInFormSection.showPasswordCheckbox}}"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontOpenCustomerChangePasswordPageActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontOpenCustomerChangePasswordPageActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontOpenCustomerChangePasswordPageActionGroup">
+        <annotations>
+            <description>Goes to the Storefront Customer Change Password page.</description>
+        </annotations>
+
+        <amOnPage url="{{StorefrontCustomerAccountChangePasswordPage.url}}" stepKey="goToCustomerAccountChangePasswordPage"/>
+        <waitForPageLoad stepKey="waitForPageLoaded"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontRegistrationFormClickShowPasswordActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontRegistrationFormClickShowPasswordActionGroup.xml
@@ -8,14 +8,11 @@
 
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
-    <actionGroup name="StorefrontClickShowPasswordActionGroup">
+    <actionGroup name="StorefrontRegistrationFormClickShowPasswordActionGroup">
         <annotations>
-            <description>Click on the show password checkbox</description>
+            <description>Click on the show password checkbox in registration form</description>
         </annotations>
-        <arguments>
-            <argument name="fieldSelector" type="string"/>
-        </arguments>
-        
-        <click stepKey="clickShowPasswordCheckbox" selector="{{fieldSelector}}"/>
+
+        <click stepKey="clickShowPasswordCheckbox" selector="{{StorefrontCustomerCreateFormSection.showPasswordCheckbox}}"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/Section/StorefrontCustomerAccountInformationSection.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Section/StorefrontCustomerAccountInformationSection.xml
@@ -18,6 +18,7 @@
         <element name="currentPassword" type="input" selector="#current-password"/>
         <element name="newPassword" type="input" selector="#password"/>
         <element name="confirmNewPassword" type="input" selector="#password-confirmation"/>
+        <element name="showPasswordCheckbox" type="input" selector="#show-password"/>
         <element name="confirmNewPasswordError" type="text" selector="#password-confirmation-error"/>
         <element name="email" type="input" selector=".form-edit-account input[name='email']" />
         <element name="emailErrorMessage" type="text" selector="#email-error"/>

--- a/app/code/Magento/Customer/Test/Mftf/Section/StorefrontCustomerCreateFormSection/StorefrontCustomerCreateFormSection.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Section/StorefrontCustomerCreateFormSection/StorefrontCustomerCreateFormSection.xml
@@ -16,6 +16,7 @@
         <element name="emailField" type="input" selector="#email_address"/>
         <element name="passwordField" type="input" selector="#password"/>
         <element name="confirmPasswordField" type="input" selector="#password-confirmation"/>
+        <element name="showPasswordCheckbox" type="input" selector="#show-password"/>
         <element name="createAccountButton" type="button" selector="button.action.submit.primary" timeout="30"/>
         <element name="passwordErrorMessages" type="text" selector="#password-error"/>
     </section>

--- a/app/code/Magento/Customer/Test/Mftf/Section/StorefrontCustomerSignInFormSection/StorefrontCustomerSignInFormSection.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Section/StorefrontCustomerSignInFormSection/StorefrontCustomerSignInFormSection.xml
@@ -10,6 +10,7 @@
     <section name="StorefrontCustomerSignInFormSection">
         <element name="emailField" type="input" selector="#email"/>
         <element name="passwordField" type="input" selector="#pass"/>
+        <element name="showPasswordCheckbox" type="input" selector="#show-password"/>
         <element name="signInAccountButton" type="button" selector="#send2" timeout="30"/>
         <element name="forgotPasswordLink" type="button" selector=".action.remind" timeout="10"/>
         <element name="customerLoginBlock" type="text" selector=".login-container .block.block-customer-login"/>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontChangePasswordFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontChangePasswordFormShowPasswordTest.xml
@@ -35,19 +35,15 @@
         </actionGroup>
         <actionGroup ref="StorefrontClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox">
             <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.showPasswordCheckbox}}"/>
-            <argument name="passwordFieldSelector" value="{{StorefrontCustomerAccountInformationSection.currentPassword}}"/>
         </actionGroup>
         <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertCurrentPasswordField">
             <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.currentPassword}}" />
-            <argument name="passwordFieldType" value="{$clickShowPasswordCheckbox}" />
         </actionGroup>
         <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertNewPasswordField">
             <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.newPassword}}" />
-            <argument name="passwordFieldType" value="{$clickShowPasswordCheckbox}" />
         </actionGroup>
         <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertNewConfirmPasswordField">
             <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.confirmNewPassword}}" />
-            <argument name="passwordFieldType" value="{$clickShowPasswordCheckbox}" />
         </actionGroup>
     </test>
 </tests>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontChangePasswordFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontChangePasswordFormShowPasswordTest.xml
@@ -33,17 +33,7 @@
         <actionGroup ref="StorefrontFillChangePasswordFormActionGroup" stepKey="fillChangePasswordForm">
             <argument name="customer" value="Simple_US_Customer"/>
         </actionGroup>
-        <actionGroup ref="StorefrontClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox">
-            <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.showPasswordCheckbox}}"/>
-        </actionGroup>
-        <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertCurrentPasswordField">
-            <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.currentPassword}}" />
-        </actionGroup>
-        <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertNewPasswordField">
-            <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.newPassword}}" />
-        </actionGroup>
-        <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertNewConfirmPasswordField">
-            <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.confirmNewPassword}}" />
-        </actionGroup>
+        <actionGroup ref="StorefrontCustomerEditFormClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox"/>
+        <actionGroup ref="AssertCustomerEditFormPasswordFieldActionGroup" stepKey="AssertCurrentPasswordField"/>
     </test>
 </tests>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontChangePasswordFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontChangePasswordFormShowPasswordTest.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontChangePasswordFormShowPasswordTest">
+        <annotations>
+            <features value="Customer"/>
+            <stories value="Customer Password Update"/>
+            <title value="Show Password Checkbox"/>
+            <description value="Check Show Password Functionality in Customer Password Update Form"/>
+            <group value="Customer"/>
+        </annotations>
+        <before>
+            <createData stepKey="customer" entity="Simple_US_Customer"/>
+        </before>
+        <after>
+            <deleteData stepKey="deleteCustomer" createDataKey="customer" />
+        </after>
+
+        <actionGroup ref="StorefrontOpenCustomerLoginPageActionGroup" stepKey="goToSignInPage"/>
+        <actionGroup ref="StorefrontFillCustomerLoginFormActionGroup" stepKey="fillLoginFormWithCorrectCredentials">
+            <argument name="customer" value="$$customer$$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontClickSignOnCustomerLoginFormActionGroup" stepKey="clickSignInAccountButton" />
+        <actionGroup ref="StorefrontOpenCustomerChangePasswordPageActionGroup" stepKey="openCustomerPasswordUpdatePage"/>
+        <actionGroup ref="StorefrontFillChangePasswordFormActionGroup" stepKey="fillChangePasswordForm">
+            <argument name="customer" value="Simple_US_Customer"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox">
+            <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.showPasswordCheckbox}}"/>
+        </actionGroup>
+        <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertCurrentPasswordField">
+            <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.currentPassword}}" />
+        </actionGroup>
+        <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertNewPasswordField">
+            <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.newPassword}}" />
+        </actionGroup>
+        <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertNewConfirmPasswordField">
+            <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.confirmNewPassword}}" />
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontChangePasswordFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontChangePasswordFormShowPasswordTest.xml
@@ -14,6 +14,7 @@
             <stories value="Customer Password Update"/>
             <title value="Show Password Checkbox"/>
             <description value="Check Show Password Functionality in Customer Password Update Form"/>
+            <severity value="MAJOR"/>
             <group value="Customer"/>
         </annotations>
         <before>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontChangePasswordFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontChangePasswordFormShowPasswordTest.xml
@@ -12,7 +12,7 @@
         <annotations>
             <features value="Customer"/>
             <stories value="Customer Password Update"/>
-            <title value="Show Password Checkbox"/>
+            <title value="Show Password Checkbox on Customer Change Password Form"/>
             <description value="Check Show Password Functionality in Customer Password Update Form"/>
             <severity value="MAJOR"/>
             <group value="Customer"/>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontChangePasswordFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontChangePasswordFormShowPasswordTest.xml
@@ -35,15 +35,19 @@
         </actionGroup>
         <actionGroup ref="StorefrontClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox">
             <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.showPasswordCheckbox}}"/>
+            <argument name="passwordFieldSelector" value="{{StorefrontCustomerAccountInformationSection.currentPassword}}"/>
         </actionGroup>
         <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertCurrentPasswordField">
             <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.currentPassword}}" />
+            <argument name="passwordFieldType" value="{$clickShowPasswordCheckbox}" />
         </actionGroup>
         <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertNewPasswordField">
             <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.newPassword}}" />
+            <argument name="passwordFieldType" value="{$clickShowPasswordCheckbox}" />
         </actionGroup>
         <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertNewConfirmPasswordField">
             <argument name="fieldSelector" value="{{StorefrontCustomerAccountInformationSection.confirmNewPassword}}" />
+            <argument name="passwordFieldType" value="{$clickShowPasswordCheckbox}" />
         </actionGroup>
     </test>
 </tests>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerFormShowPasswordTest.xml
@@ -24,12 +24,15 @@
         </actionGroup>
         <actionGroup ref="StorefrontClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox">
             <argument name="fieldSelector" value="{{StorefrontCustomerCreateFormSection.showPasswordCheckbox}}"/>
+            <argument name="passwordFieldSelector" value="{{StorefrontCustomerCreateFormSection.passwordField}}"/>
         </actionGroup>
         <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertPasswordField">
             <argument name="fieldSelector" value="{{StorefrontCustomerCreateFormSection.passwordField}}" />
+            <argument name="passwordFieldType" value="{$clickShowPasswordCheckbox}" />
         </actionGroup>
         <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertConfirmPasswordField">
             <argument name="fieldSelector" value="{{StorefrontCustomerCreateFormSection.confirmPasswordField}}" />
+            <argument name="passwordFieldType" value="{$clickShowPasswordCheckbox}" />
         </actionGroup>
     </test>
 </tests>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerFormShowPasswordTest.xml
@@ -22,14 +22,7 @@
         <actionGroup ref="StorefrontFillCustomerAccountCreationFormActionGroup" stepKey="fillCreateAccountForm">
             <argument name="customer" value="Simple_US_Customer"/>
         </actionGroup>
-        <actionGroup ref="StorefrontClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox">
-            <argument name="fieldSelector" value="{{StorefrontCustomerCreateFormSection.showPasswordCheckbox}}"/>
-        </actionGroup>
-        <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertPasswordField">
-            <argument name="fieldSelector" value="{{StorefrontCustomerCreateFormSection.passwordField}}" />
-        </actionGroup>
-        <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertConfirmPasswordField">
-            <argument name="fieldSelector" value="{{StorefrontCustomerCreateFormSection.confirmPasswordField}}" />
-        </actionGroup>
+        <actionGroup ref="StorefrontRegistrationFormClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox"/>
+        <actionGroup ref="AssertRegistrationFormPasswordFieldActionGroup" stepKey="AssertPasswordField"/>
     </test>
 </tests>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerFormShowPasswordTest.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontCreateCustomerFormShowPasswordTest">
+        <annotations>
+            <features value="Customer"/>
+            <stories value="Customer Creation"/>
+            <title value="Show Password Checkbox"/>
+            <description value="Check Show Password Functionality in Customer Creation Form"/>
+            <group value="Customer"/>
+        </annotations>
+
+        <actionGroup ref="StorefrontOpenCustomerAccountCreatePageActionGroup" stepKey="openCreateAccountPage"/>
+        <actionGroup ref="StorefrontFillCustomerAccountCreationFormActionGroup" stepKey="fillCreateAccountForm">
+            <argument name="customer" value="Simple_US_Customer"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox">
+            <argument name="fieldSelector" value="{{StorefrontCustomerCreateFormSection.showPasswordCheckbox}}"/>
+        </actionGroup>
+        <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertPasswordField">
+            <argument name="fieldSelector" value="{{StorefrontCustomerCreateFormSection.passwordField}}" />
+        </actionGroup>
+        <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertConfirmPasswordField">
+            <argument name="fieldSelector" value="{{StorefrontCustomerCreateFormSection.confirmPasswordField}}" />
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerFormShowPasswordTest.xml
@@ -14,6 +14,7 @@
             <stories value="Customer Creation"/>
             <title value="Show Password Checkbox"/>
             <description value="Check Show Password Functionality in Customer Creation Form"/>
+            <severity value="MAJOR"/>
             <group value="Customer"/>
         </annotations>
 

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerFormShowPasswordTest.xml
@@ -12,7 +12,7 @@
         <annotations>
             <features value="Customer"/>
             <stories value="Customer Creation"/>
-            <title value="Show Password Checkbox"/>
+            <title value="Show Password Checkbox on Customer Create Form"/>
             <description value="Check Show Password Functionality in Customer Creation Form"/>
             <severity value="MAJOR"/>
             <group value="Customer"/>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerFormShowPasswordTest.xml
@@ -24,15 +24,12 @@
         </actionGroup>
         <actionGroup ref="StorefrontClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox">
             <argument name="fieldSelector" value="{{StorefrontCustomerCreateFormSection.showPasswordCheckbox}}"/>
-            <argument name="passwordFieldSelector" value="{{StorefrontCustomerCreateFormSection.passwordField}}"/>
         </actionGroup>
         <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertPasswordField">
             <argument name="fieldSelector" value="{{StorefrontCustomerCreateFormSection.passwordField}}" />
-            <argument name="passwordFieldType" value="{$clickShowPasswordCheckbox}" />
         </actionGroup>
         <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertConfirmPasswordField">
             <argument name="fieldSelector" value="{{StorefrontCustomerCreateFormSection.confirmPasswordField}}" />
-            <argument name="passwordFieldType" value="{$clickShowPasswordCheckbox}" />
         </actionGroup>
     </test>
 </tests>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginFormShowPasswordTest.xml
@@ -28,11 +28,7 @@
         <actionGroup ref="StorefrontFillCustomerLoginFormWithWrongPasswordActionGroup" stepKey="fillLoginFormWithCustomerData">
             <argument name="customer" value="$$customer$$"/>
         </actionGroup>
-        <actionGroup ref="StorefrontClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox">
-            <argument name="fieldSelector" value="{{StorefrontCustomerSignInFormSection.showPasswordCheckbox}}"/>
-        </actionGroup>
-        <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertPasswordField">
-            <argument name="fieldSelector" value="{{StorefrontCustomerSignInFormSection.passwordField}}" />
-        </actionGroup>
+        <actionGroup ref="StorefrontLoginFormClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox"/>
+        <actionGroup ref="AssertLoginFormPasswordFieldActionGroup" stepKey="AssertPasswordField"/>
     </test>
 </tests>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginFormShowPasswordTest.xml
@@ -30,9 +30,11 @@
         </actionGroup>
         <actionGroup ref="StorefrontClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox">
             <argument name="fieldSelector" value="{{StorefrontCustomerSignInFormSection.showPasswordCheckbox}}"/>
+            <argument name="passwordFieldSelector" value="{{StorefrontCustomerSignInFormSection.passwordField}}"/>
         </actionGroup>
         <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertPasswordField">
             <argument name="fieldSelector" value="{{StorefrontCustomerSignInFormSection.passwordField}}" />
+            <argument name="passwordFieldType" value="{$clickShowPasswordCheckbox}" />
         </actionGroup>
     </test>
 </tests>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginFormShowPasswordTest.xml
@@ -14,6 +14,7 @@
             <stories value="Customer Login"/>
             <title value="Show Password Checkbox"/>
             <description value="Check Show Password Functionality"/>
+            <severity value="MAJOR"/>
             <group value="Customer"/>
         </annotations>
         <before>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginFormShowPasswordTest.xml
@@ -12,8 +12,8 @@
         <annotations>
             <features value="Customer"/>
             <stories value="Customer Login"/>
-            <title value="Show Password Checkbox"/>
-            <description value="Check Show Password Functionality"/>
+            <title value="Show Password Checkbox on Customer Login Form"/>
+            <description value="Check Show Password Functionality on Customer Login Form"/>
             <severity value="MAJOR"/>
             <group value="Customer"/>
         </annotations>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginFormShowPasswordTest.xml
@@ -30,11 +30,9 @@
         </actionGroup>
         <actionGroup ref="StorefrontClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox">
             <argument name="fieldSelector" value="{{StorefrontCustomerSignInFormSection.showPasswordCheckbox}}"/>
-            <argument name="passwordFieldSelector" value="{{StorefrontCustomerSignInFormSection.passwordField}}"/>
         </actionGroup>
         <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertPasswordField">
             <argument name="fieldSelector" value="{{StorefrontCustomerSignInFormSection.passwordField}}" />
-            <argument name="passwordFieldType" value="{$clickShowPasswordCheckbox}" />
         </actionGroup>
     </test>
 </tests>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginFormShowPasswordTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontLoginFormShowPasswordTest.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontLoginFormShowPasswordTest">
+        <annotations>
+            <features value="Customer"/>
+            <stories value="Customer Login"/>
+            <title value="Show Password Checkbox"/>
+            <description value="Check Show Password Functionality"/>
+            <group value="Customer"/>
+        </annotations>
+        <before>
+            <createData stepKey="customer" entity="Simple_US_Customer"/>
+        </before>
+        <after>
+            <deleteData stepKey="deleteCustomer" createDataKey="customer" />
+        </after>
+
+        <actionGroup ref="StorefrontOpenCustomerLoginPageActionGroup" stepKey="goToSignInPage"/>
+        <actionGroup ref="StorefrontFillCustomerLoginFormWithWrongPasswordActionGroup" stepKey="fillLoginFormWithCustomerData">
+            <argument name="customer" value="$$customer$$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontClickShowPasswordActionGroup" stepKey="clickShowPasswordCheckbox">
+            <argument name="fieldSelector" value="{{StorefrontCustomerSignInFormSection.showPasswordCheckbox}}"/>
+        </actionGroup>
+        <actionGroup ref="AssertPasswordFieldActionGroup" stepKey="AssertPasswordField">
+            <argument name="fieldSelector" value="{{StorefrontCustomerSignInFormSection.passwordField}}" />
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/Customer/view/frontend/requirejs-config.js
+++ b/app/code/Magento/Customer/view/frontend/requirejs-config.js
@@ -12,6 +12,7 @@ var config = {
             passwordStrengthIndicator: 'Magento_Customer/js/password-strength-indicator',
             zxcvbn: 'Magento_Customer/js/zxcvbn',
             addressValidation: 'Magento_Customer/js/addressValidation',
+            showPassword: 'Magento_Customer/js/show-password',
             'Magento_Customer/address': 'Magento_Customer/js/address',
             'Magento_Customer/change-email-password': 'Magento_Customer/js/change-email-password'
         }

--- a/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
@@ -104,6 +104,10 @@ use Magento\Customer\Block\Widget\Name;
                     autocomplete="off" />
             </div>
         </div>
+        <div class="field choice">
+            <input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-mage-init='{"showPassword": {"passwordSelector": "#current-password,#password,#password-confirmation"}}'>
+            <label for="show-password" class="label"><span><?= $block->escapeHtml(__('Show Password')) ?></span></label>
+        </div>
     </fieldset>
 
     <fieldset class="fieldset additional_info">

--- a/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
@@ -104,9 +104,8 @@ use Magento\Customer\Block\Widget\Name;
                     autocomplete="off" />
             </div>
         </div>
-        <div class="field choice">
-            <input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-mage-init='{"showPassword": {"passwordSelector": "#current-password,#password,#password-confirmation"}}'>
-            <label for="show-password" class="label"><span><?= $escaper->escapeHtml(__('Show Password')) ?></span></label>
+        <div class="field choice" data-bind="scope: 'showPassword'">
+            <!-- ko template: getTemplate() --><!-- /ko -->
         </div>
     </fieldset>
 
@@ -179,6 +178,16 @@ script;
         "[data-container=new-password]": {
             "passwordStrengthIndicator": {
                 "formSelector": "form.form-edit-account"
+            }
+        },
+        "*": {
+            "Magento_Ui/js/core/app": {
+                "components": {
+                    "showPassword": {
+                        "component": "Magento_Customer/js/show-password",
+                        "passwordSelector": "#current-password,#password,#password-confirmation"
+                    }
+                }
             }
         }
     }

--- a/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
@@ -106,7 +106,7 @@ use Magento\Customer\Block\Widget\Name;
         </div>
         <div class="field choice">
             <input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-mage-init='{"showPassword": {"passwordSelector": "#current-password,#password,#password-confirmation"}}'>
-            <label for="show-password" class="label"><span><?= $block->escapeHtml(__('Show Password')) ?></span></label>
+            <label for="show-password" class="label"><span><?= $escaper->escapeHtml(__('Show Password')) ?></span></label>
         </div>
     </fieldset>
 

--- a/app/code/Magento/Customer/view/frontend/templates/form/login.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/login.phtml
@@ -44,7 +44,7 @@
                 </div>
                 <div class="field choice">
                     <input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-mage-init='{"showPassword": {"passwordSelector": "#pass"}}'>
-                    <label for="show-password" class="label"><span><?= $block->escapeHtml(__('Show Password')) ?></span></label>
+                    <label for="show-password" class="label"><span><?= $escaper->escapeHtml(__('Show Password')) ?></span></label>
                 </div>
                 <?= $block->getChildHtml('form_additional_info') ?>
                 <div class="actions-toolbar">

--- a/app/code/Magento/Customer/view/frontend/templates/form/login.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/login.phtml
@@ -42,9 +42,8 @@
                                data-validate="{required:true}">
                     </div>
                 </div>
-                <div class="field choice">
-                    <input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-mage-init='{"showPassword": {"passwordSelector": "#pass"}}'>
-                    <label for="show-password" class="label"><span><?= $escaper->escapeHtml(__('Show Password')) ?></span></label>
+                <div class="field choice" data-bind="scope: 'showPassword'">
+                    <!-- ko template: getTemplate() --><!-- /ko -->
                 </div>
                 <?= $block->getChildHtml('form_additional_info') ?>
                 <div class="actions-toolbar">
@@ -59,6 +58,14 @@
             "*": {
                 "Magento_Customer/js/block-submit-on-send": {
                     "formId": "login-form"
+                },
+                "Magento_Ui/js/core/app": {
+                    "components": {
+                        "showPassword": {
+                            "component": "Magento_Customer/js/show-password",
+                            "passwordSelector": "#pass"
+                        }
+                    }
                 }
             }
         }

--- a/app/code/Magento/Customer/view/frontend/templates/form/login.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/login.phtml
@@ -42,6 +42,10 @@
                                data-validate="{required:true}">
                     </div>
                 </div>
+                <div class="field choice">
+                    <input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-mage-init='{"showPassword": {"passwordSelector": "#pass"}}'>
+                    <label for="show-password" class="label"><span><?= $block->escapeHtml(__('Show Password')) ?></span></label>
+                </div>
                 <?= $block->getChildHtml('form_additional_info') ?>
                 <div class="actions-toolbar">
                     <div class="primary"><button type="submit" class="action login primary" name="send" id="send2"><span><?= $block->escapeHtml(__('Sign In')) ?></span></button></div>

--- a/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
@@ -259,9 +259,8 @@ $formData = $block->getFormData();
                        autocomplete="off">
             </div>
         </div>
-        <div class="field choice">
-            <input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-mage-init='{"showPassword": {"passwordSelector": "#password,#password-confirmation"}}'>
-            <label for="show-password" class="label"><span><?= $escaper->escapeHtml(__('Show Password')) ?></span></label>
+        <div class="field choice" data-bind="scope: 'showPassword'">
+            <!-- ko template: getTemplate() --><!-- /ko -->
         </div>
     </fieldset>
 
@@ -358,6 +357,14 @@ script;
         "*": {
             "Magento_Customer/js/block-submit-on-send": {
                 "formId": "form-validate"
+            },
+            "Magento_Ui/js/core/app": {
+                "components": {
+                    "showPassword": {
+                        "component": "Magento_Customer/js/show-password",
+                        "passwordSelector": "#password,#password-confirmation"
+                    }
+                }
             }
         }
     }

--- a/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
@@ -261,7 +261,7 @@ $formData = $block->getFormData();
         </div>
         <div class="field choice">
             <input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-mage-init='{"showPassword": {"passwordSelector": "#password,#password-confirmation"}}'>
-            <label for="show-password" class="label"><span><?= $block->escapeHtml(__('Show Password')) ?></span></label>
+            <label for="show-password" class="label"><span><?= $escaper->escapeHtml(__('Show Password')) ?></span></label>
         </div>
     </fieldset>
 

--- a/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
@@ -259,6 +259,10 @@ $formData = $block->getFormData();
                        autocomplete="off">
             </div>
         </div>
+        <div class="field choice">
+            <input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-mage-init='{"showPassword": {"passwordSelector": "#password,#password-confirmation"}}'>
+            <label for="show-password" class="label"><span><?= $block->escapeHtml(__('Show Password')) ?></span></label>
+        </div>
     </fieldset>
 
     <fieldset class="fieldset additional_info">

--- a/app/code/Magento/Customer/view/frontend/templates/form/resetforgottenpassword.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/resetforgottenpassword.phtml
@@ -37,6 +37,10 @@
                 <input type="password" class="input-text" name="password_confirmation" id="password-confirmation" data-validate="{required:true,equalTo:'#password'}" autocomplete="off">
             </div>
         </div>
+        <div class="field choice">
+            <input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-mage-init='{"showPassword": {"passwordSelector": "#password,#password-confirmation"}}'>
+            <label for="show-password" class="label"><span><?= $block->escapeHtml(__('Show Password')) ?></span></label>
+        </div>
     </fieldset>
     <div class="actions-toolbar">
         <div class="primary">

--- a/app/code/Magento/Customer/view/frontend/templates/form/resetforgottenpassword.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/resetforgottenpassword.phtml
@@ -37,9 +37,8 @@
                 <input type="password" class="input-text" name="password_confirmation" id="password-confirmation" data-validate="{required:true,equalTo:'#password'}" autocomplete="off">
             </div>
         </div>
-        <div class="field choice">
-            <input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-mage-init='{"showPassword": {"passwordSelector": "#password,#password-confirmation"}}'>
-            <label for="show-password" class="label"><span><?= $escaper->escapeHtml(__('Show Password')) ?></span></label>
+        <div class="field choice" data-bind="scope: 'showPassword'">
+            <!-- ko template: getTemplate() --><!-- /ko -->
         </div>
     </fieldset>
     <div class="actions-toolbar">
@@ -48,3 +47,17 @@
         </div>
     </div>
 </form>
+<script type="text/x-magento-init">
+    {
+        "*": {
+            "Magento_Ui/js/core/app": {
+                "components": {
+                    "showPassword": {
+                        "component": "Magento_Customer/js/show-password",
+                        "passwordSelector": "#password,#password-confirmation"
+                    }
+                }
+            }
+        }
+    }
+</script>

--- a/app/code/Magento/Customer/view/frontend/templates/form/resetforgottenpassword.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/resetforgottenpassword.phtml
@@ -39,7 +39,7 @@
         </div>
         <div class="field choice">
             <input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-mage-init='{"showPassword": {"passwordSelector": "#password,#password-confirmation"}}'>
-            <label for="show-password" class="label"><span><?= $block->escapeHtml(__('Show Password')) ?></span></label>
+            <label for="show-password" class="label"><span><?= $escaper->escapeHtml(__('Show Password')) ?></span></label>
         </div>
     </fieldset>
     <div class="actions-toolbar">

--- a/app/code/Magento/Customer/view/frontend/web/js/show-password.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/show-password.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+define([
+    'jquery'
+], function($) {
+    'use strict';
+
+    $.widget('mage.showPassword', {
+        options: {
+            passwordSelector: '',
+            showPasswordSelector: '[data-role=show-password]',
+            passwordInputType: 'password',
+            textInputType: 'text'
+        },
+
+        /**
+         * Widget initialization
+         * @private
+         */
+        _create: function () {
+            this._bind();
+        },
+
+        /**
+         * Event binding, will monitor click event on show password.
+         * @private
+         */
+        _bind: function () {
+            this._on(this.options.showPasswordSelector, {
+                'click': this._showPassword
+            });
+        },
+
+        /**
+         * Show/Hide password
+         * @private
+         */
+        _showPassword: function () {
+            if ($(this.options.passwordSelector).attr("type") == this.options.passwordInputType) {
+                $(this.options.passwordSelector).attr("type", this.options.textInputType);
+            } else {
+                $(this.options.passwordSelector).attr("type", this.options.passwordInputType);
+            }
+        }
+    });
+});

--- a/app/code/Magento/Customer/view/frontend/web/js/show-password.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/show-password.js
@@ -39,11 +39,11 @@ define([
          * @private
          */
         _showPassword: function () {
-            if ($(this.options.passwordSelector).attr("type") == this.options.passwordInputType) {
-                $(this.options.passwordSelector).attr("type", this.options.textInputType);
-            } else {
-                $(this.options.passwordSelector).attr("type", this.options.passwordInputType);
-            }
+            var passwordField = this.options.passwordSelector;
+            $(passwordField).attr(
+                "type",
+                ($(passwordField).attr("type") == this.options.passwordInputType) ? this.options.textInputType : this.options.passwordInputType
+            );
         }
     });
 });

--- a/app/code/Magento/Customer/view/frontend/web/js/show-password.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/show-password.js
@@ -5,40 +5,30 @@
 
 define([
     'jquery',
-    'ko',
     'uiComponent'
-], function ($, ko, Component) {
+], function ($, Component) {
     'use strict';
 
     return Component.extend({
         passwordSelector: '',
-        showPasswordSelector: '[data-role=show-password]',
         passwordInputType: 'password',
         textInputType: 'text',
 
         defaults: {
-            template: 'Magento_Customer/show-password'
-        },
-
-        /** @inheritdoc */
-        initialize: function () {
-            this._super();
+            template: 'Magento_Customer/show-password',
+            isPasswordVisible: false
         },
 
         /**
          * @return {Object}
          */
         initObservable: function () {
-            var self = this;
-
             this._super()
-                .observe({
-                    isChecked: ko.observable(false)
-                });
+                .observe(['isPasswordVisible']);
 
-            this.isChecked.subscribe(function () {
-                self._showPassword();
-            });
+            this.isPasswordVisible.subscribe(function (isChecked) {
+                this._showPassword(isChecked);
+            }.bind(this));
 
             return this;
         },
@@ -47,12 +37,9 @@ define([
          * Show/Hide password
          * @private
          */
-        _showPassword: function () {
-            var passwordField = this.passwordSelector;
-
-            $(passwordField).attr('type',
-                $(passwordField).attr('type') === this.passwordInputType ?
-                this.textInputType : this.passwordInputType
+        _showPassword: function (isChecked) {
+            $(this.passwordSelector).attr('type',
+                isChecked ? this.textInputType : this.passwordInputType
             );
         }
     });

--- a/app/code/Magento/Customer/view/frontend/web/js/show-password.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/show-password.js
@@ -42,8 +42,8 @@ define([
             var passwordField = this.options.passwordSelector;
 
             $(passwordField).attr('type',
-                $(passwordField).attr('type') === this.options.passwordInputType
-                ? this.options.textInputType : this.options.passwordInputType
+                $(passwordField).attr('type') === this.options.passwordInputType ?
+                this.options.textInputType : this.options.passwordInputType
             );
         }
     });

--- a/app/code/Magento/Customer/view/frontend/web/js/show-password.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/show-password.js
@@ -30,6 +30,7 @@ define([
          */
         initObservable: function () {
             var self = this;
+
             this._super()
                 .observe({
                     isChecked: ko.observable(false)
@@ -38,6 +39,7 @@ define([
             this.isChecked.subscribe(function () {
                 self._showPassword();
             });
+
             return this;
         },
 

--- a/app/code/Magento/Customer/view/frontend/web/js/show-password.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/show-password.js
@@ -5,7 +5,7 @@
 
 define([
     'jquery'
-], function($) {
+], function ($) {
     'use strict';
 
     $.widget('mage.showPassword', {
@@ -40,9 +40,10 @@ define([
          */
         _showPassword: function () {
             var passwordField = this.options.passwordSelector;
-            $(passwordField).attr(
-                "type",
-                ($(passwordField).attr("type") == this.options.passwordInputType) ? this.options.textInputType : this.options.passwordInputType
+
+            $(passwordField).attr('type',
+                $(passwordField).attr('type') === this.options.passwordInputType
+                ? this.options.textInputType : this.options.passwordInputType
             );
         }
     });

--- a/app/code/Magento/Customer/view/frontend/web/js/show-password.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/show-password.js
@@ -1,37 +1,44 @@
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
- */
+* Copyright © Magento, Inc. All rights reserved.
+* See COPYING.txt for license details.
+*/
 
 define([
-    'jquery'
-], function ($) {
+    'jquery',
+    'ko',
+    'uiComponent'
+], function ($, ko, Component) {
     'use strict';
 
-    $.widget('mage.showPassword', {
-        options: {
-            passwordSelector: '',
-            showPasswordSelector: '[data-role=show-password]',
-            passwordInputType: 'password',
-            textInputType: 'text'
+    return Component.extend({
+        passwordSelector: '',
+        showPasswordSelector: '[data-role=show-password]',
+        passwordInputType: 'password',
+        textInputType: 'text',
+
+        defaults: {
+            template: 'Magento_Customer/show-password'
+        },
+
+        /** @inheritdoc */
+        initialize: function () {
+            this._super();
         },
 
         /**
-         * Widget initialization
-         * @private
+         * @return {Object}
          */
-        _create: function () {
-            this._bind();
-        },
+        initObservable: function () {
+            var self = this;
+            this._super()
+                .observe({
+                    isChecked: ko.observable(false)
+                });
 
-        /**
-         * Event binding, will monitor click event on show password.
-         * @private
-         */
-        _bind: function () {
-            this._on(this.options.showPasswordSelector, {
-                'click': this._showPassword
+            this.isChecked.subscribe(function () {
+                self._showPassword();
             });
+            return this;
         },
 
         /**
@@ -39,11 +46,11 @@ define([
          * @private
          */
         _showPassword: function () {
-            var passwordField = this.options.passwordSelector;
+            var passwordField = this.passwordSelector;
 
             $(passwordField).attr('type',
-                $(passwordField).attr('type') === this.options.passwordInputType ?
-                this.options.textInputType : this.options.passwordInputType
+                $(passwordField).attr('type') === this.passwordInputType ?
+                this.textInputType : this.passwordInputType
             );
         }
     });

--- a/app/code/Magento/Customer/view/frontend/web/template/show-password.html
+++ b/app/code/Magento/Customer/view/frontend/web/template/show-password.html
@@ -1,2 +1,9 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+ -->
+
 <input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-bind="checked: isChecked">
 <label for="show-password" class="label"><span data-bind="i18n: 'Show Password'"></span></label>

--- a/app/code/Magento/Customer/view/frontend/web/template/show-password.html
+++ b/app/code/Magento/Customer/view/frontend/web/template/show-password.html
@@ -5,5 +5,5 @@
  */
  -->
 
-<input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-bind="checked: isChecked">
-<label for="show-password" class="label"><span data-bind="i18n: 'Show Password'"></span></label>
+<input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" ko-checked="isPasswordVisible">
+<label for="show-password" class="label"><span translate="'Show Password'"></span></label>

--- a/app/code/Magento/Customer/view/frontend/web/template/show-password.html
+++ b/app/code/Magento/Customer/view/frontend/web/template/show-password.html
@@ -1,0 +1,2 @@
+<input type="checkbox" name="show-password" title="Show Password" id="show-password" class="checkbox" data-role="show-password" data-bind="checked: isChecked">
+<label for="show-password" class="label"><span data-bind="i18n: 'Show Password'"></span></label>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Added a jquery widget that will display a checkbox below the password field in the forms to show/hide the password.
Users can able to toggle between showing/hiding the password.
**Below are sections that are affected by this widget:**
1. Customer Login Page.
2. Customer Registration Page.
3. Customer Edit Page (Change Password section).
4. Customer Set New Password Page.

**Screenshot:**
![Customer-Login-show-password](https://user-images.githubusercontent.com/47966038/103281864-0cc7bb80-49fa-11eb-8de2-77c3eecc9c92.png)

### Related Pull Requests
https://github.com/magento/partners-magento2ee/pull/451
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Navigate to the customer login page and enter the email and password and then validated the show password functionality.
2. Navigate to the customer registration page and enter the details in the form and then validated the Show password functionality.
3. Navigate to the customer edit page and clicked the Change Password checkbox and then validated the Show password functionality.
4. Navigate to the New Password setup page and validated the Show Password functionality.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31557: show or hide password widget created