### PR TITLE
Magento_User: avoid using deprecated escape* methods from AbstractBlock

### DIFF
--- a/app/code/Magento/User/Block/Role/Grid/User.php
+++ b/app/code/Magento/User/Block/Role/Grid/User.php
@@ -206,7 +206,7 @@ class User extends \Magento\Backend\Block\Widget\Grid\Extended
             if ($json) {
                 return $this->getJSONString($inRoleUser);
             }
-            return $this->escapeJs($this->escapeHtml($inRoleUser));
+            return $this->_escaper->escapeJs($this->_escaper->escapeHtml($inRoleUser));
         }
         $roleId = $this->getRoleId();
         $users = $this->getUsersFormData();

--- a/app/code/Magento/User/Block/User/Edit.php
+++ b/app/code/Magento/User/Block/User/Edit.php
@@ -72,7 +72,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
                 [
                     'label' => __('Force Sign-In'),
                     'class' => 'invalidate-token',
-                    'onclick' => "deleteConfirm('" . $this->escapeJs($this->escapeHtml($deleteConfirmMsg)) .
+                    'onclick' => "deleteConfirm('" . $this->_escaper->escapeJs($this->_escaper->escapeHtml($deleteConfirmMsg)) .
                         "', '" . $this->getInvalidateUrl() . "')",
                 ]
             );
@@ -126,7 +126,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
     public function getHeaderText()
     {
         if ($this->_coreRegistry->registry('permissions_user')->getId()) {
-            $username = $this->escapeHtml($this->_coreRegistry->registry('permissions_user')->getUsername());
+            $username = $this->_escaper->escapeHtml($this->_coreRegistry->registry('permissions_user')->getUsername());
             return __("Edit User '%1'", $username);
         } else {
             return __('New User');

--- a/app/code/Magento/User/Block/User/Edit/Tab/Roles.php
+++ b/app/code/Magento/User/Block/User/Edit/Tab/Roles.php
@@ -158,7 +158,7 @@ class Roles extends \Magento\Backend\Block\Widget\Grid\Extended
                 $result = json_decode($userRoles);
                 return $result ? $this->_jsonEncoder->encode($result) : '{}';
             }
-            return $this->escapeJs($this->escapeHtml($userRoles));
+            return $this->_escaper->escapeJs($this->_escaper->escapeHtml($userRoles));
         }
         /* @var $user \Magento\User\Model\User */
         $user = $this->_coreRegistry->registry('permissions_user');

--- a/app/code/Magento/User/view/adminhtml/templates/admin/forgotpassword.phtml
+++ b/app/code/Magento/User/view/adminhtml/templates/admin/forgotpassword.phtml
@@ -3,16 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <form method="post" action="" id="login-form" data-mage-init='{"form": {}, "validation": {}}'>
     <fieldset class="admin__fieldset">
