### PR TITLE
Magento_Config: avoid using deprecated escape* methods from AbstractB…

### DIFF
--- a/app/code/Magento/Config/view/adminhtml/templates/page/system/config/robots/reset.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/page/system/config/robots/reset.phtml
@@ -6,7 +6,7 @@
 
 /**
  * @deprecated
- * @var $block \Magento\Backend\Block\Page\System\Config\Robots\Reset
+ * @var \Magento\Backend\Block\Page\System\Config\Robots\Reset $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 

--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/edit.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/edit.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <?php
@@ -25,7 +26,7 @@
     '.highlighted { background-color: #DFF7FF!important; }'
 ) ?>
 
-<form action="<?= $block->escapeUrl($block->getSaveUrl()) ?>" method="post" id="config-edit-form"
+<form action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>" method="post" id="config-edit-form"
       enctype="multipart/form-data">
     <?= $block->getBlockHtml('formkey') ?>
     <div class="accordion">

--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 
 <?php
@@ -12,33 +15,33 @@ $_htmlId = $block->getHtmlId() ? $block->getHtmlId() : '_' . uniqid();
 $_colspan = $block->isAddAfter() ? 2 : 1;
 ?>
 
-<div class="design_theme_ua_regexp" id="grid<?= $block->escapeHtmlAttr($_htmlId) ?>">
+<div class="design_theme_ua_regexp" id="grid<?= $escaper->escapeHtmlAttr($_htmlId) ?>">
     <div class="admin__control-table-wrapper">
-        <table class="admin__control-table" id="<?= $block->escapeHtmlAttr($block->getElement()->getId()) ?>">
+        <table class="admin__control-table" id="<?= $escaper->escapeHtmlAttr($block->getElement()->getId()) ?>">
             <thead>
             <tr>
                 <?php foreach ($block->getColumns() as $columnName => $column): ?>
-                    <th><?= $block->escapeHtml($column['label']) ?></th>
+                    <th><?= $escaper->escapeHtml($column['label']) ?></th>
                 <?php endforeach; ?>
-                <th class="col-actions" colspan="<?= (int)$_colspan ?>"><?= $block->escapeHtml(__('Action')) ?></th>
+                <th class="col-actions" colspan="<?= (int)$_colspan ?>"><?= $escaper->escapeHtml(__('Action')) ?></th>
             </tr>
             </thead>
             <tfoot>
             <tr>
                 <td colspan="<?= count($block->getColumns())+$_colspan ?>" class="col-actions-add">
-                    <button id="addToEndBtn<?= $block->escapeHtmlAttr($_htmlId) ?>"
+                    <button id="addToEndBtn<?= $escaper->escapeHtmlAttr($_htmlId) ?>"
                             class="action-add"
-                            title="<?= $block->escapeHtmlAttr(__('Add')) ?>"
+                            title="<?= $escaper->escapeHtmlAttr(__('Add')) ?>"
                             type="button">
-                        <span><?= $block->escapeHtml($block->getAddButtonLabel()) ?></span>
+                        <span><?= $escaper->escapeHtml($block->getAddButtonLabel()) ?></span>
                     </button>
                 </td>
             </tr>
             </tfoot>
-            <tbody id="addRow<?= $block->escapeHtmlAttr($_htmlId) ?>"></tbody>
+            <tbody id="addRow<?= $escaper->escapeHtmlAttr($_htmlId) ?>"></tbody>
         </table>
     </div>
-    <input type="hidden" name="<?= $block->escapeHtmlAttr($block->getElement()->getName()) ?>[__empty]" value="" />
+    <input type="hidden" name="<?= $escaper->escapeHtmlAttr($block->getElement()->getName()) ?>[__empty]" value="" />
 
     <?php $scriptString = <<<script
         require([
@@ -46,7 +49,7 @@ $_colspan = $block->isAddAfter() ? 2 : 1;
             'prototype'
         ], function (mageTemplate) {
         // create row creator
-        window.arrayRow{$block->escapeJs($_htmlId)} = {
+        window.arrayRow{$escaper->escapeJs($_htmlId)} = {
 
             // define row prototypeJS template
             template: mageTemplate(
@@ -56,7 +59,7 @@ script;
         $scriptString .= <<<script
 
                         + '<td>'
-                        + '{$block->escapeJs($block->renderCellTemplate($columnName))}'
+                        + '{$escaper->escapeJs($block->renderCellTemplate($columnName))}'
                         + '<\/td>'
 script;
     endforeach;
@@ -65,7 +68,7 @@ script;
         $scriptString .= <<<script
 
                         + '<td><button class="action-add" type="button" id="addAfterBtn<%- _id %>"><span>'
-                        + '{$block->escapeJs(__('Add after'))}'
+                        + '{$escaper->escapeJs(__('Add after'))}'
                         + '<\/span><\/button><\/td>'
 script;
     endif;
@@ -73,17 +76,17 @@ script;
 
                     + '<td class="col-actions"><button '
                     + 'class="action-delete" type="button">'
-                    + '<span>{$block->escapeJs(__('Delete'))}<\/span><\/button><\/td>'
+                    + '<span>{$escaper->escapeJs(__('Delete'))}<\/span><\/button><\/td>'
                     + '<\/tr>'
 
 script;
     $scriptString1 = /* $noEscape */ $secureRenderer->renderEventListenerAsTag(
         'onclick',
-        "arrayRow" . $block->escapeJs($_htmlId) . ".del('<%- _id %>')",
+        "arrayRow" . $escaper->escapeJs($_htmlId) . ".del('<%- _id %>')",
         "tr#<%- _id %> button.action-delete"
     );
 
