### PR TITLE
[MFTF] Refactoring AdminOrdersReleaseInUnholdStatusTest

### DIFF
--- a/app/code/Magento/Sales/Test/Mftf/Data/HoldOrderData.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Data/HoldOrderData.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<entities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:DataGenerator/etc/dataProfileSchema.xsd">
+
+    <entity name="HoldOrder" type="HoldOrder">
+       <var key="quote_id" entityKey="return" entityType="CustomerCart"/>
+    </entity>
+
+</entities>

--- a/app/code/Magento/Sales/Test/Mftf/Metadata/HoldOrderMeta.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Metadata/HoldOrderMeta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<operations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:DataGenerator/etc/dataOperation.xsd">
+    <operation name="CreateHoldOrder" dataType="HoldOrder" type="create" auth="adminOauth" url="V1/orders/{return}/hold" method="POST">
+        <contentType>application/json</contentType>
+         <object key="cartItem" dataType="CartItem">
+            <field key="quote_id">string</field>
+        </object>
+    </operation>
+</operations>

--- a/app/code/Magento/Sales/Test/Mftf/Test/AdminOrdersReleaseInUnholdStatusTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/AdminOrdersReleaseInUnholdStatusTest.xml
@@ -21,53 +21,56 @@
         <before>
             <actionGroup ref="AdminLoginActionGroup" stepKey="LoginAsAdmin"/>
 
-            <!-- Create Data -->
             <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
             <createData entity="_defaultCategory" stepKey="createCategory"/>
             <createData entity="defaultSimpleProduct" stepKey="createProduct">
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
+            <createData entity="CustomerCart" stepKey="createCustomerCart">
+                <requiredEntity createDataKey="createCustomer"/>
+            </createData>
+            <createData entity="CustomerCartItem" stepKey="addCartItemOne">
+                <requiredEntity createDataKey="createCustomerCart"/>
+                <requiredEntity createDataKey="createProduct"/>
+            </createData>
+            <createData entity="CustomerAddressInformation" stepKey="addCustomerOrderAddress">
+                <requiredEntity createDataKey="createCustomerCart"/>
+            </createData>
+            <updateData createDataKey="createCustomerCart" entity="CustomerOrderPaymentMethod" stepKey="sendCustomerPaymentInformationOne">
+                <requiredEntity createDataKey="createCustomerCart"/>
+            </updateData>
+            <createData entity="HoldOrder" stepKey="holdOrder">
+                <requiredEntity createDataKey="createCustomerCart"/>
+            </createData> 
         </before>
         <after>
-            <!-- Delete data -->
             <deleteData createDataKey="createCustomer" stepKey="deleteCustomer"/>
             <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
             <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
 
-        <!-- Create order -->
-        <actionGroup ref="CreateOrderActionGroup" stepKey="createFirstOrder">
-            <argument name="product" value="$$createProduct$$"/>
-            <argument name="customer" value="$$createCustomer$$"/>
-        </actionGroup>
-        <grabTextFrom selector="|Order # (\d+)|" stepKey="getOrderId"/>
-        <assertNotEmpty stepKey="assertOrderIdIsNotEmpty" after="getOrderId">
-			<actualResult type="const">$getOrderId</actualResult>
-        </assertNotEmpty>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="createFirstOrder"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="getOrderId"/> 
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="assertOrderIdIsNotEmpty"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="pushButtonHold"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="waitForHold"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="seeHoldMessage"/>
 
-        <!-- Hold Order -->
-        <click selector="{{AdminOrderDetailsMainActionsSection.hold}}" stepKey="pushButtonHold"/>
-        <waitForPageLoad stepKey="waitForHold"/>
-        <see userInput="You put the order on hold." stepKey="seeHoldMessage"/>
-
-        <!-- Navigate to backend: Go to Sales > Orders -->
         <actionGroup ref="AdminOrdersPageOpenActionGroup" stepKey="onOrderPage"/>
         <actionGroup ref="AdminOrdersGridClearFiltersActionGroup" stepKey="clearFilters"/>
-
-        <!-- Select Mass Action according to dataset: Unhold -->
+        <grabTextFrom selector="{{AdminOrdersGridSection.orderIdByIncrementId($createCustomerCart.return$)}}" stepKey="grabOrderId"/>
         <actionGroup ref="AdminOrderActionOnGridActionGroup" stepKey="actionUnold">
             <argument name="action" value="Unhold"/>
-            <argument name="orderId" value="$getOrderId"/>
+            <argument name="orderId" value="$grabOrderId"/>
         </actionGroup>
         <see userInput="1 order(s) have been released from on hold status." stepKey="assertOrderReleaseSuccessMessage"/>
 
-        <!--Assert order in orders grid -->
         <actionGroup ref="AdminOrderFilterByOrderIdAndStatusActionGroup" stepKey="seeFirstOrder">
-            <argument name="orderId" value="{$getOrderId}"/>
+            <argument name="orderId" value="{$grabOrderId}"/>
             <argument name="orderStatus" value="Pending"/>
         </actionGroup>
-        <see userInput="{$getOrderId}" selector="{{AdminOrdersGridSection.gridCell('1','ID')}}" stepKey="assertOrderID"/>
+        <see userInput="{$grabOrderId}" selector="{{AdminOrdersGridSection.gridCell('1','ID')}}" stepKey="assertOrderID"/>
         <see userInput="Pending" selector="{{AdminOrdersGridSection.gridCell('1','Status')}}" stepKey="assertOrderStatus"/>
     </test>
 </tests>


### PR DESCRIPTION
### Description (*)
The test is refactored to improve execution time

### Manual testing scenarios (*)

1. Create an order
2. Hold the order
3. Unhold the order from the Orders grid
4. Make assertions


### Resolved issues:
1. [x] resolves magento/magento2#31521: [MFTF] Refactoring AdminOrdersReleaseInUnholdStatusTest