-        <legend class="admin__legend"><span><?= $block->escapeHtml(__('Password Help')) ?></span></legend><br/>
-        <input name="form_key" type="hidden" value="<?= $block->escapeHtmlAttr($block->getFormKey()) ?>" />
-        <p class="admin__field-info"><?= $block->escapeHtml(
+        <legend class="admin__legend"><span><?= $escaper->escapeHtml(__('Password Help')) ?></span></legend><br/>
+        <input name="form_key" type="hidden" value="<?= $escaper->escapeHtmlAttr($block->getFormKey()) ?>" />
+        <p class="admin__field-info"><?= $escaper->escapeHtml(
             __('Enter your email address.  You will receive an email with a link to reset your password.')
         ) ?></p>
         <div class="admin__field _required field-email">
-            <label for="email" class="admin__field-label"><span><?= $block->escapeHtml(__('Email address')) ?></span></label>
+            <label for="email" class="admin__field-label"><span><?= $escaper->escapeHtml(__('Email address')) ?></span></label>
             <div class="admin__field-control">
                 <input type="text" id="email" name="email" value=""
                        data-validate="{required:true, 'validate-email':true}" class="admin__control-text" />
@@ -22,13 +26,13 @@
         <div class="form-actions">
             <div class="actions">
                 <button class="action-retrieve action-primary" type="submit">
-                    <span><?= $block->escapeHtml(__('Retrieve Password')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Retrieve Password')) ?></span>
                 </button>
             </div>
             <div class="links">
                 <a class="action-back"
-                   href="<?= $block->escapeUrl($block->getUrl('adminhtml', ['_nosecret' => true])) ?>">
-                    <?= $block->escapeHtml(__('Back to Sign in')) ?>
+                   href="<?= $escaper->escapeUrl($block->getUrl('adminhtml', ['_nosecret' => true])) ?>">
+                    <?= $escaper->escapeHtml(__('Back to Sign in')) ?>
                 </a>
             </div>
         </div>

--- a/app/code/Magento/User/view/adminhtml/templates/admin/forgotpassword_url.phtml
+++ b/app/code/Magento/User/view/adminhtml/templates/admin/forgotpassword_url.phtml
@@ -3,10 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="links">
 <a class="action-forgotpassword"
-   href="<?= $block->escapeUrl($block->getUrl('adminhtml/auth/forgotpassword', ['_nosecret' => true])) ?>">
-    <?= $block->escapeHtml(__('Forgot your password?')) ?>
+   href="<?= $escaper->escapeUrl($block->getUrl('adminhtml/auth/forgotpassword', ['_nosecret' => true])) ?>">
+    <?= $escaper->escapeHtml(__('Forgot your password?')) ?>
 </a>
 </div>

--- a/app/code/Magento/User/view/adminhtml/templates/admin/resetforgottenpassword.phtml
+++ b/app/code/Magento/User/view/adminhtml/templates/admin/resetforgottenpassword.phtml
@@ -3,20 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 
 <form method="post" data-mage-init='{"form": {}, "validation": {}}'
-      action="<?= $block->escapeUrl(
+      action="<?= $escaper->escapeUrl(
           $block->getUrl(
               '*/auth/resetpasswordpost',
               ['_query' => ['id' => $block->getUserId(), 'token' => $block->getResetPasswordLinkToken()]]
           )
       ) ?>" id="reset-password-form" autocomplete="off">
     <fieldset class="admin__fieldset">
-        <legend class="admin__legend"><span><?= $block->escapeHtml(__('Reset a Password')) ?></span></legend><br />
-        <input name="form_key" type="hidden" value="<?= $block->escapeHtmlAttr($block->getFormKey()) ?>" />
+        <legend class="admin__legend"><span><?= $escaper->escapeHtml(__('Reset a Password')) ?></span></legend><br />
+        <input name="form_key" type="hidden" value="<?= $escaper->escapeHtmlAttr($block->getFormKey()) ?>" />
         <div class="admin__field _required field-password">
-            <label class="admin__field-label" for="password"><span><?= $block->escapeHtml(__('New Password')) ?></span></label>
+            <label class="admin__field-label" for="password"><span><?= $escaper->escapeHtml(__('New Password')) ?></span></label>
             <div class="admin__field-control">
                 <input type="password" class="admin__control-text"
                        data-validate="{required:true, 'validate-admin-password':true}" name="password" id="password"
@@ -24,7 +28,7 @@
             </div>
         </div>
         <div class="admin__field _required field-confirmation">
-            <label class="admin__field-label" for="confirmation"><span><?= $block->escapeHtml(__('Confirm New Password')) ?></span></label>
+            <label class="admin__field-label" for="confirmation"><span><?= $escaper->escapeHtml(__('Confirm New Password')) ?></span></label>
             <div class="admin__field-control">
                 <input type="password" class="admin__control-text"
                        data-validate="{required:true, 'validate-cpassword':true}" name="confirmation" id="confirmation"
@@ -33,10 +37,10 @@
         </div>
         <div class="form-actions">
             <div class="actions">
-                <button type="submit" title="<?= $block->escapeHtml(__('Reset Password')) ?>" class="action-reset action-primary"><span><?= $block->escapeHtml(__('Reset Password')) ?></span></button>
+                <button type="submit" title="<?= $escaper->escapeHtml(__('Reset Password')) ?>" class="action-reset action-primary"><span><?= $escaper->escapeHtml(__('Reset Password')) ?></span></button>
             </div>
             <div class="links">
-                <a class="action-back" href="<?= $block->escapeUrl($block->getUrl('adminhtml', ['_nosecret' => true])) ?>"><?= $block->escapeHtml(__('Back to Sign in')) ?></a>
+                <a class="action-back" href="<?= $escaper->escapeUrl($block->getUrl('adminhtml', ['_nosecret' => true])) ?>"><?= $escaper->escapeHtml(__('Back to Sign in')) ?></a>
             </div>
         </div>
     </fieldset>

--- a/app/code/Magento/User/view/adminhtml/templates/role/edit.phtml
+++ b/app/code/Magento/User/view/adminhtml/templates/role/edit.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var $block \Magento\User\Block\Role\Tab\Edit
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -14,19 +15,19 @@
 
 <fieldset class="fieldset form-inline entry-edit">
     <legend class="legend">
-        <span><?= $block->escapeHtml(__('Roles Resources')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Roles Resources')) ?></span>
     </legend><br />
 
     <div class="field">
-        <label class="label" for="all"><span><?= $block->escapeHtml(__('Resource Access')) ?></span></label>
+        <label class="label" for="all"><span><?= $escaper->escapeHtml(__('Resource Access')) ?></span></label>
 
         <div class="control">
             <select id="all" name="all" class="select">
                 <option value="0" <?= ($block->isEverythingAllowed() ? '' : 'selected="selected"') ?>>
-                    <?= $block->escapeHtml(__('Custom')) ?>
+                    <?= $escaper->escapeHtml(__('Custom')) ?>
                 </option>
                 <option value="1" <?= ($block->isEverythingAllowed() ? 'selected="selected"' : '') ?>>
-                    <?= $block->escapeHtml(__('All')) ?>
+                    <?= $escaper->escapeHtml(__('All')) ?>
                 </option>
             </select>
             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
@@ -42,11 +43,11 @@
             no-display
         <?php endif ?>"
          data-role="tree-resources-container">
-        <label class="label"><span><?= $block->escapeHtml(__('Resources')) ?></span></label>
+        <label class="label"><span><?= $escaper->escapeHtml(__('Resources')) ?></span></label>
 
         <div class="control">
             <div class="tree x-tree" data-role="resource-tree" data-mage-init='<?=
-                $block->escapeHtmlAttr($block->getJsonSerializer()->serialize([
+                $escaper->escapeHtmlAttr($block->getJsonSerializer()->serialize([
                     'rolesTree' => [
                         "treeInitData" => $block->getTree(),
                         "treeInitSelectedData" => $block->getSelectedResources(),

--- a/app/code/Magento/User/view/adminhtml/templates/role/info.phtml
+++ b/app/code/Magento/User/view/adminhtml/templates/role/info.phtml
@@ -4,9 +4,12 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<form action="<?= $block->escapeUrl($block->getUrl('*/*/saverole')) ?>" method="post" id="role-edit-form">
+<form action="<?= $escaper->escapeUrl($block->getUrl('*/*/saverole')) ?>" method="post" id="role-edit-form">
     <?= $block->getBlockHtml('formkey') ?>
 </form>
 <?php $scriptString = <<<script

--- a/app/code/Magento/User/view/adminhtml/templates/role/users.phtml
+++ b/app/code/Magento/User/view/adminhtml/templates/role/users.phtml
@@ -3,9 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <fieldset class="fieldset">
-    <legend class="legend"><span><?= $block->escapeHtml(__('Role Users')) ?></span></legend>
+    <legend class="legend"><span><?= $escaper->escapeHtml(__('Role Users')) ?></span></legend>
     <br />
     <?= $block->getGridHtml() ?>
 </fieldset>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
