### PR TITLE
Magento_Swatches: avoid using deprecated escape* methods from Abstrac…

### DIFF
--- a/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/attribute/text.phtml
+++ b/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/attribute/text.phtml
@@ -4,24 +4,27 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Text */
+/**
+ * @var $block \Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Text
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $stores = $block->getStoresSortedBySortOrder();
 ?>
 <fieldset class="fieldset">
     <legend class="legend">
-        <span><?= $block->escapeHtml(__('Manage Swatch (Values of Your Attribute)')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Manage Swatch (Values of Your Attribute)')) ?></span>
     </legend>
     <div id="swatch-text-options-panel">
         <table class="data-table clearfix" cellspacing="0">
             <thead>
             <tr id="swatch-text-options-table">
                 <th class="col-draggable"></th>
-                <th class="col-default"><span><?= $block->escapeHtml(__('Is Default')) ?></span></th>
+                <th class="col-default"><span><?= $escaper->escapeHtml(__('Is Default')) ?></span></th>
                 <?php foreach ($stores as $_store) : ?>
                     <th class="col-swatch col-swatch-min-width col-<%- data.id %><?= ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) ? ' _required' : '' ?>"
                         colspan="2">
-                        <span><?= $block->escapeHtml($_store->getName()) ?></span>
+                        <span><?= $escaper->escapeHtml($_store->getName()) ?></span>
                     </th>
                 <?php endforeach; ?>
                 <?php $colTotal = count($stores) * 2 + 3; ?>
@@ -40,9 +43,9 @@ $stores = $block->getStoresSortedBySortOrder();
                 <th colspan="<?= (int)$colTotal ?>" class="col-actions-add">
                     <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) : ?>
                         <button id="add_new_swatch_text_option_button"
-                                title="<?= $block->escapeHtml(__('Add Swatch')) ?>"
+                                title="<?= $escaper->escapeHtml(__('Add Swatch')) ?>"
                                 type="button" class="action- scalable add">
-                            <span><?= $block->escapeHtml(__('Add Swatch')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Add Swatch')) ?></span>
                         </button>
                     <?php endif; ?>
                 </th>
@@ -57,7 +60,7 @@ $stores = $block->getStoresSortedBySortOrder();
                 <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) : ?>
                     <div data-role="draggable-handle"
                          class="draggable-handle"
-                         title="<?= $block->escapeHtmlAttr(__('Sort Option')) ?>"></div>
+                         title="<?= $escaper->escapeHtmlAttr(__('Sort Option')) ?>"></div>
                 <?php endif; ?>
                 <input data-role="order" type="hidden" name="optiontext[order][<%- data.id %>]"
                        value="<%- data.sort_order %>"
@@ -78,22 +81,22 @@ $stores = $block->getStoresSortedBySortOrder();
                         <?= ($storeId == \Magento\Store\Model\Store::DEFAULT_STORE_ID) ? ' required-option required-unique' : '' ?>"
                            name="swatchtext[value][<%- data.id %>][<?= /* @noEscape */ $storeId ?>]"
                            type="text" value="<%- data.swatch<?= /* @noEscape */ $storeId ?> %>"
-                           placeholder="<?= $block->escapeHtmlAttr(__("Swatch")) ?>"/>
+                           placeholder="<?= $escaper->escapeHtmlAttr(__("Swatch")) ?>"/>
                 </td>
                 <td class="col-swatch-min-width swatch-col-<%- data.id %>">
                     <input name="optiontext[value][<%- data.id %>][<?= /* @noEscape */ $storeId ?>]"
                            value="<%- data.store<?= /* @noEscape */ $storeId ?> %>"
                            class="input-text<?= ($storeId == \Magento\Store\Model\Store::DEFAULT_STORE_ID) ? ' required-option' : '' ?>"
                            type="text" <?= ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) ? ' disabled="disabled"' : ''?>
-                           placeholder="<?= $block->escapeHtmlAttr(__("Description")) ?>"/>
+                           placeholder="<?= $escaper->escapeHtmlAttr(__("Description")) ?>"/>
                 </td>
             <?php endforeach; ?>
             <td id="delete_button_swatch_container_<%- data.id %>" class="col-delete">
                 <input type="hidden" class="delete-flag" name="optiontext[delete][<%- data.id %>]" value="" />
                 <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) : ?>
