### PR TITLE
Video preview isssue #30324

### DIFF
--- a/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
+++ b/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
@@ -482,7 +482,7 @@ define([
                         return;
                     }
 
-                    if(this._shouldCancelVideoRequest){
+                    if (this._shouldCancelVideoRequest) {
                         return;
                     }
 
@@ -517,7 +517,7 @@ define([
 
                         return null;
                     }
-                    if(this._shouldCancelVideoRequest){
+                    if (this._shouldCancelVideoRequest) {
                         return;
                     }
                     tmp = data;

--- a/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
+++ b/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
@@ -350,9 +350,13 @@ define([
 
             _VIDEO_URL_VALIDATE_TRIGGER: 'validate_video_url',
 
+            _CANCEL_VIDEO_INFORMATION_TRIGGER: 'cancelled_video_information',
+
             _videoInformation: null,
 
             _currentVideoUrl: null,
+
+            _shouldCancelVideoRequest: false,
 
             /**
              * @private
@@ -366,6 +370,11 @@ define([
                     }, this
                 ));
                 this.element.on(this._VIDEO_URL_VALIDATE_TRIGGER, $.proxy(this._onUrlValidateHandler, this));
+                this.element.on(this._CANCEL_VIDEO_INFORMATION_TRIGGER, $.proxy(
+                    function () {
+                        this._shouldCancelVideoRequest = true;
+                    }, this
+                ));
             },
 
             /**
@@ -394,6 +403,8 @@ define([
                     type,
                     id,
                     googleapisUrl;
+
+                this._shouldCancelVideoRequest = false;
 
                 if (this._currentVideoUrl === url) {
                     return;
@@ -471,6 +482,10 @@ define([
                         return;
                     }
 
+                    if(this._shouldCancelVideoRequest){
+                        return;
+                    }
+
                     tmp = data.items[0];
                     uploadedFormatted = tmp.snippet.publishedAt.replace('T', ' ').replace(/\..+/g, '');
                     respData = {
@@ -502,6 +517,11 @@ define([
 
                         return null;
                     }
+
+                    if(this._shouldCancelVideoRequest){
+                        return;
+                    }
+
                     tmp = data[0];
                     respData = {
                         duration: this._formatVimeoDuration(tmp.duration),

--- a/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
+++ b/app/code/Magento/ProductVideo/view/adminhtml/web/js/get-video-information.js
@@ -517,6 +517,7 @@ define([
 
                         return null;
                     }
+
                     if (this._shouldCancelVideoRequest) {
                         return;
                     }

--- a/app/code/Magento/ProductVideo/view/adminhtml/web/js/new-video-dialog.js
+++ b/app/code/Magento/ProductVideo/view/adminhtml/web/js/new-video-dialog.js
@@ -722,6 +722,7 @@ define([
                     modalTitleElement = modal.find('.modal-title');
 
                     if (!file) {
+                        this._videoUrlWidget.trigger('cancelled_video_information');
                         widget._blockActionButtons(true);
 
                         modal.find('.video-delete-button').hide();
@@ -1103,6 +1104,7 @@ define([
                 this._previewImage = null;
             }
             this._tempPreviewImageData = null;
+            this._videoUrlWidget.trigger('cancelled_video_information');
             this.element.trigger('reset');
             newVideoForm = this.element.find(this._videoFormSelector);
 

--- a/app/code/Magento/ProductVideo/view/adminhtml/web/js/new-video-dialog.js
+++ b/app/code/Magento/ProductVideo/view/adminhtml/web/js/new-video-dialog.js
@@ -722,7 +722,7 @@ define([
                     modalTitleElement = modal.find('.modal-title');
 
                     if (!file) {
-                        this._videoUrlWidget.trigger('cancelled_video_information');
+                        widget._videoUrlWidget.trigger('cancelled_video_information');
                         widget._blockActionButtons(true);
 
                         modal.find('.video-delete-button').hide();

--- a/app/code/Magento/ProductVideo/view/adminhtml/web/js/new-video-dialog.js
+++ b/app/code/Magento/ProductVideo/view/adminhtml/web/js/new-video-dialog.js
@@ -246,6 +246,8 @@ define([
 
         _gallery: null,
 
+        _isUpdatingVideo: false,
+
         /**
          * Bind events
          * @private
@@ -335,6 +337,7 @@ define([
         _onGetVideoInformationSuccess: function (e, data) {
             var self = this;
 
+            this._isUpdatingVideo = true;
             self.element.on('finish_update_video finish_create_video', $.proxy(function (element, playerData) {
                     if (!self._onlyVideoPlayer ||
                         !self._isEditPage && playerData.oldVideoId !== playerData.newVideoId ||
@@ -395,6 +398,9 @@ define([
                 data: 'remote_image=' + sourceUrl,
                 type: 'post',
                 success: $.proxy(function (result) {
+                    if (!self._isUpdatingVideo) {
+                        return;
+                    }
                     this._tempPreviewImageData = result;
                     this._getPreviewImage().attr('src', sourceUrl).show();
                     this._blockActionButtons(false, true);
@@ -1098,6 +1104,7 @@ define([
 
             this._isEditPage = true;
             this.imageData = null;
+            this._isUpdatingVideo = false;
 
             if (this._previewImage) {
                 this._previewImage.remove();


### PR DESCRIPTION
### Summary
This PR fix the #30324 
The error as I understand is caused by not cancelling the video-api request. More on description below.

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
1. When making a request to the server. While the request has not been fulfilled yet, the user closes the edit modal and then opens add-new modal.
2. At the time the request finished, the user is already on the add-new-video modal, so the data from the request now renders on this new modal
3. The code make sure that it only renders new data in the correct modals/pages.

### Fixed Issues (if relevant)
magento/magento2#30324

### Manual testing scenarios (*)
1. Add setTimeout in the ajax's success function (which call _onVimeoLoaded/_onYouTubeLoaded). Keep this timeout long enough to deplay the render function.
2. Follow the steps in original issue: Add and save new video -> open edit page -> close edit page -> click "Add Video" button to open add-new-video modal

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
