### PR TITLE
Magento_Email: avoid using deprecated escape* methods from AbstractBlock

### DIFF
--- a/app/code/Magento/Email/Block/Adminhtml/Template/Grid/Renderer/Action.php
+++ b/app/code/Magento/Email/Block/Adminhtml/Template/Grid/Renderer/Action.php
@@ -42,7 +42,7 @@ class Action extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Action
     protected function _getEscapedValue($value)
     {
         // phpcs:ignore Magento2.Functions.DiscouragedFunction
-        return addcslashes($this->escapeHtml($value), '\\\'');
+        return addcslashes($this->_escaper->escapeHtml($value), '\\\'');
     }
 
     /**

--- a/app/code/Magento/Email/Block/Adminhtml/Template/Grid/Renderer/Sender.php
+++ b/app/code/Magento/Email/Block/Adminhtml/Template/Grid/Renderer/Sender.php
@@ -23,7 +23,7 @@ class Sender extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Abstract
         $str = '';
 
         if ($row->getTemplateSenderName()) {
-            $str .= $this->escapeHtml($row->getTemplateSenderName()) . ' ';
+            $str .= $this->_escaper->escapeHtml($row->getTemplateSenderName()) . ' ';
         }
 
         if ($row->getTemplateSenderEmail()) {

--- a/app/code/Magento/Email/Block/Adminhtml/Template/Preview.php
+++ b/app/code/Magento/Email/Block/Adminhtml/Template/Preview.php
@@ -81,7 +81,7 @@ class Preview extends \Magento\Backend\Block\Widget
         $templateProcessed = $this->_maliciousCode->filter($templateProcessed);
 
         if ($template->isPlain()) {
-            $templateProcessed = "<pre>" . $this->escapeHtml($templateProcessed) . "</pre>";
+            $templateProcessed = "<pre>" . $this->_escaper->escapeHtml($templateProcessed) . "</pre>";
         }
 
         \Magento\Framework\Profiler::stop($this->profilerName);

--- a/app/code/Magento/Email/Test/Unit/Block/Adminhtml/Template/Render/SenderTest.php
+++ b/app/code/Magento/Email/Test/Unit/Block/Adminhtml/Template/Render/SenderTest.php
@@ -8,27 +8,35 @@ declare(strict_types=1);
 
 namespace Magento\Email\Test\Unit\Block\Adminhtml\Template\Render;
 
+use Magento\Backend\Block\Context;
 use Magento\Email\Block\Adminhtml\Template\Grid\Renderer\Sender;
 use Magento\Framework\DataObject;
+use Magento\Framework\Escaper;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class SenderTest extends TestCase
 {
     /**
-     * @var MockObject|Sender
+     * @var Sender
      */
-    protected $block;
+    private $block;
+
+    /**
+     * @var MockObject|Escaper
+     */
+    private $escaperMock;
 
     /**
      * Setup environment
      */
     protected function setUp(): void
     {
-        $this->block = $this->getMockBuilder(Sender::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['escapeHtml'])
-            ->getMock();
+        $this->escaperMock = $this->createMock(Escaper::class);
+        $contextMock = $this->createMock(Context::class);
+        $contextMock->method('getEscaper')->willReturn($this->escaperMock);
+
+        $this->block = new Sender($contextMock);
     }
 
     /**
@@ -37,8 +45,8 @@ class SenderTest extends TestCase
     public function testRenderWithSenderNameAndEmail()
     {
         $templateSenderEmail = 'test';
-        $this->block->expects($this->any())->method('escapeHtml')->with($templateSenderEmail)
-            ->willReturn('test');
+        $this->escaperMock->expects($this->any())->method('escapeHtml')->with($templateSenderEmail)
+            ->willReturn($templateSenderEmail);
         $actualResult = $this->block->render(
             new DataObject(
                 [
@@ -56,8 +64,8 @@ class SenderTest extends TestCase
     public function testRenderWithNoSenderNameAndEmail()
     {
         $templateSenderEmail = '';
-        $this->block->expects($this->any())->method('escapeHtml')->with($templateSenderEmail)
-            ->willReturn('');
+        $this->escaperMock->expects($this->any())->method('escapeHtml')->with($templateSenderEmail)
+            ->willReturn($templateSenderEmail);
         $actualResult = $this->block->render(
             new DataObject(
                 [

--- a/app/code/Magento/Email/view/adminhtml/templates/preview/iframeswitcher.phtml
+++ b/app/code/Magento/Email/view/adminhtml/templates/preview/iframeswitcher.phtml
@@ -4,25 +4,28 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Backend\Block\Page $block */
+/**
+ * @var \Magento\Backend\Block\Page $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div id="preview" class="cms-revision-preview">
     <iframe name="preview_iframe"
             id="preview_iframe"
             frameborder="0"
-            title="<?= $block->escapeHtmlAttr(__('Preview')) ?>"
+            title="<?= $escaper->escapeHtmlAttr(__('Preview')) ?>"
             width="100%"
             sandbox="allow-same-origin allow-pointer-lock"
     ></iframe>
     <form id="preview_form"
-          action="<?= $block->escapeUrl($block->getUrl('*/*/popup')) ?>"
+          action="<?= $escaper->escapeUrl($block->getUrl('*/*/popup')) ?>"
           method="post"
           target="preview_iframe"
     >
     <input type="hidden" name="form_key" value="<?= /* @noEscape */ $block->getFormKey() ?>" />
     <?php foreach ($block->getPreviewFormViewModel()->getFormFields() as $name => $value): ?>
