### PR TITLE
Fixing the flaky MFTF and Integration tests that fail because of the wrong formatted date value

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/Test/CreateProductAttributeEntityTest/CreateProductAttributeEntityDateTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/CreateProductAttributeEntityTest/CreateProductAttributeEntityDateTest.xml
@@ -34,7 +34,7 @@
 
         <!--Generate date for use as default value, needs to be MM/d/YYYY and mm/d/yy-->
         <generateDate date="now" format="m/j/Y" stepKey="generateDefaultDate"/>
-        <generateDate date="now" format="m/j/y" stepKey="generateDateCompressedFormat"/>
+        <generateDate date="now" format="n/j/y" stepKey="generateDateCompressedFormat"/>
 
         <!--Navigate to Stores > Attributes > Product.-->
         <actionGroup ref="AdminOpenProductAttributePageActionGroup" stepKey="goToProductAttributes"/>

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/View/Options/Type/DateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Product/View/Options/Type/DateTest.php
@@ -207,19 +207,21 @@ HTML;
      */
     public function toHtmlWithDropDownDataProvider(): array
     {
+        $currentYear = date('Y');
+
         return [
             [
                 [
                     'month' => '3',
                     'day' => '5',
-                    'year' => '2020',
+                    'year' => $currentYear,
                     'hour' => '2',
                     'minute' => '15',
                     'day_part' => 'am',
-                    'date_internal' => '2020-09-30 02:15:00'
+                    'date_internal' => sprintf('%s-09-30 02:15:00', $currentYear)
                 ],
                 [
-                    '//select[@id="options_{id}_year"]/option[@selected]' => '2020',
+                    '//select[@id="options_{id}_year"]/option[@selected]' => $currentYear,
                     '//select[@id="options_{id}_month"]/option[@selected]' => '3',
                     '//select[@id="options_{id}_day"]/option[@selected]' => '5',
                     '//select[@id="options_{id}_hour"]/option[@selected]' => '2',
@@ -233,10 +235,10 @@ HTML;
                     'hour' => '2',
                     'minute' => '15',
                     'day_part' => 'am',
-                    'date_internal' => '2020-09-30 02:15:00'
+                    'date_internal' => sprintf('%s-09-30 02:15:00', $currentYear)
                 ],
                 [
-                    '//select[@id="options_{id}_year"]/option[@selected]' => '2020',
+                    '//select[@id="options_{id}_year"]/option[@selected]' => $currentYear,
                     '//select[@id="options_{id}_month"]/option[@selected]' => '9',
                     '//select[@id="options_{id}_day"]/option[@selected]' => '30',
                     '//select[@id="options_{id}_hour"]/option[@selected]' => '2',


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR is supposed to fix the following failing flaky tests:

- MFTF - `CreateProductAttributeEntityDateTest`
- Integration - `\Magento\Catalog\Block\Product\View\Options\Type\DateTest`

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments

Actually, the MFTF root issue is somewhere deeper, because the date input removes the 0 for days like `04/4/2021` after saving the product attribute.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31518: Fixing the flaky test that fails because of the wrong formatted date value