### PR TITLE
Magento_Integration: avoid using deprecated escape* methods from Abst…

### DIFF
--- a/app/code/Magento/Integration/Block/Adminhtml/Integration/Edit.php
+++ b/app/code/Magento/Integration/Block/Adminhtml/Integration/Edit.php
@@ -109,7 +109,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
         } else {
             return __(
                 "Edit Integration '%1'",
-                $this->escapeHtml(
+                $this->_escaper->escapeHtml(
                     $this->_registry->registry(Integration::REGISTRY_KEY_CURRENT_INTEGRATION)[Info::DATA_NAME]
                 )
             );

--- a/app/code/Magento/Integration/Block/Adminhtml/Widget/Grid/Column/Renderer/Button.php
+++ b/app/code/Magento/Integration/Block/Adminhtml/Widget/Grid/Column/Renderer/Button.php
@@ -144,7 +144,7 @@ class Button extends AbstractRenderer
             $attributes[] = sprintf(
                 '%s="%s"',
                 $attributeName,
-                $this->escapeHtmlAttr($attributeValue, false)
+                $this->_escaper->escapeHtmlAttr($attributeValue, false)
             );
         }
 
@@ -165,7 +165,7 @@ class Button extends AbstractRenderer
                 //Will render event handlers and style as separate tags
                 continue;
             }
-            $html .= ($html ? ' ' : '') ."{$attributeName}=\"{$this->escapeHtmlAttr($attributeValue)}\"";
+            $html .= ($html ? ' ' : '') ."{$attributeName}=\"{$this->_escaper->escapeHtmlAttr($attributeValue)}\"";
         }
 
         return $html;

--- a/app/code/Magento/Integration/Block/Adminhtml/Widget/Grid/Column/Renderer/Link.php
+++ b/app/code/Magento/Integration/Block/Adminhtml/Widget/Grid/Column/Renderer/Link.php
@@ -121,7 +121,7 @@ class Link extends AbstractRenderer
             if ($value === null || $value == '') {
                 continue;
             }
-            $html[] = sprintf('%s="%s"', $key, $this->escapeHtmlAttr($value, false));
+            $html[] = sprintf('%s="%s"', $key, $this->_escaper->escapeHtmlAttr($value, false));
         }
 
         return join(' ', $html);

--- a/app/code/Magento/Integration/view/adminhtml/templates/integration/activate/permissions.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/integration/activate/permissions.phtml
@@ -6,9 +6,10 @@
  * See COPYING.txt for license details.
  *
  * @var \Magento\Backend\Block\Widget\Form\Container $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
-<div><p><?= $block->escapeHtml(__('The integration you selected asks you to approve access to the following:')) ?></p></div>
+<div><p><?= $escaper->escapeHtml(__('The integration you selected asks you to approve access to the following:')) ?></p></div>
 <div id="integration-activate-permissions-tabs">
     <?= $block->getChildHtml('tabs') ?>
 </div>

--- a/app/code/Magento/Integration/view/adminhtml/templates/integration/activate/permissions/tab/webapi.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/integration/activate/permissions/tab/webapi.phtml
@@ -6,13 +6,14 @@
  * See COPYING.txt for license details.
  *
  * @var \Magento\Integration\Block\Adminhtml\Integration\Activate\Permissions\Tab\Webapi $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <fieldset class="admin__fieldset form-inline entry-edit">
     <?php if ($block->isTreeEmpty()): ?>
-        <p class="empty"><?= $block->escapeHtml(__('No permissions requested')) ?></p>
+        <p class="empty"><?= $escaper->escapeHtml(__('No permissions requested')) ?></p>
     <?php else: ?>
         <div class="field" data-role="tree-resources-container">
             <div class="control">

--- a/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
@@ -6,10 +6,9 @@
  * See COPYING.txt for license details.
  *
  * @var \Magento\Backend\Block\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
-
-/** @var \Magento\Backend\Block\Template $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $scriptString = <<<script
@@ -22,30 +21,30 @@
     ], function ($, Confirm) {
 
         window.integration = new Integration(
-            '{$block->escapeJs(
+            '{$escaper->escapeJs(
                 $block->getUrl(
                     '*/*/permissionsDialog',
                     ['id' => ':id', 'reauthorize' => ':isReauthorize', '_escape_params' => false]
                 )
             )}',
