### PR TITLE
[MFTF] Refactoring AdminMassOrdersCancelProcessingAndClosedTest

### DIFF
--- a/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersCancelClosedAndProcessingTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersCancelClosedAndProcessingTest.xml
@@ -6,70 +6,76 @@
   */
 -->
 
-<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
-    <test name="AdminMassOrdersCancelProcessingAndClosedTest" deprecated="Use AdminMassOrdersCancelClosedAndProcessingTest instead">
+    <test name="AdminMassOrdersCancelClosedAndProcessingTest">
         <annotations>
             <stories value="Mass Update Orders"/>
-            <title value="DEPRECATED. Mass cancel orders in status  Processing, Closed"/>
+            <title value="Mass cancel orders in status  Processing, Closed"/>
             <description value="Try to cancel orders in status Processing, Closed"/>
             <severity value="MAJOR"/>
             <testCaseId value="MC-16184"/>
             <group value="sales"/>
             <group value="mtf_migrated"/>
-            <skip>
-                <issueId value="DEPRECATED">Use AdminMassOrdersCancelClosedAndProcessingTest instead</issueId>
-            </skip>
         </annotations>
         <before>
             <actionGroup ref="AdminLoginActionGroup" stepKey="LoginAsAdmin"/>
 
-            <!-- Create Data -->
             <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
             <createData entity="_defaultCategory" stepKey="createCategory"/>
             <createData entity="defaultSimpleProduct" stepKey="createProduct">
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
+
+            <createData entity="CustomerCart" stepKey="createCustomerCartOne">
+                <requiredEntity createDataKey="createCustomer"/>
+            </createData>
+            <createData entity="CustomerCartItem" stepKey="addCartItemOne">
+                <requiredEntity createDataKey="createCustomerCartOne"/>
+                <requiredEntity createDataKey="createProduct"/>
+            </createData>
+            <createData entity="CustomerAddressInformation" stepKey="addCustomerOrderAddress">
+                <requiredEntity createDataKey="createCustomerCartOne"/>
+            </createData>
+            <updateData createDataKey="createCustomerCartOne" entity="CustomerOrderPaymentMethod" stepKey="sendCustomerPaymentInformationOne">
+                <requiredEntity createDataKey="createCustomerCartOne"/>
+            </updateData>
+            <createData entity="Invoice" stepKey="invoiceOrderOne">
+                <requiredEntity createDataKey="createCustomerCartOne"/>
+            </createData>
+
+            <createData entity="CustomerCart" stepKey="createCustomerCartTwo">
+                <requiredEntity createDataKey="createCustomer"/>
+            </createData>
+            <createData entity="CustomerCartItem" stepKey="addCartItemTwo">
+                <requiredEntity createDataKey="createCustomerCartTwo"/>
+                <requiredEntity createDataKey="createProduct"/>
+            </createData>
+            <createData entity="CustomerAddressInformation" stepKey="addCustomerOrderAddressTwo">
+                <requiredEntity createDataKey="createCustomerCartTwo"/>
+            </createData>
+            <updateData createDataKey="createCustomerCartTwo" entity="CustomerOrderPaymentMethod" stepKey="sendCustomerPaymentInformationTwo">
+                <requiredEntity createDataKey="createCustomerCartTwo"/>
+            </updateData>
+            <createData entity="Invoice" stepKey="invoiceOrderTwo">
+                <requiredEntity createDataKey="createCustomerCartTwo"/>
+            </createData>
+            <createData entity="CreditMemo" stepKey="refundOrderTwo">
+                <requiredEntity createDataKey="createCustomerCartTwo"/>
+            </createData>
         </before>
         <after>
-            <!-- Delete data -->
             <deleteData createDataKey="createCustomer" stepKey="deleteCustomer"/>
             <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
             <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
 
