### PR TITLE
[MFTF] Refactoring AdminMassOrdersHoldOnPendingAndProcessingTest

### DIFF
--- a/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersHoldOnProcessingAndPendingTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/AdminMassOrdersHoldOnProcessingAndPendingTest.xml
@@ -8,65 +8,68 @@
 
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
-    <test name="AdminMassOrdersHoldOnPendingAndProcessingTest" deprecated="Use AdminMassOrdersHoldOnProcessingAndPendingTest">
+    <test name="AdminMassOrdersHoldOnProcessingAndPendingTest">
         <annotations>
             <stories value="Mass Update Orders"/>
-            <title value="DEPRECATED. Mass put orders in statuses Pending, Processing on Hold"/>
+            <title value="Mass put orders in statuses Pending, Processing on Hold"/>
             <description value="Put orders in statuses Pending, Processing on Hold"/>
             <severity value="MAJOR"/>
             <testCaseId value="MC-16185"/>
             <group value="sales"/>
             <group value="mtf_migrated"/>
-            <skip>
-                <issueId value="DEPRECATED">Use AdminMassOrdersHoldOnProcessingAndPendingTest</issueId>
-            </skip>
         </annotations>
         <before>
             <actionGroup ref="AdminLoginActionGroup" stepKey="LoginAsAdmin"/>
 
-            <!-- Create Data -->
             <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
             <createData entity="_defaultCategory" stepKey="createCategory"/>
             <createData entity="defaultSimpleProduct" stepKey="createProduct">
                 <requiredEntity createDataKey="createCategory"/>
             </createData>
+
+            <createData entity="CustomerCart" stepKey="createCustomerCartOne">
+                <requiredEntity createDataKey="createCustomer"/>
+            </createData>
+            <createData entity="CustomerCartItem" stepKey="addCartItemOne">
+                <requiredEntity createDataKey="createCustomerCartOne"/>
+                <requiredEntity createDataKey="createProduct"/>
+            </createData>
+            <createData entity="CustomerAddressInformation" stepKey="addCustomerOrderAddress">
+                <requiredEntity createDataKey="createCustomerCartOne"/>
+            </createData>
+            <updateData createDataKey="createCustomerCartOne" entity="CustomerOrderPaymentMethod" stepKey="sendCustomerPaymentInformationOne">
+                <requiredEntity createDataKey="createCustomerCartOne"/>
+            </updateData>
+
+            <createData entity="CustomerCart" stepKey="createCustomerCartTwo">
+                <requiredEntity createDataKey="createCustomer"/>
+            </createData>
+            <createData entity="CustomerCartItem" stepKey="addCartItemTwo">
+                <requiredEntity createDataKey="createCustomerCartTwo"/>
+                <requiredEntity createDataKey="createProduct"/>
+            </createData>
+            <createData entity="CustomerAddressInformation" stepKey="addCustomerOrderAddressTwo">
+                <requiredEntity createDataKey="createCustomerCartTwo"/>
+            </createData>
+            <updateData createDataKey="createCustomerCartTwo" entity="CustomerOrderPaymentMethod" stepKey="sendCustomerPaymentInformationTwo">
+                <requiredEntity createDataKey="createCustomerCartTwo"/>
+            </updateData>
+            <createData entity="Invoice" stepKey="invoiceOrderTwo">
+                <requiredEntity createDataKey="createCustomerCartTwo"/>
+            </createData>
         </before>
         <after>
-            <!-- Delete data -->
             <deleteData createDataKey="createCustomer" stepKey="deleteCustomer"/>
             <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
             <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
 
-        <!-- Create first order -->
-        <actionGroup ref="CreateOrderActionGroup" stepKey="createFirstOrder">
-            <argument name="product" value="$$createProduct$$"/>
-            <argument name="customer" value="$$createCustomer$$"/>
-        </actionGroup>
-        <grabTextFrom selector="|Order # (\d+)|" stepKey="getFirstOrderId"/>
-        <assertNotEmpty stepKey="assertOrderIdIsNotEmpty" after="getFirstOrderId">
-			<actualResult type="const">$getFirstOrderId</actualResult>
-        </assertNotEmpty>
-
-        <!-- Create second order -->
-        <actionGroup ref="CreateOrderActionGroup" stepKey="createSecondOrder">
-            <argument name="product" value="$$createProduct$$"/>
-            <argument name="customer" value="$$createCustomer$$"/>
-        </actionGroup>
-        <grabTextFrom selector="|Order # (\d+)|" stepKey="getSecondOrderId"/>
-        <assertNotEmpty stepKey="assertSecondOrderIdIsNotEmpty" after="getSecondOrderId">
-			<actualResult type="const">$getSecondOrderId</actualResult>
-        </assertNotEmpty>
-
-        <!-- Create Invoice for second Order -->
-        <actionGroup ref="AdminCreateInvoiceActionGroup" stepKey="createInvoice"/>
-
-        <!-- Navigate to backend: Go to Sales > Orders -->
         <actionGroup ref="AdminOrdersPageOpenActionGroup" stepKey="onOrderPage"/>
         <actionGroup ref="AdminOrdersGridClearFiltersActionGroup" stepKey="clearFilters"/>
+        <grabTextFrom selector="{{AdminOrdersGridSection.orderIdByIncrementId($createCustomerCartOne.return$)}}" stepKey="getFirstOrderId"/>
+        <grabTextFrom selector="{{AdminOrdersGridSection.orderIdByIncrementId($createCustomerCartTwo.return$)}}" stepKey="getSecondOrderId"/>
 
-        <!-- Select Mass Action according to dataset: Hold -->
         <actionGroup ref="AdminTwoOrderActionOnGridActionGroup" stepKey="massActionHold">
             <argument name="action" value="Hold"/>
             <argument name="orderId" value="{$getFirstOrderId}"/>
@@ -74,7 +77,6 @@
         </actionGroup>
         <see userInput="You have put 2 order(s) on hold." stepKey="assertOrderOnHoldSuccessMessage"/>
 
-        <!--Assert first order in orders grid -->
         <actionGroup ref="AdminOrderFilterByOrderIdAndStatusActionGroup" stepKey="seeFirstOrder">
             <argument name="orderId" value="{$getFirstOrderId}"/>
             <argument name="orderStatus" value="On Hold"/>
@@ -82,7 +84,6 @@
         <see userInput="{$getFirstOrderId}" selector="{{AdminOrdersGridSection.gridCell('1','ID')}}" stepKey="assertFirstOrderID"/>
         <see userInput="On Hold" selector="{{AdminOrdersGridSection.gridCell('1','Status')}}" stepKey="assertFirstOrderStatus"/>
 
-        <!--Assert second order in orders grid -->
         <actionGroup ref="AdminOrderFilterByOrderIdAndStatusActionGroup" stepKey="seeSecondOrder">
             <argument name="orderId" value="{$getSecondOrderId}"/>
             <argument name="orderStatus" value="On Hold"/>


### PR DESCRIPTION
### Description (*)
A new test has been created to improve execution time.
The old "AdminMassOrdersHoldOnPendingAndProcessingTest" has been deprecated.

### Manual testing scenarios (*)

1. Create two orders
2. Invoice the second order
3. Go to the Orders Grid
4. Hold both orders via mass update
5. Verify the result


### Resolved issues:
1. [x] resolves magento/magento2#31516: [MFTF] Refactoring AdminMassOrdersHoldOnPendingAndProcessingTest