### PR TITLE
Magento_TaxImportExport: avoid using deprecated escape* methods from …

### DIFF
--- a/app/code/Magento/TaxImportExport/view/adminhtml/templates/importExport.phtml
+++ b/app/code/Magento/TaxImportExport/view/adminhtml/templates/importExport.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\TaxImportExport\Block\Adminhtml\Rate\ImportExport */
+/**
+ * @var $block \Magento\TaxImportExport\Block\Adminhtml\Rate\ImportExport
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="import-export-tax-rates">
@@ -13,14 +16,14 @@
         <?php if ($block->getUseContainer()):?>
         <form id="import-form"
               class="admin__fieldset"
-              action="<?= $block->escapeUrl($block->getUrl('tax/rate/importPost')) ?>"
+              action="<?= $escaper->escapeUrl($block->getUrl('tax/rate/importPost')) ?>"
               method="post"
               enctype="multipart/form-data">
         <?php endif; ?>
             <?= $block->getBlockHtml('formkey') ?>
             <div class="fieldset admin__field">
                 <label for="import_rates_file" class="admin__field-label">
-                    <span><?= $block->escapeHtml(__('Import Tax Rates')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Import Tax Rates')) ?></span>
                 </label>
                 <div class="admin__field-control">
                     <input type="file"
@@ -66,13 +69,13 @@ script;
         <?php if ($block->getUseContainer()):?>
         <form id="export_form"
               class="admin__fieldset"
-              action="<?= $block->escapeUrl($block->getUrl('tax/rate/exportPost')) ?>"
+              action="<?= $escaper->escapeUrl($block->getUrl('tax/rate/exportPost')) ?>"
               method="post"
               enctype="multipart/form-data">
         <?php endif; ?>
             <?= $block->getBlockHtml('formkey') ?>
             <div class="fieldset admin__field">
-                <span class="admin__field-label"><span><?= $block->escapeHtml(__('Export Tax Rates')) ?></span></span>
+                <span class="admin__field-label"><span><?= $escaper->escapeHtml(__('Export Tax Rates')) ?></span></span>
                 <div class="admin__field-control">
                     <?= $block->getButtonHtml(__('Export Tax Rates'), "export_form.submit()") ?>
                 </div>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
