### PR TITLE
Magento_Customer: avoid using deprecated escape* methods from Abstrac…

### DIFF
--- a/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
+++ b/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
@@ -57,7 +57,7 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
     public function getConfig()
     {
         return [
-            'autocomplete' => $this->escapeHtml($this->isAutocompleteEnabled()),
+            'autocomplete' => $this->_escaper->escapeHtml($this->isAutocompleteEnabled()),
             'customerRegisterUrl' => $this->escapeUrl($this->getCustomerRegisterUrlUrl()),
             'customerForgotPasswordUrl' => $this->escapeUrl($this->getCustomerForgotPasswordUrl()),
             'baseUrl' => $this->escapeUrl($this->getBaseUrl())

--- a/app/code/Magento/Customer/Block/Address/Renderer/DefaultRenderer.php
+++ b/app/code/Magento/Customer/Block/Address/Renderer/DefaultRenderer.php
@@ -194,7 +194,7 @@ class DefaultRenderer extends AbstractBlock implements RendererInterface
         }
         if ($this->getType()->getEscapeHtml()) {
             foreach ($data as $key => $value) {
-                $data[$key] = $this->escapeHtml($value);
+                $data[$key] = $this->_escaper->escapeHtml($value);
             }
         }
         $format = $format !== null ? $format : $this->getFormatArray($addressAttributes);

--- a/app/code/Magento/Customer/Block/Adminhtml/Edit.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit.php
@@ -121,7 +121,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
                 'invalidate_token',
                 [
                     'label' => __('Force Sign-In'),
-                    'onclick' => 'deleteConfirm(\'' . $this->escapeJs($this->escapeHtml($deleteConfirmMsg)) .
+                    'onclick' => 'deleteConfirm(\'' . $this->_escaper->escapeJs($this->_escaper->escapeHtml($deleteConfirmMsg)) .
                         '\', \'' . $url . '\')',
                     'class' => 'invalidate-token'
                 ],
@@ -161,7 +161,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
         $customerId = $this->getCustomerId();
         if ($customerId) {
             $customerData = $this->customerRepository->getById($customerId);
-            return $this->escapeHtml($this->_viewHelper->getCustomerName($customerData));
+            return $this->_escaper->escapeHtml($this->_viewHelper->getCustomerName($customerData));
         } else {
             return __('New Customer');
         }

--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/View/Grid/Renderer/Item.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/View/Grid/Renderer/Item.php
@@ -123,7 +123,7 @@ class Item extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractRe
         $this->setItem($item);
         $product = $this->getProduct();
         $options = $this->getOptionList();
-        return $options ? $this->_renderItemOptions($product, $options) : $this->escapeHtml($product->getName());
+        return $options ? $this->_renderItemOptions($product, $options) : $this->_escaper->escapeHtml($product->getName());
     }
 
     /**
@@ -135,12 +135,12 @@ class Item extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractRe
      */
     protected function _renderItemOptions(Product $product, array $options)
     {
-        $html = '<div class="product-title">' . $this->escapeHtml(
+        $html = '<div class="product-title">' . $this->_escaper->escapeHtml(
             $product->getName()
         ) . '</div>' . '<dl class="item-options">';
         foreach ($options as $option) {
             $formattedOption = $this->getFormattedOptionValue($option);
-            $html .= '<dt>' . $this->escapeHtml($option['label']) . '</dt>';
+            $html .= '<dt>' . $this->_escaper->escapeHtml($option['label']) . '</dt>';
             $html .= '<dd>' . $formattedOption['value'] . '</dd>';
         }
         $html .= '</dl>';

--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Wishlist/Grid/Renderer/Description.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/Wishlist/Grid/Renderer/Description.php
@@ -18,6 +18,6 @@ class Description extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Abs
      */
     public function render(\Magento\Framework\DataObject $row)
     {
-        return nl2br($this->escapeHtml($row->getData($this->getColumn()->getIndex())));
+        return nl2br($this->_escaper->escapeHtml($row->getData($this->getColumn()->getIndex())));
     }
 }

--- a/app/code/Magento/Customer/Block/Adminhtml/Group/Edit.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Group/Edit.php
@@ -87,7 +87,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
             return __('New Customer Group');
         } else {
             $group = $this->groupRepository->getById($groupId);
-            return __('Edit Customer Group "%1"', $this->escapeHtml($group->getCode()));
+            return __('Edit Customer Group "%1"', $this->_escaper->escapeHtml($group->getCode()));
         }
     }
 

