### PR TITLE
Magento_LayeredNavigation: avoid using deprecated escape* methods fro…

### DIFF
--- a/app/code/Magento/LayeredNavigation/view/frontend/templates/layer/state.phtml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/templates/layer/state.phtml
@@ -9,6 +9,7 @@
  * Category layered navigation state
  *
  * @var $block \Magento\LayeredNavigation\Block\Navigation\State
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <?php $_filters = $block->getActiveFilters() ?>
@@ -17,30 +18,30 @@
     <strong class="block-subtitle filter-current-subtitle"
             role="heading"
             aria-level="2"
-            data-count="<?= /* @noEscape */ count($_filters) ?>"><?= $block->escapeHtml(__('Now Shopping by')) ?></strong>
+            data-count="<?= /* @noEscape */ count($_filters) ?>"><?= $escaper->escapeHtml(__('Now Shopping by')) ?></strong>
     <ol class="items">
         <?php foreach ($_filters as $_filter) : ?>
             <li class="item">
-                <span class="filter-label"><?= $block->escapeHtml(__($_filter->getName())) ?></span>
-                <span class="filter-value"><?= $block->escapeHtml($block->stripTags($_filter->getLabel())) ?></span>
+                <span class="filter-label"><?= $escaper->escapeHtml(__($_filter->getName())) ?></span>
+                <span class="filter-value"><?= $escaper->escapeHtml($block->stripTags($_filter->getLabel())) ?></span>
                 <?php
                 $clearLinkUrl = $_filter->getClearLinkUrl();
-                $currentFilterName = $block->escapeHtmlAttr(__($_filter->getName()) . " " . $block->stripTags($_filter->getLabel()));
+                $currentFilterName = $escaper->escapeHtmlAttr(__($_filter->getName()) . " " . $block->stripTags($_filter->getLabel()));
                 if ($clearLinkUrl) :
                     ?>
-                    <a class="action previous" href="<?= $block->escapeUrl($_filter->getRemoveUrl()) ?>"
-                       title="<?= $block->escapeHtmlAttr(__('Previous')) ?>">
-                        <span><?= $block->escapeHtml(__('Previous')) ?></span>
+                    <a class="action previous" href="<?= $escaper->escapeUrl($_filter->getRemoveUrl()) ?>"
+                       title="<?= $escaper->escapeHtmlAttr(__('Previous')) ?>">
+                        <span><?= $escaper->escapeHtml(__('Previous')) ?></span>
                     </a>
                     <a class="action remove"
-                       title="<?= $block->escapeHtmlAttr($_filter->getFilter()->getClearLinkText()) ?>"
-                       href="<?= $block->escapeUrl($clearLinkUrl) ?>">
-                        <span><?= $block->escapeHtml($_filter->getFilter()->getClearLinkText()) ?></span>
+                       title="<?= $escaper->escapeHtmlAttr($_filter->getFilter()->getClearLinkText()) ?>"
+                       href="<?= $escaper->escapeUrl($clearLinkUrl) ?>">
+                        <span><?= $escaper->escapeHtml($_filter->getFilter()->getClearLinkText()) ?></span>
                     </a>
                 <?php else : ?>
-                    <a class="action remove" href="<?= $block->escapeUrl($_filter->getRemoveUrl()) ?>"
-                       title="<?= /* @noEscape */ $block->escapeHtmlAttr(__('Remove')) . " " . $currentFilterName ?>">
-                        <span><?= $block->escapeHtml(__('Remove This Item')) ?></span>
+                    <a class="action remove" href="<?= $escaper->escapeUrl($_filter->getRemoveUrl()) ?>"
+                       title="<?= /* @noEscape */ $escaper->escapeHtmlAttr(__('Remove')) . " " . $currentFilterName ?>">
+                        <span><?= $escaper->escapeHtml(__('Remove This Item')) ?></span>
                     </a>
                 <?php endif; ?>
             </li>

--- a/app/code/Magento/LayeredNavigation/view/frontend/templates/layer/view.phtml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/templates/layer/view.phtml
@@ -9,13 +9,14 @@
  * Category layered navigation
  *
  * @var $block \Magento\LayeredNavigation\Block\Navigation
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 
 <?php if ($block->canShowBlock()) : ?>
     <div class="block filter">
         <div class="block-title filter-title">
-            <strong><?= $block->escapeHtml(__('Shop By')) ?></strong>
+            <strong><?= $escaper->escapeHtml(__('Shop By')) ?></strong>
         </div>
 
         <div class="block-content filter-content">
@@ -23,18 +24,18 @@
 
             <?php if ($block->getLayer()->getState()->getFilters()) : ?>
                 <div class="block-actions filter-actions">
-                    <a href="<?= $block->escapeUrl($block->getClearUrl()) ?>" class="action clear filter-clear"><span><?= $block->escapeHtml(__('Clear All')) ?></span></a>
+                    <a href="<?= $escaper->escapeUrl($block->getClearUrl()) ?>" class="action clear filter-clear"><span><?= $escaper->escapeHtml(__('Clear All')) ?></span></a>
                 </div>
             <?php endif; ?>
             <?php $wrapOptions = false; ?>
             <?php foreach ($block->getFilters() as $filter) : ?>
                 <?php if (!$wrapOptions) : ?>
-                    <strong role="heading" aria-level="2" class="block-subtitle filter-subtitle"><?= $block->escapeHtml(__('Shopping Options')) ?></strong>
+                    <strong role="heading" aria-level="2" class="block-subtitle filter-subtitle"><?= $escaper->escapeHtml(__('Shopping Options')) ?></strong>
                     <dl class="filter-options" id="narrow-by-list">
                     <?php $wrapOptions = true;
                 endif; ?>
                     <?php if ($filter->getItemsCount()) : ?>
-                        <dt role="heading" aria-level="3" class="filter-options-title"><?= $block->escapeHtml(__($filter->getName())) ?></dt>
+                        <dt role="heading" aria-level="3" class="filter-options-title"><?= $escaper->escapeHtml(__($filter->getName())) ?></dt>
                         <dd class="filter-options-content"><?= /* @noEscape */ $block->getChildBlock('renderer')->render($filter) ?></dd>
                     <?php endif; ?>
             <?php endforeach; ?>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
