### PR TITLE
Magento_CatalogWidget: avoid using deprecated escape* methods from Ab…

### DIFF
--- a/app/code/Magento/CatalogWidget/view/adminhtml/templates/product/widget/conditions.phtml
+++ b/app/code/Magento/CatalogWidget/view/adminhtml/templates/product/widget/conditions.phtml
@@ -4,16 +4,19 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\CatalogWidget\Block\Product\Widget\Conditions $block */
+/**
+ * @var \Magento\CatalogWidget\Block\Product\Widget\Conditions $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
 $element = $block->getElement();
-$fieldId = $element->getHtmlContainerId() ? ' id="' . $block->escapeHtmlAttr($element->getHtmlContainerId()) . '"' : '';
-$fieldClass = 'field admin__field field-' . $block->escapeHtmlAttr($element->getId()) . ' '
-    . $block->escapeHtmlAttr($element->getCssClass());
+$fieldId = $element->getHtmlContainerId() ? ' id="' . $escaper->escapeHtmlAttr($element->getHtmlContainerId()) . '"' : '';
+$fieldClass = 'field admin__field field-' . $escaper->escapeHtmlAttr($element->getId()) . ' '
+    . $escaper->escapeHtmlAttr($element->getCssClass());
 $fieldClass .= $element->getRequired() ? ' required' : '';
 $fieldAttributes = $fieldId . ' class="' . $fieldClass . '" '
-    . $block->getUiId('form-field', $block->escapeHtmlAttr($element->getId()));
+    . $block->getUiId('form-field', $escaper->escapeHtmlAttr($element->getId()));
 ?>
 <div<?= /* @noEscape */ $fieldAttributes ?>>
     <?= $element->getLabelHtml() ?>
@@ -31,8 +34,8 @@ $fieldAttributes = $fieldId . ' class="' . $fieldClass . '" '
         "Magento_Rule/rules",
         "prototype"
     ], function(VarienRulesForm){
-        window.{$block->escapeJs($block->getHtmlId())} = new VarienRulesForm('{$block->escapeJs($block->getHtmlId())}',
-         '{$block->escapeUrl($block->getNewChildUrl())}');
+        window.{$escaper->escapeJs($block->getHtmlId())} = new VarienRulesForm('{$escaper->escapeJs($block->getHtmlId())}',
+         '{$escaper->escapeUrl($block->getNewChildUrl())}');
     });
 script;
 ?>

--- a/app/code/Magento/CatalogWidget/view/frontend/templates/product/widget/content/grid.phtml
+++ b/app/code/Magento/CatalogWidget/view/frontend/templates/product/widget/content/grid.phtml
@@ -5,7 +5,10 @@
  */
 use Magento\Framework\App\Action\Action;
 
-/** @var \Magento\CatalogWidget\Block\Product\ProductsList $block */
+/**
+ * @var \Magento\CatalogWidget\Block\Product\ProductsList $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($exist = ($block->getProductCollection() && $block->getProductCollection()->getSize())) : ?>
     <?php
@@ -25,7 +28,7 @@ use Magento\Framework\App\Action\Action;
     <div class="block widget block-products-list <?= /* @noEscape */ $mode ?>">
         <?php if ($block->getTitle()) : ?>
             <div class="block-title">
-                <strong><?= $block->escapeHtml(__($block->getTitle())) ?></strong>
+                <strong><?= $escaper->escapeHtml(__($block->getTitle())) ?></strong>
             </div>
         <?php endif ?>
         <div class="block-content">
@@ -36,15 +39,15 @@ use Magento\Framework\App\Action\Action;
                     <?php foreach ($items as $_item) : ?>
                         <?= /* @noEscape */ ($iterator++ == 1) ? '<li class="product-item">' : '</li><li class="product-item">' ?>
                         <div class="product-item-info">
-                            <a href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-photo">
+                            <a href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-photo">
                                 <?= $block->getImage($_item, $image)->toHtml() ?>
                             </a>
                             <div class="product-item-details">
                                 <strong class="product-item-name">
-                                    <a title="<?= $block->escapeHtml($_item->getName()) ?>"
-                                       href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>"
+                                    <a title="<?= $escaper->escapeHtml($_item->getName()) ?>"
+                                       href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>"
                                        class="product-item-link">
