### PR TITLE
Magento_Tax: avoid using deprecated escape* methods from AbstractBlock

### DIFF
--- a/app/code/Magento/Tax/Block/Checkout/Shipping.php
+++ b/app/code/Magento/Tax/Block/Checkout/Shipping.php
@@ -96,7 +96,7 @@ class Shipping extends \Magento\Checkout\Block\Total\DefaultTotal
     {
         return __(
             'Shipping Incl. Tax (%1)',
-            $this->escapeHtml($this->getQuote()->getShippingAddress()->getShippingDescription())
+            $this->_escaper->escapeHtml($this->getQuote()->getShippingAddress()->getShippingDescription())
         );
     }
 
@@ -109,7 +109,7 @@ class Shipping extends \Magento\Checkout\Block\Total\DefaultTotal
     {
         return __(
             'Shipping Excl. Tax (%1)',
-            $this->escapeHtml($this->getQuote()->getShippingAddress()->getShippingDescription())
+            $this->_escaper->escapeHtml($this->getQuote()->getShippingAddress()->getShippingDescription())
         );
     }
 

--- a/app/code/Magento/Tax/Block/Grid/Renderer/Codes.php
+++ b/app/code/Magento/Tax/Block/Grid/Renderer/Codes.php
@@ -20,6 +20,6 @@ class Codes extends \Magento\Backend\Block\Widget\Grid\Column\Renderer\AbstractR
     {
         $ratesCodes = $row->getTaxRatesCodes();
 
-        return $ratesCodes && is_array($ratesCodes) ? $this->escapeHtml(implode(', ', $ratesCodes)) : '';
+        return $ratesCodes && is_array($ratesCodes) ? $this->_escaper->escapeHtml(implode(', ', $ratesCodes)) : '';
     }
 }

--- a/app/code/Magento/Tax/view/adminhtml/templates/items/price/row.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/items/price/row.phtml
@@ -7,14 +7,17 @@
 // phpcs:disable Magento2.Templates.ThisInTemplate
 ?>
 <?php
-/** @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block */
+/**
+ * @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $_item = $block->getItem();
 ?>
 <?php if ($block->displayBothPrices() || $block->displayPriceExclTax()) : ?>
     <div class="price-excl-tax">
         <?php if ($block->displayBothPrices()) : ?>
-            <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+            <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
         <?php endif; ?>
         <?= /* @noEscape */ $block->displayPrices($_item->getBaseRowTotal(), $_item->getRowTotal()) ?>
     </div>
@@ -22,7 +25,7 @@ $_item = $block->getItem();
 <?php if ($block->displayBothPrices() || $block->displayPriceInclTax()) : ?>
     <div class="price-incl-tax">
         <?php if ($block->displayBothPrices()) : ?>
-            <span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+            <span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
         <?php endif; ?>
         <?php $_incl = $this->helper(\Magento\Checkout\Helper\Data::class)->getSubtotalInclTax($_item); ?>
         <?php $_baseIncl = $this->helper(\Magento\Checkout\Helper\Data::class)->getBaseSubtotalInclTax($_item); ?>

--- a/app/code/Magento/Tax/view/adminhtml/templates/items/price/unit.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/items/price/unit.phtml
@@ -7,7 +7,10 @@
 // phpcs:disable Magento2.Templates.ThisInTemplate
 ?>
 <?php
-/** @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block */
+/**
+ * @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $_item = $block->getItem();
 ?>
@@ -15,7 +18,7 @@ $_item = $block->getItem();
 <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displaySalesBothPrices() || $this->helper(\Magento\Tax\Helper\Data::class)->displaySalesPriceExclTax()) : ?>
     <div class="price-excl-tax">
         <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displaySalesBothPrices()) : ?>
-            <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+            <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
         <?php endif; ?>
 
         <?= /* @noEscape */ $block->displayPrices($_item->getBasePrice(), $_item->getPrice()) ?>
@@ -24,7 +27,7 @@ $_item = $block->getItem();
 <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displaySalesBothPrices() || $this->helper(\Magento\Tax\Helper\Data::class)->displaySalesPriceInclTax()) : ?>
     <div class="price-incl-tax">
         <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displaySalesBothPrices()) : ?>
-            <span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+            <span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
         <?php endif; ?>
         <?php $_incl = $this->helper(\Magento\Checkout\Helper\Data::class)->getPriceInclTax($_item); ?>
         <?php $_baseIncl = $this->helper(\Magento\Checkout\Helper\Data::class)->getBasePriceInclTax($_item); ?>

--- a/app/code/Magento/Tax/view/adminhtml/templates/order/create/items/price/row.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/order/create/items/price/row.phtml
@@ -7,21 +7,24 @@
 // phpcs:disable Magento2.Templates.ThisInTemplate
 ?>
 <?php
-/** @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block */
+/**
+ * @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $_item = $block->getItem();
 ?>
 
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices($block->getStore())) : ?>
-        <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+        <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */ $block->formatPrice($_item->getRowTotal()) ?>
 <?php endif; ?>
 
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <br /><span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+        <br /><span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
     <?php endif; ?>
     <?php $_incl = $this->helper(\Magento\Checkout\Helper\Data::class)->getSubtotalInclTax($_item); ?>
     <?= /* @noEscape */ $block->formatPrice($_incl) ?>

