### PR TITLE
Magento_Sales: avoid using deprecated escape* methods from AbstractBlock

### DIFF
--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Comment.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Comment.php
@@ -48,6 +48,6 @@ class Comment extends \Magento\Sales\Block\Adminhtml\Order\Create\AbstractCreate
      */
     public function getCommentNote()
     {
-        return $this->escapeHtml($this->getQuote()->getCustomerNote());
+        return $this->_escaper->escapeHtml($this->getQuote()->getCustomerNote());
     }
 }

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Form/Address.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Form/Address.php
@@ -387,7 +387,7 @@ class Address extends \Magento\Sales\Block\Adminhtml\Order\Create\Form\AbstractF
             $result = $formatTypeRenderer->renderArray($this->addressMapper->toFlatArray($address));
         }
 
-        return $this->escapeHtml($result);
+        return $this->_escaper->escapeHtml($result);
     }
 
     /**

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Header.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Header.php
@@ -63,7 +63,7 @@ class Header extends AbstractCreate
             return __('Edit Order #%1', $this->_getSession()->getOrder()->getIncrementId());
         }
         $out = $this->_getCreateOrderTitle();
-        return $this->escapeHtml($out);
+        return $this->_escaper->escapeHtml($out);
     }
 
     /**

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Shipping.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/Create/Totals/Shipping.php
@@ -102,7 +102,7 @@ class Shipping extends \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Defaul
     {
         return __(
             'Shipping Incl. Tax (%1)',
-            $this->escapeHtml($this->getQuote()->getShippingAddress()->getShippingDescription())
+            $this->_escaper->escapeHtml($this->getQuote()->getShippingAddress()->getShippingDescription())
         );
     }
 
@@ -115,7 +115,7 @@ class Shipping extends \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Defaul
     {
         return __(
             'Shipping Excl. Tax (%1)',
-            $this->escapeHtml($this->getQuote()->getShippingAddress()->getShippingDescription())
+            $this->_escaper->escapeHtml($this->getQuote()->getShippingAddress()->getShippingDescription())
         );
     }
 }

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Info.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Info.php
@@ -202,7 +202,7 @@ class Info extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
                 $sortOrder = $this->_prepareAccountDataSortOrder($accountData, $sortOrder);
                 $accountData[$sortOrder] = [
                     'label' => $attribute->getFrontendLabel(),
-                    'value' => $this->escapeHtml($value, ['br']),
+                    'value' => $this->_escaper->escapeHtml($value, ['br']),
                 ];
             }
         }
@@ -225,7 +225,7 @@ class Info extends \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
                 $label = __('Edit');
             }
             $url = $this->getUrl('sales/order/address', ['address_id' => $address->getId()]);
-            return '<a href="' . $this->escapeUrl($url) . '">' . $this->escapeHtml($label) . '</a>';
+            return '<a href="' . $this->escapeUrl($url) . '">' . $this->_escaper->escapeHtml($label) . '</a>';
         }
 
         return '';

--- a/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/History.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Order/View/Tab/History.php
@@ -173,7 +173,7 @@ class History extends \Magento\Backend\Block\Template implements \Magento\Backen
      */
     public function getItemTitle(array $item)
     {
-        return isset($item['title']) ? $this->escapeHtml($item['title']) : '';
+        return isset($item['title']) ? $this->_escaper->escapeHtml($item['title']) : '';
     }
 
     /**

--- a/app/code/Magento/Sales/Block/Adminhtml/Reorder/Renderer/Action.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Reorder/Renderer/Action.php
@@ -74,7 +74,7 @@ class Action extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Abstract
     protected function _getEscapedValue($value)
     {
         // phpcs:ignore Magento2.Functions.DiscouragedFunction
-        return addcslashes($this->escapeHtml($value), '\\\'');
+        return addcslashes($this->_escaper->escapeHtml($value), '\\\'');
     }
 
     /**

--- a/app/code/Magento/Sales/Block/Adminhtml/Transactions/Detail.php
+++ b/app/code/Magento/Sales/Block/Adminhtml/Transactions/Detail.php
@@ -126,17 +126,17 @@ class Detail extends \Magento\Backend\Block\Widget\Container
         ));
 
         $this->setParentTxnIdUrlHtml(
-            $this->escapeHtml($this->getUrl('sales/transactions/view', ['txn_id' => $this->_txn->getParentId()]))
+            $this->_escaper->escapeHtml($this->getUrl('sales/transactions/view', ['txn_id' => $this->_txn->getParentId()]))
         );
 
-        $this->setParentTxnIdHtml($this->escapeHtml($this->_txn->getParentTxnId()));
+        $this->setParentTxnIdHtml($this->_escaper->escapeHtml($this->_txn->getParentTxnId()));
 
-        $this->setOrderIncrementIdHtml($this->escapeHtml($this->_txn->getOrder()->getIncrementId()));
+        $this->setOrderIncrementIdHtml($this->_escaper->escapeHtml($this->_txn->getOrder()->getIncrementId()));
 
-        $this->setTxnTypeHtml($this->escapeHtml(__($this->_txn->getTxnType())));
+        $this->setTxnTypeHtml($this->_escaper->escapeHtml(__($this->_txn->getTxnType())));
 
         $this->setOrderIdUrlHtml(
-            $this->escapeHtml($this->getUrl('sales/order/view', ['order_id' => $this->_txn->getOrderId()]))
+            $this->_escaper->escapeHtml($this->getUrl('sales/order/view', ['order_id' => $this->_txn->getOrderId()]))
         );
 
         $this->setIsClosedHtml($this->_txn->getIsClosed() ? __('Yes') : __('No'));
@@ -150,7 +150,7 @@ class Detail extends \Magento\Backend\Block\Widget\Container
         ) : __(
             'N/A'
         );
-        $this->setCreatedAtHtml($this->escapeHtml($createdAt));
+        $this->setCreatedAtHtml($this->_escaper->escapeHtml($createdAt));
 
         return parent::_toHtml();
     }

--- a/app/code/Magento/Sales/Block/Order/Email/Items/DefaultItems.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items/DefaultItems.php
@@ -67,13 +67,13 @@ class DefaultItems extends Template
             return sprintf(
                 '%d',
                 $value['qty']
-            ) . ' x ' . $this->escapeHtml(
+            ) . ' x ' . $this->_escaper->escapeHtml(
                 $value['title']
             ) . " " . $this->getItem()->getOrder()->formatPrice(
                 $value['price']
             );
         } else {
-            return $this->escapeHtml($value);
+            return $this->_escaper->escapeHtml($value);
         }
     }
 

--- a/app/code/Magento/Sales/Block/Order/Email/Items/Order/DefaultOrder.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items/Order/DefaultOrder.php
@@ -60,10 +60,10 @@ class DefaultOrder extends \Magento\Framework\View\Element\Template
     {
         if (is_array($value)) {
             return sprintf('%d', $value['qty'])
-                . ' x ' . $this->escapeHtml($value['title'])
+                . ' x ' . $this->_escaper->escapeHtml($value['title'])
                 . " " . $this->getItem()->getOrder()->formatPrice($value['price']);
         } else {
-            return $this->escapeHtml($value);
+            return $this->_escaper->escapeHtml($value);
         }
     }
 

--- a/app/code/Magento/Sales/Block/Order/Item/Renderer/DefaultRenderer.php
+++ b/app/code/Magento/Sales/Block/Order/Item/Renderer/DefaultRenderer.php
@@ -223,7 +223,7 @@ class DefaultRenderer extends \Magento\Framework\View\Element\Template
      */
     public function prepareSku($sku)
     {
-        return $this->escapeHtml($this->string->splitInjection($sku));
+        return $this->_escaper->escapeHtml($this->string->splitInjection($sku));
     }
 
     /**

--- a/app/code/Magento/Sales/Block/Status/Grid/Column/Unassign.php
+++ b/app/code/Magento/Sales/Block/Status/Grid/Column/Unassign.php
@@ -62,7 +62,7 @@ class Unassign extends \Magento\Backend\Block\Widget\Grid\Column
             $url = $this->getUrl('*/*/unassign');
             $label = __('Unassign');
             $cell = '<a href="#" data-post="'
