### PR TITLE
Magento_CatalogRule: avoid using deprecated escape* methods from Abst…

### DIFF
--- a/app/code/Magento/CatalogRule/view/adminhtml/templates/promo/fieldset.phtml
+++ b/app/code/Magento/CatalogRule/view/adminhtml/templates/promo/fieldset.phtml
@@ -4,19 +4,22 @@
  * See COPYING.txt for license details.
  */
 
-/**@var \Magento\Backend\Block\Widget\Form\Renderer\Fieldset $block */
+/**
+ * @var \Magento\Backend\Block\Widget\Form\Renderer\Fieldset $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php $_element = $block->getElement() ?>
 <?php $_jsObjectName = $block->getFieldSetId() != null ? $block->getFieldSetId() : $_element->getHtmlId() ?>
 <div class="rule-tree">
-<fieldset id="<?= $block->escapeHtmlAttr($_jsObjectName) ?>" <?= /* @noEscape */ $_element->serialize(['class']) ?>
+<fieldset id="<?= $escaper->escapeHtmlAttr($_jsObjectName) ?>" <?= /* @noEscape */ $_element->serialize(['class']) ?>
           class="fieldset">
-        <legend class="legend"><span><?= $block->escapeHtml($_element->getLegend()) ?></span></legend>
+        <legend class="legend"><span><?= $escaper->escapeHtml($_element->getLegend()) ?></span></legend>
         <br>
     <?php if ($_element->getComment()): ?>
         <div class="messages">
-            <div class="message message-notice"><?= $block->escapeHtml($_element->getComment()) ?></div>
+            <div class="message message-notice"><?= $escaper->escapeHtml($_element->getComment()) ?></div>
         </div>
     <?php endif; ?>
     <div class="rule-tree-wrapper">


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