--- a/app/code/Magento/Tax/view/adminhtml/templates/order/create/items/price/total.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/order/create/items/price/total.phtml
@@ -5,7 +5,10 @@
  */
 ?>
 <?php
-/** @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block */
+/**
+ * @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $_item = $block->getItem();
 ?>
@@ -13,7 +16,7 @@ $_item = $block->getItem();
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
     <?php $_rowTotalWithoutDiscount = $_item->getRowTotal() - $_item->getTotalDiscountAmount(); ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+        <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */ $block->formatPrice(max(0, $_rowTotalWithoutDiscount)) ?>
 <?php endif; ?>
@@ -21,7 +24,7 @@ $_item = $block->getItem();
 
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices($block->getStore())) : ?>
-        <br /><span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+        <br /><span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
     <?php endif; ?>
     <?php $_incl = $block->getTotalAmount($_item); ?>
     <?= /* @noEscape */ $block->formatPrice($_incl) ?>

--- a/app/code/Magento/Tax/view/adminhtml/templates/order/create/items/price/unit.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/order/create/items/price/unit.phtml
@@ -7,14 +7,17 @@
 // phpcs:disable Magento2.Templates.ThisInTemplate
 ?>
 <?php
-/** @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block */
+/**
+ * @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $_item = $block->getItem();
 ?>
 
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+        <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */ $block->formatPrice($_item->getCalculationPrice()) ?>
 <?php endif; ?>
@@ -22,7 +25,7 @@ $_item = $block->getItem();
 
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <br /><span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+        <br /><span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
     <?php endif; ?>
     <?php $_incl = $this->helper(\Magento\Checkout\Helper\Data::class)->getPriceInclTax($_item); ?>
     <?= /* @noEscape */ $block->formatPrice($_incl) ?>

--- a/app/code/Magento/Tax/view/adminhtml/templates/rate/title.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/rate/title.phtml
@@ -3,20 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <fieldset id="tax-rate-titles-table" class="admin__fieldset">
     <?php $_labels = $block->getTitles() ?>
     <?php foreach ($block->getStores() as $_store) : ?>
         <div class="admin__field">
             <label class="admin__field-label">
-                <span><?= $block->escapeHtml($_store->getName()) ?></span>
+                <span><?= $escaper->escapeHtml($_store->getName()) ?></span>
             </label>
             <div class="admin__field-control">
                 <input
                     class="admin__control-text<?php if ($_store->getId() == 0) : ?> required-entry<?php endif; ?>"
                     type="text"
                     name="title[<?= (int) $_store->getId() ?>]"
-                    value="<?= $block->escapeHtmlAttr($_labels[(int) $_store->getId()]) ?>" />
+                    value="<?= $escaper->escapeHtmlAttr($_labels[(int) $_store->getId()]) ?>" />
             </div>
         </div>
     <?php endforeach; ?>
@@ -24,8 +28,8 @@
     <div class="messages">
         <div class="message message-notice">
             <div>
-                <strong><?= $block->escapeHtml(__('Note:')) ?></strong>
-                <?= $block->escapeHtml(__('Leave this field empty if you wish to use the tax identifier.')) ?>
+                <strong><?= $escaper->escapeHtml(__('Note:')) ?></strong>
+                <?= $escaper->escapeHtml(__('Leave this field empty if you wish to use the tax identifier.')) ?>
             </div>
         </div>
     </div>