-                .$this->escapeHtmlAttr(
+                .$this->_escaper->escapeHtmlAttr(
                     $this->json->serialize([
                         'action' => $url,
                         'data' => ['status' => $row->getStatus(), 'state' => $row->getState()]

--- a/app/code/Magento/Sales/view/adminhtml/templates/items/column/name.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/items/column/name.phtml
@@ -8,6 +8,7 @@
 <?php
 /**
  * @var $block \Magento\Sales\Block\Adminhtml\Items\Column\Name
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -19,17 +20,17 @@ $catalogHelper = $block->getData('catalogHelper');
 <?php if ($_item = $block->getItem()): ?>
     <div id="order_item_<?= (int) $_item->getId() ?>_title"
          class="product-title">
-        <?= $block->escapeHtml($_item->getName()) ?>
+        <?= $escaper->escapeHtml($_item->getName()) ?>
     </div>
     <div class="product-sku-block">
-        <span><?= $block->escapeHtml(__('SKU'))?>:</span>
-        <?= /* @noEscape */ implode('<br />', $catalogHelper->splitSku($block->escapeHtml($block->getSku()))) ?>
+        <span><?= $escaper->escapeHtml(__('SKU'))?>:</span>
+        <?= /* @noEscape */ implode('<br />', $catalogHelper->splitSku($escaper->escapeHtml($block->getSku()))) ?>
     </div>
 
     <?php if ($block->getOrderOptions()): ?>
         <dl class="item-options">
             <?php foreach ($block->getOrderOptions() as $_option): ?>
-                <dt><?= $block->escapeHtml($_option['label']) ?>:</dt>
+                <dt><?= $escaper->escapeHtml($_option['label']) ?>:</dt>
                 <dd>
                     <?php if (isset($_option['custom_view']) && $_option['custom_view']): ?>
                         <?= /* @noEscape */ $block->getCustomizedOptionValue($_option) ?>
@@ -37,11 +38,11 @@ $catalogHelper = $block->getData('catalogHelper');
                         <?php $_option = $block->getFormattedOption($_option['value']); ?>
                         <?php $dots = 'dots' . uniqid(); ?>
                         <?php $id = 'id' . uniqid(); ?>
-                        <?= $block->escapeHtml($_option['value'], ['a', 'br']) ?>
+                        <?= $escaper->escapeHtml($_option['value'], ['a', 'br']) ?>
                         <?php if (isset($_option['remainder']) && $_option['remainder']): ?>
                             <span id="<?= /* @noEscape */ $dots; ?>"> ...</span>
                             <span id="<?= /* @noEscape */ $id; ?>">
-                                <?= $block->escapeHtml($_option['remainder'], ['a']) ?>
+                                <?= $escaper->escapeHtml($_option['remainder'], ['a']) ?>
                             </span>
                             <?php $scriptString = <<<script
                                 require(['prototype'], function() {
@@ -68,5 +69,5 @@ script;
             <?php endforeach; ?>
         </dl>
     <?php endif; ?>
-    <?= $block->escapeHtml($_item->getDescription()) ?>
+    <?= $escaper->escapeHtml($_item->getDescription()) ?>
 <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/items/column/qty.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/items/column/qty.phtml
@@ -3,38 +3,41 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($item = $block->getItem()) : ?>
     <table class="qty-table">
         <tr>
-            <th><?= $block->escapeHtml(__('Ordered')); ?></th>
+            <th><?= $escaper->escapeHtml(__('Ordered')); ?></th>
             <td><?= (float) $item->getQtyOrdered() ?></td>
         </tr>
 
         <?php if ((float)$item->getQtyInvoiced()) : ?>
             <tr>
-                <th><?= $block->escapeHtml(__('Invoiced')); ?></th>
+                <th><?= $escaper->escapeHtml(__('Invoiced')); ?></th>
                 <td><?= (float) $item->getQtyInvoiced() ?></td>
             </tr>
         <?php endif; ?>
 
         <?php if ((float)$item->getQtyShipped()) : ?>
             <tr>
-                <th><?= $block->escapeHtml(__('Shipped')); ?></th>
+                <th><?= $escaper->escapeHtml(__('Shipped')); ?></th>
                 <td><?= (float) $item->getQtyShipped() ?></td>
             </tr>
         <?php endif; ?>
 
         <?php if ((float)$item->getQtyRefunded()) : ?>
             <tr>
-                <th><?= $block->escapeHtml(__('Refunded')); ?></th>
+                <th><?= $escaper->escapeHtml(__('Refunded')); ?></th>
                 <td><?= (float) $item->getQtyRefunded() ?></td>
             </tr>
         <?php endif; ?>
 
         <?php if ((float)$item->getQtyCanceled()) : ?>
             <tr>
-                <th><?= $block->escapeHtml(__('Canceled')); ?></th>
+                <th><?= $escaper->escapeHtml(__('Canceled')); ?></th>
                 <td><?= (float) $item->getQtyCanceled() ?></td>
             </tr>
         <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/items/renderer/default.phtml
@@ -5,22 +5,25 @@
  */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<?= $block->escapeHtml($block->getItem()->getName()) ?>
-<div><strong><?= $block->escapeHtml(__('SKU')) ?>:</strong> <?= /* @noEscape */ implode('<br />', $this->helper(\Magento\Catalog\Helper\Data::class)->splitSku($block->escapeHtml($block->getItem()->getSku()))) ?></div>
+<?= $escaper->escapeHtml($block->getItem()->getName()) ?>
+<div><strong><?= $escaper->escapeHtml(__('SKU')) ?>:</strong> <?= /* @noEscape */ implode('<br />', $this->helper(\Magento\Catalog\Helper\Data::class)->splitSku($escaper->escapeHtml($block->getItem()->getSku()))) ?></div>
 <?php if ($block->getOrderOptions()) : ?>
     <ul class="item-options">
     <?php foreach ($block->getOrderOptions() as $option) : ?>
-        <li><strong><?= $block->escapeHtml($option['label']) ?>:</strong><br />
+        <li><strong><?= $escaper->escapeHtml($option['label']) ?>:</strong><br />
         <?php if (is_array($option['value'])) : ?>
             <?php foreach ($option['value'] as $item) : ?>
                 <?= $block->getValueHtml($item) ?><br />
                 <?php endforeach; ?>
             <?php else : ?>
-            <?= $block->escapeHtml($option['value']) ?>
+            <?= $escaper->escapeHtml($option['value']) ?>
         <?php endif; ?>
         </li>
     <?php endforeach; ?>
     </ul>
 <?php endif; ?>
-<?= $block->escapeHtml($block->getItem()->getDescription()) ?>
+<?= $escaper->escapeHtml($block->getItem()->getDescription()) ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/address/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/address/form.phtml
@@ -3,12 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="messages">
     <div class="message message-notice">
         <div class="message-inner">
             <div class="message-content">
-                <?= $block->escapeHtml(
+                <?= $escaper->escapeHtml(
                     __('Changing address information will not recalculate shipping, tax or other order amount.')
                 ) ?>
             </div>
@@ -18,7 +22,7 @@
 
 <div class="fieldset admin__fieldset-wrapper">
     <legend class="legend admin__legend">
-        <span><?= $block->escapeHtml($block->getHeaderText()) ?></span>
+        <span><?= $escaper->escapeHtml($block->getHeaderText()) ?></span>
     </legend>
     <br>
     <div class="form-inline" data-mage-init='{"Magento_Sales/order/edit/address/form":{}}'>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/comments/view.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/comments/view.phtml
@@ -4,14 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($_entity = $block->getEntity()): ?>
 <div id="comments_block" class="edit-order-comments">
     <div class="order-history-block">
         <div class="admin__field field-row">
             <label class="admin__field-label"
-                   for="history_comment"><?= $block->escapeHtml(__('Comment Text')) ?></label>
+                   for="history_comment"><?= $escaper->escapeHtml(__('Comment Text')) ?></label>
             <div class="admin__field-control">
                 <textarea name="comment[comment]"
                           class="admin__control-textarea"
@@ -30,7 +33,7 @@
                                id="history_notify"
                                value="1" />
                         <label class="admin__field-label"
-                               for="history_notify"><?= $block->escapeHtml(__('Notify Customer by Email')) ?></label>
+                               for="history_notify"><?= $escaper->escapeHtml(__('Notify Customer by Email')) ?></label>
                     </div>
                 <?php endif; ?>
                 <div class="admin__field admin__field-option">
@@ -40,7 +43,7 @@
                            class="admin__control-checkbox"
                            value="1" />
                     <label class="admin__field-label"
-                           for="history_visible"> <?= $block->escapeHtml(__('Visible on Storefront')) ?></label>
+                           for="history_visible"> <?= $escaper->escapeHtml(__('Visible on Storefront')) ?></label>
                 </div>
             </div>
             <div class="order-history-comments-actions">
@@ -59,17 +62,17 @@
                     <?= /* @noEscape */ $block->formatTime($_comment->getCreatedAt(), \IntlDateFormatter::MEDIUM) ?>
                 </span>
                 <span class="note-list-customer">
-                    <?= $block->escapeHtml(__('Customer')) ?>
+                    <?= $escaper->escapeHtml(__('Customer')) ?>
                     <?php if ($_comment->getIsCustomerNotified()): ?>
-                        <span class="note-list-customer-notified"><?= $block->escapeHtml(__('Notified')) ?></span>
+                        <span class="note-list-customer-notified"><?= $escaper->escapeHtml(__('Notified')) ?></span>
                     <?php else: ?>
                         <span class="note-list-customer-not-notified">
-                            <?= $block->escapeHtml(__('Not Notified')) ?>
+                            <?= $escaper->escapeHtml(__('Not Notified')) ?>
                         </span>
                     <?php endif; ?>
                 </span>
                 <div class="note-list-comment">
-                    <?= $block->escapeHtml($_comment->getComment(), ['b', 'br', 'strong', 'i', 'u', 'a']) ?>
+                    <?= $escaper->escapeHtml($_comment->getComment(), ['b', 'br', 'strong', 'i', 'u', 'a']) ?>
                 </div>
             </li>
         <?php endforeach; ?>
@@ -78,7 +81,7 @@
     <?php $scriptString = <<<script
 require(['prototype'], function(){
     submitComment = function() {
-        submitAndReloadArea($('comments_block').parentNode, '{$block->escapeJs($block->getSubmitUrl())}')
+        submitAndReloadArea($('comments_block').parentNode, '{$escaper->escapeJs($block->getSubmitUrl())}')
     };
     if ($('submit_comment_button')) {
         $('submit_comment_button').observe('click', submitComment);

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/abstract.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/abstract.phtml
@@ -3,10 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 
 <div class="admin__page-section-title">
-    <span class="title"><?= $block->escapeHtml($block->getHeaderText()) ?></span>
+    <span class="title"><?= $escaper->escapeHtml($block->getHeaderText()) ?></span>
     <?php if ($block->getButtonsHtml()) : ?>
         <div class="actions"><?= $block->getButtonsHtml() ?></div>
     <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/billing/method/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/billing/method/form.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($block->hasMethods()): ?>
 <div id="order-billing_method_form">
@@ -21,10 +24,10 @@
         ?>
         <dt class="admin__field-option">
         <?php if ($_methodsCount > 1): ?>
-            <input id="p_method_<?= $block->escapeHtmlAttr($_code); ?>"
-                   value="<?= $block->escapeHtmlAttr($_code); ?>"
+            <input id="p_method_<?= $escaper->escapeHtmlAttr($_code); ?>"
+                   value="<?= $escaper->escapeHtmlAttr($_code); ?>"
                    type="radio" name="payment[method]"
-                   title="<?= $block->escapeHtmlAttr($_method->getTitle()); ?>"
+                   title="<?= $escaper->escapeHtmlAttr($_method->getTitle()); ?>"
                     <?php if ($currentSelectedMethod == $_code): ?>
                     checked="checked"
                     <?php endif; ?>
@@ -32,21 +35,21 @@
                    class="admin__control-radio"/>
             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                 'onclick',
-                "payment.switchMethod('" . $block->escapeJs($_code) . "')",
-                'input#p_method_' . $block->escapeJs($_code)
+                "payment.switchMethod('" . $escaper->escapeJs($_code) . "')",
+                'input#p_method_' . $escaper->escapeJs($_code)
             ) ?>
         <?php else:?>
             <span class="no-display">
-                <input id="p_method_<?= $block->escapeHtmlAttr($_code); ?>"
-                       value="<?= $block->escapeHtmlAttr($_code); ?>"
+                <input id="p_method_<?= $escaper->escapeHtmlAttr($_code); ?>"
+                       value="<?= $escaper->escapeHtmlAttr($_code); ?>"
                        type="radio"
                        name="payment[method]" class="admin__control-radio"
                        checked="checked"/>
             </span>
         <?php endif;?>
 
-            <label class="admin__field-label" for="p_method_<?= $block->escapeHtmlAttr($_code); ?>">
-                <?= $block->escapeHtml($_method->getTitle()) ?>
+            <label class="admin__field-label" for="p_method_<?= $escaper->escapeHtmlAttr($_code); ?>">
+                <?= $escaper->escapeHtml($_method->getTitle()) ?>
             </label>
         </dt>
         <dd class="admin__payment-method-wrapper">
@@ -65,11 +68,11 @@
 script;
     if ($_methodsCount !== 1):
         $scriptString .= <<<script
-            order.setPaymentMethod('{$block->escapeJs($currentSelectedMethod)}');
+            order.setPaymentMethod('{$escaper->escapeJs($currentSelectedMethod)}');
 script;
     else:
         $scriptString .= <<<script
-            payment.switchMethod('{$block->escapeJs($currentSelectedMethod)}');
+            payment.switchMethod('{$escaper->escapeJs($currentSelectedMethod)}');
 script;
     endif;
     $scriptString .= <<<script
@@ -80,5 +83,5 @@ script;
     ?>
     <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
 <?php else: ?>
-    <div class="admin__message-empty"><?= $block->escapeHtml(__('No Payment Methods')); ?></div>
+    <div class="admin__message-empty"><?= $escaper->escapeHtml(__('No Payment Methods')); ?></div>
 <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/comment.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/comment.phtml
@@ -6,19 +6,20 @@
 
 /**
  * @var \Magento\Sales\Block\Adminhtml\Order\Create\Comment $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
 
 <div class="admin__field field-comment">
     <label for="order-comment" class="admin__field-label">
-        <span><?= $block->escapeHtml(__('Order Comments')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Order Comments')) ?></span>
     </label>
     <div class="admin__field-control">
         <textarea
             id="order-comment"
             name="order[comment][customer_note]"
-            class="admin__control-textarea"><?= $block->escapeHtml($block->getCommentNote()) ?></textarea>
+            class="admin__control-textarea"><?= $escaper->escapeHtml($block->getCommentNote()) ?></textarea>
     </div>
 </div>
 <?php $scriptString = <<<script

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/coupons/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/coupons/form.phtml
@@ -7,11 +7,12 @@
 <?php
 /**
  * @var \Magento\Sales\Block\Adminhtml\Order\Create\Coupons $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
 <div class="admin__field field-apply-coupon-code">
-    <label class="admin__field-label"><span><?= $block->escapeHtml(__('Apply Coupon Code')) ?></span></label>
+    <label class="admin__field-label"><span><?= $escaper->escapeHtml(__('Apply Coupon Code')) ?></span></label>
     <div class="admin__field-control">
         <?php if (!$block->getCouponCode()): ?>
         <input type="text" class="admin__control-text" id="coupons:code" value="" name="coupon_code" />
@@ -19,9 +20,9 @@
         <?php endif; ?>
         <?php if ($block->getCouponCode()): ?>
         <p class="added-coupon-code">
-            <span><?= $block->escapeHtml($block->getCouponCode()) ?></span>
-            <a href="#" title="<?= $block->escapeHtmlAttr(__('Remove Coupon Code')) ?>"
-               class="action-remove"><span><?= $block->escapeHtml(__('Remove')) ?></span></a>
+            <span><?= $escaper->escapeHtml($block->getCouponCode()) ?></span>
+            <a href="#" title="<?= $escaper->escapeHtmlAttr(__('Remove Coupon Code')) ?>"
+               class="action-remove"><span><?= $escaper->escapeHtml(__('Remove')) ?></span></a>
         </p>
             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                 'onclick',

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/data.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/data.phtml
@@ -4,13 +4,16 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Sales\Block\Adminhtml\Order\Create\Data $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\Create\Data $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="page-create-order">
     <?php $scriptString = <<<script
     require(["Magento_Sales/order/create/form"], function(){
-        order.setCurrencySymbol('{$block->escapeJs($block->getCurrencySymbol($block->getCurrentCurrencyCode()))}')
+        order.setCurrencySymbol('{$escaper->escapeJs($block->getCurrencySymbol($block->getCurrentCurrencyCode()))}')
     });
 script;
     ?>
@@ -51,7 +54,7 @@ script;
 
         <section id="order-addresses" class="admin__page-section order-addresses">
             <div class="admin__page-section-title">
-                <span class="title"><?= $block->escapeHtml(__('Address Information')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Address Information')) ?></span>
             </div>
             <div class="admin__page-section-content">
                 <div id="order-billing_address" class="admin__page-section-item order-billing-address">
@@ -65,7 +68,7 @@ script;
 
         <section id="order-methods" class="admin__page-section order-methods">
             <div class="admin__page-section-title">
-                <span class="title"><?= $block->escapeHtml(__('Payment &amp; Shipping Information')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Payment &amp; Shipping Information')) ?></span>
             </div>
             <div class="admin__page-section-content">
                 <div id="order-billing_method" class="admin__page-section-item order-billing-method">
@@ -87,11 +90,11 @@ script;
 
         <section class="admin__page-section order-summary">
             <div class="admin__page-section-title">
-                <span class="title"><?= $block->escapeHtml(__('Order Total')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Order Total')) ?></span>
             </div>
             <div class="admin__page-section-content">
                 <fieldset class="admin__fieldset order-history" id="order-comment">
-                    <legend class="admin__legend"><span><?= $block->escapeHtml(__('Order History')) ?></span></legend>
+                    <legend class="admin__legend"><span><?= $escaper->escapeHtml(__('Order History')) ?></span></legend>
                     <br>
                     <?= $block->getChildHtml('comment') ?>
                 </fieldset>
@@ -106,16 +109,16 @@ script;
         <div class="order-sidebar">
             <div class="store-switcher order-currency">
                 <label class="admin__field-label" for="currency_switcher">
-                    <?= $block->escapeHtml(__('Order Currency:')) ?>
+                    <?= $escaper->escapeHtml(__('Order Currency:')) ?>
                 </label>
                 <select id="currency_switcher"
                         class="admin__control-select"
                         name="order[currency]">
                     <?php foreach ($block->getAvailableCurrencies() as $_code): ?>
-                        <option value="<?= $block->escapeHtmlAttr($_code) ?>"
+                        <option value="<?= $escaper->escapeHtmlAttr($_code) ?>"
                             <?php if ($_code == $block->getCurrentCurrencyCode()): ?> selected="selected"<?php endif; ?>
-                                symbol="<?= $block->escapeHtmlAttr($block->getCurrencySymbol($_code)) ?>">
-                            <?= $block->escapeHtml($block->getCurrencyName($_code)) ?>
+                                symbol="<?= $escaper->escapeHtmlAttr($block->getCurrencySymbol($_code)) ?>">
+                            <?= $escaper->escapeHtml($block->getCurrencyName($_code)) ?>
                         </option>
                     <?php endforeach; ?>
                 </select>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/form.phtml
@@ -4,12 +4,15 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Sales\Block\Adminhtml\Order\Create\Form $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\Create\Form $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
-<form id="edit_form" data-order-config='<?= $block->escapeHtml($block->getOrderDataJson()) ?>'
-      data-load-base-url="<?= $block->escapeUrl($block->getLoadBlockUrl()) ?>"
-      action="<?= $block->escapeUrl($block->getSaveUrl()) ?>" method="post" enctype="multipart/form-data">
+<form id="edit_form" data-order-config='<?= $escaper->escapeHtml($block->getOrderDataJson()) ?>'
+      data-load-base-url="<?= $escaper->escapeUrl($block->getLoadBlockUrl()) ?>"
+      action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>" method="post" enctype="multipart/form-data">
     <?= $block->getBlockHtml('formkey') ?>
     <div id="order-message">
         <?= $block->getChildHtml('message') ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/form/account.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/form/account.phtml
@@ -6,12 +6,13 @@
 
 /**
  * @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Form\Account
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
 
-<div class="admin__page-section-title <?= $block->escapeHtmlAttr($block->getHeaderCssClass()) ?>">
-    <span class="title"><?= $block->escapeHtml($block->getHeaderText()) ?></span>
+<div class="admin__page-section-title <?= $escaper->escapeHtmlAttr($block->getHeaderCssClass()) ?>">
+    <span class="title"><?= $escaper->escapeHtml($block->getHeaderText()) ?></span>
     <div class="actions"></div>
 </div>
 <div id="customer_account_fields" class="admin__page-section-content">

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/form/address.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/form/address.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var \Magento\Sales\Block\Adminhtml\Order\Create\Form\Address $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 
@@ -40,7 +41,7 @@ if ($block->getIsShipping()):
     $addressCollectionJson = /* @noEscape  */ $block->getAddressCollectionJson();
     $scriptString= <<<script
     require(["Magento_Sales/order/create/form"], function(){
-        order.shippingAddressContainer = '{$block->escapeJs($_fieldsContainerId)}';
+        order.shippingAddressContainer = '{$escaper->escapeJs($_fieldsContainerId)}';
         order.setAddresses({$addressCollectionJson});
     });
 script;
@@ -53,7 +54,7 @@ else:
     ?>
     <?php $scriptString = <<<script
         require(["Magento_Sales/order/create/form"], function(){
-            order.billingAddressContainer = '{$block->escapeJs($_fieldsContainerId)}';
+            order.billingAddressContainer = '{$escaper->escapeJs($_fieldsContainerId)}';
         });
 script;
     ?>
@@ -62,11 +63,11 @@ script;
 endif; ?>
 
 <fieldset class="admin__fieldset">
-    <legend class="admin__legend <?= $block->escapeHtmlAttr($block->getHeaderCssClass()) ?>">
-        <span><?= $block->escapeHtml($block->getHeaderText()) ?></span>
+    <legend class="admin__legend <?= $escaper->escapeHtmlAttr($block->getHeaderCssClass()) ?>">
+        <span><?= $escaper->escapeHtml($block->getHeaderText()) ?></span>
     </legend><br>
 
-    <fieldset id="<?= $block->escapeHtmlAttr($_addressChoiceContainerId) ?>"
+    <fieldset id="<?= $escaper->escapeHtmlAttr($_addressChoiceContainerId) ?>"
               class="admin__fieldset order-choose-address">
     <?php if ($block->getIsShipping()): ?>
         <div class="admin__field admin__field-option admin__field-shipping-same-as-billing">
@@ -74,7 +75,7 @@ endif; ?>
                    class="admin__control-checkbox"
                    <?php if ($block->getIsAsBilling()): ?>checked<?php endif; ?> />
             <label for="order-shipping_same_as_billing" class="admin__field-label">
-                <?= $block->escapeHtml(__('Same As Billing Address')) ?>
+                <?= $escaper->escapeHtml(__('Same As Billing Address')) ?>
             </label>
             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                 'onclick',
@@ -85,52 +86,52 @@ endif; ?>
     <?php endif; ?>
         <div class="admin__field admin__field-select-from-existing-address">
             <label class="admin__field-label">
-                <?= $block->escapeHtml(__('Select from existing customer addresses:')) ?>
+                <?= $escaper->escapeHtml(__('Select from existing customer addresses:')) ?>
             </label>
             <?php $_id = $block->getForm()->getHtmlIdPrefix() . 'customer_address_id' ?>
             <div class="admin__field-control">
-                <select id="<?= $block->escapeHtmlAttr($_id) ?>"
-                        name="<?= $block->escapeHtmlAttr($block->getForm()->getHtmlNamePrefix())
+                <select id="<?= $escaper->escapeHtmlAttr($_id) ?>"
+                        name="<?= $escaper->escapeHtmlAttr($block->getForm()->getHtmlNamePrefix())
                         ?>[customer_address_id]"
                         class="admin__control-select">
-                    <option value=""><?= $block->escapeHtml(__('Add New Address')) ?></option>
+                    <option value=""><?= $escaper->escapeHtml(__('Add New Address')) ?></option>
                     <?php foreach ($addressArray as $addressId => $address): ?>
                         <option
-                            value="<?= $block->escapeHtmlAttr($addressId) ?>"
+                            value="<?= $escaper->escapeHtmlAttr($addressId) ?>"
                             <?php if ($addressId == $block->getAddressId()): ?> selected="selected"<?php endif; ?>>
-                            <?= $block->escapeHtml($customerAddressFormatter->getAddressAsString($address)) ?>
+                            <?= $escaper->escapeHtml($customerAddressFormatter->getAddressAsString($address)) ?>
                         </option>
                     <?php endforeach; ?>
                 </select>
                 <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                     'onchange',
-                    "order.selectAddress(this, '" . $block->escapeJs($_fieldsContainerId) . "')",
-                    'select#' . $block->escapeJs($_id)
+                    "order.selectAddress(this, '" . $escaper->escapeJs($_fieldsContainerId) . "')",
+                    'select#' . $escaper->escapeJs($_id)
                 ) ?>
             </div>
         </div>
     </fieldset>
 
-    <div class="order-address admin__fieldset" id="<?= $block->escapeHtmlAttr($_fieldsContainerId) ?>">
+    <div class="order-address admin__fieldset" id="<?= $escaper->escapeHtmlAttr($_fieldsContainerId) ?>">
         <?= $block->getForm()->toHtml() ?>
 
         <div class="admin__field admin__field-option order-save-in-address-book">
-            <input name="<?= $block->escapeHtmlAttr($block->getForm()->getHtmlNamePrefix()) ?>[save_in_address_book]"
+            <input name="<?= $escaper->escapeHtmlAttr($block->getForm()->getHtmlNamePrefix()) ?>[save_in_address_book]"
                    type="checkbox"
-                   id="<?= $block->escapeHtmlAttr($block->getForm()->getHtmlIdPrefix()) ?>save_in_address_book"
+                   id="<?= $escaper->escapeHtmlAttr($block->getForm()->getHtmlIdPrefix()) ?>save_in_address_book"
                    value="1"
                 <?php if ($billingAddressDataProvider && $billingAddressDataProvider->getSaveInAddressBook() ||
                     $block->getIsShipping() && !$block->getDontSaveInAddressBook() && !$block->getAddressId()): ?>
                     checked="checked"
                 <?php endif; ?>
                    class="admin__control-checkbox"/>
-            <label for="<?= $block->escapeHtmlAttr($block->getForm()->getHtmlIdPrefix()) ?>save_in_address_book"
-                   class="admin__field-label"><?= $block->escapeHtml(__('Add to address book')) ?></label>
+            <label for="<?= $escaper->escapeHtmlAttr($block->getForm()->getHtmlIdPrefix()) ?>save_in_address_book"
+                   class="admin__field-label"><?= $escaper->escapeHtml(__('Add to address book')) ?></label>
         </div>
     </div>
     <?php $hideElement = 'address-' . ($block->getIsShipping() ? 'shipping' : 'billing') . '-overlay'; ?>
     <div id="<?= /* @noEscape */ $hideElement ?>" class="order-methods-overlay">
-        <span><?= $block->escapeHtml(__('You don\'t need to select a shipping address.')) ?></span>
+        <span><?= $escaper->escapeHtml(__('You don\'t need to select a shipping address.')) ?></span>
     </div>
     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
         "display: none;",
@@ -138,8 +139,8 @@ endif; ?>
     ) ?>
     <?php $scriptString = <<<script
         require(["Magento_Sales/order/create/form"], function(){
-            order.bindAddressFields('{$block->escapeJs($_fieldsContainerId)}');
-            order.bindAddressFields('{$block->escapeJs($_addressChoiceContainerId)}');
+            order.bindAddressFields('{$escaper->escapeJs($_fieldsContainerId)}');
+            order.bindAddressFields('{$escaper->escapeJs($_addressChoiceContainerId)}');
 
 script;
     if ($block->getIsShipping() && $block->getIsAsBilling()):

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/giftmessage.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/giftmessage.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var \Magento\Sales\Block\Adminhtml\Order\Create\Giftmessage $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -17,12 +18,12 @@ $giftMessageHelper = $block->getData('giftMessageHelper');
     <div id="order-giftmessage" class="giftmessage-order-create">
         <fieldset class="admin__fieldset">
             <legend class="admin__legend">
-                <span><?= $block->escapeHtml(__('Gift Message for the Entire Order')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Gift Message for the Entire Order')) ?></span>
             </legend>
             <br>
             <?php if ($giftMessageHelper->isMessagesAllowed('main', $block->getQuote(), $block->getStoreId())): ?>
                 <p>
-                    <?= $block->escapeHtml(
+                    <?= $escaper->escapeHtml(
                         __('Leave this box blank if you don\'t want to leave a gift message for the entire order.')
                     ) ?>
                 </p>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/items.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/items.phtml
@@ -4,10 +4,13 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Sales\Block\Adminhtml\Order\Create\Items $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\Create\Items $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="admin__page-section-title">
-    <strong class="title"><?= $block->escapeHtml($block->getHeaderText()) ?></strong>
+    <strong class="title"><?= $escaper->escapeHtml($block->getHeaderText()) ?></strong>
     <div class="actions">
         <?= $block->getButtonsHtml() ?>
     </div>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/items/grid.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/items/grid.phtml
@@ -8,6 +8,7 @@
 <?php
 /**
  * @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 
@@ -22,18 +23,18 @@ $catalogHelper =$block->getData('catalogHelper');
             <table class="data-table admin__table-primary order-tables">
                 <thead>
                     <tr class="headings">
-                        <th class="col-product"><span><?= $block->escapeHtml(__('Product')) ?></span></th>
-                        <th class="col-price"><span><?= $block->escapeHtml(__('Price')) ?></span></th>
-                        <th class="col-qty"><span><?= $block->escapeHtml(__('Qty')) ?></span></th>
-                        <th class="col-subtotal"><span><?= $block->escapeHtml(__('Subtotal')) ?></span></th>
-                        <th class="col-discount"><span><?= $block->escapeHtml(__('Discount')) ?></span></th>
-                        <th class="col-row-total"><span><?= $block->escapeHtml(__('Row Subtotal')) ?></span></th>
-                        <th class="col-action"><span><?= $block->escapeHtml(__('Action')) ?></span></th>
+                        <th class="col-product"><span><?= $escaper->escapeHtml(__('Product')) ?></span></th>
+                        <th class="col-price"><span><?= $escaper->escapeHtml(__('Price')) ?></span></th>
+                        <th class="col-qty"><span><?= $escaper->escapeHtml(__('Qty')) ?></span></th>
+                        <th class="col-subtotal"><span><?= $escaper->escapeHtml(__('Subtotal')) ?></span></th>
+                        <th class="col-discount"><span><?= $escaper->escapeHtml(__('Discount')) ?></span></th>
+                        <th class="col-row-total"><span><?= $escaper->escapeHtml(__('Row Subtotal')) ?></span></th>
+                        <th class="col-action"><span><?= $escaper->escapeHtml(__('Action')) ?></span></th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr class="even">
-                        <td class="empty-text" colspan="100"><?= $block->escapeHtml(__('No ordered items')) ?></td>
+                        <td class="empty-text" colspan="100"><?= $escaper->escapeHtml(__('No ordered items')) ?></td>
                     </tr>
                 </tbody>
             </table>
@@ -49,19 +50,19 @@ $catalogHelper =$block->getData('catalogHelper');
         <table class="data-table admin__table-primary order-tables">
             <thead>
                 <tr class="headings">
-                    <th class="col-product"><span><?= $block->escapeHtml(__('Product')) ?></span></th>
-                    <th class="col-price"><span><?= $block->escapeHtml(__('Price')) ?></span></th>
-                    <th class="col-qty"><span><?= $block->escapeHtml(__('Qty')) ?></span></th>
-                    <th class="col-subtotal"><span><?= $block->escapeHtml(__('Subtotal')) ?></span></th>
-                    <th class="col-discount"><span><?= $block->escapeHtml(__('Discount')) ?></span></th>
-                    <th class="col-row-total"><span><?= $block->escapeHtml(__('Row Subtotal')) ?></span></th>
-                    <th class="col-action"><span><?= $block->escapeHtml(__('Action')) ?></span></th>
+                    <th class="col-product"><span><?= $escaper->escapeHtml(__('Product')) ?></span></th>
+                    <th class="col-price"><span><?= $escaper->escapeHtml(__('Price')) ?></span></th>
+                    <th class="col-qty"><span><?= $escaper->escapeHtml(__('Qty')) ?></span></th>
+                    <th class="col-subtotal"><span><?= $escaper->escapeHtml(__('Subtotal')) ?></span></th>
+                    <th class="col-discount"><span><?= $escaper->escapeHtml(__('Discount')) ?></span></th>
+                    <th class="col-row-total"><span><?= $escaper->escapeHtml(__('Row Subtotal')) ?></span></th>
+                    <th class="col-action"><span><?= $escaper->escapeHtml(__('Action')) ?></span></th>
                 </tr>
             </thead>
             <tfoot>
                 <tr>
-                    <td class="col-total"><?= $block->escapeHtml(__('Total %1 product(s)', count($_items))) ?></td>
-                    <td colspan="2" class="col-subtotal"><?= $block->escapeHtml(__('Subtotal:')) ?></td>
+                    <td class="col-total"><?= $escaper->escapeHtml(__('Total %1 product(s)', count($_items))) ?></td>
+                    <td colspan="2" class="col-subtotal"><?= $escaper->escapeHtml(__('Subtotal:')) ?></td>
                     <td class="col-price">
                         <strong><?= /* @noEscape */ $block->formatPrice($block->getSubtotal()) ?></strong>
                     </td>
@@ -80,12 +81,12 @@ $catalogHelper =$block->getData('catalogHelper');
                     <tr>
                         <td class="col-product">
                             <span id="order_item_<?= (int) $_item->getId() ?>_title"><?=
-                                $block->escapeHtml($_item->getName()) ?></span>
+                                $escaper->escapeHtml($_item->getName()) ?></span>
                             <div class="product-sku-block">
-                                <span><?= $block->escapeHtml(__('SKU')) ?>:</span>
+                                <span><?= $escaper->escapeHtml(__('SKU')) ?>:</span>
                                 <?= /* @noEscape */ implode(
                                     '<br />',
-                                    $catalogHelper->splitSku($block->escapeHtml($_item->getSku()))
+                                    $catalogHelper->splitSku($escaper->escapeHtml($_item->getSku()))
                                 ) ?>
                             </div>
                             <div class="product-configure-block">
@@ -99,7 +100,7 @@ $catalogHelper =$block->getData('catalogHelper');
                             <?php $_isCustomPrice = $block->usedCustomPriceForItem($_item) ?>
                             <?php if ($_tier = $block->getTierHtml($_item)): ?>
                             <div id="item_tier_block_<?= (int) $_item->getId() ?>">
-                                <a href="#"><?= $block->escapeHtml(__('Tier Pricing')) ?></a>
+                                <a href="#"><?= $escaper->escapeHtml(__('Tier Pricing')) ?></a>
                                 <div id="item_tier_<?= (int) $_item->getId() ?>"><?= /* @noEscape */ $_tier ?></div>
                                 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
                                     "display:none",
@@ -127,7 +128,7 @@ $catalogHelper =$block->getData('catalogHelper');
                                     <label
                                         class="normal admin__field-label"
                                         for="item_use_custom_price_<?= (int) $_item->getId() ?>">
-                                        <span><?= $block->escapeHtml(__('Custom Price')) ?>*</span></label>
+                                        <span><?= $escaper->escapeHtml(__('Custom Price')) ?>*</span></label>
                                     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                         'onclick',
                                         "order.toggleCustomPrice(this, 'item_custom_price_" . (int) $_item->getId() .
@@ -169,7 +170,7 @@ $catalogHelper =$block->getData('catalogHelper');
                                 <label
                                     for="item_use_discount_<?= (int) $_item->getId() ?>"
                                     class="normal admin__field-label">
-                                    <span><?= $block->escapeHtml(__('Apply')) ?></span></label>
+                                    <span><?= $escaper->escapeHtml(__('Apply')) ?></span></label>
                             </div>
 
                         </td>
@@ -178,20 +179,20 @@ $catalogHelper =$block->getData('catalogHelper');
                         </td>
                         <td class="col-actions last">
                             <select class="admin__control-select" name="item[<?= (int) $_item->getId() ?>][action]">
-                                <option value=""><?= $block->escapeHtml(__('Please select')) ?></option>
-                                <option value="remove"><?= $block->escapeHtml(__('Remove')) ?></option>
+                                <option value=""><?= $escaper->escapeHtml(__('Please select')) ?></option>
+                                <option value="remove"><?= $escaper->escapeHtml(__('Remove')) ?></option>
                                 <?php if ($block->getCustomerId() && $block->getMoveToCustomerStorage()): ?>
-                                    <option value="cart"><?= $block->escapeHtml(__('Move to Shopping Cart')) ?></option>
+                                    <option value="cart"><?= $escaper->escapeHtml(__('Move to Shopping Cart')) ?></option>
                                     <?php if ($block->isMoveToWishlistAllowed($_item)): ?>
                                         <?php $wishlists = $block->getCustomerWishlists();?>
                                         <?php if (count($wishlists) <= 1): ?>
-                                            <option value="wishlist"><?= $block->escapeHtml(__('Move to Wish List')) ?>
+                                            <option value="wishlist"><?= $escaper->escapeHtml(__('Move to Wish List')) ?>
                                             </option>
                                         <?php else: ?>
-                                            <optgroup label="<?= $block->escapeHtml(__('Move to Wish List')) ?>">
+                                            <optgroup label="<?= $escaper->escapeHtml(__('Move to Wish List')) ?>">
                                                 <?php foreach ($wishlists as $wishlist):?>
                                                     <option value="wishlist_<?= (int) $wishlist->getId() ?>">
-                                                        <?= $block->escapeHtml($wishlist->getName()) ?>
+                                                        <?= $escaper->escapeHtml($wishlist->getName()) ?>
                                                     </option>
                                                 <?php endforeach;?>
                                             </optgroup>
@@ -219,7 +220,7 @@ $catalogHelper =$block->getData('catalogHelper');
                                     ?>
                                     <div class="message <?php if ($_item->getHasError()): ?>message-error<?php else:
                                         ?>message-notice<?php endif; ?>">
-                                        <?= $block->escapeHtml($message) ?>
+                                        <?= $escaper->escapeHtml($message) ?>
                                     </div>
                                 <?php endforeach; ?>
                             </td>
@@ -230,7 +231,7 @@ $catalogHelper =$block->getData('catalogHelper');
                 </tbody>
                 <?php endforeach; ?>
         </table>
-        <p><small><?= $block->escapeHtml($block->getInclExclTaxMessage()) ?></small></p>
+        <p><small><?= $escaper->escapeHtml($block->getInclExclTaxMessage()) ?></small></p>
     </div>
 
     <div class="order-discounts">

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/js.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/js.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 
 <?php $scriptString = <<<script
@@ -18,10 +21,10 @@ require([
     order.sidebarHide();
     if (window.productConfigure) {
         productConfigure.addListType('product_to_add', {
-            urlFetch: '{$block->escapeJs($block->getUrl('sales/order_create/configureProductToAdd'))}'
+            urlFetch: '{$escaper->escapeJs($block->getUrl('sales/order_create/configureProductToAdd'))}'
         });
         productConfigure.addListType('quote_items', {
-            urlFetch: '{$block->escapeJs($block->getUrl('sales/order_create/configureQuoteItems'))}'
+            urlFetch: '{$escaper->escapeJs($block->getUrl('sales/order_create/configureQuoteItems'))}'
         });
     }
 });

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/newsletter/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/newsletter/form.phtml
@@ -4,11 +4,14 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <input type="checkbox" name="newsletter:subscribe">
 <label for="newsletter:subscribe">
-    <?= $block->escapeHtml(__('Subscribe to Newsletter')) ?>
+    <?= $escaper->escapeHtml(__('Subscribe to Newsletter')) ?>
 </label>
 <?=/* @noEscape */ $secureRenderer->renderStyleAsTag("width: 90%; float: none;", "label[for='newsletter:subscribe']") ?>
 <br/>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/shipping/method/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/shipping/method/form.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method\Form
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -18,7 +19,7 @@ $taxHelper = $block->getData('taxHelper');
     <div id="order-shipping-method-choose" class="control">
         <dl class="admin__order-shipment-methods">
         <?php foreach ($_shippingRateGroups as $code => $_rates): ?>
-            <dt class="admin__order-shipment-methods-title"><?= $block->escapeHtml($block->getCarrierName($code)) ?>
+            <dt class="admin__order-shipment-methods-title"><?= $escaper->escapeHtml($block->getCarrierName($code)) ?>
             </dt>
             <dd class="admin__order-shipment-methods-options">
                 <ul class="admin__order-shipment-methods-options-list">
@@ -29,22 +30,22 @@ $taxHelper = $block->getData('taxHelper');
                         <?php if ($_rate->getErrorMessage()): ?>
                             <div class="messages">
                                <div class="message message-error error">
-                                   <div><?= $block->escapeHtml($_rate->getErrorMessage()) ?></div>
+                                   <div><?= $escaper->escapeHtml($_rate->getErrorMessage()) ?></div>
                                </div>
                             </div>
                         <?php else: ?>
                             <?php $_checked = $block->isMethodActive($_code) ? 'checked="checked"' : '' ?>
                             <input <?= /* @noEscape */ $_radioProperty ?>
-                                value="<?= $block->escapeHtmlAttr($_code) ?>"
-                                id="s_method_<?= $block->escapeHtmlAttr($_code) ?>" <?= /* @noEscape */ $_checked ?>
+                                value="<?= $escaper->escapeHtmlAttr($_code) ?>"
+                                id="s_method_<?= $escaper->escapeHtmlAttr($_code) ?>" <?= /* @noEscape */ $_checked ?>
                                 class="admin__control-radio required-entry"/>
                             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                 'onclick',
                                 "order.setShippingMethod(this.value)",
-                                'input#s_method_' . $block->escapeHtmlAttr($_code)
+                                'input#s_method_' . $escaper->escapeHtmlAttr($_code)
                             ) ?>
-                            <label class="admin__field-label" for="s_method_<?= $block->escapeHtmlAttr($_code) ?>">
-                                <?= $block->escapeHtml($_rate->getMethodTitle() ?
+                            <label class="admin__field-label" for="s_method_<?= $escaper->escapeHtmlAttr($_code) ?>">
+                                <?= $escaper->escapeHtml($_rate->getMethodTitle() ?
                                     $_rate->getMethodTitle() : $_rate->getMethodDescription()) ?> -
                                 <strong>
                                     <?php $_excl = $block->getShippingPrice(
@@ -55,7 +56,7 @@ $taxHelper = $block->getData('taxHelper');
 
                                     <?= /* @noEscape */ $_excl ?>
                                     <?php if ($taxHelper->displayShippingBothPrices() && $_incl != $_excl): ?>
-                                        (<?= $block->escapeHtml(__('Incl. Tax')) ?> <?= /* @noEscape */ $_incl ?>)
+                                        (<?= $escaper->escapeHtml(__('Incl. Tax')) ?> <?= /* @noEscape */ $_incl ?>)
                                     <?php endif; ?>
                                 </strong>
                             </label>
@@ -72,10 +73,10 @@ $taxHelper = $block->getData('taxHelper');
         <div id="order-shipping-method-info" class="order-shipping-method-info">
             <dl class="admin__order-shipment-methods">
                 <dt class="admin__order-shipment-methods-title">
-                    <?= $block->escapeHtml($block->getCarrierName($_rate->getCarrier())) ?>
+                    <?= $escaper->escapeHtml($block->getCarrierName($_rate->getCarrier())) ?>
                 </dt>
                 <dd class="admin__order-shipment-methods-options">
-                    <?= $block->escapeHtml($_rate->getMethodTitle() ?
+                    <?= $escaper->escapeHtml($_rate->getMethodTitle() ?
                         $_rate->getMethodTitle() : $_rate->getMethodDescription()) ?> -
                     <strong>
                         <?php $_excl = $block->getShippingPrice(
@@ -86,14 +87,14 @@ $taxHelper = $block->getData('taxHelper');
 
                         <?= /* @noEscape */ $_excl ?>
                         <?php if ($taxHelper->displayShippingBothPrices() && $_incl != $_excl): ?>
-                            (<?= $block->escapeHtml(__('Incl. Tax')) ?> <?= /* @noEscape */ $_incl ?>)
+                            (<?= $escaper->escapeHtml(__('Incl. Tax')) ?> <?= /* @noEscape */ $_incl ?>)
                         <?php endif; ?>
                     </strong>
                 </dd>
             </dl>
             <a href="#"
                class="action-default">
-                <span><?= $block->escapeHtml(__('Click to change shipping method')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Click to change shipping method')) ?></span>
             </a>
         </div>
         <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
@@ -113,13 +114,13 @@ script;
 <?php elseif ($block->getIsRateRequest()): ?>
     <div class="order-shipping-method-summary">
         <strong class="order-shipping-method-not-available">
-            <?= $block->escapeHtml(__('Sorry, no quotes are available for this order.')) ?>
+            <?= $escaper->escapeHtml(__('Sorry, no quotes are available for this order.')) ?>
         </strong>
     </div>
 <?php else: ?>
     <div id="order-shipping-method-summary" class="order-shipping-method-summary">
         <a href="#" class="action-default">
-            <span><?= $block->escapeHtml(__('Get shipping methods and rates')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Get shipping methods and rates')) ?></span>
         </a>
         <input type="hidden" name="order[has_shipping]" value="" class="required-entry" />
     </div>
@@ -130,7 +131,7 @@ script;
     ) ?>
 <?php endif; ?>
 <div id="shipping-method-overlay" class="order-methods-overlay">
-    <span><?= $block->escapeHtml(__('You don\'t need to select a shipping method.')) ?></span>
+    <span><?= $escaper->escapeHtml(__('You don\'t need to select a shipping method.')) ?></span>
 </div>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag("display: none;", 'div#shipping-method-overlay') ?>
 <?php $scriptString = <<<script

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/sidebar.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/sidebar.phtml
@@ -6,17 +6,18 @@
 
 /**
  * @var \Magento\Sales\Block\Adminhtml\Order\Create\Sidebar $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
 <div class="customer-current-activity-inner">
-    <h4 class="customer-activity-title"><?= $block->escapeHtml(__('Customer\'s Activities')) ?></h4>
+    <h4 class="customer-activity-title"><?= $escaper->escapeHtml(__('Customer\'s Activities')) ?></h4>
     <div class="create-order-sidebar-container">
     <?= $block->getChildHtml('top_button') ?>
     <?php foreach ($block->getLayout()->getChildBlocks($block->getNameInLayout()) as $_alias => $_child): ?>
         <?php if ($_alias != 'top_button' && $_alias != 'bottom_button'): ?>
             <?php if ($block->canDisplay($_child)): ?>
-                <div class="order-sidebar-block" id="order-sidebar_<?= $block->escapeHtmlAttr($_alias) ?>">
+                <div class="order-sidebar-block" id="order-sidebar_<?= $escaper->escapeHtmlAttr($_alias) ?>">
                     <?= $block->getChildHtml($_alias) ?>
                 </div>
             <?php endif; ?>
@@ -33,12 +34,12 @@ require([
 
     function addSidebarCompositeListType() {
         productConfigure.addListType('sidebar', {
-            urlFetch: '{$block->escapeJs($block->getUrl('sales/order_create/configureProductToAdd'))}',
-            urlConfirm: '{$block->escapeJs($block->getUrl('sales/order_create/addConfigured'))}'
+            urlFetch: '{$escaper->escapeJs($block->getUrl('sales/order_create/configureProductToAdd'))}',
+            urlConfirm: '{$escaper->escapeJs($block->getUrl('sales/order_create/addConfigured'))}'
         });
         productConfigure.addListType('sidebar_wishlist', {
-            urlFetch: '{$block->escapeJs($block->getUrl('customer/wishlist_product_composite_wishlist/configure'))}',
-            urlConfirm: '{$block->escapeJs($block->getUrl('sales/order_create/addConfigured'))}'
+            urlFetch: '{$escaper->escapeJs($block->getUrl('customer/wishlist_product_composite_wishlist/configure'))}',
+            urlConfirm: '{$escaper->escapeJs($block->getUrl('sales/order_create/addConfigured'))}'
         });
     }
 

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/sidebar/items.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/sidebar/items.phtml
@@ -4,20 +4,23 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\AbstractSidebar */
+/**
+ * @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\AbstractSidebar
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
 $blockDataId = $block->getDataId();
-$jsEscapedBlockDataId = $block->escapeJs($blockDataId);
+$jsEscapedBlockDataId = $escaper->escapeJs($blockDataId);
 ?>
-<div class="create-order-sidebar-block" id="sidebar_data_<?= $block->escapeHtmlAttr($blockDataId) ?>">
+<div class="create-order-sidebar-block" id="sidebar_data_<?= $escaper->escapeHtmlAttr($blockDataId) ?>">
     <div class="head sidebar-title-block">
-        <a href="#" class="action-refresh" title="<?= $block->escapeHtml(__('Refresh')) ?>">
-            <span><?= $block->escapeHtml(__('Refresh')) ?></span>
+        <a href="#" class="action-refresh" title="<?= $escaper->escapeHtml(__('Refresh')) ?>">
+            <span><?= $escaper->escapeHtml(__('Refresh')) ?></span>
         </a>
         <h5 class="create-order-sidebar-label">
-            <?= $block->escapeHtml($block->getHeaderText()) ?>
-            <span class="normal">(<?= $block->escapeHtml($block->getItemCount()) ?>)</span>
+            <?= $escaper->escapeHtml($block->getHeaderText()) ?>
+            <span class="normal">(<?= $escaper->escapeHtml($block->getItemCount()) ?>)</span>
         </h5>
     </div>
     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
@@ -35,29 +38,29 @@ $jsEscapedBlockDataId = $block->escapeJs($blockDataId);
         <table class="admin__table-primary">
             <thead>
                 <tr>
-                    <th class="col-item"><?= $block->escapeHtml(__('Item')) ?></th>
+                    <th class="col-item"><?= $escaper->escapeHtml(__('Item')) ?></th>
 
                     <?php if ($block->canDisplayItemQty()): ?>
-                        <th class="col-qty"><?= $block->escapeHtml(__('Qty')) ?></th>
+                        <th class="col-qty"><?= $escaper->escapeHtml(__('Qty')) ?></th>
                     <?php endif; ?>
 
                     <?php if ($block->canDisplayPrice()): ?>
-                        <th class="col-price"><?= $block->escapeHtml(__('Price')) ?></th>
+                        <th class="col-price"><?= $escaper->escapeHtml(__('Price')) ?></th>
                     <?php endif; ?>
 
                     <?php if ($block->canRemoveItems()): ?>
                         <th class="col-remove">
-                            <span title="<?= $block->escapeHtml(__('Remove')) ?>"
+                            <span title="<?= $escaper->escapeHtml(__('Remove')) ?>"
                                   class="icon icon-remove">
-                                <span><?= $block->escapeHtml(__('Remove')) ?></span>
+                                <span><?= $escaper->escapeHtml(__('Remove')) ?></span>
                             </span>
                         </th>
                     <?php endif; ?>
 
                     <th class="col-add">
-                        <span title="<?= $block->escapeHtml(__('Add To Order')) ?>"
+                        <span title="<?= $escaper->escapeHtml(__('Add To Order')) ?>"
                               class="icon icon-add">
-                            <span><?= $block->escapeHtml(__('Add To Order')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Add To Order')) ?></span>
                         </span>
                     </th>
                 </tr>
@@ -66,7 +69,7 @@ $jsEscapedBlockDataId = $block->escapeJs($blockDataId);
             <tbody>
                 <?php foreach ($block->getItems() as $_item): ?>
                     <tr id="product-id-<?= (int) $block->getProductId($_item) ?>">
-                        <td class="col-item"><?= $block->escapeHtml($_item->getName()) ?></td>
+                        <td class="col-item"><?= $escaper->escapeHtml($_item->getName()) ?></td>
 
                         <?php if ($block->canDisplayItemQty()): ?>
                             <td class="col-qty">
@@ -84,16 +87,16 @@ $jsEscapedBlockDataId = $block->escapeJs($blockDataId);
                             <td class="col-remove">
                                 <div class="admin__field-option">
                                     <input id="sidebar-remove-<?=
-                                    $block->escapeHtmlAttr($block->getSidebarStorageAction())
+                                    $escaper->escapeHtmlAttr($block->getSidebarStorageAction())
                                     ?>-<?= (int) $block->getItemId($_item) ?>"
                                            type="checkbox"
                                            class="admin__control-checkbox"
                                            name="sidebar[remove][<?= (int) $block->getItemId($_item) ?>]"
-                                           value="<?= $block->escapeHtmlAttr($blockDataId) ?>"
-                                           title="<?= $block->escapeHtml(__('Remove')) ?>" />
+                                           value="<?= $escaper->escapeHtmlAttr($blockDataId) ?>"
+                                           title="<?= $escaper->escapeHtml(__('Remove')) ?>" />
                                     <label class="admin__field-label"
                                            for="sidebar-remove-<?=
-                                            $block->escapeHtmlAttr($block->getSidebarStorageAction())
+                                            $escaper->escapeHtmlAttr($block->getSidebarStorageAction())
                                             ?>-<?= (int) $block->getItemId($_item) ?>">
                                     </label>
                                 </div>
@@ -106,8 +109,8 @@ $jsEscapedBlockDataId = $block->escapeJs($blockDataId);
                                     $blockDataId == 'wishlist'): ?>
                                     <a href="#"
                                        class="icon icon-configure"
-                                       title="<?= $block->escapeHtml(__('Configure and Add to Order')) ?>">
-                                        <span><?= $block->escapeHtml(__('Configure and Add to Order')) ?></span>
+                                       title="<?= $escaper->escapeHtml(__('Configure and Add to Order')) ?>">
+                                        <span><?= $escaper->escapeHtml(__('Configure and Add to Order')) ?></span>
                                     </a>
                                     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                         'onclick',
@@ -119,8 +122,8 @@ $jsEscapedBlockDataId = $block->escapeJs($blockDataId);
                                 <?php elseif ($block->isConfigurationRequired($_item->getTypeId())): ?>
                                     <a href="#"
                                        class="icon icon-configure"
-                                       title="<?= $block->escapeHtml(__('Configure and Add to Order')) ?>">
-                                        <span><?= $block->escapeHtml(__('Configure and Add to Order')) ?></span>
+                                       title="<?= $escaper->escapeHtml(__('Configure and Add to Order')) ?>">
+                                        <span><?= $escaper->escapeHtml(__('Configure and Add to Order')) ?></span>
                                     </a>
                                     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                         'onclick',
@@ -129,16 +132,16 @@ $jsEscapedBlockDataId = $block->escapeJs($blockDataId);
                                         'tr#product-id-' . (int) $block->getProductId($_item) . ' a.icon.icon-configure'
                                     ) ?>
                                 <?php else: ?>
-                                    <input id="sidebar-<?= $block->escapeHtmlAttr($block->getSidebarStorageAction())
+                                    <input id="sidebar-<?= $escaper->escapeHtmlAttr($block->getSidebarStorageAction())
                                     ?>-<?= (int) $block->getIdentifierId($_item) ?>"
                                            type="checkbox"
                                            class="admin__control-checkbox"
-                                           name="sidebar[<?= $block->escapeHtmlAttr($block->getSidebarStorageAction())
+                                           name="sidebar[<?= $escaper->escapeHtmlAttr($block->getSidebarStorageAction())
                                             ?>][<?= (int) $block->getIdentifierId($_item) ?>]"
                                            value="<?= $block->canDisplayItemQty() ? (float) $_item->getQty() : 1 ?>"
-                                           title="<?= $block->escapeHtml(__('Add To Order')) ?>"/>
+                                           title="<?= $escaper->escapeHtml(__('Add To Order')) ?>"/>
                                     <label class="admin__field-label"
-                                           for="sidebar-<?= $block->escapeHtmlAttr($block->getSidebarStorageAction())
+                                           for="sidebar-<?= $escaper->escapeHtmlAttr($block->getSidebarStorageAction())
                                             ?>-<?= (int) $block->getIdentifierId($_item) ?>">
                                     </label>
                                 <?php endif; ?>
@@ -149,7 +152,7 @@ $jsEscapedBlockDataId = $block->escapeJs($blockDataId);
             </tbody>
         </table>
         <?php else: ?>
-            <span class="no-items"><?= $block->escapeHtml(__('No items')) ?></span>
+            <span class="no-items"><?= $escaper->escapeHtml(__('No items')) ?></span>
         <?php endif ?>
         </div>
         <?php if ($block->getItemCount() && $block->canRemoveItems()): ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/store/select.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/store/select.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Store\Select */
+/**
+ * @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Store\Select
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="store-scope form-inline">
@@ -19,7 +22,7 @@
                         <?php $showWebsite = true; ?>
                         <div class="admin__field field-website_label">
                             <label class="admin__field-label" for="">
-                                <span><?= $block->escapeHtml($_website->getName()) ?></span>
+                                <span><?= $escaper->escapeHtml($_website->getName()) ?></span>
                             </label>
                             <div class="admin__field-control">
                                 <div class="admin__field admin__field-option">
@@ -36,7 +39,7 @@
                         <?php $showGroup = true; ?>
                         <div class="admin__field field-group_label">
                             <label class="admin__field-label" for="">
-                                <span><?= $block->escapeHtml($_group->getName()) ?></span>
+                                <span><?= $escaper->escapeHtml($_group->getName()) ?></span>
                             </label>
                             <div class="admin__field-control"></div>
                         </div>
@@ -44,7 +47,7 @@
 
                     <div class="admin__field field-store_label">
                         <label class="admin__field-label" for="">
-                            <span><?= $block->escapeHtml($_group->getName()) ?></span>
+                            <span><?= $escaper->escapeHtml($_group->getName()) ?></span>
                         </label>
                         <div class="admin__field-control">
                             <div class="nested">
@@ -52,7 +55,7 @@
                                     <input type="radio"
                                            id="store_<?= (int) $_store->getId() ?>" class="admin__control-radio"/>
                                     <label class="admin__field-label" for="store_<?= (int) $_store->getId() ?>">
-                                        <?= $block->escapeHtml($_store->getName()) ?>
+                                        <?= $escaper->escapeHtml($_store->getName()) ?>
                                     </label>
                                     <?= /* @noEscape*/ $secureRenderer->renderEventListenerAsTag(
                                         'onclick',

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals.phtml
@@ -6,10 +6,11 @@
 
 /**
  * @var \Magento\Sales\Block\Adminhtml\Order\Create\Totals $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
-<legend class="admin__legend"><span><?= $block->escapeHtml(__('Order Totals')) ?></span></legend>
+<legend class="admin__legend"><span><?= $escaper->escapeHtml(__('Order Totals')) ?></span></legend>
 <br>
 
 <table class="admin__table-secondary data-table">
@@ -25,7 +26,7 @@
                value="1"<?php if ($block->getNoteNotify()): ?> checked="checked"<?php endif; ?>
                class="admin__control-checkbox"/>
         <label for="notify_customer" class="admin__field-label">
-            <?= $block->escapeHtml(__('Append Comments')) ?>
+            <?= $escaper->escapeHtml(__('Append Comments')) ?>
         </label>
     </div>
     <?php if ($block->canSendNewOrderConfirmationEmail()): ?>
@@ -33,7 +34,7 @@
         <input type="checkbox" id="send_confirmation" name="order[send_confirmation]" value="1" checked="checked"
                class="admin__control-checkbox"/>
         <label for="send_confirmation" class="admin__field-label">
-            <?= $block->escapeHtml(__('Email Order Confirmation')) ?>
+            <?= $escaper->escapeHtml(__('Email Order Confirmation')) ?>
         </label>
     </div>
     <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/default.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/default.phtml
@@ -4,12 +4,15 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<tr id="totals-default" class="<?= $block->escapeHtmlAttr($block->getTotal()->getCode()) ?> row-totals">
+<tr id="totals-default" class="<?= $escaper->escapeHtmlAttr($block->getTotal()->getCode()) ?> row-totals">
     <td class="admin__total-mark" colspan="<?= (int) $block->getColspan() ?>">
         <?php if ($block->getRenderingArea() == $block->getTotal()->getArea()): ?><strong><?php endif; ?>
-            <?= $block->escapeHtml($block->getTotal()->getTitle()) ?>
+            <?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?>
         <?php if ($block->getRenderingArea() == $block->getTotal()->getArea()): ?></strong><?php endif; ?>
     </td>
     <td class="admin__total-amount">
@@ -18,13 +21,13 @@
         <?php if ($block->getRenderingArea() == $block->getTotal()->getArea()): ?></strong><?php endif; ?>
     </td>
 </tr>
-<?php if ($block->escapeHtmlAttr($block->getTotal()->getStyle())): ?>
+<?php if ($escaper->escapeHtmlAttr($block->getTotal()->getStyle())): ?>
     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-        $block->escapeHtmlAttr($block->getTotal()->getStyle()),
+        $escaper->escapeHtmlAttr($block->getTotal()->getStyle()),
         'tr#totals-default td.admin__total-mark'
     ) ?>
     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-        $block->escapeHtmlAttr($block->getTotal()->getStyle()),
+        $escaper->escapeHtmlAttr($block->getTotal()->getStyle()),
         'tr#totals-default td.admin__total-amount'
     ) ?>
 <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/grandtotal.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/grandtotal.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var $block \Magento\Tax\Block\Checkout\Grandtotal
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  * @see \Magento\Tax\Block\Checkout\Grandtotal
  */
@@ -13,57 +14,57 @@
 <?php if ($block->includeTax() && $block->getTotalExclTax() >= 0): ?>
     <tr id="grand-total-exclude-tax" class="row-totals">
         <td class="admin__total-mark" colspan="<?= (int) $block->getColspan() ?>">
-            <strong><?= $block->escapeHtml(__('Grand Total Excl. Tax')) ?></strong>
+            <strong><?= $escaper->escapeHtml(__('Grand Total Excl. Tax')) ?></strong>
         </td>
         <td class="admin__total-amount">
             <strong><?= /* @noEscape */ $block->formatPrice($block->getTotalExclTax()) ?></strong>
         </td>
     </tr>
-    <?php if ($block->escapeHtmlAttr($block->getStyle())): ?>
+    <?php if ($escaper->escapeHtmlAttr($block->getStyle())): ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#grand-total-exclude-tax td.admin__total-mark'
         ) ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#grand-total-exclude-tax td.admin__total-amount'
         ) ?>
     <?php endif; ?>
     <?= /* @noEscape */ $block->renderTotals('taxes', $block->getColspan()) ?>
     <tr id="grand-total-include-tax" class="row-totals">
         <td class="admin__total-mark" colspan="<?= (int) $block->getColspan() ?>">
-            <strong><?= $block->escapeHtml(__('Grand Total Incl. Tax')) ?></strong>
+            <strong><?= $escaper->escapeHtml(__('Grand Total Incl. Tax')) ?></strong>
         </td>
         <td class="admin__total-amount">
             <strong><?= /* @noEscape */ $block->formatPrice($block->getTotal()->getValue()) ?></strong>
         </td>
     </tr>
-    <?php if ($block->escapeHtmlAttr($block->getStyle())): ?>
+    <?php if ($escaper->escapeHtmlAttr($block->getStyle())): ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#grand-total-include-tax td.admin__total-mark'
         ) ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#grand-total-include-tax td.admin__total-amount'
         ) ?>
     <?php endif; ?>
     <?php else: ?>
     <tr id="grand-total" class="row-totals">
         <td class="admin__total-mark" colspan="<?= (int) $block->getColspan() ?>">
-            <strong><?= $block->escapeHtml($block->getTotal()->getTitle()) ?></strong>
+            <strong><?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?></strong>
         </td>
         <td class="admin__total-amount">
             <strong><?= /* @noEscape */ $block->formatPrice($block->getTotal()->getValue()) ?></strong>
         </td>
     </tr>
-        <?php if ($block->escapeHtmlAttr($block->getStyle())): ?>
+        <?php if ($escaper->escapeHtmlAttr($block->getStyle())): ?>
             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-                $block->escapeHtmlAttr($block->getStyle()),
+                $escaper->escapeHtmlAttr($block->getStyle()),
                 'tr#grand-total-include-tax td.admin__total-mark'
             ) ?>
             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-                $block->escapeHtmlAttr($block->getStyle()),
+                $escaper->escapeHtmlAttr($block->getStyle()),
                 'tr#grand-total-include-tax td.admin__total-amount'
             ) ?>
     <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/shipping.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/shipping.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var $block \Magento\Tax\Block\Checkout\Shipping
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  * @see \Magento\Tax\Block\Checkout\Shipping
  */
@@ -13,75 +14,75 @@
 <?php if ($block->displayBoth()):?>
 <tr id="shipping-exclude-tax" class="row-totals">
     <td class="admin__total-mark" colspan="<?= (int) $block->getColspan() ?>">
-        <?= $block->escapeHtml($block->getExcludeTaxLabel()) ?>
+        <?= $escaper->escapeHtml($block->getExcludeTaxLabel()) ?>
     </td>
     <td class="admin__total-amount">
         <?= /* @noEscape */ $block->formatPrice($block->getShippingExcludeTax()) ?>
     </td>
 </tr>
-    <?php if ($block->escapeHtmlAttr($block->getStyle())): ?>
+    <?php if ($escaper->escapeHtmlAttr($block->getStyle())): ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#shipping-exclude-tax td.admin__total-mark'
         ) ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#shipping-exclude-tax td.admin__total-amount'
         ) ?>
     <?php endif; ?>
 <tr id="shipping-include-tax" class="row-totals">
     <td class="admin__total-mark" colspan="<?= (int) $block->getColspan() ?>">
-        <?= $block->escapeHtml($block->getIncludeTaxLabel()) ?>
+        <?= $escaper->escapeHtml($block->getIncludeTaxLabel()) ?>
     </td>
     <td class="admin__total-amount">
         <?= /* @noEscape */ $block->formatPrice($block->getShippingIncludeTax()) ?>
     </td>
 </tr>
-    <?php if ($block->escapeHtmlAttr($block->getStyle())): ?>
+    <?php if ($escaper->escapeHtmlAttr($block->getStyle())): ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#shipping-include-tax td.admin__total-mark'
         ) ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#shipping-include-tax td.admin__total-amount'
         ) ?>
     <?php endif; ?>
 <?php elseif ($block->displayIncludeTax()): ?>
 <tr id="shipping-include-tax">
     <td class="admin__total-mark" colspan="<?= (int) $block->getColspan() ?>">
-        <?= $block->escapeHtml($block->getTotal()->getTitle()) ?>
+        <?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?>
     </td>
     <td class="admin__total-amount">
         <?= /* @noEscape */ $block->formatPrice($block->getShippingIncludeTax()) ?>
     </td>
 </tr>
-    <?php if ($block->escapeHtmlAttr($block->getStyle())): ?>
+    <?php if ($escaper->escapeHtmlAttr($block->getStyle())): ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#shipping-include-tax td.admin__total-mark'
         ) ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#shipping-include-tax td.admin__total-amount'
         ) ?>
     <?php endif; ?>
 <?php else: ?>
 <tr id="shipping-exclude-tax" class="row-totals">
     <td class="admin__total-mark" colspan="<?= (int) $block->getColspan() ?>">
-        <?= $block->escapeHtml($block->getTotal()->getTitle()) ?>
+        <?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?>
     </td>
     <td class="admin__total-amount">
         <?= /* @noEscape */ $block->formatPrice($block->getShippingExcludeTax()) ?>
     </td>
 </tr>
-    <?php if ($block->escapeHtmlAttr($block->getStyle())): ?>
+    <?php if ($escaper->escapeHtmlAttr($block->getStyle())): ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#shipping-exclude-tax td.admin__total-mark'
         ) ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#shipping-exclude-tax td.admin__total-amount'
         ) ?>
     <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/subtotal.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/subtotal.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Subtotal
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  * @see \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Subtotal
  */
@@ -13,56 +14,56 @@
 <?php if ($block->displayBoth()): ?>
 <tr id="subtotal-exclude-tax" class="row-totals">
     <td class="admin__total-mark" colspan="<?= (int) $block->getColspan() ?>">
-        <?= $block->escapeHtml(__('Subtotal (Excl. Tax)')) ?>
+        <?= $escaper->escapeHtml(__('Subtotal (Excl. Tax)')) ?>
     </td>
     <td class="admin__total-amount">
         <?= /* @noEscape */ $block->formatPrice($block->getTotal()->getValueExclTax()) ?>
     </td>
 </tr>
-    <?php if ($block->escapeHtmlAttr($block->getStyle())): ?>
+    <?php if ($escaper->escapeHtmlAttr($block->getStyle())): ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#subtotal-exclude-tax td.admin__total-mark'
         ) ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#subtotal-exclude-tax td.admin__total-amount'
         ) ?>
     <?php endif; ?>
 <tr id="subtotal-include-tax" class="row-totals">
     <td class="admin__total-mark" colspan="<?= (int) $block->getColspan() ?>">
