### PR TITLE
Fix issue disabled modules still include less

### DIFF
--- a/app/code/Magento/Developer/etc/di.xml
+++ b/app/code/Magento/Developer/etc/di.xml
@@ -202,11 +202,12 @@
             <argument name="fileSource" xsi:type="object">Magento\Framework\Css\PreProcessor\File\Collector\Aggregated</argument>
         </arguments>
     </type>
+
     <type name="Magento\Framework\Css\PreProcessor\File\Collector\Aggregated">
         <arguments>
             <argument name="libraryFiles" xsi:type="object">Magento\Framework\Css\PreProcessor\File\Collector\Library</argument>
             <argument name="baseFiles" xsi:type="object">cssSourceBaseFilesSorted</argument>
-            <argument name="overriddenBaseFiles" xsi:type="object">cssSourceOverriddenBaseFiles</argument>
+            <argument name="overriddenBaseFiles" xsi:type="object">cssSourceOverriddenBaseFilesSorted</argument>
         </arguments>
     </type>
 
@@ -215,14 +216,28 @@
             <argument name="subject" xsi:type="object">cssSourceBaseFilesFiltered</argument>
         </arguments>
     </virtualType>
+
     <virtualType name="cssSourceBaseFilesFiltered" type="Magento\Framework\View\File\Collector\Decorator\ModuleOutput">
         <arguments>
             <argument name="subject" xsi:type="object">cssSourceBaseFiles</argument>
         </arguments>
     </virtualType>
+
     <virtualType name="cssSourceBaseFiles" type="Magento\Framework\View\File\Collector\Base">
         <arguments>
             <argument name="subDir" xsi:type="string">web</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="cssSourceOverriddenBaseFilesSorted" type="Magento\Framework\View\File\Collector\Decorator\ModuleDependency">
+        <arguments>
+            <argument name="subject" xsi:type="object">cssSourceOverriddenBaseFilesFiltered</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="cssSourceOverriddenBaseFilesFiltered" type="Magento\Framework\View\File\Collector\Decorator\ModuleEnabled">
+        <arguments>
+            <argument name="subject" xsi:type="object">cssSourceOverriddenBaseFiles</argument>
         </arguments>
     </virtualType>
 

--- a/lib/internal/Magento/Framework/View/File/Collector/Decorator/ModuleEnabled.php
+++ b/lib/internal/Magento/Framework/View/File/Collector/Decorator/ModuleEnabled.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Framework\View\File\Collector\Decorator;
 
@@ -11,10 +12,7 @@ use Magento\Framework\View\Design\ThemeInterface;
 use Magento\Framework\View\File;
 use Magento\Framework\View\File\CollectorInterface;
 
-/**
- * Decorator that filters out view files that belong to modules, output of which is prohibited
- */
-class ModuleOutput implements CollectorInterface
+class ModuleEnabled implements CollectorInterface
 {
     /**
      * Subject
@@ -26,7 +24,7 @@ class ModuleOutput implements CollectorInterface
     /**
      * Module manager
      *
-     * @var \Magento\Framework\Module\Manager
+     * @var ModuleManager
      */
     private $moduleManager;
 
@@ -53,11 +51,11 @@ class ModuleOutput implements CollectorInterface
      * @param string $filePath
      * @return File[]
      */
-    public function getFiles(ThemeInterface $theme, $filePath)
+    public function getFiles(ThemeInterface $theme, $filePath): array
     {
         $result = [];
         foreach ($this->subject->getFiles($theme, $filePath) as $file) {
-            if ($this->moduleManager->isOutputEnabled($file->getModule())) {
+            if ($this->moduleManager->isEnabled($file->getModule())) {
                 $result[] = $file;
             }
         }

--- a/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/Decorator/ModuleEnabledTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/Decorator/ModuleEnabledTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\View\Test\Unit\File\Collector\Decorator;
+
+use Magento\Framework\Module\Manager as ModuleManager;
+use Magento\Framework\View\Design\ThemeInterface;
+use Magento\Framework\View\File;
+use Magento\Framework\View\File\Collector\Decorator\ModuleEnabled;
+use Magento\Framework\View\File\CollectorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ModuleEnabledTest extends TestCase
+{
+    /**
+     * @var ModuleEnabled
+     */
+    private $model;
+
+    /**
+     * @var CollectorInterface|MockObject
+     */
+    private $fileSourceMock;
+
+    /**
+     * @var ModuleManager|MockObject
+     */
+    private $moduleManagerMock;
+
+    protected function setUp(): void
+    {
+        $this->fileSourceMock = $this->getMockForAbstractClass(CollectorInterface::class);
+        $this->moduleManagerMock = $this->createMock(ModuleManager::class);
+        $this->moduleManagerMock
+            ->expects($this->any())
+            ->method('isEnabled')
+            ->will(
+                $this->returnValueMap(
+                    [
+                        ['Module_Enabled', true],
+                        ['Module_Disabled', false],
+                    ]
+                )
+            );
+        $this->model = new ModuleEnabled(
+            $this->fileSourceMock,
+            $this->moduleManagerMock
+        );
+    }
+
+    public function testGetFiles(): void
+    {
+        $theme = $this->getMockForAbstractClass(ThemeInterface::class);
+        $fileOne = new File('1.xml', 'Module_Enabled');
+        $fileTwo = new File('2.xml', 'Module_Disabled');
+        $fileThree = new File('3.xml', 'Module_Enabled', $theme);
+        $this->fileSourceMock->expects($this->once())
+            ->method('getFiles')
+            ->with($theme, '*.xml')
+            ->willReturn([$fileOne, $fileTwo, $fileThree]);
+        $this->assertSame([$fileOne, $fileThree], $this->model->getFiles($theme, '*.xml'));
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Retarget my old PR to new branch

This PR bring the patch for fix issue modules disabled still include less files. It's should not included in output final style files. Previously styles still included in output final css styles

Use case 1: Disable module example Company_CustomCatalog in app/etc/config.php. But assume accidental add module styles in theme folder in
app/design/frontend/theme/theme_name/Company_CustomCatalog/web/css/source/_module.less
app/code/Company/CustomModule/web/css/source/_module.less
Actually after run deploy output css magento still included Company_CustomCatalog styles in file styles-m.css in pub folder

Previously magento collect files get all files less from web dir theme follow dependency but not check files belong modules enabled or not. So some files from inactive modules (file _module.less) from theme folders still be included. That's is what we don't want in real use-case world

After patch files get correctly. If module has disabled both styles from web module area and theme area will not included

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#24666 Static content is deploying for disabled modules
Keep continue works by @Echron after long inactivity

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Magento 2.3.4+
2. blank or luma theme
3. Disable a couple module use less styles: Ex: Magento_Review, Magento_LoginAsCustomerFrontendUi
4. Run deploy static content and clear cache

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
For this pr seem will take quite long period for acceptance and delivery to 2.5 branch. In the meantime we can use this patch
https://github.com/vasilii-b/magento2-frontend-improvements/blob/master/patches/composer/magento-framework/import-styles-for-enabled-modules-only.patch. for issue
Use this with your own risk! (not official patch from magento) ( but it's works)
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
