### PR TITLE
Magento_Search: avoid using deprecated escape* methods from AbstractB…

### DIFF
--- a/app/code/Magento/Search/Block/Adminhtml/Term/Edit.php
+++ b/app/code/Magento/Search/Block/Adminhtml/Term/Edit.php
@@ -55,7 +55,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
     public function getHeaderText()
     {
         if ($this->coreRegistry->registry('current_catalog_search')->getId()) {
-            $queryText = $this->escapeHtml($this->coreRegistry->registry('current_catalog_search')->getQueryText());
+            $queryText = $this->_escaper->escapeHtml($this->coreRegistry->registry('current_catalog_search')->getQueryText());
             return __("Edit Search '%1'", $queryText);
         } else {
             return __('New Search');

--- a/app/code/Magento/Search/view/frontend/templates/term.phtml
+++ b/app/code/Magento/Search/view/frontend/templates/term.phtml
@@ -6,6 +6,7 @@
 
 /**
  * @var \Magento\Search\Block\Term $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -13,8 +14,8 @@
     <ul class="search-terms">
         <?php foreach ($block->getTerms() as $_term): ?>
             <li id="term-<?= /* @noEscape */ $_term->getId() ?>" class="item">
-                <a href="<?= $block->escapeUrl($block->getSearchUrl($_term)) ?>">
-                    <?= $block->escapeHtml($_term->getQueryText()) ?>
+                <a href="<?= $escaper->escapeUrl($block->getSearchUrl($_term)) ?>">
+                    <?= $escaper->escapeHtml($_term->getQueryText()) ?>
                 </a>
             </li>
             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
@@ -25,6 +26,6 @@
     </ul>
 <?php else: ?>
     <div class="message notice">
-        <div><?= $block->escapeHtml(__('There are no search terms available.')) ?></div>
+        <div><?= $escaper->escapeHtml(__('There are no search terms available.')) ?></div>
     </div>
 <?php endif; ?>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
