### PR TITLE
Magento_CatalogSearch: avoid using deprecated escape* methods from Ab…

### DIFF
--- a/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/form.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/form.phtml
@@ -8,6 +8,7 @@
  * Catalog advanced search form
  *
  * @var $block \Magento\CatalogSearch\Block\Advanced\Form
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -16,15 +17,15 @@
 /** @var \Magento\CatalogSearch\Helper\Data $catalogSearchHelper */
 $catalogSearchHelper = $block->getData('catalogSearchHelper'); ?>
 <?php $maxQueryLength = $catalogSearchHelper->getMaxQueryLength();?>
-<form class="form search advanced" action="<?= $block->escapeUrl($block->getSearchPostUrl()) ?>" method="get"
+<form class="form search advanced" action="<?= $escaper->escapeUrl($block->getSearchPostUrl()) ?>" method="get"
       id="form-validate">
 <fieldset class="fieldset">
-    <legend class="legend"><span><?= $block->escapeHtml(__('Search Settings')) ?></span></legend><br />
+    <legend class="legend"><span><?= $escaper->escapeHtml(__('Search Settings')) ?></span></legend><br />
     <?php foreach ($block->getSearchableAttributes() as $_attribute): ?>
         <?php $_code = $_attribute->getAttributeCode() ?>
-        <div class="field <?= $block->escapeHtmlAttr($_code) ?>">
-            <label class="label" for="<?= $block->escapeHtmlAttr($_code) ?>">
-                <span><?= $block->escapeHtml(__($block->getAttributeLabel($_attribute))) ?></span>
+        <div class="field <?= $escaper->escapeHtmlAttr($_code) ?>">
+            <label class="label" for="<?= $escaper->escapeHtmlAttr($_code) ?>">
+                <span><?= $escaper->escapeHtml(__($block->getAttributeLabel($_attribute))) ?></span>
             </label>
             <div class="control">
                 <?php
@@ -35,27 +36,27 @@ $catalogSearchHelper = $block->getData('catalogSearchHelper'); ?>
                     <div class="field no-label">
                         <div class="control">
                             <input type="text"
-                                   name="<?= $block->escapeHtmlAttr($_code) ?>[from]"
-                                   value="<?= $block->escapeHtml($block->getAttributeValue($_attribute, 'from')) ?>"
-                                   id="<?= $block->escapeHtmlAttr($_code) ?>"
-                                   title="<?= $block->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
+                                   name="<?= $escaper->escapeHtmlAttr($_code) ?>[from]"
+                                   value="<?= $escaper->escapeHtml($block->getAttributeValue($_attribute, 'from')) ?>"
+                                   id="<?= $escaper->escapeHtmlAttr($_code) ?>"
+                                   title="<?= $escaper->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
                                    class="input-text"
-                                   maxlength="<?= $block->escapeHtmlAttr($maxQueryLength) ?>"
+                                   maxlength="<?= $escaper->escapeHtmlAttr($maxQueryLength) ?>"
                                    data-validate="{number:true, 'less-than-equals-to':'#<?=
-                                    $block->escapeHtmlAttr($_code) ?>_to'}" />
+                                    $escaper->escapeHtmlAttr($_code) ?>_to'}" />
                         </div>
                     </div>
                     <div class="field no-label">
                         <div class="control">
                             <input type="text"
-                                   name="<?= $block->escapeHtmlAttr($_code) ?>[to]"
-                                   value="<?= $block->escapeHtml($block->getAttributeValue($_attribute, 'to')) ?>"
-                                   id="<?= $block->escapeHtmlAttr($_code) ?>_to"
-                                   title="<?= $block->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
+                                   name="<?= $escaper->escapeHtmlAttr($_code) ?>[to]"
+                                   value="<?= $escaper->escapeHtml($block->getAttributeValue($_attribute, 'to')) ?>"
+                                   id="<?= $escaper->escapeHtmlAttr($_code) ?>_to"
+                                   title="<?= $escaper->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
                                    class="input-text"
-                                   maxlength="<?= $block->escapeHtmlAttr($maxQueryLength) ?>"
+                                   maxlength="<?= $escaper->escapeHtmlAttr($maxQueryLength) ?>"
                                    data-validate="{number:true, 'greater-than-equals-to':'#<?=
-                                    $block->escapeHtmlAttr($_code) ?>'}" />
+                                    $escaper->escapeHtmlAttr($_code) ?>'}" />
                         </div>
                     </div>
                 </div>
@@ -66,30 +67,30 @@ $catalogSearchHelper = $block->getData('catalogSearchHelper'); ?>
                 <div class="range price fields group group-2">
                     <div class="field no-label">
                         <div class="control">
