### PR TITLE
Magento_Newsletter: avoid using deprecated escape* methods from Abstr…

### DIFF
--- a/app/code/Magento/Newsletter/Block/Adminhtml/Template/Grid/Renderer/Sender.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Template/Grid/Renderer/Sender.php
@@ -26,15 +26,15 @@ class Sender extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Abstract
     {
         $str = '';
         if ($row->getTemplateSenderName()) {
-            $str .= $this->escapeHtml($row->getTemplateSenderName()) . ' ';
+            $str .= $this->_escaper->escapeHtml($row->getTemplateSenderName()) . ' ';
         }
         if ($row->getTemplateSenderEmail()) {
-            $str .= '[' . $this->escapeHtml($row->getTemplateSenderEmail()) . ']';
+            $str .= '[' . $this->_escaper->escapeHtml($row->getTemplateSenderEmail()) . ']';
         }
         if ($str == '') {
             $str .= '---';
         }
-        
+
         return $str;
     }
 }

--- a/app/code/Magento/Newsletter/Block/Adminhtml/Template/Preview.php
+++ b/app/code/Magento/Newsletter/Block/Adminhtml/Template/Preview.php
@@ -85,7 +85,7 @@ class Preview extends \Magento\Backend\Block\Widget
         $template->revertDesign();
 
         if ($template->isPlain()) {
-            $templateProcessed = "<pre>" . $this->escapeHtml($templateProcessed) . "</pre>";
+            $templateProcessed = "<pre>" . $this->_escaper->escapeHtml($templateProcessed) . "</pre>";
         }
 
         \Magento\Framework\Profiler::stop($this->profilerName);

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/preview/iframeswitcher.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/preview/iframeswitcher.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Backend\Block\Page $block */
+/**
+ * @var \Magento\Backend\Block\Page $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div id="preview" class="cms-revision-preview">
@@ -20,7 +23,7 @@
         id="preview_iframe"
         class="preview_iframe"
         frameborder="0"
-        title="<?= $block->escapeHtmlAttr(__('Preview')) ?>"
+        title="<?= $escaper->escapeHtmlAttr(__('Preview')) ?>"
         width="100%"
         sandbox="allow-forms allow-pointer-lock allow-same-origin"
     >

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/preview/store.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/preview/store.phtml
@@ -4,12 +4,15 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 
 <?php if ($websites = $block->getWebsites()): ?>
 <div class="field field-store-switcher">
-    <label class="label" for="store_switcher"><?= $block->escapeHtml(__('Choose Store View:')) ?></label>
+    <label class="label" for="store_switcher"><?= $escaper->escapeHtml(__('Choose Store View:')) ?></label>
     <div class="control">
         <select
             id="store_switcher"
@@ -22,15 +25,15 @@
                     <?php foreach ($block->getStores($group) as $store): ?>
                         <?php if ($showWebsite == false): ?>
                             <?php $showWebsite = true; ?>
-                            <optgroup label="<?= $block->escapeHtmlAttr($website->getName()) ?>"></optgroup>
+                            <optgroup label="<?= $escaper->escapeHtmlAttr($website->getName()) ?>"></optgroup>
                         <?php endif; ?>
                         <?php if ($showGroup == false): ?>
                             <?php $showGroup = true; ?>
-                            <optgroup label="&nbsp;&nbsp;&nbsp;<?= $block->escapeHtmlAttr($group->getName()) ?>">
+                            <optgroup label="&nbsp;&nbsp;&nbsp;<?= $escaper->escapeHtmlAttr($group->getName()) ?>">
                         <?php endif; ?>
-                        <option value="<?= $block->escapeHtmlAttr($store->getId()) ?>"
+                        <option value="<?= $escaper->escapeHtmlAttr($store->getId()) ?>"
                             <?php if ($block->getStoreId() == $store->getId()): ?> selected="selected"<?php endif; ?>>
-                            &nbsp;&nbsp;&nbsp;&nbsp;<?= $block->escapeHtml($store->getName()) ?>
+                            &nbsp;&nbsp;&nbsp;&nbsp;<?= $escaper->escapeHtml($store->getName()) ?>
                         </option>
                     <?php endforeach; ?>
                     <?php if ($showGroup): ?>

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/queue/edit.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/queue/edit.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Newsletter\Block\Adminhtml\Queue\Edit */
+/**
+ * @var $block \Magento\Newsletter\Block\Adminhtml\Queue\Edit
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions">
@@ -19,11 +22,11 @@
     <?php endif ?>
 </div>
 
-<form action="<?= $block->escapeUrl($block->getSaveUrl()) ?>" method="post" id="queue_edit_form">
+<form action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>" method="post" id="queue_edit_form">
     <?= $block->getBlockHtml('formkey') ?>
     <?= $block->getChildHtml('form') ?>
 </form>
-<form action="<?= $block->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="newsletter_queue_preview_form"
+<form action="<?= $escaper->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="newsletter_queue_preview_form"
       target="_blank">
     <?= $block->getBlockHtml('formkey') ?>
     <div class="no-display">

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/queue/preview.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/queue/preview.phtml
@@ -4,13 +4,16 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Element\Template $block
+ */
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <title><?= $block->escapeHtml(__('Newsletter Message Preview')) ?></title>
+    <title><?= $escaper->escapeHtml(__('Newsletter Message Preview')) ?></title>
 </head>
 <body>
     <?= $block->getChildHtml('content') ?>

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/subscriber/list.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/subscriber/list.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Newsletter\Block\Adminhtml\Subscriber $block */
+/**
+ * @var \Magento\Newsletter\Block\Adminhtml\Subscriber $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?= $block->getChildHtml('grid') ?>
@@ -12,13 +15,13 @@
 <div class="form-buttons">
     <select id="queueList" name="queue">
     <?php foreach ($block->getQueueAsOptions() as $_queue): ?>
-        <option value="<?= $block->escapeHtmlAttr($_queue['value']) ?>">
-            <?= $block->escapeHtml($_queue['label']) ?> #<?= $block->escapeHtml($_queue['value']) ?>
+        <option value="<?= $escaper->escapeHtmlAttr($_queue['value']) ?>">
+            <?= $escaper->escapeHtml($_queue['label']) ?> #<?= $escaper->escapeHtml($_queue['value']) ?>
         </option>
     <?php endforeach; ?>
     </select>
     <button type="button" class="scalable" id="addToQueue">
-        <span><span><span><?= $block->escapeHtml(__('Add to Queue')) ?></span></span></span>
+        <span><span><span><?= $escaper->escapeHtml(__('Add to Queue')) ?></span></span></span>
     </button>
     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
         'onclick',

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/template/edit.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/template/edit.phtml
@@ -6,27 +6,30 @@
 
 use Magento\Framework\App\TemplateTypesInterface;
 
-/* @var $block \Magento\Newsletter\Block\Adminhtml\Template\Edit */
+/**
+ * @var $block \Magento\Newsletter\Block\Adminhtml\Template\Edit
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
 ?>
-<form action="<?= $block->escapeUrl($block->getSaveUrl()) ?>" method="post" id="newsletter_template_edit_form">
+<form action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>" method="post" id="newsletter_template_edit_form">
     <?= $block->getBlockHtml('formkey') ?>
     <div class="no-display">
         <input type="hidden" id="change_flag_element" name="_change_type_flag" value="" />
         <input type="hidden" id="save_as_flag" name="_save_as_flag"
-               value="<?= $block->escapeHtmlAttr($block->getSaveAsFlag()) ?>" />
+               value="<?= $escaper->escapeHtmlAttr($block->getSaveAsFlag()) ?>" />
     </div>
     <?= /* @noEscape */ $block->getForm() ?>
 </form>
