### PR TITLE
Moving array access for CAPTCHA _.isEmpty check

### DIFF
--- a/app/code/Magento/Captcha/view/frontend/web/js/view/checkout/defaultCaptcha.js
+++ b/app/code/Magento/Captcha/view/frontend/web/js/view/checkout/defaultCaptcha.js
@@ -56,7 +56,7 @@ define([
          */
         checkCustomerData: function (formId, captchaData, captcha) {
             if (!_.isEmpty(captchaData) &&
-                !_.isEmpty(captchaData)[formId] &&
+                !_.isEmpty(captchaData[formId]) &&
                 captchaData[formId].timestamp > captcha.timestamp
             ) {
                 if (!captcha.isRequired() && captchaData[formId].isRequired) {


### PR DESCRIPTION
When upgrading to 2.3.6 from 2.3.5-p2, a new CAPTCHA zone "payment_processing_request" is added.

If a customer has an existing session (from 2.3.5-p2 or prior), and tries to access checkout with their existing session data, checkout will fail to load because the check to see if `captchaData[formId]` exists is not a valid function call.
`_.isEmpty()` only returns a boolean value, so it cannot be enumerated like an array. Array access syntax has been moved in to the check, rather than outside it.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This change allows a `_.isEmpty()` check in the `defaultCaptcha.js` file to complete successfully, resolving issues with the checkout failing to load or infinitely loading after upgrading.
### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A - no reported issue for this yet?

### Manual testing scenarios (*)
1. Create an instance prior to 2.3.6 (eg: 2.3.5-p2)
2. Load the /checkout route in a valid way (eg: add to basket, create an account, click "go to checkout")
3. Observe the `captcha` key of the `mage-cache-storage` local storage key. There should **not** be an entry for `payment_processing_request`
4. Upgrade to 2.3.6 or another version that **does** include the fix introduced via [MC-36200](https://github.com/magento/magento2/commit/d31085aea48f151e0359ccc3c72d3585da3e96a1)
5. Load the `/checkout` route with the same session as before
6. Observe an infinite load on the checkout page and errors in the console along the lines of:

```
defaultCaptcha.js:60 Uncaught TypeError: Cannot read property 'timestamp' of undefined
    at UiClass.checkCustomerData (defaultCaptcha.js:60)
    at UiClass.<anonymous> (defaultCaptcha.js:43)
    at Function.each (jquery.js:382)
    at UiClass.initialize (defaultCaptcha.js:38)
    at UiClass.initialize (wrapper.js:109)
    at UiClass._super (wrapper.js:106)
    at UiClass.initialize (loginCaptcha.js:21)
    at UiClass.initialize (wrapper.js:109)
    at new UiClass (class.js:49)
    at Object.initComponent (layout.js:137)
```

7. Apply patch
8. Attempt to load `/checkout` again
9. Observe checkout loads as expected



### Questions or comments
I'm not sure if an issue is needed for this PR, but happy to make one if one is needed. This will also need to be backported to 2.3.6.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31641: Moving array access for CAPTCHA _.isEmpty check