-        <?= $block->escapeHtml(__('Subtotal (Incl. Tax)')) ?>
+        <?= $escaper->escapeHtml(__('Subtotal (Incl. Tax)')) ?>
     </td>
     <td class="admin__total-amount">
         <?= /* @noEscape */ $block->formatPrice($block->getTotal()->getValueInclTax()) ?>
     </td>
 </tr>
-    <?php if ($block->escapeHtmlAttr($block->getStyle())): ?>
+    <?php if ($escaper->escapeHtmlAttr($block->getStyle())): ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#subtotal-include-tax td.admin__total-mark'
         ) ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#subtotal-include-tax td.admin__total-amount'
         ) ?>
     <?php endif; ?>
 <?php else: ?>
 <tr id="subtotal-total" class="row-totals">
     <td class="admin__total-mark" colspan="<?= (int) $block->getColspan() ?>">
-        <?= $block->escapeHtml($block->getTotal()->getTitle()) ?>
+        <?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?>
     </td>
     <td class="admin__total-amount">
         <?= /* @noEscape */ $block->formatPrice($block->getTotal()->getValue()) ?>
     </td>
 </tr>
-    <?php if ($block->escapeHtmlAttr($block->getStyle())): ?>
+    <?php if ($escaper->escapeHtmlAttr($block->getStyle())): ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#subtotal-total td.admin__total-mark'
         ) ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getStyle()),
+            $escaper->escapeHtmlAttr($block->getStyle()),
             'tr#subtotal-total td.admin__total-amount'
         ) ?>
     <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/tax.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/tax.phtml
@@ -7,6 +7,7 @@
 // phpcs:disable Squiz.PHP.GlobalKeyword.NotAllowed
 /**
  * @var \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Tax $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 
@@ -18,15 +19,15 @@ $taxAmount = $block->getTotal()->getValue();
     global $taxIter;
     $taxIter++;
     ?>
-    <?php $class = $block->escapeHtmlAttr("{$block->getTotal()->getCode()} " . ($taxHelper->displayFullSummary() ?
+    <?php $class = $escaper->escapeHtmlAttr("{$block->getTotal()->getCode()} " . ($taxHelper->displayFullSummary() ?
         'summary-total' : '')); ?>
-    <tr id="tax-summary-<?= $block->escapeHtmlAttr($taxIter) ?>"
+    <tr id="tax-summary-<?= $escaper->escapeHtmlAttr($taxIter) ?>"
         class="<?= /* @noEscape */ $class ?> row-totals">
         <td class="admin__total-mark" colspan="<?= (int) $block->getColspan() ?>">
             <?php if ($taxHelper->displayFullSummary()): ?>
-                <div class="summary-collapse"><?= $block->escapeHtml($block->getTotal()->getTitle()) ?></div>
+                <div class="summary-collapse"><?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?></div>
             <?php else: ?>
-                <?= $block->escapeHtml($block->getTotal()->getTitle()) ?>
+                <?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?>
             <?php endif;?>
         </td>
         <td class="admin__total-amount">
@@ -36,17 +37,17 @@ $taxAmount = $block->getTotal()->getValue();
     <?php if ($taxHelper->displayFullSummary()): ?>
         <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
             'onclick',
-            "expandDetails(this, '.summary-details-" . $block->escapeJs($taxIter) ."')",
-            'tr#tax-summary-' . $block->escapeHtmlAttr($taxIter)
+            "expandDetails(this, '.summary-details-" . $escaper->escapeJs($taxIter) ."')",
+            'tr#tax-summary-' . $escaper->escapeHtmlAttr($taxIter)
         ) ?>
     <?php endif; ?>
-    <?php if ($block->escapeHtmlAttr($block->getTotal()->getStyle())): ?>
+    <?php if ($escaper->escapeHtmlAttr($block->getTotal()->getStyle())): ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getTotal()->getStyle()),
+            $escaper->escapeHtmlAttr($block->getTotal()->getStyle()),
             'tr#tax-summary td.admin__total-mark'
         ) ?>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-            $block->escapeHtmlAttr($block->getTotal()->getStyle()),
+            $escaper->escapeHtmlAttr($block->getTotal()->getStyle()),
             'tr#tax-summary td.admin__total-amount'
         ) ?>
     <?php endif; ?>
@@ -61,11 +62,11 @@ $taxAmount = $block->getTotal()->getValue();
             <?php $rates = $info['rates']; ?>
 
             <?php foreach ($rates as $rate): ?>
-                <tr id="tax-summary-details-<?= $block->escapeHtmlAttr($taxIter) ?>"
-                    class="summary-details-<?= $block->escapeHtmlAttr($taxIter) ?>
+                <tr id="tax-summary-details-<?= $escaper->escapeHtmlAttr($taxIter) ?>"
+                    class="summary-details-<?= $escaper->escapeHtmlAttr($taxIter) ?>
                      summary-details<?= ($isTop ? ' summary-details-first' : '') ?>">
                     <td class="admin__total-mark" colspan="<?= (int) $block->getColspan() ?>">
-                        <?= $block->escapeHtml($rate['title']) ?>
+                        <?= $escaper->escapeHtml($rate['title']) ?>
                         <?php if ($rate['percent'] !== null): ?>
                             (<?= (float) $rate['percent'] ?>%)
                         <?php endif; ?>
@@ -77,16 +78,16 @@ $taxAmount = $block->getTotal()->getValue();
                 </tr>
                 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
                     "display:none;",
-                    'tr#tax-summary-details-' . $block->escapeHtmlAttr($taxIter)
+                    'tr#tax-summary-details-' . $escaper->escapeHtmlAttr($taxIter)
                 ) ?>
-                <?php if ($block->escapeHtmlAttr($block->getTotal()->getStyle())): ?>
+                <?php if ($escaper->escapeHtmlAttr($block->getTotal()->getStyle())): ?>
                     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-                        $block->escapeHtmlAttr($block->getTotal()->getStyle()),
-                        'tr#tax-summary-details-' . $block->escapeHtmlAttr($taxIter) . ' td.admin__total-mark'
+                        $escaper->escapeHtmlAttr($block->getTotal()->getStyle()),
+                        'tr#tax-summary-details-' . $escaper->escapeHtmlAttr($taxIter) . ' td.admin__total-mark'
                     ) ?>
                     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-                        $block->escapeHtmlAttr($block->getTotal()->getStyle()),
-                        'tr#tax-summary-details-' . $block->escapeHtmlAttr($taxIter) . ' td.admin__total-amount'
+                        $escaper->escapeHtmlAttr($block->getTotal()->getStyle()),
+                        'tr#tax-summary-details-' . $escaper->escapeHtmlAttr($taxIter) . ' td.admin__total-amount'
                     ) ?>
                 <?php endif; ?>
                 <?php $isTop = 0; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/create/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/create/form.phtml
@@ -6,9 +6,12 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/* @var \Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Form $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Form $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<form id="edit_form" method="post" action="<?= $block->escapeUrl($block->getSaveUrl()) ?>">
+<form id="edit_form" method="post" action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>">
     <?= $block->getBlockHtml('formkey') ?>
     <?php  $_order = $block->getCreditmemo()->getOrder() ?>
 
@@ -16,7 +19,7 @@
 
     <section class="admin__page-section">
         <div class="admin__page-section-title">
-            <span class="title"><?= $block->escapeHtml(__('Payment &amp; Shipping Method')) ?></span>
+            <span class="title"><?= $escaper->escapeHtml(__('Payment &amp; Shipping Method')) ?></span>
         </div>
         <div class="admin__page-section-content">
         <?php if (!$_order->getIsVirtual()) : ?>
@@ -27,12 +30,12 @@
 
             <?php /* Billing Address */ ?>
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Payment Information')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Payment Information')) ?></span>
             </div>
             <div class="admin__page-section-item-content">
                 <div class="order-payment-method-title"><?= $block->getChildHtml('order_payment') ?></div>
                 <div class="order-payment-currency">
-                    <?= $block->escapeHtml(__('The order was placed using %1.', $_order->getOrderCurrencyCode())) ?>
+                    <?= $escaper->escapeHtml(__('The order was placed using %1.', $_order->getOrderCurrencyCode())) ?>
                 </div>
                 <div class="order-payment-additional">
                     <?= $block->getChildHtml('order_payment_additional') ?>
@@ -44,12 +47,12 @@
         <div class="admin__page-section-item order-shipping-address">
             <?php /* Shipping Address */ ?>
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Shipping Information')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Shipping Information')) ?></span>
             </div>
             <div class="admin__page-section-item-content shipping-description-wrapper">
-                <div class="shipping-description-title"><?= $block->escapeHtml($_order->getShippingDescription()) ?></div>
+                <div class="shipping-description-title"><?= $escaper->escapeHtml($_order->getShippingDescription()) ?></div>
                 <div class="shipping-description-content">
-                    <?= $block->escapeHtml(__('Total Shipping Charges')) ?>:
+                    <?= $escaper->escapeHtml(__('Total Shipping Charges')) ?>:
 
                     <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displaySalesPriceInclTax($block->getSource()->getStoreId())) : ?>
                         <?php $_excl = $block->displayShippingPriceInclTax($_order); ?>
@@ -60,7 +63,7 @@
 
                     <?= /* @noEscape */ $_excl ?>
                     <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displaySalesBothPrices($block->getSource()->getStoreId()) && $_incl != $_excl) : ?>
-                        (<?= $block->escapeHtml(__('Incl. Tax')) ?> <?= /* @noEscape */ $_incl ?>)
+                        (<?= $escaper->escapeHtml(__('Incl. Tax')) ?> <?= /* @noEscape */ $_incl ?>)
                     <?php endif; ?>
                 </div>
             </div>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/create/items.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/create/items.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/* @var \Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Items $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\Creditmemo\Create\Items $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php
@@ -18,7 +21,7 @@ $commentText = $block->getCreditmemo()->getCommentText();
 
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Items to Refund')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Items to Refund')) ?></span>
     </div>
 
     <?php if (count($_items)): ?>
@@ -26,17 +29,17 @@ $commentText = $block->getCreditmemo()->getCommentText();
         <table class="data-table admin__table-primary order-creditmemo-tables">
             <thead>
                 <tr class="headings">
-                    <th class="col-product"><span><?= $block->escapeHtml(__('Product')) ?></span></th>
-                    <th class="col-price"><span><?= $block->escapeHtml(__('Price')) ?></span></th>
-                    <th class="col-ordered-qty"><span><?= $block->escapeHtml(__('Qty')) ?></span></th>
+                    <th class="col-product"><span><?= $escaper->escapeHtml(__('Product')) ?></span></th>
+                    <th class="col-price"><span><?= $escaper->escapeHtml(__('Price')) ?></span></th>
+                    <th class="col-ordered-qty"><span><?= $escaper->escapeHtml(__('Qty')) ?></span></th>
                     <?php if ($block->canReturnToStock()): ?>
-                    <th class="col-return-to-stock"><span><?= $block->escapeHtml(__('Return to Stock')) ?></span></th>
+                    <th class="col-return-to-stock"><span><?= $escaper->escapeHtml(__('Return to Stock')) ?></span></th>
                     <?php endif; ?>
-                    <th class="col-refund"><span><?= $block->escapeHtml(__('Qty to Refund')) ?></span></th>
-                    <th class="col-subtotal"><span><?= $block->escapeHtml(__('Subtotal')) ?></span></th>
-                    <th class="col-tax-amount"><span><?= $block->escapeHtml(__('Tax Amount')) ?></span></th>
-                    <th class="col-discont"><span><?= $block->escapeHtml(__('Discount Amount')) ?></span></th>
-                    <th class="col-total last"><span><?= $block->escapeHtml(__('Row Total')) ?></span></th>
+                    <th class="col-refund"><span><?= $escaper->escapeHtml(__('Qty to Refund')) ?></span></th>
+                    <th class="col-subtotal"><span><?= $escaper->escapeHtml(__('Subtotal')) ?></span></th>
+                    <th class="col-tax-amount"><span><?= $escaper->escapeHtml(__('Tax Amount')) ?></span></th>
+                    <th class="col-discont"><span><?= $escaper->escapeHtml(__('Discount Amount')) ?></span></th>
+                    <th class="col-total last"><span><?= $escaper->escapeHtml(__('Row Total')) ?></span></th>
                 </tr>
             </thead>
             <?php if ($block->canEditQty()): ?>
@@ -65,7 +68,7 @@ $commentText = $block->getCreditmemo()->getCommentText();
     </div>
     <?php else: ?>
     <div class="no-items">
-        <?= $block->escapeHtml(__('No Items To Refund')) ?>
+        <?= $escaper->escapeHtml(__('No Items To Refund')) ?>
     </div>
     <?php endif; ?>
 </section>
@@ -81,31 +84,31 @@ $commentText = $block->getCreditmemo()->getCommentText();
 <section class="admin__page-section">
     <input type="hidden" name="creditmemo[do_offline]" id="creditmemo_do_offline" value="0" />
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Order Total')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Order Total')) ?></span>
     </div>
     <div class="admin__page-section-content">
         <div class="admin__page-section-item order-comments-history">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Credit Memo Comments')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Credit Memo Comments')) ?></span>
             </div>
             <div id="history_form" class="admin__fieldset-wrapper-content">
                 <div class="admin__field">
                     <label class="normal admin__field-label"
                            for="creditmemo_comment_text">
-                        <span><?= $block->escapeHtml(__('Comment Text')) ?></span></label>
+                        <span><?= $escaper->escapeHtml(__('Comment Text')) ?></span></label>
                     <div class="admin__field-control">
                         <textarea id="creditmemo_comment_text"
                                   class="admin__control-textarea"
                                   name="creditmemo[comment_text]"
                                   rows="3"
-                                  cols="5"><?= $block->escapeHtml($commentText) ?></textarea>
+                                  cols="5"><?= $escaper->escapeHtml($commentText) ?></textarea>
                     </div>
                 </div>
             </div>
         </div>
         <div class="admin__page-section-item order-totals creditmemo-totals">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Refund Totals')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Refund Totals')) ?></span>
             </div>
             <?= $block->getChildHtml('creditmemo_totals') ?>
             <div class="totals-actions"><?= /* @noEscape */ $viewModel->getUpdateTotalsButton() ?></div>
@@ -117,7 +120,7 @@ $commentText = $block->getCreditmemo()->getCommentText();
                            value="1"
                            type="checkbox" />
                     <label for="notify_customer" class="admin__field-label">
