### PR TITLE
Coupon with Fixed amount discount for whole cart apply rule not working in GraphQL resolved

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
@@ -33,6 +33,27 @@ class CartPrices implements ResolverInterface
     ) {
         $this->totalsCollector = $totalsCollector;
     }
+    public function getDiscountValue (Quote $quote){
+        $address = $quote->getShippingAddress();
+        $totalDiscounts = $address->getExtensionAttributes()->getDiscounts();
+        if ($totalDiscounts && is_array($totalDiscounts)) {
+            foreach ($totalDiscounts as $value) {
+                $discount = [];
+                $amount = [];
+                $discount['label'] = $value->getRuleLabel() ?: __('Discount');
+                /* @var \Magento\SalesRule\Api\Data\DiscountDataInterface $discountData */
+                $discountData = $value->getDiscountData();
+                $amount['value'] = $discountData->getAmount();
+                $amount['currency'] = $quote->getQuoteCurrencyCode();
+                $discount['amount'] = $amount;
+                $discountValues[] = $discount;
+            }
+            foreach ($discountValues as $individualDiscountValue) {
+                return $individualDiscountValue['amount']['value'];
+            }
+        }
+        return 0;
+    }
 
     /**
      * @inheritdoc
@@ -47,9 +68,11 @@ class CartPrices implements ResolverInterface
         $quote = $value['model'];
         $cartTotals = $this->totalsCollector->collectQuoteTotals($quote);
         $currency = $quote->getQuoteCurrencyCode();
+        $discountValue = $this->getDiscountValue($quote);
+        $grandTotal = $cartTotals->getGrandTotal() - $discountValue;
 
         return [
-            'grand_total' => ['value' => $cartTotals->getGrandTotal(), 'currency' => $currency],
+            'grand_total' => ['value' => $grandTotal, 'currency' => $currency],
             'subtotal_including_tax' => ['value' => $cartTotals->getSubtotalInclTax(), 'currency' => $currency],
             'subtotal_excluding_tax' => ['value' => $cartTotals->getSubtotal(), 'currency' => $currency],
             'subtotal_with_discount_excluding_tax' => [


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
**Previously:** Discount is not deducted from the grand_total in the cart query (GraphQL)
**Now:** Added the logic for deducting the discount from the grand_total in the cart query(GraphQL) 


### Fixed Issues (if relevant)

1. Fixes magento/magento2 #30719 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