-                            <input name="<?= $block->escapeHtmlAttr($_code) ?>[from]"
-                                   value="<?= $block->escapeHtml($block->getAttributeValue($_attribute, 'from')) ?>"
-                                   id="<?= $block->escapeHtmlAttr($_code) ?>"
-                                   title="<?= $block->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
+                            <input name="<?= $escaper->escapeHtmlAttr($_code) ?>[from]"
+                                   value="<?= $escaper->escapeHtml($block->getAttributeValue($_attribute, 'from')) ?>"
+                                   id="<?= $escaper->escapeHtmlAttr($_code) ?>"
+                                   title="<?= $escaper->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
                                    class="input-text"
                                    type="text"
-                                   maxlength="<?= $block->escapeHtmlAttr($maxQueryLength) ?>"
-                                   data-validate="{number:true, 'validate-not-negative-number':true, 'less-than-equals-to':'#<?= $block->escapeHtmlAttr($_code) ?>_to'}" />
+                                   maxlength="<?= $escaper->escapeHtmlAttr($maxQueryLength) ?>"
+                                   data-validate="{number:true, 'validate-not-negative-number':true, 'less-than-equals-to':'#<?= $escaper->escapeHtmlAttr($_code) ?>_to'}" />
                         </div>
                     </div>
                     <div class="field with-addon no-label">
                         <div class="control">
                             <div class="addon">
-                                <input name="<?= $block->escapeHtmlAttr($_code) ?>[to]"
-                                       value="<?= $block->escapeHtml($block->getAttributeValue($_attribute, 'to')) ?>"
-                                       id="<?= $block->escapeHtmlAttr($_code) ?>_to"
-                                       title="<?= $block->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
+                                <input name="<?= $escaper->escapeHtmlAttr($_code) ?>[to]"
+                                       value="<?= $escaper->escapeHtml($block->getAttributeValue($_attribute, 'to')) ?>"
+                                       id="<?= $escaper->escapeHtmlAttr($_code) ?>_to"
+                                       title="<?= $escaper->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
                                        class="input-text"
                                        type="text"
-                                       maxlength="<?= $block->escapeHtmlAttr($maxQueryLength) ?>"
-                                       data-validate="{number:true, 'validate-not-negative-number':true, 'greater-than-equals-to':'#<?= $block->escapeHtmlAttr($_code) ?>'}" />
+                                       maxlength="<?= $escaper->escapeHtmlAttr($maxQueryLength) ?>"
+                                       data-validate="{number:true, 'validate-not-negative-number':true, 'greater-than-equals-to':'#<?= $escaper->escapeHtmlAttr($_code) ?>'}" />
                                 <label class="addafter"
-                                       for="<?= $block->escapeHtmlAttr($_code) ?>_to">
-                                    <?= $block->escapeHtml($block->getCurrency($_attribute)) ?>
+                                       for="<?= $escaper->escapeHtmlAttr($_code) ?>_to">
+                                    <?= $escaper->escapeHtml($block->getCurrency($_attribute)) ?>
                                 </label>
                             </div>
                         </div>
@@ -126,12 +127,12 @@ $catalogSearchHelper = $block->getData('catalogSearchHelper'); ?>
                     default:
                         ?>
                 <input type="text"
-                       name="<?= $block->escapeHtmlAttr($_code) ?>"
-                       id="<?= $block->escapeHtmlAttr($_code) ?>"
-                       value="<?= $block->escapeHtml($block->getAttributeValue($_attribute)) ?>"
-                       title="<?= $block->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
-                       class="input-text <?= $block->escapeHtmlAttr($block->getAttributeValidationClass($_attribute))?>"
-                       maxlength="<?= $block->escapeHtmlAttr($maxQueryLength) ?>" />
+                       name="<?= $escaper->escapeHtmlAttr($_code) ?>"
+                       id="<?= $escaper->escapeHtmlAttr($_code) ?>"
+                       value="<?= $escaper->escapeHtml($block->getAttributeValue($_attribute)) ?>"
+                       title="<?= $escaper->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
+                       class="input-text <?= $escaper->escapeHtmlAttr($block->getAttributeValidationClass($_attribute))?>"
+                       maxlength="<?= $escaper->escapeHtmlAttr($maxQueryLength) ?>" />
             <?php endswitch; ?>
             </div>
         </div>
@@ -141,8 +142,8 @@ $catalogSearchHelper = $block->getData('catalogSearchHelper'); ?>
   <div class="primary">
     <button type="submit"
             class="action search primary"
-            title="<?= $block->escapeHtml(__('Search')) ?>">
-        <span><?= $block->escapeHtml(__('Search')) ?></span>
+            title="<?= $escaper->escapeHtml(__('Search')) ?>">
+        <span><?= $escaper->escapeHtml(__('Search')) ?></span>
     </button>
   </div>
 </div>
@@ -163,8 +164,8 @@ require([
                 }
             },
             messages: {
-                'price[to]': {'greater-than-equals-to': '{$block->escapeJs(__('Please enter a valid price range.'))}'},
-                'price[from]': {'less-than-equals-to': '{$block->escapeJs(__('Please enter a valid price range.'))}'}
+                'price[to]': {'greater-than-equals-to': '{$escaper->escapeJs(__('Please enter a valid price range.'))}'},
+                'price[from]': {'less-than-equals-to': '{$escaper->escapeJs(__('Please enter a valid price range.'))}'}
             }
         });
 });

