### PR TITLE
Magento_Widget: avoid using deprecated escape* methods from AbstractB…

### DIFF
--- a/app/code/Magento/Widget/Block/Adminhtml/Widget.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget.php
@@ -47,7 +47,7 @@ require(['mage/adminhtml/wysiwyg/widget'], function() {
         'select_widget_type',
         'widget_options',
         '{$this->getUrl('adminhtml/*/loadOptions')}',
-        '{$this->escapeJs($this->getRequest()->getParam('widget_target_id'))}'
+        '{$this->_escaper->escapeJs($this->getRequest()->getParam('widget_target_id'))}'
     );
 });
 EOJS;

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Chooser.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Chooser.php
@@ -194,7 +194,7 @@ class Chooser extends \Magento\Backend\Block\Template
             <label class="widget-option-label" id="' .
             $chooserId .
             'label">' .
-            ($this->getLabel() ? $this->escapeHtml($this->getLabel()) : __(
+            ($this->getLabel() ? $this->_escaper->escapeHtml($this->getLabel()) : __(
                 'Not Selected'
             )) .
             '</label>

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit.php
@@ -97,7 +97,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
     public function getHeaderText()
     {
         if ($this->getWidgetInstance()->getId()) {
-            return __('Widget "%1"', $this->escapeHtml($this->getWidgetInstance()->getTitle()));
+            return __('Widget "%1"', $this->_escaper->escapeHtml($this->getWidgetInstance()->getTitle()));
         } else {
             return __('New Widget Instance');
         }

--- a/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
+++ b/app/code/Magento/Widget/Block/Adminhtml/Widget/Instance/Edit/Tab/Main/Layout.php
@@ -164,31 +164,31 @@ class Layout extends Template implements RendererInterface
     protected function _getDisplayOnOptions()
     {
         $options = [];
-        $options[] = ['value' => '', 'label' => $this->escapeHtmlAttr(__('-- Please Select --'))];
+        $options[] = ['value' => '', 'label' => $this->_escaper->escapeHtmlAttr(__('-- Please Select --'))];
         $options[] = [
             'label' => __('Categories'),
             'value' => [
-                ['value' => 'anchor_categories', 'label' => $this->escapeHtmlAttr(__('Anchor Categories'))],
-                ['value' => 'notanchor_categories', 'label' => $this->escapeHtmlAttr(__('Non-Anchor Categories'))],
+                ['value' => 'anchor_categories', 'label' => $this->_escaper->escapeHtmlAttr(__('Anchor Categories'))],
+                ['value' => 'notanchor_categories', 'label' => $this->_escaper->escapeHtmlAttr(__('Non-Anchor Categories'))],
             ],
         ];
         foreach ($this->_productType->getTypes() as $typeId => $type) {
             $productsOptions[] = [
                 'value' => $typeId . '_products',
-                'label' => $this->escapeHtmlAttr($type['label']),
+                'label' => $this->_escaper->escapeHtmlAttr($type['label']),
             ];
         }
         array_unshift(
             $productsOptions,
-            ['value' => 'all_products', 'label' => $this->escapeHtmlAttr(__('All Product Types'))]
+            ['value' => 'all_products', 'label' => $this->_escaper->escapeHtmlAttr(__('All Product Types'))]
         );
-        $options[] = ['label' => $this->escapeHtmlAttr(__('Products')), 'value' => $productsOptions];
+        $options[] = ['label' => $this->_escaper->escapeHtmlAttr(__('Products')), 'value' => $productsOptions];
         $options[] = [
-            'label' => $this->escapeHtmlAttr(__('Generic Pages')),
+            'label' => $this->_escaper->escapeHtmlAttr(__('Generic Pages')),
             'value' => [
-                ['value' => 'all_pages', 'label' => $this->escapeHtmlAttr(__('All Pages'))],
-                ['value' => 'pages', 'label' => $this->escapeHtmlAttr(__('Specified Page'))],
-                ['value' => 'page_layouts', 'label' => $this->escapeHtmlAttr(__('Page Layouts'))],
+                ['value' => 'all_pages', 'label' => $this->_escaper->escapeHtmlAttr(__('All Pages'))],
+                ['value' => 'pages', 'label' => $this->_escaper->escapeHtmlAttr(__('Specified Page'))],
+                ['value' => 'page_layouts', 'label' => $this->_escaper->escapeHtmlAttr(__('Page Layouts'))],
             ],
         ];
         return $options;

--- a/app/code/Magento/Widget/view/adminhtml/templates/catalog/category/widget/tree.phtml
+++ b/app/code/Magento/Widget/view/adminhtml/templates/catalog/category/widget/tree.phtml
@@ -4,12 +4,15 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Catalog\Block\Adminhtml\Category\Widget\Chooser $block */
+/**
+ * @var \Magento\Catalog\Block\Adminhtml\Category\Widget\Chooser $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $_divId = 'tree' . $block->getId() ?>
-<div id="<?= $block->escapeHtmlAttr($_divId) ?>" class="tree"></div>
+<div id="<?= $escaper->escapeHtmlAttr($_divId) ?>" class="tree"></div>
 <script id="ie-deferred-loader" defer="defer" src="//:"></script>
 <?php
 $useMassaction = /* @noEscape */ $block->getUseMassaction() ? 1 : 0;
@@ -25,7 +28,7 @@ $scriptString = <<<script
 
 require(['jquery', "prototype", "extjs/ext-tree-checkbox"], function(jQuery){
 
-var tree{$block->escapeJs($block->getId())};
+var tree{$escaper->escapeJs($block->getId())};
 
 var useMassaction = {$useMassaction};
 
@@ -78,7 +81,7 @@ jQuery(function()
     var emptyNodeAdded = {$withEmpltyNode};
 
     var categoryLoader = new Ext.tree.TreeLoader({
-        dataUrl: '{$block->escapeJs($block->getLoadTreeUrl())}'
+        dataUrl: '{$escaper->escapeJs($block->getLoadTreeUrl())}'
     });
 
     categoryLoader.buildCategoryTree = function(parent, config)
@@ -97,7 +100,7 @@ jQuery(function()
                 // Add empty node to reset category filter
                 if(!emptyNodeAdded) {
                     var empty = Object.clone(_node);
-                    empty.text = '{$block->escapeJs($block->escapeHtml(__('None')))}';
+                    empty.text = '{$escaper->escapeJs($escaper->escapeHtml(__('None')))}';
                     empty.children = [];
                     empty.id = 'none';
                     empty.path = '1/none';
@@ -168,11 +171,11 @@ jQuery(function()
     };
 
     categoryLoader.on("beforeload", function(treeLoader, node) {
-        $('{$block->escapeJs($_divId)}').fire('category:beforeLoad', {treeLoader:treeLoader});
+        $('{$escaper->escapeJs($_divId)}').fire('category:beforeLoad', {treeLoader:treeLoader});
         treeLoader.baseParams.id = node.attributes.id;
     });
 
-    tree{$block->escapeJs($block->getId())} = new Ext.tree.TreePanel.Enhanced('{$block->escapeJs($_divId)}', {
+    tree{$escaper->escapeJs($block->getId())} = new Ext.tree.TreePanel.Enhanced('{$escaper->escapeJs($_divId)}', {
         animate:          false,
         loader:           categoryLoader,
         enableDD:         false,
@@ -184,9 +187,9 @@ jQuery(function()
     });
 
     if (useMassaction) {
-        tree{$block->escapeJs($block->getId())}.on('check', function(node) {
-            $('{$block->escapeJs($_divId)}').fire('node:changed', {node:node});
-        }, tree{$block->escapeJs($block->getId())});
+        tree{$escaper->escapeJs($block->getId())}.on('check', function(node) {
+            $('{$escaper->escapeJs($_divId)}').fire('node:changed', {node:node});
+        }, tree{$escaper->escapeJs($block->getId())});
     }
 
     // set the root node
@@ -198,7 +201,7 @@ jQuery(function()
         category_id: {$categoryId}
     };
 
-    tree{$block->escapeJs($block->getId())}.loadTree({parameters:parameters, data:{$treeJson}},true);
+    tree{$escaper->escapeJs($block->getId())}.loadTree({parameters:parameters, data:{$treeJson}},true);
 
 });
 


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
