### PR TITLE
Magento_Payment: avoid using deprecated escape* methods from Abstract…

### DIFF
--- a/app/code/Magento/Payment/Block/Form.php
+++ b/app/code/Magento/Payment/Block/Form.php
@@ -63,6 +63,6 @@ class Form extends \Magento\Framework\View\Element\Template
      */
     public function getInfoData($field)
     {
-        return $this->escapeHtml($this->getMethod()->getInfoInstance()->getData($field));
+        return $this->_escaper->escapeHtml($this->getMethod()->getInfoInstance()->getData($field));
     }
 }

--- a/app/code/Magento/Payment/Block/Info.php
+++ b/app/code/Magento/Payment/Block/Info.php
@@ -107,7 +107,7 @@ class Info extends \Magento\Framework\View\Element\Template
         }
         if ($escapeHtml) {
             foreach ($value as $_key => $_val) {
-                $value[$_key] = $this->escapeHtml($_val);
+                $value[$_key] = $this->_escaper->escapeHtml($_val);
             }
         }
         return $value;

--- a/app/code/Magento/Payment/view/adminhtml/templates/form/cc.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/templates/form/cc.phtml
@@ -6,9 +6,10 @@
 
 /**
  * @var \Magento\Payment\Block\Adminhtml\Transparent\Form $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
-$code = $block->escapeHtml($block->getMethodCode());
+$code = $escaper->escapeHtml($block->getMethodCode());
 $ccType = $block->getInfoData('cc_type');
 $ccExpMonth = $block->getInfoData('cc_exp_month');
 $ccExpYear = $block->getInfoData('cc_exp_year');
@@ -16,16 +17,16 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
 <fieldset class="admin__fieldset payment-method" id="payment_form_<?= /* @noEscape */ $code ?>">
     <div class="field-type admin__field _required">
         <label class="admin__field-label" for="<?= /* @noEscape */ $code ?>_cc_type">
