### PR TITLE
ISSUE-23181: Including new entries for including the weight when creating simple products

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Edit/Tab/Variations/Config/Matrix.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Edit/Tab/Variations/Config/Matrix.php
@@ -9,6 +9,7 @@ use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Locator\LocatorInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Directory\Helper\Data as DirectoryHelper;
 
 /**
  * Product variations matrix block
@@ -75,6 +76,7 @@ class Matrix extends \Magento\Backend\Block\Template
      * @param \Magento\Catalog\Helper\Image $image
      * @param \Magento\Framework\Locale\CurrencyInterface $localeCurrency
      * @param LocatorInterface $locator
+     * @param DirectoryHelper $directoryHelper
      * @param array $data
      */
     public function __construct(
@@ -86,6 +88,7 @@ class Matrix extends \Magento\Backend\Block\Template
         \Magento\Catalog\Helper\Image $image,
         \Magento\Framework\Locale\CurrencyInterface $localeCurrency,
         LocatorInterface $locator,
+        DirectoryHelper $directoryHelper,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -96,6 +99,7 @@ class Matrix extends \Magento\Backend\Block\Template
         $this->localeCurrency = $localeCurrency;
         $this->image = $image;
         $this->locator = $locator;
+        $this->directoryHelper = $directoryHelper;
     }
 
     /**
@@ -442,5 +446,13 @@ class Matrix extends \Magento\Backend\Block\Template
         $attributes[$attribute->getAttributeId()]['chosen'][] = $variationOption;
 
         return [$attributes, $variationOptions];
+    }
+
+    /**
+     * @return string
+     */
+    public function getWeightUnit()
+    {
+        return $this->directoryHelper->getWeightUnit();
     }
 }

