### PR TITLE
Magento_Security: avoid using deprecated escape* methods from Abstrac…

### DIFF
--- a/app/code/Magento/Security/view/adminhtml/templates/page/activity_link.phtml
+++ b/app/code/Magento/Security/view/adminhtml/templates/page/activity_link.phtml
@@ -8,15 +8,16 @@
  * Account activity template
  *
  * @var $block \Magento\Framework\View\Element\Template
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <a class="link-account-activity"
-    href="<?= $block->escapeUrl($block->getUrl('security/session/activity')) ?>"
+    href="<?= $escaper->escapeUrl($block->getUrl('security/session/activity')) ?>"
     id="footer_account_activity"
     target="_blank"
     data-mage-init='{"popupWindow": {
-        "windowURL": "<?= $block->escapeJs($block->escapeUrl($block->getUrl('security/session/activity'))) ?>",
+        "windowURL": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getUrl('security/session/activity'))) ?>",
         "windowName": "session-activity",
         "width": 600, "height": 600, "top": 50, "left": 50, "resizable": 1, "scrollbars": 1}}'>
-    <?= $block->escapeHtml(__('Account Activity')) ?>
+    <?= $escaper->escapeHtml(__('Account Activity')) ?>
 </a> |

--- a/app/code/Magento/Security/view/adminhtml/templates/session/activity.phtml
+++ b/app/code/Magento/Security/view/adminhtml/templates/session/activity.phtml
@@ -14,10 +14,10 @@ $sessionInfoCollection = $block->getSessionInfoCollection();
 ?>
 <header>
     <div class="page-title-wrapper">
-        <h1 class="page-title" align="center"><?= $block->escapeHtml(__('Account Activity')) ?></h1>
+        <h1 class="page-title" align="center"><?= $escaper->escapeHtml(__('Account Activity')) ?></h1>
         <?php
         if ($block->areMultipleSessionsActive()) {
-            echo $block->escapeHtml(__(
+            echo $escaper->escapeHtml(__(
                 'This administrator account is open in more than one location. '
                 .'Note that other locations might be different browsers or sessions on the same computer.'
             ));
@@ -28,20 +28,20 @@ $sessionInfoCollection = $block->getSessionInfoCollection();
 <div class="page-content">
     <?= $block->getLayout()->getMessagesBlock()->getGroupedHtml() ?>
     <div>
-        <div class="information-title"><?= $block->escapeHtml(__('Concurrent session information:')) ?></div>
+        <div class="information-title"><?= $escaper->escapeHtml(__('Concurrent session information:')) ?></div>
         <table cellspacing="0" border="1" class="information-table">
             <thead>
                 <tr>
-                    <th><?= $block->escapeHtml(__('IP Address')) ?></th>
-                    <th><?= $block->escapeHtml(__('Time of session start')) ?></th>
+                    <th><?= $escaper->escapeHtml(__('IP Address')) ?></th>
+                    <th><?= $escaper->escapeHtml(__('Time of session start')) ?></th>
                 </tr>
             </thead>
             <tbody>
             <?php
             foreach ($sessionInfoCollection as $item) : ?>
                 <tr>
-                    <td><?= $block->escapeHtml($item->getFormattedIp()) ?></td>
-                    <td><?= $block->escapeHtml($block->formatDateTime($item->getCreatedAt())) ?></td>
+                    <td><?= $escaper->escapeHtml($item->getFormattedIp()) ?></td>
+                    <td><?= $escaper->escapeHtml($block->formatDateTime($item->getCreatedAt())) ?></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>
@@ -52,19 +52,19 @@ $sessionInfoCollection = $block->getSessionInfoCollection();
                 <?php if ($block->areMultipleSessionsActive()) : ?>
                     data-mage-init='{"confirmRedirect":{
                         "message": "<?=
-                            $block->escapeJs(__('Are you sure that you want to log out all other sessions?'))
+                            $escaper->escapeJs(__('Are you sure that you want to log out all other sessions?'))
                         ?>",
                         "url":"<?=
-                            $block->escapeJs($block->escapeUrl($block->getUrl('security/session/logoutAll')))
+                            $escaper->escapeJs($escaper->escapeUrl($block->getUrl('security/session/logoutAll')))
                         ?>"
                     }}'
                 <?php else : ?>disabled<?php
                 endif ?>
-                title="<?= $block->escapeHtmlAttr(__('Log out all other sessions')) ?>">
-                <?= $block->escapeHtml(__('Log out all other sessions')) ?>
+                title="<?= $escaper->escapeHtmlAttr(__('Log out all other sessions')) ?>">
+                <?= $escaper->escapeHtml(__('Log out all other sessions')) ?>
             </button>
         </div>
 
-        <div><?= $block->escapeHtml(__('This computer is using IP address %1.', $block->getRemoteIp())) ?></div>
+        <div><?= $escaper->escapeHtml(__('This computer is using IP address %1.', $block->getRemoteIp())) ?></div>
     </div>
 </div>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