-                    <button title="<?= $block->escapeHtmlAttr(__('Delete')) ?>" type="button"
+                    <button title="<?= $escaper->escapeHtmlAttr(__('Delete')) ?>" type="button"
                             class="action- scalable delete delete-option">
-                        <span><?= $block->escapeHtml(__('Delete')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Delete')) ?></span>
                     </button>
                 <?php endif;?>
             </td>
@@ -105,7 +108,7 @@ $stores = $block->getStoresSortedBySortOrder();
                 "Magento_Swatches/js/text": <?= /* @noEscape */ $block->getJsonConfig() ?> ,
                 "Magento_Catalog/catalog/product/attribute/unique-validate": {
                     "element": "required-text-swatch-unique",
-                    "message": "<?= $block->escapeJs($block->escapeHtml(__("The value of Admin must be unique."))) ?>"
+                    "message": "<?= $escaper->escapeJs($escaper->escapeHtml(__("The value of Admin must be unique."))) ?>"
                 }
             }
         }

--- a/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/attribute/visual.phtml
+++ b/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/attribute/visual.phtml
@@ -4,24 +4,27 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Visual */
+/**
+ * @var $block \Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Visual
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 $stores = $block->getStoresSortedBySortOrder();
 ?>
 <fieldset class="admin__fieldset fieldset">
     <legend class="legend">
-        <span><?= $block->escapeHtml(__('Manage Swatch (Values of Your Attribute)')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Manage Swatch (Values of Your Attribute)')) ?></span>
     </legend><br />
     <div class="admin__control-table-wrapper" id="swatch-visual-options-panel">
         <table class="data-table clearfix" cellspacing="0">
             <thead>
             <tr id="swatch-visual-options-table">
                 <th class="col-draggable"></th>
-                <th class="col-default"><span><?= $block->escapeHtml(__('Is Default')) ?></span></th>
-                <th><span><?= $block->escapeHtml(__('Swatch')) ?></span></th>
+                <th class="col-default"><span><?= $escaper->escapeHtml(__('Is Default')) ?></span></th>
+                <th><span><?= $escaper->escapeHtml(__('Swatch')) ?></span></th>
                 <?php foreach ($stores as $_store) : ?>
                     <th<?= ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) ? ' class="_required"' : '' ?>
-                        <span><?= $block->escapeHtml($_store->getName()) ?></span>
+                        <span><?= $escaper->escapeHtml($_store->getName()) ?></span>
                     </th>
                 <?php endforeach; ?>
                 <?php $colTotal = count($stores) * 2 + 3; ?>
@@ -40,9 +43,9 @@ $stores = $block->getStoresSortedBySortOrder();
                 <th colspan="<?= (int)$colTotal ?>" class="col-actions-add">
                     <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) : ?>
                         <button id="add_new_swatch_visual_option_button"
-                                title="<?= $block->escapeHtml(__('Add Swatch')) ?>"
+                                title="<?= $escaper->escapeHtml(__('Add Swatch')) ?>"
                                 type="button" class="action- scalable add">
-                            <span><?= $block->escapeHtml(__('Add Swatch')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Add Swatch')) ?></span>
                         </button>
                     <?php endif; ?>
                 </th>
@@ -56,7 +59,7 @@ $stores = $block->getStoresSortedBySortOrder();
             <td class="col-draggable">
                 <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) : ?>
                     <div data-role="draggable-handle" class="draggable-handle"
-                         title="<?= $block->escapeHtml(__('Sort Option')) ?>"></div>
+                         title="<?= $escaper->escapeHtml(__('Sort Option')) ?>"></div>
                 <?php endif; ?>
                 <input data-role="order" type="hidden" name="optionvisual[order][<%- data.id %>]"  value="<%- data.sort_order %>" <?= ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) ? ' disabled="disabled"' : '' ?>/>
             </td>
@@ -70,17 +73,17 @@ $stores = $block->getStoresSortedBySortOrder();
                 <div class="swatch_sub-menu_container" id="swatch_container_option_<%- data.id %>">
                     <div class="swatch_row position-relative">
                         <div class="swatch_row_name colorpicker_handler">
-                            <p><?= $block->escapeHtml(__('Choose a color')) ?></p>
+                            <p><?= $escaper->escapeHtml(__('Choose a color')) ?></p>
                         </div>
                     </div>
                     <div class="swatch_row">
                         <div class="swatch_row_name btn_choose_file_upload" id="swatch_choose_file_option_<%- data.id %>">
-                            <p><?= $block->escapeHtml(__('Upload a file')) ?></p>
+                            <p><?= $escaper->escapeHtml(__('Upload a file')) ?></p>
                         </div>
                     </div>
                     <div class="swatch_row">
                         <div class="swatch_row_name btn_remove_swatch">
-                            <p><?= $block->escapeHtml(__('Clear')) ?></p>
+                            <p><?= $escaper->escapeHtml(__('Clear')) ?></p>
                         </div>
                     </div>
                 </div>
@@ -96,9 +99,9 @@ $stores = $block->getStoresSortedBySortOrder();
             <td id="delete_button_swatch_container_<%- data.id %>" class="col-delete">
                 <input type="hidden" class="delete-flag" name="optionvisual[delete][<%- data.id %>]" value="" />
                 <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) : ?>
-                    <button title="<?= $block->escapeHtml(__('Delete')) ?>" type="button"
+                    <button title="<?= $escaper->escapeHtml(__('Delete')) ?>" type="button"
                             class="action- scalable delete delete-option">
-                        <span><?= $block->escapeHtml(__('Delete')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Delete')) ?></span>
                     </button>
                 <?php endif;?>
             </td>
@@ -110,7 +113,7 @@ $stores = $block->getStoresSortedBySortOrder();
                 "Magento_Swatches/js/visual": <?= /* @noEscape */ $block->getJsonConfig() ?> ,
                 "Magento_Catalog/catalog/product/attribute/unique-validate": {
                     "element": "required-visual-swatch-unique",
-                    "message": "<?= $block->escapeHtml(__("The value of Admin must be unique.")) ?>"
+                    "message": "<?= $escaper->escapeHtml(__("The value of Admin must be unique.")) ?>"
                 }
             }
         }