-        <!-- Create first order -->
-        <actionGroup ref="CreateOrderActionGroup" stepKey="createFirstOrder">
-            <argument name="product" value="$$createProduct$$"/>
-            <argument name="customer" value="$$createCustomer$$"/>
-        </actionGroup>
-        <grabTextFrom selector="|Order # (\d+)|" stepKey="getFirstOrderId"/>
-        <assertNotEmpty stepKey="assertOrderIdIsNotEmpty" after="getFirstOrderId">
-			<actualResult type="const">$getFirstOrderId</actualResult>
-        </assertNotEmpty>
-
-        <!-- Create Invoice for first Order -->
-        <actionGroup ref="AdminCreateInvoiceActionGroup" stepKey="createInvoice"/>
-
-        <!-- Create second order -->
-        <actionGroup ref="CreateOrderActionGroup" stepKey="createSecondOrder">
-            <argument name="product" value="$$createProduct$$"/>
-            <argument name="customer" value="$$createCustomer$$"/>
-        </actionGroup>
-        <grabTextFrom selector="|Order # (\d+)|" stepKey="getSecondOrderId"/>
-        <assertNotEmpty stepKey="assertSecondOrderIdIsNotEmpty" after="getSecondOrderId">
-			<actualResult type="const">$getSecondOrderId</actualResult>
-        </assertNotEmpty>
-
-        <!-- Create CreditMemo for second Order -->
-        <actionGroup ref="AdminCreateInvoiceAndCreditMemoActionGroup" stepKey="createCreditMemo"/>
-
-        <!-- Navigate to backend: Go to Sales > Orders -->
         <actionGroup ref="AdminOrdersPageOpenActionGroup" stepKey="onOrderPage"/>
         <actionGroup ref="AdminOrdersGridClearFiltersActionGroup" stepKey="clearFilters"/>
+        <grabTextFrom selector="{{AdminOrdersGridSection.orderIdByIncrementId($createCustomerCartOne.return$)}}" stepKey="getFirstOrderId"/>
+        <grabTextFrom selector="{{AdminOrdersGridSection.orderIdByIncrementId($createCustomerCartTwo.return$)}}" stepKey="getSecondOrderId"/>
 
-        <!-- Select Mass Action according to dataset: Cancel -->
         <actionGroup ref="AdminTwoOrderActionOnGridActionGroup" stepKey="massActionCancel">
             <argument name="action" value="Cancel"/>
             <argument name="orderId" value="{$getFirstOrderId}"/>
@@ -77,7 +83,6 @@
         </actionGroup>
         <see userInput="You cannot cancel the order(s)." stepKey="assertOrderCancelMassActionFailMessage"/>
 
-        <!--Assert first order in orders grid -->
         <actionGroup ref="AdminOrderFilterByOrderIdAndStatusActionGroup" stepKey="seeFirstOrder">
             <argument name="orderId" value="{$getFirstOrderId}"/>
             <argument name="orderStatus" value="Processing"/>
@@ -85,7 +90,6 @@
         <see userInput="{$getFirstOrderId}" selector="{{AdminOrdersGridSection.gridCell('1','ID')}}" stepKey="assertFirstOrderID"/>
         <see userInput="Processing" selector="{{AdminOrdersGridSection.gridCell('1','Status')}}" stepKey="assertFirstOrderStatus"/>
 
-        <!--Assert second order in orders grid -->
         <actionGroup ref="AdminOrderFilterByOrderIdAndStatusActionGroup" stepKey="seeSecondOrder">
             <argument name="orderId" value="{$getSecondOrderId}"/>
             <argument name="orderStatus" value="Closed"/>


### PR DESCRIPTION
### Description (*)
A new test has been created to improve execution time.
The old "AdminMassOrdersCancelProcessingAndClosedTest" has been deprecated.

### Manual testing scenarios (*)
1. Create two orders
2. Invoice the first order
3. Invoice and refund the second order
4. Go to the Orders Grid
5. Try to cancel both orders via mass update
6. Verify the result

### Resolved issues:
1. [x] resolves magento/magento2#31517: [MFTF] Refactoring AdminMassOrdersCancelProcessingAndClosedTest