-            <span><?= $block->escapeHtml(__('Credit Card Type')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Credit Card Type')) ?></span>
         </label>
         <div class="admin__field-control">
             <select id="<?= /* @noEscape */ $code ?>_cc_type" name="payment[cc_type]"
                     class="required-entry validate-cc-type-select admin__control-select">
                 <option value=""></option>
                 <?php foreach ($block->getCcAvailableTypes() as $typeCode => $typeName): ?>
-                    <option value="<?= $block->escapeHtml($typeCode) ?>"
+                    <option value="<?= $escaper->escapeHtml($typeCode) ?>"
                             <?php if ($typeCode == $ccType): ?>selected="selected"<?php endif ?>>
-                        <?= $block->escapeHtml($typeName) ?>
+                        <?= $escaper->escapeHtml($typeName) ?>
                     </option>
                 <?php endforeach ?>
             </select>
@@ -33,35 +34,35 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
     </div>
     <div class="field-number admin__field _required">
         <label class="admin__field-label" for="<?= /* @noEscape */ $code ?>_cc_number">
-            <span><?= $block->escapeHtml(__('Credit Card Number')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Credit Card Number')) ?></span>
         </label>
         <div class="admin__field-control">
             <input type="text" id="<?= /* @noEscape */ $code ?>_cc_number" name="payment[cc_number]"
-                   title="<?= $block->escapeHtml(__('Credit Card Number')) ?>"
+                   title="<?= $escaper->escapeHtml(__('Credit Card Number')) ?>"
                    class="admin__control-text validate-cc-number"
                    value="<?= /* @noEscape */ $block->getInfoData('cc_number') ?>"/>
         </div>
     </div>
     <div class="field-date admin__field _required">
         <label class="admin__field-label" for="<?= /* @noEscape */ $code ?>_expiration">
-            <span><?= $block->escapeHtml(__('Expiration Date')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Expiration Date')) ?></span>
         </label>
         <div class="admin__field-control">
             <select id="<?= /* @noEscape */ $code ?>_expiration" name="payment[cc_exp_month]"
                     class="admin__control-select admin__control-select-month validate-cc-exp required-entry">
                 <?php foreach ($block->getCcMonths() as $k => $v): ?>
-                    <option value="<?= $block->escapeHtml($k) ?>"
+                    <option value="<?= $escaper->escapeHtml($k) ?>"
                             <?php if ($k == $ccExpMonth): ?>selected="selected"<?php endif ?>>
-                        <?= $block->escapeHtml($v) ?>
+                        <?= $escaper->escapeHtml($v) ?>
                     </option>
                 <?php endforeach; ?>
             </select>
             <select id="<?= /* @noEscape */ $code ?>_expiration_yr" name="payment[cc_exp_year]"
                     class="admin__control-select admin__control-select-year required-entry">
                 <?php foreach ($block->getCcYears() as $k => $v): ?>
-                    <option value="<?= /* @noEscape */ $k ? $block->escapeHtml($k) : '' ?>"
+                    <option value="<?= /* @noEscape */ $k ? $escaper->escapeHtml($k) : '' ?>"
                             <?php if ($k == $ccExpYear): ?>selected="selected"<?php endif ?>>
-                        <?= $block->escapeHtml($v) ?>
+                        <?= $escaper->escapeHtml($v) ?>
                     </option>
                 <?php endforeach ?>
             </select>
@@ -71,10 +72,10 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
     <?php if ($block->hasVerification()): ?>
         <div class="field-number required admin__field _required">
             <label class="admin__field-label" for="<?= /* @noEscape */ $code ?>_cc_cid">
-                <span><?= $block->escapeHtml(__('Card Verification Number')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Card Verification Number')) ?></span>
             </label>
             <div class="admin__field-control">
-                <input type="text" title="<?= $block->escapeHtml(__('Card Verification Number')) ?>"
+                <input type="text" title="<?= $escaper->escapeHtml(__('Card Verification Number')) ?>"
                        class="required-entry validate-cc-cvn admin__control-cvn admin__control-text"
                        id="<?= /* @noEscape */ $code ?>_cc_cid"
                        name="payment[cc_cid]" value="<?= /* @noEscape */ $block->getInfoData('cc_cid') ?>"/>

--- a/app/code/Magento/Payment/view/adminhtml/templates/info/default.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/templates/info/default.phtml
@@ -6,20 +6,21 @@
 
 /**
  * @var \Magento\Payment\Block\Info $block
+ * @var \Magento\Framework\Escaper $escaper
  * @see \Magento\Payment\Block\Info
  */
 $specificInfo = $block->getSpecificInformation();
 $paymentTitle = $block->getMethod()->getConfigData('title', $block->getInfo()->getOrder()->getStoreId());
 ?>
-<?= $block->escapeHtml($paymentTitle) ?>
+<?= $escaper->escapeHtml($paymentTitle) ?>
 
 <?php if ($specificInfo) : ?>
     <table class="data-table admin__table-secondary">
     <?php foreach ($specificInfo as $label => $value) : ?>
         <tr>
-            <th><?= $block->escapeHtml($label) ?>:</th>
+            <th><?= $escaper->escapeHtml($label) ?>:</th>
             <td>
-                <?= /* @noEscape */ nl2br($block->escapeHtml(implode("\n", $block->getValueAsArray($value, true)))) ?>
+                <?= /* @noEscape */ nl2br($escaper->escapeHtml(implode("\n", $block->getValueAsArray($value, true)))) ?>
             </td>
         </tr>
     <?php endforeach; ?>

--- a/app/code/Magento/Payment/view/adminhtml/templates/info/instructions.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/templates/info/instructions.phtml
@@ -6,15 +6,16 @@
 
 /**
  * @var \Magento\Payment\Block\Info $block
+ * @var \Magento\Framework\Escaper $escaper
  * @see \Magento\Payment\Block\Info
  */
 ?>
-<p><?= $block->escapeHtml($block->getMethod()->getTitle()) ?></p>
+<p><?= $escaper->escapeHtml($block->getMethod()->getTitle()) ?></p>
 <?php if ($block->getInstructions()) : ?>
     <table>
         <tbody>
             <tr>
-                <td><?= /* @noEscape */ nl2br($block->escapeHtml($block->getInstructions())) ?></td>
+                <td><?= /* @noEscape */ nl2br($escaper->escapeHtml($block->getInstructions())) ?></td>
             </tr>
         </tbody>
     </table>

--- a/app/code/Magento/Payment/view/adminhtml/templates/info/pdf/default.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/templates/info/pdf/default.phtml
@@ -7,17 +7,18 @@
 /**
  * @see \Magento\Payment\Block\Info
  * @var \Magento\Payment\Block\Info $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 $paymentTitle = $block->getMethod()->getConfigData('title', $block->getInfo()->getOrder()->getStoreId());
 ?>
-<?= $block->escapeHtml($paymentTitle) ?>{{pdf_row_separator}}
+<?= $escaper->escapeHtml($paymentTitle) ?>{{pdf_row_separator}}
 
 <?php if ($specificInfo = $block->getSpecificInformation()) : ?>
     <?php foreach ($specificInfo as $label => $value) : ?>
-        <?= $block->escapeHtml($label) ?>:
-        <?= $block->escapeHtml(implode(' ', $block->getValueAsArray($value))) ?>
+        <?= $escaper->escapeHtml($label) ?>:
+        <?= $escaper->escapeHtml(implode(' ', $block->getValueAsArray($value))) ?>
         {{pdf_row_separator}}
     <?php endforeach; ?>
 <?php endif;?>
 
-<?= $block->escapeHtml(implode('{{pdf_row_separator}}', $block->getChildPdfAsArray())) ?>
+<?= $escaper->escapeHtml(implode('{{pdf_row_separator}}', $block->getChildPdfAsArray())) ?>

--- a/app/code/Magento/Payment/view/adminhtml/templates/info/substitution.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/templates/info/substitution.phtml
@@ -6,11 +6,12 @@
 
 /**
  * @var \Magento\Payment\Block\Info $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <div>
     <?= $block->getMethod()->getTitle()
-        ? $block->escapeHtml($block->getMethod()->getTitle())
-        : $block->escapeHtml(__('Payment method')); ?>
-    <?= $block->escapeHtml(__(' is not available. You still can process offline actions.')) ?>
+        ? $escaper->escapeHtml($block->getMethod()->getTitle())
+        : $escaper->escapeHtml(__('Payment method')); ?>
+    <?= $escaper->escapeHtml(__(' is not available. You still can process offline actions.')) ?>
 </div>

--- a/app/code/Magento/Payment/view/adminhtml/templates/transparent/form.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/templates/transparent/form.phtml
@@ -4,10 +4,13 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Payment\Block\Transparent\Form $block */
+/**
+ * @var \Magento\Payment\Block\Transparent\Form $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
-$code = $block->escapeHtml($block->getMethodCode());
+$code = $escaper->escapeHtml($block->getMethodCode());
 $ccType = $block->getInfoData('cc_type');
 $ccExpYear = $block->getInfoData('cc_exp_year');
 $ccExpMonth = $block->getInfoData('cc_exp_month');
@@ -19,7 +22,7 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
         allowtransparency="true"
         frameborder="0"
         name="iframeTransparent"
-        src="<?= $block->escapeUrl($block->getViewFileUrl('blank.html')) ?>"></iframe>
+        src="<?= $escaper->escapeUrl($block->getViewFileUrl('blank.html')) ?>"></iframe>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
     "display: none; width: 100%; background-color: transparent;",
     'iframe#' . /* @noEscape */ $code . '-transparent-iframe'
@@ -29,20 +32,20 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
     class="admin__fieldset"
     data-mage-init='{
      "transparent":{
-        "controller":"<?= $block->escapeHtml($block->getRequest()->getControllerName()) ?>",
+        "controller":"<?= $escaper->escapeHtml($block->getRequest()->getControllerName()) ?>",
         "gateway":"<?= /* @noEscape */ $code ?>",
-        "dateDelim":"<?= $block->escapeHtml($block->getDateDelim()) ?>",
-        "cardFieldsMap":<?= $block->escapeHtml($block->getCardFieldsMap()) ?>,
-        "orderSaveUrl":"<?= $block->escapeUrl($block->getOrderUrl()) ?>",
-        "cgiUrl":"<?= $block->escapeUrl($block->getCgiUrl()) ?>",
-        "expireYearLength":"<?= $block->escapeHtml($block->getMethodConfigData('cc_year_length')) ?>",
-        "nativeAction":"<?= $block->escapeUrl(
+        "dateDelim":"<?= $escaper->escapeHtml($block->getDateDelim()) ?>",
+        "cardFieldsMap":<?= $escaper->escapeHtml($block->getCardFieldsMap()) ?>,
+        "orderSaveUrl":"<?= $escaper->escapeUrl($block->getOrderUrl()) ?>",
+        "cgiUrl":"<?= $escaper->escapeUrl($block->getCgiUrl()) ?>",
+        "expireYearLength":"<?= $escaper->escapeHtml($block->getMethodConfigData('cc_year_length')) ?>",
+        "nativeAction":"<?= $escaper->escapeUrl(
             $block->getUrl('*/*/save', ['_secure' => $block->getRequest()->isSecure()])
         ) ?>"
       }, "validation":[]}'>
     <div class="admin__field _required">
         <label for="<?= /* @noEscape */ $code ?>_cc_type" class="admin__field-label">
-            <span><?= $block->escapeHtml(__('Credit Card Type')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Credit Card Type')) ?></span>
         </label>
 
         <div class="admin__field-control">
@@ -51,12 +54,12 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
                     name="payment[cc_type]"
                     data-validate='{required:true, "validate-cc-type-select":"#<?= /* @noEscape */ $code ?>_cc_number"}'
                     class="admin__control-select">
-                <option value=""><?= $block->escapeHtml(__('Please Select')) ?></option>
+                <option value=""><?= $escaper->escapeHtml(__('Please Select')) ?></option>
                 <?php foreach ($block->getCcAvailableTypes() as $typeCode => $typeName): ?>
                     <option
-                        value="<?= $block->escapeHtml($typeCode) ?>"
+                        value="<?= $escaper->escapeHtml($typeCode) ?>"
                         <?php if ($typeCode == $ccType): ?> selected="selected"<?php endif ?>>
-                        <?= $block->escapeHtml($typeName) ?>
+                        <?= $escaper->escapeHtml($typeName) ?>
                     </option>
                 <?php endforeach ?>
             </select>
@@ -65,13 +68,13 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
 
     <div class="admin__field _required field-number">
         <label for="<?= /* @noEscape */ $code ?>_cc_number" class="admin__field-label">
-            <span><?= $block->escapeHtml(__('Credit Card Number')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Credit Card Number')) ?></span>
         </label>
 
         <div class="admin__field-control">
             <input type="text" id="<?= /* @noEscape */ $code ?>_cc_number"
                    data-container="<?= /* @noEscape */ $code ?>-cc-number"
-                   name="payment[cc_number]" title="<?= $block->escapeHtml(__('Credit Card Number')) ?>"
+                   name="payment[cc_number]" title="<?= $escaper->escapeHtml(__('Credit Card Number')) ?>"
                    class="admin__control-text"
                    value=""
                    data-validate='{
@@ -85,7 +88,7 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
 
     <div class="admin__field _required field-date" id="<?= /* @noEscape */ $code ?>_cc_type_exp_div">
         <label for="<?= /* @noEscape */ $code ?>_expiration" class="admin__field-label">
-            <span><?= $block->escapeHtml(__('Expiration Date')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Expiration Date')) ?></span>
         </label>
 
         <div class="admin__field-control">
@@ -95,9 +98,9 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
                     data-validate='{required:true, "validate-cc-exp":"#<?= /* @noEscape */ $code ?>_expiration_yr"}'>
                 <?php foreach ($block->getCcMonths() as $k => $v): ?>
                     <option
-                        value="<?= /* @noEscape */ $k ? $block->escapeHtml($k) : '' ?>"
+                        value="<?= /* @noEscape */ $k ? $escaper->escapeHtml($k) : '' ?>"
                         <?php if ($k == $ccExpMonth): ?> selected="selected"<?php endif; ?>>
-                        <?= $block->escapeHtml($v) ?>
+                        <?= $escaper->escapeHtml($v) ?>
                     </option>
                 <?php endforeach ?>
             </select>
@@ -107,9 +110,9 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
                     data-container="<?= /* @noEscape */ $code ?>-cc-year" data-validate='{required:true}'>
                 <?php foreach ($block->getCcYears() as $k => $v): ?>
                     <option
-                        value="<?= /* @noEscape */ $k ? $block->escapeHtml($k) : '' ?>"
+                        value="<?= /* @noEscape */ $k ? $escaper->escapeHtml($k) : '' ?>"
                         <?php if ($k == $ccExpYear): ?> selected="selected"<?php endif ?>>
-                        <?= $block->escapeHtml($v) ?>
+                        <?= $escaper->escapeHtml($v) ?>
                     </option>
                 <?php endforeach ?>
             </select>
@@ -118,11 +121,11 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
     <?php if ($block->hasVerification()): ?>
         <div class="admin__field _required field-cvv" id="<?= /* @noEscape */ $code ?>_cc_type_cvv_div">
             <label for="<?= /* @noEscape */ $code ?>_cc_cid" class="admin__field-label">
-                <span><?= $block->escapeHtml(__('Card Verification Number')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Card Verification Number')) ?></span>
             </label>
 
             <div class="admin__field-control">
-                <input type="text" title="<?= $block->escapeHtml(__('Card Verification Number')) ?>"
+                <input type="text" title="<?= $escaper->escapeHtml(__('Card Verification Number')) ?>"
                        data-container="<?= /* @noEscape */ $code ?>-cc-cvv"
                        class="admin__control-text cvv"
                        id="<?= /* @noEscape */ $code ?>_cc_cid" name="payment[cc_cid]"

--- a/app/code/Magento/Payment/view/adminhtml/templates/transparent/iframe.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/templates/transparent/iframe.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var \Magento\Payment\Block\Transparent\Iframe $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 $params = $block->getParams();
@@ -18,12 +19,12 @@ $jsonHelper = $block->getData('jsonHelper');
     <?php $scriptString = '' ?>
 <?php if (isset($params['redirect'])): ?>
     <?php $scriptString .= <<<script
-    window.location="{$block->escapeJs($params['redirect'])}";
+    window.location="{$escaper->escapeJs($params['redirect'])}";
 script;
     ?>
 <?php elseif (isset($params['redirect_parent'])): ?>
     <?php $scriptString .= <<<script
-    window.top.location="{$block->escapeJs($params['redirect_parent'])}";
+    window.top.location="{$escaper->escapeJs($params['redirect_parent'])}";
 script;
     ?>
 <?php elseif (isset($params['error_msg'])): ?>
@@ -34,7 +35,7 @@ script;
     ?>
 <?php elseif (isset($params['order_success'])): ?>
     <?php $scriptString .= <<<script
-    window.top.location = "{$block->escapeJs($params['order_success'])}";
+    window.top.location = "{$escaper->escapeJs($params['order_success'])}";
 script;
     ?>
 <?php else: ?>

--- a/app/code/Magento/Payment/view/adminhtml/templates/transparent/info.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/templates/transparent/info.phtml
@@ -6,14 +6,15 @@
 
 /**
  * @var \Magento\Payment\Block\Transparent\Info $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  * @see \Magento\Payment\Block\Transparent\Info
  */
 ?>
-<fieldset id="payment_form_<?= $block->escapeHtml($block->getMethodCode()) ?>" class="fieldset items redirect">
-    <div><?= $block->escapeHtml(__('We\'ll ask for your payment details before you place an order.')) ?></div>
+<fieldset id="payment_form_<?= $escaper->escapeHtml($block->getMethodCode()) ?>" class="fieldset items redirect">
+    <div><?= $escaper->escapeHtml(__('We\'ll ask for your payment details before you place an order.')) ?></div>
 </fieldset>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
     "display:none",
-    'fieldset#payment_form_' . $block->escapeHtml($block->getMethodCode())
+    'fieldset#payment_form_' . $escaper->escapeHtml($block->getMethodCode())
 ) ?>

--- a/app/code/Magento/Payment/view/adminhtml/templates/transparent/redirect.phtml
+++ b/app/code/Magento/Payment/view/adminhtml/templates/transparent/redirect.phtml
@@ -4,17 +4,20 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Payment\Block\Transparent\Redirect $block */
+/**
+ * @var \Magento\Payment\Block\Transparent\Redirect $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 $params = $block->getPostParams();
 $redirectUrl = $block->getRedirectUrl();
 ?>
 <html>
 <head></head>
 <body onload="document.forms['proxy_form'].submit()">
-<form id="proxy_form" action="<?= $block->escapeUrl($redirectUrl) ?>"
+<form id="proxy_form" action="<?= $escaper->escapeUrl($redirectUrl) ?>"
       method="POST" hidden enctype="application/x-www-form-urlencoded" class="no-display">
     <?php foreach ($params as $name => $value):?>
-        <input value="<?= $block->escapeHtmlAttr($value) ?>" name="<?= $block->escapeHtmlAttr($name) ?>" type="hidden"/>
+        <input value="<?= $escaper->escapeHtmlAttr($value) ?>" name="<?= $escaper->escapeHtmlAttr($name) ?>" type="hidden"/>
     <?php endforeach?>
 </form>
 </body>

--- a/app/code/Magento/Payment/view/base/templates/info/pdf/default.phtml
+++ b/app/code/Magento/Payment/view/base/templates/info/pdf/default.phtml
@@ -7,16 +7,17 @@
 /**
  * @see \Magento\Payment\Block\Info
  * @var \Magento\Payment\Block\Info $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
-<?= $block->escapeHtml($block->getMethod()->getTitle()) ?>{{pdf_row_separator}}
+<?= $escaper->escapeHtml($block->getMethod()->getTitle()) ?>{{pdf_row_separator}}
 
 <?php if ($specificInfo = $block->getSpecificInformation()) : ?>
     <?php foreach ($specificInfo as $label => $value) : ?>
-        <?= $block->escapeHtml($label) ?>:
-        <?= $block->escapeHtml(implode(' ', $block->getValueAsArray($value))) ?>
+        <?= $escaper->escapeHtml($label) ?>:
+        <?= $escaper->escapeHtml(implode(' ', $block->getValueAsArray($value))) ?>
         {{pdf_row_separator}}
     <?php endforeach; ?>
 <?php endif;?>
 
-<?= $block->escapeHtml(implode('{{pdf_row_separator}}', $block->getChildPdfAsArray())) ?>
+<?= $escaper->escapeHtml(implode('{{pdf_row_separator}}', $block->getChildPdfAsArray())) ?>

--- a/app/code/Magento/Payment/view/frontend/templates/form/cc.phtml
+++ b/app/code/Magento/Payment/view/frontend/templates/form/cc.phtml
@@ -6,9 +6,10 @@
 
 /**
  * @var \Magento\Payment\Block\Transparent\Form $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
-$code = $block->escapeHtml($block->getMethodCode());
+$code = $escaper->escapeHtml($block->getMethodCode());
 $ccType = $block->getInfoData('cc_type');
 $ccExpMonth = $block->getInfoData('cc_exp_month');
 $ccExpYear = $block->getInfoData('cc_exp_year');
@@ -17,7 +18,7 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
           id="payment_form_<?= /* @noEscape */ $code ?>">
     <div class="field type required">
         <label for="<?= /* @noEscape */ $code ?>_cc_type" class="label">
-            <span><?= $block->escapeHtml(__('Credit Card Type')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Credit Card Type')) ?></span>
         </label>
         <div class="control">
             <select id="<?= /* @noEscape */ $code ?>_cc_type"
@@ -29,11 +30,11 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
                         "validate-cc-type-select":"#<?= /* @noEscape */ $code ?>_cc_number"
                     }'
                     class="select">
-                <option value=""><?= $block->escapeHtml(__('--Please Select--')) ?></option>
+                <option value=""><?= $escaper->escapeHtml(__('--Please Select--')) ?></option>
             <?php foreach ($block->getCcAvailableTypes() as $typeCode => $typeName): ?>
-                <option value="<?= $block->escapeHtml($typeCode) ?>"
+                <option value="<?= $escaper->escapeHtml($typeCode) ?>"
                     <?php if ($typeCode == $ccType): ?> selected="selected"<?php endif; ?>>
-                    <?= $block->escapeHtml($typeName) ?>
+                    <?= $escaper->escapeHtml($typeName) ?>
                 </option>
             <?php endforeach; ?>
             </select>
@@ -41,11 +42,11 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
     </div>
     <div class="field number required">
         <label for="<?= /* @noEscape */ $code ?>_cc_number" class="label">
-            <span><?= $block->escapeHtml(__('Credit Card Number')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Credit Card Number')) ?></span>
         </label>
         <div class="control">
             <input type="number" id="<?= /* @noEscape */ $code ?>_cc_number" name="payment[cc_number]"
-                   title="<?= $block->escapeHtml(__('Credit Card Number')) ?>" class="input-text" value=""
+                   title="<?= $escaper->escapeHtml(__('Credit Card Number')) ?>" class="input-text" value=""
                    data-validate='{
                        "required-number":true,
                        "validate-cc-number":"#<?= /* @noEscape */ $code ?>_cc_type",
@@ -55,7 +56,7 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
     </div>
     <div class="field date required" id="<?= /* @noEscape */ $code ?>_cc_type_exp_div">
         <label for="<?= /* @noEscape */ $code ?>_expiration" class="label">
-            <span><?= $block->escapeHtml(__('Expiration Date')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Expiration Date')) ?></span>
         </label>
         <div class="control">
             <div class="fields group group-2">
@@ -67,9 +68,9 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
                                 data-validate='{required:true, "validate-cc-exp":"#<?= /* @noEscape */ $code
                                 ?>_expiration_yr"}'>
                             <?php foreach ($block->getCcMonths() as $k => $v): ?>
-                                <option value="<?= /* @noEscape */ $k ? $block->escapeHtml($k) : '' ?>"
+                                <option value="<?= /* @noEscape */ $k ? $escaper->escapeHtml($k) : '' ?>"
                                     <?php if ($k == $ccExpMonth): ?> selected="selected"<?php endif; ?>>
-                                    <?= $block->escapeHtml($v) ?>
+                                    <?= $escaper->escapeHtml($v) ?>
                                 </option>
                             <?php endforeach; ?>
                         </select>
@@ -80,9 +81,9 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
                         <select id="<?= /* @noEscape */ $code ?>_expiration_yr" name="payment[cc_exp_year]"
                                 class="select year" data-validate='{required:true}'>
                             <?php foreach ($block->getCcYears() as $k => $v): ?>
-                                <option value="<?= /* @noEscape */ $k ? $block->escapeHtml($k) : '' ?>
+                                <option value="<?= /* @noEscape */ $k ? $escaper->escapeHtml($k) : '' ?>
                                 "<?php if ($k == $ccExpYear): ?> selected="selected"<?php endif; ?>>
-                                    <?= $block->escapeHtml($v) ?>
+                                    <?= $escaper->escapeHtml($v) ?>
                                 </option>
                             <?php endforeach; ?>
                         </select>
@@ -94,19 +95,19 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
     <?php if ($block->hasVerification()): ?>
     <div class="field cvv required" id="<?= /* @noEscape */ $code ?>_cc_type_cvv_div">
         <label for="<?= /* @noEscape */ $code ?>_cc_cid" class="label">
-            <span><?= $block->escapeHtml(__('Card Verification Number')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Card Verification Number')) ?></span>
         </label>
         <div class="control">
-            <input type="number" title="<?= $block->escapeHtml(__('Card Verification Number')) ?>"
+            <input type="number" title="<?= $escaper->escapeHtml(__('Card Verification Number')) ?>"
                    class="input-text cvv" id="<?= /* @noEscape */ $code ?>_cc_cid" name="payment[cc_cid]" value=""
                    data-validate='{"required-number":true, "validate-cc-cvn":"#<?= /* @noEscape */ $code ?>_cc_type"}'/>
             <?php $content = '<img src=\"' . $block->getViewFileUrl('Magento_Checkout::cvv.png') . '\" alt=\"' .
-                $block->escapeHtml(__('Card Verification Number Visual Reference')) .
-                '\" title=\"' . $block->escapeHtml(__('Card Verification Number Visual Reference')) . '\" />'; ?>
+                $escaper->escapeHtml(__('Card Verification Number Visual Reference')) .
+                '\" title=\"' . $escaper->escapeHtml(__('Card Verification Number Visual Reference')) . '\" />'; ?>
             <div class="note">
-                <a href="#" class="action cvv" title="<?= $block->escapeHtml(__('What is this?')) ?>"
+                <a href="#" class="action cvv" title="<?= $escaper->escapeHtml(__('What is this?')) ?>"
                    data-mage-init='{"tooltip": {"content": "<?= /* @noEscape */ $content ?>"}}'>
-                    <span><?= $block->escapeHtml(__('What is this?')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('What is this?')) ?></span>
                 </a>
             </div>
         </div>

--- a/app/code/Magento/Payment/view/frontend/templates/info/default.phtml
+++ b/app/code/Magento/Payment/view/frontend/templates/info/default.phtml
@@ -6,10 +6,11 @@
 
 /**
  * @var \Magento\Payment\Block\Info $block
+ * @var \Magento\Framework\Escaper $escaper
  * @see \Magento\Payment\Block\Info
  */
 $specificInfo = $block->getSpecificInformation();
-$title = $block->escapeHtml($block->getMethod()->getTitle());
+$title = $escaper->escapeHtml($block->getMethod()->getTitle());
 ?>
 <dl class="payment-method">
     <dt class="title"><?= /* @noEscape */ $title ?></dt>
@@ -19,9 +20,9 @@ $title = $block->escapeHtml($block->getMethod()->getTitle());
             <caption class="table-caption"><?= /* @noEscape */ $title ?></caption>
             <?php foreach ($specificInfo as $label => $value) : ?>
                 <tr>
-                    <th scope="row"><?= $block->escapeHtml($label) ?></th>
+                    <th scope="row"><?= $escaper->escapeHtml($label) ?></th>
                     <td>
-                        <?= /* @noEscape */ nl2br($block->escapeHtml(implode("\n", $block->getValueAsArray($value, true)))) ?>
+                        <?= /* @noEscape */ nl2br($escaper->escapeHtml(implode("\n", $block->getValueAsArray($value, true)))) ?>
                     </td>
                 </tr>
             <?php endforeach; ?>

--- a/app/code/Magento/Payment/view/frontend/templates/info/instructions.phtml
+++ b/app/code/Magento/Payment/view/frontend/templates/info/instructions.phtml
@@ -6,12 +6,13 @@
 
 /**
  * @var \Magento\Payment\Block\Info $block
+ * @var \Magento\Framework\Escaper $escaper
  * @see \Magento\Payment\Block\Info
  */
 ?>
 <dl class="payment-method">
-    <dt class="title"><?= $block->escapeHtml($block->getMethod()->getTitle()) ?></dt>
+    <dt class="title"><?= $escaper->escapeHtml($block->getMethod()->getTitle()) ?></dt>
 <?php if ($block->getInstructions()) : ?>
-    <dd class="content"><?= /* @noEscape */ nl2br($block->escapeHtml($block->getInstructions())) ?></dd>
+    <dd class="content"><?= /* @noEscape */ nl2br($escaper->escapeHtml($block->getInstructions())) ?></dd>
 <?php endif; ?>
 </dl>

--- a/app/code/Magento/Payment/view/frontend/templates/info/pdf/default.phtml
+++ b/app/code/Magento/Payment/view/frontend/templates/info/pdf/default.phtml
@@ -7,16 +7,17 @@
 /**
  * @see \Magento\Payment\Block\Info
  * @var \Magento\Payment\Block\Info $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
-<?= $block->escapeHtml($block->getMethod()->getTitle()) ?>{{pdf_row_separator}}
+<?= $escaper->escapeHtml($block->getMethod()->getTitle()) ?>{{pdf_row_separator}}
 
 <?php if ($specificInfo = $block->getSpecificInformation()) : ?>
     <?php foreach ($specificInfo as $label => $value) : ?>
-        <?= $block->escapeHtml($label) ?>:
-        <?= $block->escapeHtml(implode(' ', $block->getValueAsArray($value))) ?>
+        <?= $escaper->escapeHtml($label) ?>:
+        <?= $escaper->escapeHtml(implode(' ', $block->getValueAsArray($value))) ?>
         {{pdf_row_separator}}
     <?php endforeach; ?>
 <?php endif;?>
 
-<?= $block->escapeHtml(implode('{{pdf_row_separator}}', $block->getChildPdfAsArray())) ?>
+<?= $escaper->escapeHtml(implode('{{pdf_row_separator}}', $block->getChildPdfAsArray())) ?>

--- a/app/code/Magento/Payment/view/frontend/templates/transparent/form.phtml
+++ b/app/code/Magento/Payment/view/frontend/templates/transparent/form.phtml
@@ -4,46 +4,49 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Payment\Block\Transparent\Form $block */
+/**
+ * @var \Magento\Payment\Block\Transparent\Form $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
-$code = $block->escapeHtml($block->getMethodCode());
+$code = $escaper->escapeHtml($block->getMethodCode());
 $ccExpMonth = $block->getInfoData('cc_exp_month');
 $ccExpYear = $block->getInfoData('cc_exp_year');
 $ccType = $block->getInfoData('cc_type');
-$content = '<img src=\"' . $block->escapeUrl($block->getViewFileUrl('Magento_Checkout::cvv.png')) . '\" alt=\"' .
-    $block->escapeHtml(__('Card Verification Number Visual Reference')) . '\" title=\"' .
-    $block->escapeHtml(__('Card Verification Number Visual Reference')) . '\" />';
+$content = '<img src=\"' . $escaper->escapeUrl($block->getViewFileUrl('Magento_Checkout::cvv.png')) . '\" alt=\"' .
+    $escaper->escapeHtml(__('Card Verification Number Visual Reference')) . '\" title=\"' .
+    $escaper->escapeHtml(__('Card Verification Number Visual Reference')) . '\" />';
 ?>
 
 <!-- IFRAME for request to Payment Gateway -->
 <iframe width="0" height="0" id="<?= /* @noEscape */ $code ?>-transparent-iframe"
         data-container="<?= /* @noEscape */ $code ?>-transparent-iframe" allowtransparency="true"
         frameborder="0"  name="iframeTransparent"
-        src="<?= $block->escapeUrl($block->getViewFileUrl('blank.html')) ?>"></iframe>
+        src="<?= $escaper->escapeUrl($block->getViewFileUrl('blank.html')) ?>"></iframe>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
     "display: none; width: 100%; background-color: transparent;",
     'iframe#' . /* @noEscape */ $code . '-transparent-iframe'
 ) ?>
 <form class="form" id="co-transparent-form" action="#" method="post" data-mage-init='{
     "transparent":{
-        "controller":"<?= $block->escapeHtml($block->getRequest()->getControllerName()) ?>",
+        "controller":"<?= $escaper->escapeHtml($block->getRequest()->getControllerName()) ?>",
         "gateway":"<?= /* @noEscape */ $code ?>",
-        "orderSaveUrl":"<?= $block->escapeUrl($block->getOrderUrl()) ?>",
-        "cgiUrl":"<?= $block->escapeUrl($block->getCgiUrl()) ?>",
-        "dateDelim":"<?= $block->escapeHtml($block->getDateDelim()) ?>",
-        "cardFieldsMap":<?= $block->escapeHtml($block->getCardFieldsMap()) ?>,
-        "nativeAction":"<?= $block->escapeUrl(
+        "orderSaveUrl":"<?= $escaper->escapeUrl($block->getOrderUrl()) ?>",
+        "cgiUrl":"<?= $escaper->escapeUrl($block->getCgiUrl()) ?>",
+        "dateDelim":"<?= $escaper->escapeHtml($block->getDateDelim()) ?>",
+        "cardFieldsMap":<?= $escaper->escapeHtml($block->getCardFieldsMap()) ?>,
+        "nativeAction":"<?= $escaper->escapeUrl(
             $block->getUrl('checkout/onepage/saveOrder', ['_secure' => $block->getRequest()->isSecure()])
         ) ?>"
     }, "validation":[]}'>
     <fieldset class="fieldset ccard <?= /* @noEscape */ $code ?>" id="payment_form_<?= /* @noEscape */ $code ?>">
         <legend class="legend">
-            <span><?= $block->escapeHtml(__('Credit Card Information')) ?></span>\
+            <span><?= $escaper->escapeHtml(__('Credit Card Information')) ?></span>\
         </legend><br />
         <div class="field required type">
             <label for="<?= /* @noEscape */ $code ?>_cc_type" class="label">
-                <span><?= $block->escapeHtml(__('Credit Card Type')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Credit Card Type')) ?></span>
             </label>
             <div class="control">
                 <select id="<?= /* @noEscape */ $code ?>_cc_type" data-container="<?= /* @noEscape */ $code ?>-cc-type"
@@ -52,23 +55,23 @@ $content = '<img src=\"' . $block->escapeUrl($block->getViewFileUrl('Magento_Che
                             required:true,
                             "validate-cc-type-select":"#<?= /* @noEscape */ $code ?>_cc_number"
                         }'>
-                    <option value=""><?= $block->escapeHtml(__('--Please Select--')) ?></option>
+                    <option value=""><?= $escaper->escapeHtml(__('--Please Select--')) ?></option>
                 <?php foreach ($block->getCcAvailableTypes() as $typeCode => $typeName): ?>
-                    <option value="<?= $block->escapeHtml($typeCode) ?>"
+                    <option value="<?= $escaper->escapeHtml($typeCode) ?>"
                         <?php if ($typeCode == $ccType): ?> selected="selected"<?php endif; ?>>
-                        <?= $block->escapeHtml($typeName) ?></option>
+                        <?= $escaper->escapeHtml($typeName) ?></option>
                 <?php endforeach ?>
                 </select>
             </div>
         </div>
         <div class="field required number">
             <label for="<?= /* @noEscape */ $code ?>_cc_number" class="label">
-                <span><?= $block->escapeHtml(__('Credit Card Number')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Credit Card Number')) ?></span>
             </label>
             <div class="control">
                 <input type="number" id="<?= /* @noEscape */ $code ?>_cc_number"
                        data-container="<?= /* @noEscape */ $code ?>-cc-number" name="payment[cc_number]"
-                       title="<?= $block->escapeHtml(__('Credit Card Number')) ?>" class="input-text" value=""
+                       title="<?= $escaper->escapeHtml(__('Credit Card Number')) ?>" class="input-text" value=""
                        data-validate='{
                            "required-number":true,
                            "validate-cc-number":"#<?= /* @noEscape */ $code ?>_cc_type",
@@ -79,7 +82,7 @@ $content = '<img src=\"' . $block->escapeUrl($block->getViewFileUrl('Magento_Che
         </div>
         <div class="field required date" id="<?= /* @noEscape */ $code ?>_cc_type_exp_div">
             <label for="<?= /* @noEscape */ $code ?>_expiration" class="label">
-                <span><?= $block->escapeHtml(__('Expiration Date')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Expiration Date')) ?></span>
             </label>
             <div class="control">
                 <div class="fields group group-2">
@@ -92,9 +95,9 @@ $content = '<img src=\"' . $block->escapeUrl($block->getViewFileUrl('Magento_Che
                                         "validate-cc-exp":"#<?= /* @noEscape */ $code ?>_expiration_yr"
                                     }'>
                             <?php foreach ($block->getCcMonths() as $k => $v): ?>
-                                <option value="<?= /* @noEscape */ $k ? $block->escapeHtml($k) : '' ?>"
+                                <option value="<?= /* @noEscape */ $k ? $escaper->escapeHtml($k) : '' ?>"
                                     <?php if ($k == $ccExpMonth): ?> selected="selected"<?php endif; ?>>
-                                    <?= $block->escapeHtml($v) ?>
+                                    <?= $escaper->escapeHtml($v) ?>
                                 </option>
                             <?php endforeach ?>
                             </select>
@@ -106,9 +109,9 @@ $content = '<img src=\"' . $block->escapeUrl($block->getViewFileUrl('Magento_Che
                                     class="year" data-container="<?= /* @noEscape */ $code ?>-cc-year"
                                     data-validate='{required:true}'>
                             <?php foreach ($block->getCcYears() as $k => $v): ?>
-                                <option value="<?= /* @noEscape */ $k ? $block->escapeHtml($k) : '' ?>"
+                                <option value="<?= /* @noEscape */ $k ? $escaper->escapeHtml($k) : '' ?>"
                                     <?php if ($k == $ccExpYear): ?> selected="selected"<?php endif; ?>>
-                                    <?= $block->escapeHtml($v) ?>
+                                    <?= $escaper->escapeHtml($v) ?>
                                 </option>
                             <?php endforeach ?>
                             </select>
@@ -120,10 +123,10 @@ $content = '<img src=\"' . $block->escapeUrl($block->getViewFileUrl('Magento_Che
         <?php if ($block->hasVerification()): ?>
         <div class="field required cvv" id="<?= /* @noEscape */ $code ?>_cc_type_cvv_div">
             <label for="<?= /* @noEscape */ $code ?>_cc_cid" class="label">
-                <span><?= $block->escapeHtml(__('Card Verification Number')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Card Verification Number')) ?></span>
             </label>
             <div class="control">
-                <input type="number" title="<?= $block->escapeHtml(__('Card Verification Number')) ?>"
+                <input type="number" title="<?= $escaper->escapeHtml(__('Card Verification Number')) ?>"
                        data-container="<?= /* @noEscape */ $code ?>-cc-cvv" class="input-text cvv"
                        id="<?= /* @noEscape */ $code ?>_cc_cid" name="payment[cc_cid]" value=""
                        data-validate='{
@@ -132,10 +135,10 @@ $content = '<img src=\"' . $block->escapeUrl($block->getViewFileUrl('Magento_Che
                        }' autocomplete="off"/>
                 <div class="note">
                     <a href="#" id="<?= /* @noEscape */ $code ?>-cvv-what-is-this" class="action cvv"
-                       title="<?= $block->escapeHtml(__('What is this?')) ?>" data-mage-init='{
+                       title="<?= $escaper->escapeHtml(__('What is this?')) ?>" data-mage-init='{
                            "tooltip": {"content": "<?= /* @noEscape */ $content ?>"}
                        }'>
-                        <span><?= $block->escapeHtml(__('What is this?')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('What is this?')) ?></span>
                     </a>
                 </div>
             </div>

--- a/app/code/Magento/Payment/view/frontend/templates/transparent/iframe.phtml
+++ b/app/code/Magento/Payment/view/frontend/templates/transparent/iframe.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Payment\Block\Transparent\Iframe $block */
+/**
+ * @var \Magento\Payment\Block\Transparent\Iframe $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
 $params = $block->getParams();
@@ -14,7 +17,7 @@ $params = $block->getParams();
         <?php $scriptString = '' ?>
         <?php if (isset($params['redirect'])): ?>
             <?php $scriptString .= <<<script
-            window.location="{$block->escapeJs($params['redirect'])}";
+            window.location="{$escaper->escapeJs($params['redirect'])}";
 script;
             ?>
         <?php elseif (isset($params['redirect_parent'])): ?>
@@ -27,7 +30,7 @@ script;
                 function($) {
                     var parent = window.parent;
                     $(parent).trigger('clearTimeout');
-                    parent.location="{$block->escapeJs($params['redirect_parent'])}";
+                    parent.location="{$escaper->escapeJs($params['redirect_parent'])}";
                 }
             );
 script;
@@ -72,7 +75,7 @@ script;
             ?>
         <?php elseif (isset($params['order_success'])): ?>
             <?php $scriptString .= <<<script
-            window.parent.location = "{$block->escapeJs($params['order_success'])}";
+            window.parent.location = "{$escaper->escapeJs($params['order_success'])}";
 script;
             ?>
         <?php else: ?>

--- a/app/code/Magento/Payment/view/frontend/templates/transparent/info.phtml
+++ b/app/code/Magento/Payment/view/frontend/templates/transparent/info.phtml
@@ -6,16 +6,17 @@
 
 /**
  * @var \Magento\Payment\Block\Transparent\Info $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  * @see \Magento\Payment\Block\Transparent\Info
  */
 ?>
-<fieldset id="payment_form_<?= $block->escapeHtml($block->getMethodCode()) ?>" class="fieldset items redirect">
+<fieldset id="payment_form_<?= $escaper->escapeHtml($block->getMethodCode()) ?>" class="fieldset items redirect">
     <div>
-        <?= $block->escapeHtml(__('We\'ll ask for your payment details before you place an order.')) ?>
+        <?= $escaper->escapeHtml(__('We\'ll ask for your payment details before you place an order.')) ?>
     </div>
 </fieldset>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
     "display:none",
-    'fieldset#payment_form_' . $block->escapeHtml($block->getMethodCode())
+    'fieldset#payment_form_' . $escaper->escapeHtml($block->getMethodCode())
 ) ?>

--- a/app/code/Magento/Payment/view/frontend/templates/transparent/redirect.phtml
+++ b/app/code/Magento/Payment/view/frontend/templates/transparent/redirect.phtml
@@ -4,17 +4,20 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Payment\Block\Transparent\Redirect $block */
+/**
+ * @var \Magento\Payment\Block\Transparent\Redirect $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 $params = $block->getPostParams();
 $redirectUrl = $block->getRedirectUrl();
 ?>
 <html>
 <head></head>
 <body onload="document.forms['proxy_form'].submit()">
-<form id="proxy_form" action="<?= $block->escapeUrl($redirectUrl) ?>"
+<form id="proxy_form" action="<?= $escaper->escapeUrl($redirectUrl) ?>"
       method="POST" hidden enctype="application/x-www-form-urlencoded" class="no-display">
     <?php foreach ($params as $name => $value):?>
-        <input value="<?= $block->escapeHtmlAttr($value) ?>" name="<?= $block->escapeHtmlAttr($name) ?>" type="hidden"/>
+        <input value="<?= $escaper->escapeHtmlAttr($value) ?>" name="<?= $escaper->escapeHtmlAttr($name) ?>" type="hidden"/>
     <?php endforeach?>
 </form>
 </body>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
