### PR TITLE
Fix some nested extends have been ignored at output

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_ProductVideo/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_ProductVideo/web/css/source/_module.less
@@ -10,7 +10,7 @@
 & when (@media-common = true) {
     .fotorama-video-container {
         &:after {
-            background: url(../Magento_ProductVideo/img/gallery-sprite.png) bottom right;
+            background: url('../Magento_ProductVideo/img/gallery-sprite.png') bottom right;
             bottom: 0;
             content: '';
             height: 100px;
@@ -40,7 +40,7 @@
     }
 
     .video-thumb-icon:after {
-        background: url(../Magento_ProductVideo/img/gallery-sprite.png) bottom left;
+        background: url('../Magento_ProductVideo/img/gallery-sprite.png') bottom left;
         bottom: 0;
         content: '';
         height: 40px;

--- a/app/design/frontend/Magento/blank/web/css/source/_sources.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_sources.less
@@ -4,7 +4,7 @@
 //  */
 
 @import '_variables.less';
-@import (reference) '_extends.less';
+@import '_extends.less';
 @import '_typography.less';
 @import '_layout.less';
 @import '_tables.less';

--- a/app/design/frontend/Magento/blank/web/css/styles-l.less
+++ b/app/design/frontend/Magento/blank/web/css/styles-l.less
@@ -14,7 +14,6 @@
 //  ---------------------------------------------
 
 @import '_styles.less';
-@import (reference) 'source/_extends.less';
 
 //
 //  Magento Import instructions

--- a/app/design/frontend/Magento/blank/web/css/styles-m.less
+++ b/app/design/frontend/Magento/blank/web/css/styles-m.less
@@ -15,7 +15,6 @@
 
 @import 'source/_reset.less';
 @import '_styles.less';
-@import (reference) 'source/_extends.less';
 
 //
 //  Magento Import instructions


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Difference being that .abs- styles which extend other .abs- styles in _extends.less are not output properly when compiled with Grunt, due to being nested (e.g. .abs-action-addto-product, which extends .abs-action-link-button or .abs-account-blocks). This creates differences between production and development sites, which make some style issues invisible in a standard development workflow.

More details provide
E.g. customer account page 
https://github.com/magento/magento2/blob/2.4-develop/app/design/frontend/Magento/blank/Magento_Customer/web/css/source/_module.less#L136
call .abs-account-blocks in module.less,  

.abs-account-blocks defined  in _extends.less call to .abs-account-title
https://github.com/magento/magento2/blob/2.4-develop/app/design/frontend/Magento/blank/web/css/source/_extends.less#L197

So the results output we will miss some styles. Reason see link below describe in less docs

From less doc  describe `extending does not match selectors inside a nested @media declaration:`
Reference => http://lesscss.org/features/#extend-feature (open in new tab)

Less official doc
Link http://lesscss.org/features/#import-atrules-feature (open new tab)
![Screenshot from 2021-01-23 16-05-39](https://user-images.githubusercontent.com/1908873/105574129-117f5580-5d95-11eb-9361-ea7d49836b22.png)


Before change tests

Less compile to css by php
![Screenshot from 2021-01-16 00-23-38](https://user-images.githubusercontent.com/1908873/104758601-42f29280-5791-11eb-88a9-765d5ece3672.png)

Use grunt/lessc
Magento use grunt + grunt-contrib-less for compile
![Screenshot from 2021-01-16 00-16-55](https://user-images.githubusercontent.com/1908873/104758106-7e409180-5790-11eb-9192-d5d2c9f56a62.png)
We lost some rules styles block-title

RESULTS:

After change
Both workflow output same results (php less compile vs grunt or client less compiler)

Before remove (reference)
styles-m.css 375,4 kB 14669LOC
styles-l.css 95,1 kB 3685LOC

After Remove (reference)
styles-m.css 375,4 kB 14669LOC
styles-l.css 95,1 kB 3685LOC


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#7231
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.Create a custom theme that extends Magento/blank or Magento/luma
2.Create an _extend.less file in the custom theme
3.Add various styles to each group with the same selectors and specificity
4.Recompile CSS with either Grunt or server-side compilation
5.Confirm that all common styles in styles-m.css (including those from _extend.less) are output above all media queries

Scenario1 Server-side less compilation
Normal magento use by run commands
setup:upgrade && setup:static-content:deploy
https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/css-guide/css_quick_guide_mode.html

Scenario2 Grunt compilation
https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/css-topics/css_debug.html

Scenario 3 Less frontend compilation (backend config)
1. Enable developer mode (lessjs compile not work in production)
2. Enable Client side compilation in Advanced Configuration
(Stores > Configuration > Advanced > Developer
Frontend Development Workflow => Workflow type : Client side less compilation)
3. Save and clear cache config admin

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
CC:  @Leland @krzksz  @ptylek

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