--- a/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/edit/attribute/steps/attributes_values.phtml
+++ b/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/edit/attribute/steps/attributes_values.phtml
@@ -4,12 +4,15 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\AttributeValues */
+/**
+ * @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\AttributeValues
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
-<div data-bind="scope: '<?= $block->escapeHtmlAttr($block->getComponentName()) ?>'">
-    <h2 class="steps-wizard-title"><?= $block->escapeHtml(__('Step 2: Attribute Values')) ?></h2>
+<div data-bind="scope: '<?= $escaper->escapeHtmlAttr($block->getComponentName()) ?>'">
+    <h2 class="steps-wizard-title"><?= $escaper->escapeHtml(__('Step 2: Attribute Values')) ?></h2>
     <div class="steps-wizard-info">
-        <span><?= $block->escapeHtml(__('Select from the following attribute values for this product. Each unique combination of values creates a unique product SKU.')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Select from the following attribute values for this product. Each unique combination of values creates a unique product SKU.')) ?></span>
     </div>
     <div data-bind="foreach: attributes, sortableList: attributes">
 
@@ -18,12 +21,12 @@
                 <div class="attribute-entity-title-block">
                     <span class="draggable-handle"
                           data-role="draggable"
-                          title="<?= $block->escapeHtml(__('Sort Variations')) ?>">
+                          title="<?= $escaper->escapeHtml(__('Sort Variations')) ?>">
                     </span>
                     <div class="attribute-entity-title" data-bind="text: label"></div>
                     <div class="attribute-options-block">
                         (<span class="attribute-length" data-bind="text: $data.options().length"></span>
-                        <?= $block->escapeHtml(__('Options')) ?>)
+                        <?= $escaper->escapeHtml(__('Options')) ?>)
                     </div>
                 </div>
 
@@ -31,20 +34,20 @@
                     <button type="button"
                             class="action-select-all action-tertiary"
                             data-bind="click: $parent.selectAllAttributes"
-                            title="<?= $block->escapeHtml(__('Select All')) ?>">
-                        <span><?= $block->escapeHtml(__('Select All')) ?></span>
+                            title="<?= $escaper->escapeHtml(__('Select All')) ?>">
+                        <span><?= $escaper->escapeHtml(__('Select All')) ?></span>
                     </button>
                     <button type="button"
                             class="action-deselect-all action-tertiary"
                             data-bind="click: $parent.deSelectAllAttributes"
-                            title="<?= $block->escapeHtml(__('Deselect All')) ?>">
-                        <span><?=$block->escapeHtml(__('Deselect All')) ?></span>
+                            title="<?= $escaper->escapeHtml(__('Deselect All')) ?>">
+                        <span><?=$escaper->escapeHtml(__('Deselect All')) ?></span>
                     </button>
                     <button type="button"
                             class="action-remove-all action-tertiary"
                             data-bind="click: $parent.removeAttribute.bind($parent)"
-                            title="<?= $block->escapeHtml(__('Remove Attribute')) ?>">
-                        <span><?= $block->escapeHtml(__('Remove Attribute')) ?></span>
+                            title="<?= $escaper->escapeHtml(__('Remove Attribute')) ?>">
+                        <span><?= $escaper->escapeHtml(__('Remove Attribute')) ?></span>
                     </button>
                 </div>
             </div>
@@ -69,17 +72,17 @@
                             </div>
                             <button type="button"
                                     class="action-save"
-                                    title="<?= $block->escapeHtml(__('Save Option')) ?>"
+                                    title="<?= $escaper->escapeHtml(__('Save Option')) ?>"
                                     data-action="save"
                                     data-bind="click: $parents[1].saveOption.bind($parent)">
-                                <span><?= $block->escapeHtml(__('Save Option')) ?></span>
+                                <span><?= $escaper->escapeHtml(__('Save Option')) ?></span>
                             </button>
                             <button type="button"
                                     class="action-remove"
-                                    title="<?= $block->escapeHtml(__('Remove Option')) ?>"
+                                    title="<?= $escaper->escapeHtml(__('Remove Option')) ?>"
                                     data-action="remove"
                                     data-bind="click: $parents[1].removeOption.bind($parent)">
-                                <span><?= $block->escapeHtml(__('Remove Option')) ?></span>
+                                <span><?= $escaper->escapeHtml(__('Remove Option')) ?></span>
                             </button>
                         </div>
                     </li>
@@ -89,7 +92,7 @@
                     type="button"
                     data-action="addOption"
                     data-bind="click: $parent.createOption, visible: canCreateOption">
-                <span><?= $block->escapeHtml(__('Create New Value')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Create New Value')) ?></span>
             </button>
         </div>
     </div>
@@ -99,11 +102,11 @@
         "*": {
             "Magento_Ui/js/core/app": {
                 "components": {
-                    "<?= $block->escapeJs($block->getComponentName()) ?>": {
+                    "<?= $escaper->escapeJs($block->getComponentName()) ?>": {
                         "component": "Magento_ConfigurableProduct/js/variations/steps/attributes_values",
-                        "appendTo": "<?= $block->escapeJs($block->getParentComponentName()) ?>",
-                        "optionsUrl": "<?= $block->escapeJs($block->escapeUrl($block->getUrl('catalog/product_attribute/getAttributes'))) ?>",
-                        "createOptionsUrl": "<?= $block->escapeJs($block->escapeUrl($block->getUrl('catalog/product_attribute/createOptions'))) ?>"
+                        "appendTo": "<?= $escaper->escapeJs($block->getParentComponentName()) ?>",
+                        "optionsUrl": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getUrl('catalog/product_attribute/getAttributes'))) ?>",
+                        "createOptionsUrl": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getUrl('catalog/product_attribute/createOptions'))) ?>"
                     }
                 }
             }

--- a/app/code/Magento/Swatches/view/frontend/templates/product/layered/renderer.phtml
+++ b/app/code/Magento/Swatches/view/frontend/templates/product/layered/renderer.phtml
@@ -7,28 +7,30 @@
 // phpcs:disable PSR2.ControlStructures.SwitchDeclaration
 // phpcs:disable Generic.WhiteSpace.ScopeIndent
 
-/** @var $block \Magento\Swatches\Block\LayeredNavigation\RenderLayered */
+/**
+ * @var $block \Magento\Swatches\Block\LayeredNavigation\RenderLayered
+ */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 /** @var \Magento\Framework\Escaper $escaper */
 ?>
 <?php $swatchData = $block->getSwatchData(); ?>
