### PR TITLE
Magento_Store: avoid using deprecated escape* methods from AbstractBlock

### DIFF
--- a/app/code/Magento/Store/view/frontend/templates/switch/flags.phtml
+++ b/app/code/Magento/Store/view/frontend/templates/switch/flags.phtml
@@ -5,14 +5,17 @@
  */
 
 // @deprecated
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if (count($block->getStores())>1) : ?>
 <div class="form-language">
-    <label for="select-language"><?= $block->escapeHtml(__('Your Language:')) ?></label>
-    <select id="select-language" title="<?= $block->escapeHtmlAttr(__('Your Language')) ?>" onchange="window.location.href=this.value" class="flags">
+    <label for="select-language"><?= $escaper->escapeHtml(__('Your Language:')) ?></label>
+    <select id="select-language" title="<?= $escaper->escapeHtmlAttr(__('Your Language')) ?>" onchange="window.location.href=this.value" class="flags">
     <?php foreach ($block->getStores() as $_lang) : ?>
         <?php $_selected = ($_lang->getId() == $block->getCurrentStoreId()) ? ' selected="selected"' : '' ?>
-        <option value="<?= $block->escapeUrl($_lang->getCurrentUrl()) ?>" style="background-image:url('<?= $block->escapeUrl($block->getViewFileUrl('images/flags/flag_' . $_lang->getCode() . '.gif')) ?>');"<?= /* @noEscape */ $_selected ?>><?= $block->escapeHtml($_lang->getName()) ?></option>
+        <option value="<?= $escaper->escapeUrl($_lang->getCurrentUrl()) ?>" style="background-image:url('<?= $escaper->escapeUrl($block->getViewFileUrl('images/flags/flag_' . $_lang->getCode() . '.gif')) ?>');"<?= /* @noEscape */ $_selected ?>><?= $escaper->escapeHtml($_lang->getName()) ?></option>
     <?php endforeach; ?>
     </select>
 </div>

--- a/app/code/Magento/Store/view/frontend/templates/switch/languages.phtml
+++ b/app/code/Magento/Store/view/frontend/templates/switch/languages.phtml
@@ -4,29 +4,32 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Store\Block\Switcher $block */
+/**
+ * @var \Magento\Store\Block\Switcher $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if (count($block->getStores())>1) : ?>
     <?php $id = $block->getIdModifier() ? '-' . $block->getIdModifier() : '' ?>
-    <div class="switcher language switcher-language" data-ui-id="language-switcher" id="switcher-language<?= $block->escapeHtmlAttr($id) ?>">
-        <strong class="label switcher-label"><span><?= $block->escapeHtml(__('Language')) ?></span></strong>
+    <div class="switcher language switcher-language" data-ui-id="language-switcher" id="switcher-language<?= $escaper->escapeHtmlAttr($id) ?>">
+        <strong class="label switcher-label"><span><?= $escaper->escapeHtml(__('Language')) ?></span></strong>
         <div class="actions dropdown options switcher-options">
             <div class="action toggle switcher-trigger"
-                 id="switcher-language-trigger<?= $block->escapeHtmlAttr($id) ?>"
+                 id="switcher-language-trigger<?= $escaper->escapeHtmlAttr($id) ?>"
                  data-mage-init='{"dropdown":{}}'
                  data-toggle="dropdown"
                  data-trigger-keypress-button="true">
-                <strong class="view-<?= $block->escapeHtml($block->getCurrentStoreCode()) ?>">
-                    <span><?= $block->escapeHtml($block->getStoreName()) ?></span>
+                <strong class="view-<?= $escaper->escapeHtml($block->getCurrentStoreCode()) ?>">
+                    <span><?= $escaper->escapeHtml($block->getStoreName()) ?></span>
                 </strong>
             </div>
             <ul class="dropdown switcher-dropdown"
                 data-target="dropdown">
                 <?php foreach ($block->getStores() as $_lang) : ?>
                     <?php if ($_lang->getId() != $block->getCurrentStoreId()) : ?>
-                        <li class="view-<?= $block->escapeHtml($_lang->getCode()) ?> switcher-option">
-                            <a href="<?= $block->escapeUrl($block->getViewModel()->getTargetStoreRedirectUrl($_lang)) ?>">
-                                <?= $block->escapeHtml($_lang->getName()) ?>
+                        <li class="view-<?= $escaper->escapeHtml($_lang->getCode()) ?> switcher-option">
+                            <a href="<?= $escaper->escapeUrl($block->getViewModel()->getTargetStoreRedirectUrl($_lang)) ?>">
+                                <?= $escaper->escapeHtml($_lang->getName()) ?>
                             </a>
                         </li>
                     <?php endif; ?>

--- a/app/code/Magento/Store/view/frontend/templates/switch/stores.phtml
+++ b/app/code/Magento/Store/view/frontend/templates/switch/stores.phtml
@@ -4,11 +4,14 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Store\Block\Switcher $block */
+/**
+ * @var \Magento\Store\Block\Switcher $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if (count($block->getGroups())>1) : ?>
 <div class="switcher store switcher-store" id="switcher-store">
-    <strong class="label switcher-label"><span><?= $block->escapeHtml(__('Select Store')) ?></span></strong>
+    <strong class="label switcher-label"><span><?= $escaper->escapeHtml(__('Select Store')) ?></span></strong>
     <div class="actions dropdown options switcher-options">
         <?php foreach ($block->getGroups() as $_group) : ?>
             <?php if ($_group->getId() == $block->getCurrentGroupId()) : ?>
@@ -20,7 +23,7 @@
                      data-trigger-keypress-button="true"
                      id="switcher-store-trigger">
                     <strong>
-                        <span><?= $block->escapeHtml($_group->getName()) ?></span>
+                        <span><?= $escaper->escapeHtml($_group->getName()) ?></span>
                     </strong>
                 </div>
             <?php endif; ?>
@@ -30,7 +33,7 @@
                 <?php if (!($_group->getId() == $block->getCurrentGroupId())) : ?>
                     <li class="switcher-option">
                         <a href="#" data-post='<?= /* @noEscape */ $block->getTargetStorePostData($_group->getDefaultStore()) ?>'>
-                            <?= $block->escapeHtml($_group->getName()) ?>
+                            <?= $escaper->escapeHtml($_group->getName()) ?>
                         </a>
                     </li>
                 <?php endif; ?>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
