### PR TITLE
Magento_ProductVideo: avoid using deprecated escape* methods from Abs…

### DIFF
--- a/app/code/Magento/ProductVideo/view/adminhtml/templates/helper/gallery.phtml
+++ b/app/code/Magento/ProductVideo/view/adminhtml/templates/helper/gallery.phtml
@@ -6,10 +6,11 @@
 
 /**
  * @var $block \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
-$elementNameEscaped = $block->escapeHtmlAttr($block->getElement()->getName()) . '[images]';
-$formNameEscaped = $block->escapeHtmlAttr($block->getFormName());
+$elementNameEscaped = $escaper->escapeHtmlAttr($block->getElement()->getName()) . '[images]';
+$formNameEscaped = $escaper->escapeHtmlAttr($block->getFormName());
 
 /** @var \Magento\Framework\Json\Helper\Data $jsonHelper */
 $jsonHelper = $block->getData('jsonHelper');
@@ -18,12 +19,12 @@ $jsonHelper = $block->getData('jsonHelper');
 <div class="row">
     <div class="add-video-button-container">
         <button id="add_video_button"
-                title="<?= $block->escapeHtmlAttr(__('Add Video')) ?>"
+                title="<?= $escaper->escapeHtmlAttr(__('Add Video')) ?>"
                 data-role="add-video-button"
                 type="button"
                 class="action-secondary"
                 data-ui-id="widget-button-1">
-            <span><?= $block->escapeHtml(__('Add Video')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Add Video')) ?></span>
         </button>
     </div>
 </div>
@@ -34,11 +35,11 @@ $element = $block->getElement();
 $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode():
     'toggleValueElements(this, this.parentNode.parentNode.parentNode)';
 ?>
-<div id="<?= $block->escapeHtmlAttr($block->getHtmlId()) ?>"
+<div id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>"
      class="gallery"
      data-mage-init='{"openVideoModal":{}}'
-     data-parent-component="<?= $block->escapeHtml($block->getData('config/parentComponent')) ?>"
-     data-images="<?= $block->escapeHtmlAttr($block->getImagesJson()) ?>"
+     data-parent-component="<?= $escaper->escapeHtml($block->getData('config/parentComponent')) ?>"
+     data-images="<?= $escaper->escapeHtmlAttr($block->getImagesJson()) ?>"
      data-types='<?= /* @noEscape */ $jsonHelper->jsonEncode($block->getImageTypes()) ?>'
 >
     <?php if (!$block->getElement()->getReadonly()): ?>
@@ -46,20 +47,20 @@ $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode():
             <?= $block->getUploaderHtml(); ?>
             <div class="product-image-wrapper">
                 <p class="image-placeholder-text">
-                    <?= $block->escapeHtml(__('Browse to find or drag image here')); ?>
+                    <?= $escaper->escapeHtml(__('Browse to find or drag image here')); ?>
                 </p>
             </div>
         </div>
         <?= $block->getChildHtml('additional_buttons') ?>
     <?php endif; ?>
     <?php foreach ($block->getImageTypes() as $typeData): ?>
-        <input name="<?= $block->escapeHtmlAttr($typeData['name']) ?>"
+        <input name="<?= $escaper->escapeHtmlAttr($typeData['name']) ?>"
                data-form-part="<?= /* @noEscape */ $formNameEscaped ?>"
-               class="image-<?= $block->escapeHtmlAttr($typeData['code']) ?>"
+               class="image-<?= $escaper->escapeHtmlAttr($typeData['code']) ?>"
                type="hidden"
-               value="<?= $block->escapeHtmlAttr($typeData['value']) ?>"/>
+               value="<?= $escaper->escapeHtmlAttr($typeData['value']) ?>"/>
     <?php endforeach; ?>
-    <script id="<?= $block->escapeHtmlAttr($block->getHtmlId()) ?>-template" data-template="image"
+    <script id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-template" data-template="image"
             type="text/x-magento-template">
         <div class="image item <% if (data.disabled == 1) { %>hidden-for-front<% } %>
                 <% if (data.video_url) { %>video-item<% } %>"
@@ -134,28 +135,28 @@ $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode():
                 <div class="actions">
                     <div class="tooltip">
                         <span class="delete-tooltiptext">
-                            <?= $block->escapeHtml(__('Delete image in all store views')); ?>
+                            <?= $escaper->escapeHtml(__('Delete image in all store views')); ?>
                         </span>
                         <button type="button"
                                 class="action-remove"
                                 data-role="delete-button"
                                 title="<% if (data.media_type == 'external-video') {%>
-                                <?= $block->escapeHtmlAttr(__('Delete video')); ?>
+                                <?= $escaper->escapeHtmlAttr(__('Delete video')); ?>
                             <%} else {%>
-                                <?= $block->escapeHtmlAttr(__('Delete image')); ?>
+                                <?= $escaper->escapeHtmlAttr(__('Delete image')); ?>
                             <%}%>">
                         <span>
                             <% if (data.media_type == 'external-video') { %>
-                            <?= $block->escapeHtml(__('Delete video')); ?>
+                            <?= $escaper->escapeHtml(__('Delete video')); ?>
                             <% } else {%>
-                            <?= $block->escapeHtml(__('Delete image')); ?>
+                            <?= $escaper->escapeHtml(__('Delete image')); ?>
                             <%} %>
                         </span>
                         </button>
                     </div>
                     <div class="draggable-handle"></div>
                 </div>