--- a/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Edit/Tab/Variations/Config/Matrix.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Edit/Tab/Variations/Config/Matrix.php
@@ -68,6 +68,11 @@ class Matrix extends \Magento\Backend\Block\Template
     protected $locator;
 
     /**
+     * @var DirectoryHelper
+     */
+    protected $directoryHelper;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\ConfigurableProduct\Model\Product\Type\Configurable $configurableType
      * @param \Magento\CatalogInventory\Api\StockRegistryInterface $stockRegistry

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/CreateConfigurableProductWithWeightActionGroup.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/ActionGroup/CreateConfigurableProductWithWeightActionGroup.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="CreateConfigurableProductWithWeightActionGroup">
+        <annotations>
+            <description>Goes to the Admin Product grid page. Creates a Configurable Product with weight using the default Product Options.</description>
+        </annotations>
+        <arguments>
+            <argument name="product" defaultValue="_defaultProduct"/>
+            <argument name="category" defaultValue="_defaultCategory"/>
+        </arguments>
+
+        <!-- fill in basic configurable product values -->
+        <amOnPage url="{{AdminProductIndexPage.url}}" stepKey="amOnProductGridPage"/>
+        <waitForPageLoad time="30" stepKey="wait1"/>
+        <click selector="{{AdminProductGridActionSection.addProductToggle}}" stepKey="clickOnAddProductToggle"/>
+        <click selector="{{AdminProductGridActionSection.addConfigurableProduct}}" stepKey="clickOnAddConfigurableProduct"/>
+        <fillField userInput="{{product.name}}" selector="{{AdminProductFormSection.productName}}" stepKey="fillName"/>
+        <fillField userInput="{{product.sku}}" selector="{{AdminProductFormSection.productSku}}" stepKey="fillSKU"/>
+        <fillField userInput="{{product.price}}" selector="{{AdminProductFormSection.productPrice}}" stepKey="fillPrice"/>
+        <fillField userInput="{{product.quantity}}" selector="{{AdminProductFormSection.productQuantity}}" stepKey="fillQuantity"/>
+        <searchAndMultiSelectOption selector="{{AdminProductFormSection.categoriesDropdown}}" parameterArray="[{{category.name}}]" stepKey="fillCategory"/>
+        <selectOption userInput="{{product.visibility}}" selector="{{AdminProductFormSection.visibility}}" stepKey="fillVisibility"/>
+        <click selector="{{AdminProductSEOSection.sectionHeader}}" stepKey="openSeoSection"/>
+        <fillField userInput="{{product.urlKey}}" selector="{{AdminProductSEOSection.urlKeyInput}}" stepKey="fillUrlKey"/>
+
+        <!-- create configurations for colors the product is available in -->
+        <click selector="{{AdminProductFormConfigurationsSection.createConfigurations}}" stepKey="clickOnCreateConfigurations"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.createNewAttribute}}" stepKey="clickOnNewAttribute"/>
+        <waitForPageLoad stepKey="waitForIFrame"/>
+        <switchToIFrame selector="{{AdminNewAttributePanel.newAttributeIFrame}}" stepKey="switchToNewAttributeIFrame"/>
+        <fillField selector="{{AdminNewAttributePanel.defaultLabel}}" userInput="{{colorProductAttribute.default_label}}" stepKey="fillDefaultLabel"/>
+        <click selector="{{AdminNewAttributePanel.saveAttribute}}" stepKey="clickOnNewAttributePanel"/>
+        <waitForPageLoad stepKey="waitForSaveAttribute"/>
+        <switchToIFrame stepKey="switchOutOfIFrame"/>
+        <waitForPageLoad stepKey="waitForFilters"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.filters}}" stepKey="clickOnFilters"/>
+        <fillField userInput="{{colorProductAttribute.default_label}}" selector="{{AdminCreateProductConfigurationsPanel.attributeCode}}" stepKey="fillFilterAttributeCodeField"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.applyFilters}}" stepKey="clickApplyFiltersButton"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.firstCheckbox}}" stepKey="clickOnFirstCheckbox"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.next}}" stepKey="clickOnNextButton1"/>
+        <waitForElementVisible selector="{{AdminCreateProductConfigurationsPanel.createNewValue}}" stepKey="waitCreateNewValueAppears"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.createNewValue}}" stepKey="clickOnCreateNewValue1"/>
+        <fillField userInput="{{colorProductAttribute1.name}}" selector="{{AdminCreateProductConfigurationsPanel.attributeName}}" stepKey="fillFieldForNewAttribute1"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.saveAttribute}}" stepKey="clickOnSaveNewAttribute1"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.createNewValue}}" stepKey="clickOnCreateNewValue2"/>
+        <fillField userInput="{{colorProductAttribute2.name}}" selector="{{AdminCreateProductConfigurationsPanel.attributeName}}" stepKey="fillFieldForNewAttribute2"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.saveAttribute}}" stepKey="clickOnSaveNewAttribute2"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.createNewValue}}" stepKey="clickOnCreateNewValue3"/>
+        <fillField userInput="{{colorProductAttribute3.name}}" selector="{{AdminCreateProductConfigurationsPanel.attributeName}}" stepKey="fillFieldForNewAttribute3"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.saveAttribute}}" stepKey="clickOnSaveNewAttribute3"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.selectAll}}" stepKey="clickOnSelectAll"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.next}}" stepKey="clickOnNextButton2"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.applyUniquePricesByAttributeToEachSku}}" stepKey="clickOnApplyUniquePricesByAttributeToEachSku"/>
+        <selectOption selector="{{AdminCreateProductConfigurationsPanel.selectAttribute}}" userInput="{{colorProductAttribute.default_label}}" stepKey="selectAttributes"/>
+        <fillField selector="{{AdminCreateProductConfigurationsPanel.attribute1}}" userInput="{{colorProductAttribute1.price}}" stepKey="fillAttributePrice1"/>
+        <fillField selector="{{AdminCreateProductConfigurationsPanel.attribute2}}" userInput="{{colorProductAttribute2.price}}" stepKey="fillAttributePrice2"/>
+        <fillField selector="{{AdminCreateProductConfigurationsPanel.attribute3}}" userInput="{{colorProductAttribute3.price}}" stepKey="fillAttributePrice3"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.applySingleQuantityToEachSkus}}" stepKey="clickOnApplySingleQuantityToEachSku"/>
+        <fillField selector="{{AdminCreateProductConfigurationsPanel.quantity}}" userInput="1" stepKey="enterAttributeQuantity"/>
+
+        <!-- Assigning weight to the associatted products -->
+        <click selector="{{AdminCreateProductConfigurationsPanel.applySingleWeightToEachSkus}}" stepKey="clickOnApplySingleWeightToEachSku"/>
+        <fillField selector="{{AdminCreateProductConfigurationsPanel.weight}}" userInput="1" stepKey="enterAttributeWeight"/>
+
+        <click selector="{{AdminCreateProductConfigurationsPanel.next}}" stepKey="clickOnNextButton3"/>
+        <click selector="{{AdminCreateProductConfigurationsPanel.next}}" stepKey="clickOnNextButton4"/>
+        <click selector="{{AdminProductFormActionSection.saveButton}}" stepKey="clickOnSaveButton2"/>
+        <click selector="{{AdminChooseAffectedAttributeSetPopup.confirm}}" stepKey="clickOnConfirmInPopup"/>
+        <seeElement selector="{{AdminProductMessagesSection.successMessage}}" stepKey="seeSaveProductMessage"/>
+        <seeInTitle userInput="{{product.name}}" stepKey="seeProductNameInTitle"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Section/AdminCreateProductConfigurationsPanelSection.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Section/AdminCreateProductConfigurationsPanelSection.xml
@@ -60,5 +60,7 @@
         <element name="attributeCheckboxByName" type="input" selector="//*[contains(@data-attribute-option-title,'{{arg}}')]//input[@type='checkbox']" parameterized="true"/>
         <element name="attributeColorCheckbox" type="select" selector="//div[contains(text(),'color') and @class='data-grid-cell-content']/../preceding-sibling::td/label/input"/>
         <element name="attributeRowByAttributeCode" type="block" selector="//td[count(../../..//th[./*[.='Attribute Code']]/preceding-sibling::th) + 1][./*[.='{{attribute_code}}']]/../td//input[@data-action='select-row']" parameterized="true"/>