--- a/app/code/Magento/Tax/view/adminhtml/templates/rule/edit.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/rule/edit.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Tax\Block\Adminhtml\Rule\Edit\Form */
+/**
+ * @var $block \Magento\Tax\Block\Adminhtml\Rule\Edit\Form
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php $formElementId = /* @noEscape */ \Magento\Tax\Block\Adminhtml\Rate\Form::FORM_ELEMENT_ID;
@@ -81,7 +84,7 @@ require([
             $.ajax({
                 type: "POST",
                 data: {id:id},
-                url: '{$block->escapeJs($block->getTaxRateLoadUrl())}',
+                url: '{$escaper->escapeJs($block->getTaxRateLoadUrl())}',
                 success: function(result, status) {
                     $('body').trigger('processStop');
                     if (result.success) {
@@ -98,14 +101,14 @@ require([
                             });
                         else
                             alert({
-                                content: '{$block->escapeJs(__('An error occurred'))}'
+                                content: '{$escaper->escapeJs(__('An error occurred'))}'
                             });
                     }
                 },
                 error: function () {
                     $('body').trigger('processStop');
                     alert({
-                        content: '{$block->escapeJs(__('An error occurred'))}'
+                        content: '{$escaper->escapeJs(__('An error occurred'))}'
                     });
                 },
                 dataType: "json"
@@ -116,9 +119,9 @@ require([
             var options = {
                 mselectContainer: '#tax_rate + section.mselect-list',
                 toggleAddButton:false,
-                addText: '{$block->escapeJs(__('Add New Tax Rate'))}',
+                addText: '{$escaper->escapeJs(__('Add New Tax Rate'))}',
                 parse: null,
-                nextPageUrl: '{$block->escapeJs($block->getTaxRatesPageUrl())}',
+                nextPageUrl: '{$escaper->escapeJs($block->getTaxRatesPageUrl())}',
                 selectedValues: this.settings.selected_values,
                 mselectInputSubmitCallback: function (value, options) {
                     var select = $('#tax_rate');
@@ -175,7 +178,7 @@ script;
                             rateValue = that.parent().find('input[type="checkbox"]').val();
 
                         confirm({
-                            content: '{$block->escapeJs(__('Do you really want to delete this tax rate?'))}',
+                            content: '{$escaper->escapeJs(__('Do you really want to delete this tax rate?'))}',
                             actions: {
                                 /**
                                  * Confirm action.
@@ -189,7 +192,7 @@ script;
                                             form_key: $('input[name="form_key"]').val()
                                         },
                                         dataType: 'json',
-                                        url: '{$block->escapeJs($block->getTaxRateDeleteUrl())}',
+                                        url: '{$escaper->escapeJs($block->getTaxRateDeleteUrl())}',
                                         success: function(result, status) {
                                             $('body').trigger('processStop');
                                             if (result.success) {
@@ -207,14 +210,14 @@ script;
                                                     });
                                                 else
                                                     alert({
-                                                        content: '{$block->escapeJs(__('An error occurred'))}'
+                                                        content: '{$escaper->escapeJs(__('An error occurred'))}'
                                                     });
                                             }
                                         },
                                         error: function () {
                                             $('body').trigger('processStop');
                                             alert({
-                                                content: '{$block->escapeJs(__('An error occurred'))}'
+                                                content: '{$escaper->escapeJs(__('An error occurred'))}'
                                             });
                                         }
                                     };
@@ -237,7 +240,7 @@ script;
             taxRateFormElement.mage('form').mage('validation');
 
             taxRateForm.dialogRates({
-                title: '{$block->escapeJs(__('Tax Rate'))}',
+                title: '{$escaper->escapeJs(__('Tax Rate'))}',
                 type: 'slide',
                 id: '{$jsId}',
                 modalClass: 'tax-rate-popup',
@@ -245,7 +248,7 @@ script;
                     taxRateFormElement.data('validation').clearError();
                 },
                 buttons: [{
-                    text: '{$block->escapeJs(__('Save'))}',
+                    text: '{$escaper->escapeJs(__('Save'))}',
                     'class': 'action-save action-primary',
                     click: function() {
                         this.updateItemRate();
@@ -270,7 +273,7 @@ $scriptString.= <<<script
                             type: 'POST',
                             data: itemRateData,
                             dataType: 'json',
-                            url: '{$block->escapeJs($block->getTaxRateSaveUrl())}',
+                            url: '{$escaper->escapeJs($block->getTaxRateSaveUrl())}',
                             success: function(result, status) {
                                 $('body').trigger('processStop');
                                 if (result.success) {
@@ -295,14 +298,14 @@ $scriptString.= <<<script
                                         });
                                     else
                                         alert({
-                                            content: '{$block->escapeJs(__('An error occurred'))}'
+                                            content: '{$escaper->escapeJs(__('An error occurred'))}'
                                         });
                                 }
                             },
                             error: function () {
                                 $('body').trigger('processStop');
                                 alert({
-                                    content: '{$block->escapeJs(__('An error occurred'))}'
+                                    content: '{$escaper->escapeJs(__('An error occurred'))}'
                                 });
                             }
                         };

--- a/app/code/Magento/Tax/view/adminhtml/templates/rule/rate/form.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/rule/rate/form.phtml
@@ -3,14 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/* @var $block \Magento\Tax\Block\Adminhtml\Rate\Form */
+/**
+ * @var $block \Magento\Tax\Block\Adminhtml\Rate\Form
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 
 <div data-role="spinner" class="grid-loading-mask">
     <div class="grid-loader"></div>
 </div>
 
-<div class="form-inline no-display" id="<?= $block->escapeHtmlAttr($block->getNameInLayout()) ?>">
+<div class="form-inline no-display" id="<?= $escaper->escapeHtmlAttr($block->getNameInLayout()) ?>">
     <?= $block->getFormHtml() ?>
     <?= $block->getChildHtml('form_after') ?>
 </div>

--- a/app/code/Magento/Tax/view/adminhtml/templates/toolbar/class/add.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/toolbar/class/add.phtml
@@ -4,15 +4,18 @@
  * See COPYING.txt for license details.
  */
 // @deprecated
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions">
     <button type="button" id="addNewClass">
-        <?= $block->escapeHtml(__('Add New Class')) ?>
+        <?= $escaper->escapeHtml(__('Add New Class')) ?>
     </button>
     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
         'onclick',
-        "window.location.href='" . $block->escapeJs($createUrl) . "'",
+        "window.location.href='" . $escaper->escapeJs($createUrl) . "'",
         'button#addNewClass'
     ) ?>
 </div>

--- a/app/code/Magento/Tax/view/adminhtml/templates/toolbar/class/save.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/toolbar/class/save.phtml
@@ -5,7 +5,10 @@
  */
 // @deprecated
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions">
     <?= $block->getBackButtonHtml() ?>
@@ -17,7 +20,7 @@
     <?php $scriptString = <<<script
     require(['jquery', "mage/mage"], function(jQuery){
 
-        jQuery('#{$block->escapeJs($form->getForm()->getId())}').mage('form').mage('validation');
+        jQuery('#{$escaper->escapeJs($form->getForm()->getId())}').mage('form').mage('validation');
 
     });
 script;

--- a/app/code/Magento/Tax/view/adminhtml/templates/toolbar/rate/save.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/toolbar/rate/save.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Tax\Block\Adminhtml\Rate\Form $form */
+/**
+ * @var \Magento\Tax\Block\Adminhtml\Rate\Form $form
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($form): ?>
@@ -15,7 +18,7 @@
         "mage/mage"
     ], function($){
 
-        $('#{$block->escapeJs($form->getForm()->getId())}').mage('form').mage('validation');
+        $('#{$escaper->escapeJs($form->getForm()->getId())}').mage('form').mage('validation');
 
         $(document).ready(function () {
             'use strict';

--- a/app/code/Magento/Tax/view/adminhtml/templates/toolbar/rule/add.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/toolbar/rule/add.phtml
@@ -4,15 +4,18 @@
  * See COPYING.txt for license details.
  */
 // @deprecated
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions">
     <button type="button" id="addNewTaxRule">
-        <?= $block->escapeHtml(__('Add New Tax Rule')) ?>
+        <?= $escaper->escapeHtml(__('Add New Tax Rule')) ?>
     </button>
     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
         'onclick',
-        "window.location.href='" . $block->escapeJs($createUrl) . "'",
+        "window.location.href='" . $escaper->escapeJs($createUrl) . "'",
         'button#addNewClass'
     ) ?>
 </div>

--- a/app/code/Magento/Tax/view/adminhtml/templates/toolbar/rule/save.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/toolbar/rule/save.phtml
@@ -5,7 +5,10 @@
  */
 // @deprecated
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions">
     <?= $block->getBackButtonHtml() ?>
@@ -18,7 +21,7 @@
     <?php $scriptString = <<<script
     require(['jquery', "mage/mage"], function(jQuery){
 
-        jQuery('#{$block->escapeJs($form->getForm()->getId())}').mage('form').mage('validation');
+        jQuery('#{$escaper->escapeJs($form->getForm()->getId())}').mage('form').mage('validation');
 
     });
 script;

--- a/app/code/Magento/Tax/view/base/templates/pricing/adjustment/bundle.phtml
+++ b/app/code/Magento/Tax/view/base/templates/pricing/adjustment/bundle.phtml
@@ -3,6 +3,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 
 <?php /** @var \Magento\Tax\Pricing\Render\Adjustment $block */ ?>
@@ -13,6 +17,6 @@
 <?php elseif ($block->displayBothPrices()) : ?>
     <?= /* @noEscape */ $block->getDisplayAmount() ?>
     <?php if ($block->getDisplayAmountExclTax() !== $block->getDisplayAmount()) : ?>
-        (+<?= /* @noEscape */ $block->getDisplayAmountExclTax() ?> <?= $block->escapeHtml(__('Excl. Tax')) ?>)
+        (+<?= /* @noEscape */ $block->getDisplayAmountExclTax() ?> <?= $escaper->escapeHtml(__('Excl. Tax')) ?>)
     <?php endif; ?>
 <?php endif; ?>

--- a/app/code/Magento/Tax/view/frontend/templates/checkout/cart/item/price/sidebar.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/checkout/cart/item/price/sidebar.phtml
@@ -6,17 +6,20 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Tax\Block\Item\Price\Renderer */
+/**
+ * @var $block \Magento\Tax\Block\Item\Price\Renderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php $_item = $block->getItem() ?>
     <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
-        <span class="price-wrapper price-including-tax" data-label="<?= $block->escapeHtmlAttr(__('Incl. Tax')) ?>">
+        <span class="price-wrapper price-including-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Incl. Tax')) ?>">
             <?php $_incl = $_item->getPriceInclTax(); ?>
             <?= /* @noEscape */ $this->helper(\Magento\Checkout\Helper\Data::class)->formatPrice($_incl) ?>
         </span>
     <?php endif; ?>
     <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
-        <span class="price-wrapper price-excluding-tax" data-label="<?= $block->escapeHtmlAttr(__('Excl. Tax')) ?>">
+        <span class="price-wrapper price-excluding-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Excl. Tax')) ?>">
             <?= /* @noEscape */ $this->helper(\Magento\Checkout\Helper\Data::class)->formatPrice($_item->getCalculationPrice()) ?>
         </span>
     <?php endif; ?>

--- a/app/code/Magento/Tax/view/frontend/templates/checkout/grandtotal.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/checkout/grandtotal.phtml
@@ -6,11 +6,12 @@
 
 /**
  * @var $block \Magento\Tax\Block\Checkout\Grandtotal
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
 <?php
-$style = $block->escapeHtmlAttr($block->getStyle());
+$style = $escaper->escapeHtmlAttr($block->getStyle());
 $colspan = (int) $block->getColspan();
 /** @var \Magento\Checkout\Helper\Data $checkoutHelper */
 $checkoutHelper = $block->getData('checkoutHelper');
@@ -18,9 +19,9 @@ $checkoutHelper = $block->getData('checkoutHelper');
 <?php if ($block->includeTax() && $block->getTotalExclTax() >= 0): ?>
     <tr class="grand totals excl">
         <th class="mark" colspan="<?= /* @noEscape */ $colspan ?>" scope="row">
-            <strong><?= $block->escapeHtml(__('Grand Total Excl. Tax')) ?></strong>
+            <strong><?= $escaper->escapeHtml(__('Grand Total Excl. Tax')) ?></strong>
         </th>
-        <td class="amount" data-th="<?= $block->escapeHtmlAttr(__('Grand Total Excl. Tax')) ?>">
+        <td class="amount" data-th="<?= $escaper->escapeHtmlAttr(__('Grand Total Excl. Tax')) ?>">
             <strong><?= /* @noEscape */ $checkoutHelper->formatPrice($block->getTotalExclTax()) ?></strong>
         </td>
     </tr>
@@ -31,9 +32,9 @@ $checkoutHelper = $block->getData('checkoutHelper');
     <?= /* @noEscape */ $block->renderTotals('taxes', $colspan) ?>
     <tr class="grand totals incl">
         <th class="mark" colspan="<?= /* @noEscape */ $colspan ?>" scope="row">
-            <strong><?= $block->escapeHtml(__('Grand Total Incl. Tax')) ?></strong>
+            <strong><?= $escaper->escapeHtml(__('Grand Total Incl. Tax')) ?></strong>
         </th>
-        <td class="amount" data-th="<?= $block->escapeHtmlAttr(__('Grand Total Incl. Tax')) ?>">
+        <td class="amount" data-th="<?= $escaper->escapeHtmlAttr(__('Grand Total Incl. Tax')) ?>">
             <strong><?= /* @noEscape */ $checkoutHelper->formatPrice($block->getTotal()->getValue()) ?></strong>
         </td>
     </tr>
@@ -44,9 +45,9 @@ $checkoutHelper = $block->getData('checkoutHelper');
 <?php else: ?>
     <tr class="grand totals">
         <th class="mark" colspan="<?= /* @noEscape */ $colspan ?>" scope="row">
-            <strong><?= $block->escapeHtml($block->getTotal()->getTitle()) ?></strong>
+            <strong><?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?></strong>
         </th>
-        <td class="amount" data-th="<?= $block->escapeHtmlAttr($block->getTotal()->getTitle()) ?>">
+        <td class="amount" data-th="<?= $escaper->escapeHtmlAttr($block->getTotal()->getTitle()) ?>">
             <strong><?= /* @noEscape */ $checkoutHelper->formatPrice($block->getTotal()->getValue()) ?></strong>
         </td>
     </tr>

--- a/app/code/Magento/Tax/view/frontend/templates/checkout/shipping.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/checkout/shipping.phtml
@@ -6,13 +6,14 @@
 
 /**
  * @var $block \Magento\Tax\Block\Checkout\Shipping
+ * @var \Magento\Framework\Escaper $escaper
  * @see \Magento\Tax\Block\Checkout\Shipping
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
 <?php if ($block->displayShipping()): ?>
     <?php
-        $style = $block->escapeHtmlAttr($block->getStyle());
+        $style = $escaper->escapeHtmlAttr($block->getStyle());
         $colspan = (int) $block->getColspan();
         /** @var \Magento\Checkout\Helper\Data $checkoutHelper */
         $checkoutHelper = $block->getData('checkoutHelper');
@@ -20,10 +21,10 @@
     <?php if ($block->displayBoth()): ?>
     <tr class="totals shipping excl">
         <th class="mark" colspan="<?= /* @noEscape */ $colspan ?>" scope="row">
-            <?= $block->escapeHtml($block->getExcludeTaxLabel()) ?>
+            <?= $escaper->escapeHtml($block->getExcludeTaxLabel()) ?>
         </th>
 
-        <td class="amount" data-th="<?= $block->escapeHtmlAttr($block->getExcludeTaxLabel()) ?>">
+        <td class="amount" data-th="<?= $escaper->escapeHtmlAttr($block->getExcludeTaxLabel()) ?>">
             <?= /* @noEscape */ $checkoutHelper->formatPrice($block->getShippingExcludeTax()) ?>
         </td>
     </tr>
@@ -33,9 +34,9 @@
         <?php endif; ?>
     <tr class="totals shipping incl">
         <th class="mark" colspan="<?= /* @noEscape */ $colspan ?>" scope="row">
-            <?= $block->escapeHtml($block->getIncludeTaxLabel()) ?>
+            <?= $escaper->escapeHtml($block->getIncludeTaxLabel()) ?>
         </th>
-        <td class="amount" data-th="<?= $block->escapeHtmlAttr($block->getIncludeTaxLabel()) ?>">
+        <td class="amount" data-th="<?= $escaper->escapeHtmlAttr($block->getIncludeTaxLabel()) ?>">
             <?= /* @noEscape */ $checkoutHelper->formatPrice($block->getShippingIncludeTax()) ?>
         </td>
     </tr>
@@ -46,9 +47,9 @@
     <?php elseif ($block->displayIncludeTax()): ?>
     <tr class="totals shipping incl">
         <th class="mark" colspan="<?= /* @noEscape */ $colspan ?>" scope="row">
-            <?= $block->escapeHtml($block->getTotal()->getTitle()) ?>
+            <?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?>
         </th>
-        <td class="amount" data-th="<?= $block->escapeHtmlAttr($block->getTotal()->getTitle()) ?>">
+        <td class="amount" data-th="<?= $escaper->escapeHtmlAttr($block->getTotal()->getTitle()) ?>">
             <?= /* @noEscape */ $checkoutHelper->formatPrice($block->getShippingIncludeTax()) ?>
         </td>
     </tr>
@@ -59,9 +60,9 @@
     <?php else: ?>
     <tr class="totals shipping excl">
         <th class="mark" colspan="<?= /* @noEscape */ $colspan ?>" scope="row">
-            <?= $block->escapeHtml($block->getTotal()->getTitle()) ?>
+            <?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?>
         </th>
-        <td class="amount" data-th="<?= $block->escapeHtmlAttr($block->getTotal()->getTitle()) ?>">
+        <td class="amount" data-th="<?= $escaper->escapeHtmlAttr($block->getTotal()->getTitle()) ?>">
             <?= /* @noEscape */ $checkoutHelper->formatPrice($block->getShippingExcludeTax()) ?>
         </td>
     </tr>

--- a/app/code/Magento/Tax/view/frontend/templates/checkout/shipping/price.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/checkout/shipping/price.phtml
@@ -4,7 +4,12 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Tax\Block\Checkout\Shipping\Price */ ?>
+<?php
+/**
+ * @var $block \Magento\Tax\Block\Checkout\Shipping\Price
+ * @var \Magento\Framework\Escaper $escaper
+ */
+?>
 
 <?php $_excl = $block->getShippingPriceExclTax(); ?>
 <?php $_incl = $block->getShippingPriceInclTax(); ?>
@@ -12,7 +17,7 @@
     <span class="price"><?= /* @noEscape */ $_excl ?></span>
 <?php else : ?>
     <?php if ($block->displayShippingBothPrices() && $_incl != $_excl) : ?>
-        <span class="price-including-tax" data-label="<?= $block->escapeHtmlAttr(__('Incl. Tax')) ?>">
+        <span class="price-including-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Incl. Tax')) ?>">
     <?php endif; ?>
     <span class="price"><?= /* @noEscape */ $_incl ?></span>
     <?php if ($block->displayShippingBothPrices() && $_incl != $_excl) : ?>
@@ -20,5 +25,5 @@
     <?php endif; ?>
 <?php endif; ?>
 <?php if ($block->displayShippingBothPrices() && $_incl != $_excl) : ?>
-    <span class="price-excluding-tax" data-label="<?= $block->escapeHtmlAttr(__('Excl. Tax')) ?>"><span class="price"><?= /* @noEscape */ $_excl ?></span></span>
+    <span class="price-excluding-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Excl. Tax')) ?>"><span class="price"><?= /* @noEscape */ $_excl ?></span></span>
 <?php endif; ?>

--- a/app/code/Magento/Tax/view/frontend/templates/checkout/subtotal.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/checkout/subtotal.phtml
@@ -6,12 +6,13 @@
 
 /**
  * @var $block \Magento\Tax\Block\Checkout\Subtotal
+ * @var \Magento\Framework\Escaper $escaper
  * @see \Magento\Tax\Block\Checkout\Subtotal
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
 <?php
-$style = $block->escapeHtmlAttr($block->getStyle());
+$style = $escaper->escapeHtmlAttr($block->getStyle());
 $colspan = (int) $block->getColspan();
 /** @var \Magento\Checkout\Helper\Data $checkoutHelper */
 $checkoutHelper = $block->getData('checkoutHelper');
@@ -19,9 +20,9 @@ $checkoutHelper = $block->getData('checkoutHelper');
 <?php if ($block->displayBoth()): ?>
 <tr class="totals sub excl">
     <th class="mark" colspan="<?= /* @noEscape */ $colspan ?>" scope="row">
-        <?= $block->escapeHtml(__('Subtotal (Excl. Tax)')) ?>
+        <?= $escaper->escapeHtml(__('Subtotal (Excl. Tax)')) ?>
     </th>
-    <tdclass="amount" data-th="<?= $block->escapeHtmlAttr(__('Subtotal (Excl. Tax)')) ?>">
+    <tdclass="amount" data-th="<?= $escaper->escapeHtmlAttr(__('Subtotal (Excl. Tax)')) ?>">
         <?= /* @noEscape */ $checkoutHelper->formatPrice($block->getTotal()->getValueExclTax()) ?>
     </td>
 </tr>
@@ -31,9 +32,9 @@ $checkoutHelper = $block->getData('checkoutHelper');
     <?php endif; ?>
 <tr class="totals sub incl">
     <th class="mark" colspan="<?= /* @noEscape */ $colspan ?>" scope="row">
-        <?= $block->escapeHtml(__('Subtotal (Incl. Tax)')) ?>
+        <?= $escaper->escapeHtml(__('Subtotal (Incl. Tax)')) ?>
     </th>
-    <td class="amount" data-th="<?= $block->escapeHtmlAttr(__('Subtotal (Incl. Tax)')) ?>">
+    <td class="amount" data-th="<?= $escaper->escapeHtmlAttr(__('Subtotal (Incl. Tax)')) ?>">
         <?= /* @noEscape */ $checkoutHelper->formatPrice($block->getTotal()->getValueInclTax()) ?>
     </td>
 </tr>
@@ -44,9 +45,9 @@ $checkoutHelper = $block->getData('checkoutHelper');
 <?php else: ?>
 <tr class="totals sub">
     <th class="mark" colspan="<?= /* @noEscape */ $colspan ?>" scope="row">
-        <?= $block->escapeHtml($block->getTotal()->getTitle()) ?>
+        <?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?>
     </th>
-    <td class="amount" data-th="<?= $block->escapeHtmlAttr($block->getTotal()->getTitle()) ?>">
+    <td class="amount" data-th="<?= $escaper->escapeHtmlAttr($block->getTotal()->getTitle()) ?>">
         <?= /* @noEscape */ $checkoutHelper->formatPrice($block->getTotal()->getValue()) ?>
     </td>
 </tr>

--- a/app/code/Magento/Tax/view/frontend/templates/checkout/tax.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/checkout/tax.phtml
@@ -6,13 +6,14 @@
 
 /**
  * @var $block \Magento\Tax\Block\Checkout\Tax
+ * @var \Magento\Framework\Escaper $escaper
  * @see \Magento\Tax\Block\Checkout\Tax
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
 <?php
     $_value = $block->getTotal()->getValue();
-    $_style = $block->escapeHtmlAttr($block->getTotal()->getStyle());
+    $_style = $escaper->escapeHtmlAttr($block->getTotal()->getStyle());
     /** @var \Magento\Tax\Helper\Data $taxHelper */
     $taxHelper = $block->getData('taxHelper');
     /** @var \Magento\Checkout\Helper\Data $checkoutHelper */
@@ -28,12 +29,12 @@ if ($taxHelper->displayFullSummary() && $_value != 0) {
 <tr <?= /* @noEscape */ $attributes ?>>
     <th class="mark" colspan="<?= (int) $block->getColspan() ?>" scope="row">
         <?php if ($taxHelper->displayFullSummary()): ?>
-            <span class="detailed"><?= $block->escapeHtml($block->getTotal()->getTitle()) ?></span>
+            <span class="detailed"><?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?></span>
         <?php else: ?>
-            <?= $block->escapeHtml($block->getTotal()->getTitle()) ?>
+            <?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?>
         <?php endif; ?>
     </th>
-    <td class="amount" data-th="<?= $block->escapeHtmlAttr($block->getTotal()->getTitle()) ?>">
+    <td class="amount" data-th="<?= $escaper->escapeHtmlAttr($block->getTotal()->getTitle()) ?>">
         <?= /* @noEscape */ $checkoutHelper->formatPrice($_value) ?>
     </td>
 </tr>
@@ -53,14 +54,14 @@ if ($taxHelper->displayFullSummary() && $_value != 0) {
         <?php foreach ($rates as $rate): ?>
             <tr class="totals-tax-details">
                 <th class="mark" colspan="<?= (int) $block->getColspan() ?>" scope="row">
-                    <?= $block->escapeHtml($rate['title']) ?>
+                    <?= $escaper->escapeHtml($rate['title']) ?>
                     <?php if ($rate['percent'] !== null): ?>
                         (<?= (float) $rate['percent'] ?>%)
                     <?php endif; ?>
                 </th>
                 <?php if ($isFirst): ?>
                     <td class="amount" rowspan="<?= count($rates) ?>"
-                       data-th="<?= $block->escapeHtmlAttr($rate['title']) ?>
+                       data-th="<?= $escaper->escapeHtmlAttr($rate['title']) ?>
                         <?php if ($rate['percent'] !== null): ?>(<?= (float) $rate['percent'] ?>%)<?php endif; ?>">
                         <?= /* @noEscape */ $checkoutHelper->formatPrice($amount) ?>
                     </td>

--- a/app/code/Magento/Tax/view/frontend/templates/email/items/price/row.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/email/items/price/row.phtml
@@ -7,7 +7,10 @@
 // phpcs:disable Magento2.Templates.ThisInTemplate
 ?>
 <?php
-/** @var \Magento\Tax\Block\Item\Price\Renderer $block */
+/**
+ * @var \Magento\Tax\Block\Item\Price\Renderer $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $_item = $block->getItem();
 /** @var \Magento\Sales\Model\Order $_order */
@@ -16,7 +19,7 @@ $_order = $_item->getOrder();
 
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+        <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */ $_order->formatPrice($_item->getRowTotal()) ?>
 <?php endif; ?>
@@ -24,7 +27,7 @@ $_order = $_item->getOrder();
 
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <br /><span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+        <br /><span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
     <?php endif; ?>
     <?php $_incl = $this->helper(\Magento\Checkout\Helper\Data::class)->getSubtotalInclTax($_item); ?>
     <?= /* @noEscape */ $_order->formatPrice($_incl) ?>

--- a/app/code/Magento/Tax/view/frontend/templates/item/price/row.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/item/price/row.phtml
@@ -4,12 +4,15 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Tax\Block\Item\Price\Renderer */
+/**
+ * @var $block \Magento\Tax\Block\Item\Price\Renderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $_item = $block->getItem();
 ?>
 <?php if (($block->displayPriceInclTax() || $block->displayBothPrices()) && !$_item->getNoSubtotal()) : ?>
-    <span class="price-including-tax" data-label="<?= $block->escapeHtmlAttr(__('Incl. Tax')) ?>">
+    <span class="price-including-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Incl. Tax')) ?>">
         <span class="cart-price">
             <?= /* @noEscape */ $block->formatPrice($_item->getRowTotalInclTax()) ?>
         </span>
@@ -17,7 +20,7 @@ $_item = $block->getItem();
 <?php endif; ?>
 
 <?php if (($block->displayPriceExclTax() || $block->displayBothPrices()) && !$_item->getNoSubtotal()) : ?>
-    <span class="price-excluding-tax" data-label="<?= $block->escapeHtmlAttr(__('Excl. Tax')) ?>">
+    <span class="price-excluding-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Excl. Tax')) ?>">
         <span class="cart-price">
             <?= /* @noEscape */ $block->formatPrice($_item->getRowTotal()) ?>
         </span>

--- a/app/code/Magento/Tax/view/frontend/templates/item/price/unit.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/item/price/unit.phtml
@@ -4,12 +4,15 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Tax\Block\Item\Price\Renderer */
+/**
+ * @var $block \Magento\Tax\Block\Item\Price\Renderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $_item = $block->getItem();
 ?>
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
-    <span class="price-including-tax" data-label="<?= $block->escapeHtmlAttr(__('Incl. Tax')) ?>">
+    <span class="price-including-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Incl. Tax')) ?>">
         <?php $_incl = $_item->getPriceInclTax(); ?>
         <span class="cart-price">
             <?= /* @noEscape */ $block->formatPrice($_incl) ?>
@@ -18,7 +21,7 @@ $_item = $block->getItem();
 <?php endif; ?>
 
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
-    <span class="price-excluding-tax" data-label="<?= $block->escapeHtmlAttr(__('Excl. Tax')) ?>">
+    <span class="price-excluding-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Excl. Tax')) ?>">
         <span class="cart-price">
             <?= /* @noEscape */ $block->formatPrice($block->getItemDisplayPriceExclTax()) ?>
         </span>

--- a/app/code/Magento/Tax/view/frontend/templates/order/tax.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/order/tax.phtml
@@ -6,6 +6,9 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 // phpcs:disable Squiz.PHP.GlobalKeyword.NotAllowed
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <?php
     $_order  = $block->getOrder();
@@ -25,7 +28,7 @@
             ?>
             <tr class="totals tax details details-<?= (int) $taxIter ?><?= ($block->getIsPlaneMode()) ? ' plane' : '' ?>">
                 <td <?= /* @noEscape */ $block->getLabelProperties() ?>>
-                    <?= $block->escapeHtml($title) ?>
+                    <?= $escaper->escapeHtml($title) ?>
                     <?php if ($percent !== null) : ?>
                         (<?= (float) $percent ?>%)
                     <?php endif; ?>
@@ -47,12 +50,12 @@
 <?php endif; ?>
     <th <?= /* @noEscape */ $block->getLabelProperties() ?> scope="row">
         <?php if ($block->displayFullSummary()) : ?>
-            <div class="detailed"><?= $block->escapeHtml(__('Tax')) ?></div>
+            <div class="detailed"><?= $escaper->escapeHtml(__('Tax')) ?></div>
         <?php else : ?>
-            <?= $block->escapeHtml(__('Tax')) ?>
+            <?= $escaper->escapeHtml(__('Tax')) ?>
         <?php endif; ?>
     </th>
-    <td <?= /* @noEscape */ $block->getValueProperties() ?> data-th="<?= $block->escapeHtmlAttr(__('Tax')) ?>">
+    <td <?= /* @noEscape */ $block->getValueProperties() ?> data-th="<?= $escaper->escapeHtmlAttr(__('Tax')) ?>">
         <?= /* @noEscape */ $_order->formatPrice($_source->getTaxAmount()) ?>
     </td>
 </tr>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