-<form action="<?= $block->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="newsletter_template_preview_form"
+<form action="<?= $escaper->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="newsletter_template_preview_form"
       target="_blank">
     <div class="no-display">
         <input type="hidden" id="preview_type" name="type" value="<?= /* @noEscape */ $block->isTextType() ? 1 : 2 ?>"/>
         <input type="hidden" id="preview_text" name="text" value="" />
         <input type="hidden" id="preview_styles" name="styles" value="" />
         <input type="hidden" id="preview_id" name="id" value="" />
-        <input type="hidden" name="form_key" value="<?= $block->escapeHtmlAttr($block->getFormKey()) ?>" >
+        <input type="hidden" name="form_key" value="<?= $escaper->escapeHtmlAttr($block->getFormKey()) ?>" >
     </div>
 </form>
 <?php $scriptString = <<<script
@@ -94,7 +97,7 @@ require([
             var self = this;
 
             confirm({
-                content: "{$block->escapeJs(__('Are you sure that you want to strip all tags?'))}",
+                content: "{$escaper->escapeJs(__('Are you sure that you want to strip all tags?'))}",
                 actions: {
                     confirm: function () {
                         if (wysiwyg.activeEditor()) {
@@ -145,8 +148,8 @@ require([
 
             if (\$F('code').blank() || \$F('code') == templateControl.templateName) {
                 prompt({
-                    content: '{$block->escapeJs(__('Please enter a new template name.'))}',
-                    value: templateControl.templateName + '{$block->escapeJs(__(' Copy'))}',
+                    content: '{$escaper->escapeJs(__('Please enter a new template name.'))}',
+                    value: templateControl.templateName + '{$escaper->escapeJs(__(' Copy'))}',
                     actions: {
                         confirm: function (value) {
                             $('code').value = value;
@@ -177,9 +180,9 @@ require([
 
         preview: function () {
             if (this.typeChange) {
-                $('preview_type').value = {$block->escapeJs(TemplateTypesInterface::TYPE_TEXT)};
+                $('preview_type').value = {$escaper->escapeJs(TemplateTypesInterface::TYPE_TEXT)};
             } else {
-                $('preview_type').value = {$block->escapeJs($block->getTemplateType())};
+                $('preview_type').value = {$escaper->escapeJs($block->getTemplateType())};
             }
 
             if (wysiwyg.activeEditor()) {
@@ -203,10 +206,10 @@ require([
 
         deleteTemplate: function () {
             confirm({
-                content: "{$block->escapeJs(__('Are you sure you want to delete this template?'))}",
+                content: "{$escaper->escapeJs(__('Are you sure you want to delete this template?'))}",
                 actions: {
                     confirm: function () {
-                        window.location.href = '{$block->escapeJs($block->getDeleteUrl())}';
+                        window.location.href = '{$escaper->escapeJs($block->getDeleteUrl())}';
                     }
                 }
             });
@@ -214,7 +217,7 @@ require([
     };
 
     templateControl.init();
-    templateControl.templateName = "{$block->escapeJs($block->getJsTemplateName())}";
+    templateControl.templateName = "{$escaper->escapeJs($block->getJsTemplateName())}";
 //]]>
 
 });

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/template/preview.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/template/preview.phtml
@@ -4,13 +4,16 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <title><?= $block->escapeHtml(__('Newsletter Message Preview')) ?></title>
+    <title><?= $escaper->escapeHtml(__('Newsletter Message Preview')) ?></title>
 </head>
 <body>
     <?= $block->getChildHtml('content') ?>

--- a/app/code/Magento/Newsletter/view/frontend/templates/messages/localizedSubscriptionErrorMessage.phtml
+++ b/app/code/Magento/Newsletter/view/frontend/templates/messages/localizedSubscriptionErrorMessage.phtml
@@ -4,6 +4,9 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<?= $block->escapeHtml(__($block->getData('message')), ['a']); ?>
+<?= $escaper->escapeHtml(__($block->getData('message')), ['a']); ?>

--- a/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
+++ b/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
@@ -4,14 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Newsletter\Block\Subscribe $block */
+/**
+ * @var \Magento\Newsletter\Block\Subscribe $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="block newsletter">
-    <div class="title"><strong><?= $block->escapeHtml(__('Newsletter')) ?></strong></div>
+    <div class="title"><strong><?= $escaper->escapeHtml(__('Newsletter')) ?></strong></div>
     <div class="content">
         <form class="form subscribe"
             novalidate
-            action="<?= $block->escapeUrl($block->getFormActionUrl()) ?>"
+            action="<?= $escaper->escapeUrl($block->getFormActionUrl()) ?>"
             method="post"
             data-mage-init='{"validation": {"errorClass": "mage-error"}}'
             id="newsletter-validate-detail">
@@ -19,10 +22,10 @@
                 <div class="control">
                     <label for="newsletter">
                         <span class="label">
-                            <?= $block->escapeHtml(__('Sign Up for Our Newsletter:')) ?>
+                            <?= $escaper->escapeHtml(__('Sign Up for Our Newsletter:')) ?>
                         </span>
                         <input name="email" type="email" id="newsletter"
-                               placeholder="<?= $block->escapeHtml(__('Enter your email address')) ?>"
+                               placeholder="<?= $escaper->escapeHtml(__('Enter your email address')) ?>"
                                data-mage-init='{"mage/trim-input":{}}'
                                data-validate="{required:true, 'validate-email':true}"
                         />
@@ -31,10 +34,10 @@
             </div>
             <div class="actions">
                 <button class="action subscribe primary"
-                        title="<?= $block->escapeHtmlAttr(__('Subscribe')) ?>"
+                        title="<?= $escaper->escapeHtmlAttr(__('Subscribe')) ?>"
                         type="submit"
                         aria-label="Subscribe">
-                    <span><?= $block->escapeHtml(__('Subscribe')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Subscribe')) ?></span>
                 </button>
             </div>
         </form>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