+        <element name="applySingleWeightToEachSkus" type="radio" selector=".admin__field-label[for='apply-single-weight-radio']" timeout="30" />
+        <element name="weight" type="input" selector="#apply-single-weight-input"/>
     </section>
 </sections>

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductCreateTest/AdminConfigurableProductWithWeightCreateTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductCreateTest/AdminConfigurableProductWithWeightCreateTest.xml
@@ -11,10 +11,10 @@
         <annotations>
             <features value="ConfigurableProduct"/>
             <stories value="Create, Read, Update, Delete"/>
-            <title value="admin should be able to create a configurable product with attributes"/>
-            <description value="admin should be able to create a configurable product with attributes"/>
-            <severity value="BLOCKER"/>
-            <testCaseId value="MC-84"/>
+            <title value="admin should be able to create a configurable product assigning weight to child products with attributes"/>
+            <description value="admin should be able to create a configurable product assigning weight to child products with attributes"/>
+            <severity value="AVERAGE"/>
+            <testCaseId value="MC-17466"/>
             <group value="ConfigurableProduct"/>
         </annotations>
 

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductCreateTest/AdminConfigurableProductWithWeightCreateTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductCreateTest/AdminConfigurableProductWithWeightCreateTest.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminConfigurableProductWithWeightCreateTest">
+        <annotations>
+            <features value="ConfigurableProduct"/>
+            <stories value="Create, Read, Update, Delete"/>
+            <title value="admin should be able to create a configurable product with attributes"/>
+            <description value="admin should be able to create a configurable product with attributes"/>
+            <severity value="BLOCKER"/>
+            <testCaseId value="MC-84"/>
+            <group value="ConfigurableProduct"/>
+        </annotations>
+
+        <before>
+            <createData entity="ApiCategory" stepKey="createCategory"/>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin1"/>
+        </before>
+
+        <after>
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="adminLogout"/>
+        </after>
+
+        <!-- Create a configurable product via the UI -->
+        <actionGroup ref="CreateConfigurableProductWithWeightActionGroup" stepKey="createProduct">
+            <argument name="product" value="_defaultProduct"/>
+            <argument name="category" value="$$createCategory$$"/>
+        </actionGroup>
+
+        <!-- assert color configurations on the admin create product page -->
+        <dontSee selector="{{AdminProductFormConfigurationsSection.variationLabel}}" stepKey="seeLabelNotVisible"/>
+        <seeNumberOfElements selector="{{AdminProductFormConfigurationsSection.currentVariationsRows}}" userInput="3" stepKey="seeNumberOfRows"/>
+        <see selector="{{AdminProductFormConfigurationsSection.currentVariationsNameCells}}" userInput="{{colorProductAttribute1.name}}" stepKey="seeAttributeName1InField"/>
+        <see selector="{{AdminProductFormConfigurationsSection.currentVariationsNameCells}}" userInput="{{colorProductAttribute2.name}}" stepKey="seeAttributeName2InField"/>
+        <see selector="{{AdminProductFormConfigurationsSection.currentVariationsNameCells}}" userInput="{{colorProductAttribute3.name}}" stepKey="seeAttributeName3InField"/>
+        <see selector="{{AdminProductFormConfigurationsSection.currentVariationsSkuCells}}" userInput="{{colorProductAttribute1.name}}" stepKey="seeAttributeSku1InField"/>
+        <see selector="{{AdminProductFormConfigurationsSection.currentVariationsSkuCells}}" userInput="{{colorProductAttribute2.name}}" stepKey="seeAttributeSku2InField"/>
+        <see selector="{{AdminProductFormConfigurationsSection.currentVariationsSkuCells}}" userInput="{{colorProductAttribute3.name}}" stepKey="seeAttributeSku3InField"/>
+        <see selector="{{AdminProductFormConfigurationsSection.currentVariationsPriceCells}}" userInput="{{colorProductAttribute1.price}}" stepKey="seeUniquePrice1InField"/>
+        <see selector="{{AdminProductFormConfigurationsSection.currentVariationsPriceCells}}" userInput="{{colorProductAttribute2.price}}" stepKey="seeUniquePrice2InField"/>
+        <see selector="{{AdminProductFormConfigurationsSection.currentVariationsPriceCells}}" userInput="{{colorProductAttribute3.price}}" stepKey="seeUniquePrice3InField"/>
+        <see selector="{{AdminProductFormConfigurationsSection.currentVariationsQuantityCells}}" userInput="{{colorProductAttribute.attribute_quantity}}" stepKey="seeQuantityInField"/>
+
+        <!-- assert storefront category list page -->
+        <amOnPage url="/" stepKey="amOnStorefront"/>
+        <waitForPageLoad stepKey="waitForPageLoad3"/>
+        <click userInput="$$createCategory.name$$" stepKey="clickOnCategoryName"/>
+        <waitForPageLoad stepKey="waitForPageLoad4"/>
+        <see userInput="{{_defaultProduct.name}}" stepKey="assertProductPresent"/>
+        <see userInput="{{colorProductAttribute1.price}}" stepKey="assertProductPricePresent"/>
+
+        <!-- assert storefront product details page -->
+        <click userInput="{{_defaultProduct.name}}" stepKey="clickOnProductName"/>
+        <waitForPageLoad stepKey="waitForPageLoad5"/>
+        <seeInTitle userInput="{{_defaultProduct.name}}" stepKey="assertProductNameTitle"/>
+        <see userInput="{{_defaultProduct.name}}" selector="{{StorefrontProductInfoMainSection.productName}}" stepKey="assertProductName"/>
+        <see userInput="{{colorProductAttribute1.price}}" selector="{{StorefrontProductInfoMainSection.productPrice}}" stepKey="assertProductPrice"/>
+        <see userInput="{{_defaultProduct.sku}}" selector="{{StorefrontProductInfoMainSection.productSku}}" stepKey="assertProductSku"/>
+        <see selector="{{StorefrontProductInfoMainSection.productAttributeTitle1}}" userInput="{{colorProductAttribute.default_label}}" stepKey="seeColorAttributeName1"/>
+        <see selector="{{StorefrontProductInfoMainSection.productAttributeOptions1}}" userInput="{{colorProductAttribute1.name}}" stepKey="seeInDropDown1"/>
+        <see selector="{{StorefrontProductInfoMainSection.productAttributeOptions1}}" userInput="{{colorProductAttribute2.name}}" stepKey="seeInDropDown2"/>
+        <see selector="{{StorefrontProductInfoMainSection.productAttributeOptions1}}" userInput="{{colorProductAttribute3.name}}" stepKey="seeInDropDown3"/>
+
+        <!-- Add configurable product to the cart with selected first option -->
+        <selectOption userInput="{{colorProductAttribute1.name}}" selector="{{StorefrontProductInfoMainSection.productAttributeOptionsSelectButton}}" stepKey="selectOptionForAddingToCart"/>
+        <click selector="{{StorefrontProductInfoMainSection.AddToCart}}" stepKey="clickAddToCart"/>
+        <waitForElementVisible selector="{{StorefrontCategoryMainSection.SuccessMsg}}" stepKey="waitForSuccessMessage"/>
+
+        <!-- assert storefront product checkout page -->
+        <actionGroup ref="GoToCheckoutFromMinicartActionGroup" stepKey="clickOnMiniCartCheckoutButton"/>
+
+        <waitForElement selector="{{CheckoutShippingSection.shippingTab}}" time="30" stepKey="waitForShippingSectionLoaded"/>
+    </test>
+</tests>

