### PR TITLE
Consistent behaviour for disallowed path's errors

### DIFF
--- a/app/code/Magento/MediaStorage/App/Media.php
+++ b/app/code/Magento/MediaStorage/App/Media.php
@@ -190,7 +190,8 @@ class Media implements AppInterface
             $fileAbsolutePath = $this->directoryPub->getAbsolutePath($this->relativeFileName);
             $fileRelativePath = str_replace(rtrim($this->mediaDirectoryPath, '/') . '/', '', $fileAbsolutePath);
             if (!$isAllowed($fileRelativePath, $allowedResources)) {
-                throw new LogicException('The path is not allowed: ' . $this->relativeFileName);
+                require_once 'errors/404.php';
+                exit;
             }
         }
 


### PR DESCRIPTION
### Description

If the `var/resource_config.json` file [exists](https://github.com/magento/magento2/blob/6f79389b63f72f7395e949e8e296c9967f6e58cd/pub/get.php#L36), requests to invalid paths are handled by [this piece of code](https://github.com/magento/magento2/blob/6f79389b63f72f7395e949e8e296c9967f6e58cd/pub/get.php#L49-L52), but when the file doesn't, it is handled by [another class](https://github.com/magento/magento2/blob/6f79389b63f72f7395e949e8e296c9967f6e58cd/app/code/Magento/MediaStorage/App/Media.php#L192-L194), which has a different behaviour.

### Fixed Issues

1. Fixes #31582

### Manual testing scenarios

1. same as #31582 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
