### PR TITLE
Magento_AdvancedSearch: avoid using deprecated escape* methods from A…

### DIFF
--- a/app/code/Magento/AdvancedSearch/view/adminhtml/templates/system/config/testconnection.phtml
+++ b/app/code/Magento/AdvancedSearch/view/adminhtml/templates/system/config/testconnection.phtml
@@ -3,12 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <button class="scalable" type="button" id="<?= $block->getHtmlId() ?>" data-mage-init='{"testConnection":{
-    "url": "<?= $block->escapeUrl($block->getAjaxUrl()) ?>",
+    "url": "<?= $escaper->escapeUrl($block->getAjaxUrl()) ?>",
     "elementId": "<?= $block->getHtmlId() ?>",
-    "successText": "<?= $block->escapeHtmlAttr(__('Successful! Test again?')) ?>",
-    "failedText": "<?= $block->escapeHtmlAttr(__('Connection failed! Test again?')) ?>",
+    "successText": "<?= $escaper->escapeHtmlAttr(__('Successful! Test again?')) ?>",
+    "failedText": "<?= $escaper->escapeHtmlAttr(__('Connection failed! Test again?')) ?>",
     "fieldMapping": "<?= /* @noEscape */ $block->getFieldMapping() ?>"}, "validation": {}}'>
-    <span id="<?= $block->getHtmlId() ?>_result"><?= $block->escapeHtml($block->getButtonLabel()) ?></span>
+    <span id="<?= $block->getHtmlId() ?>_result"><?= $escaper->escapeHtml($block->getButtonLabel()) ?></span>
 </button>

--- a/app/code/Magento/AdvancedSearch/view/frontend/templates/search_data.phtml
+++ b/app/code/Magento/AdvancedSearch/view/frontend/templates/search_data.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var \Magento\AdvancedSearch\Block\SearchData $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <?php
@@ -13,11 +14,11 @@
 $data = $block->getItems();
 if (count($data)) : ?>
     <dl class="block">
-        <dt class="title"><?= $block->escapeHtml(__($block->getTitle())) ?></dt>
+        <dt class="title"><?= $escaper->escapeHtml(__($block->getTitle())) ?></dt>
         <?php foreach ($data as $additionalInfo) : ?>
             <dd class="item">
-                <a href="<?= $block->escapeUrl($block->getLink($additionalInfo->getQueryText())) ?>"
-                    ><?= $block->escapeHtml($additionalInfo->getQueryText()) ?></a>
+                <a href="<?= $escaper->escapeUrl($block->getLink($additionalInfo->getQueryText())) ?>"
+                    ><?= $escaper->escapeHtml($additionalInfo->getQueryText()) ?></a>
                 <?php if ($block->isShowResultsCount()) : ?>
                     <span class="count"><?= /* @noEscape */ (int)$additionalInfo->getResultsCount() ?></span>
                 <?php endif; ?>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
