### PR TITLE
Magento_Framework: avoid using deprecated escape* methods from Abstra…

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/test_template.phtml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/test_template.phtml
@@ -13,6 +13,7 @@
  *
  * @var \Magento\Framework\View\Element\BlockInterface $block
  * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <p>This template has access to <?= $escaper->escapeHtml('<b>$escaper</b>') ?> and $block &quot;<?= $block->toHtml() ?>&quot;</p>

--- a/dev/tests/integration/testsuite/Magento/Framework/View/_files/test_template.phtml
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/_files/test_template.phtml
@@ -13,7 +13,6 @@
  *
  * @var \Magento\Framework\View\Element\BlockInterface $block
  * @var \Magento\Framework\Escaper $escaper
- * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <p>This template has access to <?= $escaper->escapeHtml('<b>$escaper</b>') ?> and $block &quot;<?= $block->toHtml() ?>&quot;</p>

--- a/lib/internal/Magento/Framework/View/Element/AbstractBlock.php
+++ b/lib/internal/Magento/Framework/View/Element/AbstractBlock.php
@@ -730,7 +730,7 @@ abstract class AbstractBlock extends \Magento\Framework\DataObject implements Bl
      */
     public function getUiId($arg1 = null, $arg2 = null, $arg3 = null, $arg4 = null, $arg5 = null)
     {
-        return ' data-ui-id="' . $this->escapeHtmlAttr($this->getJsId($arg1, $arg2, $arg3, $arg4, $arg5)) . '" ';
+        return ' data-ui-id="' . $this->_escaper->escapeHtmlAttr($this->getJsId($arg1, $arg2, $arg3, $arg4, $arg5)) . '" ';
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Element/Html/Date.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Date.php
@@ -19,7 +19,7 @@ class Date extends \Magento\Framework\View\Element\Template
     protected function _toHtml()
     {
         $html = '<input type="text" name="' . $this->getName() . '" id="' . $this->getId() . '" ';
-        $html .= 'value="' . $this->escapeHtml($this->getValue()) . '" ';
+        $html .= 'value="' . $this->_escaper->escapeHtml($this->getValue()) . '" ';
         $html .= 'class="' . $this->getClass() . '" ' . $this->getExtraParams() . '/> ';
         $calendarYearsRange = $this->getYearsRange();
         $changeMonth = $this->getChangeMonth();
@@ -78,7 +78,7 @@ class Date extends \Magento\Framework\View\Element\Template
         if ($this->getFormat() && $this->getValue()) {
             return strftime($this->getFormat(), strtotime($this->getValue()));
         }
-        return $this->escapeHtml($this->getValue());
+        return $this->_escaper->escapeHtml($this->getValue());
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Element/Html/Link.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Link.php
@@ -99,7 +99,7 @@ class Link extends \Magento\Framework\View\Element\Template
             }
             $value = $this->getDataUsingMethod($attribute);
             if ($value !== null) {
-                $attributes[$attribute] = $this->escapeHtml($value);
+                $attributes[$attribute] = $this->_escaper->escapeHtml($value);
             }
         }
 
@@ -144,7 +144,7 @@ class Link extends \Magento\Framework\View\Element\Template
             $this->setDataUsingMethod('id', 'id' .$this->random->getRandomString(8));
         }
 
-        return '<li><a ' . $this->getLinkAttributes() . ' >' . $this->escapeHtml($this->getLabel()) . '</a></li>'
+        return '<li><a ' . $this->getLinkAttributes() . ' >' . $this->_escaper->escapeHtml($this->getLabel()) . '</a></li>'
             .$this->renderSpecialAttributes();
     }
 

