### PR TITLE
31489-shopping cart rules do not applied fix

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/ShippingAddress/AvailableShippingMethods.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/ShippingAddress/AvailableShippingMethods.php
@@ -62,13 +62,15 @@ class AvailableShippingMethods implements ResolverInterface
         $address = clone $value['model'];
         $address->setLimitCarrier(null);
 
+        $cart = $address->getQuote();
+        $address = $cart->getShippingAddress();
+
         // Allow shipping rates by setting country id for new addresses
         if (!$address->getCountryId() && $address->getCountryCode()) {
             $address->setCountryId($address->getCountryCode());
         }
 
         $address->setCollectShippingRates(true);
-        $cart = $address->getQuote();
         $this->totalsCollector->collectAddressTotals($cart, $address);
         $methods = [];
         $shippingRates = $address->getGroupedAllShippingRates();


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
ShippingCartAddress available_shipping_methods wrong amount (shopping cart rules do not applied)

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#31489

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Sample data.
2. Cart Price Rule "Spend $50 or more - shipping is free!" is active.
3. Shipping method "Table Rate" is enabled.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