-<div class="swatch-attribute swatch-layered <?= $block->escapeHtmlAttr($swatchData['attribute_code']) ?>"
-     data-attribute-code="<?= $block->escapeHtmlAttr($swatchData['attribute_code']) ?>"
-     data-attribute-id="<?= $block->escapeHtmlAttr($swatchData['attribute_id']) ?>">
+<div class="swatch-attribute swatch-layered <?= $escaper->escapeHtmlAttr($swatchData['attribute_code']) ?>"
+     data-attribute-code="<?= $escaper->escapeHtmlAttr($swatchData['attribute_code']) ?>"
+     data-attribute-id="<?= $escaper->escapeHtmlAttr($swatchData['attribute_id']) ?>">
     <div class="swatch-attribute-options clearfix">
         <?php foreach ($swatchData['options'] as $option => $label): ?>
-            <a href="<?= $block->escapeUrl($label['link']) ?>" rel="nofollow"
-               aria-label="<?= $block->escapeHtmlAttr($label['label']) ?>"
+            <a href="<?= $escaper->escapeUrl($label['link']) ?>" rel="nofollow"
+               aria-label="<?= $escaper->escapeHtmlAttr($label['label']) ?>"
                class="swatch-option-link-layered">
                 <?php if (isset($swatchData['swatches'][$option]['type'])): ?>
                     <?php switch ($swatchData['swatches'][$option]['type']) {
                         case '3':
                             ?>
-                            <div class="swatch-option <?= $block->escapeHtmlAttr($label['custom_style']) ?>"
+                            <div class="swatch-option <?= $escaper->escapeHtmlAttr($label['custom_style']) ?>"
                                  tabindex="-1"
                                  data-option-type="3"
-                                 data-option-id="<?= $block->escapeHtmlAttr($option) ?>"
-                                 data-option-label="<?= $block->escapeHtmlAttr($label['label']) ?>"
+                                 data-option-id="<?= $escaper->escapeHtmlAttr($option) ?>"
+                                 data-option-label="<?= $escaper->escapeHtmlAttr($label['label']) ?>"
                                  data-option-tooltip-thumb=""
                                  data-option-tooltip-value=""
                                 ></div>
@@ -43,14 +45,14 @@
                                 'swatch_image',
                                 $swatchData['swatches'][$option]['value']
                             );