--- a/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Link/Current.php
@@ -140,13 +140,13 @@ class Current extends Template
         if ($this->isCurrent()) {
             $html = '<li class="nav item current">';
             $html .= '<strong>'
-                . $this->escapeHtml(__($this->getLabel()))
+                . $this->_escaper->escapeHtml(__($this->getLabel()))
                 . '</strong>';
             $html .= '</li>';
         } else {
-            $html = '<li class="nav item' . $highlight . '"><a href="' . $this->escapeHtml($this->getHref()) . '"';
+            $html = '<li class="nav item' . $highlight . '"><a href="' . $this->_escaper->escapeHtml($this->getHref()) . '"';
             $html .= $this->getTitle()
-                ? ' title="' . $this->escapeHtml(__($this->getTitle())) . '"'
+                ? ' title="' . $this->_escaper->escapeHtml(__($this->getTitle())) . '"'
                 : '';
             $html .= $this->getAttributesHtml() . '>';
 
@@ -154,7 +154,7 @@ class Current extends Template
                 $html .= '<strong>';
             }
 
-            $html .= $this->escapeHtml(__($this->getLabel()));
+            $html .= $this->_escaper->escapeHtml(__($this->getLabel()));
 
             if ($this->getIsHighlighted()) {
                 $html .= '</strong>';
@@ -177,7 +177,7 @@ class Current extends Template
         $attributes = $this->getAttributes();
         if ($attributes) {
             foreach ($attributes as $attribute => $value) {
-                $attributesHtml .= ' ' . $attribute . '="' . $this->escapeHtml($value) . '"';
+                $attributesHtml .= ' ' . $attribute . '="' . $this->_escaper->escapeHtml($value) . '"';
             }
         }
 

--- a/lib/internal/Magento/Framework/View/Element/Html/Links.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Links.php
@@ -76,7 +76,7 @@ class Links extends \Magento\Framework\View\Element\Template
 
         $html = '';
         if ($this->getLinks()) {
-            $html = '<ul' . ($this->hasCssClass() ? ' class="' . $this->escapeHtml(
+            $html = '<ul' . ($this->hasCssClass() ? ' class="' . $this->_escaper->escapeHtml(
                 $this->getCssClass()
             ) . '"' : '') . '>';
             foreach ($this->getLinks() as $link) {

--- a/lib/internal/Magento/Framework/View/Element/Html/Select.php
+++ b/lib/internal/Magento/Framework/View/Element/Html/Select.php
@@ -140,7 +140,7 @@ class Select extends \Magento\Framework\View\Element\AbstractBlock
             '" class="' .
             $this->getClass() .
             '" title="' .
-            $this->escapeHtml($this->getTitle()) .
+            $this->_escaper->escapeHtml($this->getTitle()) .
             '" ' .
             $this->getExtraParams() .
             '>';
@@ -166,8 +166,8 @@ class Select extends \Magento\Framework\View\Element\AbstractBlock
             }
 
             if (is_array($value)) {
-                $html .= '<optgroup label="' . $this->escapeHtml($label)
-                    . '" data-optgroup-name="' . $this->escapeHtml($optgroupName) . '">';
+                $html .= '<optgroup label="' . $this->_escaper->escapeHtml($label)
+                    . '" data-optgroup-name="' . $this->_escaper->escapeHtml($optgroupName) . '">';
                 foreach ($value as $keyGroup => $optionGroup) {
                     if (!is_array($optionGroup)) {
                         $optionGroup = ['value' => $keyGroup, 'label' => $optionGroup];
@@ -205,20 +205,20 @@ class Select extends \Magento\Framework\View\Element\AbstractBlock
             foreach ($option['params'] as $key => $value) {
                 if (is_array($value)) {
                     foreach ($value as $keyMulti => $valueMulti) {
-                        $params .= sprintf(' %s="%s" ', $keyMulti, $this->escapeHtml($valueMulti));
+                        $params .= sprintf(' %s="%s" ', $keyMulti, $this->_escaper->escapeHtml($valueMulti));
                     }
                 } else {
-                    $params .= sprintf(' %s="%s" ', $key, $this->escapeHtml($value));
+                    $params .= sprintf(' %s="%s" ', $key, $this->_escaper->escapeHtml($value));
                 }
             }
         }
 
         return sprintf(
             '<option value="%s"%s %s>%s</option>',
-            $this->escapeHtml($option['value']),
+            $this->_escaper->escapeHtml($option['value']),
             $selectedHtml,
             $params,
-            $this->escapeHtml($option['label'])
+            $this->_escaper->escapeHtml($option['label'])
         );
     }
 


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