-    $scriptString .= " + '" . $block->escapeJs($scriptString1) . "'" . PHP_EOL;
+    $scriptString .= " + '" . $escaper->escapeJs($scriptString1) . "'" . PHP_EOL;
 
     $scriptString .= <<<script
             ),
@@ -102,7 +105,7 @@ script;
     foreach ($block->getColumns() as $columnName => $column):
         $scriptString .= <<<script
 
-                            {$block->escapeJs($columnName)}: '',
+                            {$escaper->escapeJs($columnName)}: '',
                                 'option_extra_attrs': {},
 script;
     endforeach;
@@ -116,7 +119,7 @@ script;
             if (insertAfterId) {
                 Element.insert($(insertAfterId), {after: this.template(templateValues)});
             } else {
-                Element.insert($('addRow{$block->escapeJs($_htmlId)}'), {bottom: this.template(templateValues)});
+                Element.insert($('addRow{$escaper->escapeJs($_htmlId)}'), {bottom: this.template(templateValues)});
             }
 
             // Fill controls with data
@@ -149,10 +152,10 @@ script;
         }
 
         // bind add action to "Add" button in last row
-        Event.observe('addToEndBtn{$block->escapeJs($_htmlId)}',
+        Event.observe('addToEndBtn{$escaper->escapeJs($_htmlId)}',
             'click',
-            arrayRow{$block->escapeJs($_htmlId)}.add.bind(
-                arrayRow{$block->escapeJs($_htmlId)}, false, false
+            arrayRow{$escaper->escapeJs($_htmlId)}.add.bind(
+                arrayRow{$escaper->escapeJs($_htmlId)}, false, false
             )
         );
 
@@ -161,7 +164,7 @@ script;
 script;
 
     foreach ($block->getArrayRows() as $_rowId => $_row) {
-        $scriptString .= /** @noEscape */ " arrayRow" .$block->escapeJs($_htmlId) .
+        $scriptString .= /** @noEscape */ " arrayRow" .$escaper->escapeJs($_htmlId) .
             ".add(" . /** @noEscape */ $_row->toJson() . ");\n";
     }
     $scriptString .= <<<script
@@ -171,7 +174,7 @@ script;
     if ($block->getElement()->getDisabled()):
         $scriptString .= <<<script
 
-        toggleValueElements({checked: true}, $('grid{$block->escapeJs($_htmlId)}').parentNode);
+        toggleValueElements({checked: true}, $('grid{$escaper->escapeJs($_htmlId)}').parentNode);
 script;
     endif;
     $scriptString .= <<<script

--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/js.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/js.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 
@@ -75,7 +76,7 @@ originModel.prototype = {
         this.loader = new varienLoader(true);
 script;
 
-$scriptString .= 'this.regionsUrl = "' . $block->escapeJs($block->getUrl('directory/json/countryRegion')) . '";';
+$scriptString .= 'this.regionsUrl = "' . $escaper->escapeJs($block->getUrl('directory/json/countryRegion')) . '";';
 $scriptString .= <<<script
 
         this.bindCountryRegionRelation();

--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/switcher.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/switcher.phtml
@@ -4,11 +4,15 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Backend\Block\Template */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Backend\Block\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ */
+
 ?>
 <div class="field field-store-switcher">
-    <label class="label" for="store_switcher"><?= $block->escapeHtml(__('Current Configuration Scope:')) ?></label>
+    <label class="label" for="store_switcher"><?= $escaper->escapeHtml(__('Current Configuration Scope:')) ?></label>
     <div class="control">
         <select id="store_switcher" class="system-config-store-switcher">
         <?php foreach ($block->getStoreSelectOptions() as $_value => $_option): ?>
@@ -16,22 +20,22 @@
                 <?php if ($_option['is_close']): ?>
                     </optgroup>
                 <?php else: ?>
-                    <optgroup label="<?= $block->escapeHtmlAttr($_option['label']) ?>">
+                    <optgroup label="<?= $escaper->escapeHtmlAttr($_option['label']) ?>">
                         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
                             $_option['style'],
-                            "optgroup[label='" . $block->escapeJs($_option['label']) . "']"
+                            "optgroup[label='" . $escaper->escapeJs($_option['label']) . "']"
                         ) ?>
                 <?php endif; ?>
                 <?php continue ?>
             <?php endif; ?>
-              <option value="<?= $block->escapeHtmlAttr($_value) ?>"
-                      url="<?= $block->escapeUrl($_option['url']) ?>"
+              <option value="<?= $escaper->escapeHtmlAttr($_value) ?>"
+                      url="<?= $escaper->escapeUrl($_option['url']) ?>"
                       <?= $_option['selected'] ? 'selected="selected"' : '' ?>>
-                  <?= $block->escapeHtml($_option['label']) ?>
+                  <?= $escaper->escapeHtml($_option['label']) ?>
               </option>
               <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
                   $_option['style'],
-                  "optgroup[url='" . $block->escapeJs($_option['url']) . "']"
+                  "optgroup[url='" . $escaper->escapeJs($_option['url']) . "']"
               ) ?>
         <?php endforeach ?>
         </select>
@@ -44,8 +48,8 @@
     <?= $block->getHintHtml() ?>
     <?php if ($block->getAuthorization()->isAllowed('Magento_Backend::store')): ?>
         <div class="actions">
-            <a href="<?= $block->escapeUrl($block->getUrl('*/system_store')) ?>">
-                <?= $block->escapeHtml(__('Stores')) ?>
+            <a href="<?= $escaper->escapeUrl($block->getUrl('*/system_store')) ?>">
+                <?= $escaper->escapeHtml(__('Stores')) ?>
             </a>
         </div>
     <?php endif; ?>

--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/tabs.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/tabs.phtml
@@ -4,11 +4,13 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Config\Block\System\Config\Tabs */
+/**
+ * @var \Magento\Config\Block\System\Config\Tabs $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-
 <?php if ($block->getTabs()) : ?>
-    <div id="<?= $block->escapeHtmlAttr($block->getId()) ?>" class="config-nav">
+    <div id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>" class="config-nav">
         <?php
         /** @var $_tab \Magento\Config\Model\Config\Structure\Element\Tab */
         foreach ($block->getTabs() as $_tab) :
@@ -21,15 +23,15 @@
 
             <div class="config-nav-block admin__page-nav _collapsed
                 <?php if ($_tab->getClass()) : ?>
-                    <?= $block->escapeHtmlAttr($_tab->getClass()) ?>
+                    <?= $escaper->escapeHtmlAttr($_tab->getClass()) ?>
                 <?php endif ?>"
-                 data-mage-init='{"collapsible":{"active": "<?= $block->escapeHtmlAttr($activeCollapsible) ?>",
+                 data-mage-init='{"collapsible":{"active": "<?= $escaper->escapeHtmlAttr($activeCollapsible) ?>",
                  "openedState": "_show",
                  "closedState": "_hide",
                  "collapsible": true,
                  "animate": 200}}'>
                 <div class="admin__page-nav-title title _collapsible" data-role="title">
