### PR TITLE
Magento_CatalogInventory: avoid using deprecated escape* methods from…

### DIFF
--- a/app/code/Magento/CatalogInventory/view/frontend/templates/qtyincrements.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/templates/qtyincrements.phtml
@@ -6,10 +6,11 @@
 
 /**
  * @var $block \Magento\CatalogInventory\Block\Qtyincrements
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <?php if ($block->getProductQtyIncrements()) : ?>
     <div class="product pricing">
-        <?= $block->escapeHtml(__('%1 is available to buy in increments of %2', $block->getProductName(), $block->getProductQtyIncrements())) ?>
+        <?= $escaper->escapeHtml(__('%1 is available to buy in increments of %2', $block->getProductName(), $block->getProductQtyIncrements())) ?>
     </div>
 <?php endif ?>

--- a/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/composite.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/composite.phtml
@@ -6,26 +6,27 @@
 
 /**
  * @var $block \Magento\CatalogInventory\Block\Stockqty\Composite
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <?php if ($block->isMsgVisible()) : ?>
     <div class="availability only">
         <a href="#"
-           data-mage-init='{"toggleAdvanced": {"selectorsToggleClass": "active", "baseToggleClass": "expanded", "toggleContainers": "#<?= $block->escapeHtmlAttr($block->getDetailsPlaceholderId()) ?>"}}'
-           id="<?= $block->escapeHtmlAttr($block->getPlaceholderId()) ?>"
-           title="<?= $block->escapeHtmlAttr(__('Only %1 left', ($block->getStockQtyLeft()))) ?>"
+           data-mage-init='{"toggleAdvanced": {"selectorsToggleClass": "active", "baseToggleClass": "expanded", "toggleContainers": "#<?= $escaper->escapeHtmlAttr($block->getDetailsPlaceholderId()) ?>"}}'
+           id="<?= $escaper->escapeHtmlAttr($block->getPlaceholderId()) ?>"
+           title="<?= $escaper->escapeHtmlAttr(__('Only %1 left', ($block->getStockQtyLeft()))) ?>"
            class="action show">
-            <?= /* @noEscape */ __('Only %1 left', "<strong>{$block->escapeHtml($block->getStockQtyLeft())}</strong>") ?>
+            <?= /* @noEscape */ __('Only %1 left', "<strong>{$escaper->escapeHtml($block->getStockQtyLeft())}</strong>") ?>
         </a>
     </div>
-    <div class="availability only detailed" id="<?= $block->escapeHtmlAttr($block->getDetailsPlaceholderId()) ?>">
+    <div class="availability only detailed" id="<?= $escaper->escapeHtmlAttr($block->getDetailsPlaceholderId()) ?>">
         <div class="table-wrapper">
             <table class="data table">
-                <caption class="table-caption"><?= $block->escapeHtml(__('Product availability')) ?></caption>
+                <caption class="table-caption"><?= $escaper->escapeHtml(__('Product availability')) ?></caption>
                 <thead>
                 <tr>
-                    <th class="col item" scope="col"><?= $block->escapeHtml(__('Product Name')) ?></th>
-                    <th class="col qty" scope="col"><?= $block->escapeHtml(__('Qty')) ?></th>
+                    <th class="col item" scope="col"><?= $escaper->escapeHtml(__('Product Name')) ?></th>
+                    <th class="col qty" scope="col"><?= $escaper->escapeHtml(__('Qty')) ?></th>
                 </tr>
                 </thead>
                 <tbody>
@@ -33,8 +34,8 @@
                     <?php $childProductStockQty = $block->getProductStockQty($childProduct); ?>
                     <?php if ($childProductStockQty > 0) : ?>
                         <tr>
-                            <td data-th="<?= $block->escapeHtmlAttr(__('Product Name')) ?>" class="col item"><?= $block->escapeHtml($childProduct->getName()) ?></td>
-                            <td data-th="<?= $block->escapeHtmlAttr(__('Qty')) ?>" class="col qty"><?= $block->escapeHtml($childProductStockQty) ?></td>
+                            <td data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')) ?>" class="col item"><?= $escaper->escapeHtml($childProduct->getName()) ?></td>
+                            <td data-th="<?= $escaper->escapeHtmlAttr(__('Qty')) ?>" class="col qty"><?= $escaper->escapeHtml($childProductStockQty) ?></td>
                         </tr>
                     <?php endif ?>
                 <?php endforeach ?>

--- a/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/default.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/default.phtml
@@ -6,10 +6,11 @@
 
 /**
  * @var $block \Magento\CatalogInventory\Block\Stockqty\DefaultStockqty
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <?php if ($block->isMsgVisible()) : ?>
-    <div class="availability only" title="<?= $block->escapeHtmlAttr(__('Only %1 left', ($block->getStockQtyLeft()))) ?>">
-        <?= /* @noEscape */ __('Only %1 left', "<strong>{$block->escapeHtml($block->getStockQtyLeft())}</strong>") ?>
+    <div class="availability only" title="<?= $escaper->escapeHtmlAttr(__('Only %1 left', ($block->getStockQtyLeft()))) ?>">
+        <?= /* @noEscape */ __('Only %1 left', "<strong>{$escaper->escapeHtml($block->getStockQtyLeft())}</strong>") ?>
     </div>
 <?php endif ?>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