--- a/app/code/Magento/Customer/Block/Widget/Name.php
+++ b/app/code/Magento/Customer/Block/Widget/Name.php
@@ -107,7 +107,7 @@ class Name extends AbstractWidget
 
         if ($this->getObject() && !empty($prefixOptions)) {
             $prefixOption = $this->getObject()->getPrefix();
-            $oldPrefix = $this->escapeHtml(trim($prefixOption));
+            $oldPrefix = $this->_escaper->escapeHtml(trim($prefixOption));
             if ($prefixOption !== null && !isset($prefixOptions[$oldPrefix]) && !isset($prefixOptions[$prefixOption])) {
                 $prefixOptions[$oldPrefix] = $oldPrefix;
             }
@@ -165,7 +165,7 @@ class Name extends AbstractWidget
         $suffixOptions = $this->options->getNameSuffixOptions();
         if ($this->getObject() && !empty($suffixOptions)) {
             $suffixOption = $this->getObject()->getSuffix();
-            $oldSuffix = $this->escapeHtml(trim($suffixOption));
+            $oldSuffix = $this->_escaper->escapeHtml(trim($suffixOption));
             if ($suffixOption !== null && !isset($suffixOptions[$oldSuffix]) && !isset($suffixOptions[$suffixOption])) {
                 $suffixOptions[$oldSuffix] = $oldSuffix;
             }

--- a/app/code/Magento/Customer/view/adminhtml/templates/sales/order/create/address/form/renderer/vat.phtml
+++ b/app/code/Magento/Customer/view/adminhtml/templates/sales/order/create/address/form/renderer/vat.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Adminhtml\Sales\Order\Address\Form\Renderer\Vat $block */
+/**
+ * @var \Magento\Customer\Block\Adminhtml\Sales\Order\Address\Form\Renderer\Vat $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $_element = $block->getElement();
 $_note = $_element->getNote();
@@ -17,11 +20,11 @@ $_validateButton = $block->getValidateButton();
     <div class="hidden"><?= $_element->getElementHtml() ?></div>
     <?php else : ?>
     <?= $_element->getLabelHtml() ?>
-    <div class="admin__field-control <?= /* @noEscape */ $_element->hasValueClass() ? $block->escapeHtmlAttr($_element->getValueClass()) : 'value' ?><?= $_class ? $block->escapeHtmlAttr($_class) . '-value' : '' ?>">
+    <div class="admin__field-control <?= /* @noEscape */ $_element->hasValueClass() ? $escaper->escapeHtmlAttr($_element->getValueClass()) : 'value' ?><?= $_class ? $escaper->escapeHtmlAttr($_class) . '-value' : '' ?>">
         <?= $_element->getElementHtml() ?>
         <?php if ($_note) : ?>
-            <div class="admin__field-note<?= /* @noEscape */ $_class ? " {$block->escapeHtmlAttr($_class)}-note" : '' ?>" id="note_<?= $block->escapeHtmlAttr($_element->getId()) ?>">
-                <span><?= $block->escapeHtml($_note) ?></span>
+            <div class="admin__field-note<?= /* @noEscape */ $_class ? " {$escaper->escapeHtmlAttr($_class)}-note" : '' ?>" id="note_<?= $escaper->escapeHtmlAttr($_element->getId()) ?>">
+                <span><?= $escaper->escapeHtml($_note) ?></span>
             </div>
         <?php endif; ?>
         <div class="actions">

--- a/app/code/Magento/Customer/view/adminhtml/templates/system/config/validatevat.phtml
+++ b/app/code/Magento/Customer/view/adminhtml/templates/system/config/validatevat.phtml
@@ -4,15 +4,16 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Adminhtml\System\Config\Validatevat $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
+/**
+ * @var \Magento\Customer\Block\Adminhtml\System\Config\Validatevat $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ */
 
-<?php
- $merchantCountryField = $block->escapeJs($block->getMerchantCountryField());
- $merchantVatNumberField = $block->escapeJs($block->getMerchantVatNumberField());
- $ajaxUrl = $block->escapeJs($block->getAjaxUrl());
- $errorMessage = $block->escapeJs($block->escapeHtml(__('Error during VAT Number verification.')));
+ $merchantCountryField = $escaper->escapeJs($block->getMerchantCountryField());
+ $merchantVatNumberField = $escaper->escapeJs($block->getMerchantVatNumberField());
+ $ajaxUrl = $escaper->escapeJs($block->getAjaxUrl());
+ $errorMessage = $escaper->escapeJs($escaper->escapeHtml(__('Error during VAT Number verification.')));
 
  $scriptString = <<<script
 require(['prototype'], function(){
@@ -61,7 +62,7 @@ script;
 <div class="actions actions-validate-vat">
     <p class="admin__field-error hidden" id="validation_result"></p>
     <button class="action-validate-vat" type="button" id="<?= /* @noEscape */ $block->getHtmlId() ?>">
-        <span><?= $block->escapeHtml($block->getButtonLabel()) ?></span>
+        <span><?= $escaper->escapeHtml($block->getButtonLabel()) ?></span>
     </button>
 </div>
 <?= /* @noEscape */ $secureRenderer->renderTag('style', [], '#validation_result {margin-bottom: 10px;}', false); ?>

--- a/app/code/Magento/Customer/view/adminhtml/templates/tab/cart.phtml
+++ b/app/code/Magento/Customer/view/adminhtml/templates/tab/cart.phtml
@@ -4,14 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-/* @var \Magento\Customer\Block\Adminhtml\Edit\Tab\Cart $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Customer\Block\Adminhtml\Edit\Tab\Cart $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ */
 ?>
 <?php if ($block->getCartHeader()): ?>
 <div class="content-header skip-header">
     <table>
         <tr>
-            <td><h4><?= $block->escapeHtml($block->getCartHeader()) ?></h4></td>
+            <td><h4><?= $escaper->escapeHtml($block->getCartHeader()) ?></h4></td>
         </tr>
     </table>
     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag("width:50%;", 'div.content-header.skip-header table tr td') ?>
@@ -27,19 +30,19 @@
             "Magento_Catalog/catalog/product/composite/configure"
         ], function(alert, confirm){
 
-        {$block->escapeJs($block->getJsObjectName())}cartControl = {
+        {$escaper->escapeJs($block->getJsObjectName())}cartControl = {
             reload: function (params) {
             if (!params) {
                 params = {};
             }
-            {$block->escapeJs($block->getJsObjectName())}.reloadParams = params;
-            {$block->escapeJs($block->getJsObjectName())}.reload();
-            {$block->escapeJs($block->getJsObjectName())}.reloadParams = {};
+            {$escaper->escapeJs($block->getJsObjectName())}.reloadParams = params;
+            {$escaper->escapeJs($block->getJsObjectName())}.reload();
+            {$escaper->escapeJs($block->getJsObjectName())}.reloadParams = {};
         },
 
         configureItem: function (itemId) {
-            productConfigure.setOnLoadIFrameCallback('{$block->escapeJs($listType)}', this.cbOnLoadIframe.bind(this));
-            productConfigure.showItemConfiguration('{$block->escapeJs($listType)}', itemId);
+            productConfigure.setOnLoadIFrameCallback('{$escaper->escapeJs($listType)}', this.cbOnLoadIframe.bind(this));
+            productConfigure.showItemConfiguration('{$escaper->escapeJs($listType)}', itemId);
             return false;
         },
 
@@ -55,14 +58,14 @@
 
             if (!itemId) {
                 alert({
-                    content: '{$block->escapeJs(__('No item specified.'))}'
+                    content: '{$escaper->escapeJs(__('No item specified.'))}'
                 });
 
                 return false;
             }
 
             confirm({
-                content: '{$block->escapeJs(__('Are you sure you want to remove this item?'))}',
+                content: '{$escaper->escapeJs(__('Are you sure you want to remove this item?'))}',
                 actions: {
                     confirm: function(){
                         self.reload({'delete':itemId});
@@ -80,10 +83,10 @@ script;
     ];
     $scriptString .= <<<script
     productConfigure.addListType(
-        '{$block->escapeJs($listType)}',
+        '{$escaper->escapeJs($listType)}',
         {
-            urlFetch: '{$block->escapeJs($block->getUrl('customer/cart_product_composite_cart/configure', $params))}',
-            urlConfirm: '{$block->escapeJs($block->getUrl('customer/cart_product_composite_cart/update', $params))}'
+            urlFetch: '{$escaper->escapeJs($block->getUrl('customer/cart_product_composite_cart/configure', $params))}',
+            urlConfirm: '{$escaper->escapeJs($block->getUrl('customer/cart_product_composite_cart/update', $params))}'
         }
     );
 

--- a/app/code/Magento/Customer/view/adminhtml/templates/tab/view/personal_info.phtml
+++ b/app/code/Magento/Customer/view/adminhtml/templates/tab/view/personal_info.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Adminhtml\Edit\Tab\View\PersonalInfo $block */
+/**
+ * @var \Magento\Customer\Block\Adminhtml\Edit\Tab\View\PersonalInfo $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $lastLoginDateAdmin = $block->getLastLoginDate();
 $lastLoginDateStore = $block->getStoreLastLoginDate();
@@ -15,52 +18,52 @@ $allowedAddressHtmlTags = ['b', 'br', 'em', 'i', 'li', 'ol', 'p', 'strong', 'sub
 ?>
 <div class="fieldset-wrapper customer-information">
     <div class="fieldset-wrapper-title">
-        <span class="title"><?= $block->escapeHtml(__('Personal Information')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Personal Information')) ?></span>
     </div>
     <table class="admin__table-secondary">
         <tbody>
         <?= $block->getChildHtml() ?>
         <tr>
-            <th><?= $block->escapeHtml(__('Last Logged In:')) ?></th>
-            <td><?= $block->escapeHtml($lastLoginDateAdmin) ?> (<?= $block->escapeHtml($block->getCurrentStatus()) ?>)</td>
+            <th><?= $escaper->escapeHtml(__('Last Logged In:')) ?></th>
+            <td><?= $escaper->escapeHtml($lastLoginDateAdmin) ?> (<?= $escaper->escapeHtml($block->getCurrentStatus()) ?>)</td>
         </tr>
         <?php if ($lastLoginDateAdmin != $lastLoginDateStore) : ?>
         <tr>
-            <th><?= $block->escapeHtml(__('Last Logged In (%1):', $block->getStoreLastLoginDateTimezone())) ?></th>
-            <td><?= $block->escapeHtml($lastLoginDateStore) ?> (<?= $block->escapeHtml($block->getCurrentStatus()) ?>)</td>
+            <th><?= $escaper->escapeHtml(__('Last Logged In (%1):', $block->getStoreLastLoginDateTimezone())) ?></th>
+            <td><?= $escaper->escapeHtml($lastLoginDateStore) ?> (<?= $escaper->escapeHtml($block->getCurrentStatus()) ?>)</td>
         </tr>
         <?php endif; ?>
         <tr>
-            <th><?= $block->escapeHtml(__('Account Lock:')) ?></th>
-            <td><?= $block->escapeHtml($block->getAccountLock()) ?></td>
+            <th><?= $escaper->escapeHtml(__('Account Lock:')) ?></th>
+            <td><?= $escaper->escapeHtml($block->getAccountLock()) ?></td>
         </tr>
         <tr>
-            <th><?= $block->escapeHtml(__('Confirmed email:')) ?></th>
-            <td><?= $block->escapeHtml($block->getIsConfirmedStatus()) ?></td>
+            <th><?= $escaper->escapeHtml(__('Confirmed email:')) ?></th>
+            <td><?= $escaper->escapeHtml($block->getIsConfirmedStatus()) ?></td>
         </tr>
         <tr>
-            <th><?= $block->escapeHtml(__('Account Created:')) ?></th>
-            <td><?= $block->escapeHtml($createDateAdmin) ?></td>
+            <th><?= $escaper->escapeHtml(__('Account Created:')) ?></th>
+            <td><?= $escaper->escapeHtml($createDateAdmin) ?></td>
         </tr>
         <?php if ($createDateAdmin != $createDateStore) : ?>
             <tr>
-                <th><?= $block->escapeHtml(__('Account Created on (%1):', $block->getStoreCreateDateTimezone())) ?></th>
-                <td><?= $block->escapeHtml($createDateStore) ?></td>
+                <th><?= $escaper->escapeHtml(__('Account Created on (%1):', $block->getStoreCreateDateTimezone())) ?></th>
+                <td><?= $escaper->escapeHtml($createDateStore) ?></td>
             </tr>
         <?php endif; ?>
         <tr>
-            <th><?= $block->escapeHtml(__('Account Created in:')) ?></th>
-            <td><?= $block->escapeHtml($block->getCreatedInStore()) ?></td>
+            <th><?= $escaper->escapeHtml(__('Account Created in:')) ?></th>
+            <td><?= $escaper->escapeHtml($block->getCreatedInStore()) ?></td>
         </tr>
         <tr>
-            <th><?= $block->escapeHtml(__('Customer Group:')) ?></th>
-            <td><?= $block->escapeHtml($block->getGroupName()) ?></td>
+            <th><?= $escaper->escapeHtml(__('Customer Group:')) ?></th>
+            <td><?= $escaper->escapeHtml($block->getGroupName()) ?></td>
         </tr>
         </tbody>
     </table>
     <address>
-        <strong><?= $block->escapeHtml(__('Default Billing Address')) ?></strong><br/>
-        <?= $block->escapeHtml($block->getBillingAddressHtml(), $allowedAddressHtmlTags) ?>
+        <strong><?= $escaper->escapeHtml(__('Default Billing Address')) ?></strong><br/>
+        <?= $escaper->escapeHtml($block->getBillingAddressHtml(), $allowedAddressHtmlTags) ?>
     </address>
 
 </div>

--- a/app/code/Magento/Customer/view/adminhtml/templates/tab/view/sales.phtml
+++ b/app/code/Magento/Customer/view/adminhtml/templates/tab/view/sales.phtml
@@ -4,34 +4,37 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Adminhtml\Edit\Tab\View\Sales $block */
+/**
+ * @var \Magento\Customer\Block\Adminhtml\Edit\Tab\View\Sales $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $singleStoreMode = $block->isSingleStoreMode();
 ?>
 <div class="entry-edit fieldset-wrapper">
 
     <div class="fieldset-wrapper-title">
-        <span class="title"><?= $block->escapeHtml(__('Sales Statistics')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Sales Statistics')) ?></span>
     </div>
 
     <table class="data-table">
         <thead>
         <tr>
             <?php if (!$singleStoreMode) : ?>
-            <th><?= $block->escapeHtml(__('Web Site')) ?></th>
-            <th><?= $block->escapeHtml(__('Store')) ?></th>
-            <th><?= $block->escapeHtml(__('Store View')) ?></th>
+            <th><?= $escaper->escapeHtml(__('Web Site')) ?></th>
+            <th><?= $escaper->escapeHtml(__('Store')) ?></th>
+            <th><?= $escaper->escapeHtml(__('Store View')) ?></th>
             <?php endif; ?>
-            <th><?= $block->escapeHtml(__('Lifetime Sales')) ?></th>
-            <th class="last"><?= $block->escapeHtml(__('Average Sale')) ?></th>
+            <th><?= $escaper->escapeHtml(__('Lifetime Sales')) ?></th>
+            <th class="last"><?= $escaper->escapeHtml(__('Average Sale')) ?></th>
         </tr>
         </thead>
         <?php if (!$singleStoreMode) : ?>
         <tfoot>
         <tr>
-            <td colspan="3"><strong><?= $block->escapeHtml(__('All Store Views')) ?></strong></td>
-            <td class="emph"><strong><?= $block->escapeHtml($block->formatCurrency($block->getTotals()->getBaseLifetime())) ?></strong></td>
-            <td class="emph last"><strong><?= $block->escapeHtml($block->formatCurrency($block->getTotals()->getAvgsale())) ?></strong></td>
+            <td colspan="3"><strong><?= $escaper->escapeHtml(__('All Store Views')) ?></strong></td>
+            <td class="emph"><strong><?= $escaper->escapeHtml($block->formatCurrency($block->getTotals()->getBaseLifetime())) ?></strong></td>
+            <td class="emph last"><strong><?= $escaper->escapeHtml($block->formatCurrency($block->getTotals()->getAvgsale())) ?></strong></td>
         </tr>
         </tfoot>
         <?php endif; ?>
@@ -45,24 +48,24 @@ $singleStoreMode = $block->isSingleStoreMode();
                     <?php foreach ($_stores as $_row) : ?>
                         <?php if (!$singleStoreMode) : ?>
                             <?php if ($_row->getStoreId() == 0) : ?>
-                                <td colspan="3"><?= $block->escapeHtml($_row->getStoreName()) ?></td>
+                                <td colspan="3"><?= $escaper->escapeHtml($_row->getStoreName()) ?></td>
                             <?php else : ?>
                                 <tr<?= ($_i++ % 2 ? ' class="even"' : '') ?>>
                                 <?php if (!$_websiteRow) : ?>
-                                    <td rowspan="<?= $block->escapeHtmlAttr($block->getWebsiteCount($_websiteId)) ?>"><?= $block->escapeHtml($_row->getWebsiteName()) ?></td>
+                                    <td rowspan="<?= $escaper->escapeHtmlAttr($block->getWebsiteCount($_websiteId)) ?>"><?= $escaper->escapeHtml($_row->getWebsiteName()) ?></td>
                                     <?php $_websiteRow = true; ?>
                                 <?php endif; ?>
                                 <?php if (!$_groupRow) : ?>
-                                    <td rowspan="<?= count($_stores) ?>"><?= $block->escapeHtml($_row->getGroupName()) ?></td>
+                                    <td rowspan="<?= count($_stores) ?>"><?= $escaper->escapeHtml($_row->getGroupName()) ?></td>
                                     <?php $_groupRow = true; ?>
                                 <?php endif; ?>
-                                <td><?= $block->escapeHtml($_row->getStoreName()) ?></td>
+                                <td><?= $escaper->escapeHtml($_row->getStoreName()) ?></td>
                             <?php endif; ?>
                         <?php else : ?>
                             <tr>
                         <?php endif; ?>
-                        <td><?= $block->escapeHtml($block->formatCurrency($_row->getLifetime(), $_row->getWebsiteId())) ?></td>
-                        <td><?= $block->escapeHtml($block->formatCurrency($_row->getAvgsale(), $_row->getWebsiteId())) ?></td>
+                        <td><?= $escaper->escapeHtml($block->formatCurrency($_row->getLifetime(), $_row->getWebsiteId())) ?></td>
+                        <td><?= $escaper->escapeHtml($block->formatCurrency($_row->getAvgsale(), $_row->getWebsiteId())) ?></td>
                         </tr>
                     <?php endforeach; ?>
                 <?php endforeach; ?>

--- a/app/code/Magento/Customer/view/frontend/templates/account/authentication-popup.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/authentication-popup.phtml
@@ -4,8 +4,11 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Account\AuthenticationPopup $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Customer\Block\Account\AuthenticationPopup $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ */
 ?>
 <div id="authenticationPopup" data-bind="scope:'authenticationPopup', style: {display: 'none'}">
     <?php $scriptString = 'window.authenticationPopup = ' . /* @noEscape */ $block->getSerializedConfig(); ?>
@@ -17,7 +20,7 @@
                 "Magento_Ui/js/core/app": <?= /* @noEscape */ $block->getJsLayout() ?>
             },
             "*": {
-                "Magento_Ui/js/block-loader": "<?= $block->escapeJs($block->escapeUrl($block->getViewFileUrl(
+                "Magento_Ui/js/block-loader": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getViewFileUrl(
                     'images/loader-1.gif'
                 ))) ?>"
             }

--- a/app/code/Magento/Customer/view/frontend/templates/account/customer.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/customer.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var Magento\Customer\Block\Account\Customer $block */
+/**
+ * @var Magento\Customer\Block\Account\Customer $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($block->customerLoggedIn()) : ?>
     <li class="customer-welcome">
@@ -19,7 +22,7 @@
                     class="action switch"
                     tabindex="-1"
                     data-action="customer-menu-toggle">
-                <span><?= $block->escapeHtml(__('Change')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Change')) ?></span>
             </button>
         </span>
         <script type="text/x-magento-init">

--- a/app/code/Magento/Customer/view/frontend/templates/account/dashboard/address.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/dashboard/address.phtml
@@ -4,17 +4,20 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Account\Dashboard\Address $block */
+/**
+ * @var \Magento\Customer\Block\Account\Dashboard\Address $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="block block-dashboard-addresses">
     <div class="block-title">
-        <strong><?= $block->escapeHtml(__('Address Book')) ?></strong>
-        <a class="action edit" href="<?= $block->escapeUrl($block->getAddressBookUrl()) ?>"><span><?= $block->escapeHtml(__('Manage Addresses')) ?></span></a>
+        <strong><?= $escaper->escapeHtml(__('Address Book')) ?></strong>
+        <a class="action edit" href="<?= $escaper->escapeUrl($block->getAddressBookUrl()) ?>"><span><?= $escaper->escapeHtml(__('Manage Addresses')) ?></span></a>
     </div>
     <div class="block-content">
         <div class="box box-billing-address">
             <strong class="box-title">
-                <span><?= $block->escapeHtml(__('Default Billing Address')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Default Billing Address')) ?></span>
             </strong>
             <div class="box-content">
                 <address>
@@ -22,12 +25,12 @@
                 </address>
             </div>
             <div class="box-actions">
-                <a class="action edit" href="<?= $block->escapeUrl($block->getPrimaryBillingAddressEditUrl()) ?>" data-ui-id="default-billing-edit-link"><span><?= $block->escapeHtml(__('Edit Address')) ?></span></a>
+                <a class="action edit" href="<?= $escaper->escapeUrl($block->getPrimaryBillingAddressEditUrl()) ?>" data-ui-id="default-billing-edit-link"><span><?= $escaper->escapeHtml(__('Edit Address')) ?></span></a>
             </div>
         </div>
         <div class="box box-shipping-address">
             <strong class="box-title">
-                <span><?= $block->escapeHtml(__('Default Shipping Address')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Default Shipping Address')) ?></span>
             </strong>
             <div class="box-content">
                 <address>
@@ -35,7 +38,7 @@
                 </address>
             </div>
             <div class="box-actions">
-                <a class="action edit" href="<?= $block->escapeUrl($block->getPrimaryShippingAddressEditUrl()) ?>" data-ui-id="default-shipping-edit-link"><span><?= $block->escapeHtml(__('Edit Address')) ?></span></a>
+                <a class="action edit" href="<?= $escaper->escapeUrl($block->getPrimaryShippingAddressEditUrl()) ?>" data-ui-id="default-shipping-edit-link"><span><?= $escaper->escapeHtml(__('Edit Address')) ?></span></a>
             </div>
         </div>
     </div>

--- a/app/code/Magento/Customer/view/frontend/templates/account/dashboard/info.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/dashboard/info.phtml
@@ -4,48 +4,51 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Account\Dashboard\Info $block */
+/**
+ * @var \Magento\Customer\Block\Account\Dashboard\Info $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="block block-dashboard-info">
-    <div class="block-title"><strong><?= $block->escapeHtml(__('Account Information')) ?></strong></div>
+    <div class="block-title"><strong><?= $escaper->escapeHtml(__('Account Information')) ?></strong></div>
     <div class="block-content">
         <div class="box box-information">
             <strong class="box-title">
-                <span><?= $block->escapeHtml(__('Contact Information')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Contact Information')) ?></span>
             </strong>
             <div class="box-content">
                 <p>
-                    <?= $block->escapeHtml($block->getName()) ?><br>
-                    <?= $block->escapeHtml($block->getCustomer()->getEmail()) ?><br>
+                    <?= $escaper->escapeHtml($block->getName()) ?><br>
+                    <?= $escaper->escapeHtml($block->getCustomer()->getEmail()) ?><br>
                 </p>
                 <?= $block->getChildHtml('customer.account.dashboard.info.extra'); ?>
             </div>
             <div class="box-actions">
-                <a class="action edit" href="<?= $block->escapeUrl($block->getUrl('customer/account/edit')) ?>">
-                    <span><?= $block->escapeHtml(__('Edit')) ?></span>
+                <a class="action edit" href="<?= $escaper->escapeUrl($block->getUrl('customer/account/edit')) ?>">
+                    <span><?= $escaper->escapeHtml(__('Edit')) ?></span>
                 </a>
-                <a href="<?= $block->escapeUrl($block->getChangePasswordUrl()) ?>" class="action change-password">
-                    <?= $block->escapeHtml(__('Change Password')) ?>
+                <a href="<?= $escaper->escapeUrl($block->getChangePasswordUrl()) ?>" class="action change-password">
+                    <?= $escaper->escapeHtml(__('Change Password')) ?>
                 </a>
             </div>
         </div>
         <?php if ($block->isNewsletterEnabled()): ?>
             <div class="box box-newsletter">
                 <strong class="box-title">
-                    <span><?= $block->escapeHtml(__('Newsletters')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Newsletters')) ?></span>
                 </strong>
                 <div class="box-content">
                     <p>
                         <?php if ($block->getIsSubscribed()): ?>
-                            <?= $block->escapeHtml(__('You are subscribed to "General Subscription".')) ?>
+                            <?= $escaper->escapeHtml(__('You are subscribed to "General Subscription".')) ?>
                         <?php else: ?>
-                            <?= $block->escapeHtml(__('You aren\'t subscribed to our newsletter.')) ?>
+                            <?= $escaper->escapeHtml(__('You aren\'t subscribed to our newsletter.')) ?>
                         <?php endif; ?>
                     </p>
                 </div>
                 <div class="box-actions">
-                    <a class="action edit" href="<?= $block->escapeUrl($block->getUrl('newsletter/manage')) ?>">
-                        <span><?= $block->escapeHtml(__('Edit')) ?></span></a>
+                    <a class="action edit" href="<?= $escaper->escapeUrl($block->getUrl('newsletter/manage')) ?>">
+                        <span><?= $escaper->escapeHtml(__('Edit')) ?></span></a>
                 </div>
             </div>
         <?php endif; ?>

--- a/app/code/Magento/Customer/view/frontend/templates/account/link/back.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/link/back.phtml
@@ -3,7 +3,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="actions-toolbar">
-    <div class="secondary"><a class="action back" href="<?= $block->escapeUrl($block->getBackUrl()) ?>"><span><?= $block->escapeHtml(__('Back')) ?></span></a></div>
+    <div class="secondary"><a class="action back" href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>"><span><?= $escaper->escapeHtml(__('Back')) ?></span></a></div>
 </div>

--- a/app/code/Magento/Customer/view/frontend/templates/account/navigation.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/navigation.phtml
@@ -4,11 +4,14 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Framework\View\Element\Html\Links */
+/**
+ * @var $block \Magento\Framework\View\Element\Html\Links
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="block account-nav">
     <div class="title">
-        <strong><?= $block->escapeHtml(__('My Account')) ?></strong>
+        <strong><?= $escaper->escapeHtml(__('My Account')) ?></strong>
     </div>
     <div class="content">
         <nav class="account-nav">

--- a/app/code/Magento/Customer/view/frontend/templates/address/book.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/address/book.phtml
@@ -4,15 +4,18 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Address\Book $block */
+/**
+ * @var \Magento\Customer\Block\Address\Book $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="block block-addresses-default">
-    <div class="block-title"><strong><?= $block->escapeHtml(__('Default Addresses')) ?></strong></div>
+    <div class="block-title"><strong><?= $escaper->escapeHtml(__('Default Addresses')) ?></strong></div>
     <div class="block-content">
         <?php if ($_pAddsses = $block->getDefaultBilling()) : ?>
             <div class="box box-address-billing">
                 <strong class="box-title">
-                    <span><?= $block->escapeHtml(__('Default Billing Address')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Default Billing Address')) ?></span>
                 </strong>
                 <div class="box-content">
                     <address>
@@ -20,16 +23,16 @@
                     </address>
                 </div>
                 <div class="box-actions">
-                    <a class="action edit" href="<?= $block->escapeUrl($block->getAddressEditUrl($_pAddsses)) ?>">
-                        <span><?= $block->escapeHtml(__('Change Billing Address')) ?></span>
+                    <a class="action edit" href="<?= $escaper->escapeUrl($block->getAddressEditUrl($_pAddsses)) ?>">
+                        <span><?= $escaper->escapeHtml(__('Change Billing Address')) ?></span>
                     </a>
                 </div>
             </div>
         <?php else : ?>
             <div class="box box-billing-address">
-                <strong class="box-title"><span><?= $block->escapeHtml(__('Default Billing Address')) ?></span></strong>
+                <strong class="box-title"><span><?= $escaper->escapeHtml(__('Default Billing Address')) ?></span></strong>
                 <div class="box-content">
-                    <p><?= $block->escapeHtml(__('You have no default billing address in your address book.')) ?></p>
+                    <p><?= $escaper->escapeHtml(__('You have no default billing address in your address book.')) ?></p>
                 </div>
             </div>
         <?php endif ?>
@@ -37,7 +40,7 @@
         <?php if ($_pAddsses = $block->getDefaultShipping()) : ?>
             <div class="box box-address-shipping">
                 <strong class="box-title">
-                    <span><?= $block->escapeHtml(__('Default Shipping Address')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Default Shipping Address')) ?></span>
                 </strong>
                 <div class="box-content">
                     <address>
@@ -45,16 +48,16 @@
                     </address>
                 </div>
                 <div class="box-actions">
-                    <a class="action edit" href="<?= $block->escapeUrl($block->getAddressEditUrl($_pAddsses)) ?>">
-                        <span><?= $block->escapeHtml(__('Change Shipping Address')) ?></span>
+                    <a class="action edit" href="<?= $escaper->escapeUrl($block->getAddressEditUrl($_pAddsses)) ?>">
+                        <span><?= $escaper->escapeHtml(__('Change Shipping Address')) ?></span>
                     </a>
                 </div>
             </div>
         <?php else : ?>
             <div class="box box-shipping-address">
-                <strong class="box-title"><span><?= $block->escapeHtml(__('Default Shipping Address')) ?></span></strong>
+                <strong class="box-title"><span><?= $escaper->escapeHtml(__('Default Shipping Address')) ?></span></strong>
                 <div class="box-content">
-                    <p><?= $block->escapeHtml(__('You have no default shipping address in your address book.')) ?></p>
+                    <p><?= $escaper->escapeHtml(__('You have no default shipping address in your address book.')) ?></p>
                 </div>
             </div>
         <?php endif ?>

--- a/app/code/Magento/Customer/view/frontend/templates/address/grid.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/address/grid.phtml
@@ -4,45 +4,48 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Address\Grid $block */
+/**
+ * @var \Magento\Customer\Block\Address\Grid $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 $customerAddressView = $block->getData('customer_address');
 ?>
 
 <div class="block block-addresses-list">
-    <div class="block-title"><strong><?= $block->escapeHtml(__('Additional Address Entries')) ?></strong></div>
+    <div class="block-title"><strong><?= $escaper->escapeHtml(__('Additional Address Entries')) ?></strong></div>
     <div class="block-content">
         <?php if ($_pAddsses = $block->getAdditionalAddresses()) : ?>
 
             <div class="table-wrapper additional-addresses">
                 <table class="data table table-additional-addresses-items history" id="additional-addresses-table">
-                    <caption class="table-caption"><?= $block->escapeHtml(__('Additional addresses')) ?></caption>
+                    <caption class="table-caption"><?= $escaper->escapeHtml(__('Additional addresses')) ?></caption>
                     <thead>
                     <tr>
-                        <th scope="col" class="col firstname"><?= $block->escapeHtml(__('First Name')) ?></th>
-                        <th scope="col" class="col lastname"><?= $block->escapeHtml(__('Last Name')) ?></th>
-                        <th scope="col" class="col streetaddress"><?= $block->escapeHtml(__('Street Address')) ?></th>
-                        <th scope="col" class="col city"><?= $block->escapeHtml(__('City')) ?></th>
-                        <th scope="col" class="col country"><?= $block->escapeHtml(__('Country')) ?></th>
-                        <th scope="col" class="col state"><?= $block->escapeHtml(__('State')) ?></th>
-                        <th scope="col" class="col zip"><?= $block->escapeHtml(__('Zip/Postal Code')) ?></th>
-                        <th scope="col" class="col phone"><?= $block->escapeHtml(__('Phone')) ?></th>
+                        <th scope="col" class="col firstname"><?= $escaper->escapeHtml(__('First Name')) ?></th>
+                        <th scope="col" class="col lastname"><?= $escaper->escapeHtml(__('Last Name')) ?></th>
+                        <th scope="col" class="col streetaddress"><?= $escaper->escapeHtml(__('Street Address')) ?></th>
+                        <th scope="col" class="col city"><?= $escaper->escapeHtml(__('City')) ?></th>
+                        <th scope="col" class="col country"><?= $escaper->escapeHtml(__('Country')) ?></th>
+                        <th scope="col" class="col state"><?= $escaper->escapeHtml(__('State')) ?></th>
+                        <th scope="col" class="col zip"><?= $escaper->escapeHtml(__('Zip/Postal Code')) ?></th>
+                        <th scope="col" class="col phone"><?= $escaper->escapeHtml(__('Phone')) ?></th>
                         <th scope="col" class="col actions"> </th>
                     </tr>
                     </thead>
                     <tbody>
                     <?php foreach ($_pAddsses as $address) : ?>
                         <tr>
-                            <td data-th="<?= $block->escapeHtml(__('First Name')) ?>" class="col firstname"><?= $block->escapeHtml($address->getFirstname()) ?></td>
-                            <td data-th="<?= $block->escapeHtml(__('Last Name')) ?>" class="col lastname"><?= $block->escapeHtml($address->getLastname()) ?></td>
-                            <td data-th="<?= $block->escapeHtml(__('Street Address')) ?>" class="col streetaddress"><?= $block->escapeHtml($block->getStreetAddress($address)) ?></td>
-                            <td data-th="<?= $block->escapeHtml(__('City')) ?>" class="col city"><?= $block->escapeHtml($address->getCity()) ?></td>
-                            <td data-th="<?= $block->escapeHtml(__('Country')) ?>" class="col country"><?= $block->escapeHtml($block->getCountryByCode($address->getCountryId())) ?></td>
-                            <td data-th="<?= $block->escapeHtml(__('State')) ?>" class="col state"><?= $block->escapeHtml($address->getRegion()->getRegion()) ?></td>
-                            <td data-th="<?= $block->escapeHtml(__('Zip/Postal Code')) ?>" class="col zip"><?= $block->escapeHtml($address->getPostcode()) ?></td>
-                            <td data-th="<?= $block->escapeHtml(__('Phone')) ?>" class="col phone"><?= $block->escapeHtml($address->getTelephone()) ?></td>
-                            <td data-th="<?= $block->escapeHtml(__('Actions')) ?>" class="col actions">
-                                <a class="action edit" href="<?= $block->escapeUrl($block->getUrl('customer/address/edit', ['id' => $address->getId()])) ?>"><span><?= $block->escapeHtml(__('Edit')) ?></span></a>
-                                <a class="action delete" href="#" role="delete-address" data-address="<?= $block->escapeHtmlAttr($address->getId()) ?>"><span><?= $block->escapeHtml(__('Delete')) ?></span></a>
+                            <td data-th="<?= $escaper->escapeHtml(__('First Name')) ?>" class="col firstname"><?= $escaper->escapeHtml($address->getFirstname()) ?></td>
+                            <td data-th="<?= $escaper->escapeHtml(__('Last Name')) ?>" class="col lastname"><?= $escaper->escapeHtml($address->getLastname()) ?></td>
+                            <td data-th="<?= $escaper->escapeHtml(__('Street Address')) ?>" class="col streetaddress"><?= $escaper->escapeHtml($block->getStreetAddress($address)) ?></td>
+                            <td data-th="<?= $escaper->escapeHtml(__('City')) ?>" class="col city"><?= $escaper->escapeHtml($address->getCity()) ?></td>
+                            <td data-th="<?= $escaper->escapeHtml(__('Country')) ?>" class="col country"><?= $escaper->escapeHtml($block->getCountryByCode($address->getCountryId())) ?></td>
+                            <td data-th="<?= $escaper->escapeHtml(__('State')) ?>" class="col state"><?= $escaper->escapeHtml($address->getRegion()->getRegion()) ?></td>
+                            <td data-th="<?= $escaper->escapeHtml(__('Zip/Postal Code')) ?>" class="col zip"><?= $escaper->escapeHtml($address->getPostcode()) ?></td>
+                            <td data-th="<?= $escaper->escapeHtml(__('Phone')) ?>" class="col phone"><?= $escaper->escapeHtml($address->getTelephone()) ?></td>
+                            <td data-th="<?= $escaper->escapeHtml(__('Actions')) ?>" class="col actions">
+                                <a class="action edit" href="<?= $escaper->escapeUrl($block->getUrl('customer/address/edit', ['id' => $address->getId()])) ?>"><span><?= $escaper->escapeHtml(__('Edit')) ?></span></a>
+                                <a class="action delete" href="#" role="delete-address" data-address="<?= $escaper->escapeHtmlAttr($address->getId()) ?>"><span><?= $escaper->escapeHtml(__('Delete')) ?></span></a>
                             </td>
                         </tr>
                     <?php endforeach; ?>
@@ -53,17 +56,17 @@ $customerAddressView = $block->getData('customer_address');
                 <div class="customer-addresses-toolbar toolbar bottom"><?= $block->getChildHtml('pager') ?></div>
             <?php endif ?>
         <?php else : ?>
-            <p class="empty"><?= $block->escapeHtml(__('You have no other address entries in your address book.')) ?></p>
+            <p class="empty"><?= $escaper->escapeHtml(__('You have no other address entries in your address book.')) ?></p>
         <?php endif ?>
     </div>
 </div>
 
 <div class="actions-toolbar">
     <div class="primary">
-        <button type="button" role="add-address" title="<?= $block->escapeHtmlAttr(__('Add New Address')) ?>" class="action primary add"><span><?= $block->escapeHtml(__('Add New Address')) ?></span></button>
+        <button type="button" role="add-address" title="<?= $escaper->escapeHtmlAttr(__('Add New Address')) ?>" class="action primary add"><span><?= $escaper->escapeHtml(__('Add New Address')) ?></span></button>
     </div>
     <div class="secondary">
-        <a class="action back" href="<?= $block->escapeUrl($block->getUrl('customer/account')) ?>"><span><?= $block->escapeHtml(__('Back')) ?></span></a>
+        <a class="action back" href="<?= $escaper->escapeUrl($block->getUrl('customer/account')) ?>"><span><?= $escaper->escapeHtml(__('Back')) ?></span></a>
     </div>
 </div>
 <script type="text/x-magento-init">
@@ -71,9 +74,9 @@ $customerAddressView = $block->getData('customer_address');
         ".page-main": {
             "address": {
                 "deleteAddress": "td a[role='delete-address']",
-                "deleteUrlPrefix": "<?= $block->escapeJs($block->escapeUrl($block->getDeleteUrl())) ?>id/",
+                "deleteUrlPrefix": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getDeleteUrl())) ?>id/",
                 "addAddress": "button[role='add-address']",
-                "addAddressLocation": "<?= $block->escapeJs($block->escapeUrl($block->getAddAddressUrl())) ?>"
+                "addAddressLocation": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getAddAddressUrl())) ?>"
             }
         }
     }

--- a/app/code/Magento/Customer/view/frontend/templates/form/confirmation.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/confirmation.phtml
@@ -4,24 +4,27 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <form action="" method="post" id="form-validate" class="form send confirmation" data-mage-init='{"validation":{}}'>
-    <fieldset class="fieldset" data-hasrequired="<?= $block->escapeHtmlAttr(__('* Required Fields')) ?>">
-        <p class="field note"><?= $block->escapeHtml(__('Please enter your email below and we will send you the confirmation link.')) ?></p>
+    <fieldset class="fieldset" data-hasrequired="<?= $escaper->escapeHtmlAttr(__('* Required Fields')) ?>">
+        <p class="field note"><?= $escaper->escapeHtml(__('Please enter your email below and we will send you the confirmation link.')) ?></p>
         <div class="field email required">
-            <label for="email_address" class="label"><span><?= $block->escapeHtml(__('Email')) ?></span></label>
+            <label for="email_address" class="label"><span><?= $escaper->escapeHtml(__('Email')) ?></span></label>
             <div class="control">
-                <input type="email" name="email" id="email_address" class="input-text" value="<?= $block->escapeHtmlAttr($block->getEmail()) ?>" data-validate="{required:true, 'validate-email':true}" data-mage-init='{"mage/trim-input":{}}'>
+                <input type="email" name="email" id="email_address" class="input-text" value="<?= $escaper->escapeHtmlAttr($block->getEmail()) ?>" data-validate="{required:true, 'validate-email':true}" data-mage-init='{"mage/trim-input":{}}'>
             </div>
         </div>
     </fieldset>
     <div class="actions-toolbar">
         <div class="primary">
-            <button type="submit" class="action send primary"><span><?= $block->escapeHtml(__('Send confirmation link')) ?></span></button>
+            <button type="submit" class="action send primary"><span><?= $escaper->escapeHtml(__('Send confirmation link')) ?></span></button>
         </div>
         <div class="secondary">
-            <a href="<?= $block->escapeUrl($block->getLoginUrl()) ?>" class="action back"><span><?= $block->escapeHtml(__('Back to Sign In')) ?></span></a>
+            <a href="<?= $escaper->escapeUrl($block->getLoginUrl()) ?>" class="action back"><span><?= $escaper->escapeHtml(__('Back to Sign In')) ?></span></a>
         </div>
     </div>
 </form>

--- a/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/edit.phtml
@@ -6,18 +6,21 @@
 
 use Magento\Customer\Block\Widget\Name;
 
-/** @var \Magento\Customer\Block\Form\Edit $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Customer\Block\Form\Edit $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ */
 ?>
 <form class="form form-edit-account"
-      action="<?= $block->escapeUrl($block->getUrl('customer/account/editPost')) ?>"
+      action="<?= $escaper->escapeUrl($block->getUrl('customer/account/editPost')) ?>"
       method="post" id="form-validate"
       enctype="multipart/form-data"
-      data-hasrequired="<?= $block->escapeHtmlAttr(__('* Required Fields')) ?>"
+      data-hasrequired="<?= $escaper->escapeHtmlAttr(__('* Required Fields')) ?>"
       autocomplete="off">
     <fieldset class="fieldset info">
         <?= $block->getBlockHtml('formkey') ?>
-        <legend class="legend"><span><?= $block->escapeHtml(__('Account Information')) ?></span></legend><br>
+        <legend class="legend"><span><?= $escaper->escapeHtml(__('Account Information')) ?></span></legend><br>
         <?= $block->getLayout()->createBlock(Name::class)->setObject($block->getCustomer())->toHtml() ?>
 
         <?php $_dob = $block->getLayout()->createBlock(\Magento\Customer\Block\Widget\Dob::class) ?>
@@ -34,17 +37,17 @@ use Magento\Customer\Block\Widget\Name;
         <?php endif ?>
         <div class="field choice">
             <input type="checkbox" name="change_email" id="change-email" data-role="change-email" value="1"
-                   title="<?= $block->escapeHtmlAttr(__('Change Email')) ?>" class="checkbox" />
+                   title="<?= $escaper->escapeHtmlAttr(__('Change Email')) ?>" class="checkbox" />
             <label class="label" for="change-email">
-                <span><?= $block->escapeHtml(__('Change Email')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Change Email')) ?></span>
             </label>
         </div>
         <div class="field choice">
             <input type="checkbox" name="change_password" id="change-password" data-role="change-password" value="1"
-                   title="<?= $block->escapeHtmlAttr(__('Change Password')) ?>"
+                   title="<?= $escaper->escapeHtmlAttr(__('Change Password')) ?>"
                 <?php if ($block->getChangePassword()): ?> checked="checked"<?php endif; ?> class="checkbox" />
             <label class="label" for="change-password">
-                <span><?= $block->escapeHtml(__('Change Password')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Change Password')) ?></span>
             </label>
         </div>
         <?= $block->getChildHtml('fieldset_edit_info_additional') ?>
@@ -52,21 +55,21 @@ use Magento\Customer\Block\Widget\Name;
 
     <fieldset class="fieldset password" data-container="change-email-password">
         <legend class="legend">
-            <span data-title="change-email-password"><?= $block->escapeHtml(__('Change Email and Password')) ?></span>
+            <span data-title="change-email-password"><?= $escaper->escapeHtml(__('Change Email and Password')) ?></span>
         </legend><br>
         <div class="field email required" data-container="change-email">
-            <label class="label" for="email"><span><?= $block->escapeHtml(__('Email')) ?></span></label>
+            <label class="label" for="email"><span><?= $escaper->escapeHtml(__('Email')) ?></span></label>
             <div class="control">
                 <input type="email" name="email" id="email" autocomplete="email" data-input="change-email"
-                       value="<?= $block->escapeHtmlAttr($block->getCustomer()->getEmail()) ?>"
-                       title="<?= $block->escapeHtmlAttr(__('Email')) ?>"
+                       value="<?= $escaper->escapeHtmlAttr($block->getCustomer()->getEmail()) ?>"
+                       title="<?= $escaper->escapeHtmlAttr(__('Email')) ?>"
                        class="input-text"
                        data-validate="{required:true, 'validate-email':true}" />
             </div>
         </div>
         <div class="field password current required">
             <label class="label" for="current-password">
-                <span><?= $block->escapeHtml(__('Current Password')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Current Password')) ?></span>
             </label>
             <div class="control">
                 <input type="password" class="input-text" name="current_password" id="current-password"
@@ -75,20 +78,20 @@ use Magento\Customer\Block\Widget\Name;
             </div>
         </div>
         <div class="field new password required" data-container="new-password">
-            <label class="label" for="password"><span><?= $block->escapeHtml(__('New Password')) ?></span></label>
+            <label class="label" for="password"><span><?= $escaper->escapeHtml(__('New Password')) ?></span></label>
             <div class="control">
                 <?php $minCharacterSets = $block->getRequiredCharacterClassesNumber() ?>
                 <input type="password" class="input-text" name="password" id="password"
-                    data-password-min-length="<?= $block->escapeHtml($block->getMinimumPasswordLength()) ?>"
-                    data-password-min-character-sets="<?= $block->escapeHtml($minCharacterSets) ?>"
+                    data-password-min-length="<?= $escaper->escapeHtml($block->getMinimumPasswordLength()) ?>"
+                    data-password-min-character-sets="<?= $escaper->escapeHtml($minCharacterSets) ?>"
                     data-input="new-password"
                     data-validate="{required:true, 'validate-customer-password':true}"
                     autocomplete="off" />
                 <div id="password-strength-meter-container" data-role="password-strength-meter" aria-live="polite">
                     <div id="password-strength-meter" class="password-strength-meter">
-                        <?= $block->escapeHtml(__('Password Strength')) ?>:
+                        <?= $escaper->escapeHtml(__('Password Strength')) ?>:
                         <span id="password-strength-meter-label" data-role="password-strength-meter-label">
-                            <?= $block->escapeHtml(__('No Password')) ?>
+                            <?= $escaper->escapeHtml(__('No Password')) ?>
                         </span>
                     </div>
                 </div>
@@ -96,7 +99,7 @@ use Magento\Customer\Block\Widget\Name;
         </div>
         <div class="field confirmation password required" data-container="confirm-password">
             <label class="label" for="password-confirmation">
-                <span><?= $block->escapeHtml(__('Confirm New Password')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Confirm New Password')) ?></span>
             </label>
             <div class="control">
                 <input type="password" class="input-text" name="password_confirmation" id="password-confirmation"
@@ -112,13 +115,13 @@ use Magento\Customer\Block\Widget\Name;
 
     <div class="actions-toolbar">
         <div class="primary">
-            <button type="submit" class="action save primary" title="<?= $block->escapeHtmlAttr(__('Save')) ?>">
-                <span><?= $block->escapeHtml(__('Save')) ?></span>
+            <button type="submit" class="action save primary" title="<?= $escaper->escapeHtmlAttr(__('Save')) ?>">
+                <span><?= $escaper->escapeHtml(__('Save')) ?></span>
             </button>
         </div>
         <div class="secondary">
-            <a class="action back" href="<?= $block->escapeUrl($block->getBackUrl()) ?>">
-                <span><?= $block->escapeHtml(__('Go back')) ?></span>
+            <a class="action back" href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>">
+                <span><?= $escaper->escapeHtml(__('Go back')) ?></span>
             </a>
         </div>
     </div>
@@ -162,14 +165,14 @@ $scriptString .= <<<script
 script;
 ?>
 <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
-<?php $changeEmailAndPasswordTitle = $block->escapeHtml(__('Change Email and Password')) ?>
+<?php $changeEmailAndPasswordTitle = $escaper->escapeHtml(__('Change Email and Password')) ?>
 <script type="text/x-magento-init">
     {
         "[data-role=change-email], [data-role=change-password]": {
             "changeEmailPassword": {
-                "titleChangeEmail": "<?= $block->escapeJs($block->escapeHtml(__('Change Email'))) ?>",
-                "titleChangePassword": "<?= $block->escapeJs($block->escapeHtml(__('Change Password'))) ?>",
-                "titleChangeEmailAndPassword": "<?= $block->escapeJs($changeEmailAndPasswordTitle) ?>"
+                "titleChangeEmail": "<?= $escaper->escapeJs($escaper->escapeHtml(__('Change Email'))) ?>",
+                "titleChangePassword": "<?= $escaper->escapeJs($escaper->escapeHtml(__('Change Password'))) ?>",
+                "titleChangeEmailAndPassword": "<?= $escaper->escapeJs($changeEmailAndPasswordTitle) ?>"
             }
         },
         "[data-container=new-password]": {

--- a/app/code/Magento/Customer/view/frontend/templates/form/forgotpassword.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/forgotpassword.phtml
@@ -8,29 +8,32 @@
 
 // phpcs:disable Generic.Files.LineLength.TooLong
 
-/** @var \Magento\Customer\Block\Account\Forgotpassword $block */
+/**
+ * @var \Magento\Customer\Block\Account\Forgotpassword $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <form class="form password forget"
-      action="<?= $block->escapeUrl($block->getUrl('*/*/forgotpasswordpost')) ?>"
+      action="<?= $escaper->escapeUrl($block->getUrl('*/*/forgotpasswordpost')) ?>"
       method="post"
       id="form-validate"
       data-mage-init='{"validation":{}}'>
-    <fieldset class="fieldset" data-hasrequired="<?= $block->escapeHtmlAttr(__('* Required Fields')) ?>">
-        <div class="field note"><?= $block->escapeHtml(__('Please enter your email address below to receive a password reset link.')) ?></div>
+    <fieldset class="fieldset" data-hasrequired="<?= $escaper->escapeHtmlAttr(__('* Required Fields')) ?>">
+        <div class="field note"><?= $escaper->escapeHtml(__('Please enter your email address below to receive a password reset link.')) ?></div>
         <div class="field email required">
-            <label for="email_address" class="label"><span><?= $block->escapeHtml(__('Email')) ?></span></label>
+            <label for="email_address" class="label"><span><?= $escaper->escapeHtml(__('Email')) ?></span></label>
             <div class="control">
-                <input type="email" name="email" alt="email" id="email_address" class="input-text" value="<?= $block->escapeHtmlAttr($block->getEmailValue()) ?>" data-mage-init='{"mage/trim-input":{}}' data-validate="{required:true, 'validate-email':true}">
+                <input type="email" name="email" alt="email" id="email_address" class="input-text" value="<?= $escaper->escapeHtmlAttr($block->getEmailValue()) ?>" data-mage-init='{"mage/trim-input":{}}' data-validate="{required:true, 'validate-email':true}">
             </div>
         </div>
         <?= $block->getChildHtml('form_additional_info') ?>
     </fieldset>
     <div class="actions-toolbar">
         <div class="primary">
-            <button type="submit" class="action submit primary"><span><?= $block->escapeHtml(__('Reset My Password')) ?></span></button>
+            <button type="submit" class="action submit primary"><span><?= $escaper->escapeHtml(__('Reset My Password')) ?></span></button>
         </div>
         <div class="secondary">
-            <a class="action back" href="<?= $block->escapeUrl($block->getLoginUrl()) ?>"><span><?= $block->escapeHtml(__('Go back')) ?></span></a>
+            <a class="action back" href="<?= $escaper->escapeUrl($block->getLoginUrl()) ?>"><span><?= $escaper->escapeHtml(__('Go back')) ?></span></a>
         </div>
     </div>
 </form>

--- a/app/code/Magento/Customer/view/frontend/templates/form/login.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/login.phtml
@@ -6,46 +6,49 @@
 
 // phpcs:disable Generic.Files.LineLength.TooLong
 
-/** @var \Magento\Customer\Block\Form\Login $block */
+/**
+ * @var \Magento\Customer\Block\Form\Login $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="block block-customer-login">
     <div class="block-title">
-        <strong id="block-customer-login-heading" role="heading" aria-level="2"><?= $block->escapeHtml(__('Registered Customers')) ?></strong>
+        <strong id="block-customer-login-heading" role="heading" aria-level="2"><?= $escaper->escapeHtml(__('Registered Customers')) ?></strong>
     </div>
     <div class="block-content" aria-labelledby="block-customer-login-heading">
         <form class="form form-login"
-              action="<?= $block->escapeUrl($block->getPostActionUrl()) ?>"
+              action="<?= $escaper->escapeUrl($block->getPostActionUrl()) ?>"
               method="post"
               id="login-form"
               data-mage-init='{"validation":{}}'>
             <?= $block->getBlockHtml('formkey') ?>
-            <fieldset class="fieldset login" data-hasrequired="<?= $block->escapeHtml(__('* Required Fields')) ?>">
-                <div class="field note"><?= $block->escapeHtml(__('If you have an account, sign in with your email address.')) ?></div>
+            <fieldset class="fieldset login" data-hasrequired="<?= $escaper->escapeHtml(__('* Required Fields')) ?>">
+                <div class="field note"><?= $escaper->escapeHtml(__('If you have an account, sign in with your email address.')) ?></div>
                 <div class="field email required">
-                    <label class="label" for="email"><span><?= $block->escapeHtml(__('Email')) ?></span></label>
+                    <label class="label" for="email"><span><?= $escaper->escapeHtml(__('Email')) ?></span></label>
                     <div class="control">
-                        <input name="login[username]" value="<?= $block->escapeHtmlAttr($block->getUsername()) ?>"
+                        <input name="login[username]" value="<?= $escaper->escapeHtmlAttr($block->getUsername()) ?>"
                             <?php if ($block->isAutocompleteDisabled()): ?> autocomplete="off"<?php endif; ?>
                                id="email" type="email" class="input-text"
-                               title="<?= $block->escapeHtmlAttr(__('Email')) ?>"
+                               title="<?= $escaper->escapeHtmlAttr(__('Email')) ?>"
                                data-mage-init='{"mage/trim-input":{}}'
                                data-validate="{required:true, 'validate-email':true}">
                     </div>
                 </div>
                 <div class="field password required">
-                    <label for="pass" class="label"><span><?= $block->escapeHtml(__('Password')) ?></span></label>
+                    <label for="pass" class="label"><span><?= $escaper->escapeHtml(__('Password')) ?></span></label>
                     <div class="control">
                         <input name="login[password]" type="password"
                             <?php if ($block->isAutocompleteDisabled()): ?> autocomplete="off"<?php endif; ?>
                                class="input-text" id="pass"
-                               title="<?= $block->escapeHtmlAttr(__('Password')) ?>"
+                               title="<?= $escaper->escapeHtmlAttr(__('Password')) ?>"
                                data-validate="{required:true}">
                     </div>
                 </div>
                 <?= $block->getChildHtml('form_additional_info') ?>
                 <div class="actions-toolbar">
-                    <div class="primary"><button type="submit" class="action login primary" name="send" id="send2"><span><?= $block->escapeHtml(__('Sign In')) ?></span></button></div>
-                    <div class="secondary"><a class="action remind" href="<?= $block->escapeUrl($block->getForgotPasswordUrl()) ?>"><span><?= $block->escapeHtml(__('Forgot Your Password?')) ?></span></a></div>
+                    <div class="primary"><button type="submit" class="action login primary" name="send" id="send2"><span><?= $escaper->escapeHtml(__('Sign In')) ?></span></button></div>
+                    <div class="secondary"><a class="action remind" href="<?= $escaper->escapeUrl($block->getForgotPasswordUrl()) ?>"><span><?= $escaper->escapeHtml(__('Forgot Your Password?')) ?></span></a></div>
                 </div>
             </fieldset>
         </form>

--- a/app/code/Magento/Customer/view/frontend/templates/form/newsletter.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/newsletter.phtml
@@ -4,23 +4,26 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Newsletter $block */
+/**
+ * @var \Magento\Customer\Block\Newsletter $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?= $block->getChildHtml('form_before') ?>
-    <form class="form form-newsletter-manage" action="<?= $block->escapeUrl($block->getAction()) ?>" method="post" id="form-validate">
+    <form class="form form-newsletter-manage" action="<?= $escaper->escapeUrl($block->getAction()) ?>" method="post" id="form-validate">
         <fieldset class="fieldset">
             <?= $block->getBlockHtml('formkey') ?>
-            <legend class="legend"><span><?= $block->escapeHtml(__('Subscription option')) ?></span></legend><br>
+            <legend class="legend"><span><?= $escaper->escapeHtml(__('Subscription option')) ?></span></legend><br>
             <div class="field choice">
-                <input type="checkbox" name="is_subscribed" id="subscription" value="1" title="<?= $block->escapeHtmlAttr(__('General Subscription')) ?>"<?php if ($block->getIsSubscribed()) : ?> checked="checked"<?php endif; ?> class="checkbox">
-                <label for="subscription" class="label"><span><?= $block->escapeHtml(__('General Subscription')) ?></span></label>
+                <input type="checkbox" name="is_subscribed" id="subscription" value="1" title="<?= $escaper->escapeHtmlAttr(__('General Subscription')) ?>"<?php if ($block->getIsSubscribed()) : ?> checked="checked"<?php endif; ?> class="checkbox">
+                <label for="subscription" class="label"><span><?= $escaper->escapeHtml(__('General Subscription')) ?></span></label>
             </div>
             <?php /* Extensions placeholder */ ?>
             <?= $block->getChildHtml('customer.form.newsletter.extra') ?>
         </fieldset>
         <div class="actions-toolbar">
-            <div class="primary"><button type="submit" title="<?= $block->escapeHtmlAttr(__('Save')) ?>" class="action save primary"><span><?= $block->escapeHtml(__('Save')) ?></span></button></div>
-            <div class="secondary"><a class="action back" href="<?= $block->escapeUrl($block->getBackUrl()) ?>"><span><?= $block->escapeHtml(__('Back')) ?></span></a></div>
+            <div class="primary"><button type="submit" title="<?= $escaper->escapeHtmlAttr(__('Save')) ?>" class="action save primary"><span><?= $escaper->escapeHtml(__('Save')) ?></span></button></div>
+            <div class="secondary"><a class="action back" href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>"><span><?= $escaper->escapeHtml(__('Back')) ?></span></a></div>
         </div>
     </form>
 <?php /* Extensions placeholder */ ?>

--- a/app/code/Magento/Customer/view/frontend/templates/form/resetforgottenpassword.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/resetforgottenpassword.phtml
@@ -4,35 +4,38 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Account\Resetpassword $block */
+/**
+ * @var \Magento\Customer\Block\Account\Resetpassword $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<form action="<?= $block->escapeUrl($block->getUrl('*/*/resetpasswordpost', ['_query' => ['token' => $block->getResetPasswordLinkToken()]])) ?>"
+<form action="<?= $escaper->escapeUrl($block->getUrl('*/*/resetpasswordpost', ['_query' => ['token' => $block->getResetPasswordLinkToken()]])) ?>"
       method="post"
         <?php if ($block->isAutocompleteDisabled()) : ?> autocomplete="off"<?php endif; ?>
       id="form-validate"
       class="form password reset"
       data-mage-init='{"validation":{}}'>
-    <fieldset class="fieldset" data-hasrequired="<?= $block->escapeHtmlAttr(__('* Required Fields')) ?>">
+    <fieldset class="fieldset" data-hasrequired="<?= $escaper->escapeHtmlAttr(__('* Required Fields')) ?>">
         <div class="field password required" data-mage-init='{"passwordStrengthIndicator": {}}'>
-            <label class="label" for="password"><span><?= $block->escapeHtml(__('New Password')) ?></span></label>
+            <label class="label" for="password"><span><?= $escaper->escapeHtml(__('New Password')) ?></span></label>
             <div class="control">
                 <input type="password" class="input-text" name="password" id="password"
-                       data-password-min-length="<?= $block->escapeHtmlAttr($block->getMinimumPasswordLength()) ?>"
-                       data-password-min-character-sets="<?= $block->escapeHtmlAttr($block->getRequiredCharacterClassesNumber()) ?>"
+                       data-password-min-length="<?= $escaper->escapeHtmlAttr($block->getMinimumPasswordLength()) ?>"
+                       data-password-min-character-sets="<?= $escaper->escapeHtmlAttr($block->getRequiredCharacterClassesNumber()) ?>"
                        data-validate="{required:true, 'validate-customer-password':true}"
                        autocomplete="off">
                 <div id="password-strength-meter-container" data-role="password-strength-meter" aria-live="polite">
                     <div id="password-strength-meter" class="password-strength-meter">
-                        <?= $block->escapeHtml(__('Password Strength')) ?>:
+                        <?= $escaper->escapeHtml(__('Password Strength')) ?>:
                         <span id="password-strength-meter-label" data-role="password-strength-meter-label">
-                            <?= $block->escapeHtml(__('No Password')) ?>
+                            <?= $escaper->escapeHtml(__('No Password')) ?>
                         </span>
                     </div>
                 </div>
             </div>
         </div>
         <div class="field confirmation required">
-            <label class="label" for="password-confirmation"><span><?= $block->escapeHtml(__('Confirm New Password')) ?></span></label>
+            <label class="label" for="password-confirmation"><span><?= $escaper->escapeHtml(__('Confirm New Password')) ?></span></label>
             <div class="control">
                 <input type="password" class="input-text" name="password_confirmation" id="password-confirmation" data-validate="{required:true,equalTo:'#password'}" autocomplete="off">
             </div>
@@ -40,7 +43,7 @@
     </fieldset>
     <div class="actions-toolbar">
         <div class="primary">
-            <button type="submit" class="action submit primary"><span><?= $block->escapeHtml(__('Set a New Password')) ?></span></button>
+            <button type="submit" class="action submit primary"><span><?= $escaper->escapeHtml(__('Set a New Password')) ?></span></button>
         </div>
     </div>
 </form>

--- a/app/code/Magento/Customer/view/frontend/templates/js/customer-data.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/js/customer-data.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\CustomerData $block */
+/**
+ * @var \Magento\Customer\Block\CustomerData $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundHelper
 ?>
@@ -12,12 +15,12 @@
     {
         "*": {
             "Magento_Customer/js/customer-data": {
-                "sectionLoadUrl": "<?= $block->escapeJs($block->getCustomerDataUrl('customer/section/load')) ?>",
+                "sectionLoadUrl": "<?= $escaper->escapeJs($block->getCustomerDataUrl('customer/section/load')) ?>",
                 "expirableSectionLifetime": <?= (int)$block->getExpirableSectionLifetime() ?>,
                 "expirableSectionNames": <?= /* @noEscape */ $this->helper(\Magento\Framework\Json\Helper\Data::class)
                     ->jsonEncode($block->getExpirableSectionNames()) ?>,
-                "cookieLifeTime": "<?= $block->escapeJs($block->getCookieLifeTime()) ?>",
-                "updateSessionUrl": "<?= $block->escapeJs(
+                "cookieLifeTime": "<?= $escaper->escapeJs($block->getCookieLifeTime()) ?>",
+                "updateSessionUrl": "<?= $escaper->escapeJs(
                     $block->getCustomerDataUrl('customer/account/updateSession')
                 ) ?>"
             }

--- a/app/code/Magento/Customer/view/frontend/templates/js/customer-data/invalidation-rules.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/js/customer-data/invalidation-rules.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Customer\Block\CustomerScopeData */
+/**
+ * @var $block \Magento\Customer\Block\CustomerScopeData
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <script type="text/x-magento-init">
     {
@@ -14,7 +17,7 @@
                     "website-rule": {
                         "Magento_Customer/js/invalidation-rules/website-rule": {
                             "scopeConfig": {
-                                "websiteId": "<?= $block->escapeJs($block->getWebsiteId()) ?>"
+                                "websiteId": "<?= $escaper->escapeJs($block->getWebsiteId()) ?>"
                             }
                         }
                     }

--- a/app/code/Magento/Customer/view/frontend/templates/logout.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/logout.phtml
@@ -4,14 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<p><?= $block->escapeHtml(__('You have signed out and will go to our homepage in 5 seconds.')) ?></p>
+<p><?= $escaper->escapeHtml(__('You have signed out and will go to our homepage in 5 seconds.')) ?></p>
 <script type="text/x-magento-init">
     {
         "*": {
             "Magento_Customer/js/logout-redirect": {
-                "url": "<?= $block->escapeJs($block->escapeUrl($block->getUrl())) ?>"
+                "url": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getUrl())) ?>"
             }
         }
     }

--- a/app/code/Magento/Customer/view/frontend/templates/messages/confirmAccountSuccessMessage.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/messages/confirmAccountSuccessMessage.phtml
@@ -4,6 +4,9 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<?= $block->escapeHtml(__('You must confirm your account. Please check your email for the confirmation link or <a href="%1">click here</a> for a new link.', $block->getData('url')), ['a']);
+<?= $escaper->escapeHtml(__('You must confirm your account. Please check your email for the confirmation link or <a href="%1">click here</a> for a new link.', $block->getData('url')), ['a']);

--- a/app/code/Magento/Customer/view/frontend/templates/messages/customerAlreadyExistsErrorMessage.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/messages/customerAlreadyExistsErrorMessage.phtml
@@ -4,6 +4,9 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<?= $block->escapeHtml(__('There is already an account with this email address. If you are sure that it is your email address, <a href="%1">click here</a> to get your password and access your account.', $block->getData('url')), ['a']);
+<?= $escaper->escapeHtml(__('There is already an account with this email address. If you are sure that it is your email address, <a href="%1">click here</a> to get your password and access your account.', $block->getData('url')), ['a']);

--- a/app/code/Magento/Customer/view/frontend/templates/messages/customerVatBillingAddressSuccessMessage.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/messages/customerVatBillingAddressSuccessMessage.phtml
@@ -4,6 +4,9 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<?= $block->escapeHtml(__('If you are a registered VAT customer, please <a href="%1">click here</a> to enter your billing address for proper VAT calculation.', $block->getData('url')), ['a']);
+<?= $escaper->escapeHtml(__('If you are a registered VAT customer, please <a href="%1">click here</a> to enter your billing address for proper VAT calculation.', $block->getData('url')), ['a']);

--- a/app/code/Magento/Customer/view/frontend/templates/messages/customerVatShippingAddressSuccessMessage.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/messages/customerVatShippingAddressSuccessMessage.phtml
@@ -4,6 +4,9 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<?= $block->escapeHtml(__('If you are a registered VAT customer, please <a href="%1">click here</a> to enter your shipping address for proper VAT calculation.', $block->getData('url')), ['a']);
+<?= $escaper->escapeHtml(__('If you are a registered VAT customer, please <a href="%1">click here</a> to enter your shipping address for proper VAT calculation.', $block->getData('url')), ['a']);

--- a/app/code/Magento/Customer/view/frontend/templates/newcustomer.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/newcustomer.phtml
@@ -4,18 +4,21 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Form\Login\Info $block */
+/**
+ * @var \Magento\Customer\Block\Form\Login\Info $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($block->getRegistration()->isAllowed()) : ?>
 <div class="block block-new-customer">
     <div class="block-title">
-        <strong id="block-new-customer-heading" role="heading" aria-level="2"><?= $block->escapeHtml(__('New Customers')) ?></strong>
+        <strong id="block-new-customer-heading" role="heading" aria-level="2"><?= $escaper->escapeHtml(__('New Customers')) ?></strong>
     </div>
     <div class="block-content" aria-labelledby="block-new-customer-heading">
-        <p><?= $block->escapeHtml(__('Creating an account has many benefits: check out faster, keep more than one address, track orders and more.')) ?></p>
+        <p><?= $escaper->escapeHtml(__('Creating an account has many benefits: check out faster, keep more than one address, track orders and more.')) ?></p>
         <div class="actions-toolbar">
             <div class="primary">
-                <a href="<?= $block->escapeUrl($block->getCreateAccountUrl()) ?>" class="action create primary"><span><?= $block->escapeHtml(__('Create an Account')) ?></span></a>
+                <a href="<?= $escaper->escapeUrl($block->getCreateAccountUrl()) ?>" class="action create primary"><span><?= $escaper->escapeHtml(__('Create an Account')) ?></span></a>
             </div>
         </div>
     </div>

--- a/app/code/Magento/Customer/view/frontend/templates/widget/company.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/company.phtml
@@ -4,17 +4,20 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Widget\Company $block */
+/**
+ * @var \Magento\Customer\Block\Widget\Company $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="field company <?= $block->isRequired() ? 'required' : '' ?>">
     <label for="company" class="label">
         <span>
-            <?= $block->escapeHtml(__('Company')) ?>
+            <?= $escaper->escapeHtml(__('Company')) ?>
         </span>
     </label>
     <div class="control">
             <?php
-            $_validationClass = $block->escapeHtmlAttr(
+            $_validationClass = $escaper->escapeHtmlAttr(
                 $this->helper(\Magento\Customer\Helper\Address::class)
                      ->getAttributeValidationClass('company')
             );
@@ -22,8 +25,8 @@
         <input type="text"
                name="company"
                id="company"
-               value="<?= $block->escapeHtmlAttr($block->getCompany()) ?>"
-               title="<?= $block->escapeHtmlAttr(__('Company')) ?>"
+               value="<?= $escaper->escapeHtmlAttr($block->getCompany()) ?>"
+               title="<?= $escaper->escapeHtmlAttr(__('Company')) ?>"
                class="input-text <?= $_validationClass ?: '' ?>"
          >
     </div>

--- a/app/code/Magento/Customer/view/frontend/templates/widget/dob.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/dob.phtml
@@ -4,8 +4,11 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-/** @var \Magento\Customer\Block\Widget\Dob $block */
+/**
+ * @var \Magento\Customer\Block\Widget\Dob $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ */
 
 /*
 <?= $block->getLayout()->createBlock('Magento\Customer\Block\Widget\Dob')
@@ -28,14 +31,14 @@ $translatedCalendarConfigJson = $block->getTranslatedCalendarConfigJson();
 $fieldCssClass = 'field date field-' . $block->getHtmlId();
 $fieldCssClass .= $block->isRequired() ? ' required' : '';
 ?>
-<div class="<?= $block->escapeHtmlAttr($fieldCssClass) ?>">
-    <label class="label" for="<?= $block->escapeHtmlAttr($block->getHtmlId()) ?>">
-        <span><?= $block->escapeHtml($block->getStoreLabel('dob')) ?></span>
+<div class="<?= $escaper->escapeHtmlAttr($fieldCssClass) ?>">
+    <label class="label" for="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>">
+        <span><?= $escaper->escapeHtml($block->getStoreLabel('dob')) ?></span>
     </label>
     <div class="control customer-dob">
         <?= $block->getFieldHtml() ?>
         <?php if ($_message = $block->getAdditionalDescription()): ?>
-            <div class="note"><?= $block->escapeHtml($_message) ?></div>
+            <div class="note"><?= $escaper->escapeHtml($_message) ?></div>
         <?php endif; ?>
     </div>
 </div>

--- a/app/code/Magento/Customer/view/frontend/templates/widget/fax.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/fax.phtml
@@ -4,18 +4,21 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Widget\Fax $block */
+/**
+ * @var \Magento\Customer\Block\Widget\Fax $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 
 <div class="field fax <?= $block->isRequired() ? 'required' : '' ?>">
     <label for="fax" class="label">
         <span>
-            <?= $block->escapeHtml(__('Fax')) ?>
+            <?= $escaper->escapeHtml(__('Fax')) ?>
         </span>
     </label>
     <div class="control">
             <?php
-            $_validationClass = $block->escapeHtmlAttr(
+            $_validationClass = $escaper->escapeHtmlAttr(
                 $this->helper(\Magento\Customer\Helper\Address::class)
                      ->getAttributeValidationClass('fax')
             );
@@ -23,8 +26,8 @@
         <input type="text"
                name="fax"
                id="fax"
-               value="<?= $block->escapeHtmlAttr($block->getFax()) ?>"
-               title="<?= $block->escapeHtmlAttr(__('Fax')) ?>"
+               value="<?= $escaper->escapeHtmlAttr($block->getFax()) ?>"
+               title="<?= $escaper->escapeHtmlAttr(__('Fax')) ?>"
                class="input-text <?= $_validationClass ?: '' ?>"
         >
     </div>

--- a/app/code/Magento/Customer/view/frontend/templates/widget/gender.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/gender.phtml
@@ -4,16 +4,19 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Widget\Gender $block */
+/**
+ * @var \Magento\Customer\Block\Widget\Gender $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="field gender<?= $block->isRequired() ? ' required' : ''?>">
-    <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('gender')) ?>"><span><?= $block->escapeHtml($block->getStoreLabel('gender')) ?></span></label>
+    <label class="label" for="<?= $escaper->escapeHtmlAttr($block->getFieldId('gender')) ?>"><span><?= $escaper->escapeHtml($block->getStoreLabel('gender')) ?></span></label>
     <div class="control">
-        <select id="<?= $block->escapeHtmlAttr($block->getFieldId('gender')) ?>" name="<?= $block->escapeHtmlAttr($block->getFieldName('gender')) ?>" title="<?= $block->escapeHtmlAttr($block->getStoreLabel('gender')) ?>"<?php if ($block->isRequired()) : ?> class="validate-select" data-validate="{required:true}"<?php endif; ?>>
+        <select id="<?= $escaper->escapeHtmlAttr($block->getFieldId('gender')) ?>" name="<?= $escaper->escapeHtmlAttr($block->getFieldName('gender')) ?>" title="<?= $escaper->escapeHtmlAttr($block->getStoreLabel('gender')) ?>"<?php if ($block->isRequired()) : ?> class="validate-select" data-validate="{required:true}"<?php endif; ?>>
             <?php $options = $block->getGenderOptions(); ?>
             <?php $value = $block->getGender(); ?>
             <?php foreach ($options as $option) : ?>
-                <option value="<?= $block->escapeHtmlAttr($option->getValue()) ?>"<?= ($option->getValue() == $value) ? ' selected="selected"' : '' ?>><?= $block->escapeHtml(__($option->getLabel())) ?></option>
+                <option value="<?= $escaper->escapeHtmlAttr($option->getValue()) ?>"<?= ($option->getValue() == $value) ? ' selected="selected"' : '' ?>><?= $escaper->escapeHtml(__($option->getLabel())) ?></option>
             <?php endforeach;?>
         </select>
     </div>

--- a/app/code/Magento/Customer/view/frontend/templates/widget/name.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/name.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Widget\Name $block */
+/**
+ * @var \Magento\Customer\Block\Widget\Name $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 /*
 <?= $block->getLayout()->createBlock('Magento\Customer\Block\Widget\Name')
@@ -25,8 +28,8 @@ $middle = $block->showMiddlename();
 $suffix = $block->showSuffix();
 ?>
 <?php if (($prefix || $middle || $suffix) && !$block->getNoWrap()) : ?>
-<div class="field required fullname <?= $block->escapeHtmlAttr($block->getContainerClassName()) ?>">
-    <label for="<?= $block->escapeHtmlAttr($block->getFieldId('firstname')) ?>" class="label"><span><?= $block->escapeHtml(__('Name')) ?></span></label>
+<div class="field required fullname <?= $escaper->escapeHtmlAttr($block->getContainerClassName()) ?>">
+    <label for="<?= $escaper->escapeHtmlAttr($block->getFieldId('firstname')) ?>" class="label"><span><?= $escaper->escapeHtml(__('Name')) ?></span></label>
     <div class="control">
         <fieldset class="fieldset fieldset-fullname">
         <div class="fields">
@@ -34,22 +37,22 @@ $suffix = $block->showSuffix();
 
     <?php if ($prefix) : ?>
         <div class="field field-name-prefix<?= $block->isPrefixRequired() ? ' required' : '' ?>">
-            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('prefix')) ?>"><span><?= $block->escapeHtml($block->getStoreLabel('prefix')) ?></span></label>
+            <label class="label" for="<?= $escaper->escapeHtmlAttr($block->getFieldId('prefix')) ?>"><span><?= $escaper->escapeHtml($block->getStoreLabel('prefix')) ?></span></label>
             <div class="control">
                 <?php if ($block->getPrefixOptions() === false) : ?>
-                    <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('prefix')) ?>"
-                           name="<?= $block->escapeHtmlAttr($block->getFieldName('prefix')) ?>"
-                           value="<?= $block->escapeHtmlAttr($block->getObject()->getPrefix()) ?>"
-                           title="<?= $block->escapeHtmlAttr($block->getStoreLabel('prefix')) ?>"
-                           class="input-text <?= $block->escapeHtmlAttr($block->getAttributeValidationClass('prefix')) ?>" <?= $block->isPrefixRequired() ? ' data-validate="{required:true}"' : '' ?>>
+                    <input type="text" id="<?= $escaper->escapeHtmlAttr($block->getFieldId('prefix')) ?>"
+                           name="<?= $escaper->escapeHtmlAttr($block->getFieldName('prefix')) ?>"
+                           value="<?= $escaper->escapeHtmlAttr($block->getObject()->getPrefix()) ?>"
+                           title="<?= $escaper->escapeHtmlAttr($block->getStoreLabel('prefix')) ?>"
+                           class="input-text <?= $escaper->escapeHtmlAttr($block->getAttributeValidationClass('prefix')) ?>" <?= $block->isPrefixRequired() ? ' data-validate="{required:true}"' : '' ?>>
                 <?php else : ?>
-                    <select id="<?= $block->escapeHtmlAttr($block->getFieldId('prefix')) ?>"
-                            name="<?= $block->escapeHtmlAttr($block->getFieldName('prefix')) ?>"
-                            title="<?= $block->escapeHtmlAttr($block->getStoreLabel('prefix')) ?>"
-                            class="<?= $block->escapeHtmlAttr($block->getAttributeValidationClass('prefix')) ?>" <?= $block->isPrefixRequired() ? ' data-validate="{required:true}"' : '' ?> >
+                    <select id="<?= $escaper->escapeHtmlAttr($block->getFieldId('prefix')) ?>"
+                            name="<?= $escaper->escapeHtmlAttr($block->getFieldName('prefix')) ?>"
+                            title="<?= $escaper->escapeHtmlAttr($block->getStoreLabel('prefix')) ?>"
+                            class="<?= $escaper->escapeHtmlAttr($block->getAttributeValidationClass('prefix')) ?>" <?= $block->isPrefixRequired() ? ' data-validate="{required:true}"' : '' ?> >
                         <?php foreach ($block->getPrefixOptions() as $_option) : ?>
-                            <option value="<?= $block->escapeHtmlAttr($_option) ?>"<?php if ($block->getObject()->getPrefix() == $_option) : ?> selected="selected"<?php endif; ?>>
-                                <?= $block->escapeHtml(__($_option)) ?>
+                            <option value="<?= $escaper->escapeHtmlAttr($_option) ?>"<?php if ($block->getObject()->getPrefix() == $_option) : ?> selected="selected"<?php endif; ?>>
+                                <?= $escaper->escapeHtml(__($_option)) ?>
                             </option>
                         <?php endforeach; ?>
                     </select>
@@ -58,56 +61,56 @@ $suffix = $block->showSuffix();
         </div>
     <?php endif; ?>
         <div class="field field-name-firstname required">
-            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('firstname')) ?>"><span><?= $block->escapeHtml($block->getStoreLabel('firstname')) ?></span></label>
+            <label class="label" for="<?= $escaper->escapeHtmlAttr($block->getFieldId('firstname')) ?>"><span><?= $escaper->escapeHtml($block->getStoreLabel('firstname')) ?></span></label>
             <div class="control">
-                <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('firstname')) ?>"
-                       name="<?= $block->escapeHtmlAttr($block->getFieldName('firstname')) ?>"
-                       value="<?= $block->escapeHtmlAttr($block->getObject()->getFirstname()) ?>"
-                       title="<?= $block->escapeHtmlAttr($block->getStoreLabel('firstname')) ?>"
-                       class="input-text <?= $block->escapeHtmlAttr($block->getAttributeValidationClass('firstname')) ?>" <?= ($block->getAttributeValidationClass('firstname') == 'required-entry') ? ' data-validate="{required:true}"' : '' ?>>
+                <input type="text" id="<?= $escaper->escapeHtmlAttr($block->getFieldId('firstname')) ?>"
+                       name="<?= $escaper->escapeHtmlAttr($block->getFieldName('firstname')) ?>"
+                       value="<?= $escaper->escapeHtmlAttr($block->getObject()->getFirstname()) ?>"
+                       title="<?= $escaper->escapeHtmlAttr($block->getStoreLabel('firstname')) ?>"
+                       class="input-text <?= $escaper->escapeHtmlAttr($block->getAttributeValidationClass('firstname')) ?>" <?= ($block->getAttributeValidationClass('firstname') == 'required-entry') ? ' data-validate="{required:true}"' : '' ?>>
             </div>
         </div>
     <?php if ($middle) : ?>
         <?php $isMiddlenameRequired = $block->isMiddlenameRequired(); ?>
         <div class="field field-name-middlename<?= $isMiddlenameRequired ? ' required' : '' ?>">
-            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('middlename')) ?>"><span><?= $block->escapeHtml($block->getStoreLabel('middlename')) ?></span></label>
+            <label class="label" for="<?= $escaper->escapeHtmlAttr($block->getFieldId('middlename')) ?>"><span><?= $escaper->escapeHtml($block->getStoreLabel('middlename')) ?></span></label>
             <div class="control">
-                <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('middlename')) ?>"
-                       name="<?= $block->escapeHtmlAttr($block->getFieldName('middlename')) ?>"
-                       value="<?= $block->escapeHtmlAttr($block->getObject()->getMiddlename()) ?>"
-                       title="<?= $block->escapeHtmlAttr($block->getStoreLabel('middlename')) ?>"
-                       class="input-text <?= $block->escapeHtmlAttr($block->getAttributeValidationClass('middlename')) ?>" <?= $isMiddlenameRequired ? ' data-validate="{required:true}"' : '' ?>>
+                <input type="text" id="<?= $escaper->escapeHtmlAttr($block->getFieldId('middlename')) ?>"
+                       name="<?= $escaper->escapeHtmlAttr($block->getFieldName('middlename')) ?>"
+                       value="<?= $escaper->escapeHtmlAttr($block->getObject()->getMiddlename()) ?>"
+                       title="<?= $escaper->escapeHtmlAttr($block->getStoreLabel('middlename')) ?>"
+                       class="input-text <?= $escaper->escapeHtmlAttr($block->getAttributeValidationClass('middlename')) ?>" <?= $isMiddlenameRequired ? ' data-validate="{required:true}"' : '' ?>>
             </div>
         </div>
     <?php endif; ?>
         <div class="field field-name-lastname required">
-            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('lastname')) ?>"><span><?= $block->escapeHtml($block->getStoreLabel('lastname')) ?></span></label>
+            <label class="label" for="<?= $escaper->escapeHtmlAttr($block->getFieldId('lastname')) ?>"><span><?= $escaper->escapeHtml($block->getStoreLabel('lastname')) ?></span></label>
             <div class="control">
-                <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('lastname')) ?>"
-                       name="<?= $block->escapeHtmlAttr($block->getFieldName('lastname')) ?>"
-                       value="<?= $block->escapeHtmlAttr($block->getObject()->getLastname()) ?>"
-                       title="<?= $block->escapeHtmlAttr($block->getStoreLabel('lastname')) ?>"
-                       class="input-text <?= $block->escapeHtmlAttr($block->getAttributeValidationClass('lastname')) ?>" <?= ($block->getAttributeValidationClass('lastname') == 'required-entry') ? ' data-validate="{required:true}"' : '' ?>>
+                <input type="text" id="<?= $escaper->escapeHtmlAttr($block->getFieldId('lastname')) ?>"
+                       name="<?= $escaper->escapeHtmlAttr($block->getFieldName('lastname')) ?>"
+                       value="<?= $escaper->escapeHtmlAttr($block->getObject()->getLastname()) ?>"
+                       title="<?= $escaper->escapeHtmlAttr($block->getStoreLabel('lastname')) ?>"
+                       class="input-text <?= $escaper->escapeHtmlAttr($block->getAttributeValidationClass('lastname')) ?>" <?= ($block->getAttributeValidationClass('lastname') == 'required-entry') ? ' data-validate="{required:true}"' : '' ?>>
             </div>
         </div>
     <?php if ($suffix) : ?>
         <div class="field field-name-suffix<?= $block->isSuffixRequired() ? ' required' : '' ?>">
-            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('suffix')) ?>"><span><?= $block->escapeHtml($block->getStoreLabel('suffix')) ?></span></label>
+            <label class="label" for="<?= $escaper->escapeHtmlAttr($block->getFieldId('suffix')) ?>"><span><?= $escaper->escapeHtml($block->getStoreLabel('suffix')) ?></span></label>
             <div class="control">
                 <?php if ($block->getSuffixOptions() === false) : ?>
-                    <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('suffix')) ?>"
-                           name="<?= $block->escapeHtmlAttr($block->getFieldName('suffix')) ?>"
-                           value="<?= $block->escapeHtmlAttr($block->getObject()->getSuffix()) ?>"
-                           title="<?= $block->escapeHtmlAttr($block->getStoreLabel('suffix')) ?>"
-                           class="input-text <?= $block->escapeHtmlAttr($block->getAttributeValidationClass('suffix')) ?>" <?= $block->isSuffixRequired() ? ' data-validate="{required:true}"' : '' ?>>
+                    <input type="text" id="<?= $escaper->escapeHtmlAttr($block->getFieldId('suffix')) ?>"
+                           name="<?= $escaper->escapeHtmlAttr($block->getFieldName('suffix')) ?>"
+                           value="<?= $escaper->escapeHtmlAttr($block->getObject()->getSuffix()) ?>"
+                           title="<?= $escaper->escapeHtmlAttr($block->getStoreLabel('suffix')) ?>"
+                           class="input-text <?= $escaper->escapeHtmlAttr($block->getAttributeValidationClass('suffix')) ?>" <?= $block->isSuffixRequired() ? ' data-validate="{required:true}"' : '' ?>>
                 <?php else : ?>
-                    <select id="<?= $block->escapeHtmlAttr($block->getFieldId('suffix')) ?>"
-                            name="<?= $block->escapeHtmlAttr($block->getFieldName('suffix')) ?>"
-                            title="<?= $block->escapeHtmlAttr($block->getStoreLabel('suffix')) ?>"
-                            class="<?= $block->escapeHtmlAttr($block->getAttributeValidationClass('suffix')) ?>" <?= $block->isSuffixRequired() ? ' data-validate="{required:true}"' : '' ?>>
+                    <select id="<?= $escaper->escapeHtmlAttr($block->getFieldId('suffix')) ?>"
+                            name="<?= $escaper->escapeHtmlAttr($block->getFieldName('suffix')) ?>"
+                            title="<?= $escaper->escapeHtmlAttr($block->getStoreLabel('suffix')) ?>"
+                            class="<?= $escaper->escapeHtmlAttr($block->getAttributeValidationClass('suffix')) ?>" <?= $block->isSuffixRequired() ? ' data-validate="{required:true}"' : '' ?>>
                         <?php foreach ($block->getSuffixOptions() as $_option) : ?>
-                            <option value="<?= $block->escapeHtmlAttr($_option) ?>"<?php if ($block->getObject()->getSuffix() == $_option) : ?> selected="selected"<?php endif; ?>>
-                                <?= $block->escapeHtml(__($_option)) ?>
+                            <option value="<?= $escaper->escapeHtmlAttr($_option) ?>"<?php if ($block->getObject()->getSuffix() == $_option) : ?> selected="selected"<?php endif; ?>>
+                                <?= $escaper->escapeHtml(__($_option)) ?>
                             </option>
                         <?php endforeach; ?>
                     </select>

--- a/app/code/Magento/Customer/view/frontend/templates/widget/taxvat.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/taxvat.phtml
@@ -4,11 +4,14 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Widget\Taxvat $block */
+/**
+ * @var \Magento\Customer\Block\Widget\Taxvat $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="field taxvat<?= $block->isRequired() ? ' required' : ''; ?>">
-    <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId('taxvat')) ?>"><span><?= $block->escapeHtml($block->getStoreLabel('taxvat')) ?></span></label>
+    <label class="label" for="<?= $escaper->escapeHtmlAttr($block->getFieldId('taxvat')) ?>"><span><?= $escaper->escapeHtml($block->getStoreLabel('taxvat')) ?></span></label>
     <div class="control">
-        <input type="text" id="<?= $block->escapeHtmlAttr($block->getFieldId('taxvat')) ?>" name="<?= $block->escapeHtmlAttr($block->getFieldName('taxvat')) ?>" value="<?= $block->escapeHtmlAttr($block->getTaxvat()) ?>" title="<?= $block->escapeHtmlAttr($block->getStoreLabel('taxvat')) ?>" class="input-text <?= $block->escapeHtmlAttr($this->helper(\Magento\Customer\Helper\Address::class)->getAttributeValidationClass('taxvat')) ?>" <?= $block->isRequired() ? ' data-validate="{required:true}"' : '' ?>>
+        <input type="text" id="<?= $escaper->escapeHtmlAttr($block->getFieldId('taxvat')) ?>" name="<?= $escaper->escapeHtmlAttr($block->getFieldName('taxvat')) ?>" value="<?= $escaper->escapeHtmlAttr($block->getTaxvat()) ?>" title="<?= $escaper->escapeHtmlAttr($block->getStoreLabel('taxvat')) ?>" class="input-text <?= $escaper->escapeHtmlAttr($this->helper(\Magento\Customer\Helper\Address::class)->getAttributeValidationClass('taxvat')) ?>" <?= $block->isRequired() ? ' data-validate="{required:true}"' : '' ?>>
     </div>
 </div>

--- a/app/code/Magento/Customer/view/frontend/templates/widget/telephone.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/widget/telephone.phtml
@@ -4,22 +4,25 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Customer\Block\Widget\Telephone $block */
+/**
+ * @var \Magento\Customer\Block\Widget\Telephone $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 
 <div class="field telephone <?= $block->isRequired() ? 'required' : '' ?>">
     <label for="telephone" class="label">
         <span>
-            <?= $block->escapeHtml(__('Phone Number')) ?>
+            <?= $escaper->escapeHtml(__('Phone Number')) ?>
         </span>
     </label>
     <div class="control">
         <input type="tel"
                name="telephone"
                id="telephone"
-               value="<?= $block->escapeHtmlAttr($block->getTelephone()) ?>"
-               title="<?= $block->escapeHtmlAttr(__('Phone Number')) ?>"
-               class="input-text <?= $block->escapeHtmlAttr(
+               value="<?= $escaper->escapeHtmlAttr($block->getTelephone()) ?>"
+               title="<?= $escaper->escapeHtmlAttr(__('Phone Number')) ?>"
+               class="input-text <?= $escaper->escapeHtmlAttr(
                    $block->getAttributeValidationClass('telephone')
                ) ?>"
         >


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
