### PR TITLE
fix to Vimeo Video not Found Issue #31753

### DIFF
--- a/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
+++ b/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
@@ -316,7 +316,7 @@ define([
                 }
 
                 src = 'https://player.vimeo.com/video/' +
-                    this._code + '?api=1&player_id=vimeo' +
+                    this._code + '?api=2&player_id=vimeo' +
                     this._code +
                     timestamp +
                     additionalParams;
@@ -493,6 +493,9 @@ define([
                 /**
                  * @private
                  */
+                function jsonResults(json){
+                   return json;
+                }
                 function _onVimeoLoaded(data) {
                     var tmp,
                         respData;
@@ -539,8 +542,9 @@ define([
                     );
                 } else if (type === 'vimeo') {
                     $.ajax({
-                        url: 'https://www.vimeo.com/api/v2/video/' + id + '.json',
+                        url: 'https://vimeo.com/api/v2/video/' + id + '.json',
                         dataType: 'jsonp',
+                        jsonpCallback:"jsonResults",
                         data: {
                             format: 'json'
                         },


### PR DESCRIPTION
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Change to file app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
     - Issue Vimeo Product Video Not Found #31753,
     - Manual testing scenarios - Unable to add Vimeo Video to Product Catalog Edit Image Form



### Description (*)
<!---
   Changes to line 319. Add a JS Function to read Json on line 396. Added "jsonpCallback:"jsonResults","
-->

### Related Pull Requests
<!-- https://github.com/magento/magento2/pull/31767 -->
There is this pull request concerning the same issue but it uses oembed url and I proposed another fix because I'm not sure if oembed would raise security concerns (pull/31767)

### Fixed Issues (if relevant)
<!---
Vimeo has changed API causing incompatibility in fetching video information
Magento is now able  to fetch Vimeo Video Information  again

-->
1. Fixes magento/magento2#31753
### Manual testing scenarios (*)

1-  Change to file app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js with proposed changes
2- php magento static:content:deploy --theme Magento/backend en_US -f
3- clear cache
4- Go to product Edit Page. 
5 - Try to insert a Vimeo Video
6- Magento now fetchs video information

### Questions or comments
<!---
I would like feedback. 
-->

### Contribution checklist (*)
 - [ x] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x] All automated tests passed successfully (all builds are green)
