### PR TITLE
MC-23915: Wrong currency symbol in creditmemo_grid & sales_order_view creditmemo grid for subtotal & Shipping and Handling fee

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/Collection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/Collection.php
@@ -33,4 +33,32 @@ class Collection extends \Magento\Framework\View\Element\UiComponent\DataProvide
     ) {
         parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $mainTable, $resourceModel);
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected function _translateCondition($field, $condition)
+    {
+        if ($field !== 'order_currency_code'
+            && !isset($this->_map['fields'][$field])
+        ) {
+            $this->_map['fields'][$field] = 'main_table.' . $field;
+        }
+
+        return parent::_translateCondition($field, $condition);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function _renderFiltersBefore()
+    {
+        $this->getSelect()->joinLeft(
+            ['cgf' => $this->getTable('sales_order_grid')],
+            'main_table.order_id = cgf.entity_id',
+            [
+                'order_currency_code' => 'order_currency_code',
+            ]
+        );
+    }
 }

--- a/app/code/Magento/Sales/etc/di.xml
+++ b/app/code/Magento/Sales/etc/di.xml
@@ -834,7 +834,7 @@
                 <item name="sales_order_creditmemo_grid_data_source" xsi:type="string">Magento\Sales\Model\ResourceModel\Order\Creditmemo\Grid\Collection</item>
                 <item name="sales_order_view_invoice_grid_data_source" xsi:type="string">Magento\Sales\Model\ResourceModel\Order\Invoice\Orders\Grid\Collection</item>
                 <item name="sales_order_view_shipment_grid_data_source" xsi:type="string">Magento\Sales\Model\ResourceModel\Order\Shipment\Order\Grid\Collection</item>
-                <item name="sales_order_view_creditmemo_grid_data_source" xsi:type="string">Magento\Sales\Model\ResourceModel\Order\Creditmemo\Order\Grid\Collection</item>
+                <item name="sales_order_view_creditmemo_grid_data_source" xsi:type="string">Magento\Sales\Model\ResourceModel\Order\Creditmemo\Grid\Collection</item>
             </argument>
         </arguments>
     </type>

--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_creditmemo_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_creditmemo_grid.xml
@@ -194,14 +194,14 @@
                 <visible>false</visible>
             </settings>
         </column>
-        <column name="subtotal" class="Magento\Sales\Ui\Component\Listing\Column\Price">
+        <column name="subtotal" class="Magento\Sales\Ui\Component\Listing\Column\PurchasedPrice">
             <settings>
                 <filter>textRange</filter>
                 <label translate="true">Subtotal</label>
                 <visible>false</visible>
             </settings>
         </column>
-        <column name="shipping_and_handling" class="Magento\Sales\Ui\Component\Listing\Column\Price">
+        <column name="shipping_and_handling" class="Magento\Sales\Ui\Component\Listing\Column\PurchasedPrice">
             <settings>
                 <filter>textRange</filter>
                 <label translate="true">Shipping &amp; Handling</label>

--- a/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_view_creditmemo_grid.xml
+++ b/app/code/Magento/Sales/view/adminhtml/ui_component/sales_order_view_creditmemo_grid.xml
@@ -207,14 +207,14 @@
                 <visible>false</visible>
             </settings>
         </column>
-        <column name="subtotal" class="Magento\Sales\Ui\Component\Listing\Column\Price">
+        <column name="subtotal" class="Magento\Sales\Ui\Component\Listing\Column\PurchasedPrice">
             <settings>
                 <filter>textRange</filter>
                 <label translate="true">Subtotal</label>
                 <visible>false</visible>
             </settings>
         </column>
-        <column name="shipping_and_handling" class="Magento\Sales\Ui\Component\Listing\Column\Price">
+        <column name="shipping_and_handling" class="Magento\Sales\Ui\Component\Listing\Column\PurchasedPrice">
             <settings>
                 <filter>textRange</filter>
                 <label translate="true">Shipping &amp; Handling</label>

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/ResourceModel/Order/Creditmemo/Grid/CollectionTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Model\ResourceModel\Order\Creditmemo\Grid;
+
+use Magento\Framework\ObjectManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test Magento\Sales\Model\ResourceModel\Order\Creditmemo\Grid
+ */
+class CollectionTest extends TestCase
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/creditmemo_list.php
+     *
+     * @return void
+     */
+    public function testCollectionOrderCurrencyCodeExist(): void
+    {
+        /** @var $collection Collection */
+        $collection = $this->objectManager->get(Collection::class);
+        $collection->addFieldToFilter('increment_id', ['eq' => '456']);
+        foreach ($collection as $item) {
+            $this->assertNotNull($item->getOrderCurrencyCode());
+        }
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#22662

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See: magento/magento2#22662

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