-                        <span><?= $block->escapeHtml(__('Append Comments')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Append Comments')) ?></span>
                     </label>
                 </div>
                 <?php if ($block->canSendCreditmemoEmail()):?>
@@ -128,7 +131,7 @@ $commentText = $block->getCreditmemo()->getCommentText();
                            value="1"
                            type="checkbox" />
                     <label for="send_email" class="admin__field-label">
-                        <span><?= $block->escapeHtml(__('Email Copy of Credit Memo')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Email Copy of Credit Memo')) ?></span>
                     </label>
                 </div>
                 <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/create/totals/adjustments.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/create/totals/adjustments.phtml
@@ -4,13 +4,16 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_source  = $block->getSource() ?>
 <?php if ($_source): ?>
     <tr>
         <td class="label">
-            <?= $block->escapeHtml($block->getShippingLabel()) ?>
+            <?= $escaper->escapeHtml($block->getShippingLabel()) ?>
             <div id="shipping_amount_adv"></div>
         </td>
         <td>
@@ -23,7 +26,7 @@
     </tr>
     <tr>
         <td class="label">
-            <?= $block->escapeHtml(__('Adjustment Refund')) ?>
+            <?= $escaper->escapeHtml(__('Adjustment Refund')) ?>
             <div id="adjustment_positive_adv"></div>
         </td>
         <td>
@@ -36,7 +39,7 @@
     </tr>
     <tr>
         <td class="label">
-            <?= $block->escapeHtml(__('Adjustment Fee')) ?>
+            <?= $escaper->escapeHtml(__('Adjustment Fee')) ?>
             <div id="adjustment_negative_adv"></div>
         </td>
         <td>
@@ -52,7 +55,7 @@
                 Validation.addAllThese([
                     [
                         'not-negative-amount',
-                        '{$block->escapeJs(__('Please enter a positive number in this field.'))}',
+                        '{$escaper->escapeJs(__('Please enter a positive number in this field.'))}',
                         function (v) {
                             if (v.length)
                                 return /^\s*\d+([,.]\d+)*\s*%?\s*$/.test(v);

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/view/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/view/form.phtml
@@ -6,13 +6,16 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/* @var \Magento\Sales\Block\Adminhtml\Order\Creditmemo\View\Form $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\Creditmemo\View\Form $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php  $_order = $block->getCreditmemo()->getOrder() ?>
 <?= $block->getChildHtml('order_info') ?>
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Payment &amp; Shipping Method')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Payment &amp; Shipping Method')) ?></span>
     </div>
     <div class="admin__page-section-content">
 
@@ -23,11 +26,11 @@
         <?php endif; ?>
             <?php /* Billing Address */?>
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Payment Information')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Payment Information')) ?></span>
             </div>
             <div class="admin__page-section-item-content">
                 <div class="order-payment-method-title"><?= $block->getChildHtml('order_payment') ?></div>
-                <div class="order-payment-currency"><?= $block->escapeHtml(__('The order was placed using %1.', $_order->getOrderCurrencyCode())) ?></div>
+                <div class="order-payment-currency"><?= $escaper->escapeHtml(__('The order was placed using %1.', $_order->getOrderCurrencyCode())) ?></div>
                 <div class="order-payment-additional"><?= $block->getChildHtml('order_payment_additional') ?></div>
             </div>
         </div>
@@ -36,12 +39,12 @@
         <div class="admin__page-section-item order-shipping-address">
             <?php /* Shipping Address */ ?>
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Shipping Information')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Shipping Information')) ?></span>
             </div>
             <div class="shipping-description-wrapper admin__page-section-item-content">
-                <div class="shipping-description-title"><?= $block->escapeHtml($_order->getShippingDescription()) ?></div>
+                <div class="shipping-description-title"><?= $escaper->escapeHtml($_order->getShippingDescription()) ?></div>
                 <div class="shipping-description-content">
-                    <?= $block->escapeHtml(__('Total Shipping Charges')) ?>:
+                    <?= $escaper->escapeHtml(__('Total Shipping Charges')) ?>:
 
                     <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displayShippingPriceIncludingTax()) : ?>
                         <?php $_excl = $block->displayShippingPriceInclTax($_order); ?>
@@ -52,7 +55,7 @@
 
                     <?= /* @noEscape */ $_excl ?>
                     <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displayShippingBothPrices() && $_incl != $_excl) : ?>
-                        (<?= $block->escapeHtml(__('Incl. Tax')) ?> <?= /* @noEscape */ $_incl ?>)
+                        (<?= $escaper->escapeHtml(__('Incl. Tax')) ?> <?= /* @noEscape */ $_incl ?>)
                     <?php endif; ?>
                 </div>
             </div>
@@ -69,26 +72,26 @@
 <?php else : ?>
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Items Refunded')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Items Refunded')) ?></span>
     </div>
-    <div class="no-items admin__page-section-content"><?= $block->escapeHtml(__('No Items')) ?></div>
+    <div class="no-items admin__page-section-content"><?= $escaper->escapeHtml(__('No Items')) ?></div>
 </section>
 <?php endif; ?>
 
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Memo Total')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Memo Total')) ?></span>
     </div>
     <div class="admin__page-section-content">
         <div class="admin__page-section-item order-comments-history">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Credit Memo History')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Credit Memo History')) ?></span>
             </div>
             <div class="admin__page-section-item-content"><?= $block->getChildHtml('order_comments') ?></div>
         </div>
         <div class="admin__page-section-item order-totals" id="history_form">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Credit Memo Totals')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Credit Memo Totals')) ?></span>
             </div>
             <div class="admin__page-section-content"><?= $block->getChildHtml('creditmemo_totals') ?></div>
         </div>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/view/items.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/view/items.phtml
@@ -4,25 +4,28 @@
  * See COPYING.txt for license details.
  */
 
-/* @var \Magento\Sales\Block\Adminhtml\Order\Creditmemo\View\Items $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\Creditmemo\View\Items $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_items = $block->getCreditmemo()->getAllItems() ?>
 <div class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Items Refunded')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Items Refunded')) ?></span>
     </div>
     <div class="admin__page-section-content">
         <div class="admin__table-wrapper">
             <table class="data-table admin__table-primary order-creditmemo-tables">
                 <thead>
                     <tr class="headings">
-                        <th class="col-product"><span><?= $block->escapeHtml(__('Product')) ?></span></th>
-                        <th class="col-price"><span><?= $block->escapeHtml(__('Price')) ?></span></th>
-                        <th class="col-qty"><span><?= $block->escapeHtml(__('Qty')) ?></span></th>
-                        <th class="col-subtotal"><span><?= $block->escapeHtml(__('Subtotal')) ?></span></th>
-                        <th class="col-tax"><span><?= $block->escapeHtml(__('Tax Amount')) ?></span></th>
-                        <th class="col-discount"><span><?= $block->escapeHtml(__('Discount Amount')) ?></span></th>
-                        <th class="col-total last"><span><?= $block->escapeHtml(__('Row Total')) ?></span></th>
+                        <th class="col-product"><span><?= $escaper->escapeHtml(__('Product')) ?></span></th>
+                        <th class="col-price"><span><?= $escaper->escapeHtml(__('Price')) ?></span></th>
+                        <th class="col-qty"><span><?= $escaper->escapeHtml(__('Qty')) ?></span></th>
+                        <th class="col-subtotal"><span><?= $escaper->escapeHtml(__('Subtotal')) ?></span></th>
+                        <th class="col-tax"><span><?= $escaper->escapeHtml(__('Tax Amount')) ?></span></th>
+                        <th class="col-discount"><span><?= $escaper->escapeHtml(__('Discount Amount')) ?></span></th>
+                        <th class="col-total last"><span><?= $escaper->escapeHtml(__('Row Total')) ?></span></th>
                     </tr>
                 </thead>
                 <?php $i = 0; foreach ($_items as $_item) : ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/details.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/details.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/* @var \Magento\Sales\Block\Adminhtml\Order\Details $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\Details $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
 /* @var \Magento\Sales\Model\Order $_order */
@@ -13,9 +16,9 @@ $_order = $block->getOrder();
 $giftMessageHelper = $block->getData('giftMessageHelper');
 ?>
 <div>
-<?= $block->escapeHtml(__('Customer Name: %1', $_order->getCustomerFirstname() ? $_order->getCustomerName() :
+<?= $escaper->escapeHtml(__('Customer Name: %1', $_order->getCustomerFirstname() ? $_order->getCustomerName() :
     $_order->getBillingAddress()->getName())) ?><br />
-<?= $block->escapeHtml(__('Purchased From: %1', $_order->getStore()->getGroup()->getName())) ?><br />
+<?= $escaper->escapeHtml(__('Purchased From: %1', $_order->getStore()->getGroup()->getName())) ?><br />
 </div>
 <table id="order-details" cellpadding="0" border="0" width="100%">
     <thead>
@@ -29,13 +32,13 @@ $giftMessageHelper = $block->getData('giftMessageHelper');
     <tbody>
 <?php $i = 0; foreach ($_order->getAllItems() as $_item): $i++ ?>
         <tr id="item-<?= /* @noEscape */ $i ?>" <?= $i%2 ? 'bgcolor="#eeeded"' : '' ?>>
-            <td align="left" valign="top"><strong><?= $block->escapeHtml($_item->getName()) ?></strong>
+            <td align="left" valign="top"><strong><?= $escaper->escapeHtml($_item->getName()) ?></strong>
             <?php if ($_item->getGiftMessageId() &&
                 $_giftMessage = $giftMessageHelper->getGiftMessage($_item->getGiftMessageId())): ?>
-            <br /><strong><?= $block->escapeHtml(__('Gift Message')) ?></strong>
-            <br /><?= $block->escapeHtml(__('From:')) ?> <?= $block->escapeHtml($_giftMessage->getSender()) ?>
-            <br /><?= $block->escapeHtml(__('To:')) ?> <?= $block->escapeHtml($_giftMessage->getRecipient()) ?>
-            <br /><?= $block->escapeHtml(__('Message:')) ?><br /> <?= $block->escapeHtml($_giftMessage->getMessage()) ?>
+            <br /><strong><?= $escaper->escapeHtml(__('Gift Message')) ?></strong>
+            <br /><?= $escaper->escapeHtml(__('From:')) ?> <?= $escaper->escapeHtml($_giftMessage->getSender()) ?>
+            <br /><?= $escaper->escapeHtml(__('To:')) ?> <?= $escaper->escapeHtml($_giftMessage->getRecipient()) ?>
+            <br /><?= $escaper->escapeHtml(__('Message:')) ?><br /> <?= $escaper->escapeHtml($_giftMessage->getMessage()) ?>
             <?php endif; ?>
             </td>
             <td align="center" valign="top"><?= (float) $_item->getQtyOrdered() ?></td>
@@ -61,10 +64,10 @@ $giftMessageHelper = $block->getData('giftMessageHelper');
         $_giftMessage = $giftMessageHelper->getGiftMessage($_order->getGiftMessageId())): ?>
         <tr id="gift-message">
             <td colspan="3" align="left">
-            <strong><?= $block->escapeHtml(__('Gift Message')) ?></strong>
-            <br /><?= $block->escapeHtml(__('From:')) ?> <?= $block->escapeHtml($_giftMessage->getSender()) ?>
-            <br /><?= $block->escapeHtml(__('To:')) ?> <?= $block->escapeHtml($_giftMessage->getRecipient()) ?>
-            <br /><?= $block->escapeHtml(__('Message:')) ?><br /> <?= $block->escapeHtml($_giftMessage->getMessage()) ?>
+            <strong><?= $escaper->escapeHtml(__('Gift Message')) ?></strong>
+            <br /><?= $escaper->escapeHtml(__('From:')) ?> <?= $escaper->escapeHtml($_giftMessage->getSender()) ?>
+            <br /><?= $escaper->escapeHtml(__('To:')) ?> <?= $escaper->escapeHtml($_giftMessage->getRecipient()) ?>
+            <br /><?= $escaper->escapeHtml(__('Message:')) ?><br /> <?= $escaper->escapeHtml($_giftMessage->getMessage()) ?>
             </td>
         </tr>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
@@ -73,7 +76,7 @@ $giftMessageHelper = $block->getData('giftMessageHelper');
         ) ?>
     <?php endif; ?>
         <tr id="subtotal">
-            <td colspan="2" align="right"><?= $block->escapeHtml(__('Subtotal')) ?></td>
+            <td colspan="2" align="right"><?= $escaper->escapeHtml(__('Subtotal')) ?></td>
             <td align="right"><?= /* @noEscape */ $_order->formatPrice($_order->getSubtotal()) ?></td>
         </tr>
     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
@@ -87,7 +90,7 @@ $giftMessageHelper = $block->getData('giftMessageHelper');
 
         <?php if ($_order->getDiscountAmount() > 0): ?>
             <tr id="discount">
-                <td colspan="2" align="right"><?= $block->escapeHtml((($_order->getCouponCode()) ?
+                <td colspan="2" align="right"><?= $escaper->escapeHtml((($_order->getCouponCode()) ?
                         __('Discount (%1)', $_order->getCouponCode()) : __('Discount'))) ?></td>
                 <td align="right"><?= /* @noEscape */ $_order->formatPrice(0.00 - $_order->getDiscountAmount()) ?></td>
             </tr>
@@ -102,7 +105,7 @@ $giftMessageHelper = $block->getData('giftMessageHelper');
         <?php endif; ?>
         <?php if ($_order->getShippingAmount() || $_order->getShippingDescription()): ?>
             <tr id="shipping">
-                <td colspan="2" align="right"><?= $block->escapeHtml(__('Shipping &amp; Handling')) ?></td>
+                <td colspan="2" align="right"><?= $escaper->escapeHtml(__('Shipping &amp; Handling')) ?></td>
                 <td align="right"><?= /* @noEscape */ $_order->formatPrice($_order->getShippingAmount()) ?></td>
             </tr>
             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
@@ -116,7 +119,7 @@ $giftMessageHelper = $block->getData('giftMessageHelper');
         <?php endif; ?>
         <?php if ($_order->getTaxAmount() > 0): ?>
             <tr id="tax">
-                <td colspan="2" align="right"><?= $block->escapeHtml(__('Tax')) ?></td>
+                <td colspan="2" align="right"><?= $escaper->escapeHtml(__('Tax')) ?></td>
                 <td align="right"><?= /* @noEscape */ $_order->formatPrice($_order->getTaxAmount()) ?></td>
             </tr>
             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
@@ -129,7 +132,7 @@ $giftMessageHelper = $block->getData('giftMessageHelper');
             ) ?>
         <?php endif; ?>
         <tr id="grand-total" bgcolor="#DEE5E8">
-            <td colspan="2" align="right"><strong><?= $block->escapeHtml(__('Grand Total')) ?></strong></td>
+            <td colspan="2" align="right"><strong><?= $escaper->escapeHtml(__('Grand Total')) ?></strong></td>
             <td align="right"><strong><?= /* @noEscape */ $_order->formatPrice($_order->getGrandTotal())?></strong></td>
         </tr>
     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/giftoptions.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/giftoptions.phtml
@@ -3,10 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($block->getChildHtml()) : ?>
 <section class="admin__page-section order-gift-options">
-    <div class="admin__page-section-title"><strong class="title"><?= $block->escapeHtml(__('Gift Options')) ?></strong></div>
+    <div class="admin__page-section-title"><strong class="title"><?= $escaper->escapeHtml(__('Gift Options')) ?></strong></div>
     <?= $block->getChildHtml() ?>
 </section>
 <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/create/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/create/form.phtml
@@ -4,10 +4,13 @@
  * See COPYING.txt for license details.
  */
 
-/* @var \Magento\Sales\Block\Adminhtml\Order\Invoice\Create\Form $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\Invoice\Create\Form $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
-<form id="edit_form" class="order-invoice-edit" method="post" action="<?= $block->escapeUrl($block->getSaveUrl()) ?>">
+<form id="edit_form" class="order-invoice-edit" method="post" action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>">
     <?= $block->getBlockHtml('formkey') ?>
     <?php $_order = $block->getInvoice()->getOrder() ?>
     <?php
@@ -18,18 +21,18 @@
 
     <section class="admin__page-section">
         <div class="admin__page-section-title">
-            <span class="title"><?= $block->escapeHtml(__('Payment &amp; Shipping Method')) ?></span>
+            <span class="title"><?= $escaper->escapeHtml(__('Payment &amp; Shipping Method')) ?></span>
         </div>
         <div class="admin__page-section-content">
             <div class="admin__page-section-item order-payment-method
             <?php if ($_order->getIsVirtual()): ?> order-payment-method-virtual<?php endif; ?>">
                 <div class="admin__page-section-item-title">
-                    <span class="title"><?= $block->escapeHtml(__('Payment Information')) ?></span>
+                    <span class="title"><?= $escaper->escapeHtml(__('Payment Information')) ?></span>
                 </div>
                 <div class="admin__page-section-item-content">
                     <div class="order-payment-method-title"><?= $block->getChildHtml('order_payment') ?></div>
                     <div class="order-payment-currency">
-                        <?= $block->escapeHtml(__('The order was placed using %1.', $_order->getOrderCurrencyCode())) ?>
+                        <?= $escaper->escapeHtml(__('The order was placed using %1.', $_order->getOrderCurrencyCode())) ?>
                     </div>
                     <div class="order-payment-additional"><?= $block->getChildHtml('order_payment_additional') ?></div>
                 </div>
@@ -38,14 +41,14 @@
                 <div class="admin__page-section-item order-shipping-address">
                     <?php /*Shipping Address */ ?>
                     <div class="admin__page-section-item-title">
-                        <span class="title"><?= $block->escapeHtml(__('Shipping Information')) ?></span>
+                        <span class="title"><?= $escaper->escapeHtml(__('Shipping Information')) ?></span>
                     </div>
                     <div class="admin__page-section-item-content">
                         <div class="shipping-description-wrapper">
                             <div class="shipping-description-title">
-                                <?= $block->escapeHtml($_order->getShippingDescription()) ?></div>
+                                <?= $escaper->escapeHtml($_order->getShippingDescription()) ?></div>
                             <div class="shipping-description-content">
-                                <?= $block->escapeHtml(__('Total Shipping Charges')) ?>:
+                                <?= $escaper->escapeHtml(__('Total Shipping Charges')) ?>:
 
                                 <?php if ($taxHelper->displayShippingPriceIncludingTax()): ?>
                                     <?php $_excl = $block->displayShippingPriceInclTax($_order); ?>
@@ -56,7 +59,7 @@
 
                                 <?= /* @noEscape */ $_excl ?>
                                 <?php if ($taxHelper->displayShippingBothPrices() && $_incl != $_excl): ?>
-                                    (<?= $block->escapeHtml(__('Incl. Tax')) ?> <?= /* @noEscape */ $_incl ?>)
+                                    (<?= $escaper->escapeHtml(__('Incl. Tax')) ?> <?= /* @noEscape */ $_incl ?>)
                                 <?php endif; ?>
                             </div>
                         </div>
@@ -67,12 +70,12 @@
                                     <?= $block->hasInvoiceShipmentTypeMismatch() ? ' disabled="disabled"' : '' ?> />
                                 <label for="invoice_do_shipment"
                                        class="admin__field-label">
-                                    <span><?= $block->escapeHtml(__('Create Shipment')) ?></span>
+                                    <span><?= $escaper->escapeHtml(__('Create Shipment')) ?></span>
                                 </label>
                             </div>
                             <?php if ($block->hasInvoiceShipmentTypeMismatch()): ?>
                                 <small>
-                                    <?= $block->escapeHtml(__(
+                                    <?= $escaper->escapeHtml(__(
                                         'Invoice and shipment types do not match for some items on this order. ' .
                                         'You can create a shipment only after creating the invoice.'
                                     )) ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/create/items.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/create/items.phtml
@@ -4,27 +4,30 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Sales\Block\Adminhtml\Order\Invoice\Create\Items $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\Invoice\Create\Items $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <section class="admin__page-section">
     <div class="admin__page-section-title">
         <?php $_itemsGridLabel = $block->getForcedShipmentCreate() ? 'Items to Invoice and Ship' : 'Items to Invoice';?>
-        <span class="title"><?= $block->escapeHtml(__('%1', $_itemsGridLabel)) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('%1', $_itemsGridLabel)) ?></span>
     </div>
     <div class="admin__page-section-content grid">
         <div class="admin__table-wrapper">
             <table class="data-table admin__table-primary order-invoice-tables">
                 <thead>
                     <tr class="headings">
-                        <th class="col-product"><span><?= $block->escapeHtml(__('Product')) ?></span></th>
-                        <th class="col-price"><span><?= $block->escapeHtml(__('Price')) ?></span></th>
-                        <th class="col-ordered-qty"><span><?= $block->escapeHtml(__('Qty')) ?></span></th>
-                        <th class="col-qty-invoice"><span><?= $block->escapeHtml(__('Qty to Invoice')) ?></span></th>
-                        <th class="col-subtotal"><span><?= $block->escapeHtml(__('Subtotal')) ?></span></th>
-                        <th class="col-tax"><span><?= $block->escapeHtml(__('Tax Amount')) ?></span></th>
-                        <th class="col-discount"><span><?= $block->escapeHtml(__('Discount Amount')) ?></span></th>
-                        <th class="col-total last"><span><?= $block->escapeHtml(__('Row Total')) ?></span></th>
+                        <th class="col-product"><span><?= $escaper->escapeHtml(__('Product')) ?></span></th>
+                        <th class="col-price"><span><?= $escaper->escapeHtml(__('Price')) ?></span></th>
+                        <th class="col-ordered-qty"><span><?= $escaper->escapeHtml(__('Qty')) ?></span></th>
+                        <th class="col-qty-invoice"><span><?= $escaper->escapeHtml(__('Qty to Invoice')) ?></span></th>
+                        <th class="col-subtotal"><span><?= $escaper->escapeHtml(__('Subtotal')) ?></span></th>
+                        <th class="col-tax"><span><?= $escaper->escapeHtml(__('Tax Amount')) ?></span></th>
+                        <th class="col-discount"><span><?= $escaper->escapeHtml(__('Discount Amount')) ?></span></th>
+                        <th class="col-total last"><span><?= $escaper->escapeHtml(__('Row Total')) ?></span></th>
                     </tr>
                 </thead>
                 <?php if ($block->canEditQty()): ?>
@@ -63,24 +66,24 @@
 
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Order Total')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Order Total')) ?></span>
     </div>
     <div class="admin__page-section-content">
         <div class="admin__page-section-item order-comments-history">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Invoice History')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Invoice History')) ?></span>
             </div>
             <div id="history_form" class="admin__page-section-item-content order-history-form">
                 <div class="admin__field">
                     <label for="invoice_comment_text" class="admin__field-label">
-                        <span><?= $block->escapeHtml(__('Invoice Comments')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Invoice Comments')) ?></span>
                     </label>
                     <div class="admin__field-control">
                         <textarea id="invoice_comment_text"
                                   name="invoice[comment_text]"
                                   class="admin__control-textarea"
                                   rows="3"
-                                  cols="5"><?= $block->escapeHtml($block->getInvoice()->getCommentText())?></textarea>
+                                  cols="5"><?= $escaper->escapeHtml($block->getInvoice()->getCommentText())?></textarea>
                     </div>
                 </div>
             </div>
@@ -88,7 +91,7 @@
 
         <div id="invoice_totals" class="admin__page-section-item order-totals">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Invoice Totals')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Invoice Totals')) ?></span>
             </div>
             <div class="admin__page-section-item-content order-totals-actions">
                 <?= $block->getChildHtml('invoice_totals') ?>
@@ -96,18 +99,18 @@
                     <?php if ($block->canCapture()): ?>
                         <div class="admin__field">
                           <label for="invoice_do_capture" class="admin__field-label">
-                              <?= $block->escapeHtml(__('Amount')) ?>
+                              <?= $escaper->escapeHtml(__('Amount')) ?>
                           </label>
                           <select class="admin__control-select" name="invoice[capture_case]">
-                              <option value="online"><?= $block->escapeHtml(__('Capture Online')) ?></option>
-                              <option value="offline"><?= $block->escapeHtml(__('Capture Offline')) ?></option>
-                              <option value="not_capture"><?= $block->escapeHtml(__('Not Capture')) ?></option>
+                              <option value="online"><?= $escaper->escapeHtml(__('Capture Online')) ?></option>
+                              <option value="offline"><?= $escaper->escapeHtml(__('Capture Offline')) ?></option>
+                              <option value="not_capture"><?= $escaper->escapeHtml(__('Not Capture')) ?></option>
                           </select>
                         </div>
                     <?php elseif ($block->isGatewayUsed()):?>
                         <input type="hidden" name="invoice[capture_case]" value="offline"/>
                         <div>
-                            <?= $block->escapeHtml(__(
+                            <?= $escaper->escapeHtml(__(
                                 'The invoice will be created offline without the payment gateway.'
                             )) ?>
                         </div>
@@ -117,7 +120,7 @@
                     <input id="notify_customer" name="invoice[comment_customer_notify]" value="1" type="checkbox"
                            class="admin__control-checkbox" />
                     <label class="admin__field-label" for="notify_customer">
-                        <?= $block->escapeHtml(__('Append Comments')) ?>
+                        <?= $escaper->escapeHtml(__('Append Comments')) ?>
                     </label>
                 </div>
                 <?php if ($block->canSendInvoiceEmail()): ?>
@@ -125,7 +128,7 @@
                     <input id="send_email" name="invoice[send_email]" value="1" type="checkbox"
                            class="admin__control-checkbox" />
                     <label class="admin__field-label" for="send_email">
-                        <?= $block->escapeHtml(__('Email Copy of Invoice')) ?>
+                        <?= $escaper->escapeHtml(__('Email Copy of Invoice')) ?>
                     </label>
                 </div>
                 <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/view/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/view/form.phtml
@@ -6,7 +6,10 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/* @var \Magento\Sales\Block\Adminhtml\Order\Invoice\View\Form $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\Invoice\View\Form $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_invoice = $block->getInvoice() ?>
 <?php $_order = $_invoice->getOrder() ?>
@@ -14,18 +17,18 @@
 
 <section class="admin__page-section order-view-billing-shipping">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Payment &amp; Shipping Method')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Payment &amp; Shipping Method')) ?></span>
     </div>
     <div class="admin__page-section-content">
         <div class="admin__page-section-item order-payment-method<?php if ($_order->getIsVirtual()) : ?> order-payment-method-virtual<?php endif; ?> admin__fieldset-wrapper">
             <?php /*Billing Address */ ?>
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Payment Information')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Payment Information')) ?></span>
             </div>
             <div class="admin__page-section-item-content">
                 <div class="order-payment-method-title"><?= $block->getChildHtml('order_payment') ?></div>
                 <div class="order-payment-currency">
-                    <?= $block->escapeHtml(__('The order was placed using %1.', $_order->getOrderCurrencyCode())) ?>
+                    <?= $escaper->escapeHtml(__('The order was placed using %1.', $_order->getOrderCurrencyCode())) ?>
                 </div>
                 <div class="order-payment-additional"><?= $block->getChildHtml('order_payment_additional') ?></div>
             </div>
@@ -35,14 +38,14 @@
             <div class="admin__page-section-item order-shipping-address">
                 <?php /*Shipping Address */ ?>
                 <div class="admin__page-section-item-title">
-                    <span class="title"><?= $block->escapeHtml(__('Shipping Information')) ?></span>
+                    <span class="title"><?= $escaper->escapeHtml(__('Shipping Information')) ?></span>
                 </div>
                 <div class="admin__page-section-item-content shipping-description-wrapper">
                     <div class="shipping-description-title">
-                        <?= $block->escapeHtml($_order->getShippingDescription()) ?>
+                        <?= $escaper->escapeHtml($_order->getShippingDescription()) ?>
                     </div>
                     <div class="shipping-description-content">
-                        <?= $block->escapeHtml(__('Total Shipping Charges')) ?>:
+                        <?= $escaper->escapeHtml(__('Total Shipping Charges')) ?>:
 
                         <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displayShippingPriceIncludingTax()) : ?>
                             <?php $_excl = $block->displayShippingPriceInclTax($_order); ?>
@@ -53,7 +56,7 @@
 
                         <?= /* @noEscape */ $_excl ?>
                         <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displayShippingBothPrices() && $_incl != $_excl) : ?>
-                            (<?= $block->escapeHtml(__('Incl. Tax')) ?> <?= /* @noEscape */ $_incl ?>)
+                            (<?= $escaper->escapeHtml(__('Incl. Tax')) ?> <?= /* @noEscape */ $_incl ?>)
                         <?php endif; ?>
                         <div><?= $block->getChildHtml('shipment_tracking') ?></div>
                     </div>
@@ -66,7 +69,7 @@
 
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Items Invoiced')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Items Invoiced')) ?></span>
     </div>
 
     <div id="invoice_item_container" class="admin__page-section-content">
@@ -76,12 +79,12 @@
 
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Order Total')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Order Total')) ?></span>
     </div>
     <div class="admin__page-section-content">
         <div class="admin__page-section-item order-comments-history">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Invoice History')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Invoice History')) ?></span>
             </div>
             <div class="admin__page-section-item-content">
                 <?= $block->getChildHtml('order_comments') ?>
@@ -90,7 +93,7 @@
 
         <div id="history_form" class="admin__page-section-item order-totals">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Invoice Totals')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Invoice Totals')) ?></span>
             </div>
             <?= $block->getChildHtml('invoice_totals') ?>
         </div>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/view/items.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/view/items.phtml
@@ -4,19 +4,22 @@
  * See COPYING.txt for license details.
  */
 
-/* @var \Magento\Sales\Block\Adminhtml\Order\Invoice\View\Items $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\Invoice\View\Items $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="admin__table-wrapper">
     <table class="data-table admin__table-primary order-invoice-tables">
         <thead>
             <tr class="headings">
-                <th class="col-product"><span><?= $block->escapeHtml(__('Product')) ?></span></th>
-                <th class="col-price"><span><?= $block->escapeHtml(__('Price')) ?></span></th>
-                <th class="col-qty"><span><?= $block->escapeHtml(__('Qty')) ?></span></th>
-                <th class="col-subtotal"><span><?= $block->escapeHtml(__('Subtotal')) ?></span></th>
-                <th class="col-tax"><span><?= $block->escapeHtml(__('Tax Amount')) ?></span></th>
-                <th class="col-discount"><span><?= $block->escapeHtml(__('Discount Amount')) ?></span></th>
-                <th class="col-total last"><span><?= $block->escapeHtml(__('Row Total')) ?></span></th>
+                <th class="col-product"><span><?= $escaper->escapeHtml(__('Product')) ?></span></th>
+                <th class="col-price"><span><?= $escaper->escapeHtml(__('Price')) ?></span></th>
+                <th class="col-qty"><span><?= $escaper->escapeHtml(__('Qty')) ?></span></th>
+                <th class="col-subtotal"><span><?= $escaper->escapeHtml(__('Subtotal')) ?></span></th>
+                <th class="col-tax"><span><?= $escaper->escapeHtml(__('Tax Amount')) ?></span></th>
+                <th class="col-discount"><span><?= $escaper->escapeHtml(__('Discount Amount')) ?></span></th>
+                <th class="col-total last"><span><?= $escaper->escapeHtml(__('Row Total')) ?></span></th>
             </tr>
         </thead>
         <?php $_items = $block->getInvoice()->getAllItems() ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/totalbar.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/totalbar.phtml
@@ -4,6 +4,9 @@
  * See COPYING.txt for license details.
  */
 
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 // @deprecated
 $totals = $block->getTotals();
 ?>
@@ -14,8 +17,8 @@ $totals = $block->getTotals();
         <td <?php if ($total['grand']) :
             ?>class="grand-total"<?php
             endif; ?>>
-            <?= $block->escapeHtml($total['label']) ?><br />
-            <?= $block->escapeHtml($total['value']) ?>
+            <?= $escaper->escapeHtml($total['label']) ?><br />
+            <?= $escaper->escapeHtml($total['value']) ?>
         </td>
     <?php endforeach; ?>
     </tr>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/totals.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/totals.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/* @var \Magento\Sales\Block\Adminhtml\Order\Totals $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\Totals $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <table class="data-table admin__table-secondary order-subtotal-table">
     <?php $_totals = $block->getTotals('footer') ?>
@@ -15,9 +18,9 @@
                 <?php if ($_total->getBlockName()) : ?>
                     <?= $block->getChildHtml($_total->getBlockName(), false) ?>
                 <?php else : ?>
-                <tr class="col-<?= $block->escapeHtmlAttr($_code) ?>">
+                <tr class="col-<?= $escaper->escapeHtmlAttr($_code) ?>">
                     <td <?= /* @noEscape */ $block->getLabelProperties() ?> class="label">
