### PR TITLE
Magento_Variable: avoid using deprecated escape* methods from Abstrac…

### DIFF
--- a/app/code/Magento/Variable/Block/System/Variable/Edit.php
+++ b/app/code/Magento/Variable/Block/System/Variable/Edit.php
@@ -101,7 +101,7 @@ class Edit extends \Magento\Backend\Block\Widget\Form\Container
     public function getHeaderText()
     {
         if ($this->getVariable()->getId()) {
-            return __('Custom Variable "%1"', $this->escapeHtml($this->getVariable()->getName()));
+            return __('Custom Variable "%1"', $this->_escaper->escapeHtml($this->getVariable()->getName()));
         } else {
             return __('New Custom Variable');
         }


### PR DESCRIPTION
### Description (*)

Avoid using deprecated escape* methods from AbstractBlock

### Related Pull Requests

https://github.com/magento/magento2/pull/31610

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
