### PR TITLE
Magento_Analytics: avoid using deprecated escape* methods from Abstra…

### DIFF
--- a/app/code/Magento/Analytics/view/adminhtml/templates/dashboard/section.phtml
+++ b/app/code/Magento/Analytics/view/adminhtml/templates/dashboard/section.phtml
@@ -3,25 +3,30 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
+
 ?>
 
 <section class="dashboard-advanced-reports" data-index="dashboard-advanced-reports">
     <div class="dashboard-advanced-reports-description">
         <header class="dashboard-advanced-reports-title">
-            <?= $block->escapeHtml(__('Advanced Reporting')) ?>
+            <?= $escaper->escapeHtml(__('Advanced Reporting')) ?>
         </header>
         <div class="dashboard-advanced-reports-content">
-            <?= $block->escapeHtml(__('Gain new insights and take command of your business\' performance,' .
+            <?= $escaper->escapeHtml(__('Gain new insights and take command of your business\' performance,' .
                 ' using our dynamic product, order, and customer reports tailored to your customer data.')) ?>
         </div>
     </div>
     <div class="dashboard-advanced-reports-actions">
-        <a href="<?= $block->escapeUrl($block->getUrl('analytics/reports/show')) ?>"
+        <a href="<?= $escaper->escapeUrl($block->getUrl('analytics/reports/show')) ?>"
            target="_blank"
            class="action action-advanced-reports"
            data-index="analytics-service-link"
-           title="<?= $block->escapeHtmlAttr(__('Go to Advanced Reporting')) ?>">
-            <span><?= $block->escapeHtml(__('Go to Advanced Reporting')) ?></span>
+           title="<?= $escaper->escapeHtmlAttr(__('Go to Advanced Reporting')) ?>">
+            <span><?= $escaper->escapeHtml(__('Go to Advanced Reporting')) ?></span>
         </a>
     </div>
 </section>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
