### PR TITLE
Magento_Directory: avoid using deprecated escape* methods from Abstra…

### DIFF
--- a/app/code/Magento/Directory/Block/Data.php
+++ b/app/code/Magento/Directory/Block/Data.php
@@ -142,7 +142,7 @@ class Data extends \Magento\Framework\View\Element\Template
         )->setId(
             $id
         )->setTitle(
-            $this->escapeHtmlAttr(__($title))
+            $this->_escaper->escapeHtmlAttr(__($title))
         )->setValue(
             $defValue
         )->setOptions(

--- a/app/code/Magento/Directory/view/adminhtml/templates/js/optional_zip_countries.phtml
+++ b/app/code/Magento/Directory/view/adminhtml/templates/js/optional_zip_countries.phtml
@@ -8,15 +8,13 @@
  * JS block for including Countries with Optional Zip
  *
  * @see \Magento\Backend\Block\Template
+ *
+ * @var \Magento\Backend\Block\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Directory\Helper\Data $directoryHelper
  */
 
-/**
- * @var \Magento\Backend\Block\Template $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
-?>
-<?php
-/** @var \Magento\Directory\Helper\Data $directoryHelper */
 $directoryHelper = $block->getData('directoryHelper');
 $countriesWithOptionalZip = /* @noEscape */ $directoryHelper->getCountriesWithOptionalZip(true);
 $scriptString = <<<script

--- a/app/code/Magento/Directory/view/frontend/templates/currency.phtml
+++ b/app/code/Magento/Directory/view/frontend/templates/currency.phtml
@@ -8,6 +8,7 @@
  * Currency switcher
  *
  * @var \Magento\Directory\Block\Currency $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 
 ?>
@@ -15,23 +16,23 @@
     <?php $currencies = $block->getCurrencies(); ?>
     <?php $currentCurrencyCode = $block->getCurrentCurrencyCode(); ?>
     <?php $id = $block->getIdModifier() ? '-' . $block->getIdModifier() : '' ?>
-    <div class="switcher currency switcher-currency" id="switcher-currency<?= $block->escapeHtmlAttr($id) ?>">
-        <strong class="label switcher-label"><span><?= $block->escapeHtml(__('Currency')) ?></span></strong>
+    <div class="switcher currency switcher-currency" id="switcher-currency<?= $escaper->escapeHtmlAttr($id) ?>">
+        <strong class="label switcher-label"><span><?= $escaper->escapeHtml(__('Currency')) ?></span></strong>
         <div class="actions dropdown options switcher-options">
             <div class="action toggle switcher-trigger"
-                 id="switcher-currency-trigger<?= $block->escapeHtmlAttr($id) ?>"
+                 id="switcher-currency-trigger<?= $escaper->escapeHtmlAttr($id) ?>"
                  data-mage-init='{"dropdown":{}}'
                  data-toggle="dropdown"
                  data-trigger-keypress-button="true">
-                <strong class="language-<?= $block->escapeHtml($block->getCurrentCurrencyCode()) ?>">
-                    <span><?= $block->escapeHtml($currentCurrencyCode) ?> - <?= $currencies[$currentCurrencyCode] ? $block->escapeHtml($currencies[$currentCurrencyCode]) : '' ?></span>
+                <strong class="language-<?= $escaper->escapeHtml($block->getCurrentCurrencyCode()) ?>">
+                    <span><?= $escaper->escapeHtml($currentCurrencyCode) ?> - <?= $currencies[$currentCurrencyCode] ? $escaper->escapeHtml($currencies[$currentCurrencyCode]) : '' ?></span>
                 </strong>
             </div>
             <ul class="dropdown switcher-dropdown" data-target="dropdown">
                 <?php foreach ($currencies as $_code => $_name) : ?>
                     <?php if ($_code != $currentCurrencyCode) : ?>
-                        <li class="currency-<?= $block->escapeHtmlAttr($_code) ?> switcher-option">
-                            <a href="#" data-post='<?= /* @noEscape */ $block->getSwitchCurrencyPostData($_code) ?>'><?= $block->escapeHtml($_code) ?> - <?= $block->escapeHtml($_name) ?></a>
+                        <li class="currency-<?= $escaper->escapeHtmlAttr($_code) ?> switcher-option">
+                            <a href="#" data-post='<?= /* @noEscape */ $block->getSwitchCurrencyPostData($_code) ?>'><?= $escaper->escapeHtml($_code) ?> - <?= $escaper->escapeHtml($_name) ?></a>
                         </li>
                     <?php endif; ?>
                 <?php endforeach; ?>

--- a/app/code/Magento/Directory/view/frontend/templates/currency/switch.phtml
+++ b/app/code/Magento/Directory/view/frontend/templates/currency/switch.phtml
@@ -4,8 +4,11 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 ?>
-<p><?= $block->escapeHtml(__('Your current currency is: %1.', $currency->getCode())) ?></p>
-<p><a href="<?= $block->escapeUrl($block->getBaseUrl()) ?>" class="action continue"><span><?= $block->escapeHtml(__('Continue')) ?></span></a></p>
+<p><?= $escaper->escapeHtml(__('Your current currency is: %1.', $currency->getCode())) ?></p>
+<p><a href="<?= $escaper->escapeUrl($block->getBaseUrl()) ?>" class="action continue"><span><?= $escaper->escapeHtml(__('Continue')) ?></span></a></p>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