-                            $escapedUrl = $block->escapeUrl($swatchImagePath);
+                            $escapedUrl = $escaper->escapeUrl($swatchImagePath);
                             ?>
-                            <div class="swatch-option image <?= $block->escapeHtmlAttr($label['custom_style']) ?>"
+                            <div class="swatch-option image <?= $escaper->escapeHtmlAttr($label['custom_style']) ?>"
                                  tabindex="-1"
                                  data-option-type="2"
-                                 data-option-id="<?= $block->escapeHtmlAttr($option) ?>"
-                                 data-option-label="<?= $block->escapeHtmlAttr($label['label']) ?>"
-                                 data-option-tooltip-thumb="<?= $block->escapeUrl($swatchThumbPath) ?>"
+                                 data-option-id="<?= $escaper->escapeHtmlAttr($option) ?>"
+                                 data-option-label="<?= $escaper->escapeHtmlAttr($label['label']) ?>"
+                                 data-option-tooltip-thumb="<?= $escaper->escapeUrl($swatchThumbPath) ?>"
                                  data-option-tooltip-value="">
                             </div>
                             <?php
@@ -66,13 +68,13 @@
                             <?php break;
                         case '1':
                             ?>
-                            <div class="swatch-option color <?= $block->escapeHtmlAttr($label['custom_style']) ?>"
+                            <div class="swatch-option color <?= $escaper->escapeHtmlAttr($label['custom_style']) ?>"
                                  tabindex="-1"
                                  data-option-type="1"
