### PR TITLE
Magento_Eav: avoid using deprecated escape* methods from AbstractBlock

### DIFF
--- a/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Options/Options.php
+++ b/app/code/Magento/Eav/Block/Adminhtml/Attribute/Edit/Options/Options.php
@@ -264,7 +264,7 @@ class Options extends \Magento\Backend\Block\Template
         foreach ($this->getStores() as $store) {
             $storeId = $store->getId();
             $value['store' . $storeId] = $storeId ==
-            \Magento\Store\Model\Store::DEFAULT_STORE_ID ? $valuePrefix . $this->escapeHtml($option['label']) : '';
+            \Magento\Store\Model\Store::DEFAULT_STORE_ID ? $valuePrefix . $this->_escaper->escapeHtml($option['label']) : '';
         }
 
         return [$value];
@@ -292,7 +292,7 @@ class Options extends \Magento\Backend\Block\Template
             $storeValues = $this->getStoreOptionValues($storeId);
             $value['store' . $storeId] = isset(
                 $storeValues[$optionId]
-            ) ? $this->escapeHtml(
+            ) ? $this->_escaper->escapeHtml(
                 $storeValues[$optionId]
             ) : '';
         }


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
