### PR TITLE
Magento_Shipping: avoid using deprecated escape* methods from Abstrac…

### DIFF
--- a/app/code/Magento/Shipping/view/adminhtml/templates/create/form.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/create/form.phtml
@@ -6,44 +6,45 @@
 
 /**
  * @var \Magento\Shipping\Block\Adminhtml\Create\Form $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 
 /** @var \Magento\Tax\Helper\Data $taxHelper */
 $taxHelper = $block->getData('taxHelper');
 ?>
-<form id="edit_form" method="post" action="<?= $block->escapeUrl($block->getSaveUrl()) ?>">
+<form id="edit_form" method="post" action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>">
     <?= $block->getBlockHtml('formkey') ?>
     <?php  $_order = $block->getShipment()->getOrder() ?>
     <?= $block->getChildHtml('order_info') ?>
     <div class="admin__page-section">
         <div class="admin__page-section-title">
-            <span class="title"><?= $block->escapeHtml(__('Payment &amp; Shipping Method')) ?></span>
+            <span class="title"><?= $escaper->escapeHtml(__('Payment &amp; Shipping Method')) ?></span>
         </div>
         <div class="admin__page-section-content">
             <div class="admin__page-section-item order-payment-method">
                 <?php /* Billing Address */ ?>
                 <div class="admin__page-section-item-title">
-                    <span class="title"><?=$block->escapeHtml(__('Payment Information')) ?></span>
+                    <span class="title"><?=$escaper->escapeHtml(__('Payment Information')) ?></span>
                 </div>
                 <div class="admin__page-section-item-content">
                     <div><?= $block->getPaymentHtml() ?></div>
                     <div class="order-payment-currency">
-                        <?= $block->escapeHtml(__('The order was placed using %1.', $_order->getOrderCurrencyCode())) ?>
+                        <?= $escaper->escapeHtml(__('The order was placed using %1.', $_order->getOrderCurrencyCode())) ?>
                     </div>
                 </div>
             </div>
             <div class="admin__page-section-item order-shipping-address">
                 <?php /* Shipping Address */ ?>
                 <div class="admin__page-section-item-title">
-                    <span class="title"><?= $block->escapeHtml(__('Shipping Information')) ?></span>
+                    <span class="title"><?= $escaper->escapeHtml(__('Shipping Information')) ?></span>
                 </div>
                 <div class="admin__page-section-item-content shipping-description-wrapper">
                     <div class="shipping-description-title">
-                        <?= $block->escapeHtml($_order->getShippingDescription()) ?>
+                        <?= $escaper->escapeHtml($_order->getShippingDescription()) ?>
                     </div>
                     <div class="shipping-description-content">
-                        <?= $block->escapeHtml(__('Total Shipping Charges')) ?>:
+                        <?= $escaper->escapeHtml(__('Total Shipping Charges')) ?>:
 
                         <?php if ($taxHelper->displayShippingPriceIncludingTax()): ?>
                             <?php $_excl = $block->displayShippingPriceInclTax($_order); ?>
@@ -54,7 +55,7 @@ $taxHelper = $block->getData('taxHelper');
                         <?= /** @noEscape */ $_excl ?>
                         <?php if ($taxHelper->displayShippingBothPrices()
                             && $_incl != $_excl): ?>
-                        (<?= $block->escapeHtml(__('Incl. Tax')) ?> <?= /** @noEscape */ $_incl ?>)
+                        (<?= $escaper->escapeHtml(__('Incl. Tax')) ?> <?= /** @noEscape */ $_incl ?>)
                         <?php endif; ?>
                     </div>
                 </div>

--- a/app/code/Magento/Shipping/view/adminhtml/templates/create/items.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/create/items.phtml
@@ -4,24 +4,27 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Items to Ship')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Items to Ship')) ?></span>
     </div>
     <div class="admin__table-wrapper">
         <table class="data-table admin__table-primary order-shipment-table">
             <thead>
                 <tr class="headings">
-                    <th class="col-product"><span><?= $block->escapeHtml(__('Product')) ?></span></th>
-                    <th class="col-ordered-qty"><span><?= $block->escapeHtml(__('Qty')) ?></span></th>
+                    <th class="col-product"><span><?= $escaper->escapeHtml(__('Product')) ?></span></th>
+                    <th class="col-ordered-qty"><span><?= $escaper->escapeHtml(__('Qty')) ?></span></th>
                     <th class="col-qty<?php if ($block->isShipmentRegular()): ?> last<?php endif; ?>">
-                        <span><?= $block->escapeHtml(__('Qty to Ship')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Qty to Ship')) ?></span>
                     </th>
                     <?php if (!$block->canShipPartiallyItem()): ?>
-                    <th class="col-ship last"><span><?= $block->escapeHtml(__('Ship')) ?></span></th>
+                    <th class="col-ship last"><span><?= $escaper->escapeHtml(__('Ship')) ?></span></th>
                     <?php endif; ?>
                 </tr>
             </thead>
@@ -42,24 +45,24 @@
 
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Shipment Total')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Shipment Total')) ?></span>
     </div>
     <div class="admin__page-section-content order-comments-history">
         <div class="admin__page-section-item">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Shipment Comments')) ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Shipment Comments')) ?></span>
             </div>
             <div class="admin__page-section-item-content">
                 <div id="order-history_form" class="admin__field">
                     <label class="admin__field-label"
                            for="shipment_comment_text">
-                        <span><?= $block->escapeHtml(__('Comment Text')) ?></span></label>
+                        <span><?= $escaper->escapeHtml(__('Comment Text')) ?></span></label>
                     <div class="admin__field-control">
                         <textarea id="shipment_comment_text"
                                   class="admin__control-textarea"
                                   name="shipment[comment_text]"
                                   rows="3"
-                                  cols="5"><?= $block->escapeHtml($block->getShipment()->getCommentText()) ?></textarea>
+                                  cols="5"><?= $escaper->escapeHtml($block->getShipment()->getCommentText()) ?></textarea>
                     </div>
                 </div>
             </div>
@@ -67,7 +70,7 @@
     </div>
     <div class="admin__page-section-item order-totals order-totals-actions">
         <div class="admin__page-section-item-title">
-            <span class="title"><?= $block->escapeHtml(__('Shipment Options')) ?></span>
+            <span class="title"><?= $escaper->escapeHtml(__('Shipment Options')) ?></span>
         </div>
         <div class="admin__page-section-item-content">
             <?php if ($block->canCreateShippingLabel()): ?>
@@ -79,7 +82,7 @@
                            type="checkbox"/>
                     <label class="admin__field-label"
                            for="create_shipping_label">
-                        <span><?= $block->escapeHtml(__('Create Shipping Label')) ?></span></label>
+                        <span><?= $escaper->escapeHtml(__('Create Shipping Label')) ?></span></label>
                     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                         'onclick',
                         'toggleCreateLabelCheckbox();',
@@ -96,7 +99,7 @@
                        type="checkbox"/>
                 <label class="admin__field-label"
                        for="notify_customer">
-                    <span><?=$block->escapeHtml(__('Append Comments')) ?></span></label>
+                    <span><?=$escaper->escapeHtml(__('Append Comments')) ?></span></label>
             </div>
 
             <?php if ($block->canSendShipmentEmail()): ?>
@@ -108,7 +111,7 @@
                            type="checkbox"/>
                     <label class="admin__field-label"
                            for="send_email">
-                        <span><?= $block->escapeHtml(__('Email Copy of Shipment')) ?></span></label>
+                        <span><?= $escaper->escapeHtml(__('Email Copy of Shipment')) ?></span></label>
                 </div>
             <?php endif; ?>
             <?= $block->getChildHtml('submit_before') ?>