-                                 data-option-id="<?= $block->escapeHtmlAttr($option) ?>"
-                                 data-option-label="<?= $block->escapeHtmlAttr($label['label']) ?>"
+                                 data-option-id="<?= $escaper->escapeHtmlAttr($option) ?>"
+                                 data-option-label="<?= $escaper->escapeHtmlAttr($label['label']) ?>"
                                  data-option-tooltip-thumb=""
-                                 data-option-tooltip-value="<?= $block->escapeHtmlAttr(
+                                 data-option-tooltip-value="<?= $escaper->escapeHtmlAttr(
                                      $swatchData['swatches'][$option]['value']
                                  ) ?>">
                             </div>
@@ -93,14 +95,14 @@
                         case '0':
                         default:
                             ?>
-                            <div class="swatch-option text <?= $block->escapeHtmlAttr($label['custom_style']) ?>"
+                            <div class="swatch-option text <?= $escaper->escapeHtmlAttr($label['custom_style']) ?>"
                                  tabindex="-1"
                                  data-option-type="0"
-                                 data-option-id="<?= $block->escapeHtmlAttr($option) ?>"
-                                 data-option-label="<?= $block->escapeHtmlAttr($label['label']) ?>"
+                                 data-option-id="<?= $escaper->escapeHtmlAttr($option) ?>"
+                                 data-option-label="<?= $escaper->escapeHtmlAttr($label['label']) ?>"
                                  data-option-tooltip-thumb=""
                                  data-option-tooltip-value=""
-                                ><?= $block->escapeHtml($swatchData['swatches'][$option]['value']) ?></div>
+                                ><?= $escaper->escapeHtml($swatchData['swatches'][$option]['value']) ?></div>
                         <?php break;
                     } ?>
                 <?php endif; ?>
@@ -111,7 +113,7 @@
 <?php $scriptString = <<<script
 
     require(["jquery", "Magento_Swatches/js/swatch-renderer"], function ($) {
-        $('.swatch-layered.{$block->escapeJs($swatchData['attribute_code'])}')
+        $('.swatch-layered.{$escaper->escapeJs($swatchData['attribute_code'])}')
             .find('[data-option-type="1"], [data-option-type="2"], [data-option-type="0"], [data-option-type="3"]')
             .SwatchRendererTooltip();
     });

--- a/app/code/Magento/Swatches/view/frontend/templates/product/listing/renderer.phtml
+++ b/app/code/Magento/Swatches/view/frontend/templates/product/listing/renderer.phtml
@@ -5,10 +5,14 @@
  */
 
 use Magento\Catalog\Model\Product;
+use Magento\Framework\Escaper;
 use Magento\Swatches\Block\Product\Renderer\Listing\Configurable;
 use Magento\Swatches\ViewModel\Product\Renderer\Configurable as ConfigurableViewModel;
 
-/** @var Configurable $block */
+/**
+ * @var Configurable $block
+ * @var Escaper $escaper
+ */
 /** @var Product $product */
 $product = $block->getProduct()
 ?>
@@ -16,22 +20,22 @@ $product = $block->getProduct()
     <?php $productId = $product->getId() ?>
     <?php /** @var ConfigurableViewModel $configurableViewModel */ ?>
     <?php $configurableViewModel = $block->getConfigurableViewModel() ?>
