### PR TITLE
Unable to add configurable product to cart on any non-default store view

### DIFF
--- a/app/code/Magento/ConfigurableProductGraphQl/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
+++ b/app/code/Magento/ConfigurableProductGraphQl/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
@@ -93,7 +93,7 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
             throw new GraphQlNoSuchEntityException(__('Could not find specified product.'));
         }
 
-        $this->checkProductStock($sku, (float) $qty, (int) $cart->getStoreId());
+        $this->checkProductStock($sku, (float) $qty, (int) $cart->getStore()->getWebsite()->getId());
 
         $configurableProductLinks = $parentProduct->getExtensionAttributes()->getConfigurableProductLinks();
         if (!in_array($product->getId(), $configurableProductLinks)) {

--- a/app/code/Magento/QuoteGraphQl/Model/Cart/AddSimpleProductToCart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/AddSimpleProductToCart.php
@@ -63,7 +63,7 @@ class AddSimpleProductToCart
 
         try {
             $result = $cart->addProduct($product, $this->buyRequestBuilder->build($cartItemData));
-        } catch (Exception $e) {
+        } catch (Exception $e) {die($e);
             throw new GraphQlInputException(
                 __(
                     'Could not add the product with SKU %sku to the shopping cart: %message',

--- a/app/code/Magento/QuoteGraphQl/Model/Cart/AddSimpleProductToCart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/AddSimpleProductToCart.php
@@ -63,7 +63,7 @@ class AddSimpleProductToCart
 
         try {
             $result = $cart->addProduct($product, $this->buyRequestBuilder->build($cartItemData));
-        } catch (Exception $e) {die($e);
+        } catch (Exception $e) {
             throw new GraphQlInputException(
                 __(
                     'Could not add the product with SKU %sku to the shopping cart: %message',

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/AddConfigurableProductToCartTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/ConfigurableProduct/AddConfigurableProductToCartTest.php
@@ -417,6 +417,44 @@ QUERY;
     }
 
     /**
+     * @magentoApiDataFixture Magento/ConfigurableProduct/_files/product_configurable.php
+     * @magentoApiDataFixture Magento/Checkout/_files/active_quote.php
+     * @magentoApiDataFixture Magento/Store/_files/second_store.php
+     */
+    public function testAddConfigurableProductToCartWithDifferentStoreHeader()
+    {
+        $searchResponse = $this->graphQlQuery($this->getFetchProductQuery('configurable'));
+        $product = current($searchResponse['products']['items']);
+
+        $quantity = 2;
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_order_1');
+        $parentSku = $product['sku'];
+        $sku = 'simple_20';
+        $attributeId = (int) $product['configurable_options'][0]['attribute_id'];
+        $optionId = $product['configurable_options'][0]['values'][1]['value_index'];
+
+        $query = $this->getQuery(
+            $maskedQuoteId,
+            $parentSku,
+            $sku,
+            $quantity
+        );
+        $headerMap = ['Store' => 'fixture_second_store'];
+        $response = $this->graphQlMutation($query, [], '', $headerMap);
+
+        $cartItem = current($response['addConfigurableProductsToCart']['cart']['items']);
+        self::assertEquals($quantity, $cartItem['quantity']);
+        self::assertEquals($parentSku, $cartItem['product']['sku']);
+        self::assertArrayHasKey('configurable_options', $cartItem);
+
+        $option = current($cartItem['configurable_options']);
+        self::assertEquals($attributeId, $option['id']);
+        self::assertEquals($optionId, $option['value_id']);
+        self::assertArrayHasKey('option_label', $option);
+        self::assertArrayHasKey('value_label', $option);
+    }
+
+    /**
      * @param string $maskedQuoteId
      * @param string $parentSku
      * @param string $sku


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
**Note: Simple Products work across website/store code, this bug is specific to configurable products**

PWA Repro:

URL - <https://integration-5ojmyuq-jnz3dtiuj77ca.us-4.magentosite.cloud/montana-wind-jacket.html>

**Steps -** 

    Go to above URL.

    Switch to French Store and try adding configurable to to cart.

 

**Expected -** Product should get added.

Actual - User gets error "Could not add item to cart. Please check required options and try again."

**GQL Repro:**

    Using a backend on 2.4.2-beta3, create a cart
    Attempt to add a configurable item to the "french" store:

// Query
```
mutation addConfigurableProductToCart(
  $cartId: String!
  $quantity: Float!
  $sku: String!
  $parentSku: String!
) {
  addConfigurableProductsToCart(
    input: {
      cart_id: $cartId
      cart_items: [
        { data: { quantity: $quantity, sku: $sku }, parent_sku: $parentSku }
      ]
    }
  ) {
    cart {
      id
      total_quantity
    }
  }
}
{code}

{code:java}
// Query Variables
{
  "cartId":"9cfw1jBRxnyyic8jVoBLXELkDOZtobJ4",
  "quantity": 1,
  "sku": "WT09-XL-Yellow",
  "parentSku": "WT09"
} {code}
{code:java}
// Header
{ 
  "store": "fr" 
}{code}
 

Expected:
{code:java}
 {
  "data": {
    "addConfigurableProductsToCart": {
      "cart": {
        "id": "9cfw1jBRxnyyic8jVoBLXELkDOZtobJ4",
        "total_quantity": 4
      }
    }
  }
}{code}
 

Actual:
{code:java}
{
  "errors": [
    {
      "message": "Could not add the product with SKU WT09 to the shopping cart: The website with id 2 that was requested wasn't found. Verify the website and try again.",
      "extensions": {
        "category": "graphql-input"
      },
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "addConfigurableProductsToCart"
      ]
    }
  >,
  "data": {
    "addConfigurableProductsToCart": null
  }
} 
```
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes https://github.com/magento/magento2/issues/31660

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