-                    <strong><?= $block->escapeHtml($_tab->getLabel()) ?></strong>
+                    <strong><?= $escaper->escapeHtml($_tab->getLabel()) ?></strong>
                 </div>
 
                 <ul class="admin__page-nav-items items" data-role="content">
@@ -38,12 +40,12 @@
                     /** @var $_section \Magento\Config\Model\Config\Structure\Element\Section */
                     foreach ($_tab->getChildren() as $_section) : ?>
                         <li class="admin__page-nav-item item
-                            <?= $block->escapeHtml($_section->getClass()) ?>
+                            <?= $escaper->escapeHtml($_section->getClass()) ?>
                             <?php if ($block->isSectionActive($_section)) : ?> _active<?php endif ?>
                             <?= $_tab->getChildren()->isLast($_section) ? ' _last' : '' ?>">
-                            <a href="<?= $block->escapeUrl($block->getSectionUrl($_section)) ?>"
+                            <a href="<?= $escaper->escapeUrl($block->getSectionUrl($_section)) ?>"
                                class="admin__page-nav-link item-nav">
-                               <span><?= $block->escapeHtml($_section->getLabel()) ?></span>
+                               <span><?= $escaper->escapeHtml($_section->getLabel()) ?></span>
                             </a>
                         </li>
                         <?php $_iterator++; ?>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