-    <div class="swatch-opt-<?= $block->escapeHtmlAttr($productId) ?>"
-         data-role="swatch-option-<?= $block->escapeHtmlAttr($productId) ?>"></div>
+    <div class="swatch-opt-<?= $escaper->escapeHtmlAttr($productId) ?>"
+         data-role="swatch-option-<?= $escaper->escapeHtmlAttr($productId) ?>"></div>
 
     <script type="text/x-magento-init">
         {
-            "[data-role=swatch-option-<?= $block->escapeJs($productId) ?>]": {
+            "[data-role=swatch-option-<?= $escaper->escapeJs($productId) ?>]": {
                 "Magento_Swatches/js/swatch-renderer": {
                     "selectorProduct": ".product-item-details",
                     "onlySwatches": true,
                     "enableControlLabel": false,
-                    "numberToShow": <?=  $block->escapeJs($block->getNumberSwatchesPerProduct()) ?>,
+                    "numberToShow": <?=  $escaper->escapeJs($block->getNumberSwatchesPerProduct()) ?>,
                     "jsonConfig": <?= /* @noEscape */ $block->getJsonConfig() ?>,
                     "jsonSwatchConfig": <?= /* @noEscape */ $block->getJsonSwatchConfig() ?>,
-                    "mediaCallback": "<?= $block->escapeJs($block->escapeUrl($block->getMediaCallback())) ?>",
+                    "mediaCallback": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getMediaCallback())) ?>",
                     "jsonSwatchImageSizeConfig": <?= /* @noEscape */ $block->getJsonSwatchSizeConfig() ?>,
-                    "showTooltip": <?= $block->escapeJs($configurableViewModel->getShowSwatchTooltip()) ?>
+                    "showTooltip": <?= $escaper->escapeJs($configurableViewModel->getShowSwatchTooltip()) ?>
                 }
             }
         }
@@ -39,7 +43,7 @@ $product = $block->getProduct()
 
     <script type="text/x-magento-init">
         {
-            "[data-role=priceBox][data-price-box=product-id-<?= $block->escapeJs($productId) ?>]": {
+            "[data-role=priceBox][data-price-box=product-id-<?= $escaper->escapeJs($productId) ?>]": {
                 "priceBox": {
                     "priceConfig": {
                         "priceFormat": <?= /* @noEscape */ $block->getPriceFormatJson() ?>,

--- a/app/code/Magento/Swatches/view/frontend/templates/product/view/renderer.phtml
+++ b/app/code/Magento/Swatches/view/frontend/templates/product/view/renderer.phtml
@@ -5,7 +5,10 @@
  */
 ?>
 <?php
-/** @var $block \Magento\Swatches\Block\Product\Renderer\Configurable */
+/**
+ * @var $block \Magento\Swatches\Block\Product\Renderer\Configurable
+ * @var \Magento\Framework\Escaper $escaper
+ */
 /** @var \Magento\Swatches\ViewModel\Product\Renderer\Configurable $configurableViewModel */
 $configurableViewModel = $block->getConfigurableViewModel()
 ?>
@@ -17,10 +20,10 @@ $configurableViewModel = $block->getConfigurableViewModel()
             "Magento_Swatches/js/swatch-renderer": {
                 "jsonConfig": <?= /* @noEscape */ $swatchOptions = $block->getJsonConfig() ?>,
                 "jsonSwatchConfig": <?= /* @noEscape */ $swatchOptions = $block->getJsonSwatchConfig() ?>,
-                "mediaCallback": "<?= $block->escapeJs($block->escapeUrl($block->getMediaCallback())) ?>",
-                "gallerySwitchStrategy": "<?= $block->escapeJs($block->getVar('gallery_switch_strategy', 'Magento_ConfigurableProduct')) ?: 'replace'; ?>",
+                "mediaCallback": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getMediaCallback())) ?>",
+                "gallerySwitchStrategy": "<?= $escaper->escapeJs($block->getVar('gallery_switch_strategy', 'Magento_ConfigurableProduct')) ?: 'replace'; ?>",
                 "jsonSwatchImageSizeConfig": <?= /* @noEscape */ $block->getJsonSwatchSizeConfig() ?>,
-                "showTooltip": <?= $block->escapeJs($configurableViewModel->getShowSwatchTooltip()) ?>
+                "showTooltip": <?= $escaper->escapeJs($configurableViewModel->getShowSwatchTooltip()) ?>
             }
         },
         "*" : {


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
