### PR TITLE
Magento_Rule: avoid using deprecated escape* methods from AbstractBlock

### DIFF
--- a/app/code/Magento/Rule/Block/Editable.php
+++ b/app/code/Magento/Rule/Block/Editable.php
@@ -54,15 +54,15 @@ class Editable extends AbstractBlock implements RendererInterface
 
         if ($element->getShowAsText()) {
             $html = ' <input type="hidden" class="hidden" id="' .
-                $this->escapeHtmlAttr($element->getHtmlId()) .
+                $this->_escaper->escapeHtmlAttr($element->getHtmlId()) .
                 '" name="' .
-                $this->escapeHtmlAttr($element->getName()) .
+                $this->_escaper->escapeHtmlAttr($element->getName()) .
                 '" value="' .
-                $this->escapeHtmlAttr($element->getValue()) .
+                $this->_escaper->escapeHtmlAttr($element->getValue()) .
                 '" data-form-part="' .
-                $this->escapeHtmlAttr($element->getData('data-form-part')) .
+                $this->_escaper->escapeHtmlAttr($element->getData('data-form-part')) .
                 '"/> ' .
-                $this->escapeHtml(
+                $this->_escaper->escapeHtml(
                     $valueName
                 ) . '&nbsp;';
         } else {
@@ -74,9 +74,9 @@ class Editable extends AbstractBlock implements RendererInterface
                 '<a href="javascript:void(0)" class="label">';
 
             if ($this->inlineTranslate->isAllowed()) {
-                $html .= $this->escapeHtml($valueName);
+                $html .= $this->_escaper->escapeHtml($valueName);
             } else {
-                $html .= $this->escapeHtml(
+                $html .= $this->_escaper->escapeHtml(
                     $this->filterManager->truncate($valueName, ['length' => 33, 'etc' => '...'])
                 );
             }


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
