### PR TITLE
Magento_AdminAnalytics: avoid using deprecated escape* methods from A…

### DIFF
--- a/app/code/Magento/AdminAnalytics/view/adminhtml/templates/tracking.phtml
+++ b/app/code/Magento/AdminAnalytics/view/adminhtml/templates/tracking.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 
@@ -24,15 +25,15 @@
 $metadata = $block->getMetadata();
 $scriptString = '
     var adminAnalyticsMetadata = {
-        "secure_base_url": "' . $block->escapeJs($metadata->getSecureBaseUrlForScope()) . '",
-        "version": "' . $block->escapeJs($metadata->getMagentoVersion()) . '",
-        "product_edition": "' . $block->escapeJs($metadata->getProductEdition()) . '",
-        "user": "' . $block->escapeJs($metadata->getCurrentUser()) . '",
-        "mode": "' . $block->escapeJs($metadata->getMode()) . '",
-        "store_name_default": "' . $block->escapeJs($metadata->getStoreNameForScope()) . '",
-        "admin_user_created": "' . $block->escapeJs($metadata->getCurrentUserCreatedDate()) . '",
-        "admin_user_logdate": "' . $block->escapeJs($metadata->getCurrentUserLogDate()) . '",
-        "admin_user_role_name": "' . $block->escapeJs($metadata->getCurrentUserRoleName()) . '"
+        "secure_base_url": "' . $escaper->escapeJs($metadata->getSecureBaseUrlForScope()) . '",
+        "version": "' . $escaper->escapeJs($metadata->getMagentoVersion()) . '",
+        "product_edition": "' . $escaper->escapeJs($metadata->getProductEdition()) . '",
+        "user": "' . $escaper->escapeJs($metadata->getCurrentUser()) . '",
+        "mode": "' . $escaper->escapeJs($metadata->getMode()) . '",
+        "store_name_default": "' . $escaper->escapeJs($metadata->getStoreNameForScope()) . '",
+        "admin_user_created": "' . $escaper->escapeJs($metadata->getCurrentUserCreatedDate()) . '",
+        "admin_user_logdate": "' . $escaper->escapeJs($metadata->getCurrentUserLogDate()) . '",
+        "admin_user_role_name": "' . $escaper->escapeJs($metadata->getCurrentUserRoleName()) . '"
     };
 ';
 ?>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
