### PR TITLE
Magento_Downloadable: avoid using deprecated escape* methods from Abs…

### DIFF
--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Links.php
@@ -252,7 +252,7 @@ class Links extends \Magento\Backend\Block\Template
         foreach ($links as $item) {
             $tmpLinkItem = [
                 'link_id' => $item->getId(),
-                'title' => $this->escapeHtml($item->getTitle()),
+                'title' => $this->_escaper->escapeHtml($item->getTitle()),
                 'price' => $this->getCanReadPrice() ? $this->getPriceValue($item->getPrice()) : '',
                 'number_of_downloads' => $item->getNumberOfDownloads(),
                 'is_shareable' => $item->getIsShareable(),

--- a/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
+++ b/app/code/Magento/Downloadable/Block/Adminhtml/Catalog/Product/Edit/Tab/Downloadable/Samples.php
@@ -149,7 +149,7 @@ class Samples extends \Magento\Backend\Block\Widget
         foreach ($samples as $item) {
             $tmpSampleItem = [
                 'sample_id' => $item->getId(),
-                'title' => $this->escapeHtml($item->getTitle()),
+                'title' => $this->_escaper->escapeHtml($item->getTitle()),
                 'sample_url' => $item->getSampleUrl(),
                 'sample_type' => $item->getSampleType(),
                 'sort_order' => $item->getSortOrder(),

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/composite/fieldset/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/composite/fieldset/downloadable.phtml
@@ -5,8 +5,12 @@
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 // @deprecated
+
+/**
+ * @var $block \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Downloadable
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<?php /* @var $block \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Downloadable */ ?>
 <?php $_linksPurchasedSeparately = $block->getLinksPurchasedSeparately(); ?>
 <?php $_skipSaleableCheck = $this->helper(Magento\Catalog\Helper\Product::class)->getSkipSaleableCheck(); ?>
 <?php if (($block->getProduct()->isSaleable() || $_skipSaleableCheck) && $block->hasLinks()) :?>
@@ -14,29 +18,29 @@
 <fieldset id="catalog_product_composite_configure_fields_downloadable"
           class="fieldset admin__fieldset downloadable information<?= $block->getIsLastFieldset() ? ' last-fieldset' : '' ?>">
     <legend class="legend admin__legend">
-        <span><?= $block->escapeHtml(__('Downloadable Information')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Downloadable Information')) ?></span>
     </legend><br />
     <?php $_links = $block->getLinks(); ?>
     <?php $_isRequired = $block->getLinkSelectionRequired(); ?>
     <div class="field admin__field link<?php if ($_isRequired) { echo ' _required'; } ?>">
-        <label class="label admin__field-label"><span><?= $block->escapeHtml($block->getLinksTitle()) ?></span></label>
+        <label class="label admin__field-label"><span><?= $escaper->escapeHtml($block->getLinksTitle()) ?></span></label>
         <div class="control admin__field-control" id="downloadable-links-list">
             <?php foreach ($_links as $_link) : ?>
                 <div class="nested admin__field-option">
                 <?php if ($_linksPurchasedSeparately) : ?>
                     <input type="checkbox"
                            class="admin__control-checkbox checkbox<?php if ($_isRequired) :?> required-entry<?php endif; ?> product downloadable link"
-                           name="links[]" id="links_<?= $block->escapeHtmlAttr($_link->getId()) ?>"
-                           value="<?= $block->escapeHtmlAttr($_link->getId()) ?>"
-                           <?= $block->escapeHtml($block->getLinkCheckedValue($_link)) ?>
-                           price="<?= $block->escapeHtmlAttr($block->getCurrencyPrice($_link->getPrice())) ?>"/>
+                           name="links[]" id="links_<?= $escaper->escapeHtmlAttr($_link->getId()) ?>"
+                           value="<?= $escaper->escapeHtmlAttr($_link->getId()) ?>"
+                           <?= $escaper->escapeHtml($block->getLinkCheckedValue($_link)) ?>
+                           price="<?= $escaper->escapeHtmlAttr($block->getCurrencyPrice($_link->getPrice())) ?>"/>
                     <?php endif; ?>
-                    <label for="links_<?= $block->escapeHtmlAttr($_link->getId()) ?>" class="label admin__field-label">
-                        <?= $block->escapeHtml($_link->getTitle()) ?>
+                    <label for="links_<?= $escaper->escapeHtmlAttr($_link->getId()) ?>" class="label admin__field-label">
+                        <?= $escaper->escapeHtml($_link->getTitle()) ?>
                         <?php if ($_link->getSampleFile() || $_link->getSampleUrl()) : ?>
-                            &nbsp;(<a href="<?= $block->escapeUrl($block->getLinkSampleUrl($_link)) ?>"
+                            &nbsp;(<a href="<?= $escaper->escapeUrl($block->getLinkSampleUrl($_link)) ?>"
                                 <?= /* @noEscape */ $block->getIsOpenInNewWindow() ? 'onclick="this.target=\'_blank\'"' : '' ?>>
-                                <?= $block->escapeHtml(__('sample')) ?>
+                                <?= $escaper->escapeHtml(__('sample')) ?>
                             </a>)
                         <?php endif; ?>
                         <?php if ($_linksPurchasedSeparately) : ?>
@@ -50,8 +54,8 @@
                         require(['prototype'], function(){
 
                             //<![CDATA[
-                            $('links_<?= $block->escapeJs($_link->getId()) ?>').advaiceContainer = 'links-advice-container';
-                            $('links_<?= $block->escapeJs($_link->getId()) ?>').callbackFunction = 'validateDownloadableCallback';
+                            $('links_<?= $escaper->escapeJs($_link->getId()) ?>').advaiceContainer = 'links-advice-container';
+                            $('links_<?= $escaper->escapeJs($_link->getId()) ?>').callbackFunction = 'validateDownloadableCallback';
                             //]]>
 
                         });

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable.phtml
@@ -5,11 +5,10 @@
  */
 
 // @deprecated
-?>
 
-<?php
 /**
  * @var $block \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <script>
@@ -28,7 +27,7 @@ var uploaderTemplate = '<div class="no-display" id="[[idName]]-template">' +
                                 '<div class="no-display" id="[[idName]]-template-progress">' +
                                 '<%- data.percent %>% <%- data.uploaded %> / <%- data.total %>' +
                                 '</div>',
-    
+
     fileListTemplate = '<span class="file-info">' +
                                 '<span class="file-info-name"><%= data.name %></span>' +
                                 ' ' +
@@ -202,15 +201,15 @@ var uploaderTemplate = '<div class="no-display" id="[[idName]]-template">' +
 });
 </script>
 
-<div data-tab-type="tab_content_downloadableInfo" id="<?= $block->escapeHtmlAttr($block->getId()) ?>_content"
-    <?= $block->escapeHtml($block->getUiId('tab', 'content', $block->getId())) ?>
+<div data-tab-type="tab_content_downloadableInfo" id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>_content"
+    <?= $escaper->escapeHtml($block->getUiId('tab', 'content', $block->getId())) ?>
 >
 <div id="alert_messages_block"><?= $block->getMessageHtml() ?></div>
 <div class="admin__field admin__field-option admin__field-is-downloaodable">
     <input type="checkbox" data-action="change-type-product-downloadable"  class="admin__control-checkbox"
            name="is_downloadable" id="is-downloaodable" <?= $block->isDownloadable() ? 'checked="checked"' : ''?> />
     <label class="admin__field-label" for="is-downloaodable">
-        <span><?= $block->escapeHtml(__('Is this a downloadable Product?')); ?></span>
+        <span><?= $escaper->escapeHtml(__('Is this a downloadable Product?')); ?></span>
     </label>
 </div>
 <div class="entry-edit" id="product_info_tabs_downloadable_items">

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/links.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/links.phtml
@@ -10,28 +10,29 @@
 
 /**
  * @var $block \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable\Links
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <?php $_product = $block->getProduct()?>
 <?php $block->getConfigJson() ?>
 <fieldset class="admin__fieldset downloadable-form" data-ui-id="downloadable-links">
-    <legend class="admin__legend"><span><?= $block->escapeHtml(__('Links')) ?></span></legend><br>
-    <p class="note"><?= $block->escapeHtml(__('Add links to your product files here.')) ?></p>
-    <div class="admin__field" <?= $block->escapeHtml(!$block->isSingleStoreMode() ? ' data-config-scope="' . __('[STORE VIEW]') . '"' : '') ?>>
-        <label class="admin__field-label" for="downloadable_links_title"><span><?= $block->escapeHtml(__('Title')) ?></span></label>
+    <legend class="admin__legend"><span><?= $escaper->escapeHtml(__('Links')) ?></span></legend><br>
+    <p class="note"><?= $escaper->escapeHtml(__('Add links to your product files here.')) ?></p>
+    <div class="admin__field" <?= $escaper->escapeHtml(!$block->isSingleStoreMode() ? ' data-config-scope="' . __('[STORE VIEW]') . '"' : '') ?>>
+        <label class="admin__field-label" for="downloadable_links_title"><span><?= $escaper->escapeHtml(__('Title')) ?></span></label>
         <div class="admin__field-control">
-            <input type="text" class="admin__control-text" id="downloadable_links_title" name="product[links_title]" value="<?= $block->escapeHtml($block->getLinksTitle()) ?>" <?= ($_product->getStoreId() && $block->getUsedDefault()) ? 'disabled="disabled"' : '' ?>>
+            <input type="text" class="admin__control-text" id="downloadable_links_title" name="product[links_title]" value="<?= $escaper->escapeHtml($block->getLinksTitle()) ?>" <?= ($_product->getStoreId() && $block->getUsedDefault()) ? 'disabled="disabled"' : '' ?>>
             <?php if ($_product->getStoreId()) : ?>
                 <div class="admin__field admin__field-option">
                     <input id="link_title_default" class="admin__control-checkbox" type="checkbox" name="use_default[]" value="links_title" onclick="toggleValueElements(this, this.parentNode.parentNode)" <?= $block->getUsedDefault() ? 'checked="checked"' : '' ?> />
-                    <label class="admin__field-label" for="link_title_default"><span><?= $block->escapeHtml(__('Use Default Value')) ?></span></label>
+                    <label class="admin__field-label" for="link_title_default"><span><?= $escaper->escapeHtml(__('Use Default Value')) ?></span></label>
                 </div>
             <?php endif; ?>
         </div>
     </div>
 
-    <div class="admin__field" <?= $block->escapeHtml(!$block->isSingleStoreMode() ? ' data-config-scope="' . __('[GLOBAL]') . '"' : '') ?>>
-        <label class="admin__field-label" for="downloadable_link_purchase_type"><span><?= $block->escapeHtml(__('Links can be purchased separately')) ?></span></label>
+    <div class="admin__field" <?= $escaper->escapeHtml(!$block->isSingleStoreMode() ? ' data-config-scope="' . __('[GLOBAL]') . '"' : '') ?>>
+        <label class="admin__field-label" for="downloadable_link_purchase_type"><span><?= $escaper->escapeHtml(__('Links can be purchased separately')) ?></span></label>
         <div class="admin__field-control">
             <div class="admin__field-control link-switcher" data-role="link-switcher">
                 <div class="admin__field-control-group">
@@ -69,15 +70,15 @@
                 <table class="admin__control-table">
                     <thead>
                         <tr>
-                            <th class="col-sort"><span><?= $block->escapeHtml(__('Sort Order')) ?></span></th>
-                            <th class="col-title _required"><span><?= $block->escapeHtml(__('Title')) ?></span></th>
+                            <th class="col-sort"><span><?= $escaper->escapeHtml(__('Sort Order')) ?></span></th>
+                            <th class="col-title _required"><span><?= $escaper->escapeHtml(__('Title')) ?></span></th>
                             <?php if ($block->getCanReadPrice() !== false) : ?>
-                                <th class="col-price"><span><?= $block->escapeHtml(__('Price')) ?></span></th>
+                                <th class="col-price"><span><?= $escaper->escapeHtml(__('Price')) ?></span></th>
                             <?php endif; ?>
-                            <th class="col-file"><span><?= $block->escapeHtml(__('Attach File or Enter Link')) ?></span></th>
-                            <th class="col-sample"><span><?= $block->escapeHtml(__('Sample')) ?></span></th>
-                            <th class="col-share"><span><?= $block->escapeHtml(__('Shareable')) ?></span></th>
-                            <th class="col-limit"><span><?= $block->escapeHtml(__('Max. Downloads')) ?></span></th>
+                            <th class="col-file"><span><?= $escaper->escapeHtml(__('Attach File or Enter Link')) ?></span></th>
+                            <th class="col-sample"><span><?= $escaper->escapeHtml(__('Sample')) ?></span></th>
+                            <th class="col-share"><span><?= $escaper->escapeHtml(__('Shareable')) ?></span></th>
+                            <th class="col-limit"><span><?= $escaper->escapeHtml(__('Max. Downloads')) ?></span></th>
                             <th class="col-actions">&nbsp;</th>
                         </tr>
                     </thead>
@@ -91,7 +92,7 @@
                 </table>
             </div>
             <div class="admin__field-note">
-                <span><?= $block->escapeHtml(__('Alphanumeric, dash and underscore characters are recommended for filenames. Improper characters are replaced with \'_\'.')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Alphanumeric, dash and underscore characters are recommended for filenames. Improper characters are replaced with \'_\'.')) ?></span>
             </div>
         </div>
     </div>
@@ -113,7 +114,7 @@ require([
             'data.id' +
             ' %>][sort_order]" ' +
             'value="<%- data.sort_order %>" class="input-text admin__control-text sort" />' +
-                '<span class="draggable-handle" title="<?= $block->escapeJs($block->escapeHtml(__('Sort Variations'))) ?>"></span>' +
+                '<span class="draggable-handle" title="<?= $escaper->escapeJs($escaper->escapeHtml(__('Sort Variations'))) ?>"></span>' +
             '</td>'+
             '<td class="col-title">'+
                 '<input type="hidden" class="__delete__" name="downloadable[link][<%- data.id %>][is_delete]" value="" />'+
@@ -122,7 +123,7 @@ require([
                 <?php if ($_product->getStoreId()) : ?>
                     '<div class="admin__field admin__field-option">'+
                     '<input type="checkbox" id="downloadable_link_<%- data.id %>_title" name="downloadable[link][<%- data.id %>][use_default_title]" value="1" class="admin__control-checkbox" />'+
-                    '<label for="downloadable_link_<%- data.id %>_title" class="admin__field-label"><span><?= $block->escapeJs($block->escapeHtml(__('Use Default Value'))) ?></span></label>'+
+                    '<label for="downloadable_link_<%- data.id %>_title" class="admin__field-label"><span><?= $escaper->escapeJs($escaper->escapeHtml(__('Use Default Value'))) ?></span></label>'+
                     '</div>' +
                 <?php endif; ?>
                 <?php if ($block->getCanReadPrice() == false) : ?>
@@ -136,12 +137,12 @@ require([
                 '<td class="col-price">'+
                     '<div class="admin__control-addon">' +
                         '<input type="text" id="downloadable_link_<%- data.id %>_price_value" class="input-text admin__control-text validate-number link-prices<?php if ($block->getCanEditPrice() === false) : ?> disabled<?php endif; ?>" name="downloadable[link][<%- data.id %>][price]" value="<%- data.price %>"<?php if ($block->getCanEditPrice() === false) : ?> disabled="disabled"<?php endif; ?> /> ' +
-                        '<label class="admin__addon-prefix"><span><?= $block->escapeHtml($block->getBaseCurrencySymbol($_product->getStoreId())) ?></span></label>' +
+                        '<label class="admin__addon-prefix"><span><?= $escaper->escapeHtml($block->getBaseCurrencySymbol($_product->getStoreId())) ?></span></label>' +
                     '</div>' +
                     <?php if ($_product->getStoreId() && $block->getIsPriceWebsiteScope()) : ?>
                         '<div class="admin__field admin__field-option">'+
                             '<input type="checkbox" id="downloadable_link_<%- data.id %>_price" name="downloadable[link][<%- data.id %>][use_default_price]" value="1"<?php if ($block->getCanEditPrice() === false) : ?> disabled="disabled"<?php endif; ?> class="admin__control-checkbox" />'+
-                            '<label for="downloadable_link_<%- data.id %>_price" class="admin__field-label"><span><?= $block->escapeJs($block->escapeHtml(__('Use Default Value'))) ?></span></label>' +
+                            '<label for="downloadable_link_<%- data.id %>_price" class="admin__field-label"><span><?= $escaper->escapeJs($escaper->escapeHtml(__('Use Default Value'))) ?></span></label>' +
                         '</div>' +
                     <?php endif; ?>
                 '</td>' +
@@ -149,25 +150,25 @@ require([
             '<td class="col-file">'+
                 '<div class="admin__field admin__field-option">'+
                     '<input type="radio" class="admin__control-radio validate-one-required-by-name" id="downloadable_link_<%- data.id %>_file_type" name="downloadable[link][<%- data.id %>][type]" value="file"<%- data.file_checked %> />' +
-                    '<label for="downloadable_link_<%- data.id %>_file_type" class="admin__field-label"><span><?= $block->escapeJs($block->escapeHtml(__('File'))) ?></span></label>'+
+                    '<label for="downloadable_link_<%- data.id %>_file_type" class="admin__field-label"><span><?= $escaper->escapeJs($escaper->escapeHtml(__('File'))) ?></span></label>'+
                     '<input type="hidden" class="validate-downloadable-file" id="downloadable_link_<%- data.id %>_file_save" name="downloadable[link][<%- data.id %>][file]" value="<%- data.file_save %>" />'+
 
                     '<div id="downloadable_link_<%- data.id %>_file" class="admin__field-uploader">'+
                         '<div id="downloadable_link_<%- data.id %>_file-old" class="file-row-info"></div>'+
                         '<div id="downloadable_link_<%- data.id %>_file-new" class="file-row-info new-file"></div>'+
                         '<div class="fileinput-button form-buttons">'+
-                            '<span><?= $block->escapeJs($block->escapeHtml(__('Browse Files...'))) ?></span>' +
-                            '<input id="downloadable_link_<%- data.id %>_file" type="file" name="<?=  $block->escapeJs($block->escapeHtmlAttr($block->getFileFieldName('links'))) ?>">' +
+                            '<span><?= $escaper->escapeJs($escaper->escapeHtml(__('Browse Files...'))) ?></span>' +
+                            '<input id="downloadable_link_<%- data.id %>_file" type="file" name="<?=  $escaper->escapeJs($escaper->escapeHtmlAttr($block->getFileFieldName('links'))) ?>">' +
                             '<script>' +
-                                'linksUploader("#downloadable_link_<%- data.id %>_file", "<?=  $block->escapeJs($block->escapeUrl($block->getUploadUrl('links'))) ?>"); ' +
+                                'linksUploader("#downloadable_link_<%- data.id %>_file", "<?=  $escaper->escapeJs($escaper->escapeUrl($block->getUploadUrl('links'))) ?>"); ' +
                             '</scr'+'ipt>'+
                         '</div>'+
                     '</div>'+
                 '</div>'+
                 '<div class="admin__field admin__field-option admin__field-file-url">'+
                     '<input type="radio" class="admin__control-radio validate-one-required-by-name" id="downloadable_link_<%- data.id %>_url_type" name="downloadable[link][<%- data.id %>][type]" value="url"<%- data.url_checked %> />' +
-                    '<label for="downloadable_link_<%- data.id %>_url_type" class="admin__field-label"><span><?= $block->escapeJs($block->escapeHtml(__('URL'))) ?></span></label>' +
-                    '<input type="text" class="validate-downloadable-url validate-url admin__control-text" name="downloadable[link][<%- data.id %>][link_url]" value="<%- data.link_url %>" placeholder="<?= $block->escapeJs($block->escapeHtmlAttr(__('URL'))) ?>" />'+
+                    '<label for="downloadable_link_<%- data.id %>_url_type" class="admin__field-label"><span><?= $escaper->escapeJs($escaper->escapeHtml(__('URL'))) ?></span></label>' +
+                    '<input type="text" class="validate-downloadable-url validate-url admin__control-text" name="downloadable[link][<%- data.id %>][link_url]" value="<%- data.link_url %>" placeholder="<?= $escaper->escapeJs($escaper->escapeHtmlAttr(__('URL'))) ?>" />'+
                 '</div>'+
                 '<div>'+
                     '<span id="downloadable_link_<%- data.id %>_link_container"></span>'+
@@ -176,16 +177,16 @@ require([
             '<td class="col-sample">'+
                 '<div class="admin__field admin__field-option">'+
                     '<input type="radio" class="admin__control-radio" id="downloadable_link_<%- data.id %>_sample_file_type" name="downloadable[link][<%- data.id %>][sample][type]" value="file"<%- data.sample_file_checked %> />' +
-                    '<label for="downloadable_link_<%- data.id %>_sample_file_type" class="admin__field-label"><span><?= $block->escapeJs($block->escapeHtml(__('File'))) ?>:</span></label>'+
+                    '<label for="downloadable_link_<%- data.id %>_sample_file_type" class="admin__field-label"><span><?= $escaper->escapeJs($escaper->escapeHtml(__('File'))) ?>:</span></label>'+
                     '<input type="hidden" id="downloadable_link_<%- data.id %>_sample_file_save" name="downloadable[link][<%- data.id %>][sample][file]" value="<%- data.sample_file_save %>" class="validate-downloadable-file"/>'+
                     '<div id="downloadable_link_<%- data.id %>_sample_file" class="admin__field-uploader">'+
                         '<div id="downloadable_link_<%- data.id %>_sample_file-old" class="file-row-info"></div>'+
                         '<div id="downloadable_link_<%- data.id %>_sample_file-new" class="file-row-info new-file"></div>'+
                         '<div class="fileinput-button form-buttons">'+
-                        '<span><?= $block->escapeJs($block->escapeHtml(__('Browse Files...'))) ?></span>' +
-                        '<input id="downloadable_link_<%- data.id %>_sample_file" type="file" name="<?= $block->escapeJs($block->escapeHtmlAttr($block->getFileFieldName('link_samples'), '"')) ?>">' +
+                        '<span><?= $escaper->escapeJs($escaper->escapeHtml(__('Browse Files...'))) ?></span>' +
+                        '<input id="downloadable_link_<%- data.id %>_sample_file" type="file" name="<?= $escaper->escapeJs($escaper->escapeHtmlAttr($block->getFileFieldName('link_samples'), '"')) ?>">' +
                         '<script>'+
-                        'linksUploader("#downloadable_link_<%- data.id %>_sample_file", "<?=  $block->escapeJs($block->escapeUrl($block->getUploadUrl('link_samples'))) ?>"); ' +
+                        'linksUploader("#downloadable_link_<%- data.id %>_sample_file", "<?=  $escaper->escapeJs($escaper->escapeUrl($block->getUploadUrl('link_samples'))) ?>"); ' +
                         '</scr'+'ipt>'+
                         '</div>'+
                     '</div>'+
@@ -193,8 +194,8 @@ require([
 
                 '<div class="admin__field admin__field-option admin__field-file-url">'+
                     '<input type="radio" class="admin__control-radio validate-one-required-by-name" id="downloadable_link_<%- data.id %>_sample_url_type" name="downloadable[link][<%- data.id %>][sample][type]" value="url"<%- data.sample_url_checked %> />' +
-                    '<label for="downloadable_link_<%- data.id %>_sample_url_type" class="admin__field-label"><span><?= $block->escapeJs($block->escapeHtml(__('URL'))) ?></span></label>'+
-                    '<input type="text" class="validate-downloadable-url validate-url admin__control-text" name="downloadable[link][<%- data.id %>][sample][url]" value="<%- data.sample_url %>" placeholder="<?= $block->escapeJs($block->escapeHtmlAttr(__('URL'))) ?>" />'+
+                    '<label for="downloadable_link_<%- data.id %>_sample_url_type" class="admin__field-label"><span><?= $escaper->escapeJs($escaper->escapeHtml(__('URL'))) ?></span></label>'+
+                    '<input type="text" class="validate-downloadable-url validate-url admin__control-text" name="downloadable[link][<%- data.id %>][sample][url]" value="<%- data.sample_url %>" placeholder="<?= $escaper->escapeJs($escaper->escapeHtmlAttr(__('URL'))) ?>" />'+
                 '</div>'+
                 '<div>'+
                     '<span id="downloadable_link_<%- data.id %>_sample_container"></span>'+
@@ -202,20 +203,20 @@ require([
             '</td>'+
             '<td class="col-share">'+
                 '<select id="downloadable_link _<%- data.id %>_shareable" class="admin__control-select" name="downloadable[link][<%- data.id %>][is_shareable]">'+
-                    '<option value="1"><?= $block->escapeJs($block->escapeHtml(__('Yes'))) ?></option>'+
-                    '<option value="0"><?= $block->escapeJs($block->escapeHtml(__('No'))) ?></option>'+
-                    '<option value="2" selected="selected"><?= $block->escapeJs($block->escapeHtml(__('Use config'))) ?></option>'+
+                    '<option value="1"><?= $escaper->escapeJs($escaper->escapeHtml(__('Yes'))) ?></option>'+
+                    '<option value="0"><?= $escaper->escapeJs($escaper->escapeHtml(__('No'))) ?></option>'+
+                    '<option value="2" selected="selected"><?= $escaper->escapeJs($escaper->escapeHtml(__('Use config'))) ?></option>'+
                 '</select>'+
             '</td>'+
             '<td class="col-limit">' +
                 '<input type="text" id="downloadable_link_<%- data.id %>_downloads" name="downloadable[link][<%- data.id %>][number_of_downloads]" class="input-text validate-zero-or-greater admin__control-text downloads" value="<%- data.number_of_downloads %>" />'+
                 '<div class="admin__field admin__field-option">' +
                     '<input type="checkbox" class="admin__control-checkbox" id="downloadable_link_<%- data.id %>_is_unlimited" name="downloadable[link][<%- data.id %>][is_unlimited]" value="1" <%- data.is_unlimited %> />' +
-                    '<label for="downloadable_link_<%- data.id %>_is_unlimited" class="admin__field-label"><span><?= $block->escapeJs($block->escapeHtml(__('Unlimited'))) ?></span></label>' +
+                    '<label for="downloadable_link_<%- data.id %>_is_unlimited" class="admin__field-label"><span><?= $escaper->escapeJs($escaper->escapeHtml(__('Unlimited'))) ?></span></label>' +
                 '</div>' +
             '</td>'+
             '<td class="col-action">'+
-                '<button id="downloadable_link_<%- data.id %>_delete_button" type="button" class="action-delete" title="<?= $block->escapeJs($block->escapeHtmlAttr(__('Delete'))) ?>"><span><?= $block->escapeJs($block->escapeHtml(__('Delete'))) ?></span></button>'+
+                '<button id="downloadable_link_<%- data.id %>_delete_button" type="button" class="action-delete" title="<?= $escaper->escapeJs($escaper->escapeHtmlAttr(__('Delete'))) ?>"><span><?= $escaper->escapeJs($escaper->escapeHtml(__('Delete'))) ?></span></button>'+
             '</td>'+
         '</tr>';
 
@@ -232,7 +233,7 @@ require([
                     data.link_id  = 0;
                     data.link_type = 'file';
                     data.sample_type = 'none';
-                    data.number_of_downloads = '<?= $block->escapeJs($block->getConfigMaxDownloads()) ?>';
+                    data.number_of_downloads = '<?= $escaper->escapeJs($block->getConfigMaxDownloads()) ?>';
                     data.sort_order = this.itemCount + 1;
                 }
 

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/samples.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/samples.phtml
@@ -5,22 +5,22 @@
  */
 
 // @deprecated
-?>
-<?php
+
 /**
- * @var $block \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable\Links
+ * @var \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable\Links $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 
 $_product = $block->getProduct();
 $block->getConfigJson();
 ?>
 <fieldset class="admin__fieldset downloadable-form" data-ui-id="downloadable-samples">
-    <legend class="admin__legend"><span><?= $block->escapeHtml(__('Samples')) ?></span></legend><br>
-    <p class="note"><?= $block->escapeHtml(__('Add product preview files here.')) ?></p>
-    <div class="admin__field"<?= $block->escapeHtml(!$block->isSingleStoreMode() ? ' data-config-scope="' . __('[STORE VIEW]') . '"' : '') ?>>
-        <label class="admin__field-label" for="downloadable_samples_title"><span><?= $block->escapeHtml(__('Title')) ?></span></label>
+    <legend class="admin__legend"><span><?= $escaper->escapeHtml(__('Samples')) ?></span></legend><br>
+    <p class="note"><?= $escaper->escapeHtml(__('Add product preview files here.')) ?></p>
+    <div class="admin__field"<?= $escaper->escapeHtml(!$block->isSingleStoreMode() ? ' data-config-scope="' . __('[STORE VIEW]') . '"' : '') ?>>
+        <label class="admin__field-label" for="downloadable_samples_title"><span><?= $escaper->escapeHtml(__('Title')) ?></span></label>
         <div class="admin__field-control">
-            <input type="text" class="admin__control-text" id="downloadable_samples_title" name="product[samples_title]" value="<?= $block->escapeHtml($block->getSamplesTitle()) ?>" <?= /* @noEscape */ ($_product->getStoreId() && $block->getUsedDefault()) ? 'disabled="disabled"' : '' ?>>
+            <input type="text" class="admin__control-text" id="downloadable_samples_title" name="product[samples_title]" value="<?= $escaper->escapeHtml($block->getSamplesTitle()) ?>" <?= /* @noEscape */ ($_product->getStoreId() && $block->getUsedDefault()) ? 'disabled="disabled"' : '' ?>>
             <?php if ($_product->getStoreId()) : ?>
                 <div class="admin__field admin__field-option">
                     <input id="sample_title_default" class="admin__control-checkbox" type="checkbox" name="use_default[]" value="samples_title" onclick="toggleValueElements(this, this.parentNode.parentNode)" <?= /* @noEscape */ $block->getUsedDefault() ? 'checked="checked"' : '' ?> />
@@ -35,9 +35,9 @@ $block->getConfigJson();
                 <table class="admin__control-table">
                     <thead>
                         <tr>
-                            <th class="col-sort"><span><?= $block->escapeHtml(__('Sort Order')) ?></span></th>
-                            <th class="_required col-title"><span><?= $block->escapeHtml(__('Title')) ?></span></th>
-                            <th class="col-file"><span><?= $block->escapeHtml(__('Attach File or Enter Link')) ?></span></th>
+                            <th class="col-sort"><span><?= $escaper->escapeHtml(__('Sort Order')) ?></span></th>
+                            <th class="_required col-title"><span><?= $escaper->escapeHtml(__('Title')) ?></span></th>
+                            <th class="col-file"><span><?= $escaper->escapeHtml(__('Attach File or Enter Link')) ?></span></th>
                             <th class="col-actions">&nbsp;</th>
                         </tr>
                     </thead>
@@ -51,7 +51,7 @@ $block->getConfigJson();
                 </table>
             </div>
             <div class="admin__field-note">
-                <?= $block->escapeHtml(__('Alphanumeric, dash and underscore characters are recommended for filenames. Improper characters are replaced with \'_\'.')) ?>
+                <?= $escaper->escapeHtml(__('Alphanumeric, dash and underscore characters are recommended for filenames. Improper characters are replaced with \'_\'.')) ?>
             </div>
         </div>
     </div>
@@ -69,7 +69,7 @@ require([
         var sampleTemplate = '<tr>'+
             '<td class="col-sort" data-role="draggable-handle">' +
                 '<input data-container="link-order" type="hidden" name="downloadable[sample][<%- data.id %>][sort_order]" value="<%- data.sort_order %>" class="sort" />' +
-                '<span class="draggable-handle" title="<?= $block->escapeJs($block->escapeHtmlAttr(__('Sort Variations'))) ?>"></span>' +
+                '<span class="draggable-handle" title="<?= $escaper->escapeJs($escaper->escapeHtmlAttr(__('Sort Variations'))) ?>"></span>' +
             '</td>'+
             '<td class="col-title">'+
                 '<input type="hidden" class="__delete__" name="downloadable[sample][<%- data.id %>][is_delete]" value="" />'+
@@ -78,20 +78,20 @@ require([
                 <?php if ($_product->getStoreId()) : ?>
                     '<div class="admin__field admin__field-option">'+
                         '<input type="checkbox" id="downloadable_sample_<%- data.id %>_title" name="downloadable[sample][<%- data.id %>][use_default_title]" value="1" class="admin__control-checkbox" />'+
-                        '<label for="downloadable_link_<%- data.id %>_price" class="admin__field-label"><span><?= $block->escapeJs($block->escapeHtml(__('Use Default Value'))) ?></span></label>'+
+                        '<label for="downloadable_link_<%- data.id %>_price" class="admin__field-label"><span><?= $escaper->escapeJs($escaper->escapeHtml(__('Use Default Value'))) ?></span></label>'+
                     '</div>' +
                 <?php endif; ?>
             '</td>'+
             '<td class="col-file">'+
                 '<div class="admin__field admin__field-option">'+
                     '<input type="radio" class="admin__control-radio validate-one-required-by-name" id="downloadable_sample_<%- data.id %>_file_type" name="downloadable[sample][<%- data.id %>][type]" value="file"<%- data.file_checked %> />' +
-                    '<label for="downloadable_sample_<%- data.id %>_file_type" class="admin__field-label"><span><?= $block->escapeJs($block->escapeHtml(__('File'))) ?>:</span></label>'+
+                    '<label for="downloadable_sample_<%- data.id %>_file_type" class="admin__field-label"><span><?= $escaper->escapeJs($escaper->escapeHtml(__('File'))) ?>:</span></label>'+
                     '<input type="hidden" class="validate-downloadable-file" id="downloadable_sample_<%- data.id %>_file_save" name="downloadable[sample][<%- data.id %>][file]" value="<%- data.file_save %>" />'+
                     '<div id="downloadable_sample_<%- data.id %>_file" class="admin__field-uploader">'+
                         '<div id="downloadable_sample_<%- data.id %>_file-old" class="file-row-info"></div>'+
                         '<div id="downloadable_sample_<%- data.id %>_file-new" class="file-row-info new-file"></div>'+
                         '<div class="fileinput-button">'+
-                            '<span><?= $block->escapeJs($block->escapeHtml(__('Browse Files...'))) ?></span>' +
+                            '<span><?= $escaper->escapeJs($escaper->escapeHtml(__('Browse Files...'))) ?></span>' +
                             '<input id="downloadable_sample_<%- data.id %>_file" type="file" name="<?= /* @noEscape */ $block->getConfig()->getFileField() ?>" data-url="<?= /* @noEscape */ $block->getConfig()->getUrl() ?>">' +
                             '<script>' +
                             '/*<![CDATA[*/' +
@@ -103,15 +103,15 @@ require([
                 '</div>'+
                 '<div class="admin__field admin__field-option admin__field-file-url">'+
                     '<input type="radio" class="admin__control-radio validate-one-required-by-name" id="downloadable_sample_<%- data.id %>_url_type" name="downloadable[sample][<%- data.id %>][type]" value="url"<%- data.url_checked %> />' +
-                    '<label for="downloadable_sample_<%- data.id %>_url_type" class="admin__field-label"><span><?= $block->escapeJs($block->escapeHtml(__('URL'))) ?></span></label>' +
-                    '<input type="text" class="validate-downloadable-url validate-url admin__control-text" name="downloadable[sample][<%- data.id %>][sample_url]" value="<%- data.sample_url %>" placeholder="<?= $block->escapeJs($block->escapeHtmlAttr(__('URL'))) ?>" />'+
+                    '<label for="downloadable_sample_<%- data.id %>_url_type" class="admin__field-label"><span><?= $escaper->escapeJs($escaper->escapeHtml(__('URL'))) ?></span></label>' +
+                    '<input type="text" class="validate-downloadable-url validate-url admin__control-text" name="downloadable[sample][<%- data.id %>][sample_url]" value="<%- data.sample_url %>" placeholder="<?= $escaper->escapeJs($escaper->escapeHtmlAttr(__('URL'))) ?>" />'+
                 '</div>'+
                 '<div>'+
                     '<span id="downloadable_sample_<%- data.id %>_container"></span>'+
                 '</div>'+
             '</td>'+
             '<td class="col-actions">'+
-                '<button type="button" class="action-delete" title="<?= $block->escapeJs($block->escapeHtmlAttr(__('Delete'))) ?>"><span><?= $block->escapeJs($block->escapeHtml(__('Delete'))) ?></span></button>'+
+                '<button type="button" class="action-delete" title="<?= $escaper->escapeJs($escaper->escapeHtmlAttr(__('Delete'))) ?>"><span><?= $escaper->escapeJs($escaper->escapeHtml(__('Delete'))) ?></span></button>'+
             '</td>'+
         '</tr>';
         sampleItems = {

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/sales/items/column/downloadable/creditmemo/name.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/sales/items/column/downloadable/creditmemo/name.phtml
@@ -6,31 +6,30 @@
 
 /**
  * @var \Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Catalog\Helper\Data $catalogHelper
  */
-?>
 
-<?php
-/** @var \Magento\Catalog\Helper\Data $catalogHelper */
 $catalogHelper = $block->getData('catalogHelper');
 if ($_item = $block->getItem()): ?>
-    <div class="product-title"><?= $block->escapeHtml($_item->getName()) ?></div>
-    <div><strong><?= $block->escapeHtml(__('SKU')) ?>:</strong>
+    <div class="product-title"><?= $escaper->escapeHtml($_item->getName()) ?></div>
+    <div><strong><?= $escaper->escapeHtml(__('SKU')) ?>:</strong>
         <?= /* @noEscape */ implode('<br />', $catalogHelper->splitSku($block->getSku())) ?></div>
     <?php if ($block->getOrderOptions()): ?>
         <dl class="item-options">
         <?php foreach ($block->getOrderOptions() as $_option): ?>
-            <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+            <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
             <dd>
             <?php if (isset($_option['custom_view']) && $_option['custom_view']): ?>
-                <?= $block->escapeHtml($_option['value']) ?>
+                <?= $escaper->escapeHtml($_option['value']) ?>
             <?php else: ?>
-                <?= $block->escapeHtml($block->truncateString($_option['value'], 55, '', $_remainder)) ?>
+                <?= $escaper->escapeHtml($block->truncateString($_option['value'], 55, '', $_remainder)) ?>
                 <?php if ($_remainder):?>
-                    ... <span id="<?= $block->escapeHtmlAttr($_id = 'id' . uniqid()) ?>">
-                        <?= $block->escapeHtml($_remainder) ?>
+                    ... <span id="<?= $escaper->escapeHtmlAttr($_id = 'id' . uniqid()) ?>">
+                        <?= $escaper->escapeHtml($_remainder) ?>
                     </span>
-                    <?php $escapedId = /* @noEscape */ $block->escapeJs($_id);
+                    <?php $escapedId = /* @noEscape */ $escaper->escapeJs($_id);
                     $scriptString = <<<script
                         require(['prototype'], function(){
                             $('{$escapedId}').hide();
@@ -48,11 +47,11 @@ script;
     <?php endif; ?>
     <?php if ($block->getLinks()): ?>
         <dl class="item-options">
-            <dt><?= $block->escapeHtml($block->getLinksTitle()) ?></dt>
+            <dt><?= $escaper->escapeHtml($block->getLinksTitle()) ?></dt>
             <?php foreach ($block->getLinks()->getPurchasedItems() as $_link): ?>
-                <dd><?= $block->escapeHtml($_link->getLinkTitle()) ?></dd>
+                <dd><?= $escaper->escapeHtml($_link->getLinkTitle()) ?></dd>
             <?php endforeach; ?>
         </dl>
     <?php endif; ?>
-    <?= $block->escapeHtml($_item->getDescription()) ?>
+    <?= $escaper->escapeHtml($_item->getDescription()) ?>
 <?php endif; ?>

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/sales/items/column/downloadable/invoice/name.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/sales/items/column/downloadable/invoice/name.phtml
@@ -4,31 +4,32 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
+/**
+ * @var \Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Catalog\Helper\Data  $catalogHelper
+ */
 
-<?php
-/** @var \Magento\Catalog\Helper\Data  $catalogHelper */
 $catalogHelper = $block->getData('catalogHelper');
 if ($_item = $block->getItem()): ?>
-    <div class="product-title"><?= $block->escapeHtml($_item->getName()) ?></div>
-    <div><strong><?= $block->escapeHtml(__('SKU')) ?>:</strong>
+    <div class="product-title"><?= $escaper->escapeHtml($_item->getName()) ?></div>
+    <div><strong><?= $escaper->escapeHtml(__('SKU')) ?>:</strong>
         <?= /* @noEscape */ implode('<br />', $catalogHelper->splitSku($block->getSku())) ?></div>
     <?php if ($block->getOrderOptions()): ?>
         <dl class="item-options">
         <?php foreach ($block->getOrderOptions() as $_option): ?>
-            <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+            <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
             <dd>
             <?php if (isset($_option['custom_view']) && $_option['custom_view']): ?>
-                <?= $block->escapeHtml($_option['value']) ?>
+                <?= $escaper->escapeHtml($_option['value']) ?>
             <?php else: ?>
-                <?= $block->escapeHtml($block->truncateString($_option['value'], 55, '', $_remainder)) ?>
+                <?= $escaper->escapeHtml($block->truncateString($_option['value'], 55, '', $_remainder)) ?>
                 <?php if ($_remainder):?>
-                    ... <span id="<?= $block->escapeHtmlAttr($_id = 'id' . uniqid()) ?>">
-                        <?= $block->escapeHtml($_remainder) ?>
+                    ... <span id="<?= $escaper->escapeHtmlAttr($_id = 'id' . uniqid()) ?>">
+                        <?= $escaper->escapeHtml($_remainder) ?>
                     </span>
-                    <?php $escapedId = /* @noEscape */ $block->escapeJs($_id);
+                    <?php $escapedId = /* @noEscape */ $escaper->escapeJs($_id);
                     $scriptString = <<<script
                         require(['prototype'], function(){
                             $('{$escapedId}').hide();
@@ -46,14 +47,14 @@ script;
     <?php endif; ?>
     <?php if ($block->getLinks()): ?>
         <dl class="item-options">
-            <dt><?= $block->escapeHtml($block->getLinksTitle()) ?></dt>
+            <dt><?= $escaper->escapeHtml($block->getLinksTitle()) ?></dt>
             <?php foreach ($block->getLinks()->getPurchasedItems() as $_link): ?>
-                <dd><?= $block->escapeHtml($_link->getLinkTitle()) ?>
-                    (<?= $block->escapeHtml($_link->getNumberOfDownloadsBought() ?
+                <dd><?= $escaper->escapeHtml($_link->getLinkTitle()) ?>
+                    (<?= $escaper->escapeHtml($_link->getNumberOfDownloadsBought() ?
                         $_link->getNumberOfDownloadsBought() : __('Unlimited')) ?>)
                 </dd>
             <?php endforeach; ?>
         </dl>
     <?php endif; ?>
-    <?= $block->escapeHtml($_item->getDescription()) ?>
+    <?= $escaper->escapeHtml($_item->getDescription()) ?>
 <?php endif; ?>

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/sales/items/column/downloadable/name.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/sales/items/column/downloadable/name.phtml
@@ -4,33 +4,33 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-
-<?php
-/** @var \Magento\Catalog\Helper\Data  $catalogHelper */
+/**
+ * @var \Magento\Downloadable\Block\Adminhtml\Sales\Items\Column\Downloadable\Name $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Catalog\Helper\Data  $catalogHelper
+ */
 $catalogHelper = $block->getData('catalogHelper');
 if ($_item = $block->getItem()): ?>
-    <div class="product-title"><?= $block->escapeHtml($_item->getName()) ?></div>
+    <div class="product-title"><?= $escaper->escapeHtml($_item->getName()) ?></div>
     <div class="product-sku-block">
-        <span><?= $block->escapeHtml(__('SKU')) ?>:</span>
+        <span><?= $escaper->escapeHtml(__('SKU')) ?>:</span>
         <?= /* @noEscape */ implode('<br />', $catalogHelper->splitSku($block->getSku())) ?>
     </div>
     <?php if ($block->getOrderOptions()): ?>
         <dl class="item-options">
         <?php foreach ($block->getOrderOptions() as $_option): ?>
-            <dt><?= $block->escapeHtml($_option['label']) ?>:</dt>
+            <dt><?= $escaper->escapeHtml($_option['label']) ?>:</dt>
             <dd>
             <?php if (isset($_option['custom_view']) && $_option['custom_view']): ?>
-                <?= $block->escapeHtml($_option['value']) ?>
+                <?= $escaper->escapeHtml($_option['value']) ?>
             <?php else: ?>
-                <?= $block->escapeHtml($block->truncateString($_option['value'], 55, '', $_remainder)) ?>
+                <?= $escaper->escapeHtml($block->truncateString($_option['value'], 55, '', $_remainder)) ?>
                 <?php if ($_remainder):?>
-                    ... <span id="<?= $block->escapeHtmlAttr($_id = 'id' . uniqid()) ?>">
-                        <?= $block->escapeHtml($_remainder) ?>
+                    ... <span id="<?= $escaper->escapeHtmlAttr($_id = 'id' . uniqid()) ?>">
+                        <?= $escaper->escapeHtml($_remainder) ?>
                     </span>
-                    <?php $escapedId = /* @noEscape */ $block->escapeJs($_id);
+                    <?php $escapedId = /* @noEscape */ $escaper->escapeJs($_id);
                     $scriptString = <<<script
                         require(['prototype'], function(){
                             $('{$escapedId}').hide();
@@ -48,14 +48,14 @@ script;
     <?php endif; ?>
     <?php if ($block->getLinks()): ?>
         <dl class="item-options">
-            <dt><?= $block->escapeHtml($block->getLinksTitle()) ?>:</dt>
+            <dt><?= $escaper->escapeHtml($block->getLinksTitle()) ?>:</dt>
             <?php foreach ($block->getLinks()->getPurchasedItems() as $_link): ?>
-                <dd><?= $block->escapeHtml($_link->getLinkTitle()) ?>
-                    (<?= $block->escapeHtml($_link->getNumberOfDownloadsUsed() . ' / ' .
+                <dd><?= $escaper->escapeHtml($_link->getLinkTitle()) ?>
+                    (<?= $escaper->escapeHtml($_link->getNumberOfDownloadsUsed() . ' / ' .
                         ($_link->getNumberOfDownloadsBought() ? $_link->getNumberOfDownloadsBought() : __('U'))) ?>)
                 </dd>
             <?php endforeach; ?>
         </dl>
     <?php endif; ?>
-    <?= $block->escapeHtml($_item->getDescription()) ?>
+    <?= $escaper->escapeHtml($_item->getDescription()) ?>
 <?php endif; ?>

--- a/app/code/Magento/Downloadable/view/frontend/templates/catalog/product/links.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/catalog/product/links.phtml
@@ -3,21 +3,25 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Downloadable\Block\Catalog\Product\Links $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<?php /* @var $block \Magento\Downloadable\Block\Catalog\Product\Links */ ?>
 <?php $_linksPurchasedSeparately = $block->getLinksPurchasedSeparately(); ?>
 <?php if ($block->getProduct()->isSaleable() && $block->hasLinks()) :?>
     <?php $_links = $block->getLinks(); ?>
     <?php $_linksLength = 0; ?>
     <?php $_isRequired = $block->getLinkSelectionRequired(); ?>
-    <legend class="legend links-title"><span><?= $block->escapeHtml($block->getLinksTitle()) ?></span></legend><br>
+    <legend class="legend links-title"><span><?= $escaper->escapeHtml($block->getLinksTitle()) ?></span></legend><br>
     <div class="field downloads<?php if ($_isRequired) { echo ' required'; } ?><?php if (!$_linksPurchasedSeparately) { echo ' downloads-no-separately'; } ?>">
-        <label class="label"><span><?= $block->escapeHtml($block->getLinksTitle()) ?></span></label>
+        <label class="label"><span><?= $escaper->escapeHtml($block->getLinksTitle()) ?></span></label>
         <div class="control" id="downloadable-links-list"
              data-mage-init='{"downloadable":{
                  "linkElement":"input:checkbox[value]",
                  "allElements":"#links_all",
-                 "config":<?= $block->escapeHtmlAttr($block->getJsonConfig()) ?>}
+                 "config":<?= $escaper->escapeHtmlAttr($block->getJsonConfig()) ?>}
              }'
              data-container-for="downloadable-links">
             <?php foreach ($_links as $_link) : ?>
@@ -27,15 +31,15 @@
                         <input type="checkbox"
                                <?php if ($_isRequired) : ?>data-validate="{'validate-one-checkbox-required-by-name':'downloadable-links-list'}" <?php endif; ?>
                                name="links[]"
-                               id="links_<?= $block->escapeHtmlAttr($_link->getId()) ?>"
-                               value="<?= $block->escapeHtmlAttr($_link->getId()) ?>" <?= $block->escapeHtml($block->getLinkCheckedValue($_link)) ?> />
+                               id="links_<?= $escaper->escapeHtmlAttr($_link->getId()) ?>"
+                               value="<?= $escaper->escapeHtmlAttr($_link->getId()) ?>" <?= $escaper->escapeHtml($block->getLinkCheckedValue($_link)) ?> />
                     <?php endif; ?>
-                    <label class="label" for="links_<?= $block->escapeHtmlAttr($_link->getId()) ?>">
-                        <span><?= $block->escapeHtml($_link->getTitle()) ?></span>
+                    <label class="label" for="links_<?= $escaper->escapeHtmlAttr($_link->getId()) ?>">
+                        <span><?= $escaper->escapeHtml($_link->getTitle()) ?></span>
                         <?php if ($_link->getSampleFile() || $_link->getSampleUrl()) : ?>
                             <a class="sample link"
-                               href="<?= $block->escapeUrl($block->getLinkSampleUrl($_link)) ?>" <?= $block->getIsOpenInNewWindow() ? 'target="_blank"' : '' ?>>
-                                <?= $block->escapeHtml(__('sample')) ?>
+                               href="<?= $escaper->escapeUrl($block->getLinkSampleUrl($_link)) ?>" <?= $block->getIsOpenInNewWindow() ? 'target="_blank"' : '' ?>>
+                                <?= $escaper->escapeHtml(__('sample')) ?>
                             </a>
                         <?php endif; ?>
                         <?php if ($_linksPurchasedSeparately) : ?>
@@ -47,10 +51,10 @@
             <?php if ($_linksPurchasedSeparately && $_linksLength > 1) : ?>
                 <div class="field choice downloads-all">
                     <input type="checkbox"
-                           data-notchecked="<?= $block->escapeHtmlAttr(__('Select all')) ?>"
-                           data-checked="<?= $block->escapeHtmlAttr(__('Unselect all')) ?>"
+                           data-notchecked="<?= $escaper->escapeHtmlAttr(__('Select all')) ?>"
+                           data-checked="<?= $escaper->escapeHtmlAttr(__('Unselect all')) ?>"
                            id="links_all" />
-                    <label class="label" for="links_all"><span><?= $block->escapeHtml(__('Select all')) ?></span></label>
+                    <label class="label" for="links_all"><span><?= $escaper->escapeHtml(__('Select all')) ?></span></label>
                 </div>
             <?php endif; ?>
         </div>

--- a/app/code/Magento/Downloadable/view/frontend/templates/catalog/product/samples.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/catalog/product/samples.phtml
@@ -8,18 +8,19 @@
  * Downloadable product links
  *
  * @var $block \Magento\Downloadable\Block\Catalog\Product\Samples
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 
 <?php if ($block->hasSamples()) : ?>
     <dl class="items samples">
-        <dt class="item-title samples-item-title"><?= $block->escapeHtml($block->getSamplesTitle()) ?></dt>
+        <dt class="item-title samples-item-title"><?= $escaper->escapeHtml($block->getSamplesTitle()) ?></dt>
         <?php $_samples = $block->getSamples() ?>
         <?php foreach ($_samples as $_sample) : ?>
             <dd class="item samples-item">
-                <a href="<?= $block->escapeHtml($block->getSampleUrl($_sample)) ?>" <?= $block->getIsOpenInNewWindow() ? 'onclick="this.target=\'_blank\'"' : '' ?>
+                <a href="<?= $escaper->escapeHtml($block->getSampleUrl($_sample)) ?>" <?= $block->getIsOpenInNewWindow() ? 'onclick="this.target=\'_blank\'"' : '' ?>
                    class="item-link samples-item-link">
-                    <?= $block->escapeHtml($_sample->getTitle()) ?>
+                    <?= $escaper->escapeHtml($_sample->getTitle()) ?>
                 </a>
             </dd>
         <?php endforeach; ?>

--- a/app/code/Magento/Downloadable/view/frontend/templates/catalog/product/type.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/catalog/product/type.phtml
@@ -8,17 +8,18 @@
  * Downloadable product type
  *
  * @var $block \Magento\Downloadable\Block\Catalog\Product\View\Type
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <?php $_product = $block->getProduct() ?>
 
 <?php if ($_product->getIsSalable()) : ?>
-    <div class="stock available" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>">
-        <span><?= $block->escapeHtml(__('In stock')) ?></span>
+    <div class="stock available" title="<?= $escaper->escapeHtmlAttr(__('Availability')) ?>">
+        <span><?= $escaper->escapeHtml(__('In stock')) ?></span>
     </div>
 <?php else : ?>
-    <div class="stock unavailable" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>">
-        <span><?= $block->escapeHtml(__('Out of stock')) ?></span>
+    <div class="stock unavailable" title="<?= $escaper->escapeHtmlAttr(__('Availability')) ?>">
+        <span><?= $escaper->escapeHtml(__('Out of stock')) ?></span>
     </div>
 <?php endif; ?>
 <?= $block->getChildHtml() ?>

--- a/app/code/Magento/Downloadable/view/frontend/templates/checkout/success.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/checkout/success.phtml
@@ -3,7 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($block->getOrderHasDownloadable()) : ?>
-    <?= /* @noEscape */ __('Go to <a href="%1">My Downloadable Products</a>', $block->escapeUrl($block->getDownloadableProductsUrl())) ?>
+    <?= /* @noEscape */ __('Go to <a href="%1">My Downloadable Products</a>', $escaper->escapeUrl($block->getDownloadableProductsUrl())) ?>
 <?php endif; ?>

--- a/app/code/Magento/Downloadable/view/frontend/templates/customer/products/list.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/customer/products/list.phtml
@@ -8,6 +8,7 @@ use Magento\Downloadable\Model\Link\Purchased\Item;
 
 /**
  * @var $block \Magento\Downloadable\Block\Customer\Products\ListProducts
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -15,38 +16,38 @@ use Magento\Downloadable\Model\Link\Purchased\Item;
 <?php if (count($_items)): ?>
     <div class="table-wrapper downloadable-products">
         <table id="my-downloadable-products-table" class="data table table-downloadable-products">
-            <caption class="table-caption"><?= $block->escapeHtml(__('Downloadable Products')) ?></caption>
+            <caption class="table-caption"><?= $escaper->escapeHtml(__('Downloadable Products')) ?></caption>
             <thead>
                 <tr>
-                    <th scope="col" class="col id"><?= $block->escapeHtml(__('Order #')) ?></th>
-                    <th scope="col" class="col date"><?= $block->escapeHtml(__('Date')) ?></th>
-                    <th scope="col" class="col title"><?= $block->escapeHtml(__('Title')) ?></th>
-                    <th scope="col" class="col status"><?= $block->escapeHtml(__('Status')) ?></th>
-                    <th scope="col" class="col remaining"><?= $block->escapeHtml(__('Remaining Downloads')) ?></th>
+                    <th scope="col" class="col id"><?= $escaper->escapeHtml(__('Order #')) ?></th>
+                    <th scope="col" class="col date"><?= $escaper->escapeHtml(__('Date')) ?></th>
+                    <th scope="col" class="col title"><?= $escaper->escapeHtml(__('Title')) ?></th>
+                    <th scope="col" class="col status"><?= $escaper->escapeHtml(__('Status')) ?></th>
+                    <th scope="col" class="col remaining"><?= $escaper->escapeHtml(__('Remaining Downloads')) ?></th>
                 </tr>
             </thead>
             <tbody>
             <?php foreach ($_items as $_item): ?>
                 <tr>
-                    <td data-th="<?= $block->escapeHtmlAttr(__('Order #')) ?>" class="col id">
-                        <a href="<?= $block->escapeUrl($block->getOrderViewUrl($_item->getPurchased()->getOrderId()))?>"
-                            title="<?= $block->escapeHtml(__('View Order')) ?>">
-                            <?= $block->escapeHtml($_item->getPurchased()->getOrderIncrementId()) ?>
+                    <td data-th="<?= $escaper->escapeHtmlAttr(__('Order #')) ?>" class="col id">
+                        <a href="<?= $escaper->escapeUrl($block->getOrderViewUrl($_item->getPurchased()->getOrderId()))?>"
+                            title="<?= $escaper->escapeHtml(__('View Order')) ?>">
+                            <?= $escaper->escapeHtml($_item->getPurchased()->getOrderIncrementId()) ?>
                         </a>
                     </td>
-                    <td data-th="<?= $block->escapeHtmlAttr(__('Date')) ?>" class="col date">
-                        <?= $block->escapeHtml($block->formatDate($_item->getPurchased()->getCreatedAt())) ?>
+                    <td data-th="<?= $escaper->escapeHtmlAttr(__('Date')) ?>" class="col date">
+                        <?= $escaper->escapeHtml($block->formatDate($_item->getPurchased()->getCreatedAt())) ?>
                     </td>
-                    <td data-th="<?= $block->escapeHtmlAttr(__('Title')) ?>" class="col title">
+                    <td data-th="<?= $escaper->escapeHtmlAttr(__('Title')) ?>" class="col title">
                         <strong class="product-name">
-                            <?= $block->escapeHtml($_item->getPurchased()->getProductName()) ?>
+                            <?= $escaper->escapeHtml($_item->getPurchased()->getProductName()) ?>
                         </strong>
                         <?php if ($_item->getStatus() == Item::LINK_STATUS_AVAILABLE): ?>
-                            <a href="<?= $block->escapeUrl($block->getDownloadUrl($_item)) ?>"
+                            <a href="<?= $escaper->escapeUrl($block->getDownloadUrl($_item)) ?>"
                                id="download_<?= /* @noEscape */ $_item->getPurchased()->getProductId() ?>"
-                               title="<?= $block->escapeHtmlAttr(__('Start Download')) ?>"
+                               title="<?= $escaper->escapeHtmlAttr(__('Start Download')) ?>"
                                class="action download">
-                                <?= $block->escapeHtml($_item->getLinkTitle()) ?>
+                                <?= $escaper->escapeHtml($_item->getLinkTitle()) ?>
                             </a>
                             <?php if ($block->getIsOpenInNewWindow()): ?>
                                 <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
@@ -57,11 +58,11 @@ use Magento\Downloadable\Model\Link\Purchased\Item;
                             <?php endif; ?>
                         <?php endif; ?>
                     </td>
-                    <td data-th="<?= $block->escapeHtmlAttr(__('Status')) ?>" class="col status">
-                        <?= $block->escapeHtml(__(ucfirst($_item->getStatus()))) ?>
+                    <td data-th="<?= $escaper->escapeHtmlAttr(__('Status')) ?>" class="col status">
+                        <?= $escaper->escapeHtml(__(ucfirst($_item->getStatus()))) ?>
                     </td>
-                    <td data-th="<?= $block->escapeHtmlAttr(__('Remaining Downloads')) ?>" class="col remaining">
-                        <?= $block->escapeHtml($block->getRemainingDownloads($_item)) ?>
+                    <td data-th="<?= $escaper->escapeHtmlAttr(__('Remaining Downloads')) ?>" class="col remaining">
+                        <?= $escaper->escapeHtml($block->getRemainingDownloads($_item)) ?>
                     </td>
                 </tr>
             <?php endforeach; ?>
@@ -75,14 +76,14 @@ use Magento\Downloadable\Model\Link\Purchased\Item;
     <?php endif; ?>
 <?php else: ?>
     <div class="message info empty">
-        <span><?= $block->escapeHtml(__('You have not purchased any downloadable products yet.')) ?></span>
+        <span><?= $escaper->escapeHtml(__('You have not purchased any downloadable products yet.')) ?></span>
     </div>
 <?php endif; ?>
 
 <div class="actions-toolbar">
     <div class="secondary">
-        <a href="<?= $block->escapeUrl($block->getBackUrl()) ?>" class="action back">
-            <span><?= $block->escapeHtml(__('Back')) ?></span>
+        <a href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>" class="action back">
+            <span><?= $escaper->escapeHtml(__('Back')) ?></span>
         </a>
     </div>
 </div>

--- a/app/code/Magento/Downloadable/view/frontend/templates/email/order/items/creditmemo/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/email/order/items/creditmemo/downloadable.phtml
@@ -3,33 +3,37 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<?php /** @var $block \Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable */ ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrder(); ?>
 <tr>
     <td class="item-info has-extra">
-        <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
-        <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
+        <p class="product-name"><?= $escaper->escapeHtml($_item->getName()) ?></p>
+        <p class="sku"><?= $escaper->escapeHtml(__('SKU')) ?>: <?= $escaper->escapeHtml($block->getSku($_item)) ?></p>
         <?php if ($block->getItemOptions()) : ?>
         <dl>
             <?php foreach ($block->getItemOptions() as $option) : ?>
-            <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
-            <dd><?= $block->escapeHtml($option['value']) ?></dd>
+            <dt><strong><em><?= $escaper->escapeHtml($option['label']) ?></em></strong></dt>
+            <dd><?= $escaper->escapeHtml($option['value']) ?></dd>
             <?php endforeach; ?>
         </dl>
         <?php endif; ?>
         <?php if ($links = $block->getLinks()->getPurchasedItems()) : ?>
         <dl>
-            <dt><strong><em><?= $block->escapeHtml($block->getLinksTitle()) ?></em></strong></dt>
+            <dt><strong><em><?= $escaper->escapeHtml($block->getLinksTitle()) ?></em></strong></dt>
             <?php foreach ($links as $link) : ?>
                 <dd>
-                    <?= $block->escapeHtml($link->getLinkTitle()) ?>
+                    <?= $escaper->escapeHtml($link->getLinkTitle()) ?>
                 </dd>
             <?php endforeach; ?>
         </dl>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
     </td>
     <td class="item-qty"><?= (float)$_item->getQty() * 1 ?></td>
     <td class="item-price">

--- a/app/code/Magento/Downloadable/view/frontend/templates/email/order/items/invoice/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/email/order/items/invoice/downloadable.phtml
@@ -3,34 +3,38 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<?php /** @var $block \Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable */ ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrder() ?>
 <tr>
     <td class="item-info has-extra">
-        <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
-        <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
+        <p class="product-name"><?= $escaper->escapeHtml($_item->getName()) ?></p>
+        <p class="sku"><?= $escaper->escapeHtml(__('SKU')) ?>: <?= $escaper->escapeHtml($block->getSku($_item)) ?></p>
         <?php if ($block->getItemOptions()) : ?>
         <dl>
             <?php foreach ($block->getItemOptions() as $option) : ?>
-            <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
-            <dd><?= $block->escapeHtml($option['value']) ?></dd>
+            <dt><strong><em><?= $escaper->escapeHtml($option['label']) ?></em></strong></dt>
+            <dd><?= $escaper->escapeHtml($option['value']) ?></dd>
             <?php endforeach; ?>
         </dl>
         <?php endif; ?>
         <?php if ($links = $block->getLinks()->getPurchasedItems()) : ?>
         <dl>
-            <dt><strong><em><?= $block->escapeHtml($block->getLinksTitle()) ?></em></strong></dt>
+            <dt><strong><em><?= $escaper->escapeHtml($block->getLinksTitle()) ?></em></strong></dt>
             <?php foreach ($links as $link) : ?>
                 <dd>
-                    <?= $block->escapeHtml($link->getLinkTitle()) ?>&nbsp;
-                    (<a href="<?= $block->escapeUrl($block->getPurchasedLinkUrl($link)) ?>"><?= $block->escapeHtml(__('download')) ?></a>)
+                    <?= $escaper->escapeHtml($link->getLinkTitle()) ?>&nbsp;
+                    (<a href="<?= $escaper->escapeUrl($block->getPurchasedLinkUrl($link)) ?>"><?= $escaper->escapeHtml(__('download')) ?></a>)
                 </dd>
             <?php endforeach; ?>
         </dl>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
     </td>
     <td class="item-qty"><?= (float)$_item->getQty() * 1 ?></td>
     <td class="item-price">

--- a/app/code/Magento/Downloadable/view/frontend/templates/email/order/items/order/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/email/order/items/order/downloadable.phtml
@@ -4,43 +4,47 @@
  * See COPYING.txt for license details.
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
+
+/**
+ * @var \Magento\Downloadable\Block\Sales\Order\Email\Items\Order\Downloadable $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<?php /** @var $block \Magento\Downloadable\Block\Sales\Order\Email\Items\Order\Downloadable */ ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrder() ?>
 <tr>
     <td class="item-info has-extra">
-        <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
-        <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
+        <p class="product-name"><?= $escaper->escapeHtml($_item->getName()) ?></p>
+        <p class="sku"><?= $escaper->escapeHtml(__('SKU')) ?>: <?= $escaper->escapeHtml($block->getSku($_item)) ?></p>
         <?php if ($block->getItemOptions()) : ?>
         <dl>
             <?php foreach ($block->getItemOptions() as $option) : ?>
-            <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
-            <dd><?= $block->escapeHtml($option['value']) ?></dd>
+            <dt><strong><em><?= $escaper->escapeHtml($option['label']) ?></em></strong></dt>
+            <dd><?= $escaper->escapeHtml($option['value']) ?></dd>
             <?php endforeach; ?>
         </dl>
         <?php endif; ?>
         <?php if ($links = $block->getLinks()->getPurchasedItems()) : ?>
         <dl>
-            <dt><strong><em><?= $block->escapeHtml($block->getLinksTitle()) ?></em></strong></dt>
+            <dt><strong><em><?= $escaper->escapeHtml($block->getLinksTitle()) ?></em></strong></dt>
             <?php foreach ($links as $link) : ?>
                 <dd>
-                    <?= $block->escapeHtml($link->getLinkTitle()) ?>&nbsp;
-                    (<a href="<?= $block->escapeUrl($block->getPurchasedLinkUrl($link)) ?>"><?= $block->escapeHtml(__('download')) ?></a>)
+                    <?= $escaper->escapeHtml($link->getLinkTitle()) ?>&nbsp;
+                    (<a href="<?= $escaper->escapeUrl($block->getPurchasedLinkUrl($link)) ?>"><?= $escaper->escapeHtml(__('download')) ?></a>)
                 </dd>
             <?php endforeach; ?>
         </dl>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
         <?php if ($_item->getGiftMessageId() && $_giftMessage = $this->helper(Magento\GiftMessage\Helper\Message::class)->getGiftMessage($_item->getGiftMessageId())) : ?>
             <table class="message-gift">
                 <tr>
                     <td>
-                        <h3><?= $block->escapeHtml(__('Gift Message')) ?></h3>
-                        <strong><?= $block->escapeHtml(__('From:')) ?></strong> <?= $block->escapeHtml($_giftMessage->getSender()) ?>
-                        <br /><strong><?= $block->escapeHtml(__('To:')) ?></strong> <?= $block->escapeHtml($_giftMessage->getRecipient()) ?>
-                        <br /><strong><?= $block->escapeHtml(__('Message:')) ?></strong>
-                        <br /><?= $block->escapeHtml($_giftMessage->getMessage()) ?>
+                        <h3><?= $escaper->escapeHtml(__('Gift Message')) ?></h3>
+                        <strong><?= $escaper->escapeHtml(__('From:')) ?></strong> <?= $escaper->escapeHtml($_giftMessage->getSender()) ?>
+                        <br /><strong><?= $escaper->escapeHtml(__('To:')) ?></strong> <?= $escaper->escapeHtml($_giftMessage->getRecipient()) ?>
+                        <br /><strong><?= $escaper->escapeHtml(__('Message:')) ?></strong>
+                        <br /><?= $escaper->escapeHtml($_giftMessage->getMessage()) ?>
                     </td>
                 </tr>
             </table>

--- a/app/code/Magento/Downloadable/view/frontend/templates/sales/order/creditmemo/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/sales/order/creditmemo/items/renderer/downloadable.phtml
@@ -4,17 +4,20 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable */
+/**
+ * @var $block \Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrderItem()->getOrder() ?>
-<tr class="border" id="order-item-row-<?= $block->escapeHtmlAttr($_item->getId()) ?>">
-    <td class="col name" data-th="<?= $block->escapeHtmlAttr(__('Product Name')) ?>">
-        <strong class="product name product-item-name"><?= $block->escapeHtml($_item->getName()) ?></strong>
+<tr class="border" id="order-item-row-<?= $escaper->escapeHtmlAttr($_item->getId()) ?>">
+    <td class="col name" data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')) ?>">
+        <strong class="product name product-item-name"><?= $escaper->escapeHtml($_item->getName()) ?></strong>
         <?php if ($_options = $block->getItemOptions()) : ?>
             <dl class="item-options links">
                 <?php foreach ($_options as $_option) : ?>
-                    <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                    <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                     <?php if (!$block->getPrintStatus()) : ?>
                         <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
                         <dd<?php if (isset($_formatedOptionValue['full_view'])) : ?> class="tooltip wrapper"<?php endif; ?>>
@@ -22,14 +25,14 @@
                             <?php if (isset($_formatedOptionValue['full_view'])) : ?>
                                 <div class="tooltip content">
                                     <dl class="item options">
-                                        <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                                        <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                                         <dd><?= /* @noEscape */ $_formatedOptionValue['full_view'] ?></dd>
                                     </dl>
                                 </div>
                             <?php endif; ?>
                         </dd>
                     <?php else : ?>
-                        <dd><?= $block->escapeHtml((isset($_option['print_value']) ? $_option['print_value'] : $_option['value'])) ?></dd>
+                        <dd><?= $escaper->escapeHtml((isset($_option['print_value']) ? $_option['print_value'] : $_option['value'])) ?></dd>
                     <?php endif; ?>
                 <?php endforeach; ?>
             </dl>
@@ -37,9 +40,9 @@
         <?php /* downloadable */?>
         <?php if ($links = $block->getLinks()) : ?>
             <dl class="item-options links">
-                <dt><?= $block->escapeHtml($block->getLinksTitle()) ?></dt>
+                <dt><?= $escaper->escapeHtml($block->getLinksTitle()) ?></dt>
                 <?php foreach ($links->getPurchasedItems() as $link) : ?>
-                    <dd><?= $block->escapeHtml($link->getLinkTitle()) ?></dd>
+                    <dd><?= $escaper->escapeHtml($link->getLinkTitle()) ?></dd>
                 <?php endforeach; ?>
             </dl>
         <?php endif; ?>
@@ -49,18 +52,18 @@
         <?php if ($addInfoBlock) :?>
             <?= $addInfoBlock->setItem($_item->getOrderItem())->toHtml() ?>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
     </td>
-    <td class="col sku" data-th="<?= $block->escapeHtmlAttr(__('SKU')) ?>"><?= /* @noEscape */ $block->prepareSku($block->getSku()) ?></td>
-    <td class="col price" data-th="<?= $block->escapeHtmlAttr(__('Price')) ?>">
+    <td class="col sku" data-th="<?= $escaper->escapeHtmlAttr(__('SKU')) ?>"><?= /* @noEscape */ $block->prepareSku($block->getSku()) ?></td>
+    <td class="col price" data-th="<?= $escaper->escapeHtmlAttr(__('Price')) ?>">
         <?= $block->getItemPriceHtml() ?>
     </td>
-    <td class="col qty" data-th="<?= $block->escapeHtmlAttr(__('Qty')) ?>"><?= (float)$_item->getQty() * 1 ?></td>
-    <td class="col subtotal" data-th="<?= $block->escapeHtmlAttr(__('Subtotal')) ?>">
+    <td class="col qty" data-th="<?= $escaper->escapeHtmlAttr(__('Qty')) ?>"><?= (float)$_item->getQty() * 1 ?></td>
+    <td class="col subtotal" data-th="<?= $escaper->escapeHtmlAttr(__('Subtotal')) ?>">
         <?= $block->getItemRowTotalHtml() ?>
     </td>
-    <td class="col discount" data-th="<?= $block->escapeHtmlAttr(__('Discount Amount')) ?>"><?= /* @noEscape */ $_order->formatPrice(-$_item->getDiscountAmount()) ?></td>
-    <td class="col total" data-th="<?= $block->escapeHtmlAttr(__('Row Total')) ?>">
+    <td class="col discount" data-th="<?= $escaper->escapeHtmlAttr(__('Discount Amount')) ?>"><?= /* @noEscape */ $_order->formatPrice(-$_item->getDiscountAmount()) ?></td>
+    <td class="col total" data-th="<?= $escaper->escapeHtmlAttr(__('Row Total')) ?>">
         <?= $block->getItemRowTotalAfterDiscountHtml() ?>
     </td>
 </tr>

--- a/app/code/Magento/Downloadable/view/frontend/templates/sales/order/invoice/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/sales/order/invoice/items/renderer/downloadable.phtml
@@ -4,17 +4,20 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable */
+/**
+ * @var $block \Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrderItem()->getOrder() ?>
-<tr id="order-item-row-<?= $block->escapeHtmlAttr($_item->getId()) ?>">
-    <td class="col name" data-th="<?= $block->escapeHtmlAttr(__('Product Name')) ?>">
-        <strong class="product name product-item-name"><?= $block->escapeHtml($_item->getName()) ?></strong>
+<tr id="order-item-row-<?= $escaper->escapeHtmlAttr($_item->getId()) ?>">
+    <td class="col name" data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')) ?>">
+        <strong class="product name product-item-name"><?= $escaper->escapeHtml($_item->getName()) ?></strong>
         <?php if ($_options = $block->getItemOptions()) : ?>
             <dl class="item-options links">
                 <?php foreach ($_options as $_option) : ?>
-                    <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                    <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                     <?php if (!$block->getPrintStatus()) : ?>
                         <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
                         <dd<?php if (isset($_formatedOptionValue['full_view'])) : ?> class="tooltip wrapper"<?php endif; ?>>
@@ -22,14 +25,14 @@
                             <?php if (isset($_formatedOptionValue['full_view'])) : ?>
                                 <div class="tooltip content">
                                     <dl class="item options">
-                                        <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                                        <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                                         <dd><?= /* @noEscape */ $_formatedOptionValue['full_view'] ?></dd>
                                     </dl>
                                 </div>
                             <?php endif; ?>
                         </dd>
                     <?php else : ?>
-                        <dd><?= $block->escapeHtml((isset($_option['print_value']) ? $_option['print_value'] : $_option['value'])) ?></dd>
+                        <dd><?= $escaper->escapeHtml((isset($_option['print_value']) ? $_option['print_value'] : $_option['value'])) ?></dd>
                     <?php endif; ?>
                 <?php endforeach; ?>
             </dl>
@@ -37,9 +40,9 @@
         <?php /* downloadable */ ?>
         <?php if ($links = $block->getLinks()) : ?>
             <dl class="item-options links">
-                <dt><?= $block->escapeHtml($block->getLinksTitle()) ?></dt>
+                <dt><?= $escaper->escapeHtml($block->getLinksTitle()) ?></dt>
                 <?php foreach ($links->getPurchasedItems() as $link) : ?>
-                    <dd><?= $block->escapeHtml($link->getLinkTitle()) ?></dd>
+                    <dd><?= $escaper->escapeHtml($link->getLinkTitle()) ?></dd>
                 <?php endforeach; ?>
             </dl>
         <?php endif; ?>
@@ -48,16 +51,16 @@
         <?php if ($addInfoBlock) :?>
             <?= $addInfoBlock->setItem($_item->getOrderItem())->toHtml() ?>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
     </td>
-    <td class="col sku" data-th="<?= $block->escapeHtmlAttr(__('SKU')) ?>"><?= /* @noEscape */ $block->prepareSku($block->getSku()) ?></td>
-    <td class="col price" data-th="<?= $block->escapeHtmlAttr(__('Price')) ?>">
+    <td class="col sku" data-th="<?= $escaper->escapeHtmlAttr(__('SKU')) ?>"><?= /* @noEscape */ $block->prepareSku($block->getSku()) ?></td>
+    <td class="col price" data-th="<?= $escaper->escapeHtmlAttr(__('Price')) ?>">
         <?= $block->getItemPriceHtml() ?>
     </td>
-    <td class="col qty" data-th="<?= $block->escapeHtmlAttr(__('Qty Invoiced')) ?>">
-        <span class="qty summary" data-label="<?= $block->escapeHtmlAttr(__('Qty Invoiced')) ?>"><?= (float)$_item->getQty() * 1 ?></span>
+    <td class="col qty" data-th="<?= $escaper->escapeHtmlAttr(__('Qty Invoiced')) ?>">
+        <span class="qty summary" data-label="<?= $escaper->escapeHtmlAttr(__('Qty Invoiced')) ?>"><?= (float)$_item->getQty() * 1 ?></span>
     </td>
-    <td class="col subtotal" data-th="<?= $block->escapeHtmlAttr(__('Subtotal')) ?>">
+    <td class="col subtotal" data-th="<?= $escaper->escapeHtmlAttr(__('Subtotal')) ?>">
         <?= $block->getItemRowTotalHtml() ?>
     </td>
 </tr>

--- a/app/code/Magento/Downloadable/view/frontend/templates/sales/order/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/sales/order/items/renderer/downloadable.phtml
@@ -4,16 +4,19 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable */
+/**
+ * @var $block \Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_item = $block->getItem() ?>
-<tr id="order-item-row-<?= $block->escapeHtmlAttr($_item->getId()) ?>">
-    <td class="col name" data-th="<?= $block->escapeHtmlAttr(__('Product Name')) ?>">
-        <strong class="product name product-item-name"><?= $block->escapeHtml($_item->getName()) ?></strong>
+<tr id="order-item-row-<?= $escaper->escapeHtmlAttr($_item->getId()) ?>">
+    <td class="col name" data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')) ?>">
+        <strong class="product name product-item-name"><?= $escaper->escapeHtml($_item->getName()) ?></strong>
         <?php if ($_options = $block->getItemOptions()) : ?>
             <dl class="item-options links">
                 <?php foreach ($_options as $_option) : ?>
-                    <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                    <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                     <?php if (!$block->getPrintStatus()) : ?>
                         <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
                         <dd<?php if (isset($_formatedOptionValue['full_view'])) : ?> class="tooltip wrapper"<?php endif; ?>>
@@ -21,7 +24,7 @@
                             <?php if (isset($_formatedOptionValue['full_view'])) : ?>
                                 <div class="tooltip content">
                                     <dl class="item options">
-                                        <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                                        <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                                         <dd><?= /* @noEscape */ $_formatedOptionValue['full_view'] ?></dd>
                                     </dl>
                                 </div>
@@ -38,9 +41,9 @@
         <?php /* downloadable */ ?>
         <?php if ($links = $block->getLinks()) : ?>
             <dl class="item-options links">
-                <dt><?= $block->escapeHtml($block->getLinksTitle()) ?></dt>
+                <dt><?= $escaper->escapeHtml($block->getLinksTitle()) ?></dt>
                 <?php foreach ($links->getPurchasedItems() as $link) : ?>
-                    <dd><?= $block->escapeHtml($link->getLinkTitle()) ?></dd>
+                    <dd><?= $escaper->escapeHtml($link->getLinkTitle()) ?></dd>
                 <?php endforeach; ?>
             </dl>
         <?php endif; ?>
@@ -49,41 +52,41 @@
         <?php if ($addtInfoBlock) :?>
             <?= $addtInfoBlock->setItem($_item)->toHtml() ?>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
     </td>
-    <td class="col sku" data-th="<?= $block->escapeHtmlAttr(__('SKU')) ?>"><?= /* @noEscape */ $block->prepareSku($block->getSku()) ?></td>
-    <td class="col price" data-th="<?= $block->escapeHtmlAttr(__('Price')) ?>">
+    <td class="col sku" data-th="<?= $escaper->escapeHtmlAttr(__('SKU')) ?>"><?= /* @noEscape */ $block->prepareSku($block->getSku()) ?></td>
+    <td class="col price" data-th="<?= $escaper->escapeHtmlAttr(__('Price')) ?>">
         <?= $block->getItemPriceHtml() ?>
     </td>
-    <td class="col qty" data-th="<?= $block->escapeHtmlAttr(__('Qty')) ?>">
+    <td class="col qty" data-th="<?= $escaper->escapeHtmlAttr(__('Qty')) ?>">
         <ul class="items-qty">
             <?php if ($block->getItem()->getQtyOrdered() > 0) : ?>
                 <li class="item">
-                    <span class="title"><?= $block->escapeHtml(__('Ordered')) ?></span>
+                    <span class="title"><?= $escaper->escapeHtml(__('Ordered')) ?></span>
                     <span class="content"><?= (float)$block->getItem()->getQtyOrdered() * 1 ?></span>
                 </li>
             <?php endif; ?>
             <?php if ($block->getItem()->getQtyShipped() > 0) : ?>
                 <li class="item">
-                    <span class="title"><?= $block->escapeHtml(__('Shipped')) ?></span>
+                    <span class="title"><?= $escaper->escapeHtml(__('Shipped')) ?></span>
                     <span class="content"><?= (float)$block->getItem()->getQtyShipped() * 1 ?></span>
                 </li>
             <?php endif; ?>
             <?php if ($block->getItem()->getQtyCanceled() > 0) : ?>
                 <li class="item">
-                    <span class="title"><?= $block->escapeHtml(__('Canceled')) ?></span>
+                    <span class="title"><?= $escaper->escapeHtml(__('Canceled')) ?></span>
                     <span class="content"><?= (float)$block->getItem()->getQtyCanceled() * 1 ?></span>
                 </li>
             <?php endif; ?>
             <?php if ($block->getItem()->getQtyRefunded() > 0) : ?>
                 <li class="item">
-                    <span class="title"><?= $block->escapeHtml(__('Refunded')) ?></span>
+                    <span class="title"><?= $escaper->escapeHtml(__('Refunded')) ?></span>
                     <span class="content"><?= (float)$block->getItem()->getQtyRefunded() * 1 ?></span>
                 </li>
             <?php endif; ?>
         </ul>
     </td>
-    <td class="col subtotal" data-th="<?= $block->escapeHtmlAttr(__('Subtotal')) ?>">
+    <td class="col subtotal" data-th="<?= $escaper->escapeHtmlAttr(__('Subtotal')) ?>">
         <?= $block->getItemRowTotalHtml() ?>
     </td>
 </tr>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
