### PR TITLE
Magento_CheckoutAgreements: avoid using deprecated escape* methods fr…

### DIFF
--- a/app/code/Magento/CheckoutAgreements/view/frontend/templates/additional_agreements.phtml
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/templates/additional_agreements.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\CheckoutAgreements\Block\Agreements
+ * @var \Magento\CheckoutAgreements\Block\Agreements $block
  */
 if (!$block->getAgreements()) {
     return;

--- a/app/code/Magento/CheckoutAgreements/view/frontend/templates/agreements.phtml
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/templates/agreements.phtml
@@ -5,12 +5,12 @@
  */
 
 use Magento\CheckoutAgreements\Model\AgreementModeOptions;
-?>
-<?php
+
 /**
- * @var $block \Magento\CheckoutAgreements\Block\Agreements
+ * @var \Magento\CheckoutAgreements\Block\Agreements $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if (!$block->getAgreements()) {
     return;
@@ -23,7 +23,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                 <?php if ($agreement->getIsHtml()):?>
                     <?= /* @noEscape */ $agreement->getContent() ?>
                 <?php else:?>
-                    <?= $block->escapeHtml(nl2br($agreement->getContent())) ?>
+                    <?= $escaper->escapeHtml(nl2br($agreement->getContent())) ?>
                 <?php endif; ?>
             </div>
             <?php if ($agreement->getContentHeight()): ?>
@@ -39,7 +39,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                        id="agreement-<?= (int) $agreement->getAgreementId() ?>"
                        name="agreement[<?= (int) $agreement->getAgreementId() ?>]"
                        value="1"
-                       title="<?= $block->escapeHtml($agreement->getCheckboxText()) ?>"
+                       title="<?= $escaper->escapeHtml($agreement->getCheckboxText()) ?>"
                        class="checkbox"
                        data-validate="{required:true}"/>
                 <label class="label" for="agreement-<?= (int) $agreement->getAgreementId() ?>">
@@ -47,7 +47,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                         <?php if ($agreement->getIsHtml()):?>
                             <?= /* @noEscape */ $agreement->getCheckboxText() ?>
                         <?php else:?>
-                            <?= $block->escapeHtml($agreement->getCheckboxText()) ?>
+                            <?= $escaper->escapeHtml($agreement->getCheckboxText()) ?>
                         <?php endif; ?>
                     </span>
                 </label>
@@ -57,7 +57,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                         <?php if ($agreement->getIsHtml()):?>
                             <?= /* @noEscape */ $agreement->getCheckboxText() ?>
                         <?php else:?>
-                            <?= $block->escapeHtml($agreement->getCheckboxText()) ?>
+                            <?= $escaper->escapeHtml($agreement->getCheckboxText()) ?>
                         <?php endif; ?>
                     </span>
                 </div>

--- a/app/code/Magento/CheckoutAgreements/view/frontend/templates/multishipping_agreements.phtml
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/templates/multishipping_agreements.phtml
@@ -5,10 +5,10 @@
  */
 
 use Magento\CheckoutAgreements\Model\AgreementModeOptions;
-?>
-<?php
+
 /**
- * @var $block \Magento\CheckoutAgreements\Block\Agreements
+ * @var \Magento\CheckoutAgreements\Block\Agreements $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -23,7 +23,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                 <?php if ($agreement->getIsHtml()):?>
                     <?= /* @noEscape */ $agreement->getContent() ?>
                 <?php else:?>
-                    <?= $block->escapeHtml(nl2br($agreement->getContent())) ?>
+                    <?= $escaper->escapeHtml(nl2br($agreement->getContent())) ?>
                 <?php endif; ?>
             </div>
                 <?php if ($agreement->getContentHeight()): ?>
@@ -39,7 +39,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                        id="agreement-<?= (int) $agreement->getAgreementId() ?>"
                        name="agreement[<?= (int) $agreement->getAgreementId() ?>]"
                        value="1"
-                       title="<?= $block->escapeHtml($agreement->getCheckboxText()) ?>"
+                       title="<?= $escaper->escapeHtml($agreement->getCheckboxText()) ?>"
                        class="checkbox"
                        data-validate="{required:true}"/>
                 <label class="label" for="agreement-<?= (int) $agreement->getAgreementId() ?>">
@@ -47,7 +47,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                         <?php if ($agreement->getIsHtml()):?>
                             <?= /* @noEscape */ $agreement->getCheckboxText() ?>
                         <?php else:?>
-                            <?= $block->escapeHtml($agreement->getCheckboxText()) ?>
+                            <?= $escaper->escapeHtml($agreement->getCheckboxText()) ?>
                         <?php endif; ?>
                     </span>
                 </label>
@@ -58,7 +58,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                     <?php if ($agreement->getIsHtml()):?>
                         <?= /* @noEscape */ $agreement->getCheckboxText() ?>
                     <?php else:?>
-                        <?= $block->escapeHtml($agreement->getCheckboxText()) ?>
+                        <?= $escaper->escapeHtml($agreement->getCheckboxText()) ?>
                     <?php endif; ?>
                 </span>
             </div>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
