### PR TITLE
Magento_Rss: avoid using deprecated escape* methods from AbstractBlock

### DIFF
--- a/app/code/Magento/Rss/view/frontend/templates/feeds.phtml
+++ b/app/code/Magento/Rss/view/frontend/templates/feeds.phtml
@@ -4,28 +4,31 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Rss\Block\Feeds $block */
+/**
+ * @var \Magento\Rss\Block\Feeds $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
 
 ?>
 <table class="data table rss">
-    <caption class="table-caption"><?= $block->escapeHtml(__('Feed')) ?></caption>
+    <caption class="table-caption"><?= $escaper->escapeHtml(__('Feed')) ?></caption>
     <tbody>
-        <th colspan="2" scope="col"><?= $block->escapeHtml(__('Miscellaneous Feeds')) ?></th>
+        <th colspan="2" scope="col"><?= $escaper->escapeHtml(__('Miscellaneous Feeds')) ?></th>
     <?php foreach ($block->getFeeds() as $feed) : ?>
         <?php if (!isset($feed['group'])) : ?>
         <tr>
-            <td class="col feed"><?= $block->escapeHtml($feed['label']) ?></td>
+            <td class="col feed"><?= $escaper->escapeHtml($feed['label']) ?></td>
             <td class="col action">
-                <a href="<?= $block->escapeUrl($feed['link']) ?>" class="action get"><span><?= $block->escapeHtml(__('Get Feed')) ?></span></a>
+                <a href="<?= $escaper->escapeUrl($feed['link']) ?>" class="action get"><span><?= $escaper->escapeHtml(__('Get Feed')) ?></span></a>
             </td>
         </tr>
         <?php else : ?>
-            <th colspan="2" scope="col"><?= $block->escapeHtml($feed['group']) ?></th>
+            <th colspan="2" scope="col"><?= $escaper->escapeHtml($feed['group']) ?></th>
             <?php foreach ($feed['feeds'] as $item) :?>
                 <tr>
-                    <td class="col feed"><?= $block->escapeHtml($item['label']) ?></td>
+                    <td class="col feed"><?= $escaper->escapeHtml($item['label']) ?></td>
                     <td class="col action">
-                        <a href="<?= $block->escapeUrl($item['link']) ?>" class="action get"><span><?= $block->escapeHtml(__('Get Feed')) ?></span></a>
+                        <a href="<?= $escaper->escapeUrl($item['link']) ?>" class="action get"><span><?= $escaper->escapeHtml(__('Get Feed')) ?></span></a>
                     </td>
                 </tr>
             <?php endforeach; ?>


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
