### PR TITLE
Magento_Ui: avoid using deprecated escape* methods from AbstractBlock

### DIFF
--- a/app/code/Magento/Ui/Block/Wysiwyg/ActiveEditor.php
+++ b/app/code/Magento/Ui/Block/Wysiwyg/ActiveEditor.php
@@ -59,6 +59,6 @@ class ActiveEditor extends \Magento\Framework\View\Element\Template
         if ($adapterPath !== self::DEFAULT_EDITOR_PATH && !isset($this->availableAdapterPaths[$adapterPath])) {
             $adapterPath = self::DEFAULT_EDITOR_PATH;
         }
-        return $this->escapeHtml($adapterPath);
+        return $this->_escaper->escapeHtml($adapterPath);
     }
 }

--- a/app/code/Magento/Ui/Component/Control/Button.php
+++ b/app/code/Magento/Ui/Component/Control/Button.php
@@ -178,7 +178,7 @@ class Button extends Template implements ControlInterface
             if ($attributeValue === null || $attributeValue == '') {
                 continue;
             }
-            $html .= $attributeKey . '="' . $this->escapeHtmlAttr($attributeValue, false) . '" ';
+            $html .= $attributeKey . '="' . $this->_escaper->escapeHtmlAttr($attributeValue, false) . '" ';
         }
 
         return $html;

--- a/app/code/Magento/Ui/view/base/templates/control/button/default.phtml
+++ b/app/code/Magento/Ui/view/base/templates/control/button/default.phtml
@@ -6,10 +6,11 @@
 
 /**
  * @var $block \Magento\Ui\Component\Control\Button
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <?= $block->getBeforeHtml() ?>
 <button <?= /* @noEscape */ $block->getAttributesHtml(), /* @noEscape */ $block->getUiId() ?>>
-    <span><?= $block->escapeHtml($block->getLabel()) ?></span>
+    <span><?= $escaper->escapeHtml($block->getLabel()) ?></span>
 </button>
 <?= $block->getAfterHtml() ?>

--- a/app/code/Magento/Ui/view/base/templates/control/button/split.phtml
+++ b/app/code/Magento/Ui/view/base/templates/control/button/split.phtml
@@ -4,16 +4,19 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Ui\Component\Control\SplitButton */
+/**
+ * @var $block \Magento\Ui\Component\Control\SplitButton
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 
 <div <?= $block->getAttributesHtml() ?>>
     <button <?= $block->getButtonAttributesHtml() ?>>
-        <span><?= $block->escapeHtml($block->getLabel()) ?></span>
+        <span><?= $escaper->escapeHtml($block->getLabel()) ?></span>
     </button>
     <?php if ($block->hasSplit()): ?>
         <button <?= $block->getToggleAttributesHtml() ?>>
-            <span><?= $block->escapeHtml(__('Select')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Select')) ?></span>
         </button>
 
         <?php if (!$block->getDisabled()): ?>
@@ -21,12 +24,12 @@
                 <?php foreach ($block->getOptions() as $key => $option): ?>
                 <li>
                     <span <?= $block->getOptionAttributesHtml($key, $option) ?>>
-                        <?= $block->escapeHtml($option['label']) ?>
+                        <?= $escaper->escapeHtml($option['label']) ?>
                     </span>
                     <?php if (isset($option['hint'])): ?>
                     <div class="tooltip" <?= /* @noEscape */ $block->getUiId('item', $key, 'tooltip') ?>>
-                        <a href="<?= $block->escapeUrl($option['hint']['href']) ?>" class="help">
-                            <?= $block->escapeHtml($option['hint']['label']) ?>
+                        <a href="<?= $escaper->escapeUrl($option['hint']['href']) ?>" class="help">
+                            <?= $escaper->escapeHtml($option['hint']['label']) ?>
                         </a>
                     </div>
                     <?php endif; ?>

--- a/app/code/Magento/Ui/view/base/templates/form/default.phtml
+++ b/app/code/Magento/Ui/view/base/templates/form/default.phtml
@@ -6,15 +6,16 @@
 
 /**
  * @var \Magento\Ui\Component\Form $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <?=/* @noEscape */ $block->renderChildComponent('before_form') ?>
 <div data-role="spinner"
-     data-component="<?= $block->escapeHtmlAttr($block->getName()) ?>.areas"
+     data-component="<?= $escaper->escapeHtmlAttr($block->getName()) ?>.areas"
      class="admin__data-grid-loading-mask">
     <div class="grid-loader"></div>
 </div>
-<div data-bind="scope: '<?= $block->escapeHtmlAttr($block->getName()) ?>.areas'"
+<div data-bind="scope: '<?= $escaper->escapeHtmlAttr($block->getName()) ?>.areas'"
      class="entry-edit form-inline">
     <!-- ko template: getTemplate() --><!-- /ko -->
 </div>

--- a/app/code/Magento/Ui/view/base/templates/label/default.phtml
+++ b/app/code/Magento/Ui/view/base/templates/label/default.phtml
@@ -3,7 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <span>
-    <?= $block->escapeHtml($block->getData('label')) ?>
+    <?= $escaper->escapeHtml($block->getData('label')) ?>
 </span>

