### PR TITLE
Magento_Vault: avoid using deprecated escape* methods from AbstractBlock

### DIFF
--- a/app/code/Magento/Vault/view/adminhtml/templates/form/vault.phtml
+++ b/app/code/Magento/Vault/view/adminhtml/templates/form/vault.phtml
@@ -6,9 +6,10 @@
 
 /**
  * @var Magento\Vault\Block\Form $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
-$code = $block->escapeHtml($block->getMethodCode());
+$code = $escaper->escapeHtml($block->getMethodCode());
 ?>
 <fieldset data-mage-init='{
         "Magento_Vault/js/vault": {

--- a/app/code/Magento/Vault/view/frontend/templates/cards_list.phtml
+++ b/app/code/Magento/Vault/view/frontend/templates/cards_list.phtml
@@ -4,18 +4,21 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Vault\Block\Customer\CreditCards $block */
+/**
+ * @var \Magento\Vault\Block\Customer\CreditCards $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 $tokens = $block->getPaymentTokens();
 ?>
 <?php if (count($tokens) !== 0) : ?>
     <div class="table-wrapper my-credit-cards">
         <table class="data table table-credit-cards" id="my-orders-table">
-            <caption class="table-caption"><?= $block->escapeHtml(__('Stored Payment Methods')) ?></caption>
+            <caption class="table-caption"><?= $escaper->escapeHtml(__('Stored Payment Methods')) ?></caption>
             <thead>
             <tr>
-                <th scope="col" class="col card-number"><?= $block->escapeHtml(__('Card Number')) ?></th>
-                <th scope="col" class="col expire"><?= $block->escapeHtml(__('Expiration Date')) ?></th>
-                <th scope="col" class="col card-type"><?= $block->escapeHtml(__('Type')) ?></th>
+                <th scope="col" class="col card-number"><?= $escaper->escapeHtml(__('Card Number')) ?></th>
+                <th scope="col" class="col expire"><?= $escaper->escapeHtml(__('Expiration Date')) ?></th>
+                <th scope="col" class="col card-type"><?= $escaper->escapeHtml(__('Type')) ?></th>
                 <th scope="col" class="col actions">&nbsp;</th>
             </tr>
             </thead>
@@ -30,5 +33,5 @@ $tokens = $block->getPaymentTokens();
     </div>
 
 <?php elseif (!$block->isExistsCustomerTokens()) : ?>
-    <div class="message info empty"><span><?= $block->escapeHtml(__('You have no stored payment methods.')) ?></span></div>
+    <div class="message info empty"><span><?= $escaper->escapeHtml(__('You have no stored payment methods.')) ?></span></div>
 <?php endif ?>

--- a/app/code/Magento/Vault/view/frontend/templates/customer_account/credit_card.phtml
+++ b/app/code/Magento/Vault/view/frontend/templates/customer_account/credit_card.phtml
@@ -7,27 +7,30 @@ use Magento\Framework\View\Element\Template;
 use Magento\Vault\Api\Data\PaymentTokenInterface;
 use Magento\Vault\Block\CardRendererInterface;
 
-/** @var CardRendererInterface|Template $block */
+/**
+ * @var CardRendererInterface|Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
-$ccNumberView = $block->escapeHtml($block->getNumberLast4Digits());
+$ccNumberView = $escaper->escapeHtml($block->getNumberLast4Digits());
 ?>
 <tr>
-    <td data-th="<?= $block->escapeHtml(__('Card Number')) ?>" class="col card-number">
-        <span><?= $block->escapeHtml(__('ending')) ?></span> <?= /* @noEscape */ $ccNumberView ?>
+    <td data-th="<?= $escaper->escapeHtml(__('Card Number')) ?>" class="col card-number">
+        <span><?= $escaper->escapeHtml(__('ending')) ?></span> <?= /* @noEscape */ $ccNumberView ?>
     </td>
-    <td data-th="<?= $block->escapeHtml(__('Expiration Date')) ?>" class="col card-expire">
-        <?= $block->escapeHtml($block->getExpDate()) ?>
+    <td data-th="<?= $escaper->escapeHtml(__('Expiration Date')) ?>" class="col card-expire">
+        <?= $escaper->escapeHtml($block->getExpDate()) ?>
     </td>
-    <td data-th="<?= $block->escapeHtml(__('Type')) ?>" class="col card-type">
+    <td data-th="<?= $escaper->escapeHtml(__('Type')) ?>" class="col card-type">
         <img src="<?= /* @noEscape */ $block->getIconUrl() ?>"
              width="<?= /* @noEscape */ $block->getIconWidth() ?>"
              height="<?= /* @noEscape */ $block->getIconHeight() ?>"
         >
     </td>
-    <td data-th="<?= $block->escapeHtml(__('Actions')) ?>" class="col actions">
+    <td data-th="<?= $escaper->escapeHtml(__('Actions')) ?>" class="col actions">
         <form
             class="form"
-            action="<?= $block->escapeUrl($block->getUrl('vault/cards/deleteaction')) ?>"
+            action="<?= $escaper->escapeUrl($block->getUrl('vault/cards/deleteaction')) ?>"
             method="post"
             >
             <?= $block->getBlockHtml('formkey') ?>
@@ -42,11 +45,11 @@ $ccNumberView = $block->escapeHtml($block->getNumberLast4Digits());
                                         "type": "popup",
                                         "modalClass": "my-credit-cards-popup",
                                         "toggleEvent": "click",
-                                        "title": "<?= $block->escapeHtml(__('Delete')) ?>",
-                                        "content": "<?= $block->escapeHtml(__('Are you sure you want to delete this card: %1?', $ccNumberView)) ?>"
+                                        "title": "<?= $escaper->escapeHtml(__('Delete')) ?>",
+                                        "content": "<?= $escaper->escapeHtml(__('Are you sure you want to delete this card: %1?', $ccNumberView)) ?>"
                                     }
                                 }'>
-                <span><?= $block->escapeHtml(__('Delete')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Delete')) ?></span>
             </button>
         </form>
     </td>

--- a/app/code/Magento/Vault/view/frontend/templates/token_list.phtml
+++ b/app/code/Magento/Vault/view/frontend/templates/token_list.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Vault\Block\Customer\AccountTokens $block */
+/**
+ * @var \Magento\Vault\Block\Customer\AccountTokens $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 $tokens = $block->getPaymentTokens();
 ?>
 <?php if (count($tokens) !== 0) : ?>
@@ -12,7 +15,7 @@ $tokens = $block->getPaymentTokens();
         <table class="data table table-credit-cards" id="token-list-table">
             <thead>
             <tr>
-                <th scope="col" class="col"><?= $block->escapeHtml(__('PayPal Account')) ?></th>
+                <th scope="col" class="col"><?= $escaper->escapeHtml(__('PayPal Account')) ?></th>
                 <th scope="col" class="col actions">&nbsp;</th>
             </tr>
             </thead>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
