### PR TITLE
Magento_Persistent: avoid using deprecated escape* methods from Abstr…

### DIFF
--- a/app/code/Magento/Persistent/view/frontend/templates/remember_me.phtml
+++ b/app/code/Magento/Persistent/view/frontend/templates/remember_me.phtml
@@ -9,15 +9,18 @@
  * Customer "Remember Me" template
  */
 
-/** @var \Magento\Persistent\Block\Form\Remember $block */
+/**
+ * @var \Magento\Persistent\Block\Form\Remember $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 ?>
 <div id="remember-me-box" class="field choice persistent">
     <?php $rememberMeId = 'remember_me' . $block->getRandomString(10); ?>
-    <input type="checkbox" name="persistent_remember_me" class="checkbox" id="<?= $block->escapeHtmlAttr($rememberMeId) ?>" <?php if ($block->isRememberMeChecked()) : ?> checked="checked" <?php endif; ?> title="<?= $block->escapeHtmlAttr(__('Remember Me')) ?>" />
-    <label for="<?= $block->escapeHtmlAttr($rememberMeId) ?>" class="label"><span><?= $block->escapeHtml(__('Remember Me')) ?></span></label>
+    <input type="checkbox" name="persistent_remember_me" class="checkbox" id="<?= $escaper->escapeHtmlAttr($rememberMeId) ?>" <?php if ($block->isRememberMeChecked()) : ?> checked="checked" <?php endif; ?> title="<?= $escaper->escapeHtmlAttr(__('Remember Me')) ?>" />
+    <label for="<?= $escaper->escapeHtmlAttr($rememberMeId) ?>" class="label"><span><?= $escaper->escapeHtml(__('Remember Me')) ?></span></label>
     <span class="tooltip wrapper">
-        <strong class="tooltip toggle"> <?= $block->escapeHtml(__('What\'s this?')) ?></strong>
-        <span class="tooltip content"> <?= $block->escapeHtml(__('Check &quot;Remember Me&quot; to access your shopping cart on this computer even if you are not signed in.')) ?></span>
+        <strong class="tooltip toggle"> <?= $escaper->escapeHtml(__('What\'s this?')) ?></strong>
+        <span class="tooltip content"> <?= $escaper->escapeHtml(__('Check &quot;Remember Me&quot; to access your shopping cart on this computer even if you are not signed in.')) ?></span>
     </span>
 </div>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
