### PR TITLE
Magento_Backup: avoid using deprecated escape* methods from AbstractB…

### DIFF
--- a/app/code/Magento/Backup/view/adminhtml/templates/backup/dialogs.phtml
+++ b/app/code/Magento/Backup/view/adminhtml/templates/backup/dialogs.phtml
@@ -4,14 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <!-- TODO: refactor form styles and js -->
 <script type="text/x-magento-template" id="rollback-warning-template">
-<p><?= $block->escapeHtml(__(
+<p><?= $escaper->escapeHtml(__(
     'You will lose any data created since the backup was made, including admin users, customers and orders.'
 )) ?></p>
-<p><?= $block->escapeHtml(__('Are you sure you want to continue?')) ?></p>
+<p><?= $escaper->escapeHtml(__('Are you sure you want to continue?')) ?></p>
 </script>
 <script type="text/x-magento-template" id="backup-options-template">
     <div class="backup-messages no-display">
@@ -19,14 +22,14 @@
     </div>
     <div class="messages">
         <div class="message message-warning">
-            <?= $block->escapeHtml(__('This may take a few moments.')) ?>
-            <?= $block->escapeHtml(__('Be sure your store is in maintenance mode during backup.')) ?></div>
+            <?= $escaper->escapeHtml(__('This may take a few moments.')) ?>
+            <?= $escaper->escapeHtml(__('Be sure your store is in maintenance mode during backup.')) ?></div>
     </div>
     <form action="" method="post" id="backup-form" class="form-inline">
         <fieldset class="admin__fieldset form-list question">
             <div class="admin__field field _required">
                 <label for="backup_name" class="admin__field-label">
-                    <span><?= $block->escapeHtml(__('Backup Name')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Backup Name')) ?></span>
                 </label>
                 <div class="admin__field-control">
                     <input type="text" name="backup_name" id="backup_name"
@@ -34,7 +37,7 @@
                             maximum-length-50"
                            maxlength="50" />
                     <div class="admin__field-note">
-                        <?= $block->escapeHtml(__(
+                        <?= $escaper->escapeHtml(__(
                             'Please use only letters (a-z or A-Z), numbers (0-9) or spaces in this field.'
                         )) ?>
                     </div>
@@ -43,7 +46,7 @@
 
             <div class="admin__field field maintenance-checkbox-container">
                 <label for="backup_maintenance_mode" class="admin__field-label">
-                    <span><?= $block->escapeHtml(__('Maintenance mode')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Maintenance mode')) ?></span>
                 </label>
                 <div class="admin__field-control">
                     <div class="admin__field-option">
@@ -53,7 +56,7 @@
                                value="1"
                                id="backup_maintenance_mode"/>
                         <label class="admin__field-label"
-                               for="backup_maintenance_mode"><?= $block->escapeHtml(__(
+                               for="backup_maintenance_mode"><?= $escaper->escapeHtml(__(
                                    'Please put your store into maintenance mode during backup.'
                                )) ?></label>
                     </div>
@@ -63,7 +66,7 @@
             <div class="admin__field field maintenance-checkbox-container no-display"
                  id="exclude-media-checkbox-container">
                 <label for="exclude_media" class="admin__field-label">
-                    <span><?= $block->escapeHtml(__('Exclude')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Exclude')) ?></span>
                 </label>
                 <div class="admin__field-control">
                     <div class="admin__field-option">
@@ -73,7 +76,7 @@
                                value="1"
                                id="exclude_media"/>
                         <label class="admin__field-label"
-                               for="exclude_media"><?= $block->escapeHtml(__('Exclude media folder from backup')) ?>
+                               for="exclude_media"><?= $escaper->escapeHtml(__('Exclude media folder from backup')) ?>
                         </label>
                     </div>
                 </div>
@@ -88,16 +91,16 @@
     </div>
     <div class="messages">
         <div class="message message-warning">
-            <?= $block->escapeHtml(__('Please enter the password to confirm rollback.')) ?><br>
-            <?= $block->escapeHtml(__('This action cannot be undone.')) ?>
-            <p><?= $block->escapeHtml(__('Are you sure you want to continue?')) ?></p>
+            <?= $escaper->escapeHtml(__('Please enter the password to confirm rollback.')) ?><br>
+            <?= $escaper->escapeHtml(__('This action cannot be undone.')) ?>
+            <p><?= $escaper->escapeHtml(__('Are you sure you want to continue?')) ?></p>
         </div>
     </div>
     <form action="" method="post" id="rollback-form" class="form-inline">
         <fieldset class="admin__fieldset password-box-container">
             <div class="admin__field field _required">
                 <label for="password" class="admin__field-label">
-                    <span><?= $block->escapeHtml(__('User Password')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('User Password')) ?></span>
                 </label>
                 <div class="admin__field-control">
                     <input type="password" name="password" id="password" class="admin__control-text required-entry"
@@ -107,14 +110,14 @@
 
             <div class="admin__field field maintenance-checkbox-container">
                 <label for="rollback_maintenance_mode" class="admin__field-label">
-                    <span><?= $block->escapeHtml(__('Maintenance mode')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Maintenance mode')) ?></span>
                 </label>
                 <div class="admin__field-control">
                     <div class="admin__field-option">
                         <input class="admin__control-checkbox" type="checkbox" name="maintenance_mode" value="1"
                                id="rollback_maintenance_mode"/>
                         <label class="admin__field-label" for="rollback_maintenance_mode">
-                            <?= $block->escapeHtml(__(
+                            <?= $escaper->escapeHtml(__(
                                 'Please put your store into maintenance mode during rollback processing.'
                             )) ?></label>
                     </div>
@@ -123,13 +126,13 @@
 
             <div class="admin__field field maintenance-checkbox-container" id="use-ftp-checkbox-row">
                 <label for="use_ftp" class="admin__field-label">
-                    <span><?= $block->escapeHtml(__('FTP')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('FTP')) ?></span>
                 </label>
                 <div class="admin__field-control">
                     <div class="admin__field-option">
                         <input class="admin__control-checkbox" type="checkbox" name="use_ftp" value="1" id="use_ftp"/>
                         <label class="admin__field-label" for="use_ftp">
-                            <?= $block->escapeHtml(__('Use FTP Connection')) ?>
+                            <?= $escaper->escapeHtml(__('Use FTP Connection')) ?>
                         </label>
                     </div>
                 </div>
@@ -138,11 +141,11 @@
         <div class="entry-edit no-display" id="ftp-credentials-container">
             <fieldset class="admin__fieldset">
                 <legend class="admin__legend legend">
-                    <span><?= $block->escapeHtml(__('FTP credentials')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('FTP credentials')) ?></span>
                 </legend><br />
                 <div class="admin__field field _required">
                     <label class="admin__field-label" for="ftp_host">
-                        <span><?= $block->escapeHtml(__('FTP Host')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('FTP Host')) ?></span>
                     </label>
                     <div class="admin__field-control">
                         <input type="text" class="admin__control-text" name="ftp_host" id="ftp_host">
@@ -151,7 +154,7 @@
 
                 <div class="admin__field field _required">
                     <label class="admin__field-label" for="ftp_user">
-                        <span><?= $block->escapeHtml(__('FTP Login')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('FTP Login')) ?></span>
                     </label>
                     <div class="admin__field-control">
                         <input type="text" class="admin__control-text" name="ftp_user" id="ftp_user">
@@ -159,7 +162,7 @@
                 </div>
                 <div class="admin__field field _required">
                     <label class="admin__field-label" for="ftp_pass">
-                        <span><?= $block->escapeHtml(__('FTP Password')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('FTP Password')) ?></span>
                     </label>
                     <div class="admin__field-control">
                         <input type="password" class="admin__control-text" name="ftp_pass" id="ftp_pass"
@@ -168,7 +171,7 @@
                 </div>
                 <div class="admin__field field">
                     <label class="admin__field-label" for="ftp_path">
-                        <span><?= $block->escapeHtml(__('Magento root directory')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Magento root directory')) ?></span>
                     </label>
                     <div class="admin__field-control">
                         <input type="text" class="admin__control-text" name="ftp_path" id="ftp_path">
@@ -192,8 +195,8 @@ require([
 
 //<![CDATA[
     backup = new AdminBackup();
-    backup.rollbackUrl = '{$block->escapeJs($rollbackUrl)}';
-    backup.backupUrl = '{$block->escapeJs($backupUrl)}';
+    backup.rollbackUrl = '{$escaper->escapeJs($rollbackUrl)}';
+    backup.backupUrl = '{$escaper->escapeJs($backupUrl)}';
 //]]>
 
 });

--- a/app/code/Magento/Backup/view/adminhtml/templates/backup/left.phtml
+++ b/app/code/Magento/Backup/view/adminhtml/templates/backup/left.phtml
@@ -3,5 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<h3><?= $block->escapeHtml(__('Create Backup')) ?></h3>
+<h3><?= $escaper->escapeHtml(__('Create Backup')) ?></h3>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
