### PR TITLE
Magento_ImportExport: avoid using deprecated escape* methods from Abs…

### DIFF
--- a/app/code/Magento/ImportExport/Block/Adminhtml/Export/Filter.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Export/Filter.php
@@ -102,8 +102,8 @@ class Filter extends \Magento\Backend\Block\Widget\Grid\Extended
         $fromValue = null;
         $toValue = null;
         if (is_array($value) && count($value) == 2) {
-            $fromValue = $this->escapeHtml(reset($value));
-            $toValue = $this->escapeHtml(next($value));
+            $fromValue = $this->_escaper->escapeHtml(reset($value));
+            $toValue = $this->_escaper->escapeHtml(next($value));
         }
 
         return '<strong class="admin__control-support-text">' . __('From') . ':</strong>&nbsp;'
@@ -125,7 +125,7 @@ class Filter extends \Magento\Backend\Block\Widget\Grid\Extended
             $attribute->getAttributeCode()
         ) . '" class="admin__control-text input-text input-text-export-filter"';
         if ($value) {
-            $html .= ' value="' . $this->escapeHtml($value) . '"';
+            $html .= ' value="' . $this->_escaper->escapeHtml($value) . '"';
         }
         return $html . ' />';
     }
@@ -184,8 +184,8 @@ class Filter extends \Magento\Backend\Block\Widget\Grid\Extended
         $toValue = null;
         $name = $this->getFilterElementName($attribute->getAttributeCode());
         if (is_array($value) && count($value) == 2) {
-            $fromValue = $this->escapeHtml(reset($value));
-            $toValue = $this->escapeHtml(next($value));
+            $fromValue = $this->_escaper->escapeHtml(reset($value));
+            $toValue = $this->_escaper->escapeHtml(next($value));
         }
 
         return '<strong class="admin__control-support-text">' .

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Grid/Column/Renderer/Download.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Grid/Column/Renderer/Download.php
@@ -20,9 +20,9 @@ class Download extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Text
      */
     public function _getValue(\Magento\Framework\DataObject $row)
     {
-        return '<p> ' . $this->escapeHtml($row->getData('imported_file')) .  '</p><a href="'
+        return '<p> ' . $this->_escaper->escapeHtml($row->getData('imported_file')) .  '</p><a href="'
         . $this->getUrl('*/*/download', ['filename' => $row->getData('imported_file')]) . '">'
-        . $this->escapeHtml(__('Download'))
+        . $this->_escaper->escapeHtml(__('Download'))
         . '</a>';
     }
 }

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Grid/Column/Renderer/Error.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Grid/Column/Renderer/Error.php
@@ -22,9 +22,9 @@ class Error extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\Text
     {
         $result = '';
         if ($row->getData('error_file') != '') {
-            $result = '<p> ' . $this->escapeHtml($row->getData('error_file')) .  '</p><a href="'
+            $result = '<p> ' . $this->_escaper->escapeHtml($row->getData('error_file')) .  '</p><a href="'
                 . $this->getUrl('*/*/download', ['filename' => $row->getData('error_file')]) . '">'
-                . $this->escapeHtml(__('Download'))
+                . $this->_escaper->escapeHtml(__('Download'))
                 . '</a>';
         }
         return $result;

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit/Form.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit/Form.php
@@ -242,7 +242,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
                 'required' => false,
                 'class' => 'input-text',
                 'note' => __(
-                    $this->escapeHtml(
+                    $this->_escaper->escapeHtml(
                         'For Type "Local Server" use relative path to &lt;Magento root directory&gt;/'
                         .$this->imagesDirectoryProvider->getDirectoryRelativePath()
                         .', e.g. <i>product_images</i>, <i>import_images/batch1</i>.<br><br>'

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Import/Frame/Result.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Import/Frame/Result.php
@@ -102,7 +102,7 @@ class Result extends \Magento\Backend\Block\Template
                 $this->addError($row);
             }
         } else {
-            $this->_messages['error'][] = $this->escapeHtml($message);
+            $this->_messages['error'][] = $this->_escaper->escapeHtml($message);
         }
         return $this;
     }
@@ -140,7 +140,7 @@ class Result extends \Magento\Backend\Block\Template
                 $this->addSuccess($row);
             }
         } else {
-            $escapedMessage = $this->escapeHtml($message);
+            $escapedMessage = $this->_escaper->escapeHtml($message);
             $this->_messages['success'][] = $escapedMessage . ($appendImportButton ? $this->getImportButtonHtml() : '');
         }
         return $this;

--- a/app/code/Magento/ImportExport/view/adminhtml/templates/busy.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/busy.phtml
@@ -3,14 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="fieldset">
     <div class="legend">