--- a/app/code/Magento/ConfigurableProduct/composer.json
+++ b/app/code/Magento/ConfigurableProduct/composer.json
@@ -16,7 +16,8 @@
         "magento/module-media-storage": "*",
         "magento/module-quote": "*",
         "magento/module-store": "*",
-        "magento/module-ui": "*"
+        "magento/module-ui": "*",
+        "magento/module-directory": "*"
     },
     "suggest": {
         "magento/module-msrp": "*",

--- a/app/code/Magento/ConfigurableProduct/etc/module.xml
+++ b/app/code/Magento/ConfigurableProduct/etc/module.xml
@@ -14,6 +14,7 @@
             <module name="Magento_Sales"/>
             <module name="Magento_Quote"/>
             <module name="Magento_Checkout"/>
+            <module name="Magento_Directory"/>
         </sequence>
     </module>
 </config>

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/bulk.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/bulk.phtml
@@ -753,6 +753,114 @@ $jsonHelper = $block->getData('jsonHelper');
             </div>
         </div>
     </div>
+
+    <div data-bind="with: sections().weight" class="steps-wizard-section">
+        <div data-role="section">
+            <div class="steps-wizard-section-title">
+                <span><?= $block->escapeHtml(__('Weight')) ?></span>
+            </div>
+            <ul class="steps-wizard-section-list">
+                <li>
+                    <div class="admin__field admin__field-option">
+                        <input type="radio"
+                               id="apply-single-weight-radio"
+                               class="admin__control-radio"
+                               value="single"
+                               data-bind="checked: type" />
+                        <label for="apply-single-weight-radio" class="admin__field-label">
+                            <span><?= $block->escapeHtml(__('Apply single weight to each SKUs')) ?></span>
+                        </label>
+                    </div>
+                </li>
+                <li>
+                    <div class="admin__field admin__field-option">
+                        <input type="radio"
+                               id="apply-unique-weight-radio"
+                               class="admin__control-radio"
+                               value="each"
+                               data-bind="checked: type" />
+                        <label for="apply-unique-weight-radio" class="admin__field-label">
+                            <span><?= $block->escapeHtml(__('Apply unique weight by attribute to each SKU')) ?></span>
+                        </label>
+                    </div>
+                </li>
+                <li>
+                    <div class="admin__field admin__field-option">
+                        <input type="radio"
+                               id="skip-weight-radio"
+                               class="admin__control-radio"
+                               value="none"
+                               checked
+                               data-bind="checked: type" />
+                        <label for="skip-weight-radio" class="admin__field-label">
+                            <span><?= $block->escapeHtml(__('Skip weight at this time')) ?></span>
+                        </label>
+                    </div>
+                </li>
+            </ul>
+
+            <form data-role="attributes-values-form">
+                <fieldset class="admin__fieldset bulk-attribute-values" data-bind="visible: type() == 'single'">
+                    <div class="admin__field _required">
+                        <label for="apply-single-weight-input" class="admin__field-label">
+                            <span><?= $block->escapeHtml(__('Weight')) ?></span>
+                        </label>
+                        <div class="admin__field-control">
+                            <div class="admin__control-addon">
+                                <input type="text"
+                                       id="apply-single-weight-input"
+                                       class="admin__control-text required-entry validate-zero-or-greater"
+                                       data-bind="value: value, uniqueName: true" />
+                                <label for="apply-single-weight-input" class="admin__addon-suffix">
+                                    <span data-bind="text: unit"></span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </form>
+
+            <div data-bind="visible: type() == 'each'">
+                <fieldset class="admin__fieldset bulk-attribute-values">
+                    <div class="admin__field _required">
+                        <label for="apply-single-weight-input-qty" class="admin__field-label">
+                            <span><?= $block->escapeHtml(__('Select attribute')) ?></span>
+                        </label>
+                        <div class="admin__field-control">
+                            <select id="apply-single-weight-input-qty" class="admin__control-select" data-bind="
+                                options: $parent.attributes,
+                                optionsText: 'label',
+                                value: attribute,
+                                optionsCaption: 'Select'"></select>
+                        </div>
+                    </div>
+                </fieldset>
+                <form data-role="attributes-values-form">
+                    <fieldset class="admin__fieldset bulk-attribute-values" data-bind="if:attribute">
+                        <!-- ko foreach: attribute().chosen -->
+                        <div class="admin__field _required">
+                            <label data-bind="attr: {for: 'apply-weight-input-' + $index()}" class="admin__field-label">
+                                <span data-bind="text:label"></span>
+                            </label>
+                            <div class="admin__field-control">
+                                <div class="admin__control-addon">
+                                    <input id="apply-single-weight-input-value"
+                                       class="admin__control-text required-entry validate-zero-or-greater" type="text"
+                                       data-bind="value:sections()[$parent.label], uniqueName: true,
+                                            attr: {id: 'apply-weight-input-' + $index()}"/>
+                                    <label data-bind="attr: {for: 'apply-weight-input-' + $index()}"
+                                           class="admin__addon-suffix">
+                                        <span data-bind="text: $parent.unit"></span>
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- /ko -->
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
     </form>
 </div>
 

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/wizard.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/wizard.phtml
@@ -13,6 +13,7 @@ $jsonHelper = $block->getData('jsonHelper');
 $productMatrix = $block->getProductMatrix();
 $attributes = $block->getProductAttributes();
 $currencySymbol = $block->getCurrencySymbol();
+$weightUnit = $block->getWeightUnit();
 ?>
 <div class="<?= /* @noEscape */ $block->getData('config/dataScope') ?>"
      data-role="step-wizard-dialog"
@@ -62,6 +63,7 @@ $currencySymbol = $block->getCurrencySymbol();
                         "productUrl": "<?= /* @noEscape */ $block->getUrl('catalog/product/edit', ['id' => '%id%']) ?>",
                         "variations": <?= /* @noEscape */ $jsonHelper->jsonEncode($productMatrix) ?>,
                         "currencySymbol": "<?= /* @noEscape */ $currencySymbol ?>",
+                        "weightUnit": "<?= /* @noEscape */ $weightUnit ?>",
                         "attributeSetCreationUrl": "<?= /* @noEscape */ $block->getUrl('*/product_set/save') ?>"
                     }
                 }

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/steps/bulk.js
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/steps/bulk.js
@@ -67,11 +67,19 @@ define([
                     type: ko.observable('none'),
                     value: ko.observable(),
                     attribute: ko.observable()
+                },
+                weight: {
+                    label: 'weight',
+                    type: ko.observable('none'),
+                    value: ko.observable(),
+                    attribute: ko.observable(),
+                    unit: ''
                 }
             });
 
             this.variationsComponent(function (variationsComponent) {
                 this.sections().price.currencySymbol = variationsComponent.getCurrencySymbol();
+                this.sections().weight.unit = variationsComponent.getWeightUnit();
             }.bind(this));
 
             /**
@@ -81,7 +89,8 @@ define([
                 return {
                     images: new this.makeImages(null),
                     price: this.price,
-                    quantity: this.quantity
+                    quantity: this.quantity,
+                    weight: this.weight
                 };
             }.bind(this);
 

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/steps/summary.js
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/steps/summary.js
@@ -51,7 +51,13 @@ define([
                 }
             }),
             attributes: [],
-            attributesName: [$.mage.__('Images'), $.mage.__('SKU'), $.mage.__('Quantity'), $.mage.__('Price')],
+            attributesName: [
+                $.mage.__('Images'),
+                $.mage.__('SKU'),
+                $.mage.__('Quantity'),
+                $.mage.__('Weight'),
+                $.mage.__('Price')
+            ],
             sections: [],
             gridTemplate: 'Magento_ConfigurableProduct/variations/steps/summary-grid',
             quantityFieldName: 'quantity'
@@ -100,7 +106,7 @@ define([
 
             this.variations = [];
             _.each(variations, function (options) {
-                var product, images, sku, name, quantity, price, variation,
+                var product, images, sku, name, quantity, price, variation, weight,
                     productId = this.variationsComponent().getProductIdByOptions(options);
 
                 if (productId) {
@@ -129,6 +135,13 @@ define([
                 if (productId && !images.file) {
                     images = product.images;
                 }
+
+                weight = getSectionValue('weight', options);
+
+                if(!weight && productWeight.length > 0) {
+                    weight = productWeight;
+                }
+
                 variation = {
                     options: options,
                     images: images,
@@ -136,7 +149,7 @@ define([
                     name: name,
                     price: price,
                     productId: productId,
-                    weight: productWeight,
+                    weight: weight,
                     editable: true
                 };
                 variation[this.quantityFieldName] = quantity;
@@ -199,6 +212,7 @@ define([
             _.each(variation.options, function (option) {
                 row.push(option.label);
             });
+            row.push(variation.weight);
             row.push(this.variationsComponent().getCurrencySymbol() +  ' ' + variation.price);
 
             return row;

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/steps/summary.js
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/steps/summary.js
@@ -138,7 +138,7 @@ define([
 
                 weight = getSectionValue('weight', options);
 
-                if(!weight && productWeight.length > 0) {
+                if (!weight && productWeight.length > 0) {
                     weight = productWeight;
                 }
 

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/variations.js
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/web/js/variations/variations.js
@@ -220,6 +220,7 @@ define([
                     productId: variation.productId || null,
                     name: variation.name || variation.sku,
                     priceCurrency: this.currencySymbol,
+                    unitWeight: this.unitWeight,
                     weight: variation.weight,
                     attribute: JSON.stringify(attributes),
                     variationKey: this.getVariationKey(variation.options),
@@ -377,6 +378,14 @@ define([
          */
         getCurrencySymbol: function () {
             return this.currencySymbol;
+        },
+
+        /**
+         * Get unit weight
+         * @returns {String}
+         */
+        getWeightUnit: function () {
+            return this.weightUnit;
         },
 
         /**


### PR DESCRIPTION
### Description (*)
Including new entries for including the weight on the step of creating simple products on the admin panel through the configurable product creation page. Before adding these fields when creating simple products using that way, when the configurable product had not a weight assign it has caused the creating of virtual products instead.

With those new fields, the user can assign the weight for the products similar to the way how the quantity and price are assigned.

The user is still capable to ignore the weight when creating the products, however, they will still be created as virtual.

### Fixed Issues (if relevant)
1. Fixes magento/magento2 #23181 

### Manual testing scenarios (*)
see #23181 

### Acceptance tests

app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductCreateTest/AdminConfigurableProductWithWeightCreateTest.xml

app/code/Magento/ConfigurableProduct/Test/Mftf/Test/AdminConfigurableProductCreateTest/AdminConfigurableProductCreateTest.xml

### Questions or comments
I was unable to find for myself a way to fix the option available for price and quantity:  
1. `Skip the price at this time` ;
2. `Skip the quantity at this time`.

 `Skip the weight at this time` will keep not assigning a weight for the products, and they will still be created as virtual instead of simple type.

I am opened to any ideas that you can suggest to sort off it.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
