### PR TITLE
Magento_UrlRewrite: avoid using deprecated escape* methods from Abstr…

### DIFF
--- a/app/code/Magento/UrlRewrite/Block/Catalog/Category/Tree.php
+++ b/app/code/Magento/UrlRewrite/Block/Catalog/Category/Tree.php
@@ -163,7 +163,7 @@ class Tree extends \Magento\Catalog\Block\Adminhtml\Category\AbstractCategory
             'children_count' => (int)$node->getChildrenCount(),
             'is_active' => (bool)$node->getIsActive(),
             // Scrub names for raw js output
-            'name' => $this->escapeHtml($node->getName()),
+            'name' => $this->_escaper->escapeHtml($node->getName()),
             'level' => (int)$node->getLevel(),
             'product_count' => (int)$node->getProductCount(),
         ];

--- a/app/code/Magento/UrlRewrite/Block/Link.php
+++ b/app/code/Magento/UrlRewrite/Block/Link.php
@@ -22,7 +22,7 @@ class Link extends \Magento\Framework\View\Element\AbstractBlock
      */
     protected function _toHtml()
     {
-        return '<p>' . $this->getLabel() . ' <a href="' . $this->getItemUrl() . '">' . $this->escapeHtml(
+        return '<p>' . $this->getLabel() . ' <a href="' . $this->getItemUrl() . '">' . $this->_escaper->escapeHtml(
             $this->getItemName()
         ) . '</a></p>';
     }

--- a/app/code/Magento/UrlRewrite/view/adminhtml/templates/categories.phtml
+++ b/app/code/Magento/UrlRewrite/view/adminhtml/templates/categories.phtml
@@ -4,10 +4,13 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\UrlRewrite\Block\Catalog\Category\Tree $block */
+/**
+ * @var \Magento\UrlRewrite\Block\Catalog\Category\Tree $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
     <fieldset class="admin__fieldset" data-ui-id="category-selector">
-        <legend class="admin__legend"><span><?= $block->escapeHtml(__('Select Category')) ?></span></legend>
+        <legend class="admin__legend"><span><?= $escaper->escapeHtml(__('Select Category')) ?></span></legend>
         <div class="content content-category-tree">
             <input type="hidden" name="categories" id="product_categories" value=""/>
             <?php if ($block->getRoot()) : ?>
@@ -22,7 +25,7 @@
             "categoryTree": {
                 "data": <?= /* @noEscape */
                 $this->helper(\Magento\Framework\Json\Helper\Data::class)->jsonEncode($block->getTreeArray()); ?>,
-                "url": "<?= $block->escapeJs($block->escapeUrl($block->getLoadTreeUrl())); ?>"
+                "url": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getLoadTreeUrl())); ?>"
             }
         }
     }

--- a/app/code/Magento/UrlRewrite/view/adminhtml/templates/edit.phtml
+++ b/app/code/Magento/UrlRewrite/view/adminhtml/templates/edit.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\UrlRewrite\Block\Edit $block */
+/**
+ * @var \Magento\UrlRewrite\Block\Edit $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?= $block->getChildHtml() ?>
 <?php if ($block->getChildBlock('form')) : ?>
@@ -12,7 +15,7 @@
     {
         "#edit_form": {
             "Magento_UrlRewrite/js/url-rewrite-validation" : {
-                "url": "<?= $block->escapeUrl($block->getValidationUrl()) ?>"
+                "url": "<?= $escaper->escapeUrl($block->getValidationUrl()) ?>"
             }
         }
     }

--- a/app/code/Magento/UrlRewrite/view/adminhtml/templates/messages/url_duplicate_message.phtml
+++ b/app/code/Magento/UrlRewrite/view/adminhtml/templates/messages/url_duplicate_message.phtml
@@ -4,14 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 $urls = $block->getData('urls');
 ?>
 <h4>
-<?=$block->escapeHtml(__('The value specified in the URL Key field would generate a URL that already exists.')); ?>
+<?=$escaper->escapeHtml(__('The value specified in the URL Key field would generate a URL that already exists.')); ?>
 </h4>
 <p>
-<?=$block->escapeHtml(
+<?=$escaper->escapeHtml(
     __(
         'To resolve this conflict, you can either change the value of the URL Key field '
         . '(located in the Search Engine Optimization section) to a unique value, or change the Request Path fields'
@@ -23,7 +26,7 @@ $urls = $block->getData('urls');
 if (!empty($urls)) {
     foreach ($urls as $url => $urlTitle) {
         ?>
-        <?='<p> - <a href="' . $block->escapeHtml($url) . '">' . $block->escapeHtml($urlTitle) . '</a></p>'; ?>
+        <?='<p> - <a href="' . $escaper->escapeHtml($url) . '">' . $escaper->escapeHtml($urlTitle) . '</a></p>'; ?>
         <?php
     }
 }

--- a/app/code/Magento/UrlRewrite/view/adminhtml/templates/selector.phtml
+++ b/app/code/Magento/UrlRewrite/view/adminhtml/templates/selector.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var \Magento\UrlRewrite\Block\Selector $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -13,13 +14,13 @@
     <fieldset class="admin__fieldset fieldset" data-container-for="entity-type-selector">
         <div class="admin__field field field-entity-type-selector">
             <label for="entity-type-selector" class="admin__field-label label">
-                <span><?= $block->escapeHtml($block->getSelectorLabel()) ?></span>
+                <span><?= $escaper->escapeHtml($block->getSelectorLabel()) ?></span>
             </label>
             <div class="admin__field-control control">
                 <select data-role="entity-type-selector" class="admin__control-select select" id="entity-type-selector">
                 <?php foreach ($block->getModes() as $mode => $label): ?>
                     <option <?= /* @noEscape */ $block->isMode($mode) ? 'selected="selected" ' : '' ?>
-                        value="<?= $block->escapeUrl($block->getModeUrl($mode)) ?>"><?= $block->escapeHtml($label) ?>
+                        value="<?= $escaper->escapeUrl($block->getModeUrl($mode)) ?>"><?= $escaper->escapeHtml($label) ?>
                     </option>
                 <?php endforeach; ?>
                 </select>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