-            '{$block->escapeJs(
+            '{$escaper->escapeJs(
                 $block->getUrl(
                     '*/*/tokensDialog',
                     ['id' => ':id', 'reauthorize' => ':isReauthorize', '_escape_params' => false]
                 )
             )}',
-            '{$block->escapeJs(
+            '{$escaper->escapeJs(
                 $block->getUrl(
                     '*/*/tokensExchange',
                     ['id' => ':id', 'reauthorize' => ':isReauthorize', '_escape_params' => false]
                 )
             )}',
-            '{$block->escapeJs(
+            '{$escaper->escapeJs(
                 $block->getUrl(
                     '*/*'
                 )
             )}',
-            '{$block->escapeJs(
+            '{$escaper->escapeJs(
                 $block->getUrl(
                     '*/*/loginSuccessCallback'
                 )
@@ -59,8 +58,8 @@
             $('div#integrationGrid').on('click', 'button#delete', function (e) {
 
                 new Confirm({
-                    title: '{$block->escapeJs(__('Are you sure?'))}',
-                    content: "{$block->escapeJs(__("Are you sure you want to delete this integration? " .
+                    title: '{$escaper->escapeJs(__('Are you sure?'))}',
+                    content: "{$escaper->escapeJs(__("Are you sure you want to delete this integration? " .
                                                      "You can't undo this action."))}",
                     actions: {
                         confirm: function () {

--- a/app/code/Magento/Integration/view/adminhtml/templates/integration/tokens_exchange.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/integration/tokens_exchange.phtml
@@ -6,6 +6,7 @@
  * See COPYING.txt for license details.
  *
  * @var \Magento\Backend\Block\Template $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
-<div><p><?= $block->escapeHtml(__("Please setup or sign in into your 3rd party account to complete setup of this integration.")) ?></p></div>
+<div><p><?= $escaper->escapeHtml(__("Please setup or sign in into your 3rd party account to complete setup of this integration.")) ?></p></div>

--- a/app/code/Magento/Integration/view/adminhtml/templates/resourcetree.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/resourcetree.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Webapi */
+/**
+ * @var $block \Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Webapi
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 
@@ -12,19 +15,19 @@
 
 <fieldset class="fieldset form-inline entry-edit">
     <legend class="legend">
-        <span><?= $block->escapeHtml(__('Available APIs')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Available APIs')) ?></span>
     </legend><br />
 
     <div class="field">
-        <label class="label" for="all_resources"><span><?= $block->escapeHtml(__('Resource Access')) ?></span></label>
+        <label class="label" for="all_resources"><span><?= $escaper->escapeHtml(__('Resource Access')) ?></span></label>
 
         <div class="control">
             <select id="all_resources" name="all_resources" class="select">
                 <option value="0" <?= ($block->isEverythingAllowed() ? '' : 'selected="selected"') ?>>
-                    <?= $block->escapeHtml(__('Custom')) ?>
+                    <?= $escaper->escapeHtml(__('Custom')) ?>
                 </option>
                 <option value="1" <?= ($block->isEverythingAllowed() ? 'selected="selected"' : '') ?>>
-                    <?= $block->escapeHtml(__('All')) ?>
+                    <?= $escaper->escapeHtml(__('All')) ?>
                 </option>
             </select>
             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
@@ -40,11 +43,11 @@
             no-display
         <?php endif ?>"
          data-role="tree-resources-container">
-        <label class="label"><span><?= $block->escapeHtml(__('Resources')) ?></span></label>
+        <label class="label"><span><?= $escaper->escapeHtml(__('Resources')) ?></span></label>
 
         <div class="control">
             <div class="tree x-tree" data-role="resource-tree" data-mage-init='<?=
-                $block->escapeHtmlAttr($block->getJsonSerializer()->serialize([
+                $escaper->escapeHtmlAttr($block->getJsonSerializer()->serialize([
                     'rolesTree' => [
                         "treeInitData" => $block->getTree(),
                         "treeInitSelectedData" => $block->getSelectedResources(),


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