-                        <strong><?= $block->escapeHtml($_total->getLabel()) ?></strong>
+                        <strong><?= $escaper->escapeHtml($_total->getLabel()) ?></strong>
                     </td>
                     <td <?= /* @noEscape */ $block->getValueProperties() ?>>
                         <strong><?= /* @noEscape */ $block->formatValue($_total) ?></strong>
@@ -35,12 +38,12 @@
                 <?php if ($_total->getBlockName()) : ?>
                     <?= $block->getChildHtml($_total->getBlockName(), false) ?>
                 <?php else : ?>
-                    <tr class="col-<?= $block->escapeHtmlAttr($_code) ?>">
+                    <tr class="col-<?= $escaper->escapeHtmlAttr($_code) ?>">
                         <td <?= /* @noEscape */ $block->getLabelProperties() ?> class="label">
                             <?php if ($_total->getStrong()) : ?>
-                            <strong><?= $block->escapeHtml($_total->getLabel()) ?></strong>
+                            <strong><?= $escaper->escapeHtml($_total->getLabel()) ?></strong>
                             <?php else : ?>
-                            <?= $block->escapeHtml($_total->getLabel()) ?>
+                            <?= $escaper->escapeHtml($_total->getLabel()) ?>
                             <?php endif?>
                         </td>
 

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/totals/discount.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/totals/discount.phtml
@@ -3,6 +3,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_source  = $block->getSource() ?>
 <?php $_order   = $block->getOrder() ?>
@@ -12,9 +16,9 @@
     <tr>
         <td class="label">
             <?php if ($_order->getCouponCode()) : ?>
-                <?= $block->escapeHtml(__('Discount (%1)', $_order->getCouponCode())) ?>
+                <?= $escaper->escapeHtml(__('Discount (%1)', $_order->getCouponCode())) ?>
             <?php else : ?>
-                <?= $block->escapeHtml(__('Discount')) ?>
+                <?= $escaper->escapeHtml(__('Discount')) ?>
             <?php endif; ?>
         </td>
         <td><?= /* @noEscape */ $block->displayPriceAttribute('discount_amount') ?></td>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/totals/due.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/totals/due.phtml
@@ -4,11 +4,14 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($block->getCanDisplayTotalDue()): ?>
 <tr id="total-due">
-    <td class="label"><strong><?= $block->escapeHtml(__('Total Due')) ?></strong></td>
+    <td class="label"><strong><?= $escaper->escapeHtml(__('Total Due')) ?></strong></td>
 
     <td class="emph"><?= /* @noEscape */ $block->displayPriceAttribute('total_due', true) ?></td>
 </tr>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/totals/grand.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/totals/grand.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_source  = $block->getSource() ?>
 <?php $block->setPriceDataObject($_source) ?>
@@ -13,9 +16,9 @@
     <td class="label">
         <strong>
         <?php if ($block->getGrandTotalTitle()): ?>
-            <?= $block->escapeHtml($block->getGrandTotalTitle()) ?>
+            <?= $escaper->escapeHtml($block->getGrandTotalTitle()) ?>
         <?php else: ?>
-            <?= $block->escapeHtml(__('Grand Total')) ?>
+            <?= $escaper->escapeHtml(__('Grand Total')) ?>
         <?php endif; ?>
         </strong>
     </td>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/totals/item.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/totals/item.phtml
@@ -3,6 +3,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_source = $block->getSource() ?>
 <?php $block->setPriceDataObject($_source) ?>
@@ -13,12 +17,12 @@
             <?php if ($block->getStrong()) : ?>
                 <strong>
             <?php endif; ?>
-            <?= $block->escapeHtml(__($block->getLabel())) ?>
+            <?= $escaper->escapeHtml(__($block->getLabel())) ?>
             <?php if ($block->getStrong()) : ?>
                 </strong>
             <?php endif; ?>
         </td>
-        <td <?= $block->getHtmlClass() ? ('class="' . $block->escapeHtmlAttr($block->getHtmlClass()) . '"') : '' ?>>
+        <td <?= $block->getHtmlClass() ? ('class="' . $escaper->escapeHtmlAttr($block->getHtmlClass()) . '"') : '' ?>>
             <?php if ($block->getStrong()) : ?><strong><?php endif; ?>
             <?= /* @noEscape */ $block->displayPriceAttribute($block->getSourceField()) ?>
             <?php if ($block->getStrong()) : ?></strong><?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/totals/paid.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/totals/paid.phtml
@@ -3,10 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($block->getCanDisplayTotalPaid()) : ?>
 <tr>
-    <td class="label"><strong><?= $block->escapeHtml(__('Total Paid')) ?></strong></td>
+    <td class="label"><strong><?= $escaper->escapeHtml(__('Total Paid')) ?></strong></td>
     <td class="emph"><?= /* @noEscape */ $block->displayPriceAttribute('total_paid', true) ?>
     </td>
 </tr>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/totals/refunded.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/totals/refunded.phtml
@@ -3,10 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($block->getCanDisplayTotalRefunded()) : ?>
 <tr>
-    <td class="label"><strong><?= $block->escapeHtml(__('Total Refunded')) ?></strong></td>
+    <td class="label"><strong><?= $escaper->escapeHtml(__('Total Refunded')) ?></strong></td>
     <td class="emph"><?= /* @noEscape */ $block->displayPriceAttribute('total_refunded', true) ?></td>
 </tr>
 <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/totals/shipping.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/totals/shipping.phtml
@@ -3,13 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_source  = $block->getSource() ?>
 <?php $block->setPriceDataObject($_source) ?>
 
 <?php if ((float) $_source->getShippingAmount() || $_source->getShippingDescription()) : ?>
     <tr>
-        <td class="label"><?= $block->escapeHtml(__('Shipping &amp; Handling')) ?></td>
+        <td class="label"><?= $escaper->escapeHtml(__('Shipping &amp; Handling')) ?></td>
         <td><?= /* @noEscape */ $block->displayPriceAttribute('shipping_amount') ?></td>
     </tr>
 <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/totals/tax.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/totals/tax.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var $block \Magento\Sales\Block\Adminhtml\Order\Totals\Tax
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 
@@ -28,9 +29,9 @@ $randomHelper = $block->getData('randomHelper');
     <td class="label">
         <div class="summary-collapse" tabindex="0">
             <?php if ($taxHelper->displayFullSummary()): ?>
-                <?= $block->escapeHtml(__('Total Tax')) ?>
+                <?= $escaper->escapeHtml(__('Total Tax')) ?>
             <?php else: ?>
-                <?= $block->escapeHtml(__('Tax')) ?>
+                <?= $escaper->escapeHtml(__('Tax')) ?>
             <?php endif;?>
         </div>
     </td>
@@ -63,10 +64,10 @@ $randomHelper = $block->getData('randomHelper');
                     class="summary-details<?= ($isTop ? ' summary-details-first' : '') ?>">
                     <?php if ($rate['percent'] !== null): ?>
                         <td class="admin__total-mark">
-                            <?= $block->escapeHtml($rate['title']) ?> (<?= (float)$rate['percent'] ?>%)<br />
+                            <?= $escaper->escapeHtml($rate['title']) ?> (<?= (float)$rate['percent'] ?>%)<br />
                         </td>
                     <?php else: ?>
-                        <td class="admin__total-mark"><?= $block->escapeHtml($rate['title']) ?><br /></td>
+                        <td class="admin__total-mark"><?= $escaper->escapeHtml($rate['title']) ?><br /></td>
                     <?php endif; ?>
                     <?php if ($isFirst): ?>
                         <td rowspan="<?= count($rates) ?>">
@@ -94,10 +95,10 @@ $randomHelper = $block->getData('randomHelper');
                 class="summary-details<?= ($isTop ? ' summary-details-first' : '') ?>">
                 <?php if ($info['percent'] !== null): ?>
                     <td class="admin__total-mark">
-                        <?= $block->escapeHtml($info['title']) ?> (<?= (float)$info['percent'] ?>%)<br />
+                        <?= $escaper->escapeHtml($info['title']) ?> (<?= (float)$info['percent'] ?>%)<br />
                     </td>
                 <?php else: ?>
-                    <td class="admin__total-mark"><?= $block->escapeHtml($info['title']) ?><br /></td>
+                    <td class="admin__total-mark"><?= $escaper->escapeHtml($info['title']) ?><br /></td>
                 <?php endif; ?>
                     <td><?= /* @noEscape */ $block->displayAmount($amount, $baseAmount) ?></td>
             </tr>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/giftmessage.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/giftmessage.phtml
@@ -4,53 +4,56 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Sales\Block\Adminhtml\Order\View\Giftmessage */
+/**
+ * @var $block \Magento\Sales\Block\Adminhtml\Order\View\Giftmessage
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($block->canDisplayGiftmessage()) : ?>
     <?php $_required = $block->getMessage()->getMessage() != '' ?>
-    <div id="<?= $block->escapeHtmlAttr($block->getHtmlId()) ?>" class="admin__page-section-content giftmessage-whole-order-container">
-        <form class="entry-edit form-inline" id="<?= $block->escapeHtmlAttr($block->getFieldId('form')) ?>" action="<?= $block->escapeUrl($block->getSaveUrl()) ?>">
+    <div id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>" class="admin__page-section-content giftmessage-whole-order-container">
+        <form class="entry-edit form-inline" id="<?= $escaper->escapeHtmlAttr($block->getFieldId('form')) ?>" action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>">
             <fieldset class="admin__fieldset">
-                <legend class="admin__legend"><span><?= $block->escapeHtml(__('Gift Message for the Entire Order')) ?></span></legend>
+                <legend class="admin__legend"><span><?= $escaper->escapeHtml(__('Gift Message for the Entire Order')) ?></span></legend>
                 <br/>
 
-                <input type="hidden" id="<?= $block->escapeHtmlAttr($block->getFieldId('type')) ?>"
-                       name="<?= $block->escapeHtmlAttr($block->getFieldName('type')) ?>"
+                <input type="hidden" id="<?= $escaper->escapeHtmlAttr($block->getFieldId('type')) ?>"
+                       name="<?= $escaper->escapeHtmlAttr($block->getFieldName('type')) ?>"
                        value="order"/>
 
                 <div class="admin__field field-from-name<?= $_required ? ' required' : '' ?>">
                     <label class="admin__field-label"
-                           for="<?= $block->escapeHtmlAttr($block->getFieldId('sender')) ?>"><span><?= $block->escapeHtml(__('From Name')) ?></span></label>
+                           for="<?= $escaper->escapeHtmlAttr($block->getFieldId('sender')) ?>"><span><?= $escaper->escapeHtml(__('From Name')) ?></span></label>
 
                     <div class="admin__field-control">
                         <input class="admin__control-text <?= $_required ? 'required-entry' : '' ?>" type="text"
-                               id="<?= $block->escapeHtmlAttr($block->getFieldId('sender')) ?>"
-                               name="<?= $block->escapeHtmlAttr($block->getFieldName('sender')) ?>"
-                               value="<?= $block->escapeHtml($block->getMessage()->getSender()) ?>"/>
+                               id="<?= $escaper->escapeHtmlAttr($block->getFieldId('sender')) ?>"
+                               name="<?= $escaper->escapeHtmlAttr($block->getFieldName('sender')) ?>"
+                               value="<?= $escaper->escapeHtml($block->getMessage()->getSender()) ?>"/>
                     </div>
                 </div>
 
                 <div class="admin__field field-to-name<?= $_required ? ' required' : '' ?>">
                     <label class="admin__field-label"
-                           for="<?= $block->escapeHtmlAttr($block->getFieldId('recipient')) ?>"><span><?= $block->escapeHtml(__('To Name')) ?></span></label>
+                           for="<?= $escaper->escapeHtmlAttr($block->getFieldId('recipient')) ?>"><span><?= $escaper->escapeHtml(__('To Name')) ?></span></label>
 
                     <div class="admin__field-control">
                         <input class="admin__control-text <?= $_required ? 'required-entry' : '' ?>" type="text"
-                               id="<?= $block->escapeHtmlAttr($block->getFieldId('recipient')) ?>"
-                               name="<?= $block->escapeHtmlAttr($block->getFieldName('recipient')) ?>"
-                               value="<?= $block->escapeHtml($block->getMessage()->getRecipient()) ?>"/>
+                               id="<?= $escaper->escapeHtmlAttr($block->getFieldId('recipient')) ?>"
+                               name="<?= $escaper->escapeHtmlAttr($block->getFieldName('recipient')) ?>"
+                               value="<?= $escaper->escapeHtml($block->getMessage()->getRecipient()) ?>"/>
                     </div>
                 </div>
 
                 <div class="admin__field field-gift-message">
                     <label class="admin__field-label"
-                           for="<?= $block->escapeHtmlAttr($block->getFieldId('message')) ?>"><span><?= $block->escapeHtml(__('Gift Message')) ?></span></label>
+                           for="<?= $escaper->escapeHtmlAttr($block->getFieldId('message')) ?>"><span><?= $escaper->escapeHtml(__('Gift Message')) ?></span></label>
                     <div class="admin__field-control">
-                        <textarea id="<?= $block->escapeHtmlAttr($block->getFieldId('message')) ?>"
-                                  name="<?= $block->escapeHtmlAttr($block->getFieldName('message')) ?>"
+                        <textarea id="<?= $escaper->escapeHtmlAttr($block->getFieldId('message')) ?>"
+                                  name="<?= $escaper->escapeHtmlAttr($block->getFieldName('message')) ?>"
                                   class="admin__control-textarea"
                                   rows="2"
-                                  cols="15"><?= $block->escapeHtml($block->getMessage()->getMessage()) ?></textarea>
+                                  cols="15"><?= $escaper->escapeHtml($block->getMessage()->getMessage()) ?></textarea>
                     </div>
                 </div>
 

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/history.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/history.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Sales\Block\Adminhtml\Order\View\History $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\View\History $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div id="order_history_block" class="edit-order-comments">
@@ -12,14 +15,14 @@
         <div class="order-history-block" id="history_form">
 
             <div class="admin__field">
-                <label for="history_status" class="admin__field-label"><?= $block->escapeHtml(__('Status')) ?></label>
+                <label for="history_status" class="admin__field-label"><?= $escaper->escapeHtml(__('Status')) ?></label>
                 <div class="admin__field-control">
                     <select name="history[status]" id="history_status" class="admin__control-select">
                         <?php foreach ($block->getStatuses() as $_code => $_label): ?>
-                            <option value="<?= $block->escapeHtmlAttr($_code) ?>"
+                            <option value="<?= $escaper->escapeHtmlAttr($_code) ?>"
                                 <?php if ($_code == $block->getOrder()->getStatus()): ?> selected="selected"
                                 <?php endif; ?>>
-                                <?= $block->escapeHtml($_label) ?>
+                                <?= $escaper->escapeHtml($_label) ?>
                             </option>
                         <?php endforeach; ?>
                     </select>
@@ -28,7 +31,7 @@
 
             <div class="admin__field">
                 <label for="history_comment" class="admin__field-label">
-                    <?= $block->escapeHtml(__('Comment')) ?>
+                    <?= $escaper->escapeHtml(__('Comment')) ?>
                 </label>
                 <div class="admin__field-control">
                     <textarea name="history[comment]"
@@ -49,7 +52,7 @@
                                    class="admin__control-checkbox"
                                    value="1" />
                             <label class="admin__field-label" for="history_notify">
-                                <?= $block->escapeHtml(__('Notify Customer by Email')) ?>
+                                <?= $escaper->escapeHtml(__('Notify Customer by Email')) ?>
                             </label>
                         <?php endif; ?>
                     </div>
@@ -61,7 +64,7 @@
                                class="admin__control-checkbox"
                                value="1" />
                         <label class="admin__field-label" for="history_visible">
-                            <?= $block->escapeHtml(__('Visible on Storefront')) ?>
+                            <?= $escaper->escapeHtml(__('Visible on Storefront')) ?>
                         </label>
                     </div>
                 </div>
@@ -82,22 +85,22 @@
             <span class="note-list-time">
                 <?= /* @noEscape */ $block->formatTime($_item->getCreatedAt(), \IntlDateFormatter::MEDIUM) ?>
             </span>
-            <span class="note-list-status"><?= $block->escapeHtml($_item->getStatusLabel()) ?></span>
+            <span class="note-list-status"><?= $escaper->escapeHtml($_item->getStatusLabel()) ?></span>
             <span class="note-list-customer">
-                <?= $block->escapeHtml(__('Customer')) ?>
+                <?= $escaper->escapeHtml(__('Customer')) ?>
                 <?php if ($block->isCustomerNotificationNotApplicable($_item)): ?>
                     <span class="note-list-customer-notapplicable">
-                        <?= $block->escapeHtml(__('Notification Not Applicable')) ?>
+                        <?= $escaper->escapeHtml(__('Notification Not Applicable')) ?>
                     </span>
                 <?php elseif ($_item->getIsCustomerNotified()): ?>
-                    <span class="note-list-customer-notified"><?= $block->escapeHtml(__('Notified')) ?></span>
+                    <span class="note-list-customer-notified"><?= $escaper->escapeHtml(__('Notified')) ?></span>
                 <?php else: ?>
-                    <span class="note-list-customer-not-notified"><?= $block->escapeHtml(__('Not Notified')) ?></span>
+                    <span class="note-list-customer-not-notified"><?= $escaper->escapeHtml(__('Not Notified')) ?></span>
                 <?php endif; ?>
             </span>
             <?php if ($_item->getComment()): ?>
                 <div class="note-list-comment">
-                    <?= $block->escapeHtml($_item->getComment(), ['b', 'br', 'strong', 'i', 'u', 'a']) ?>
+                    <?= $escaper->escapeHtml($_item->getComment(), ['b', 'br', 'strong', 'i', 'u', 'a']) ?>
                 </div>
             <?php endif; ?>
         </li>
@@ -105,7 +108,7 @@
     </ul>
     <?php $scriptString = <<<script
         require(['prototype'], function(){
-            if($('order_status'))$('order_status').update('{$block->escapeJs($block->getOrder()->getStatusLabel())}');
+            if($('order_status'))$('order_status').update('{$escaper->escapeJs($block->getOrder()->getStatusLabel())}');
         });
 script;
     ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/info.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/info.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var \Magento\Sales\Block\Adminhtml\Order\View\Info $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 $order = $block->getOrder();
 
@@ -33,7 +34,7 @@ $allowedAddressHtmlTags = ['b', 'br', 'em', 'i', 'li', 'ol', 'p', 'strong', 'sub
 
 <section class="admin__page-section order-view-account-information">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Order & Account Information')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Order & Account Information')) ?></span>
     </div>
     <div class="admin__page-section-content">
         <div class="admin__page-section-item order-information">
@@ -42,72 +43,72 @@ $allowedAddressHtmlTags = ['b', 'br', 'em', 'i', 'li', 'ol', 'p', 'strong', 'sub
             <div class="admin__page-section-item-title">
                 <span class="title">
                     <?php if ($block->getNoUseOrderLink()) : ?>
-                        <?= $block->escapeHtml(__('Order # %1', $order->getRealOrderId())) ?> (<span><?= $block->escapeHtml($confirmationEmailStatusMessage) ?></span>)
+                        <?= $escaper->escapeHtml(__('Order # %1', $order->getRealOrderId())) ?> (<span><?= $escaper->escapeHtml($confirmationEmailStatusMessage) ?></span>)
                     <?php else : ?>
-                        <a href="<?= $block->escapeUrl($block->getViewUrl($order->getId())) ?>"><?= $block->escapeHtml(__('Order # %1', $order->getRealOrderId())) ?></a>
-                        <span>(<?= $block->escapeHtml($confirmationEmailStatusMessage) ?>)</span>
+                        <a href="<?= $escaper->escapeUrl($block->getViewUrl($order->getId())) ?>"><?= $escaper->escapeHtml(__('Order # %1', $order->getRealOrderId())) ?></a>
+                        <span>(<?= $escaper->escapeHtml($confirmationEmailStatusMessage) ?>)</span>
                     <?php endif; ?>
                 </span>
             </div>
             <div class="admin__page-section-item-content">
                 <table class="admin__table-secondary order-information-table">
                 <tr>
-                    <th><?= $block->escapeHtml(__('Order Date')) ?></th>
-                    <td><?= $block->escapeHtml($orderAdminDate) ?></td>
+                    <th><?= $escaper->escapeHtml(__('Order Date')) ?></th>
+                    <td><?= $escaper->escapeHtml($orderAdminDate) ?></td>
                 </tr>
                 <?php if ($orderAdminDate != $orderStoreDate) : ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Order Date (%1)', $block->getTimezoneForStore($order->getStore()))) ?></th>
-                        <td><?= $block->escapeHtml($orderStoreDate) ?></td>
+                        <th><?= $escaper->escapeHtml(__('Order Date (%1)', $block->getTimezoneForStore($order->getStore()))) ?></th>
+                        <td><?= $escaper->escapeHtml($orderStoreDate) ?></td>
                     </tr>
                 <?php endif;?>
                 <tr>
-                    <th><?= $block->escapeHtml(__('Order Status')) ?></th>
-                    <td><span id="order_status"><?= $block->escapeHtml($order->getStatusLabel()) ?></span></td>
+                    <th><?= $escaper->escapeHtml(__('Order Status')) ?></th>
+                    <td><span id="order_status"><?= $escaper->escapeHtml($order->getStatusLabel()) ?></span></td>
                 </tr>
                 <?= $block->getChildHtml() ?>
                 <?php if ($block->isSingleStoreMode() == false) : ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Purchased From')) ?></th>
-                        <td><?= $block->escapeHtml($block->getOrderStoreName(), ['br']) ?></td>
+                        <th><?= $escaper->escapeHtml(__('Purchased From')) ?></th>
+                        <td><?= $escaper->escapeHtml($block->getOrderStoreName(), ['br']) ?></td>
                     </tr>
                 <?php endif; ?>
                 <?php if ($order->getRelationChildId()) : ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Link to the New Order')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Link to the New Order')) ?></th>
                         <td>
-                            <a href="<?= $block->escapeUrl($block->getViewUrl($order->getRelationChildId())) ?>">
-                                <?= $block->escapeHtml($order->getRelationChildRealId()) ?>
+                            <a href="<?= $escaper->escapeUrl($block->getViewUrl($order->getRelationChildId())) ?>">
+                                <?= $escaper->escapeHtml($order->getRelationChildRealId()) ?>
                             </a>
                         </td>
                     </tr>
                 <?php endif; ?>
                 <?php if ($order->getRelationParentId()) : ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Link to the Previous Order')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Link to the Previous Order')) ?></th>
                         <td>
-                            <a href="<?= $block->escapeUrl($block->getViewUrl($order->getRelationParentId())) ?>">
-                                <?= $block->escapeHtml($order->getRelationParentRealId()) ?>
+                            <a href="<?= $escaper->escapeUrl($block->getViewUrl($order->getRelationParentId())) ?>">
+                                <?= $escaper->escapeHtml($order->getRelationParentRealId()) ?>
                             </a>
                         </td>
                     </tr>
                 <?php endif; ?>
                 <?php if ($order->getRemoteIp() && $block->shouldDisplayCustomerIp()) : ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Placed from IP')) ?></th>
-                        <td><?= $block->escapeHtml($order->getRemoteIp()); ?><?= $order->getXForwardedFor() ? ' (' . $block->escapeHtml($order->getXForwardedFor()) . ')' : ''; ?></td>
+                        <th><?= $escaper->escapeHtml(__('Placed from IP')) ?></th>
+                        <td><?= $escaper->escapeHtml($order->getRemoteIp()); ?><?= $order->getXForwardedFor() ? ' (' . $escaper->escapeHtml($order->getXForwardedFor()) . ')' : ''; ?></td>
                     </tr>
                 <?php endif; ?>
                 <?php if ($globalCurrencyCode !== $baseCurrencyCode) : ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('%1 / %2 rate:', $globalCurrencyCode, $baseCurrencyCode)) ?></th>
-                        <td><?= $block->escapeHtml($order->getBaseToGlobalRate()) ?></td>
+                        <th><?= $escaper->escapeHtml(__('%1 / %2 rate:', $globalCurrencyCode, $baseCurrencyCode)) ?></th>
+                        <td><?= $escaper->escapeHtml($order->getBaseToGlobalRate()) ?></td>
                     </tr>
                 <?php endif; ?>
                 <?php if ($baseCurrencyCode !== $orderCurrencyCode && $globalCurrencyCode !== $orderCurrencyCode) : ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('%1 / %2 rate:', $orderCurrencyCode, $baseCurrencyCode)) ?></th>
-                        <td><?= $block->escapeHtml($order->getBaseToOrderRate()) ?></td>
+                        <th><?= $escaper->escapeHtml(__('%1 / %2 rate:', $orderCurrencyCode, $baseCurrencyCode)) ?></th>
+                        <td><?= $escaper->escapeHtml($order->getBaseToOrderRate()) ?></td>
                     </tr>
                 <?php endif; ?>
             </table>
@@ -117,11 +118,11 @@ $allowedAddressHtmlTags = ['b', 'br', 'em', 'i', 'li', 'ol', 'p', 'strong', 'sub
         <div class="admin__page-section-item order-account-information">
             <?php /* Account Information */ ?>
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Account Information')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Account Information')) ?></span>
                 <div class="actions">
                     <?php if ($customerUrl) : ?>
                         <a href="<?= /* @noEscape */ $customerUrl ?>" target="_blank">
-                            <?= $block->escapeHtml(__('Edit Customer')) ?>
+                            <?= $escaper->escapeHtml(__('Edit Customer')) ?>
                         </a>
                     <?php endif; ?>
                 </div>
@@ -129,31 +130,31 @@ $allowedAddressHtmlTags = ['b', 'br', 'em', 'i', 'li', 'ol', 'p', 'strong', 'sub
             <div class="admin__page-section-item-content">
                 <table class="admin__table-secondary order-account-information-table">
                     <tr>
-                        <th><?= $block->escapeHtml(__('Customer Name')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Customer Name')) ?></th>
                         <td>
                             <?php if ($customerUrl) : ?>
-                                <a href="<?= $block->escapeUrl($customerUrl) ?>" target="_blank">
-                                    <span><?= $block->escapeHtml($order->getCustomerName()) ?></span>
+                                <a href="<?= $escaper->escapeUrl($customerUrl) ?>" target="_blank">
+                                    <span><?= $escaper->escapeHtml($order->getCustomerName()) ?></span>
                                 </a>
                             <?php else : ?>
-                                <?= $block->escapeHtml($order->getCustomerName()) ?>
+                                <?= $escaper->escapeHtml($order->getCustomerName()) ?>
                             <?php endif; ?>
                         </td>
                     </tr>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Email')) ?></th>
-                        <td><a href="mailto:<?= $block->escapeHtmlAttr($order->getCustomerEmail()) ?>"><?= $block->escapeHtml($order->getCustomerEmail()) ?></a></td>
+                        <th><?= $escaper->escapeHtml(__('Email')) ?></th>
+                        <td><a href="mailto:<?= $escaper->escapeHtmlAttr($order->getCustomerEmail()) ?>"><?= $escaper->escapeHtml($order->getCustomerEmail()) ?></a></td>
                     </tr>
                     <?php if ($groupName = $block->getCustomerGroupName()) : ?>
                         <tr>
-                            <th><?= $block->escapeHtml(__('Customer Group')) ?></th>
-                            <td><?= $block->escapeHtml($groupName) ?></td>
+                            <th><?= $escaper->escapeHtml(__('Customer Group')) ?></th>
+                            <td><?= $escaper->escapeHtml($groupName) ?></td>
                         </tr>
                     <?php endif; ?>
                     <?php foreach ($block->getCustomerAccountData() as $data) : ?>
                         <tr>
-                            <th><?= $block->escapeHtml($data['label']) ?></th>
-                            <td><?= $block->escapeHtml($data['value'], ['br']) ?></td>
+                            <th><?= $escaper->escapeHtml($data['label']) ?></th>
+                            <td><?= $escaper->escapeHtml($data['value'], ['br']) ?></td>
                         </tr>
                     <?php endforeach;?>
                     <?= $block->getChildHtml('extra_customer_info') ?>
@@ -165,25 +166,25 @@ $allowedAddressHtmlTags = ['b', 'br', 'em', 'i', 'li', 'ol', 'p', 'strong', 'sub
 
 <section class="admin__page-section order-addresses">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Address Information')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Address Information')) ?></span>
     </div>
     <div class="admin__page-section-content">
         <div class="admin__page-section-item order-billing-address">
             <?php /* Billing Address */ ?>
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Billing Address')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Billing Address')) ?></span>
                 <div class="actions"><?= /* @noEscape */ $block->getAddressEditLink($order->getBillingAddress()); ?></div>
             </div>
-            <address class="admin__page-section-item-content"><?= $block->escapeHtml($block->getFormattedAddress($order->getBillingAddress()), $allowedAddressHtmlTags); ?></address>
+            <address class="admin__page-section-item-content"><?= $escaper->escapeHtml($block->getFormattedAddress($order->getBillingAddress()), $allowedAddressHtmlTags); ?></address>
         </div>
         <?php if (!$block->getOrder()->getIsVirtual()) : ?>
             <div class="admin__page-section-item order-shipping-address">
                 <?php /* Shipping Address */ ?>
                 <div class="admin__page-section-item-title">
-                    <span class="title"><?= $block->escapeHtml(__('Shipping Address')) ?></span>
+                    <span class="title"><?= $escaper->escapeHtml(__('Shipping Address')) ?></span>
                     <div class="actions"><?= /* @noEscape */ $block->getAddressEditLink($order->getShippingAddress()); ?></div>
                 </div>
-                <address class="admin__page-section-item-content"><?= $block->escapeHtml($block->getFormattedAddress($order->getShippingAddress()), $allowedAddressHtmlTags); ?></address>
+                <address class="admin__page-section-item-content"><?= $escaper->escapeHtml($block->getFormattedAddress($order->getShippingAddress()), $allowedAddressHtmlTags); ?></address>
             </div>
         <?php endif; ?>
     </div>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/items.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/items.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var \Magento\Sales\Block\Adminhtml\Order\View\Items $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 $_order = $block->getOrder() ?>
 <div class="admin__table-wrapper">
@@ -17,7 +18,7 @@ $_order = $block->getOrder() ?>
                 $lastItemNumber = count($columns) ?>
                 <?php foreach ($columns as $columnName => $columnTitle) : ?>
                     <?php $i++; ?>
-                    <th class="col-<?= $block->escapeHtmlAttr($columnName) ?><?= /* @noEscape */ ($i === $lastItemNumber ? ' last' : '') ?>"><span><?= $block->escapeHtml($columnTitle) ?></span></th>
+                    <th class="col-<?= $escaper->escapeHtmlAttr($columnName) ?><?= /* @noEscape */ ($i === $lastItemNumber ? ' last' : '') ?>"><span><?= $escaper->escapeHtml($columnTitle) ?></span></th>
                 <?php endforeach; ?>
             </tr>
         </thead>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/tab/history.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/tab/history.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Sales\Block\Adminhtml\Order\View\Tab\History $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Order\View\Tab\History $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <section class="admin__page-section edit-order-comments">
     <ul class="note-list">