-                                        <?= $block->escapeHtml($_item->getName()) ?>
+                                        <?= $escaper->escapeHtml($_item->getName()) ?>
                                     </a>
                                 </strong>
                                 <?php if ($templateType) : ?>
@@ -62,21 +65,21 @@ use Magento\Framework\App\Action\Action;
                                                 <div class="actions-primary">
                                                     <?php if ($_item->isSaleable()) : ?>
                                                         <?php $postParams = $block->getAddToCartPostParams($_item); ?>
-                                                        <form data-role="tocart-form" data-product-sku="<?= $block->escapeHtml($_item->getSku()) ?>" action="<?= $block->escapeUrl($postParams['action']) ?>" method="post">
-                                                            <input type="hidden" name="product" value="<?= $block->escapeHtmlAttr($postParams['data']['product']) ?>">
+                                                        <form data-role="tocart-form" data-product-sku="<?= $escaper->escapeHtml($_item->getSku()) ?>" action="<?= $escaper->escapeUrl($postParams['action']) ?>" method="post">
+                                                            <input type="hidden" name="product" value="<?= $escaper->escapeHtmlAttr($postParams['data']['product']) ?>">
                                                             <input type="hidden" name="<?= /* @noEscape */ Action::PARAM_NAME_URL_ENCODED ?>" value="<?= /* @noEscape */ $postParams['data'][Action::PARAM_NAME_URL_ENCODED] ?>">
                                                             <?= $block->getBlockHtml('formkey') ?>
                                                             <button type="submit"
-                                                                    title="<?= $block->escapeHtml(__('Add to Cart')) ?>"
+                                                                    title="<?= $escaper->escapeHtml(__('Add to Cart')) ?>"
                                                                     class="action tocart primary">
-                                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                             </button>
                                                         </form>
                                                     <?php else : ?>
                                                         <?php if ($_item->getIsSalable()) : ?>
-                                                            <div class="stock available"><span><?= $block->escapeHtml(__('In stock')) ?></span></div>
+                                                            <div class="stock available"><span><?= $escaper->escapeHtml(__('In stock')) ?></span></div>
                                                         <?php else : ?>
-                                                            <div class="stock unavailable"><span><?= $block->escapeHtml(__('Out of stock')) ?></span></div>
+                                                            <div class="stock unavailable"><span><?= $escaper->escapeHtml(__('Out of stock')) ?></span></div>
                                                         <?php endif; ?>
                                                     <?php endif; ?>
                                                 </div>
@@ -85,14 +88,14 @@ use Magento\Framework\App\Action\Action;
                                                 <div class="actions-secondary" data-role="add-to-links">
                                                     <?php if ($this->helper(\Magento\Wishlist\Helper\Data::class)->isAllow() && $showWishlist) : ?>
                                                         <a href="#"
-                                                           data-post='<?= /* @noEscape */ $block->getAddToWishlistParams($_item) ?>' class="action towishlist" data-action="add-to-wishlist" title="<?= $block->escapeHtmlAttr(__('Add to Wish List')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Wish List')) ?></span>
+                                                           data-post='<?= /* @noEscape */ $block->getAddToWishlistParams($_item) ?>' class="action towishlist" data-action="add-to-wishlist" title="<?= $escaper->escapeHtmlAttr(__('Add to Wish List')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Wish List')) ?></span>
                                                         </a>
                                                     <?php endif; ?>
                                                     <?php if ($block->getAddToCompareUrl() && $showCompare) : ?>
                                                         <?php $compareHelper = $this->helper(\Magento\Catalog\Helper\Product\Compare::class);?>
-                                                        <a href="#" class="action tocompare" data-post='<?= /* @noEscape */ $compareHelper->getPostDataParams($_item) ?>' title="<?= $block->escapeHtmlAttr(__('Add to Compare')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Compare')) ?></span>
+                                                        <a href="#" class="action tocompare" data-post='<?= /* @noEscape */ $compareHelper->getPostDataParams($_item) ?>' title="<?= $escaper->escapeHtmlAttr(__('Add to Compare')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Compare')) ?></span>
                                                         </a>
                                                     <?php endif; ?>
                                                 </div>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
