### PR TITLE
Magento_SalesRule: avoid using deprecated escape* methods from Abstra…

### DIFF
--- a/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Widget/Chooser.php
+++ b/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Widget/Chooser.php
@@ -91,7 +91,7 @@ class Chooser extends \Magento\Backend\Block\Widget\Grid\Extended
         if ($element->getValue()) {
             $rule = $this->ruleFactory->create()->load((int)$element->getValue());
             if ($rule->getId()) {
-                $chooser->setLabel($this->escapeHtml($rule->getName()));
+                $chooser->setLabel($this->_escaper->escapeHtml($rule->getName()));
             }
         }
 


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