@@ -15,13 +18,13 @@
             <span class="note-list-status"><?= /* @noEscape */ $block->getItemTitle($_item) ?></span>
             <?php if ($block->isItemNotified($_item, false)) : ?>
                 <span class="note-list-customer">
-                    <?= $block->escapeHtml(__('Customer')) ?>
+                    <?= $escaper->escapeHtml(__('Customer')) ?>
                     <?php if ($block->isCustomerNotificationNotApplicable($_item)) : ?>
-                        <span class="note-list-customer-notapplicable"><?= $block->escapeHtml(__('Notification Not Applicable')) ?></span>
+                        <span class="note-list-customer-notapplicable"><?= $escaper->escapeHtml(__('Notification Not Applicable')) ?></span>
                     <?php elseif ($block->isItemNotified($_item)) : ?>
-                        <span class="note-list-customer-notified"><?= $block->escapeHtml(__('Notified')) ?></span>
+                        <span class="note-list-customer-notified"><?= $escaper->escapeHtml(__('Notified')) ?></span>
                     <?php else : ?>
-                        <span class="note-list-customer-not-notified"><?= $block->escapeHtml(__('Not Notified')) ?></span>
+                        <span class="note-list-customer-not-notified"><?= $escaper->escapeHtml(__('Not Notified')) ?></span>
                     <?php endif; ?>
                 </span>
             <?php endif; ?>
@@ -30,7 +33,7 @@
     </ul>
     <div class="edit-order-comments-block">
         <div class="edit-order-comments-block-title">
-            <?= $block->escapeHtml(__('Notes for this Order')) ?>
+            <?= $escaper->escapeHtml(__('Notes for this Order')) ?>
         </div>
         <?php foreach ($block->getFullHistory() as $_item) : ?>
             <?php if ($_comment = $block->getItemComment($_item)) : ?>
@@ -39,7 +42,7 @@
                         <?= /* @noEscape */ $_comment ?>
                     </div>
                     <span class="comments-block-item-date-time">
-                        <?= $block->escapeHtml(__('Comment added')) ?>
+                        <?= $escaper->escapeHtml(__('Comment added')) ?>
                         <?= /* @noEscape */ $block->getItemCreatedAt($_item) ?>
                         <?= /* @noEscape */ $block->getItemCreatedAt($_item, 'time') ?>
                     </span>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/tab/info.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/tab/info.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Sales\Block\Adminhtml\Order\View\Tab\Info */
+/**
+ * @var $block \Magento\Sales\Block\Adminhtml\Order\View\Tab\Info
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php $_order = $block->getOrder() ?>
@@ -18,19 +21,19 @@
 
 <section class="admin__page-section order-view-billing-shipping">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Payment &amp; Shipping Method')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Payment &amp; Shipping Method')) ?></span>
     </div>
     <div class="admin__page-section-content">
         <div class="admin__page-section-item order-payment-method<?= ($_order->getIsVirtual() ?
             ' order-payment-method-virtual' : '') ?>">
             <?php /* Payment Method */ ?>
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Payment Information')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Payment Information')) ?></span>
             </div>
             <div class="admin__page-section-item-content">
                 <div class="order-payment-method-title"><?= $block->getPaymentHtml() ?></div>
                 <div class="order-payment-currency">
-                    <?= $block->escapeHtml(__('The order was placed using %1.', $_order->getOrderCurrencyCode())) ?>
+                    <?= $escaper->escapeHtml(__('The order was placed using %1.', $_order->getOrderCurrencyCode())) ?>
                 </div>
                 <div class="order-payment-additional">
                     <?= $block->getChildHtml('order_payment_additional') ?>
@@ -48,26 +51,26 @@
 
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Items Ordered')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Items Ordered')) ?></span>
     </div>
     <?= $block->getItemsHtml() ?>
 </section>
 
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Order Total')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Order Total')) ?></span>
     </div>
     <div class="admin__page-section-content">
         <div class="admin__page-section-item order-comments-history">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Notes for this Order')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Notes for this Order')) ?></span>
             </div>
             <?= $block->getChildHtml('order_history') ?>
         </div>
 
         <div class="admin__page-section-item order-totals">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Order Totals')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Order Totals')) ?></span>
             </div>
             <?= $block->getChildHtml('order_totals') ?>
         </div>

--- a/app/code/Magento/Sales/view/adminhtml/templates/rss/order/grid/link.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/rss/order/grid/link.phtml
@@ -4,8 +4,11 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Sales\Block\Adminhtml\Rss\Order\Grid\Link */
+/**
+ * @var $block \Magento\Sales\Block\Adminhtml\Rss\Order\Grid\Link
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($block->isRssAllowed() && $block->getLink()) : ?>
-<a href="<?= $block->escapeUrl($block->getLink()) ?>" class="link-feed"><?= $block->escapeHtml($block->getLabel()) ?></a>
+<a href="<?= $escaper->escapeUrl($block->getLink()) ?>" class="link-feed"><?= $escaper->escapeHtml($block->getLabel()) ?></a>
 <?php endif; ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/transactions/detail.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/transactions/detail.phtml
@@ -4,34 +4,37 @@
  * See COPYING.txt for license details.
  */
 
-/* @var \Magento\Sales\Block\Adminhtml\Transactions\Detail $block */
+/**
+ * @var \Magento\Sales\Block\Adminhtml\Transactions\Detail $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions"><?= $block->getButtonsHtml() ?></div>
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Transaction Data')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Transaction Data')) ?></span>
     </div>
     <div id="log_details_fieldset" class="admin__page-section-content log-details">
         <table class="log-info data-table admin__table-secondary">
             <tbody>
             <tr>
-                <th><?= $block->escapeHtml(__('Transaction ID')) ?></th>
+                <th><?= $escaper->escapeHtml(__('Transaction ID')) ?></th>
                 <td><?= $block->getTxnIdHtml() ?></td>
             </tr>
             <tr>
-                <th><?= $block->escapeHtml(__('Parent Transaction ID')) ?></th>
+                <th><?= $escaper->escapeHtml(__('Parent Transaction ID')) ?></th>
                 <td>
                     <?php if ($block->getParentTxnIdHtml()) : ?>
                     <a href="<?= $block->getParentTxnIdUrlHtml() ?>">
                         <?= $block->getParentTxnIdHtml() ?>
                     </a>
                     <?php else : ?>
-                    <?= $block->escapeHtml(__('N/A')) ?>
+                    <?= $escaper->escapeHtml(__('N/A')) ?>
                     <?php endif; ?>
                 </td>
             </tr>
             <tr>
-                <th><?= $block->escapeHtml(__('Order ID')) ?></th>
+                <th><?= $escaper->escapeHtml(__('Order ID')) ?></th>
                 <td>
                     <a href="<?= $block->getOrderIdUrlHtml() ?>">
                         <?= $block->getOrderIncrementIdHtml() ?>
@@ -39,15 +42,15 @@
                 </td>
             </tr>
             <tr>
-                <th><?= $block->escapeHtml(__('Transaction Type')) ?></th>
+                <th><?= $escaper->escapeHtml(__('Transaction Type')) ?></th>
                 <td><?= $block->getTxnTypeHtml() ?></td>
             </tr>
             <tr>
-                <th><?= $block->escapeHtml(__('Is Closed')) ?></th>
+                <th><?= $escaper->escapeHtml(__('Is Closed')) ?></th>
                 <td><?= $block->getIsClosedHtml() ?></td>
             </tr>
             <tr>
-                <th><?= $block->escapeHtml(__('Created At')) ?></th>
+                <th><?= $escaper->escapeHtml(__('Created At')) ?></th>
                 <td><?= $block->getCreatedAtHtml() ?></td>
             </tr>
             </tbody>
@@ -57,7 +60,7 @@
 
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Child Transactions')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Child Transactions')) ?></span>
     </div>
     <div class="admin__page-section-content log-details-grid">
         <?= $block->getChildHtml('child_grid') ?>
@@ -66,7 +69,7 @@
 
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Transaction Details')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Transaction Details')) ?></span>
     </div>
     <div class="admin__page-section-content log-details-grid">
         <?= $block->getChildHtml('detail_grid') ?>

--- a/app/code/Magento/Sales/view/frontend/templates/email/creditmemo/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/creditmemo/items.phtml
@@ -4,6 +4,9 @@
  * See COPYING.txt for license details.
  */
 
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_creditmemo = $block->getCreditmemo() ?>
 <?php $_order      = $block->getOrder() ?>
@@ -12,13 +15,13 @@
         <thead>
             <tr>
                 <th class="item-info">
-                    <?= $block->escapeHtml(__('Items')) ?>
+                    <?= $escaper->escapeHtml(__('Items')) ?>
                 </th>
                 <th class="item-qty">
-                    <?= $block->escapeHtml(__('Qty')) ?>
+                    <?= $escaper->escapeHtml(__('Qty')) ?>
                 </th>
                 <th class="item-subtotal">
-                    <?= $block->escapeHtml(__('Subtotal')) ?>
+                    <?= $escaper->escapeHtml(__('Subtotal')) ?>
                 </th>
             </tr>
         </thead>

--- a/app/code/Magento/Sales/view/frontend/templates/email/invoice/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/invoice/items.phtml
@@ -4,6 +4,9 @@
  * See COPYING.txt for license details.
  */
 
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_invoice = $block->getInvoice() ?>
 <?php $_order   = $block->getOrder() ?>
@@ -12,13 +15,13 @@
         <thead>
             <tr>
                 <th class="item-info">
-                    <?= $block->escapeHtml(__('Items')) ?>
+                    <?= $escaper->escapeHtml(__('Items')) ?>
                 </th>
                 <th class="item-qty">
-                    <?= $block->escapeHtml(__('Qty')) ?>
+                    <?= $escaper->escapeHtml(__('Qty')) ?>
                 </th>
                 <th class="item-subtotal">
-                    <?= $block->escapeHtml(__('Subtotal')) ?>
+                    <?= $escaper->escapeHtml(__('Subtotal')) ?>
                 </th>
             </tr>
         </thead>

--- a/app/code/Magento/Sales/view/frontend/templates/email/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items.phtml
@@ -6,7 +6,10 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Sales\Block\Order\Email\Items */
+/**
+ * @var $block \Magento\Sales\Block\Order\Email\Items
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_order = $block->getOrder() ?>
 <?php if ($_order) : ?>
@@ -15,13 +18,13 @@
         <thead>
             <tr>
                 <th class="item-info">
-                    <?= $block->escapeHtml(__('Items')) ?>
+                    <?= $escaper->escapeHtml(__('Items')) ?>
                 </th>
                 <th class="item-qty">
-                    <?= $block->escapeHtml(__('Qty')) ?>
+                    <?= $escaper->escapeHtml(__('Qty')) ?>
                 </th>
                 <th class="item-price">
-                    <?= $block->escapeHtml(__('Price')) ?>
+                    <?= $escaper->escapeHtml(__('Price')) ?>
                 </th>
             </tr>
         </thead>
@@ -47,11 +50,11 @@
             <table class="message-gift">
                 <tr>
                     <td>
-                        <h3><?= $block->escapeHtml(__('Gift Message for this Order')) ?></h3>
-                        <strong><?= $block->escapeHtml(__('From:')) ?></strong> <?= $block->escapeHtml($_giftMessage->getSender()) ?>
-                        <br /><strong><?= $block->escapeHtml(__('To:')) ?></strong> <?= $block->escapeHtml($_giftMessage->getRecipient()) ?>
-                        <br /><strong><?= $block->escapeHtml(__('Message:')) ?></strong>
-                        <br /><?= $block->escapeHtml($_giftMessage->getMessage()) ?>
+                        <h3><?= $escaper->escapeHtml(__('Gift Message for this Order')) ?></h3>
+                        <strong><?= $escaper->escapeHtml(__('From:')) ?></strong> <?= $escaper->escapeHtml($_giftMessage->getSender()) ?>
+                        <br /><strong><?= $escaper->escapeHtml(__('To:')) ?></strong> <?= $escaper->escapeHtml($_giftMessage->getRecipient()) ?>
+                        <br /><strong><?= $escaper->escapeHtml(__('Message:')) ?></strong>
+                        <br /><?= $escaper->escapeHtml($_giftMessage->getMessage()) ?>
                     </td>
                 </tr>
             </table>

--- a/app/code/Magento/Sales/view/frontend/templates/email/items/creditmemo/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/creditmemo/default.phtml
@@ -4,19 +4,22 @@
  * See COPYING.txt for license details.
  */
 
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrder(); ?>
 <tr>
     <td class="item-info<?= ($block->getItemOptions() ? ' has-extra' : '') ?>">
-        <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
-        <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
+        <p class="product-name"><?= $escaper->escapeHtml($_item->getName()) ?></p>
+        <p class="sku"><?= $escaper->escapeHtml(__('SKU')) ?>: <?= $escaper->escapeHtml($block->getSku($_item)) ?></p>
         <?php if ($block->getItemOptions()) : ?>
             <dl>
                 <?php foreach ($block->getItemOptions() as $option) : ?>
-                    <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
+                    <dt><strong><em><?= $escaper->escapeHtml($option['label']) ?></em></strong></dt>
                     <dd>
-                        <?= /* @noEscape */  nl2br($block->escapeHtml($option['value'])) ?>
+                        <?= /* @noEscape */  nl2br($escaper->escapeHtml($option['value'])) ?>
                     </dd>
                 <?php endforeach; ?>
             </dl>
@@ -25,7 +28,7 @@
         <?php if ($addInfoBlock) :?>
             <?= $addInfoBlock->setItem($_item->getOrderItem())->toHtml() ?>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
     </td>
     <td class="item-qty"><?= (float) $_item->getQty() ?></td>
     <td class="item-price">

--- a/app/code/Magento/Sales/view/frontend/templates/email/items/invoice/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/invoice/default.phtml
@@ -3,19 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrder(); ?>
 <tr>
     <td class="item-info<?= ($block->getItemOptions() ? ' has-extra' : '') ?>">
-        <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
-        <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
+        <p class="product-name"><?= $escaper->escapeHtml($_item->getName()) ?></p>
+        <p class="sku"><?= $escaper->escapeHtml(__('SKU')) ?>: <?= $escaper->escapeHtml($block->getSku($_item)) ?></p>
         <?php if ($block->getItemOptions()) : ?>
             <dl>
                 <?php foreach ($block->getItemOptions() as $option) : ?>
-                    <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
+                    <dt><strong><em><?= $escaper->escapeHtml($option['label']) ?></em></strong></dt>
                     <dd>
-                        <?= /* @noEscape */  nl2br($block->escapeHtml($option['value'])) ?>
+                        <?= /* @noEscape */  nl2br($escaper->escapeHtml($option['value'])) ?>
                     </dd>
                 <?php endforeach; ?>
             </dl>
@@ -24,7 +28,7 @@
         <?php if ($addInfoBlock) : ?>
             <?= $addInfoBlock->setItem($_item->getOrderItem())->toHtml() ?>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
     </td>
     <td class="item-qty"><?= (float) $_item->getQty() ?></td>
     <td class="item-price">

--- a/app/code/Magento/Sales/view/frontend/templates/email/items/order/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/order/default.phtml
@@ -6,7 +6,10 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Sales\Block\Order\Email\Items\DefaultItems */
+/**
+ * @var $block \Magento\Sales\Block\Order\Email\Items\DefaultItems
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 /** @var $_item \Magento\Sales\Model\Order\Item */
 $_item = $block->getItem();
@@ -14,14 +17,14 @@ $_order = $_item->getOrder();
 ?>
 <tr>
     <td class="item-info<?= ($block->getItemOptions() ? ' has-extra' : '') ?>">
-        <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
-        <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
+        <p class="product-name"><?= $escaper->escapeHtml($_item->getName()) ?></p>
+        <p class="sku"><?= $escaper->escapeHtml(__('SKU')) ?>: <?= $escaper->escapeHtml($block->getSku($_item)) ?></p>
         <?php if ($block->getItemOptions()) : ?>
             <dl class="item-options">
             <?php foreach ($block->getItemOptions() as $option) : ?>
-                <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
+                <dt><strong><em><?= $escaper->escapeHtml($option['label']) ?></em></strong></dt>
                 <dd>
-                    <?= /* @noEscape */  nl2br($block->escapeHtml($option['value'])) ?>
+                    <?= /* @noEscape */  nl2br($escaper->escapeHtml($option['value'])) ?>
                 </dd>
             <?php endforeach; ?>
             </dl>
@@ -30,7 +33,7 @@ $_order = $_item->getOrder();
         <?php if ($addInfoBlock) :?>
             <?= $addInfoBlock->setItem($_item)->toHtml() ?>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
     </td>
     <td class="item-qty"><?= (float) $_item->getQtyOrdered() ?></td>
     <td class="item-price">
@@ -46,11 +49,11 @@ $_order = $_item->getOrder();
         <table class="message-gift">
             <tr>
                 <td>
-                    <h3><?= $block->escapeHtml(__('Gift Message')) ?></h3>
-                    <strong><?= $block->escapeHtml(__('From:')) ?></strong> <?= $block->escapeHtml($_giftMessage->getSender()) ?>
-                    <br /><strong><?= $block->escapeHtml(__('To:')) ?></strong> <?= $block->escapeHtml($_giftMessage->getRecipient()) ?>
-                    <br /><strong><?= $block->escapeHtml(__('Message:')) ?></strong>
-                    <br /><?= $block->escapeHtml($_giftMessage->getMessage()) ?>
+                    <h3><?= $escaper->escapeHtml(__('Gift Message')) ?></h3>
+                    <strong><?= $escaper->escapeHtml(__('From:')) ?></strong> <?= $escaper->escapeHtml($_giftMessage->getSender()) ?>
+                    <br /><strong><?= $escaper->escapeHtml(__('To:')) ?></strong> <?= $escaper->escapeHtml($_giftMessage->getRecipient()) ?>
+                    <br /><strong><?= $escaper->escapeHtml(__('Message:')) ?></strong>
+                    <br /><?= $escaper->escapeHtml($_giftMessage->getMessage()) ?>
                 </td>
             </tr>
         </table>

--- a/app/code/Magento/Sales/view/frontend/templates/email/items/shipment/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/shipment/default.phtml
@@ -4,16 +4,19 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $_item \Magento\Sales\Model\Order\Item */
+/**
+ * @var $_item \Magento\Sales\Model\Order\Item
+ * @var \Magento\Framework\Escaper $escaper
+ */
 $_item = $block->getItem() ?>
 <tr>
     <td class="item-info<?= ($block->getItemOptions() ? ' has-extra' : '') ?>">
-        <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
-        <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
+        <p class="product-name"><?= $escaper->escapeHtml($_item->getName()) ?></p>
+        <p class="sku"><?= $escaper->escapeHtml(__('SKU')) ?>: <?= $escaper->escapeHtml($block->getSku($_item)) ?></p>
         <?php if ($block->getItemOptions()) : ?>
             <dl class="item-options">
                 <?php foreach ($block->getItemOptions() as $option) : ?>
-                    <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
+                    <dt><strong><em><?= $escaper->escapeHtml($option['label']) ?></em></strong></dt>
                     <dd>
                         <?= /* @noEscape */  nl2br($option['value']) ?>
                     </dd>
@@ -24,7 +27,7 @@ $_item = $block->getItem() ?>
         <?php if ($addInfoBlock) : ?>
             <?= $addInfoBlock->setItem($_item->getOrderItem())->toHtml() ?>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
     </td>
     <td class="item-qty"><?= (float) $_item->getQty() ?></td>
 </tr>

--- a/app/code/Magento/Sales/view/frontend/templates/email/shipment/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/shipment/items.phtml
@@ -4,6 +4,9 @@
  * See COPYING.txt for license details.
  */
 
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_shipment = $block->getShipment() ?>
 <?php $_order    = $block->getOrder() ?>
@@ -12,10 +15,10 @@
         <thead>
             <tr>
                 <th class="item-info">
-                    <?= $block->escapeHtml(__('Items')) ?>
+                    <?= $escaper->escapeHtml(__('Items')) ?>
                 </th>
                 <th class="item-qty">
-                    <?= $block->escapeHtml(__('Qty')) ?>
+                    <?= $escaper->escapeHtml(__('Qty')) ?>
                 </th>
             </tr>
         </thead>

--- a/app/code/Magento/Sales/view/frontend/templates/email/shipment/track.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/shipment/track.phtml
@@ -4,7 +4,12 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /* @var \Magento\Framework\View\Element\Template $block */ ?>
+<?php
+/**
+ * @var \Magento\Framework\View\Element\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
+?>
 <?php $_shipment = $block->getShipment() ?>
 <?php
 /* @var \Magento\Sales\Model\Order $_order */
@@ -16,17 +21,17 @@ $_order = $block->getOrder() ?>
         <table class="shipment-track">
             <thead>
             <tr>
-                <th><?= $block->escapeHtml(__('Shipped By')) ?></th>
-                <th><?= $block->escapeHtml(__('Tracking Number')) ?></th>
+                <th><?= $escaper->escapeHtml(__('Shipped By')) ?></th>
+                <th><?= $escaper->escapeHtml(__('Tracking Number')) ?></th>
             </tr>
             </thead>
             <tbody>
             <?php foreach ($trackCollection as $_item) : ?>
                 <tr>
-                    <td><?= $block->escapeHtml($_item->getTitle()) ?>:</td>
+                    <td><?= $escaper->escapeHtml($_item->getTitle()) ?>:</td>
                     <td>
-                        <a href="<?= $block->escapeUrl($block->getTrackingUrl()->getUrl($_item)) ?>" target="_blank">
-                            <?= $block->escapeHtml($_item->getNumber()) ?>
+                        <a href="<?= $escaper->escapeUrl($block->getTrackingUrl()->getUrl($_item)) ?>" target="_blank">
+                            <?= $escaper->escapeHtml($_item->getNumber()) ?>
                         </a>
                     </td>
                 </tr>

--- a/app/code/Magento/Sales/view/frontend/templates/guest/form.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/guest/form.phtml
@@ -4,19 +4,22 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <form class="form form-orders-search"
       id="oar-widget-orders-and-returns-form"
       data-mage-init='{"ordersReturns":{}, "validation":{}}'
-      action="<?= $block->escapeUrl($block->getActionUrl()) ?>"
+      action="<?= $escaper->escapeUrl($block->getActionUrl()) ?>"
       method="post" name="guest_post">
     <fieldset class="fieldset">
-        <legend class="legend"><span><?= $block->escapeHtml(__('Order Information')) ?></span></legend>
+        <legend class="legend"><span><?= $escaper->escapeHtml(__('Order Information')) ?></span></legend>
         <br>
 
         <div class="field id required">
-            <label class="label" for="oar-order-id"><span><?= $block->escapeHtml(__('Order ID')) ?></span></label>
+            <label class="label" for="oar-order-id"><span><?= $escaper->escapeHtml(__('Order ID')) ?></span></label>
 
             <div class="control">
                 <input type="text" class="input-text" id="oar-order-id" name="oar_order_id"
@@ -25,7 +28,7 @@
         </div>
         <div class="field lastname required">
             <label class="label" for="oar-billing-lastname">
