### PR TITLE
Magento_Translation: avoid using deprecated escape* methods from Abst…

### DIFF
--- a/app/code/Magento/Translation/view/adminhtml/templates/translate_inline.phtml
+++ b/app/code/Magento/Translation/view/adminhtml/templates/translate_inline.phtml
@@ -6,13 +6,14 @@
 
 /**
  * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
 <link rel="stylesheet" type="text/css"
-      href="<?= $block->escapeUrl($block->getViewFileUrl('prototype/windows/themes/default.css')) ?>"/>
+      href="<?= $escaper->escapeUrl($block->getViewFileUrl('prototype/windows/themes/default.css')) ?>"/>
 <link rel="stylesheet" type="text/css"
-      href="<?= $block->escapeUrl($block->getViewFileUrl('mage/translate-inline.css')) ?>"/>
+      href="<?= $escaper->escapeUrl($block->getViewFileUrl('mage/translate-inline.css')) ?>"/>
 
 <script id="translate-inline-icon" type="text/x-magento-template">
     <img src="<%- data.img %>" height="16" width="16" class="translate-edit-icon">
@@ -57,7 +58,7 @@
 </script>
 
 <div data-role="translate-dialog"
-     data-mage-init='{"translateInline":{"ajaxUrl":"<?= $block->escapeJs($block->escapeUrl($block->getAjaxUrl())) ?>"},
+     data-mage-init='{"translateInline":{"ajaxUrl":"<?= $escaper->escapeJs($escaper->escapeUrl($block->getAjaxUrl())) ?>"},
      "loader":{}}'>
 </div>
 <?php $scriptString = <<<script
@@ -69,7 +70,7 @@ require([
 ], function($){
         $('body').editTrigger(
             {
-                img: '{$block->escapeJs($block->getViewFileUrl('Magento_Theme::fam_book_open.png'))}',
+                img: '{$escaper->escapeJs($block->getViewFileUrl('Magento_Theme::fam_book_open.png'))}',
                 alwaysShown: true,
                 singleElement: false
             }

--- a/app/code/Magento/Translation/view/base/templates/translate.phtml
+++ b/app/code/Magento/Translation/view/base/templates/translate.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var \Magento\Translation\Block\Js $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  * @deprecated logic was refactored in order to not use localstorage at all.
  *

--- a/app/code/Magento/Translation/view/frontend/templates/translate_inline.phtml
+++ b/app/code/Magento/Translation/view/frontend/templates/translate_inline.phtml
@@ -4,11 +4,14 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<link rel="stylesheet" type="text/css" href="<?= $block->escapeUrl($block->getViewFileUrl('prototype/windows/themes/default.css')) ?>"/>
-<link rel="stylesheet" type="text/css" href="<?= $block->escapeUrl($block->getViewFileUrl('Magento_Theme::prototype/magento.css')) ?>"/>
-<link rel="stylesheet" type="text/css" href="<?= $block->escapeUrl($block->getViewFileUrl('mage/translate-inline.css')) ?>"/>
+<link rel="stylesheet" type="text/css" href="<?= $escaper->escapeUrl($block->getViewFileUrl('prototype/windows/themes/default.css')) ?>"/>
+<link rel="stylesheet" type="text/css" href="<?= $escaper->escapeUrl($block->getViewFileUrl('Magento_Theme::prototype/magento.css')) ?>"/>
+<link rel="stylesheet" type="text/css" href="<?= $escaper->escapeUrl($block->getViewFileUrl('mage/translate-inline.css')) ?>"/>
 
 <script id="translate-inline-icon" type="text/x-magento-template">
     <img src="<%- data.img %>" height="16" width="16" class="translate-edit-icon">
@@ -54,12 +57,12 @@
 </script>
 
 <div data-role="translate-dialog"
-     data-mage-init='{"translateInline":{"ajaxUrl":"<?= $block->escapeJs($block->escapeUrl($block->getAjaxUrl())) ?>"},"loader":{}}'></div>
+     data-mage-init='{"translateInline":{"ajaxUrl":"<?= $escaper->escapeJs($escaper->escapeUrl($block->getAjaxUrl())) ?>"},"loader":{}}'></div>
 <script type="text/x-magento-init">
     {
         "body": {
             "editTrigger": {
-                "img": "<?= $block->escapeJs($block->escapeUrl($block->getViewFileUrl('Magento_Theme::fam_book_open.png'))) ?>",
+                "img": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getViewFileUrl('Magento_Theme::fam_book_open.png'))) ?>",
                 "alwaysShown":true,
                 "singleElement":false
             },


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
