### PR TITLE
Magento_Swagger: avoid using deprecated escape* methods from Abstract…

### DIFF
--- a/app/code/Magento/Swagger/view/frontend/templates/swagger-ui/index.phtml
+++ b/app/code/Magento/Swagger/view/frontend/templates/swagger-ui/index.phtml
@@ -14,6 +14,7 @@
 
 /**
  * @var \Magento\Swagger\Block\Index $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 
 $schemaUrl = $block->getSchemaUrl();
@@ -57,7 +58,7 @@ $schemaUrl = $block->getSchemaUrl();
     <div class="swagger-ui-wrap">
         <a id="logo" href="http://swagger.io">swagger</a>
         <form id='api_selector'>
-            <input id="input_baseUrl" type="hidden" value="<?= $block->escapeUrl($schemaUrl) ?>"/>
+            <input id="input_baseUrl" type="hidden" value="<?= $escaper->escapeUrl($schemaUrl) ?>"/>
             <div class='input'><input placeholder="api_key" id="input_apiKey" name="apiKey" type="text"/></div>
             <div class='input'><a id="explore" href="#" data-sw-translate>apply</a></div>
         </form>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