--- a/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/link.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/link.phtml
@@ -6,11 +6,14 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 
- /** @var \Magento\CatalogSearch\Helper\Data $helper */
+ /**
+  * @var \Magento\CatalogSearch\Helper\Data $helper
+  * @var \Magento\Framework\Escaper $escaper
+  */
 $helper = $this->helper(\Magento\CatalogSearch\Helper\Data::class);
 ?>
 <div class="nested">
-    <a class="action advanced" href="<?= $block->escapeUrl($helper->getAdvancedSearchUrl()) ?>" data-action="advanced-search">
-        <?= $block->escapeHtml(__('Advanced Search')) ?>
+    <a class="action advanced" href="<?= $escaper->escapeUrl($helper->getAdvancedSearchUrl()) ?>" data-action="advanced-search">
+        <?= $escaper->escapeHtml(__('Advanced Search')) ?>
     </a>
 </div>

--- a/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/result.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/result.phtml
@@ -7,6 +7,7 @@
 <?php
 /**
  * @var $block \Magento\CatalogSearch\Block\Advanced\Result
+ * @var \Magento\Framework\Escaper $escaper
  */
 /** this changes need for valid apply filters and configuration before search process is started */
 $productList = $block->getProductListHtml();
@@ -22,7 +23,7 @@ $productList = $block->getProductListHtml();
 <?php else : ?>
     <div role="alert" class="message error">
         <div>
-            <?= $block->escapeHtml(__('We can\'t find any items matching these search criteria.')) ?> <a href="<?= $block->escapeUrl($block->getFormUrl()) ?>"><?= $block->escapeHtml(__('Modify your search.')) ?></a>
+            <?= $escaper->escapeHtml(__('We can\'t find any items matching these search criteria.')) ?> <a href="<?= $escaper->escapeUrl($block->getFormUrl()) ?>"><?= $escaper->escapeHtml(__('Modify your search.')) ?></a>
         </div>
     </div>
 <?php endif; ?>
@@ -33,7 +34,7 @@ $productList = $block->getProductListHtml();
         <?php if (!empty($searchCriterias[$side])) : ?>
             <ul class="items">
                 <?php foreach ($searchCriterias[$side] as $criteria) : ?>
-                    <li class="item"><strong><?= $block->escapeHtml(__($criteria['name'])) ?>:</strong> <?= $block->escapeHtml($criteria['value']) ?></li>
+                    <li class="item"><strong><?= $escaper->escapeHtml(__($criteria['name'])) ?>:</strong> <?= $escaper->escapeHtml($criteria['value']) ?></li>
                 <?php endforeach; ?>
             </ul>
         <?php endif; ?>
@@ -42,8 +43,8 @@ $productList = $block->getProductListHtml();
 <?php if ($block->getResultCount()) : ?>
     <div class="message notice">
         <div>
-            <?= $block->escapeHtml(__("Don't see what you're looking for?")) ?>
-            <a href="<?= $block->escapeUrl($block->getFormUrl()) ?>"><?= $block->escapeHtml(__('Modify your search.')) ?></a>
+            <?= $escaper->escapeHtml(__("Don't see what you're looking for?")) ?>
+            <a href="<?= $escaper->escapeUrl($block->getFormUrl()) ?>"><?= $escaper->escapeHtml(__('Modify your search.')) ?></a>
         </div>
     </div>
 <?php endif; ?>

--- a/app/code/Magento/CatalogSearch/view/frontend/templates/result.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/templates/result.phtml
@@ -4,6 +4,9 @@
  * See COPYING.txt for license details.
  */
 
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** This changes need to valid applying filters and configuration before search process is started. */
 $productList = $block->getProductListHtml();
 ?>
@@ -25,7 +28,7 @@ $productList = $block->getProductListHtml();
 
 <div class="message notice">
     <div>
-        <?= $block->escapeHtml($block->getNoResultText() ? $block->getNoResultText() : __('Your search returned no results.')) ?>
+        <?= $escaper->escapeHtml($block->getNoResultText() ? $block->getNoResultText() : __('Your search returned no results.')) ?>
         <?= /* @noEscape */ $block->getAdditionalHtml() ?>
         <?php if ($messages = $block->getNoteMessages()) : ?>
             <?php foreach ($messages as $message) : ?>

--- a/app/code/Magento/CatalogSearch/view/frontend/templates/search_terms_log.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/templates/search_terms_log.phtml
@@ -3,13 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($block->getSearchTermsLog()->isPageCacheable()) : ?>
     <script type="text/x-magento-init">
     {
         "*": {
             "Magento_CatalogSearch/js/search-terms-log": {
-                "url": "<?= $block->escapeUrl($block->getUrl('catalogsearch/searchTermsLog/save')) ?>"
+                "url": "<?= $escaper->escapeUrl($block->getUrl('catalogsearch/searchTermsLog/save')) ?>"
             }
         }
     }


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