-        <input type="hidden" name="<?= $block->escapeHtmlAttr($name) ?>" value="<?= $block->escapeHtmlAttr($value) ?>"/>
+        <input type="hidden" name="<?= $escaper->escapeHtmlAttr($name) ?>" value="<?= $escaper->escapeHtmlAttr($value) ?>"/>
     <?php endforeach; ?>
     </form>
 </div>

--- a/app/code/Magento/Email/view/adminhtml/templates/template/edit.phtml
+++ b/app/code/Magento/Email/view/adminhtml/templates/template/edit.phtml
@@ -8,28 +8,31 @@ use Magento\Framework\App\TemplateTypesInterface;
 
 // phpcs:disable Generic.Files.LineLength.TooLong
 
-/** @var $block \Magento\Email\Block\Adminhtml\Template\Edit */
+/**
+ * @var $block \Magento\Email\Block\Adminhtml\Template\Edit
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if (!$block->getEditMode()): ?>
-<form action="<?= $block->escapeUrl($block->getLoadUrl()) ?>" method="post" id="email_template_load_form">
+<form action="<?= $escaper->escapeUrl($block->getLoadUrl()) ?>" method="post" id="email_template_load_form">
     <?= $block->getBlockHtml('formkey') ?>
     <fieldset class="admin__fieldset form-inline">
-        <legend class="admin__legend"><span><?= $block->escapeHtml(__('Load Default Template')) ?></span></legend><br>
+        <legend class="admin__legend"><span><?= $escaper->escapeHtml(__('Load Default Template')) ?></span></legend><br>
         <div class="admin__field required">
             <label class="admin__field-label" for="template_select">
-                <span><?= $block->escapeHtml(__('Template')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Template')) ?></span>
             </label>
             <div class="admin__field-control">
                 <select id="template_select" name="code" class="admin__control-select required-entry">
                     <?php foreach ($block->getTemplateOptions() as $group => $options): ?>
                         <?php if ($group): ?>
-                            <optgroup label="<?= $block->escapeHtmlAttr($group) ?>">
+                            <optgroup label="<?= $escaper->escapeHtmlAttr($group) ?>">
                         <?php endif; ?>
                         <?php foreach ($options as $option): ?>
-                            <option value="<?= $block->escapeHtmlAttr($option['value']) ?>"
+                            <option value="<?= $escaper->escapeHtmlAttr($option['value']) ?>"
                                 <?= /* @noEscape */ $block->getOrigTemplateCode() == $option['value'] ?
-                                    ' selected="selected"' : '' ?>><?= $block->escapeHtml($option['label']) ?>
+                                    ' selected="selected"' : '' ?>><?= $escaper->escapeHtml($option['label']) ?>
                             </option>
                         <?php endforeach; ?>
                         <?php if ($group): ?>
@@ -49,15 +52,15 @@ use Magento\Framework\App\TemplateTypesInterface;
 </form>
 <?php endif ?>
 
-<form action="<?= $block->escapeUrl($block->getSaveUrl()) ?>" method="post" id="email_template_edit_form">
+<form action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>" method="post" id="email_template_edit_form">
     <?= /* @noEscape */ $block->getBlockHtml('formkey') ?>
     <input type="hidden" id="change_flag_element" name="_change_type_flag" value="" />
     <input type="hidden" id="orig_template_code" name="orig_template_code"
-           value="<?= $block->escapeHtmlAttr($block->getOrigTemplateCode()) ?>" />
+           value="<?= $escaper->escapeHtmlAttr($block->getOrigTemplateCode()) ?>" />
     <?= /* @noEscape */ $block->getFormHtml() ?>
 </form>
 
-<form action="<?= $block->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="email_template_preview_form"
+<form action="<?= $escaper->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="email_template_preview_form"
       target="_blank">
     <?= /* @noEscape */ $block->getBlockHtml('formkey') ?>
     <div class="no-display">
@@ -132,7 +135,7 @@ require([
             var self = this;
 
             confirm({
-                content: "{$block->escapeJs(__('Are you sure you want to strip tags?'))}",
+                content: "{$escaper->escapeJs(__('Are you sure you want to strip tags?'))}",
                 actions: {
                     confirm: function () {
                         self.unconvertedText = $('template_text').value;
@@ -188,10 +191,10 @@ require([
 
         deleteTemplate: function() {
             confirm({
-                content: "{$block->escapeJs(__('Are you sure you want to delete this template?'))}",
+                content: "{$escaper->escapeJs(__('Are you sure you want to delete this template?'))}",
                 actions: {
                     confirm: function () {
-                        window.location.href = '{$block->escapeJs($block->getDeleteUrl())}';
+                        window.location.href = '{$escaper->escapeJs($block->getDeleteUrl())}';
                     }
                 }
             });
@@ -238,7 +241,7 @@ require([
                        }.bind(this));
                    } else {
                        alert({
-                           content: '{$block->escapeJs(__(
+                           content: '{$escaper->escapeJs(__(
                                'The template did not load. Please review the log for details.'
                             ))}'
                        });

--- a/app/code/Magento/Email/view/adminhtml/templates/template/preview.phtml
+++ b/app/code/Magento/Email/view/adminhtml/templates/template/preview.phtml
@@ -4,13 +4,16 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Email\Block\Adminhtml\Template\Preview */
+/**
+ * @var $block \Magento\Email\Block\Adminhtml\Template\Preview
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <title><?= $block->escapeHtml(__('Email Preview')) ?></title>
+    <title><?= $escaper->escapeHtml(__('Email Preview')) ?></title>
 </head>
 <body>
     <?= $block->getChildHtml('content') ?>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