@@ -155,7 +158,7 @@ window.toggleCreateLabelCheckbox = function() {
 window.submitShipment = function(btn) {
     if (!validQtyItems()) {
         alert({
-            content: '{$block->escapeJs(__('Invalid value(s) for Qty to Ship'))}'
+            content: '{$escaper->escapeJs(__('Invalid value(s) for Qty to Ship'))}'
         });
         return;
     }

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/grid.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/grid.phtml
@@ -6,6 +6,7 @@
 //phpcs:disable Squiz.PHP.NonExecutableCode.Unreachable
 /**
  * @var \Magento\Shipping\Block\Adminhtml\Order\Packaging $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -20,7 +21,7 @@
                         <input type="checkbox"
                                id="select-items-<?= /* @noEscape */ $randomId ?>"
                                class="checkbox admin__control-checkbox"
-                               title="<?= $block->escapeHtmlAttr(__('Select All')) ?>">
+                               title="<?= $escaper->escapeHtmlAttr(__('Select All')) ?>">
                         <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                             'onchange',
                             'packaging.checkAllItems(this);',
@@ -29,10 +30,10 @@
                         <label for="select-items-<?= /* @noEscape */ $randomId ?>"></label>
                     </label>
                 </th>
-                <th class="data-grid-th"><?= $block->escapeHtml(__('Product Name')) ?></th>
-                <th class="data-grid-th"><?= $block->escapeHtml(__('Weight')) ?></th>
+                <th class="data-grid-th"><?= $escaper->escapeHtml(__('Product Name')) ?></th>
+                <th class="data-grid-th"><?= $escaper->escapeHtml(__('Weight')) ?></th>
                 <th class="data-grid-th custom-value">
-                    <?= $block->escapeHtml(__('Customs Value')) ?>
+                    <?= $escaper->escapeHtml(__('Customs Value')) ?>
                 </th>
                 <?php if (!$block->displayCustomsValue()): ?>
                     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
@@ -40,8 +41,8 @@
                         '#packaging-data-grid-' . $randomId . ' th.custom-value'
                     ) ?>
                 <?php endif ?>
-                <th class="data-grid-th"><?= $block->escapeHtml(__('Qty Ordered')) ?></th>
-                <th class="data-grid-th"><?= $block->escapeHtml(__('Qty')) ?></th>
+                <th class="data-grid-th"><?= $escaper->escapeHtml(__('Qty Ordered')) ?></th>
+                <th class="data-grid-th"><?= $escaper->escapeHtml(__('Qty')) ?></th>
             </tr>
             </thead>
             <tbody>
@@ -71,10 +72,10 @@
                         </label>
                     </td>
                     <td>
-                        <?= $block->escapeHtml($item->getName()) ?>
+                        <?= $escaper->escapeHtml($item->getName()) ?>
                     </td>
                     <td data-role="item-weight">
-                        <?= $block->escapeHtml($item->getWeight()) ?>
+                        <?= $escaper->escapeHtml($item->getWeight()) ?>
                     </td>
                     <?php
                     if ($block->displayCustomsValue()) {
@@ -88,7 +89,7 @@
                         <input type="text"
                                name="customs_value"
                                class="input-text admin__control-text <?= /* @noEscape */ $customsValueValidation ?>"
-                               value="<?= $block->escapeHtmlAttr($block->formatPrice($item->getPrice())) ?>"
+                               value="<?= $escaper->escapeHtmlAttr($block->formatPrice($item->getPrice())) ?>"
                                size="10">
                     </td>
                     <?php if (!$block->displayCustomsValue()): ?>
@@ -101,7 +102,7 @@
                         <?= /* @noEscape */ $item->getOrderItem()->getQtyOrdered() * 1 ?>
                     </td>
                     <td>
-                        <input type="hidden" name="price" value="<?= $block->escapeHtml($item->getPrice()) ?>">
+                        <input type="hidden" name="price" value="<?= $escaper->escapeHtml($item->getPrice()) ?>">
                         <input type="text"
                                name="qty"
                                value="<?= /* @noEscape */ $item->getQty() * 1 ?>"
@@ -113,7 +114,7 @@
                                 id="packaging-delete-item-<?= /* @noEscape */ $randomId . '-' . $id ?>"
                                 class="action-delete"
                                 data-action="package-delete-item">
-                            <span><?= $block->escapeHtml(__('Delete')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Delete')) ?></span>
                         </button>
                         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
                             'display:none',

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/packed.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/packed.phtml
@@ -4,7 +4,10 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 /** @var \Magento\Shipping\Helper\Carrier $carrierHelper */
 $carrierHelper = $block->getData('carrierHelper');
@@ -16,7 +19,7 @@ $carrierHelper = $block->getData('carrierHelper');
     <?php $params = new \Magento\Framework\DataObject($package->getParams()) ?>
     <section class="admin__page-section">
         <div class="admin__page-section-title">
-            <span class="title"><?= $block->escapeHtml(__('Package') . ' ' . $packageId) ?></span>
+            <span class="title"><?= $escaper->escapeHtml(__('Package') . ' ' . $packageId) ?></span>
         </div>
         <div class="admin__page-section-content">
             <div class="row row-gutter">
@@ -24,27 +27,27 @@ $carrierHelper = $block->getData('carrierHelper');
                     <table class="admin__table-secondary">
                         <tbody>
                             <tr>
-                                <th><?= $block->escapeHtml(__('Type')) ?></th>
+                                <th><?= $escaper->escapeHtml(__('Type')) ?></th>
                                 <td>
-                                    <?= $block->escapeHtml($block->getContainerTypeByCode($params->getContainer())) ?>
+                                    <?= $escaper->escapeHtml($block->getContainerTypeByCode($params->getContainer())) ?>
                                 </td>
                             </tr>
                             <tr>
                             <?php if ($block->displayCustomsValue()): ?>
-                                <th><?= $block->escapeHtml(__('Customs Value')) ?></th>
-                                <td><?= $block->escapeHtml($block->displayCustomsPrice($params->getCustomsValue())) ?>
+                                <th><?= $escaper->escapeHtml(__('Customs Value')) ?></th>
+                                <td><?= $escaper->escapeHtml($block->displayCustomsPrice($params->getCustomsValue())) ?>
                                 </td>
                             <?php else: ?>
-                                <th><?= $block->escapeHtml(__('Total Weight')) ?></th>
-                                <td><?= $block->escapeHtml($params->getWeight() . ' ' .
+                                <th><?= $escaper->escapeHtml(__('Total Weight')) ?></th>
+                                <td><?= $escaper->escapeHtml($params->getWeight() . ' ' .
                                         $carrierHelper->getMeasureWeightName($params->getWeightUnits())) ?>
                                 </td>
                             <?php endif; ?>
                             </tr>
                         <?php if ($params->getSize()): ?>
                             <tr>
-                                <th><?= $block->escapeHtml(__('Size')) ?></th>
-                                <td><?= $block->escapeHtml(ucfirst(strtolower($params->getSize()))) ?></td>
+                                <th><?= $escaper->escapeHtml(__('Size')) ?></th>
+                                <td><?= $escaper->escapeHtml(ucfirst(strtolower($params->getSize()))) ?></td>
                             </tr>
                         <?php endif; ?>
                         </tbody>
@@ -54,10 +57,10 @@ $carrierHelper = $block->getData('carrierHelper');
                     <table class="admin__table-secondary">
                         <tbody>
                             <tr>
-                                <th><?= $block->escapeHtml(__('Length')) ?></th>
+                                <th><?= $escaper->escapeHtml(__('Length')) ?></th>
                                 <td>
                                 <?php if ($params->getLength() != null): ?>
-                                    <?= $block->escapeHtml($params->getLength() . ' ' .
+                                    <?= $escaper->escapeHtml($params->getLength() . ' ' .
                                         $carrierHelper->getMeasureDimensionName($params->getDimensionUnits())) ?>
                                 <?php else: ?>
                                     --
@@ -65,10 +68,10 @@ $carrierHelper = $block->getData('carrierHelper');
                                 </td>
                             </tr>
                             <tr>
-                                <th><?= $block->escapeHtml(__('Width')) ?></th>
+                                <th><?= $escaper->escapeHtml(__('Width')) ?></th>
                                 <td>
                                 <?php if ($params->getWidth() != null): ?>
-                                    <?= $block->escapeHtml($params->getWidth() . ' ' .
+                                    <?= $escaper->escapeHtml($params->getWidth() . ' ' .
                                         $carrierHelper->getMeasureDimensionName($params->getDimensionUnits())) ?>
                                 <?php else: ?>
                                     --
@@ -76,10 +79,10 @@ $carrierHelper = $block->getData('carrierHelper');
                                 </td>
                             </tr>
                             <tr>
-                                <th><?= $block->escapeHtml(__('Height')) ?></th>
+                                <th><?= $escaper->escapeHtml(__('Height')) ?></th>
                                 <td>
                                 <?php if ($params->getHeight() != null): ?>
-                                    <?= $block->escapeHtml($params->getHeight() . ' ' .
+                                    <?= $escaper->escapeHtml($params->getHeight() . ' ' .
                                         $carrierHelper->getMeasureDimensionName($params->getDimensionUnits())) ?>
                                 <?php else: ?>
                                     --
@@ -94,29 +97,29 @@ $carrierHelper = $block->getData('carrierHelper');
                         <tbody>
                         <?php if ($params->getDeliveryConfirmation() != null): ?>
                             <tr>
-                                <th><?= $block->escapeHtml(__('Signature Confirmation')) ?></th>
+                                <th><?= $escaper->escapeHtml(__('Signature Confirmation')) ?></th>
                                 <td>
-                                    <?= $block->escapeHtml(
+                                    <?= $escaper->escapeHtml(
                                         $block->getDeliveryConfirmationTypeByCode($params->getDeliveryConfirmation())
                                     ) ?></td>
                             </tr>
                         <?php endif; ?>
                         <?php if ($params->getContentType() != null): ?>
                             <tr>
-                                <th><?= $block->escapeHtml(__('Contents')) ?></th>
+                                <th><?= $escaper->escapeHtml(__('Contents')) ?></th>
                                 <?php if ($params->getContentType() == 'OTHER'): ?>
-                                    <td><?= $block->escapeHtml($params->getContentTypeOther()) ?></td>
+                                    <td><?= $escaper->escapeHtml($params->getContentTypeOther()) ?></td>
                                 <?php else: ?>
                                     <td>
-                                        <?= $block->escapeHtml($block->getContentTypeByCode($params->getContentType()))
+                                        <?= $escaper->escapeHtml($block->getContentTypeByCode($params->getContentType()))
                                         ?></td>
                                 <?php endif; ?>
                             </tr>
                         <?php endif; ?>
                         <?php if ($params->getGirth()): ?>
                             <tr>
-                                <th><?= $block->escapeHtml(__('Girth')) ?></th>
-                                <td><?= $block->escapeHtml($params->getGirth() . ' ' .
+                                <th><?= $escaper->escapeHtml(__('Girth')) ?></th>
+                                <td><?= $escaper->escapeHtml($params->getGirth() . ' ' .
                                         $carrierHelper->getMeasureDimensionName($params->getGirthDimensionUnits())) ?>
                                 </td>
                             </tr>
@@ -127,19 +130,19 @@ $carrierHelper = $block->getData('carrierHelper');
             </div>
         </div>
         <div class="admin__page-section-item-title">
-            <span class="title"><?= $block->escapeHtml(__('Items in the Package')) ?></span>
+            <span class="title"><?= $escaper->escapeHtml(__('Items in the Package')) ?></span>
         </div>
         <div class="admin__table-wrapper">
             <table class="data-table admin__table-primary">
                 <thead>
                 <tr class="headings">
-                    <th class="col-product"><span><?= $block->escapeHtml(__('Product')) ?></span></th>
-                    <th class="col-weight"><span><?= $block->escapeHtml(__('Weight')) ?></span></th>
+                    <th class="col-product"><span><?= $escaper->escapeHtml(__('Product')) ?></span></th>
+                    <th class="col-weight"><span><?= $escaper->escapeHtml(__('Weight')) ?></span></th>
                     <?php if ($block->displayCustomsValue()): ?>
-                        <th class="col-custom"><span><?= $block->escapeHtml(__('Customs Value')) ?></span></th>
+                        <th class="col-custom"><span><?= $escaper->escapeHtml(__('Customs Value')) ?></span></th>
                     <?php endif; ?>
-                    <th class="col-qty"><span><?= $block->escapeHtml(__('Qty Ordered')) ?></span></th>
-                    <th class="col-qty"><span><?= $block->escapeHtml(__('Qty')) ?></span></th>
+                    <th class="col-qty"><span><?= $escaper->escapeHtml(__('Qty Ordered')) ?></span></th>
+                    <th class="col-qty"><span><?= $escaper->escapeHtml(__('Qty')) ?></span></th>
                 </tr>
                 </thead>
                 <tbody id="">
@@ -147,18 +150,18 @@ $carrierHelper = $block->getData('carrierHelper');
                     <?php $item = new \Magento\Framework\DataObject($item) ?>
                     <tr title="#" id="">
                         <td class="col-product">
-                            <?= $block->escapeHtml($item->getName()) ?>
+                            <?= $escaper->escapeHtml($item->getName()) ?>
                         </td>
                         <td class="col-weight">
-                            <?= $block->escapeHtml($item->getWeight()) ?>
+                            <?= $escaper->escapeHtml($item->getWeight()) ?>
                         </td>
                         <?php if ($block->displayCustomsValue()): ?>
                             <td class="col-custom">
-                                <?= $block->escapeHtml($block->displayCustomsPrice($item->getCustomsValue())) ?>
+                                <?= $escaper->escapeHtml($block->displayCustomsPrice($item->getCustomsValue())) ?>
                             </td>
                         <?php endif; ?>
                         <td class="col-qty">
-                            <?= $block->escapeHtml($block->getQtyOrderedItem($item->getOrderItemId())) ?>
+                            <?= $escaper->escapeHtml($block->getQtyOrderedItem($item->getOrderItemId())) ?>
                         </td>
                         <td class="col-qty">
                             <?= /* @noEscape */ $item->getQty()*1 ?>
@@ -186,8 +189,8 @@ script;
         "#packed_window": {
             "Magento_Shipping/js/packages":{
                 "type":"slide",
-                "title":"<?= $block->escapeHtml(__('Packages')) ?>",
-                "url": "<?= $block->escapeUrl($block->getPrintButton()) ?>"
+                "title":"<?= $escaper->escapeHtml(__('Packages')) ?>",
+                "url": "<?= $escaper->escapeUrl($block->getPrintButton()) ?>"
             }
         }
     }

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/popup.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/popup.phtml
@@ -8,6 +8,7 @@
 
 /**
  * @var $block \Magento\Shipping\Block\Adminhtml\Order\Packaging
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -37,7 +38,7 @@ $girthEnabled = $block->isDisplayGirthValue() && $block->isGirthAllowed() ? 1 : 
             packaging.sendCreateLabelRequest();
         });
         packaging.setLabelCreatedCallback(function(response){
-            setLocation("{$block->escapeJs($block->getUrl(
+            setLocation("{$escaper->escapeJs($block->getUrl(
                 'sales/order/view',
                 ['order_id' => $block->getShipment()->getOrderId()]
             ))}");
@@ -61,23 +62,23 @@ $girthEnabled = $block->isDisplayGirthValue() && $block->isGirthAllowed() ? 1 : 
         });
         jQuery('#packaging_window').modal({
             type: 'slide',
-            title: '{$block->escapeJs(__('Create Packages'))}',
+            title: '{$escaper->escapeJs(__('Create Packages'))}',
             buttons: [{
-                text: '{$block->escapeJs(__('Cancel'))}',
+                text: '{$escaper->escapeJs(__('Cancel'))}',
                 'class': 'action-secondary',
                 click: function () {
                     packaging.cancelPackaging();
                     this.closeModal();
                     }
                 }, {
-                text: '{$block->escapeJs(__('Save'))}',
+                text: '{$escaper->escapeJs(__('Save'))}',
                 'attr': {'disabled':'disabled', 'data-action':'save-packages'},
                 'class': 'action-primary _disabled',
                 click: function () {
                     packaging.confirmPackaging();
                     }
                 }, {
-                    text: '{$block->escapeJs(__('Add Package'))}',
+                    text: '{$escaper->escapeJs(__('Add Package'))}',
                     'attr': {'data-action':'add-packages'},
                     'class': 'action-secondary',
                     click: function () {

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/popup_content.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/popup_content.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var \Magento\Shipping\Block\Adminhtml\Order\Packaging $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -14,18 +15,18 @@
     <section class="admin__page-section" id="package_template">
         <div class="admin__page-section-title">
             <span class="title">
-                <?= $block->escapeHtml(__('Package')) ?> <span data-role="package-number"></span>
+                <?= $escaper->escapeHtml(__('Package')) ?> <span data-role="package-number"></span>
             </span>
             <div class="actions _primary">
                 <button type="button"
                         class="action-secondary"
                         data-action="package-save-items">
-                    <span><?= $block->escapeHtml(__('Add Selected Product(s) to Package')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Add Selected Product(s) to Package')) ?></span>
                 </button>
                 <button type="button"
                         class="action-secondary"
                         data-action="package-add-items">
-                    <span><?= $block->escapeHtml(__('Add Products to Package')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Add Products to Package')) ?></span>
                 </button>
             </div>
         </div>
@@ -33,25 +34,25 @@
             <table class="data-table admin__control-table">
                 <thead>
                     <tr>
-                        <th class="col-type"><?= $block->escapeHtml(__('Type')) ?></th>
+                        <th class="col-type"><?= $escaper->escapeHtml(__('Type')) ?></th>
                         <?php if ($girthEnabled == 1): ?>
-                        <th class="col-size"><?= $block->escapeHtml(__('Size')) ?></th>
-                        <th class="col-girth"><?= $block->escapeHtml(__('Girth')) ?></th>
+                        <th class="col-size"><?= $escaper->escapeHtml(__('Size')) ?></th>
+                        <th class="col-girth"><?= $escaper->escapeHtml(__('Girth')) ?></th>
                         <th>&nbsp;</th>
                         <?php endif; ?>
                         <th class="col-custom">
-                            <?= $block->escapeHtml(__('Customs Value')) ?>
+                            <?= $escaper->escapeHtml(__('Customs Value')) ?>
                         </th>
                         <?php if (!$block->displayCustomsValue()): ?>
                             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag('display: none', 'th.col-custom') ?>
                         <?php endif ?>
-                        <th class="col-total-weight"><?= $block->escapeHtml(__('Total Weight')) ?></th>
-                        <th class="col-length"><?= $block->escapeHtml(__('Length')) ?></th>
-                        <th class="col-width"><?= $block->escapeHtml(__('Width')) ?></th>
-                        <th class="col-height"><?= $block->escapeHtml(__('Height')) ?></th>
+                        <th class="col-total-weight"><?= $escaper->escapeHtml(__('Total Weight')) ?></th>
+                        <th class="col-length"><?= $escaper->escapeHtml(__('Length')) ?></th>
+                        <th class="col-width"><?= $escaper->escapeHtml(__('Width')) ?></th>
+                        <th class="col-height"><?= $escaper->escapeHtml(__('Height')) ?></th>
                         <th>&nbsp;</th>
                         <?php if ($block->getDeliveryConfirmationTypes()): ?>
-                        <th class="col-signature"><?= $block->escapeHtml(__('Signature Confirmation')) ?></th>
+                        <th class="col-signature"><?= $escaper->escapeHtml(__('Signature Confirmation')) ?></th>
                         <?php endif; ?>
                         <th class="col-actions">&nbsp;</th>
                     </tr>
@@ -63,7 +64,7 @@
                             <?php $containers = $block->getContainers(); ?>
                             <select name="package_container"
                                     <?php if (empty($containers)): ?>
-                                        title="<?= $block->escapeHtmlAttr(__(
+                                        title="<?= $escaper->escapeHtmlAttr(__(
                                             'USPS domestic shipments don\'t use package types.'
                                         )) ?>"
                                         disabled=""
@@ -72,8 +73,8 @@
                                         class="admin__control-select"
                                     <?php endif; ?>>
                                 <?php foreach ($containers as $key => $value): ?>
-                                    <option value="<?= $block->escapeHtmlAttr($key) ?>" >
-                                        <?= $block->escapeHtml($value) ?>
+                                    <option value="<?= $escaper->escapeHtmlAttr($key) ?>" >
+                                        <?= $escaper->escapeHtml($value) ?>
                                     </option>
                                 <?php endforeach; ?>
                             </select>
@@ -82,8 +83,8 @@
                         <td>
                             <select name="package_size" class="admin__control-select">
                                 <?php foreach ($sizeSource as $key => $value): ?>
-                                <option value="<?= $block->escapeHtmlAttr($sizeSource[$key]['value']) ?>">
-                                    <?= $block->escapeHtml($sizeSource[$key]['label']) ?>
+                                <option value="<?= $escaper->escapeHtmlAttr($sizeSource[$key]['value']) ?>">
+                                    <?= $escaper->escapeHtml($sizeSource[$key]['label']) ?>
                                 </option>
                                 <?php endforeach; ?>
                             </select>
@@ -97,10 +98,10 @@
                             <select name="container_girth_dimension_units"
                                     class="options-units-dimensions measures admin__control-select">
                                 <option value="<?= /* @noEscape */ Zend_Measure_Length::INCH ?>" selected="selected" >
-                                    <?= $block->escapeHtml(__('in')) ?>
+                                    <?= $escaper->escapeHtml(__('in')) ?>
                                 </option>
                                 <option value="<?= /* @noEscape */ Zend_Measure_Length::CENTIMETER ?>" >
-                                    <?= $block->escapeHtml(__('cm')) ?>
+                                    <?= $escaper->escapeHtml(__('cm')) ?>
                                 </option>
                             </select>
                         </td>
@@ -120,7 +121,7 @@
                                        name="package_customs_value" />
                                 <span class="admin__addon-suffix">
                                     <span class="customs-value-currency">
-                                        <?= $block->escapeHtml($block->getCustomValueCurrencyCode()) ?>
+                                        <?= $escaper->escapeHtml($block->getCustomValueCurrencyCode()) ?>
                                     </span>
                                 </span>
                             </div>
@@ -137,10 +138,10 @@
                                     <select name="container_weight_units"
                                             class="options-units-weight measures admin__control-select">
                                         <option value="<?= /* @noEscape */ Zend_Measure_Weight::POUND
-                                        ?>" selected="selected"  ><?= $block->escapeHtml(__('lb')) ?>
+                                        ?>" selected="selected"  ><?= $escaper->escapeHtml(__('lb')) ?>
                                         </option>
                                         <option value="<?= /* @noEscape */ Zend_Measure_Weight::KILOGRAM ?>" >
-                                            <?= $block->escapeHtml(__('kg')) ?>
+                                            <?= $escaper->escapeHtml(__('kg')) ?>
                                         </option>
                                     </select>
                                 <span class="admin__addon-prefix"></span>
@@ -165,10 +166,10 @@
                             <select name="container_dimension_units"
                                     class="options-units-dimensions measures admin__control-select">
                                 <option value="<?= /* @noEscape */ Zend_Measure_Length::INCH ?>" selected="selected" >
-                                    <?= $block->escapeHtml(__('in')) ?>
+                                    <?= $escaper->escapeHtml(__('in')) ?>
                                 </option>
                                 <option value="<?= /* @noEscape */ Zend_Measure_Length::CENTIMETER ?>" >
-                                    <?= $block->escapeHtml(__('cm')) ?>
+                                    <?= $escaper->escapeHtml(__('cm')) ?>
                                 </option>
                             </select>
                         </td>
@@ -176,8 +177,8 @@
                         <td>
                             <select name="delivery_confirmation_types" class="admin__control-select">
                                 <?php foreach ($block->getDeliveryConfirmationTypes() as $key => $value): ?>
-                                <option value="<?= $block->escapeHtmlAttr($key) ?>" >
-                                    <?= $block->escapeHtml($value) ?>
+                                <option value="<?= $escaper->escapeHtmlAttr($key) ?>" >
+                                    <?= $escaper->escapeHtml($value) ?>
                                 </option>
                                 <?php endforeach; ?>
                             </select>
@@ -186,7 +187,7 @@
                         <td class="col-actions">
                             <button type="button"
                                     class="action-delete DeletePackageBtn">
-                                <span><?= $block->escapeHtml(__('Delete Package')) ?></span>
+                                <span><?= $escaper->escapeHtml(__('Delete Package')) ?></span>
                             </button>
                         </td>
                     </tr>
@@ -196,8 +197,8 @@
                 <table class="data-table admin__control-table" cellspacing="0">
                     <thead>
                         <tr>
-                            <th><?= $block->escapeHtml(__('Contents')) ?></th>
-                            <th><?= $block->escapeHtml(__('Explanation')) ?></th>
+                            <th><?= $escaper->escapeHtml(__('Contents')) ?></th>
+                            <th><?= $escaper->escapeHtml(__('Explanation')) ?></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -206,8 +207,8 @@
                             <select name="content_type"
                                     class="admin__control-select">
                                 <?php foreach ($block->getContentTypes() as $key => $value): ?>
-                                    <option value="<?= $block->escapeHtmlAttr($key) ?>" >
-                                        <?= $block->escapeHtml($value) ?>
+                                    <option value="<?= $escaper->escapeHtmlAttr($key) ?>" >
+                                        <?= $escaper->escapeHtml($value) ?>
                                     </option>
                                 <?php endforeach; ?>
                             </select>
@@ -238,7 +239,7 @@ require(['jquery'], function($){
     $("div#packages_content").on('change', "select[name='package_container']",
         function(){
             packaging.changeContainerType(this);
-            packaging.checkSizeAndGirthParameter(this, {$block->escapeJs($girthEnabled)})
+            packaging.checkSizeAndGirthParameter(this, {$escaper->escapeJs($girthEnabled)})
         });
     $("div#packages_content").on('change', "select[name='container_weight_units']",
         function(){packaging.changeMeasures(this)});
@@ -250,7 +251,7 @@ script;
     if ($girthEnabled == 1 && !empty($sizeSource)) {
         $scriptString .= <<<script
     $("div#packages_content").on('change', "select[name='package_size']",
-        function(){packaging.checkSizeAndGirthParameter(this, {$block->escapeJs($girthEnabled)})});
+        function(){packaging.checkSizeAndGirthParameter(this, {$escaper->escapeJs($girthEnabled)})});
     $("div#packages_content").on('change', "select[name='container_girth_dimension_units']",
         function(){packaging.changeMeasures(this)});
 script;

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking.phtml
@@ -7,6 +7,7 @@
 <?php
 /**
  * @var $block Magento\Shipping\Block\Adminhtml\Order\Tracking
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -76,7 +77,7 @@ script;
                     class="select admin__control-select carrier"
                     disabled="disabled">
                 <?php foreach ($block->getCarriers() as $_code => $_name): ?>
-                    <option value="<?= $block->escapeHtmlAttr($_code) ?>"><?= $block->escapeHtml($_name) ?></option>
+                    <option value="<?= $escaper->escapeHtmlAttr($_code) ?>"><?= $escaper->escapeHtml($_name) ?></option>
                 <?php endforeach; ?>
             </select>
         </td>
@@ -101,7 +102,7 @@ script;
                 type="button"
                 class="action-default action-delete"
                 onclick="trackingControl.deleteRow(event);return false">
-                <span><?= $block->escapeHtml(__('Delete')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Delete')) ?></span>
             </button>
         </td>
     </tr>
@@ -111,10 +112,10 @@ script;
     <table class="data-table admin__control-table" id="tracking_numbers_table">
         <thead>
         <tr class="headings">
-            <th class="col-carrier"><?= $block->escapeHtml(__('Carrier')) ?></th>
-            <th class="col-title"><?= $block->escapeHtml(__('Title')) ?></th>
-            <th class="col-number"><?= $block->escapeHtml(__('Number')) ?></th>
-            <th class="col-delete"><?= $block->escapeHtml(__('Action')) ?></th>
+            <th class="col-carrier"><?= $escaper->escapeHtml(__('Carrier')) ?></th>
+            <th class="col-title"><?= $escaper->escapeHtml(__('Title')) ?></th>
+            <th class="col-number"><?= $escaper->escapeHtml(__('Number')) ?></th>
+            <th class="col-delete"><?= $escaper->escapeHtml(__('Action')) ?></th>
         </tr>
         </thead>
         <tfoot>

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking/view.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking/view.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var $block Magento\Shipping\Block\Adminhtml\Order\Tracking\View
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 
@@ -17,10 +18,10 @@ $shippingHelper = $block->getData('shippingHelper');
         <table class="data-table admin__control-table" id="shipment_tracking_info">
             <thead>
                 <tr class="headings">
-                    <th class="col-carrier"><?= $block->escapeHtml(__('Carrier')) ?></th>
-                    <th class="col-title"><?= $block->escapeHtml(__('Title')) ?></th>
-                    <th class="col-number"><?= $block->escapeHtml(__('Number')) ?></th>
-                    <th class="col-delete last"><?= $block->escapeHtml(__('Action')) ?></th>
+                    <th class="col-carrier"><?= $escaper->escapeHtml(__('Carrier')) ?></th>
+                    <th class="col-title"><?= $escaper->escapeHtml(__('Title')) ?></th>
+                    <th class="col-number"><?= $escaper->escapeHtml(__('Number')) ?></th>
+                    <th class="col-delete last"><?= $escaper->escapeHtml(__('Action')) ?></th>
                 </tr>
             </thead>
             <tfoot>
@@ -28,8 +29,8 @@ $shippingHelper = $block->getData('shippingHelper');
                     <td class="col-carrier">
                         <select name="carrier" class="select admin__control-select">
                             <?php foreach ($block->getCarriers() as $_code => $_name): ?>
-                            <option value="<?= $block->escapeHtmlAttr($_code) ?>">
-                                <?= $block->escapeHtml($_name) ?></option>
+                            <option value="<?= $escaper->escapeHtmlAttr($_code) ?>">
+                                <?= $escaper->escapeHtml($_name) ?></option>
                             <?php endforeach; ?>
                         </select>
                         <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
@@ -60,20 +61,20 @@ $shippingHelper = $block->getData('shippingHelper');
             <?php $i = 0; foreach ($_tracks as $_track): $i++ ?>
                 <tr class="<?= /* @noEscape */ ($i%2 == 0) ? 'even' : 'odd' ?>">
                     <td class="col-carrier">
-                        <?= $block->escapeHtml($block->getCarrierTitle($_track->getCarrierCode())) ?>
+                        <?= $escaper->escapeHtml($block->getCarrierTitle($_track->getCarrierCode())) ?>
                     </td>
-                    <td class="col-title"><?= $block->escapeHtml($_track->getTitle()) ?></td>
+                    <td class="col-title"><?= $escaper->escapeHtml($_track->getTitle()) ?></td>
                     <td class="col-number">
                         <?php if ($_track->isCustom()): ?>
-                            <?= $block->escapeHtml($_track->getNumber()) ?>
+                            <?= $escaper->escapeHtml($_track->getNumber()) ?>
                         <?php else: ?>
                         <a id="col-track-<?= (int) $_track->getId() ?>" href="#">
-                            <?= $block->escapeHtml($_track->getNumber()) ?>
+                            <?= $escaper->escapeHtml($_track->getNumber()) ?>
                          </a>
                             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                 'onclick',
                                 "event.preventDefault();
-                                popWin('{$block->escapeJs($shippingHelper->getTrackingPopupUrlBySalesModel($_track))}',
+                                popWin('{$escaper->escapeJs($shippingHelper->getTrackingPopupUrlBySalesModel($_track))}',
                                 'trackorder','width=800,height=600,resizable=yes,scrollbars=yes')",
                                 'a#col-track-' .  (int) $_track->getId()
                             ) ?>
@@ -82,12 +83,12 @@ $shippingHelper = $block->getData('shippingHelper');
                     </td>
                     <td class="col-delete last">
                         <button class="action-delete" type="button" id="del-track-<?= (int) $_track->getId() ?>">
-                            <span><?= $block->escapeHtml(__('Delete')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Delete')) ?></span>
                         </button>
                     </td>
                     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                         'onclick',
-                        "deleteTrackingNumber('{$block->escapeJs($block->getRemoveUrl($_track))}');
+                        "deleteTrackingNumber('{$escaper->escapeJs($block->getRemoveUrl($_track))}');
                          event.preventDefault();",
                         '#del-track-' . (int) $_track->getId()
                     ) ?>
@@ -117,7 +118,7 @@ function saveTrackingInfo(node, url) {
 
 function deleteTrackingNumber(url) {
     confirm({
-        content: '{$block->escapeJs(__('Are you sure?'))}',
+        content: '{$escaper->escapeJs(__('Are you sure?'))}',
         actions: {
             /**
              * Confirm action.

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/view/info.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/view/info.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var $block \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 
@@ -22,24 +23,24 @@ endif; ?>
 <?php /* Shipping Method */ ?>
 <div class="admin__page-section-item order-shipping-method">
     <div class="admin__page-section-item-title">
-        <span class="title"><?= $block->escapeHtml(__('Shipping &amp; Handling Information')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Shipping &amp; Handling Information')) ?></span>
     </div>
     <div class="admin__page-section-item-content">
         <?php  if ($order->getTracksCollection()->count()): ?>
             <p>
-                <a href="#" id="linkId" title="<?= $block->escapeHtmlAttr(__('Track Order')) ?>">
-                    <?= $block->escapeHtml(__('Track Order')) ?>
+                <a href="#" id="linkId" title="<?= $escaper->escapeHtmlAttr(__('Track Order')) ?>">
+                    <?= $escaper->escapeHtml(__('Track Order')) ?>
                 </a>
             </p>
             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                 'onclick',
-                "popWin('" . $block->escapeJs($shippingHelper->getTrackingPopupUrlBySalesModel($order)) .
+                "popWin('" . $escaper->escapeJs($shippingHelper->getTrackingPopupUrlBySalesModel($order)) .
                 "','trackorder','width=800,height=600,resizable=yes,scrollbars=yes')",
                 'a#linkId'
             ) ?>
         <?php endif; ?>
         <?php if ($order->getShippingDescription()): ?>
-            <strong><?= $block->escapeHtml($order->getShippingDescription()) ?></strong>
+            <strong><?= $escaper->escapeHtml($order->getShippingDescription()) ?></strong>
 
             <?php if ($taxHelper->displayShippingPriceIncludingTax()): ?>
                 <?php $_excl = $block->displayShippingPriceInclTax($order); ?>
@@ -50,10 +51,10 @@ endif; ?>
 
             <?= /** @noEscape */ $_excl ?>
             <?php if ($taxHelper->displayShippingBothPrices() && $_incl != $_excl): ?>
-                (<?= $block->escapeHtml(__('Incl. Tax')) ?> <?= /** @noEscape */ $_incl ?>)
+                (<?= $escaper->escapeHtml(__('Incl. Tax')) ?> <?= /** @noEscape */ $_incl ?>)
             <?php endif; ?>
         <?php else: ?>
-            <?= $block->escapeHtml(__('No shipping information available')) ?>
+            <?= $escaper->escapeHtml(__('No shipping information available')) ?>
         <?php endif; ?>
     </div>
 </div>

--- a/app/code/Magento/Shipping/view/adminhtml/templates/view/form.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/view/form.phtml
@@ -5,6 +5,7 @@
  */
 /**
  * @var \Magento\Shipping\Block\Adminhtml\View\Form $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 
@@ -18,36 +19,36 @@ $order = $block->getShipment()->getOrder();
 <?= $block->getChildHtml('order_info'); ?>
 <section class="admin__page-section order-shipment-billing-shipping">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Payment &amp; Shipping Method')); ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Payment &amp; Shipping Method')); ?></span>
     </div>
     <div class="admin__page-section-content">
         <div class="admin__page-section-item order-payment-method">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Payment Information')); ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Payment Information')); ?></span>
             </div>
             <div class="admin__page-section-item-content">
                 <div><?= $block->getChildHtml('order_payment') ?></div>
                 <div class="order-payment-currency">
-                    <?= $block->escapeHtml(__('The order was placed using %1.', $order->getOrderCurrencyCode())); ?>
+                    <?= $escaper->escapeHtml(__('The order was placed using %1.', $order->getOrderCurrencyCode())); ?>
                 </div>
             </div>
         </div>
 
         <div class="admin__page-section-item order-shipping-address">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Shipping and Tracking Information')); ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Shipping and Tracking Information')); ?></span>
             </div>
             <div class="admin__page-section-item-content">
                 <div class="shipping-description-wrapper">
                     <?php if ($block->getShipment()->getTracksCollection()->count()): ?>
                         <p>
-                            <a href="#" id="linkId" title="<?= $block->escapeHtml(__('Track this shipment')); ?>">
-                                <?= $block->escapeHtml(__('Track this shipment')); ?>
+                            <a href="#" id="linkId" title="<?= $escaper->escapeHtml(__('Track this shipment')); ?>">
+                                <?= $escaper->escapeHtml(__('Track this shipment')); ?>
                             </a>
                             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                 'onclick',
                                 'event.preventDefault();' .
-                                "popWin('{$block->escapeJs($shippingHelper->getTrackingPopupUrlBySalesModel(
+                                "popWin('{$escaper->escapeJs($shippingHelper->getTrackingPopupUrlBySalesModel(
                                     $block->getShipment()
                                     ))}','trackshipment','width=800,height=600,resizable=yes,scrollbars=yes')",
                                 'a#linkId'
@@ -55,10 +56,10 @@ $order = $block->getShipment()->getOrder();
                         </p>
                     <?php endif; ?>
                     <div class="shipping-description-title">
-                        <?= $block->escapeHtml($order->getShippingDescription()); ?>
+                        <?= $escaper->escapeHtml($order->getShippingDescription()); ?>
                     </div>
 
-                    <?= $block->escapeHtml(__('Total Shipping Charges')); ?>:
+                    <?= $escaper->escapeHtml(__('Total Shipping Charges')); ?>:
 
                     <?php if ($taxHelper->displayShippingPriceIncludingTax()): ?>
                         <?php $excl = $block->displayShippingPriceInclTax($order); ?>
@@ -69,7 +70,7 @@ $order = $block->getShipment()->getOrder();
 
                     <?= /* @noEscape */ $excl; ?>
                     <?php if ($taxHelper->displayShippingBothPrices() && $incl != $excl): ?>
-                        (<?= $block->escapeHtml(__('Incl. Tax')); ?> <?= /* @noEscape */ $incl; ?>)
+                        (<?= $escaper->escapeHtml(__('Incl. Tax')); ?> <?= /* @noEscape */ $incl; ?>)
                     <?php endif; ?>
                 </div>
 
@@ -98,7 +99,7 @@ $order = $block->getShipment()->getOrder();
                                 window.packaging.sendCreateLabelRequest();
                             });
                             window.packaging.setLabelCreatedCallback(function () {
-                                setLocation("{$block->escapeJs($block->getUrl(
+                                setLocation("{$escaper->escapeJs($block->getUrl(
                                         'adminhtml/order_shipment/view',
                                         ['shipment_id' => $block->getShipment()->getId()]
                                     ))}");
@@ -123,21 +124,21 @@ script;
 
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Items Shipped')); ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Items Shipped')); ?></span>
     </div>
     <?= $block->getChildHtml('shipment_items'); ?>
 </section>
 
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('Order Total')); ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('Order Total')); ?></span>
     </div>
     <div class="admin__page-section-content">
         <?= $block->getChildHtml('shipment_packed'); ?>
 
         <div class="admin__page-section-item order-comments-history">
             <div class="admin__page-section-item-title">
-                <span class="title"><?= $block->escapeHtml(__('Shipment History')); ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Shipment History')); ?></span>
             </div>
             <div class="admin__page-section-item-content"><?= $block->getChildHtml('order_comments'); ?></div>
         </div>

--- a/app/code/Magento/Shipping/view/adminhtml/templates/view/items.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/view/items.phtml
@@ -3,13 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+/**
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 <div class="admin__table-wrapper">
     <table class="data-table admin__table-primary order-shipment-table">
         <thead>
             <tr class="headings">
-                <th class="col-product"><span><?= $block->escapeHtml(__('Product')) ?></span></th>
-                <th class="col-qty last"><span><?= $block->escapeHtml(__('Qty Shipped')) ?></span></th>
+                <th class="col-product"><span><?= $escaper->escapeHtml(__('Product')) ?></span></th>
+                <th class="col-qty last"><span><?= $escaper->escapeHtml(__('Qty Shipped')) ?></span></th>
             </tr>
         </thead>
         <?php $_items = $block->getShipment()->getAllItems() ?>

--- a/app/code/Magento/Shipping/view/frontend/templates/items.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/items.phtml
@@ -14,34 +14,34 @@
     <?php if ($_order->getTracksCollection()->count()) : ?>
         <?= $block->getChildHtml('track-all-link') ?>
     <?php endif; ?>
-    <a href="<?= $block->escapeUrl($block->getPrintAllShipmentsUrl($_order)) ?>"
+    <a href="<?= $escaper->escapeUrl($block->getPrintAllShipmentsUrl($_order)) ?>"
        class="action print"
        target="_blank"
        rel="noopener">
-        <span><?= $block->escapeHtml(__('Print All Shipments')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Print All Shipments')) ?></span>
     </a>
 </div>
 <?php foreach ($_order->getShipmentsCollection() as $_shipment) : ?>
     <div class="order-title">
-        <strong><?= $block->escapeHtml(__('Shipment #')) ?><?= $block->escapeHtml($_shipment->getIncrementId()) ?></strong>
-        <a href="<?= $block->escapeUrl($block->getPrintShipmentUrl($_shipment)) ?>"
+        <strong><?= $escaper->escapeHtml(__('Shipment #')) ?><?= $escaper->escapeHtml($_shipment->getIncrementId()) ?></strong>
+        <a href="<?= $escaper->escapeUrl($block->getPrintShipmentUrl($_shipment)) ?>"
            class="action print"
            target="_blank"
            rel="noopener">
-            <span><?= $block->escapeHtml(__('Print Shipment')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Print Shipment')) ?></span>
         </a>
         <a href="#"
-           data-mage-init='{"popupWindow": {"windowURL":"<?= $block->escapeUrl($this->helper(Magento\Shipping\Helper\Data::class)->getTrackingPopupUrlBySalesModel($_shipment)) ?>","windowName":"trackshipment","width":800,"height":600,"top":0,"left":0,"resizable":1,"scrollbars":1}}'
-           title="<?= $block->escapeHtml(__('Track this shipment')) ?>"
+           data-mage-init='{"popupWindow": {"windowURL":"<?= $escaper->escapeUrl($this->helper(Magento\Shipping\Helper\Data::class)->getTrackingPopupUrlBySalesModel($_shipment)) ?>","windowName":"trackshipment","width":800,"height":600,"top":0,"left":0,"resizable":1,"scrollbars":1}}'
+           title="<?= $escaper->escapeHtml(__('Track this shipment')) ?>"
            class="action track">
-            <span><?= $block->escapeHtml(__('Track this shipment')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Track this shipment')) ?></span>
         </a>
     </div>
     <?php $tracks = $_shipment->getTracksCollection(); ?>
     <?php  if ($tracks->count()) : ?>
         <dl class="order-tracking" id="my-tracking-table-<?= (int) $_shipment->getId() ?>">
             <dt class="tracking-title">
-                <?= $block->escapeHtml(__('Tracking Number(s):')) ?>
+                <?= $escaper->escapeHtml(__('Tracking Number(s):')) ?>
             </dt>
             <dd class="tracking-content">
                 <?php
@@ -49,11 +49,11 @@
                 $_size = $tracks->count();
                 foreach ($tracks as $track) : ?>
                     <?php if ($track->isCustom()) : ?>
-                        <?= $block->escapeHtml($track->getNumber()) ?>
+                        <?= $escaper->escapeHtml($track->getNumber()) ?>
                     <?php else : ?>
                         <a href="#"
-                            data-mage-init='{"popupWindow": {"windowURL":"<?= $block->escapeUrl($this->helper(Magento\Shipping\Helper\Data::class)->getTrackingPopupUrlBySalesModel($track)) ?>","windowName":"trackorder","width":800,"height":600,"left":0,"top":0,"resizable":1,"scrollbars":1}}'
-                            class="action track"><span><?= $block->escapeHtml($track->getNumber()) ?></span>
+                            data-mage-init='{"popupWindow": {"windowURL":"<?= $escaper->escapeUrl($this->helper(Magento\Shipping\Helper\Data::class)->getTrackingPopupUrlBySalesModel($track)) ?>","windowName":"trackorder","width":800,"height":600,"left":0,"top":0,"resizable":1,"scrollbars":1}}'
+                            class="action track"><span><?= $escaper->escapeHtml($track->getNumber()) ?></span>
                             </a>
                     <?php endif; ?>
                     <?php if ($i != $_size) : ?>, <?php endif; ?>
@@ -64,12 +64,12 @@
     <?php  endif; ?>
     <div class="table-wrapper order-items-shipment">
         <table class="data table table-order-items shipment" id="my-shipment-table-<?= (int) $_shipment->getId() ?>">
-            <caption class="table-caption"><?= $block->escapeHtml(__('Items Shipped')) ?></caption>
+            <caption class="table-caption"><?= $escaper->escapeHtml(__('Items Shipped')) ?></caption>
             <thead>
                 <tr>
-                    <th class="col name"><?= $block->escapeHtml(__('Product Name')) ?></th>
-                    <th class="col sku"><?= $block->escapeHtml(__('SKU')) ?></th>
-                    <th class="col qty"><?= $block->escapeHtml(__('Qty Shipped')) ?></th>
+                    <th class="col name"><?= $escaper->escapeHtml(__('Product Name')) ?></th>
+                    <th class="col sku"><?= $escaper->escapeHtml(__('SKU')) ?></th>
+                    <th class="col qty"><?= $escaper->escapeHtml(__('Qty Shipped')) ?></th>
                 </tr>
             </thead>
             <?php $_items = $_shipment->getAllItems(); ?>

--- a/app/code/Magento/Shipping/view/frontend/templates/order/shipment.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/order/shipment.phtml
@@ -8,8 +8,8 @@
     <?= $block->getChildHtml('shipment_items') ?>
     <div class="actions-toolbar">
         <div class="secondary">
-            <a href="<?= $block->escapeUrl($block->getBackUrl()) ?>" class="action back">
-                <span><?= $block->escapeHtml($block->getBackTitle()) ?></span>
+            <a href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>" class="action back">
+                <span><?= $escaper->escapeHtml($block->getBackTitle()) ?></span>
             </a>
         </div>
     </div>

--- a/app/code/Magento/Shipping/view/frontend/templates/tracking/details.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/tracking/details.phtml
@@ -20,47 +20,47 @@ $fields = [
 ];
 $number = is_object($track) ? $track->getTracking() : $track['number'];
 ?>
-<table class="data table order tracking" id="tracking-table-popup-<?= $block->escapeHtml($number) ?>">
-    <caption class="table-caption"><?= $block->escapeHtml(__('Order tracking')) ?></caption>
+<table class="data table order tracking" id="tracking-table-popup-<?= $escaper->escapeHtml($number) ?>">
+    <caption class="table-caption"><?= $escaper->escapeHtml(__('Order tracking')) ?></caption>
     <tbody>
     <?php if (is_object($track)) : ?>
         <tr>
-            <th class="col label" scope="row"><?= $block->escapeHtml(__('Tracking Number:')) ?></th>
-            <td class="col value"><?= $block->escapeHtml($number) ?></td>
+            <th class="col label" scope="row"><?= $escaper->escapeHtml(__('Tracking Number:')) ?></th>
+            <td class="col value"><?= $escaper->escapeHtml($number) ?></td>
         </tr>
         <?php if ($track->getCarrierTitle()) : ?>
             <tr>
-                <th class="col label" scope="row"><?= $block->escapeHtml(__('Carrier:')) ?></th>
-                <td class="col value"><?= $block->escapeHtml($track->getCarrierTitle()) ?></td>
+                <th class="col label" scope="row"><?= $escaper->escapeHtml(__('Carrier:')) ?></th>
+                <td class="col value"><?= $escaper->escapeHtml($track->getCarrierTitle()) ?></td>
             </tr>
         <?php endif; ?>
         <?php if ($track->getErrorMessage()) : ?>
             <tr>
-                <th class="col label" scope="row"><?= $block->escapeHtml(__('Error:')) ?></th>
+                <th class="col label" scope="row"><?= $escaper->escapeHtml(__('Error:')) ?></th>
                 <td class="col error">
-                    <?= $block->escapeHtml(__('Tracking information is currently not available. Please ')) ?>
+                    <?= $escaper->escapeHtml(__('Tracking information is currently not available. Please ')) ?>
                     <?php if ($parentBlock->getContactUsEnabled()) : ?>
-                        <a href="<?= $block->escapeUrl($parentBlock->getContactUs()) ?>" target="_blank"
-                           title="<?= $block->escapeHtml(__('contact us')) ?>">
-                            <?= $block->escapeHtml(__('contact us')) ?>
+                        <a href="<?= $escaper->escapeUrl($parentBlock->getContactUs()) ?>" target="_blank"
+                           title="<?= $escaper->escapeHtml(__('contact us')) ?>">
+                            <?= $escaper->escapeHtml(__('contact us')) ?>
                         </a>
-                        <?= $block->escapeHtml(__(' for more information or ')) ?>
+                        <?= $escaper->escapeHtml(__(' for more information or ')) ?>
                     <?php endif; ?>
-                    <?= $block->escapeHtml(__('email us at ')) ?>
+                    <?= $escaper->escapeHtml(__('email us at ')) ?>
                     <a href="mailto:<?= /* @noEscape */ $email ?>"><?= /* @noEscape */ $email ?></a>
                 </td>
             </tr>
         <?php elseif ($track->getTrackSummary()) : ?>
             <tr>
-                <th class="col label" scope="row"><?= $block->escapeHtml(__('Info:')) ?></th>
-                <td class="col value"><?= $block->escapeHtml($track->getTrackSummary()) ?></td>
+                <th class="col label" scope="row"><?= $escaper->escapeHtml(__('Info:')) ?></th>
+                <td class="col value"><?= $escaper->escapeHtml($track->getTrackSummary()) ?></td>
             </tr>
         <?php elseif ($track->getUrl()) : ?>
             <tr>
-                <th class="col label" scope="row"><?= $block->escapeHtml(__('Track:')) ?></th>
+                <th class="col label" scope="row"><?= $escaper->escapeHtml(__('Track:')) ?></th>
                 <td class="col value">
-                    <a href="<?= $block->escapeUrl($track->getUrl()) ?>" target="_blank">
-                        <?= $block->escapeUrl($track->getUrl()) ?>
+                    <a href="<?= $escaper->escapeUrl($track->getUrl()) ?>" target="_blank">
+                        <?= $escaper->escapeUrl($track->getUrl()) ?>
                     </a>
                 </td>
             </tr>
@@ -68,15 +68,15 @@ $number = is_object($track) ? $track->getTracking() : $track['number'];
             <?php foreach ($fields as $title => $property) : ?>
                 <?php if (!empty($track->$property())) : ?>
                     <tr>
-                        <th class="col label" scope="row"><?= /* @noEscape */ $block->escapeHtml(__($title . ':')) ?></th>
-                        <td class="col value"><?= $block->escapeHtml($track->$property()) ?></td>
+                        <th class="col label" scope="row"><?= /* @noEscape */ $escaper->escapeHtml(__($title . ':')) ?></th>
+                        <td class="col value"><?= $escaper->escapeHtml($track->$property()) ?></td>
                     </tr>
                 <?php endif;?>
             <?php endforeach; ?>
 
             <?php if ($track->getDeliverydate()) : ?>
                 <tr>
-                    <th class="col label" scope="row"><?= $block->escapeHtml($parentBlock->getDeliveryDateTitle()->getTitle($track)) ?></th>
+                    <th class="col label" scope="row"><?= $escaper->escapeHtml($parentBlock->getDeliveryDateTitle()->getTitle($track)) ?></th>
                     <td class="col value">
                         <?= /* @noEscape */ $parentBlock->formatDeliveryDateTime($track->getDeliverydate(), $track->getDeliverytime()) ?>
                     </td>
@@ -87,9 +87,9 @@ $number = is_object($track) ? $track->getTracking() : $track['number'];
         <?php /* if the tracking is custom value */ ?>
         <tr>
             <th class="col label" scope="row">
-                <?= ($track['title'] ? $block->escapeHtml($track['title']) : $block->escapeHtml(__('N/A'))) ?>:
+                <?= ($track['title'] ? $escaper->escapeHtml($track['title']) : $escaper->escapeHtml(__('N/A'))) ?>:
             </th>
-            <td class="col value"><?= (isset($track['number']) ? $block->escapeHtml($track['number']) : '') ?></td>
+            <td class="col value"><?= (isset($track['number']) ? $escaper->escapeHtml($track['number']) : '') ?></td>
         </tr>
     <?php endif; ?>
     </tbody>

--- a/app/code/Magento/Shipping/view/frontend/templates/tracking/link.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/tracking/link.phtml
@@ -6,9 +6,9 @@
 ?>
 <?php /** @var $block \Magento\Shipping\Block\Tracking\Link */ ?>
 <?php $order = $block->getOrder() ?>
-<a href="#" class="action track" title="<?= $block->escapeHtmlAttr($block->getLabel()) ?>"
+<a href="#" class="action track" title="<?= $escaper->escapeHtmlAttr($block->getLabel()) ?>"
    data-mage-init='{"popupWindow": {
-        "windowURL":"<?= $block->escapeUrl($block->getWindowUrl($order)) ?>",
+        "windowURL":"<?= $escaper->escapeUrl($block->getWindowUrl($order)) ?>",
         "windowName":"trackorder",
         "width":800,
         "height":600,
@@ -17,5 +17,5 @@
         "resizable":1,
         "scrollbars":1
     }}'>
-    <span><?= $block->escapeHtml($block->getLabel()) ?></span>
+    <span><?= $escaper->escapeHtml($block->getLabel()) ?></span>
 </a>

--- a/app/code/Magento/Shipping/view/frontend/templates/tracking/popup.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/tracking/popup.phtml
@@ -18,7 +18,7 @@ $results = $block->getTrackingInfo();
         <?php foreach ($results as $shipId => $result): ?>
             <?php if ($shipId): ?>
                 <div class="order subtitle caption">
-                    <?= /* @noEscape */ $block->escapeHtml(__('Shipment #')) . $shipId ?>
+                    <?= /* @noEscape */ $escaper->escapeHtml(__('Shipment #')) . $shipId ?>
                 </div>
             <?php endif; ?>
             <?php if (!empty($result)): ?>
@@ -49,20 +49,20 @@ $results = $block->getTrackingInfo();
                 <?php endforeach; ?>
             <?php else: ?>
                 <div class="message info empty">
-                    <div><?= $block->escapeHtml(__('There is no tracking available for this shipment.')) ?></div>
+                    <div><?= $escaper->escapeHtml(__('There is no tracking available for this shipment.')) ?></div>
                 </div>
             <?php endif; ?>
         <?php endforeach; ?>
     <?php else: ?>
         <div class="message info empty">
-            <div><?= $block->escapeHtml(__('There is no tracking available.')) ?></div>
+            <div><?= $escaper->escapeHtml(__('There is no tracking available.')) ?></div>
         </div>
     <?php endif; ?>
     <div class="actions">
         <button type="button"
-                title="<?= $block->escapeHtml(__('Close Window')) ?>"
+                title="<?= $escaper->escapeHtml(__('Close Window')) ?>"
                 class="action close">
-            <span><?= $block->escapeHtml(__('Close Window')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Close Window')) ?></span>
         </button>
         <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
             'onclick',

--- a/app/code/Magento/Shipping/view/frontend/templates/tracking/progress.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/tracking/progress.phtml
@@ -9,14 +9,14 @@ $parentBlock = $block->getParentBlock();
 $track = $block->getData('track');
 ?>
 <div class="table-wrapper">
-    <table class="data table order tracking" id="track-history-table-<?= $block->escapeHtml($track->getTracking()) ?>">
-        <caption class="table-caption"><?= $block->escapeHtml(__('Track history')) ?></caption>
+    <table class="data table order tracking" id="track-history-table-<?= $escaper->escapeHtml($track->getTracking()) ?>">
+        <caption class="table-caption"><?= $escaper->escapeHtml(__('Track history')) ?></caption>
         <thead>
         <tr>
-            <th class="col location" scope="col"><?= $block->escapeHtml(__('Location')) ?></th>
-            <th class="col date" scope="col"><?= $block->escapeHtml(__('Date')) ?></th>
-            <th class="col time" scope="col"><?= $block->escapeHtml(__('Local Time')) ?></th>
-            <th class="col description" scope="col"><?= $block->escapeHtml(__('Description')) ?></th>
+            <th class="col location" scope="col"><?= $escaper->escapeHtml(__('Location')) ?></th>
+            <th class="col date" scope="col"><?= $escaper->escapeHtml(__('Date')) ?></th>
+            <th class="col time" scope="col"><?= $escaper->escapeHtml(__('Local Time')) ?></th>
+            <th class="col description" scope="col"><?= $escaper->escapeHtml(__('Description')) ?></th>
         </tr>
         </thead>
         <tbody>
@@ -28,16 +28,16 @@ $track = $block->getData('track');
                 $parentBlock->formatDeliveryTime($detail['deliverytime'], $detail['deliverydate']) :
                 ''); ?>
             <tr>
-                <td data-th="<?= $block->escapeHtml(__('Location')) ?>" class="col location">
-                    <?= (!empty($detail['deliverylocation']) ? $block->escapeHtml($detail['deliverylocation']) : '') ?>
+                <td data-th="<?= $escaper->escapeHtml(__('Location')) ?>" class="col location">
+                    <?= (!empty($detail['deliverylocation']) ? $escaper->escapeHtml($detail['deliverylocation']) : '') ?>
                 </td>
-                <td data-th="<?= $block->escapeHtml(__('Date')) ?>" class="col date">
+                <td data-th="<?= $escaper->escapeHtml(__('Date')) ?>" class="col date">
                     <?= /* @noEscape */ $detailDate ?>
                 </td>
-                <td data-th="<?= $block->escapeHtml(__('Local Time')) ?>" class="col time">
+                <td data-th="<?= $escaper->escapeHtml(__('Local Time')) ?>" class="col time">
                     <?= /* @noEscape */ $detailTime ?></td>
-                <td data-th="<?= $block->escapeHtml(__('Description')) ?>" class="col description">
-                    <?= (!empty($detail['activity']) ? $block->escapeHtml($detail['activity']) : '') ?>
+                <td data-th="<?= $escaper->escapeHtml(__('Description')) ?>" class="col description">
+                    <?= (!empty($detail['activity']) ? $escaper->escapeHtml($detail['activity']) : '') ?>
                 </td>
             </tr>
         <?php endforeach; ?>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
