### PR TITLE
Magento_Cms: avoid using deprecated escape* methods from AbstractBlock

### DIFF
--- a/app/code/Magento/Cms/Block/Adminhtml/Block/Widget/Chooser.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Block/Widget/Chooser.php
@@ -81,7 +81,7 @@ class Chooser extends \Magento\Backend\Block\Widget\Grid\Extended
         if ($element->getValue()) {
             $block = $this->_blockFactory->create()->load($element->getValue());
             if ($block->getId()) {
-                $chooser->setLabel($this->escapeHtml($block->getTitle()));
+                $chooser->setLabel($this->_escaper->escapeHtml($block->getTitle()));
             }
         }
 

--- a/app/code/Magento/Cms/Block/Adminhtml/Page/Widget/Chooser.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Page/Widget/Chooser.php
@@ -98,7 +98,7 @@ class Chooser extends \Magento\Backend\Block\Widget\Grid\Extended
         if ($element->getValue()) {
             $page = $this->_pageFactory->create()->load((int)$element->getValue());
             if ($page->getId()) {
-                $chooser->setLabel($this->escapeHtml($page->getTitle()));
+                $chooser->setLabel($this->_escaper->escapeHtml($page->getTitle()));
             }
         }
 

--- a/app/code/Magento/Cms/Block/Page.php
+++ b/app/code/Magento/Cms/Block/Page.php
@@ -113,7 +113,7 @@ class Page extends \Magento\Framework\View\Element\AbstractBlock implements
         if ($pageMainTitle) {
             // Setting empty page title if content heading is absent
             $cmsTitle = $page->getContentHeading() ?: ' ';
-            $pageMainTitle->setPageTitle($this->escapeHtml($cmsTitle));
+            $pageMainTitle->setPageTitle($this->_escaper->escapeHtml($cmsTitle));
         }
         return parent::_prepareLayout();
     }

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content.phtml
@@ -4,10 +4,13 @@
  * See COPYING.txt for license details.
  */
 
- /** @var $block \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content */
+ /**
+  * @var \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content $block
+  * @var \Magento\Framework\Escaper $escaper
+  */
 ?>
 
-<div class="media-gallery-modal" data-mage-init='{"mediabrowser": <?= $block->escapeHtml($block->getFilebrowserSetupObject()) ?>}'>
+<div class="media-gallery-modal" data-mage-init='{"mediabrowser": <?= $escaper->escapeHtml($block->getFilebrowserSetupObject()) ?>}'>
     <div class="page-main-actions">
         <div class="page-actions">
             <div class="page-actions-inner">

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/files.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/files.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Files */
+/**
+ * @var \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Files $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $_width  = $block->getImagesWidth();
 
@@ -20,22 +23,22 @@ $_width  = $block->getImagesWidth();
     <div
         data-row="file"
         class="filecnt"
-        id="<?= $block->escapeHtmlAttr($block->getFileId($file)) ?>"
-        data-size="<?= $block->escapeHtmlAttr($file->getSize()) ?>"
-        data-mime-type="<?= $block->escapeHtmlAttr($file->getMimeType()) ?>"
+        id="<?= $escaper->escapeHtmlAttr($block->getFileId($file)) ?>"
+        data-size="<?= $escaper->escapeHtmlAttr($file->getSize()) ?>"
+        data-mime-type="<?= $escaper->escapeHtmlAttr($file->getMimeType()) ?>"
     >
         <p class="nm">
         <?php if ($block->getFileThumbUrl($file)): ?>
-            <img src="<?= $block->escapeHtmlAttr($src) ?>" alt="<?= $block->escapeHtmlAttr($filename) ?>"/>
+            <img src="<?= $escaper->escapeHtmlAttr($src) ?>" alt="<?= $escaper->escapeHtmlAttr($filename) ?>"/>
         <?php endif; ?>
         </p>
         <?php if ($block->getFileWidth($file)): ?>
-              <small><?= $block->escapeHtmlAttr($width) ?>x<?= $block->escapeHtmlAttr($height) ?>
-                                                                   <?= $block->escapeHtml(__('px.')) ?></small><br/>
+              <small><?= $escaper->escapeHtmlAttr($width) ?>x<?= $escaper->escapeHtmlAttr($height) ?>
+                                                                   <?= $escaper->escapeHtml(__('px.')) ?></small><br/>
         <?php endif; ?>
-        <small><?= $block->escapeHtml($block->getFileShortName($file)) ?></small>
+        <small><?= $escaper->escapeHtml($block->getFileShortName($file)) ?></small>
     </div>
     <?php endforeach; ?>
 <?php else: ?>
-    <div class="empty"><?= $block->escapeHtml(__('No files found')) ?></div>
+    <div class="empty"><?= $escaper->escapeHtml(__('No files found')) ?></div>
 <?php endif; ?>

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
@@ -4,8 +4,11 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Uploader */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Uploader $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ */
 
 $filters = $block->getConfig()->getFilters() ?? [];
 $allowedExtensions = [];