-                <div class="image-fade"><span><?= $block->escapeHtml(__('Hidden')); ?></span></div>
+                <div class="image-fade"><span><?= $escaper->escapeHtml(__('Hidden')); ?></span></div>
             </div>
 
             <div class="item-description">
@@ -171,9 +172,9 @@ $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode():
 
             <ul class="item-roles" data-role="roles-labels">
                 <?php foreach ($block->getImageTypes() as $typeData): ?>
-                    <li data-role-code="<?= $block->escapeHtmlAttr($typeData['code']) ?>"
-                        class="item-role item-role-<?= $block->escapeHtmlAttr($typeData['code']) ?>">
-                        <?= $block->escapeHtml($typeData['label']) ?>
+                    <li data-role-code="<?= $escaper->escapeHtmlAttr($typeData['code']) ?>"
+                        class="item-role item-role-<?= $escaper->escapeHtmlAttr($typeData['code']) ?>">
+                        <?= $escaper->escapeHtml($typeData['label']) ?>
                     </li>
                 <?php endforeach; ?>
             </ul>
@@ -195,7 +196,7 @@ $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode():
             <fieldset class="admin__fieldset fieldset-image-panel">
                 <div class="admin__field field-image-description">
                     <label class="admin__field-label" for="image-description">
-                        <span><?= $block->escapeHtml(__('Alt Text')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Alt Text')) ?></span>
                     </label>
 
                     <div class="admin__field-control">
@@ -209,7 +210,7 @@ $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode():
 
                 <div class="admin__field field-image-role">
                     <label class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Role')); ?></span>
+                            <span><?= $escaper->escapeHtml(__('Role')); ?></span>
                     </label>
                     <div class="admin__field-control">
                         <ul class="multiselect-alt">
@@ -222,9 +223,9 @@ $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode():
                                                data-role="type-selector"
                                                data-form-part="<?= /* @noEscape */ $formNameEscaped ?>"
                                                type="checkbox"
-                                               value="<?= $block->escapeHtmlAttr($attribute->getAttributeCode()) ?>"
+                                               value="<?= $escaper->escapeHtmlAttr($attribute->getAttributeCode()) ?>"
                                         />
-                                        <?= $block->escapeHtml($attribute->getFrontendLabel()) ?>
+                                        <?= $escaper->escapeHtml($attribute->getFrontendLabel()) ?>
                                     </label>
                                 </li>
                             <?php endforeach; ?>
@@ -234,16 +235,16 @@ $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode():
 
                 <div class="admin__field admin__field-inline field-image-size" data-role="size">
                     <label class="admin__field-label">
-                        <span><?= $block->escapeHtml(__('Image Size')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Image Size')) ?></span>
                     </label>
-                    <div class="admin__field-value" data-message="<?= $block->escapeHtmlAttr(__('{size}')) ?>"></div>
+                    <div class="admin__field-value" data-message="<?= $escaper->escapeHtmlAttr(__('{size}')) ?>"></div>
                 </div>
 
                 <div class="admin__field admin__field-inline field-image-resolution" data-role="resolution">
                     <label class="admin__field-label">
-                        <span><?= $block->escapeHtml(__('Image Resolution')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Image Resolution')) ?></span>
                     </label>
-                    <div class="admin__field-value" data-message="<?= $block->escapeHtmlAttr(__('{width}^{height} px'))
+                    <div class="admin__field-value" data-message="<?= $escaper->escapeHtmlAttr(__('{width}^{height} px'))
                     ?>"></div>
                 </div>
 
@@ -260,7 +261,7 @@ $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode():
                             <% if (data.disabled == 1) { %>checked="checked"<% } %> />
 
                             <label for="hide-from-product-page" class="admin__field-label">
-                                <?= $block->escapeHtml(__('Hide from Product Page')); ?>
+                                <?= $escaper->escapeHtml(__('Hide from Product Page')); ?>
                             </label>
                         </div>
                     </div>
@@ -274,16 +275,16 @@ $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode():
         <div id="video-player-preview-location" class="video-player-sidebar">
             <div class="video-player-container"></div>
             <div class="video-information title">
-                <label><?= $block->escapeHtml(__('Title:')); ?> </label><span></span>
+                <label><?= $escaper->escapeHtml(__('Title:')); ?> </label><span></span>
             </div>
             <div class="video-information uploaded">
-                <label><?= $block->escapeHtml(__('Uploaded:')); ?> </label><span></span>
+                <label><?= $escaper->escapeHtml(__('Uploaded:')); ?> </label><span></span>
             </div>
             <div class="video-information uploader">
-                <label><?= $block->escapeHtml(__('Uploader:')); ?> </label><span></span>
+                <label><?= $escaper->escapeHtml(__('Uploader:')); ?> </label><span></span>
             </div>
             <div class="video-information duration">
-                <label><?= $block->escapeHtml(__('Duration:')); ?> </label><span></span>
+                <label><?= $escaper->escapeHtml(__('Duration:')); ?> </label><span></span>
             </div>
         </div>
     </div>

--- a/app/code/Magento/ProductVideo/view/adminhtml/templates/product/edit/base_image.phtml
+++ b/app/code/Magento/ProductVideo/view/adminhtml/templates/product/edit/base_image.phtml
@@ -4,17 +4,20 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="row">
     <div class="add-video-button-container">
         <button
             id="add_video_button"
-            title="<?= $block->escapeHtmlAttr($addVideoTitle) ?>"
+            title="<?= $escaper->escapeHtmlAttr($addVideoTitle) ?>"
             type="button"
             class="action-secondary"
             data-ui-id="widget-button-1">
-            <span><?= $block->escapeHtml(__('Add Video')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Add Video')) ?></span>
         </button>
         <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
             'onclick',
@@ -23,21 +26,21 @@
         ) ?>
     </div>
 </div>
-<div id="<?= $block->escapeHtmlAttr($htmlId) ?>-container"
+<div id="<?= $escaper->escapeHtmlAttr($htmlId) ?>-container"
      class="images"
      data-mage-init='{"baseImage":{}}'
-     data-max-file-size="<?= $block->escapeHtmlAttr($fileMaxSize) ?>"
+     data-max-file-size="<?= $escaper->escapeHtmlAttr($fileMaxSize) ?>"
     >
     <div class="image image-placeholder">
-        <input type="file" name="image" data-url="<?= $block->escapeUrl($uploadUrl) ?>" multiple="multiple" />
-        <img class="spacer" src="<?= $block->escapeUrl($spacerImage) ?>"/>
-        <p class="image-placeholder-text"><?= $block->escapeHtml($imagePlaceholderText) ?></p>
+        <input type="file" name="image" data-url="<?= $escaper->escapeUrl($uploadUrl) ?>" multiple="multiple" />
+        <img class="spacer" src="<?= $escaper->escapeUrl($spacerImage) ?>"/>
+        <p class="image-placeholder-text"><?= $escaper->escapeHtml($imagePlaceholderText) ?></p>
     </div>
-    <script id="<?= $block->escapeHtmlAttr($htmlId) ?>-template"
+    <script id="<?= $escaper->escapeHtmlAttr($htmlId) ?>-template"
             data-template="image"
             type="text/x-magento-template">
         <div class="image">
-            <img class="spacer" src="<?= $block->escapeUrl($spacerImage) ?>"/>
+            <img class="spacer" src="<?= $escaper->escapeUrl($spacerImage) ?>"/>
             <img
                 class="product-image"
                 src="<%- data.url %>"
@@ -48,25 +51,25 @@
                     type="button"
                     class="action-delete"
                     data-role="delete-button"
-                    title="<?= $block->escapeHtmlAttr($deleteImageText) ?>">
-                    <span><?= $block->escapeHtml($deleteImageText) ?></span>
+                    title="<?= $escaper->escapeHtmlAttr($deleteImageText) ?>">
+                    <span><?= $escaper->escapeHtml($deleteImageText) ?></span>
                 </button>
                 <button
                     type="button"
                     class="action-make-base"
                     data-role="make-base-button"
-                    title="<?= $block->escapeHtmlAttr($makeBaseText) ?>">
-                    <span><?= $block->escapeHtml($makeBaseText) ?></span>
+                    title="<?= $escaper->escapeHtmlAttr($makeBaseText) ?>">
+                    <span><?= $escaper->escapeHtml($makeBaseText) ?></span>
                 </button>
                 <div class="draggable-handle"></div>
             </div>
             <div class="image-label"></div>
-            <div class="image-fade"><span><?= $block->escapeHtml($hiddenText) ?></span></div>
+            <div class="image-fade"><span><?= $escaper->escapeHtml($hiddenText) ?></span></div>
         </div>
     </script>
 </div>
 <span class="action-manage-images" data-activate-tab="image-management">
-    <span><?= $block->escapeHtml($imageManagementText) ?></span>
+    <span><?= $escaper->escapeHtml($imageManagementText) ?></span>
 </span>
 <?php $scriptString = <<<script
     require([

--- a/app/code/Magento/ProductVideo/view/adminhtml/templates/product/edit/slideout/form.phtml
+++ b/app/code/Magento/ProductVideo/view/adminhtml/templates/product/edit/slideout/form.phtml
@@ -5,30 +5,31 @@
  */
 /**
  * @var Magento\ProductVideo\Block\Adminhtml\Product\Edit\NewVideo $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
-<div id="<?= $block->escapeHtmlAttr($block->getNameInLayout()) ?>"
+<div id="<?= $escaper->escapeHtmlAttr($block->getNameInLayout()) ?>"
     data-modal-info='<?= /* @noEscape */ $block->getWidgetOptions() ?>'
 >
     <?= $block->getFormHtml() ?>
     <div id="video-player-preview-location" class="video-player-sidebar">
         <div class="video-player-container"></div>
         <div class="video-information title">
-            <label><?= $block->escapeHtml(__('Title:')) ?> </label><span></span>
+            <label><?= $escaper->escapeHtml(__('Title:')) ?> </label><span></span>
         </div>
         <div class="video-information uploaded">
-            <label><?= $block->escapeHtml(__('Uploaded:')) ?> </label><span></span>
+            <label><?= $escaper->escapeHtml(__('Uploaded:')) ?> </label><span></span>
         </div>
         <div class="video-information uploader">
-            <label><?= $block->escapeHtml(__('Uploader:')) ?> </label><span></span>
+            <label><?= $escaper->escapeHtml(__('Uploader:')) ?> </label><span></span>
         </div>
         <div class="video-information duration">
-            <label><?= $block->escapeHtml(__('Duration:')) ?> </label><span></span>
+            <label><?= $escaper->escapeHtml(__('Duration:')) ?> </label><span></span>
         </div>
     </div>
 </div>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
     'display:none',
-    'div#' . $block->escapeJs($block->getNameInLayout())
+    'div#' . $escaper->escapeJs($block->getNameInLayout())
 ) ?>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