-        <span><?= $block->escapeHtml(__('Status')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Status')) ?></span>
     </div><br>
     <div class="messages">
         <div class="message message-success success">
-            <div><?= $block->escapeHtml($block->getStatusMessage()) ?></div>
+            <div><?= $escaper->escapeHtml($block->getStatusMessage()) ?></div>
         </div>
     </div>
 </div>

--- a/app/code/Magento/ImportExport/view/adminhtml/templates/export/form/after.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/export/form/after.phtml
@@ -4,20 +4,23 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\ImportExport\Block\Adminhtml\Form\After $block */
+/**
+ * @var \Magento\ImportExport\Block\Adminhtml\Form\After $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <fieldset class="admin__fieldset" id="export_filter_container">
     <legend class="admin__legend">
-        <span><?= $block->escapeHtml(__('Entity Attributes')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Entity Attributes')) ?></span>
     </legend>
     <br />
-    <form id="export_filter_form" action="<?= $block->escapeUrl($block->getUrl('*/*/export')) ?>" method="post">
+    <form id="export_filter_form" action="<?= $escaper->escapeUrl($block->getUrl('*/*/export')) ?>" method="post">
         <input name="form_key" type="hidden" value="<?= /* @noEscape */ $block->getFormKey() ?>" />
         <div id="export_filter_grid_container"><!-- --></div>
     </form>
     <button class="action- scalable" type="button">
-        <span><?= $block->escapeHtml(__('Continue')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Continue')) ?></span>
     </button>
 </fieldset>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag("display:none;", 'fieldset#export_filter_container') ?>

--- a/app/code/Magento/ImportExport/view/adminhtml/templates/export/form/before.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/export/form/before.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Backend\Block\Template $block */
+/**
+ * @var \Magento\Backend\Block\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 
@@ -48,7 +51,7 @@ require([
          */
         getFilter: function() {
             if ($('entity') && \$F('entity')) {
-                var url    = "{$block->escapeJs($block->getUrl('*/*/getFilter'))}";
+                var url    = "{$escaper->escapeJs($block->getUrl('*/*/getFilter'))}";
                 var entity = \$F('entity');
                 if (entity != this.previousGridEntity) {
                     this.previousGridEntity = entity;
@@ -93,7 +96,7 @@ require([
             form.action   = oldAction;
         } else {
             alert({
-                content: '{$block->escapeHtml(__('Invalid data'))}'
+                content: '{$escaper->escapeHtml(__('Invalid data'))}'
             });
         }
     };

--- a/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/after.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/after.phtml
@@ -4,14 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\ImportExport\Block\Adminhtml\Form\After $block */
+/**
+ * @var \Magento\ImportExport\Block\Adminhtml\Form\After $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 
 <div class="entry-edit fieldset" id="import_validation_container">
     <div class="entry-edit-head legend">
         <span class="icon-head head-edit-form fieldset-legend"
-            id="import_validation_container_header"><?= $block->escapeHtml(__('Validation Results')) ?></span>
+            id="import_validation_container_header"><?= $escaper->escapeHtml(__('Validation Results')) ?></span>
     </div><br>
     <div id="import_validation_messages" class="fieldset"><!-- --></div>
 </div>

--- a/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/before.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/before.phtml
@@ -5,10 +5,13 @@
  */
 ?>
 <?php
-/** @var $block \Magento\ImportExport\Block\Adminhtml\Import\Edit\Before */
+/**
+ * @var $block \Magento\ImportExport\Block\Adminhtml\Import\Edit\Before
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 $fieldNameSourceFile = \Magento\ImportExport\Model\Import::FIELD_NAME_SOURCE_FILE;
-$uploaderErrorMessage = $block->escapeHtml(
+$uploaderErrorMessage = $escaper->escapeHtml(
     __('Content of uploaded file was changed, please re-upload the file')
 );
 ?>
@@ -51,7 +54,7 @@ require([
          * Base url
          * @type {string}
          */
-        sampleFilesBaseUrl: '{$block->escapeJs($block->getUrl('*/*/download/', ['filename' => 'entity-name']))}',
+        sampleFilesBaseUrl: '{$escaper->escapeJs($block->getUrl('*/*/download/', ['filename' => 'entity-name']))}',
 
         /**
         * Loaded file last modified
@@ -258,7 +261,7 @@ require([
         postToFrameProcessResponse: function(response) {
             if ('object' != typeof(response)) {
                 alert({
-                    content: '{$block->escapeHtml(__('Invalid response'))}'
+                    content: '{$escaper->escapeHtml(__('Invalid response'))}'
                 });
 
                 return false;


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