@@ -22,19 +25,19 @@ $allowedExtensions = array_merge([], ...$listExtensions);
 
 $resizeConfig = $block->getImageUploadConfigData()->getIsResizeEnabled()
     ? "{action: 'resize', maxWidth: "
-        . $block->escapeHtml($block->getImageUploadMaxWidth())
+        . $escaper->escapeHtml($block->getImageUploadMaxWidth())
         . ", maxHeight: "
-        . $block->escapeHtml($block->getImageUploadMaxHeight())
+        . $escaper->escapeHtml($block->getImageUploadMaxHeight())
         . "}"
     : "{action: 'resize'}";
 ?>
 
 <div id="<?= /* @noEscape */ $blockHtmlId ?>" class="uploader">
     <span class="fileinput-button form-buttons">
-        <span><?= $block->escapeHtml(__('Upload Images')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Upload Images')) ?></span>
         <input class="fileupload" type="file"
-               name="<?= $block->escapeHtmlAttr($block->getConfig()->getFileField()) ?>"
-               data-url="<?= $block->escapeUrl($block->getConfig()->getUrl()) ?>" multiple>
+               name="<?= $escaper->escapeHtmlAttr($block->getConfig()->getFileField()) ?>"
+               data-url="<?= $escaper->escapeUrl($block->getConfig()->getUrl()) ?>" multiple>
     </span>
     <div class="clear"></div>
     <script type="text/x-magento-template" id="<?= /* @noEscape */ $blockHtmlId ?>-template">
@@ -60,8 +63,8 @@ require([
     'domReady!',
     'mage/translate'
 ], function ($, mageTemplate, validator, uiAlert) {
-    var maxFileSize = {$block->escapeJs($block->getFileSizeService()->getMaxFileSize())},
-        allowedExtensions = '{$block->escapeJs(implode(' ', $allowedExtensions))}';
+    var maxFileSize = {$escaper->escapeJs($block->getFileSizeService()->getMaxFileSize())},
+        allowedExtensions = '{$escaper->escapeJs(implode(' ', $allowedExtensions))}';
 
     $('#{$blockHtmlId} .fileupload').fileupload({
         dataType: 'json',

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/tree.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/tree.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Tree $block */
+/**
+ * @var \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Tree $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 
@@ -15,9 +18,9 @@ $jsonHelper = $block->getData('jsonHelper');
 <div class="tree-panel" >
     <div class="categories-side-col">
         <div class="tree-actions">
-            <a id="collapseAll"><?= $block->escapeHtml(__('Collapse All')) ?></a>
+            <a id="collapseAll"><?= $escaper->escapeHtml(__('Collapse All')) ?></a>
             <span class="separator">|</span>
-            <a id="expandAll"><?= $block->escapeHtml(__('Expand All')) ?></a>
+            <a id="expandAll"><?= $escaper->escapeHtml(__('Expand All')) ?></a>
         </div>
         <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
             'onclick',
@@ -30,7 +33,7 @@ $jsonHelper = $block->getData('jsonHelper');
             '#div.tree-actions a#expandAll'
         ) ?>
     </div>
-    <div data-role="tree" data-mage-init='<?= $block->escapeHtml(
+    <div data-role="tree" data-mage-init='<?= $escaper->escapeHtml(
         $jsonHelper->jsonEncode($block->getTreeWidgetOptions())
     ) ?>'>
     </div>

--- a/app/code/Magento/Cms/view/adminhtml/templates/url_filter_applier.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/url_filter_applier.phtml
@@ -4,8 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Backend\Block\Template */
-/** @var \Magento\Framework\Escaper $escaper */
+/**
+ * @var \Magento\Backend\Block\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <script type="text/x-magento-init">
     {

--- a/app/code/Magento/Cms/view/frontend/templates/widget/link/link_block.phtml
+++ b/app/code/Magento/Cms/view/frontend/templates/widget/link/link_block.phtml
@@ -6,10 +6,11 @@
 
 /**
  * @var \Magento\Cms\Block\Widget\Page\Link $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <div class="widget block block-cms-link">
     <a <?= /* @noEscape */ $block->getLinkAttributes() ?>>
-        <span><?= $block->escapeHtml($block->getLabel()) ?></span>
+        <span><?= $escaper->escapeHtml($block->getLabel()) ?></span>
     </a>
 </div>

--- a/app/code/Magento/Cms/view/frontend/templates/widget/link/link_inline.phtml
+++ b/app/code/Magento/Cms/view/frontend/templates/widget/link/link_inline.phtml
@@ -6,10 +6,11 @@
 
 /**
  * @var \Magento\Cms\Block\Widget\Page\Link $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <span class="widget block block-cms-link-inline">
     <a <?= /* @noEscape */ $block->getLinkAttributes() ?>>
-        <span><?= $block->escapeHtml($block->getLabel()) ?></span>
+        <span><?= $escaper->escapeHtml($block->getLabel()) ?></span>
     </a>
 </span>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