-                <span><?= $block->escapeHtml(__('Billing Last Name')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Billing Last Name')) ?></span>
             </label>
 
             <div class="control">
@@ -35,18 +38,18 @@
         </div>
         <div class="field find required">
             <label class="label" for="quick-search-type-id">
-                <span><?= $block->escapeHtml(__('Find Order By')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Find Order By')) ?></span>
             </label>
 
             <div class="control">
                 <select name="oar_type" id="quick-search-type-id" class="select">
-                    <option value="email"><?= $block->escapeHtml(__('Email')) ?></option>
-                    <option value="zip"><?= $block->escapeHtml(__('ZIP Code')) ?></option>
+                    <option value="email"><?= $escaper->escapeHtml(__('Email')) ?></option>
+                    <option value="zip"><?= $escaper->escapeHtml(__('ZIP Code')) ?></option>
                 </select>
             </div>
         </div>
         <div id="oar-email" class="field email required">
-            <label class="label" for="oar_email"><span><?= $block->escapeHtml(__('Email')) ?></span></label>
+            <label class="label" for="oar_email"><span><?= $escaper->escapeHtml(__('Email')) ?></span></label>
 
             <div class="control">
                 <input type="email" class="input-text" id="oar_email" name="oar_email"
@@ -54,7 +57,7 @@
             </div>
         </div>
         <div id="oar-zip" class="field zip required">
-            <label class="label" for="oar_zip"><span><?= $block->escapeHtml(__('Billing ZIP Code')) ?></span></label>
+            <label class="label" for="oar_zip"><span><?= $escaper->escapeHtml(__('Billing ZIP Code')) ?></span></label>
 
             <div class="control">
                 <input type="text" class="input-text" id="oar_zip" name="oar_zip" data-validate="{required:true}"/>
@@ -64,8 +67,8 @@
     </fieldset>
     <div class="actions-toolbar">
         <div class="primary">
-            <button type="submit" title="<?= $block->escapeHtml(__('Continue')) ?>" class="action submit primary">
-                <span><?= $block->escapeHtml(__('Continue')) ?></span>
+            <button type="submit" title="<?= $escaper->escapeHtml(__('Continue')) ?>" class="action submit primary">
+                <span><?= $escaper->escapeHtml(__('Continue')) ?></span>
             </button>
         </div>
     </div>

--- a/app/code/Magento/Sales/view/frontend/templates/items/price/row.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/items/price/row.phtml
@@ -4,10 +4,13 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer $block */
+/**
+ * @var \Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 $_item = $block->getItem();
 ?>
-<span class="price-excluding-tax" data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?>">
+<span class="price-excluding-tax" data-label="<?= $escaper->escapeHtml(__('Excl. Tax')) ?>">
     <span class="cart-price">
         <?= /* @noEscape */ $block->getOrder()->formatPrice($block->getItem()->getRowTotal()) ?>
     </span>

--- a/app/code/Magento/Sales/view/frontend/templates/items/price/unit.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/items/price/unit.phtml
@@ -4,10 +4,13 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer $block */
+/**
+ * @var \Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 $_item = $block->getItem();
 ?>
-<span class="price-excluding-tax" data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?>">
+<span class="price-excluding-tax" data-label="<?= $escaper->escapeHtml(__('Excl. Tax')) ?>">
     <span class="cart-price">
         <?= /* @noEscape */ $block->getOrder()->formatPrice($block->getItem()->getPrice()) ?>
     </span>

--- a/app/code/Magento/Sales/view/frontend/templates/order/comments.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/comments.phtml
@@ -7,19 +7,20 @@
 <?php
 /**
  * @var $block \Magento\Sales\Block\Order\Comments
+ * @var \Magento\Framework\Escaper $escaper
  * @see \Magento\Sales\Block\Order\Comments
  */
 ?>
 <?php if ($block->hasComments()) : ?>
     <div class="order additional details comments">
-        <h3 class="subtitle"><?= $block->escapeHtml($block->getTitle()) ?></h3>
+        <h3 class="subtitle"><?= $escaper->escapeHtml($block->getTitle()) ?></h3>
         <dl class="order comments">
             <?php foreach ($block->getComments() as $_commentItem) : ?>
                 <dt class="comment date">
                     <?= /* @noEscape */
                     $block->formatDate($_commentItem->getCreatedAt(), \IntlDateFormatter::MEDIUM, true) ?>
                 </dt>
-                <dd class="comment text"><?= $block->escapeHtml($_commentItem->getComment()) ?></dd>
+                <dd class="comment text"><?= $escaper->escapeHtml($_commentItem->getComment()) ?></dd>
             <?php endforeach; ?>
         </dl>
     </div>

--- a/app/code/Magento/Sales/view/frontend/templates/order/creditmemo.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/creditmemo.phtml
@@ -4,14 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Sales\Block\Order\Creditmemo */
+/**
+ * @var $block \Magento\Sales\Block\Order\Creditmemo
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="order-details-items creditmemo">
     <?= $block->getChildHtml('creditmemo_items') ?>
     <div class="actions-toolbar">
         <div class="secondary">
-            <a href="<?= $block->escapeUrl($block->getBackUrl()) ?>" class="action back">
-                <span><?= $block->escapeHtml($block->getBackTitle()) ?></span>
+            <a href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>" class="action back">
+                <span><?= $escaper->escapeHtml($block->getBackTitle()) ?></span>
             </a>
         </div>
     </div>

--- a/app/code/Magento/Sales/view/frontend/templates/order/creditmemo/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/creditmemo/items.phtml
@@ -3,39 +3,43 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_order = $block->getOrder() ?>
 <div class="actions-toolbar">
-    <a href="<?= $block->escapeUrl($block->getPrintAllCreditmemosUrl($_order)) ?>"
+    <a href="<?= $escaper->escapeUrl($block->getPrintAllCreditmemosUrl($_order)) ?>"
        class="action print"
        target="_blank"
        rel="noopener">
-        <span><?= $block->escapeHtml(__('Print All Refunds')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Print All Refunds')) ?></span>
     </a>
 </div>
 <?php foreach ($_order->getCreditmemosCollection() as $_creditmemo) : ?>
     <div class="order-title">
-        <strong><?= $block->escapeHtml(__('Refund #')) ?><?= $block->escapeHtml($_creditmemo->getIncrementId()) ?> </strong>
-        <a href="<?= $block->escapeUrl($block->getPrintCreditmemoUrl($_creditmemo)) ?>"
+        <strong><?= $escaper->escapeHtml(__('Refund #')) ?><?= $escaper->escapeHtml($_creditmemo->getIncrementId()) ?> </strong>
+        <a href="<?= $escaper->escapeUrl($block->getPrintCreditmemoUrl($_creditmemo)) ?>"
            class="action print"
            target="_blank"
            rel="noopener">
-            <span><?= $block->escapeHtml(__('Print Refund')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Print Refund')) ?></span>
         </a>
     </div>
 
     <div class="table-wrapper order-items-creditmemo">
         <table class="data table table-order-items creditmemo" id="my-refund-table-<?= (int) $_creditmemo->getId() ?>">
-            <caption class="table-caption"><?= $block->escapeHtml(__('Items Refunded')) ?></caption>
+            <caption class="table-caption"><?= $escaper->escapeHtml(__('Items Refunded')) ?></caption>
             <thead>
                 <tr>
-                    <th class="col name"><?= $block->escapeHtml(__('Product Name')) ?></th>
-                    <th class="col sku"><?= $block->escapeHtml(__('SKU')) ?></th>
-                    <th class="col price"><?= $block->escapeHtml(__('Price')) ?></th>
-                    <th class="col qty"><?= $block->escapeHtml(__('Qty')) ?></th>
-                    <th class="col subtotal"><?= $block->escapeHtml(__('Subtotal')) ?></th>
-                    <th class="col discount"><?= $block->escapeHtml(__('Discount Amount')) ?></th>
-                    <th class="col total"><?= $block->escapeHtml(__('Row Total')) ?></th>
+                    <th class="col name"><?= $escaper->escapeHtml(__('Product Name')) ?></th>
+                    <th class="col sku"><?= $escaper->escapeHtml(__('SKU')) ?></th>
+                    <th class="col price"><?= $escaper->escapeHtml(__('Price')) ?></th>
+                    <th class="col qty"><?= $escaper->escapeHtml(__('Qty')) ?></th>
+                    <th class="col subtotal"><?= $escaper->escapeHtml(__('Subtotal')) ?></th>
+                    <th class="col discount"><?= $escaper->escapeHtml(__('Discount Amount')) ?></th>
+                    <th class="col total"><?= $escaper->escapeHtml(__('Row Total')) ?></th>
                 </tr>
             </thead>
             <?php $_items = $_creditmemo->getAllItems(); ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/creditmemo/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/creditmemo/items/renderer/default.phtml
@@ -4,32 +4,37 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var  $block \Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer */ ?>
+<?php
+/**
+ * @var  $block \Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
+?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrderItem()->getOrder() ?>
 <tr id="order-item-row-<?= (int) $_item->getId() ?>">
-    <td class="col name" data-th="<?= $block->escapeHtmlAttr(__('Product Name')) ?>">
-        <strong class="product name product-item-name"><?= $block->escapeHtml($_item->getName()) ?></strong>
+    <td class="col name" data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')) ?>">
+        <strong class="product name product-item-name"><?= $escaper->escapeHtml($_item->getName()) ?></strong>
         <?php if ($_options = $block->getItemOptions()): ?>
             <dl class="item-options">
             <?php foreach ($_options as $_option): ?>
-                <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                 <?php if (!$block->getPrintStatus()): ?>
                     <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
                     <dd<?= (isset($_formatedOptionValue['full_view']) ? ' class="tooltip wrapper"' : '') ?>>
-                        <?= $block->escapeHtml($_formatedOptionValue['value'], ['a']) ?>
+                        <?= $escaper->escapeHtml($_formatedOptionValue['value'], ['a']) ?>
                         <?php if (isset($_formatedOptionValue['full_view'])): ?>
                         <div class="tooltip content">
                             <dl class="item options">
-                                <dt><?= $block->escapeHtml($_option['label']) ?></dt>
-                                <dd><?= $block->escapeHtml($_formatedOptionValue['full_view']) ?></dd>
+                                <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
+                                <dd><?= $escaper->escapeHtml($_formatedOptionValue['full_view']) ?></dd>
                             </dl>
                         </div>
                         <?php endif; ?>
                     </dd>
                 <?php else: ?>
                     <dd>
-                        <?= $block->escapeHtml($_option['print_value'] ?? $_option['value']) ?>
+                        <?= $escaper->escapeHtml($_option['print_value'] ?? $_option['value']) ?>
                     </dd>
                 <?php endif; ?>
             <?php endforeach; ?>
@@ -39,9 +44,9 @@
         <?php /* downloadable */ ?>
         <?php if ($links = $block->getLinks()): ?>
             <dl class="item options">
-                <dt><?= $block->escapeHtml($block->getLinksTitle()) ?></dt>
+                <dt><?= $escaper->escapeHtml($block->getLinksTitle()) ?></dt>
                 <?php foreach ($links->getPurchasedItems() as $link): ?>
-                    <dd><?= $block->escapeHtml($link->getLinkTitle()) ?></dd>
+                    <dd><?= $escaper->escapeHtml($link->getLinkTitle()) ?></dd>
                 <?php endforeach; ?>
             </dl>
         <?php endif; ?>
@@ -51,22 +56,22 @@
         <?php if ($addInfoBlock): ?>
             <?= $addInfoBlock->setItem($_item->getOrderItem())->toHtml() ?>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
     </td>
-    <td class="col sku" data-th="<?= $block->escapeHtml(__('SKU')) ?>">
+    <td class="col sku" data-th="<?= $escaper->escapeHtml(__('SKU')) ?>">
         <?= /* @noEscape */ $block->prepareSku($block->getSku()) ?>
     </td>
-    <td class="col price" data-th="<?= $block->escapeHtml(__('Price')) ?>">
+    <td class="col price" data-th="<?= $escaper->escapeHtml(__('Price')) ?>">
         <?= $block->getItemPriceHtml() ?>
     </td>
-    <td class="col qty" data-th="<?= $block->escapeHtml(__('Qty')) ?>"><?= (float) $_item->getQty() ?></td>
-    <td class="col subtotal" data-th="<?= $block->escapeHtml(__('Subtotal')) ?>">
+    <td class="col qty" data-th="<?= $escaper->escapeHtml(__('Qty')) ?>"><?= (float) $_item->getQty() ?></td>
+    <td class="col subtotal" data-th="<?= $escaper->escapeHtml(__('Subtotal')) ?>">
         <?= $block->getItemRowTotalHtml() ?>
     </td>
-    <td class="col discount" data-th="<?= $block->escapeHtml(__('Discount Amount')) ?>">
+    <td class="col discount" data-th="<?= $escaper->escapeHtml(__('Discount Amount')) ?>">
         <?= /* @noEscape */ $_order->formatPrice(-$_item->getDiscountAmount()) ?>
     </td>
-    <td class="col total" data-th="<?= $block->escapeHtml(__('Row Total')) ?>">
+    <td class="col total" data-th="<?= $escaper->escapeHtml(__('Row Total')) ?>">
         <?= $block->getItemRowTotalAfterDiscountHtml() ?>
     </td>
 </tr>

--- a/app/code/Magento/Sales/view/frontend/templates/order/history.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/history.phtml
@@ -7,46 +7,49 @@
 // phpcs:disable Magento2.Templates.ThisInTemplate
 // @codingStandardsIgnoreFile
 
-/** @var \Magento\Sales\Block\Order\History $block */
+/**
+ * @var \Magento\Sales\Block\Order\History $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_orders = $block->getOrders(); ?>
 <?= $block->getChildHtml('info') ?>
 <?php if ($_orders && count($_orders)) : ?>
     <div class="table-wrapper orders-history">
         <table class="data table table-order-items history" id="my-orders-table">
-            <caption class="table-caption"><?= $block->escapeHtml(__('Orders')) ?></caption>
+            <caption class="table-caption"><?= $escaper->escapeHtml(__('Orders')) ?></caption>
             <thead>
                 <tr>
-                    <th scope="col" class="col id"><?= $block->escapeHtml(__('Order #')) ?></th>
-                    <th scope="col" class="col date"><?= $block->escapeHtml(__('Date')) ?></th>
+                    <th scope="col" class="col id"><?= $escaper->escapeHtml(__('Order #')) ?></th>
+                    <th scope="col" class="col date"><?= $escaper->escapeHtml(__('Date')) ?></th>
                     <?= $block->getChildHtml('extra.column.header') ?>
-                    <th scope="col" class="col total"><?= $block->escapeHtml(__('Order Total')) ?></th>
-                    <th scope="col" class="col status"><?= $block->escapeHtml(__('Status')) ?></th>
-                    <th scope="col" class="col actions"><?= $block->escapeHtml(__('Action')) ?></th>
+                    <th scope="col" class="col total"><?= $escaper->escapeHtml(__('Order Total')) ?></th>
+                    <th scope="col" class="col status"><?= $escaper->escapeHtml(__('Status')) ?></th>
+                    <th scope="col" class="col actions"><?= $escaper->escapeHtml(__('Action')) ?></th>
                 </tr>
             </thead>
             <tbody>
                 <?php foreach ($_orders as $_order) : ?>
                     <tr>
-                        <td data-th="<?= $block->escapeHtml(__('Order #')) ?>" class="col id"><?= $block->escapeHtml($_order->getRealOrderId()) ?></td>
-                        <td data-th="<?= $block->escapeHtml(__('Date')) ?>" class="col date"><?= /* @noEscape */ $block->formatDate($_order->getCreatedAt()) ?></td>
+                        <td data-th="<?= $escaper->escapeHtml(__('Order #')) ?>" class="col id"><?= $escaper->escapeHtml($_order->getRealOrderId()) ?></td>
+                        <td data-th="<?= $escaper->escapeHtml(__('Date')) ?>" class="col date"><?= /* @noEscape */ $block->formatDate($_order->getCreatedAt()) ?></td>
                         <?php $extra = $block->getChildBlock('extra.container'); ?>
                         <?php if ($extra) : ?>
                             <?php $extra->setOrder($_order); ?>
                             <?= $extra->getChildHtml() ?>
                         <?php endif; ?>
-                        <td data-th="<?= $block->escapeHtml(__('Order Total')) ?>" class="col total"><?= /* @noEscape */ $_order->formatPrice($_order->getGrandTotal()) ?></td>
-                        <td data-th="<?= $block->escapeHtml(__('Status')) ?>" class="col status"><?= $block->escapeHtml($_order->getStatusLabel()) ?></td>
-                        <td data-th="<?= $block->escapeHtml(__('Actions')) ?>" class="col actions">
-                            <a href="<?= $block->escapeUrl($block->getViewUrl($_order)) ?>" class="action view">
-                                <span><?= $block->escapeHtml(__('View Order')) ?></span>
+                        <td data-th="<?= $escaper->escapeHtml(__('Order Total')) ?>" class="col total"><?= /* @noEscape */ $_order->formatPrice($_order->getGrandTotal()) ?></td>
+                        <td data-th="<?= $escaper->escapeHtml(__('Status')) ?>" class="col status"><?= $escaper->escapeHtml($_order->getStatusLabel()) ?></td>
+                        <td data-th="<?= $escaper->escapeHtml(__('Actions')) ?>" class="col actions">
+                            <a href="<?= $escaper->escapeUrl($block->getViewUrl($_order)) ?>" class="action view">
+                                <span><?= $escaper->escapeHtml(__('View Order')) ?></span>
                             </a>
                             <?php if ($this->helper(\Magento\Sales\Helper\Reorder::class)->canReorder($_order->getEntityId())) : ?>
                                 <a href="#" data-post='<?= /* @noEscape */
                                 $this->helper(\Magento\Framework\Data\Helper\PostHelper::class)
                                     ->getPostData($block->getReorderUrl($_order))
                                 ?>' class="action order">
-                                    <span><?= $block->escapeHtml(__('Reorder')) ?></span>
+                                    <span><?= $escaper->escapeHtml(__('Reorder')) ?></span>
                                 </a>
                             <?php endif ?>
                         </td>
@@ -59,5 +62,5 @@
         <div class="order-products-toolbar toolbar bottom"><?= $block->getPagerHtml() ?></div>
     <?php endif ?>
 <?php else : ?>
-    <div class="message info empty"><span><?= $block->escapeHtml($block->getEmptyOrdersMessage()) ?></span></div>
+    <div class="message info empty"><span><?= $escaper->escapeHtml($block->getEmptyOrdersMessage()) ?></span></div>
 <?php endif ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/info.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/info.phtml
@@ -4,16 +4,21 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Sales\Block\Order\Info */ ?>
+<?php
+/**
+ * @var $block \Magento\Sales\Block\Order\Info
+ * @var \Magento\Framework\Escaper $escaper
+ */
+?>
 <?php $_order = $block->getOrder() ?>
 <div class="block block-order-details-view">
     <div class="block-title">
-        <strong><?= $block->escapeHtml(__('Order Information')) ?></strong>
+        <strong><?= $escaper->escapeHtml(__('Order Information')) ?></strong>
     </div>
     <div class="block-content">
         <?php if (!$_order->getIsVirtual()) : ?>
             <div class="box box-order-shipping-address">
-                <strong class="box-title"><span><?= $block->escapeHtml(__('Shipping Address')) ?></span></strong>
+                <strong class="box-title"><span><?= $escaper->escapeHtml(__('Shipping Address')) ?></span></strong>
                 <div class="box-content">
                     <address><?= /* @noEscape */ $block->getFormattedAddress($_order->getShippingAddress()) ?></address>
                 </div>
@@ -21,13 +26,13 @@
 
             <div class="box box-order-shipping-method">
                 <strong class="box-title">
-                    <span><?= $block->escapeHtml(__('Shipping Method')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Shipping Method')) ?></span>
                 </strong>
                 <div class="box-content">
                 <?php if ($_order->getShippingDescription()) : ?>
-                    <?= $block->escapeHtml($_order->getShippingDescription()) ?>
+                    <?= $escaper->escapeHtml($_order->getShippingDescription()) ?>
                 <?php else : ?>
-                    <?= $block->escapeHtml(__('No shipping information available')) ?>
+                    <?= $escaper->escapeHtml(__('No shipping information available')) ?>
                 <?php endif; ?>
                 </div>
             </div>
@@ -35,7 +40,7 @@
 
         <div class="box box-order-billing-address">
             <strong class="box-title">
-                <span><?= $block->escapeHtml(__('Billing Address')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Billing Address')) ?></span>
             </strong>
             <div class="box-content">
                 <address><?= /* @noEscape */ $block->getFormattedAddress($_order->getBillingAddress()) ?></address>
@@ -43,7 +48,7 @@
         </div>
         <div class="box box-order-billing-method">
             <strong class="box-title">
-                <span><?= $block->escapeHtml(__('Payment Method')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Payment Method')) ?></span>
             </strong>
             <div class="box-content">
                 <?= $block->getPaymentInfoHtml() ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/info/buttons.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/info/buttons.phtml
@@ -5,6 +5,9 @@
  */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="actions">
     <?php $_order = $block->getOrder() ?>
@@ -13,14 +16,14 @@
         /* @noEscape */ $this->helper(\Magento\Framework\Data\Helper\PostHelper::class)
             ->getPostData($block->getReorderUrl($_order))
         ?>' class="action order">
-            <span><?= $block->escapeHtml(__('Reorder')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Reorder')) ?></span>
         </a>
     <?php endif ?>
-    <a href="<?= $block->escapeUrl($block->getPrintUrl($_order)) ?>"
+    <a href="<?= $escaper->escapeUrl($block->getPrintUrl($_order)) ?>"
        class="action print"
        target="_blank"
        rel="noopener">
-        <span><?= $block->escapeHtml(__('Print Order')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Print Order')) ?></span>
     </a>
     <?= $block->getChildHtml() ?>
 </div>

--- a/app/code/Magento/Sales/view/frontend/templates/order/info/buttons/rss.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/info/buttons/rss.phtml
@@ -4,10 +4,13 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Sales\Block\Order\Info\Buttons\Rss */
+/**
+ * @var $block \Magento\Sales\Block\Order\Info\Buttons\Rss
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php if ($block->isRssAllowed() && $block->getLink()) : ?>
-    <a href="<?= $block->escapeHtmlAttr($block->getLink()) ?>" class="action rss">
-        <span><?= $block->escapeHtml($block->getLabel()) ?></span>
+    <a href="<?= $escaper->escapeHtmlAttr($block->getLink()) ?>" class="action rss">
+        <span><?= $escaper->escapeHtml($block->getLabel()) ?></span>
     </a>
 <?php endif; ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/invoice.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/invoice.phtml
@@ -4,14 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Sales\Block\Order\Invoice */
+/**
+ * @var $block \Magento\Sales\Block\Order\Invoice
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="order-details-items invoice">
     <?= $block->getChildHtml('invoice_items') ?>
     <div class="actions-toolbar">
         <div class="secondary">
-            <a href="<?= $block->escapeUrl($block->getBackUrl()) ?>" class="action back">
-                <span><?= $block->escapeHtml($block->getBackTitle()) ?></span>
+            <a href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>" class="action back">
+                <span><?= $escaper->escapeHtml($block->getBackTitle()) ?></span>
             </a>
         </div>
     </div>

--- a/app/code/Magento/Sales/view/frontend/templates/order/invoice/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/invoice/items.phtml
@@ -3,36 +3,40 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_order = $block->getOrder() ?>
 <div class="actions-toolbar">
-    <a href="<?= $block->escapeUrl($block->getPrintAllInvoicesUrl($_order)) ?>"
+    <a href="<?= $escaper->escapeUrl($block->getPrintAllInvoicesUrl($_order)) ?>"
        class="action print"
        target="_blank"
        rel="noopener">
-        <span><?= $block->escapeHtml(__('Print All Invoices')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Print All Invoices')) ?></span>
     </a>
 </div>
 <?php foreach ($_order->getInvoiceCollection() as $_invoice) : ?>
     <div class="order-title">
-        <strong><?= $block->escapeHtml(__('Invoice #')) ?><?= $block->escapeHtml($_invoice->getIncrementId()) ?></strong>
-        <a href="<?= $block->escapeUrl($block->getPrintInvoiceUrl($_invoice)) ?>"
+        <strong><?= $escaper->escapeHtml(__('Invoice #')) ?><?= $escaper->escapeHtml($_invoice->getIncrementId()) ?></strong>
+        <a href="<?= $escaper->escapeUrl($block->getPrintInvoiceUrl($_invoice)) ?>"
            class="action print"
            target="_blank"
            rel="noopener">
-            <span><?= $block->escapeHtml(__('Print Invoice')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Print Invoice')) ?></span>
         </a>
     </div>
     <div class="table-wrapper table-order-items invoice">
         <table class="data table table-order-items invoice" id="my-invoice-table-<?= (int) $_invoice->getId() ?>">
-            <caption class="table-caption"><?= $block->escapeHtml(__('Items Invoiced')) ?></caption>
+            <caption class="table-caption"><?= $escaper->escapeHtml(__('Items Invoiced')) ?></caption>
             <thead>
                 <tr>
-                    <th class="col name"><?= $block->escapeHtml(__('Product Name')) ?></th>
-                    <th class="col sku"><?= $block->escapeHtml(__('SKU')) ?></th>
-                    <th class="col price"><?= $block->escapeHtml(__('Price')) ?></th>
-                    <th class="col qty"><?= $block->escapeHtml(__('Qty Invoiced')) ?></th>
-                    <th class="col subtotal"><?= $block->escapeHtml(__('Subtotal')) ?></th>
+                    <th class="col name"><?= $escaper->escapeHtml(__('Product Name')) ?></th>
+                    <th class="col sku"><?= $escaper->escapeHtml(__('SKU')) ?></th>
+                    <th class="col price"><?= $escaper->escapeHtml(__('Price')) ?></th>
+                    <th class="col qty"><?= $escaper->escapeHtml(__('Qty Invoiced')) ?></th>
+                    <th class="col subtotal"><?= $escaper->escapeHtml(__('Subtotal')) ?></th>
                 </tr>
             </thead>
             <?php $_items = $_invoice->getAllItems(); ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/invoice/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/invoice/items/renderer/default.phtml
@@ -4,31 +4,36 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var  $block \Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer */ ?>
+<?php
+/**
+ * @var  $block \Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
+?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrderItem()->getOrder() ?>
 <tr id="order-item-row-<?= (int) $_item->getId() ?>">
-    <td class="col name" data-th="<?= $block->escapeHtml(__('Product Name')) ?>">
-        <strong class="product name product-item-name"><?= $block->escapeHtml($_item->getName()) ?></strong>
+    <td class="col name" data-th="<?= $escaper->escapeHtml(__('Product Name')) ?>">
+        <strong class="product name product-item-name"><?= $escaper->escapeHtml($_item->getName()) ?></strong>
         <?php if ($_options = $block->getItemOptions()): ?>
             <dl class="item-options">
             <?php foreach ($_options as $_option): ?>
-                <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                 <?php if (!$block->getPrintStatus()): ?>
                     <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
                     <dd<?= (isset($_formatedOptionValue['full_view']) ? ' class="tooltip wrapper"' : '') ?>>
-                        <?= $block->escapeHtml($_formatedOptionValue['value'], ['a']) ?>
+                        <?= $escaper->escapeHtml($_formatedOptionValue['value'], ['a']) ?>
                         <?php if (isset($_formatedOptionValue['full_view'])): ?>
                             <div class="tooltip content">
                                 <dl class="item options">
-                                    <dt><?= $block->escapeHtml($_option['label']) ?></dt>
-                                    <dd><?= $block->escapeHtml($_formatedOptionValue['full_view']) ?></dd>
+                                    <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
+                                    <dd><?= $escaper->escapeHtml($_formatedOptionValue['full_view']) ?></dd>
                                 </dl>
                             </div>
                         <?php endif; ?>
                     </dd>
                 <?php else: ?>
-                    <dd><?= $block->escapeHtml($_option['print_value'] ?? $_option['value']) ?></dd>
+                    <dd><?= $escaper->escapeHtml($_option['print_value'] ?? $_option['value']) ?></dd>
                 <?php endif; ?>
             <?php endforeach; ?>
             </dl>
@@ -37,18 +42,18 @@
         <?php if ($addInfoBlock): ?>
             <?= $addInfoBlock->setItem($_item->getOrderItem())->toHtml() ?>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
     </td>
-    <td class="col sku" data-th="<?= $block->escapeHtml(__('SKU')) ?>">
+    <td class="col sku" data-th="<?= $escaper->escapeHtml(__('SKU')) ?>">
         <?= /* @noEscape */ $block->prepareSku($block->getSku()) ?>
     </td>
-    <td class="col price" data-th="<?= $block->escapeHtml(__('Price')) ?>">
+    <td class="col price" data-th="<?= $escaper->escapeHtml(__('Price')) ?>">
         <?= $block->getItemPriceHtml() ?>
     </td>
-    <td class="col qty" data-th="<?= $block->escapeHtml(__('Qty Invoiced')) ?>">
+    <td class="col qty" data-th="<?= $escaper->escapeHtml(__('Qty Invoiced')) ?>">
         <span class="qty summary"><?= (float) $_item->getQty() ?></span>
     </td>
-    <td class="col subtotal" data-th="<?= $block->escapeHtml(__('Subtotal')) ?>">
+    <td class="col subtotal" data-th="<?= $escaper->escapeHtml(__('Subtotal')) ?>">
         <?= $block->getItemRowTotalHtml() ?>
     </td>
 </tr>

--- a/app/code/Magento/Sales/view/frontend/templates/order/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/items.phtml
@@ -6,11 +6,14 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var \Magento\Sales\Block\Order\Items $block */
+/**
+ * @var \Magento\Sales\Block\Order\Items $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="table-wrapper order-items">
-    <table class="data table table-order-items" id="my-orders-table" summary="<?= $block->escapeHtml(__('Items Ordered')) ?>">
-        <caption class="table-caption"><?= $block->escapeHtml(__('Items Ordered')) ?></caption>
+    <table class="data table table-order-items" id="my-orders-table" summary="<?= $escaper->escapeHtml(__('Items Ordered')) ?>">
+        <caption class="table-caption"><?= $escaper->escapeHtml(__('Items Ordered')) ?></caption>
         <thead>
             <?php if ($block->isPagerDisplayed()) : ?>
                 <tr>
@@ -20,11 +23,11 @@
                 </tr>
             <?php endif ?>
             <tr>
-                <th class="col name"><?= $block->escapeHtml(__('Product Name')) ?></th>
-                <th class="col sku"><?= $block->escapeHtml(__('SKU')) ?></th>
-                <th class="col price"><?= $block->escapeHtml(__('Price')) ?></th>
-                <th class="col qty"><?= $block->escapeHtml(__('Qty')) ?></th>
-                <th class="col subtotal"><?= $block->escapeHtml(__('Subtotal')) ?></th>
+                <th class="col name"><?= $escaper->escapeHtml(__('Product Name')) ?></th>
+                <th class="col sku"><?= $escaper->escapeHtml(__('SKU')) ?></th>
+                <th class="col price"><?= $escaper->escapeHtml(__('Price')) ?></th>
+                <th class="col qty"><?= $escaper->escapeHtml(__('Qty')) ?></th>
+                <th class="col subtotal"><?= $escaper->escapeHtml(__('Subtotal')) ?></th>
             </tr>
         </thead>
         <?php $items = $block->getItems(); ?>
@@ -45,20 +48,20 @@
                                class="action show"
                                aria-controls="order-item-gift-message-<?= (int) $item->getId() ?>"
                                data-item-id="<?= (int) $item->getId() ?>">
-                                <?= $block->escapeHtml(__('Gift Message')) ?>
+                                <?= $escaper->escapeHtml(__('Gift Message')) ?>
                             </a>
                             <?php $giftMessage = $this->helper(\Magento\GiftMessage\Helper\Message::class)->getGiftMessageForEntity($item); ?>
                             <div class="order-gift-message" id="order-item-gift-message-<?= (int) $item->getId() ?>" role="region" aria-expanded="false" tabindex="-1">
                                 <a href="#"
-                                   title="<?= $block->escapeHtml(__('Close')) ?>"
+                                   title="<?= $escaper->escapeHtml(__('Close')) ?>"
                                    aria-controls="order-item-gift-message-<?= (int) $item->getId() ?>"
                                    data-item-id="<?= (int) $item->getId() ?>"
                                    class="action close">
-                                    <?= $block->escapeHtml(__('Close')) ?>
+                                    <?= $escaper->escapeHtml(__('Close')) ?>
                                 </a>
                                 <dl class="item-options">
-                                    <dt class="item-sender"><strong class="label"><?= $block->escapeHtml(__('From')) ?></strong><?= $block->escapeHtml($giftMessage->getSender()) ?></dt>
-                                    <dt class="item-recipient"><strong class="label"><?= $block->escapeHtml(__('To')) ?></strong><?= $block->escapeHtml($giftMessage->getRecipient()) ?></dt>
+                                    <dt class="item-sender"><strong class="label"><?= $escaper->escapeHtml(__('From')) ?></strong><?= $escaper->escapeHtml($giftMessage->getSender()) ?></dt>
+                                    <dt class="item-recipient"><strong class="label"><?= $escaper->escapeHtml(__('To')) ?></strong><?= $escaper->escapeHtml($giftMessage->getRecipient()) ?></dt>
                                     <dd class="item-message"><?= /* @noEscape */ $this->helper(\Magento\GiftMessage\Helper\Message::class)->getEscapedGiftMessage($item) ?></dd>
                                 </dl>
                             </div>

--- a/app/code/Magento/Sales/view/frontend/templates/order/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/items/renderer/default.phtml
@@ -4,32 +4,35 @@
  * See COPYING.txt for license details.
  */
 
-/** @var  $block \Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer */
+/**
+ * @var  $block \Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 $_item = $block->getItem();
 ?>
 <tr id="order-item-row-<?= (int) $_item->getId() ?>">
-    <td class="col name" data-th="<?= $block->escapeHtml(__('Product Name')) ?>">
-        <strong class="product name product-item-name"><?= $block->escapeHtml($_item->getName()) ?></strong>
+    <td class="col name" data-th="<?= $escaper->escapeHtml(__('Product Name')) ?>">
+        <strong class="product name product-item-name"><?= $escaper->escapeHtml($_item->getName()) ?></strong>
         <?php if ($_options = $block->getItemOptions()): ?>
             <dl class="item-options">
             <?php foreach ($_options as $_option): ?>
-                <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                 <?php if (!$block->getPrintStatus()): ?>
                     <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
                     <dd<?= (isset($_formatedOptionValue['full_view']) ? ' class="tooltip wrapper"' : '') ?>>
-                        <?= $block->escapeHtml($_formatedOptionValue['value'], ['a']) ?>
+                        <?= $escaper->escapeHtml($_formatedOptionValue['value'], ['a']) ?>
                         <?php if (isset($_formatedOptionValue['full_view'])): ?>
                             <div class="tooltip content">
                                 <dl class="item options">
-                                    <dt><?= $block->escapeHtml($_option['label']) ?></dt>
-                                    <dd><?= $block->escapeHtml($_formatedOptionValue['full_view']) ?></dd>
+                                    <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
+                                    <dd><?= $escaper->escapeHtml($_formatedOptionValue['full_view']) ?></dd>
                                 </dl>
                             </div>
                         <?php endif; ?>
                     </dd>
                 <?php else: ?>
                     <?php $optionValue = isset($_option['print_value']) ? $_option['print_value'] : $_option['value'] ?>
-                    <dd><?= $block->escapeHtml($optionValue) ?></dd>
+                    <dd><?= $escaper->escapeHtml($optionValue) ?></dd>
                 <?php endif; ?>
             <?php endforeach; ?>
             </dl>
@@ -38,43 +41,43 @@ $_item = $block->getItem();
         <?php if ($addtInfoBlock): ?>
             <?= $addtInfoBlock->setItem($_item)->toHtml() ?>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
     </td>
-    <td class="col sku" data-th="<?= $block->escapeHtml(__('SKU')) ?>">
+    <td class="col sku" data-th="<?= $escaper->escapeHtml(__('SKU')) ?>">
         <?= /* @noEscape */ $block->prepareSku($block->getSku()) ?>
     </td>
-    <td class="col price" data-th="<?= $block->escapeHtml(__('Price')) ?>">
+    <td class="col price" data-th="<?= $escaper->escapeHtml(__('Price')) ?>">
         <?= $block->getItemPriceHtml() ?>
     </td>
-    <td class="col qty" data-th="<?= $block->escapeHtml(__('Qty')) ?>">
+    <td class="col qty" data-th="<?= $escaper->escapeHtml(__('Qty')) ?>">
         <ul class="items-qty">
         <?php if ($block->getItem()->getQtyOrdered() > 0): ?>
             <li class="item">
-                <span class="title"><?= $block->escapeHtml(__('Ordered')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Ordered')) ?></span>
                 <span class="content"><?= (float) $block->getItem()->getQtyOrdered() ?></span>
             </li>
         <?php endif; ?>
         <?php if ($block->getItem()->getQtyShipped() > 0): ?>
             <li class="item">
-                <span class="title"><?= $block->escapeHtml(__('Shipped')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Shipped')) ?></span>
                 <span class="content"><?= (float) $block->getItem()->getQtyShipped() ?></span>
             </li>
         <?php endif; ?>
         <?php if ($block->getItem()->getQtyCanceled() > 0): ?>
             <li class="item">
-                <span class="title"><?= $block->escapeHtml(__('Canceled')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Canceled')) ?></span>
                 <span class="content"><?= (float) $block->getItem()->getQtyCanceled() ?></span>
             </li>
         <?php endif; ?>
         <?php if ($block->getItem()->getQtyRefunded() > 0): ?>
             <li class="item">
-                <span class="title"><?= $block->escapeHtml(__('Refunded')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Refunded')) ?></span>
                 <span class="content"><?= (float) $block->getItem()->getQtyRefunded() ?></span>
             </li>
         <?php endif; ?>
         </ul>
     </td>
-    <td class="col subtotal" data-th="<?= $block->escapeHtml(__('Subtotal')) ?>">
+    <td class="col subtotal" data-th="<?= $escaper->escapeHtml(__('Subtotal')) ?>">
         <?= $block->getItemRowTotalHtml() ?>
     </td>
 </tr>

--- a/app/code/Magento/Sales/view/frontend/templates/order/order_comments.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/order_comments.phtml
@@ -4,12 +4,17 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var  $block \Magento\Sales\Block\Order\View*/?>
+<?php
+/**
+ * @var  $block \Magento\Sales\Block\Order\View
+ * @var \Magento\Framework\Escaper $escaper
+ */
+?>
 
 <?php $_history = $block->getOrder()->getVisibleStatusHistory() ?>
 <?php if (!empty($_history)) : ?>
     <div class="block block-order-details-comments">
-        <div class="block-title"><strong><?= $block->escapeHtml(__('About Your Order')) ?></strong></div>
+        <div class="block-title"><strong><?= $escaper->escapeHtml(__('About Your Order')) ?></strong></div>
         <div class="block-content">
             <dl class="order-comments">
                 <?php foreach ($_history as $_historyItem) : ?>
@@ -17,7 +22,7 @@
                         <?= /* @noEscape */
                         $block->formatDate($_historyItem->getCreatedAt(), \IntlDateFormatter::MEDIUM, true) ?>
                     </dt>
-                    <dd class="comment-content"><?= $block->escapeHtml($_historyItem->getComment()) ?></dd>
+                    <dd class="comment-content"><?= $escaper->escapeHtml($_historyItem->getComment()) ?></dd>
                 <?php endforeach; ?>
             </dl>
         </div>

--- a/app/code/Magento/Sales/view/frontend/templates/order/order_date.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/order_date.phtml
@@ -3,9 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="order-date">
-    <?= $block->escapeHtml(
+    <?= $escaper->escapeHtml(
         __(
             '<span class="label">Order Date:</span> %1',
             '<span>' . $block->formatDate($block->getOrder()->getCreatedAt(), \IntlDateFormatter::LONG) . '</span>'

--- a/app/code/Magento/Sales/view/frontend/templates/order/order_status.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/order_status.phtml
@@ -4,6 +4,11 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Sales\Block\Order\Info */ ?>
+<?php
+/**
+ * @var $block \Magento\Sales\Block\Order\Info
+ * @var \Magento\Framework\Escaper $escaper
+ */
+?>
 
-<span class="order-status"><?= $block->escapeHtml($block->getOrder()->getStatusLabel()) ?></span>
+<span class="order-status"><?= $escaper->escapeHtml($block->getOrder()->getStatusLabel()) ?></span>

--- a/app/code/Magento/Sales/view/frontend/templates/order/print/creditmemo.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/print/creditmemo.phtml
@@ -3,6 +3,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_order = $block->getOrder() ?>
 <?php $_creditmemo = $block->getCreditmemo() ?>
@@ -14,20 +18,20 @@
 <?php foreach ($_creditmemos as $_creditmemo) : ?>
 <div class="order-details-items creditmemo">
     <div class="order-title">
-        <strong><?= $block->escapeHtml(__('Refund #%1', $_creditmemo->getIncrementId())) ?></strong>
+        <strong><?= $escaper->escapeHtml(__('Refund #%1', $_creditmemo->getIncrementId())) ?></strong>
     </div>
     <div class="table-wrapper order-items-creditmemo">
         <table class="data table table-order-items creditmemo" id="my-refund-table-<?= (int) $_creditmemo->getId() ?>">
-            <caption class="table-caption"><?= $block->escapeHtml(__('Items Refunded')) ?></caption>
+            <caption class="table-caption"><?= $escaper->escapeHtml(__('Items Refunded')) ?></caption>
             <thead>
                 <tr>
-                    <th class="col name"><?= $block->escapeHtml(__('Product Name')) ?></th>
-                    <th class="col sku"><?= $block->escapeHtml(__('SKU')) ?></th>
-                    <th class="col price"><?= $block->escapeHtml(__('Price')) ?></th>
-                    <th class="col qty"><?= $block->escapeHtml(__('Qty')) ?></th>
-                    <th class="col subtotal"><?= $block->escapeHtml(__('Subtotal')) ?></th>
-                    <th class="col discount"><?= $block->escapeHtml(__('Discount Amount')) ?></th>
-                    <th class="col rowtotal"><?= $block->escapeHtml(__('Row Total')) ?></th>
+                    <th class="col name"><?= $escaper->escapeHtml(__('Product Name')) ?></th>
+                    <th class="col sku"><?= $escaper->escapeHtml(__('SKU')) ?></th>
+                    <th class="col price"><?= $escaper->escapeHtml(__('Price')) ?></th>
+                    <th class="col qty"><?= $escaper->escapeHtml(__('Qty')) ?></th>
+                    <th class="col subtotal"><?= $escaper->escapeHtml(__('Subtotal')) ?></th>
+                    <th class="col discount"><?= $escaper->escapeHtml(__('Discount Amount')) ?></th>
+                    <th class="col rowtotal"><?= $escaper->escapeHtml(__('Row Total')) ?></th>
                 </tr>
             </thead>
             <?php $_items = $_creditmemo->getAllItems(); ?>
@@ -45,13 +49,13 @@
     </div>
     <div class="block block-order-details-view">
         <div class="block-title">
-            <strong><?= $block->escapeHtml(__('Order Information')) ?></strong>
+            <strong><?= $escaper->escapeHtml(__('Order Information')) ?></strong>
         </div>
         <div class="block-content">
         <?php if (!$_order->getIsVirtual()) : ?>
             <div class="box box-order-shipping-address">
                 <div class="box-title">
-                    <strong><?= $block->escapeHtml(__('Shipping Address')) ?></strong>
+                    <strong><?= $escaper->escapeHtml(__('Shipping Address')) ?></strong>
                 </div>
                 <div class="box-content">
                     <?php $_shipping = $_creditmemo->getShippingAddress() ?>
@@ -60,16 +64,16 @@
             </div>
             <div class="box box-order-shipping-method">
                 <div class="box-title">
-                    <strong><?= $block->escapeHtml(__('Shipping Method')) ?></strong>
+                    <strong><?= $escaper->escapeHtml(__('Shipping Method')) ?></strong>
                 </div>
                 <div class="box-content">
-                    <?= $block->escapeHtml($_order->getShippingDescription()) ?>
+                    <?= $escaper->escapeHtml($_order->getShippingDescription()) ?>
                 </div>
             </div>
         <?php endif; ?>
             <div class="box box-order-billing-address">
                 <div class="box-title">
-                    <strong><?= $block->escapeHtml(__('Billing Address')) ?></strong>
+                    <strong><?= $escaper->escapeHtml(__('Billing Address')) ?></strong>
                 </div>
                 <div class="box-content">
                     <?php $_billing = $_creditmemo->getbillingAddress() ?>
@@ -78,7 +82,7 @@
             </div>
             <div class="box box-order-billing-method">
                 <div class="box-title">
-                    <strong><?= $block->escapeHtml(__('Payment Method')) ?></strong>
+                    <strong><?= $escaper->escapeHtml(__('Payment Method')) ?></strong>
                 </div>
                 <div class="box-content">
                     <?= $block->getPaymentInfoHtml() ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/print/invoice.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/print/invoice.phtml
@@ -3,6 +3,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_order = $block->getOrder() ?>
 <?php $_invoice = $block->getInvoice() ?>
@@ -14,18 +18,18 @@
 <?php foreach ($_invoices as $_invoice) : ?>
 <div class="order-details-items invoice">
     <div class="order-title">
-        <strong><?= $block->escapeHtml(__('Invoice #')) ?><?= (int) $_invoice->getIncrementId() ?></strong>
+        <strong><?= $escaper->escapeHtml(__('Invoice #')) ?><?= (int) $_invoice->getIncrementId() ?></strong>
     </div>
     <div class="table-wrapper table-order-items invoice">
         <table class="data table table-order-items invoice" id="my-invoice-table-<?= (int) $_invoice->getId() ?>">
-            <caption class="table-caption"><?= $block->escapeHtml(__('Items Invoiced')) ?></caption>
+            <caption class="table-caption"><?= $escaper->escapeHtml(__('Items Invoiced')) ?></caption>
             <thead>
             <tr>
-                <th class="col name"><?= $block->escapeHtml(__('Product Name')) ?></th>
-                <th class="col sku"><?= $block->escapeHtml(__('SKU')) ?></th>
-                <th class="col price"><?= $block->escapeHtml(__('Price')) ?></th>
-                <th class="col qty"><?= $block->escapeHtml(__('Qty Invoiced')) ?></th>
-                <th class="col subtotal"><?= $block->escapeHtml(__('Subtotal')) ?></th>
+                <th class="col name"><?= $escaper->escapeHtml(__('Product Name')) ?></th>
+                <th class="col sku"><?= $escaper->escapeHtml(__('SKU')) ?></th>
+                <th class="col price"><?= $escaper->escapeHtml(__('Price')) ?></th>
+                <th class="col qty"><?= $escaper->escapeHtml(__('Qty Invoiced')) ?></th>
+                <th class="col subtotal"><?= $escaper->escapeHtml(__('Subtotal')) ?></th>
             </tr>
             </thead>
             <?php $_items = $_invoice->getItemsCollection(); ?>
@@ -43,13 +47,13 @@
     </div>
     <div class="block block-order-details-view">
         <div class="block-title">
-            <strong><?= $block->escapeHtml(__('Order Information')) ?></strong>
+            <strong><?= $escaper->escapeHtml(__('Order Information')) ?></strong>
         </div>
         <div class="block-content">
         <?php if (!$_order->getIsVirtual()) : ?>
             <div class="box box-order-shipping-address">
                 <div class="box-title">
-                    <strong><?= $block->escapeHtml(__('Shipping Address')) ?></strong>
+                    <strong><?= $escaper->escapeHtml(__('Shipping Address')) ?></strong>
                 </div>
                 <div class="box-content">
                     <?php $_shipping = $_invoice->getShippingAddress() ?>
@@ -59,20 +63,20 @@
 
             <div class="box box-order-shipping-method">
                 <div class="box-title">
-                    <strong><?= $block->escapeHtml(__('Shipping Method')) ?></strong>
+                    <strong><?= $escaper->escapeHtml(__('Shipping Method')) ?></strong>
                 </div>
                 <div class="box-content">
                     <?php if ($_order->getShippingDescription()) : ?>
-                        <?= $block->escapeHtml($_order->getShippingDescription()) ?>
+                        <?= $escaper->escapeHtml($_order->getShippingDescription()) ?>
                     <?php else : ?>
-                        <?= $block->escapeHtml(__('No shipping information available')) ?>
+                        <?= $escaper->escapeHtml(__('No shipping information available')) ?>
                     <?php endif; ?>
                 </div>
             </div>
         <?php endif; ?>
             <div class="box box-order-billing-address">
                 <div class="box-title">
-                    <strong><?= $block->escapeHtml(__('Billing Address')) ?></strong>
+                    <strong><?= $escaper->escapeHtml(__('Billing Address')) ?></strong>
                 </div>
                 <div class="box-content">
                     <?php $_billing = $_invoice->getbillingAddress() ?>
@@ -82,7 +86,7 @@
 
             <div class="box box-order-billing-method">
                 <div class="box-title">
-                    <strong><?= $block->escapeHtml(__('Payment Method')) ?></strong>
+                    <strong><?= $escaper->escapeHtml(__('Payment Method')) ?></strong>
                 </div>
                 <div class="box-content">
                     <?= $block->getPaymentInfoHtml() ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/recent.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/recent.phtml
@@ -6,7 +6,10 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Sales\Block\Order\Recent */
+/**
+ * @var $block \Magento\Sales\Block\Order\Recent
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="block block-dashboard-orders">
 <?php
@@ -14,10 +17,10 @@
     $count = count($_orders);
 ?>
     <div class="block-title order">
-        <strong><?= $block->escapeHtml(__('Recent Orders')) ?></strong>
+        <strong><?= $escaper->escapeHtml(__('Recent Orders')) ?></strong>
         <?php if ($count > 0) : ?>
-            <a class="action view" href="<?= $block->escapeUrl($block->getUrl('sales/order/history')) ?>">
-                <span><?= $block->escapeHtml(__('View All')) ?></span>
+            <a class="action view" href="<?= $escaper->escapeUrl($block->getUrl('sales/order/history')) ?>">
+                <span><?= $escaper->escapeHtml(__('View All')) ?></span>
             </a>
         <?php endif; ?>
     </div>
@@ -26,28 +29,28 @@
     <?php if ($count > 0) : ?>
         <div class="table-wrapper orders-recent">
             <table class="data table table-order-items recent" id="my-orders-table">
-                <caption class="table-caption"><?= $block->escapeHtml(__('Recent Orders')) ?></caption>
+                <caption class="table-caption"><?= $escaper->escapeHtml(__('Recent Orders')) ?></caption>
                 <thead>
                     <tr>
-                        <th scope="col" class="col id"><?= $block->escapeHtml(__('Order #')) ?></th>
-                        <th scope="col" class="col date"><?= $block->escapeHtml(__('Date')) ?></th>
-                        <th scope="col" class="col shipping"><?= $block->escapeHtml(__('Ship To')) ?></th>
-                        <th scope="col" class="col total"><?= $block->escapeHtml(__('Order Total')) ?></th>
-                        <th scope="col" class="col status"><?= $block->escapeHtml(__('Status')) ?></th>
-                        <th scope="col" class="col actions"><?= $block->escapeHtml(__('Action')) ?></th>
+                        <th scope="col" class="col id"><?= $escaper->escapeHtml(__('Order #')) ?></th>
+                        <th scope="col" class="col date"><?= $escaper->escapeHtml(__('Date')) ?></th>
+                        <th scope="col" class="col shipping"><?= $escaper->escapeHtml(__('Ship To')) ?></th>
+                        <th scope="col" class="col total"><?= $escaper->escapeHtml(__('Order Total')) ?></th>
+                        <th scope="col" class="col status"><?= $escaper->escapeHtml(__('Status')) ?></th>
+                        <th scope="col" class="col actions"><?= $escaper->escapeHtml(__('Action')) ?></th>
                     </tr>
                 </thead>
                 <tbody>
                     <?php foreach ($_orders as $_order) : ?>
                         <tr>
-                            <td data-th="<?= $block->escapeHtml(__('Order #')) ?>" class="col id"><?= $block->escapeHtml($_order->getRealOrderId()) ?></td>
-                            <td data-th="<?= $block->escapeHtml(__('Date')) ?>" class="col date"><?= $block->escapeHtml($block->formatDate($_order->getCreatedAt())) ?></td>
-                            <td data-th="<?= $block->escapeHtml(__('Ship To')) ?>" class="col shipping"><?= $_order->getShippingAddress() ? $block->escapeHtml($_order->getShippingAddress()->getName()) : "&nbsp;" ?></td>
-                            <td data-th="<?= $block->escapeHtml(__('Order Total')) ?>" class="col total"><?= /* @noEscape */ $_order->formatPrice($_order->getGrandTotal()) ?></td>
-                            <td data-th="<?= $block->escapeHtml(__('Status')) ?>" class="col status"><?= $block->escapeHtml($_order->getStatusLabel()) ?></td>
-                            <td data-th="<?= $block->escapeHtml(__('Actions')) ?>" class="col actions">
-                                <a href="<?= $block->escapeUrl($block->getViewUrl($_order)) ?>" class="action view">
-                                    <span><?= $block->escapeHtml(__('View Order')) ?></span>
+                            <td data-th="<?= $escaper->escapeHtml(__('Order #')) ?>" class="col id"><?= $escaper->escapeHtml($_order->getRealOrderId()) ?></td>
+                            <td data-th="<?= $escaper->escapeHtml(__('Date')) ?>" class="col date"><?= $escaper->escapeHtml($block->formatDate($_order->getCreatedAt())) ?></td>
+                            <td data-th="<?= $escaper->escapeHtml(__('Ship To')) ?>" class="col shipping"><?= $_order->getShippingAddress() ? $escaper->escapeHtml($_order->getShippingAddress()->getName()) : "&nbsp;" ?></td>
+                            <td data-th="<?= $escaper->escapeHtml(__('Order Total')) ?>" class="col total"><?= /* @noEscape */ $_order->formatPrice($_order->getGrandTotal()) ?></td>
+                            <td data-th="<?= $escaper->escapeHtml(__('Status')) ?>" class="col status"><?= $escaper->escapeHtml($_order->getStatusLabel()) ?></td>
+                            <td data-th="<?= $escaper->escapeHtml(__('Actions')) ?>" class="col actions">
+                                <a href="<?= $escaper->escapeUrl($block->getViewUrl($_order)) ?>" class="action view">
+                                    <span><?= $escaper->escapeHtml(__('View Order')) ?></span>
                                 </a>
                                 <?php if ($this->helper(\Magento\Sales\Helper\Reorder::class)
                                     ->canReorder($_order->getEntityId())
@@ -56,7 +59,7 @@
                                     $this->helper(\Magento\Framework\Data\Helper\PostHelper::class)
                                         ->getPostData($block->getReorderUrl($_order))
                                     ?>' class="action order">
-                                        <span><?= $block->escapeHtml(__('Reorder')) ?></span>
+                                        <span><?= $escaper->escapeHtml(__('Reorder')) ?></span>
                                     </a>
                                 <?php endif ?>
                             </td>
@@ -66,7 +69,7 @@
             </table>
         </div>
     <?php else : ?>
-        <div class="message info empty"><span><?= $block->escapeHtml(__('You have placed no orders.')) ?></span></div>
+        <div class="message info empty"><span><?= $escaper->escapeHtml(__('You have placed no orders.')) ?></span></div>
     <?php endif; ?>
     </div>
 </div>

--- a/app/code/Magento/Sales/view/frontend/templates/order/shipment/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/shipment/items/renderer/default.phtml
@@ -3,32 +3,36 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrderItem()->getOrder() ?>
 <tr id="order-item-row-<?= (int) $_item->getId() ?>">
-    <td class="col name" data-th="<?= $block->escapeHtml(__('Product Name')) ?>">
-        <strong class="product name product-item-name"><?= $block->escapeHtml($_item->getName()) ?></strong>
+    <td class="col name" data-th="<?= $escaper->escapeHtml(__('Product Name')) ?>">
+        <strong class="product name product-item-name"><?= $escaper->escapeHtml($_item->getName()) ?></strong>
         <?php if ($_options = $block->getItemOptions()): ?>
             <dl class="item options">
             <?php foreach ($_options as $_option): ?>
-                <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                 <?php if (!$block->getPrintStatus()): ?>
                     <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
                     <dd<?= (isset($_formatedOptionValue['full_view']) ? ' class="tooltip wrapper"' : '') ?>>
-                        <?= $block->escapeHtml($_formatedOptionValue['value'], ['a']) ?>
+                        <?= $escaper->escapeHtml($_formatedOptionValue['value'], ['a']) ?>
                         <?php if (isset($_formatedOptionValue['full_view'])): ?>
                         <div class="tooltip content">
                             <dl class="item options">
-                                <dt><?= $block->escapeHtml($_option['label']) ?></dt>
-                                <dd><?= $block->escapeHtml($_formatedOptionValue['full_view']) ?></dd>
+                                <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
+                                <dd><?= $escaper->escapeHtml($_formatedOptionValue['full_view']) ?></dd>
                             </dl>
                         </div>
                         <?php endif; ?>
                     </dd>
                 <?php else: ?>
                     <?php $optionValue = isset($_option['print_value']) ? $_option['print_value'] : $_option['value'] ?>
-                    <dd><?= $block->escapeHtml($optionValue) ?></dd>
+                    <dd><?= $escaper->escapeHtml($optionValue) ?></dd>
                 <?php endif; ?>
             <?php endforeach; ?>
             </dl>
@@ -37,10 +41,10 @@
         <?php if ($addInfoBlock): ?>
             <?= $addInfoBlock->setItem($_item->getOrderItem())->toHtml() ?>
         <?php endif; ?>
-        <?= $block->escapeHtml($_item->getDescription()) ?>
+        <?= $escaper->escapeHtml($_item->getDescription()) ?>
     </td>
-    <td class="col sku" data-th="<?= $block->escapeHtml(__('SKU')) ?>">
+    <td class="col sku" data-th="<?= $escaper->escapeHtml(__('SKU')) ?>">
         <?= /* @noEscape */ $block->prepareSku($block->getSku()) ?>
     </td>
-    <td class="col qty" data-th="<?= $block->escapeHtml(__('Qty Shipped')) ?>"><?= (float) $_item->getQty() ?></td>
+    <td class="col qty" data-th="<?= $escaper->escapeHtml(__('Qty Shipped')) ?>"><?= (float) $_item->getQty() ?></td>
 </tr>

--- a/app/code/Magento/Sales/view/frontend/templates/order/totals.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/totals.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var $block \Magento\Sales\Block\Order\Totals
+ * @var \Magento\Framework\Escaper $escaper
  * @see \Magento\Sales\Block\Order\Totals
  */
 ?>
@@ -13,15 +14,15 @@
     <?php if ($_total->getBlockName()) : ?>
         <?= $block->getChildHtml($_total->getBlockName(), false) ?>
     <?php else :?>
-    <tr class="<?= $block->escapeHtmlAttr($_code) ?>">
+    <tr class="<?= $escaper->escapeHtmlAttr($_code) ?>">
         <th <?= /* @noEscape */ $block->getLabelProperties() ?> scope="row">
             <?php if ($_total->getStrong()) : ?>
-                <strong><?= $block->escapeHtml($_total->getLabel()) ?></strong>
+                <strong><?= $escaper->escapeHtml($_total->getLabel()) ?></strong>
             <?php else : ?>
-                <?= $block->escapeHtml($_total->getLabel()) ?>
+                <?= $escaper->escapeHtml($_total->getLabel()) ?>
             <?php endif ?>
         </th>
-        <td <?= /* @noEscape */ $block->getValueProperties() ?> data-th="<?= $block->escapeHtmlAttr($_total->getLabel()) ?>">
+        <td <?= /* @noEscape */ $block->getValueProperties() ?> data-th="<?= $escaper->escapeHtmlAttr($_total->getLabel()) ?>">
             <?php if ($_total->getStrong()) : ?>
                 <strong><?= /* @noEscape */ $block->formatValue($_total) ?></strong>
             <?php else : ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/view.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/view.phtml
@@ -6,12 +6,17 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 ?>
-<?php /** @var  $block \Magento\Sales\Block\Order\View*/?>
+<?php
+/**
+ * @var  $block \Magento\Sales\Block\Order\View
+ * @var \Magento\Framework\Escaper $escaper
+ */
+?>
 <div class="order-details-items ordered">
     <?php $_order = $block->getOrder() ?>
 
     <div class="order-title">
-        <strong><?= $block->escapeHtml(__('Items Ordered')) ?></strong>
+        <strong><?= $escaper->escapeHtml(__('Items Ordered')) ?></strong>
         <?php if (!empty($_order->getTracksCollection()->getItems())) : ?>
             <?= $block->getChildHtml('tracking-info-link') ?>
         <?php endif; ?>
@@ -23,14 +28,14 @@
         && $_order->getGiftMessageId()
     ) : ?>
     <div class="block block-order-details-gift-message">
-        <div class="block-title"><strong><?= $block->escapeHtml(__('Gift Message for This Order')) ?></strong></div>
+        <div class="block-title"><strong><?= $escaper->escapeHtml(__('Gift Message for This Order')) ?></strong></div>
         <?php
         $_giftMessage = $this->helper(\Magento\GiftMessage\Helper\Message::class)->getGiftMessageForEntity($_order);
         ?>
         <div class="block-content">
             <dl class="item-options">
-                <dt class="item-sender"><strong class="label"><?= $block->escapeHtml(__('From')) ?></strong><?= $block->escapeHtml($_giftMessage->getSender()) ?></dt>
-                <dt class="item-recipient"><strong class="label"><?= $block->escapeHtml(__('To')) ?></strong><?= $block->escapeHtml($_giftMessage->getRecipient()) ?></dt>
+                <dt class="item-sender"><strong class="label"><?= $escaper->escapeHtml(__('From')) ?></strong><?= $escaper->escapeHtml($_giftMessage->getSender()) ?></dt>
+                <dt class="item-recipient"><strong class="label"><?= $escaper->escapeHtml(__('To')) ?></strong><?= $escaper->escapeHtml($_giftMessage->getRecipient()) ?></dt>
                 <dd class="item-message">
                     <?= /* @noEscape */
                     $this->helper(\Magento\GiftMessage\Helper\Message::class)->getEscapedGiftMessage($_order) ?>
@@ -42,8 +47,8 @@
 
     <div class="actions-toolbar">
         <div class="secondary">
-            <a class="action back" href="<?= $block->escapeUrl($block->getBackUrl()) ?>">
-                <span><?= $block->escapeHtml($block->getBackTitle()) ?></span>
+            <a class="action back" href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>">
+                <span><?= $escaper->escapeHtml($block->getBackTitle()) ?></span>
             </a>
         </div>
     </div>

--- a/app/code/Magento/Sales/view/frontend/templates/reorder/sidebar.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/reorder/sidebar.phtml
@@ -8,6 +8,7 @@
  * Last ordered items sidebar
  *
  * @var $block \Magento\Sales\Block\Reorder\Sidebar
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -15,29 +16,29 @@
     <div class="block-title no-display"
          data-bind="css: {'no-display': !lastOrderedItems().items || lastOrderedItems().items.length === 0}">
         <strong id="block-reorder-heading" role="heading" aria-level="2">
-            <?= $block->escapeHtml(__('Recently Ordered')) ?>
+            <?= $escaper->escapeHtml(__('Recently Ordered')) ?>
         </strong>
     </div>
     <div class="block-content no-display"
          data-bind="css: {'no-display': !lastOrderedItems().items || lastOrderedItems().items.length === 0}"
          aria-labelledby="block-reorder-heading">
         <form method="post" class="form reorder"
-              action="<?= $block->escapeUrl($block->getFormActionUrl()) ?>" id="reorder-validate-detail">
-            <strong class="subtitle"><?= $block->escapeHtml(__('Last Ordered Items')) ?></strong>
+              action="<?= $escaper->escapeUrl($block->getFormActionUrl()) ?>" id="reorder-validate-detail">
+            <strong class="subtitle"><?= $escaper->escapeHtml(__('Last Ordered Items')) ?></strong>
             <ol id="cart-sidebar-reorder" class="product-items product-items-names"
                 data-bind="foreach: lastOrderedItems().items">
                 <li class="product-item">
                     <div class="field item choice">
                         <label class="label" data-bind="attr: {'for': 'reorder-item-' + id}">
-                            <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                         </label>
                         <div class="control">
                             <input type="checkbox" name="order_items[]"
                                    data-bind="attr: {
                                         id: 'reorder-item-' + id,
                                         value: id,
-                                        title: is_saleable ? '<?= $block->escapeHtml(__('Add to Cart')) ?>' :
-                                         '<?= $block->escapeHtml(__('Product is not salable.')) ?>'
+                                        title: is_saleable ? '<?= $escaper->escapeHtml(__('Add to Cart')) ?>' :
+                                         '<?= $escaper->escapeHtml(__('Product is not salable.')) ?>'
                                    },
                                    disable: !is_saleable"
                                    class="checkbox" data-validate='{"validate-one-checkbox-required-by-name": true}'/>
@@ -54,15 +55,15 @@
             <div class="actions-toolbar">
                 <div class="primary"
                      data-bind="visible: isShowAddToCart">
-                    <button type="submit" title="<?= $block->escapeHtml(__('Add to Cart')) ?>"
+                    <button type="submit" title="<?= $escaper->escapeHtml(__('Add to Cart')) ?>"
                             class="action tocart primary">
-                        <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                     </button>
                 </div>
                 <div class="secondary">
                     <a class="action view"
-                       href="<?= $block->escapeUrl($block->getUrl('customer/account')) ?>#my-orders-table">
-                        <span><?= $block->escapeHtml(__('View All')) ?></span>
+                       href="<?= $escaper->escapeUrl($block->getUrl('customer/account')) ?>#my-orders-table">
+                        <span><?= $escaper->escapeHtml(__('View All')) ?></span>
                     </a>
                 </div>
             </div>

--- a/app/code/Magento/Sales/view/frontend/templates/widget/guest/form.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/widget/guest/form.phtml
@@ -6,32 +6,33 @@
 
 /**
  * @var $block \Magento\Sales\Block\Widget\Guest\Form
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
 <?php if ($block->isEnable()): ?>
     <div class="widget block block-orders-returns">
         <div class="block-title">
-            <strong role="heading" aria-level="2"><?= $block->escapeHtml(__('Orders and Returns')) ?></strong>
+            <strong role="heading" aria-level="2"><?= $escaper->escapeHtml(__('Orders and Returns')) ?></strong>
         </div>
         <div class="block-content">
             <form id="oar-widget-orders-and-returns-form" data-mage-init='{"ordersReturns":{},"validation":{}}'
-                  action="<?= $block->escapeUrl($block->getActionUrl()) ?>" method="post"
+                  action="<?= $escaper->escapeUrl($block->getActionUrl()) ?>" method="post"
                   class="form form-orders-search" name="guest_post">
                 <fieldset class="fieldset">
                     <div class="field find required">
-                        <label class="label"><span><?= $block->escapeHtml(__('Find Order By')) ?></span></label>
+                        <label class="label"><span><?= $escaper->escapeHtml(__('Find Order By')) ?></span></label>
 
                         <div class="control">
                             <select name="oar_type" id="quick-search-type-id" class="select" title="">
-                                <option value="email"><?= $block->escapeHtml(__('Email')) ?></option>
-                                <option value="zip"><?= $block->escapeHtml(__('ZIP Code')) ?></option>
+                                <option value="email"><?= $escaper->escapeHtml(__('Email')) ?></option>
+                                <option value="zip"><?= $escaper->escapeHtml(__('ZIP Code')) ?></option>
                             </select>
                         </div>
                     </div>
                     <div class="field id required">
                         <label for="oar-order-id" class="label">
-                            <span><?= $block->escapeHtml(__('Order ID')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Order ID')) ?></span>
                         </label>
 
                         <div class="control">
@@ -42,7 +43,7 @@
                     </div>
                     <div class="field lastname required">
                         <label for="oar-billing-lastname"
-                               class="label"><span><?= $block->escapeHtml(__('Billing Last Name')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Billing Last Name')) ?></span></label>
 
                         <div class="control">
                             <input type="text" class="input-text" id="oar-billing-lastname" name="oar_billing_lastname"
@@ -50,7 +51,7 @@
                         </div>
                     </div>
                     <div id="oar-email" class="field email required">
-                        <label for="oar_email" class="label"><span><?= $block->escapeHtml(__('Email')) ?></span></label>
+                        <label for="oar_email" class="label"><span><?= $escaper->escapeHtml(__('Email')) ?></span></label>
 
                         <div class="control">
                             <input type="email" class="input-text" id="oar_email" name="oar_email" autocomplete="off"
@@ -59,7 +60,7 @@
                     </div>
                     <div id="oar-zip" class="field zip required">
                         <label for="oar_zip" class="label">
-                            <span><?= $block->escapeHtml(__('Billing ZIP Code')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Billing ZIP Code')) ?></span>
                         </label>
 
                         <div class="control">
@@ -71,8 +72,8 @@
                 </fieldset>
                 <div class="actions-toolbar">
                     <div class="primary">
-                        <button type="submit" title="<?= $block->escapeHtml(__('Search')) ?>" class="action search">
-                            <span><?= $block->escapeHtml(__('Search')) ?></span>
+                        <button type="submit" title="<?= $escaper->escapeHtml(__('Search')) ?>" class="action search">
+                            <span><?= $escaper->escapeHtml(__('Search')) ?></span>
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