--- a/app/code/Magento/Ui/view/base/templates/layout/tabs/default.phtml
+++ b/app/code/Magento/Ui/view/base/templates/layout/tabs/default.phtml
@@ -6,8 +6,9 @@
 
 /**
  * @var \Magento\Ui\Component\Layout\Tabs $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
-<div data-bind="scope: '<?= $block->escapeHtmlAttr($block->getDataScope()) ?>.sections' " class="ui-tabs">
+<div data-bind="scope: '<?= $escaper->escapeHtmlAttr($block->getDataScope()) ?>.sections' " class="ui-tabs">
     <!-- ko template: getTemplate() --><!-- /ko -->
 </div>

--- a/app/code/Magento/Ui/view/base/templates/layout/tabs/nav/default.phtml
+++ b/app/code/Magento/Ui/view/base/templates/layout/tabs/nav/default.phtml
@@ -6,8 +6,9 @@
 
 /**
  * @var \Magento\Ui\Component\Layout\Tabs\Nav $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
-<div data-bind="scope: '<?= $block->escapeHtmlAttr($block->getDataScope()) ?>.sections' " class="ui-tabs">
+<div data-bind="scope: '<?= $escaper->escapeHtmlAttr($block->getDataScope()) ?>.sections' " class="ui-tabs">
     <!-- ko template: getTemplate() --><!-- /ko -->
 </div>

--- a/app/code/Magento/Ui/view/base/templates/logger.phtml
+++ b/app/code/Magento/Ui/view/base/templates/logger.phtml
@@ -4,14 +4,17 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Ui\Block\Logger */
+/**
+ * @var $block \Magento\Ui\Block\Logger
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($block->isLoggingEnabled()): ?>
     <?php $scriptString = <<<script
 
         window.onerror = function(msg, url, line) {
-            var key = "{$block->escapeJs($block->getSessionStorageKey())}";
+            var key = "{$escaper->escapeJs($block->getSessionStorageKey())}";
             var errors = {};
             if (sessionStorage.getItem(key)) {
                 errors = JSON.parse(sessionStorage.getItem(key));

--- a/app/code/Magento/Ui/view/base/templates/stepswizard.phtml
+++ b/app/code/Magento/Ui/view/base/templates/stepswizard.phtml
@@ -5,21 +5,24 @@
  */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
-/** @var $block \Magento\Ui\Block\Component\StepsWizard */
+/**
+ * @var $block \Magento\Ui\Block\Component\StepsWizard
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div data-role="steps-wizard-main"
      class="steps-wizard <?= /* @noEscape */ $block->getData('config/dataScope') ?>"
-     data-bind="scope: '<?= $block->escapeHtmlAttr($block->getComponentName()) ?>'">
+     data-bind="scope: '<?= $escaper->escapeHtmlAttr($block->getComponentName()) ?>'">
     <div data-role="messages" class="messages"></div>
 
     <div data-role="steps-wizard-controls" class="steps-wizard-navigation">
         <ul class="nav-bar">
             <?php foreach ($block->getSteps() as $step) : ?>
                 <li data-role="collapsible"
-                    data-bind="css: { 'active': selectedStep() == '<?= $block->escapeHtmlAttr($step->getComponentName()) ?>'}">
-                    <a href="#<?= $block->escapeHtmlAttr($step->getComponentName()) ?>"
+                    data-bind="css: { 'active': selectedStep() == '<?= $escaper->escapeHtmlAttr($step->getComponentName()) ?>'}">
+                    <a href="#<?= $escaper->escapeHtmlAttr($step->getComponentName()) ?>"
                        data-bind="click: showSpecificStep">
-                        <?= $block->escapeHtml($step->getCaption()) ?>
+                        <?= $escaper->escapeHtml($step->getCaption()) ?>
                     </a>
                 </li>
             <?php endforeach; ?>
@@ -28,20 +31,20 @@
             <div class="action-wrap" data-role="closeBtn">
                 <button type="button"
                         class="action-cancel action-tertiary" data-bind="click: close">
-                    <span><?= $block->escapeHtml(__('Cancel')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Cancel')) ?></span>
                 </button>
             </div>
             <div class="action-wrap action-wrap-prev" data-role="step-wizard-prev">
                 <button type="button"
                         class="action-default action-back-step"
                         data-bind="click: back, css: { 'disabled': disabled}">
-                    <span><?= $block->escapeHtml(__('Back')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Back')) ?></span>
                 </button>
             </div>
             <div class="action-wrap action-wrap-next" data-role="step-wizard-next">
                 <button type="button"
                         class="action-default action-primary action-next-step" data-bind="click: next">
-                    <span><?= $block->escapeHtml(__('Next')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Next')) ?></span>
                 </button>
             </div>
         </div>
@@ -49,7 +52,7 @@
     <div data-role="steps-wizard-tab">
         <?php foreach ($block->getSteps() as $step) : ?>
             <div data-bind="visible: selectedStep() == $element.id, css: {'no-display':false}"
-                 class="content no-display" id="<?= $block->escapeHtmlAttr($step->getComponentName()) ?>"
+                 class="content no-display" id="<?= $escaper->escapeHtmlAttr($step->getComponentName()) ?>"
                  data-role="content">
                 <?= /* @noEscape */ $step->getContent() ?>
             </div>
@@ -62,7 +65,7 @@
         "*": {
             "Magento_Ui/js/core/app": {
                 "components": {
-                        "<?= $block->escapeJs($block->getComponentName()) ?>": {
+                        "<?= $escaper->escapeJs($block->getComponentName()) ?>": {
                             "component": "Magento_Ui/js/lib/step-wizard",
                             "initData": <?= /* @noEscape */ $this->helper(Magento\Framework\Json\Helper\Data::class)->jsonEncode($block->getInitData()) ?>,
                             "stepsNames": <?= /* @noEscape */ $this->helper(Magento\Framework\Json\Helper\Data::class)->jsonEncode($block->getStepComponents()) ?>,


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
