### PR TITLE
Fix #11175 - i18n:collect-phrases -m can't find many important Magento phrases - added parsing of the attr translations via `$t('Text')`

### DIFF
--- a/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
+++ b/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
@@ -19,23 +19,24 @@ class Html extends AbstractAdapter
      * Covers
      * <span><!-- ko i18n: 'Next'--><!-- /ko --></span>
      * <th class="col col-method" data-bind="i18n: 'Select Method'"></th>
-     * @deprecated Not used anymore because of newly introduced constant
-     * @see self::HTML_REGEX_LIST
+     * @deprecated Not used anymore because of newly introduced constants
+     * @see self::REGEX_I18N_BINDING and self::REGEX_TRANSLATE_TAG_OR_ATTR
      */
     const HTML_FILTER = "/i18n:\s?'(?<value>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'/";
 
-    private const HTML_REGEX_LIST = [
-        // <span><!-- ko i18n: 'Next'--><!-- /ko --></span>
-        // <th class="col col-method" data-bind="i18n: 'Select Method'"></th>
-        "/i18n:\s?'(?<value>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'/",
-        // <translate args="'System Messages'"/>
-        // <span translate="'Examples'"></span>
-        "/translate( args|)=\"'(?<value>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)'\"/",
-        // <a data-bind="attr: { title: $t('This is \' test \' data'), href: '#'} "></a>
-        // <input type="text" data-bind="attr: { placeholder: $t('Placeholder'), title: $t('Title') }" />
-        // Double quotes are not handled correctly in the `attr` binding. Move phrase to the UI component property if needed
-        '/\\$t\(\s*([\'"])(?<value>.*?[^\\\])\1.*?[),]/'
-    ];
+    /**
+     * Covers
+     * <span><!-- ko i18n: 'Next'--><!-- /ko --></span>
+     * <th class="col col-method" data-bind="i18n: 'Select Method'"></th>
+     */
+    public const REGEX_I18N_BINDING = '/i18n:\s?\'([^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\'/';
+
+    /**
+     * Covers
+     * <translate args="'System Messages'"/>
+     * <span translate="'Examples'"></span>
+     */
+    public const REGEX_TRANSLATE_TAG_OR_ATTR = '/translate( args|)=\"\'([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\'\"/';
 
     /**
      * @inheritdoc
@@ -63,13 +64,24 @@ class Html extends AbstractAdapter
             }
         }
 
-        foreach (self::HTML_REGEX_LIST as $regex) {
-            preg_match_all($regex, $data, $results, PREG_SET_ORDER);
+        $this->extractPhrases(self::REGEX_I18N_BINDING, $data, 2, 1);
+        $this->extractPhrases(self::REGEX_TRANSLATE_TAG_OR_ATTR, $data, 3, 2);
+        $this->extractPhrases(Js::REGEX_TRANSLATE_FUNCTION, $data, 3, 2);
+    }
 
-            for ($i = 0, $count = count($results); $i < $count; $i++) {
-                if (!empty($results[$i]['value'])) {
-                    $this->_addPhrase($results[$i]['value']);
-                }
+    /**
+     * @param string $regex
+     * @param string $data
+     * @param int $expectedGroupsCount
+     * @param int $valueGroupIndex
+     */
+    protected function extractPhrases(string $regex, string $data, int $expectedGroupsCount, int $valueGroupIndex): void
+    {
+        preg_match_all($regex, $data, $results, PREG_SET_ORDER);
+
+        for ($i = 0, $count = count($results); $i < $count; $i++) {
+            if (count($results[$i]) === $expectedGroupsCount && !empty($results[$i][$valueGroupIndex])) {
+                $this->_addPhrase($results[$i][$valueGroupIndex]);
             }
         }
     }

--- a/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
+++ b/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
@@ -22,19 +22,19 @@ class Html extends AbstractAdapter
      * @deprecated Not used anymore because of newly introduced constant
      * @see self::HTML_REGEX_LIST
      */
-    const HTML_FILTER = "/i18n:\s?'(?<value>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'/i";
+    const HTML_FILTER = "/i18n:\s?'(?<value>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'/";
 
     private const HTML_REGEX_LIST = [
         // <span><!-- ko i18n: 'Next'--><!-- /ko --></span>
         // <th class="col col-method" data-bind="i18n: 'Select Method'"></th>
-        "/i18n:\s?'(?<value>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'/i",
+        "/i18n:\s?'(?<value>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'/",
         // <translate args="'System Messages'"/>
         // <span translate="'Examples'"></span>
-        "/translate( args|)=\"'(?<value>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)'\"/i",
+        "/translate( args|)=\"'(?<value>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)'\"/",
         // <a data-bind="attr: { title: $t('This is \' test \' data'), href: '#'} "></a>
         // <input type="text" data-bind="attr: { placeholder: $t('Placeholder'), title: $t('Title') }" />
         // Double quotes are not handled correctly in the `attr` binding. Move phrase to the UI component property if needed
-        '/\\$t\(\s*([\'"])(?<value>.*?[^\\\])\1.*?[),]/i'
+        '/\\$t\(\s*([\'"])(?<value>.*?[^\\\])\1.*?[),]/'
     ];
 
     /**

--- a/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
+++ b/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
@@ -30,7 +30,11 @@ class Html extends AbstractAdapter
         "/i18n:\s?'(?<value>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'/i",
         // <translate args="'System Messages'"/>
         // <span translate="'Examples'"></span>
-        "/translate( args|)=\"'(?<value>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)'\"/i"
+        "/translate( args|)=\"'(?<value>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)'\"/i",
+        // <a data-bind="attr: { title: $t('This is \' test \' data'), href: '#'} "></a>
+        // <input type="text" data-bind="attr: { placeholder: $t('Placeholder'), title: $t('Title') }" />
+        // Double quotes are not handled correctly in the `attr` binding. Move phrase to the UI component property if needed
+        '/\\$t\(\s*([\'"])(?<value>.*?[^\\\])\1.*?[),]/i'
     ];
 
     /**

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/HtmlTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/HtmlTest.php
@@ -103,6 +103,41 @@ class HtmlTest extends TestCase
                 'line' => '',
                 'quote' => '',
             ],
+            [
+                // en_US.csv: "This is ' test ' data for attribute translation with single quotes","This is ' test ' data for attribute translation with single quotes"
+                'phrase' => 'This is \\\' test \\\' data for attribute translation with single quotes',
+                'file' => $this->testFile,
+                'line' => '',
+                'quote' => '',
+            ],
+            [
+                // en_US.csv: "This is test data for attribute translation with a quote after''","This is test data for attribute translation with a quote after''"
+                'phrase' => 'This is test data for attribute translation with a quote after\\\'\\\'',
+                'file' => $this->testFile,
+                'line' => '',
+                'quote' => '',
+            ],
+            [
+                // en_US.csv: "This is test data for attribute translation with a quote after' ' ","This is test data for attribute translation with a quote after' ' "
+                'phrase' => 'This is test data for attribute translation with a quote after\\\' \\\' ',
+                'file' => $this->testFile,
+                'line' => '',
+                'quote' => '',
+            ],
+            [
+                // en_US.csv: "Attribute translation - Placeholder","Attribute translation - Placeholder"
+                'phrase' => 'Attribute translation - Placeholder',
+                'file' => $this->testFile,
+                'line' => '',
+                'quote' => '',
+            ],
+            [
+                // en_US.csv: "Attribute translation - Title","Attribute translation - Title"
+                'phrase' => 'Attribute translation - Title',
+                'file' => $this->testFile,
+                'line' => '',
+                'quote' => '',
+            ]
         ];
 
         $this->model->parse($this->testFile);

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/HtmlTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/HtmlTest.php
@@ -49,6 +49,7 @@ class HtmlTest extends TestCase
                 'line' => '',
                 'quote' => '',
             ],
+            // `I18N` is not parsed - bindings are case-sensitive
             [
                 'phrase' => 'This is test data at right side of attr',
                 'file' => $this->testFile,
@@ -97,12 +98,15 @@ class HtmlTest extends TestCase
                 'line' => '',
                 'quote' => '',
             ],
+            // `<TRANSLATE>` tag is not parsed - only lowercase tags are accepted
             [
                 'phrase' => 'This is test content in translate attribute',
                 'file' => $this->testFile,
                 'line' => '',
                 'quote' => '',
             ],
+            // `TRANSLATE` attribute is not parsed - only lowercase attribute names are accepted
+            // `$T()` is not parsed - function names in JS are case-sensitive
             [
                 // en_US.csv: "This is ' test ' data for attribute translation with single quotes","This is ' test ' data for attribute translation with single quotes"
                 'phrase' => 'This is \\\' test \\\' data for attribute translation with single quotes',

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/JsTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/JsTest.php
@@ -43,15 +43,33 @@ class JsTest extends TestCase
             [
                 'phrase' => 'Phrase 1',
                 'file' => $this->_testFile,
-                'line' => $this->_stringsCount - 2,
+                'line' => $this->_stringsCount - 4,
                 'quote' => Phrase::QUOTE_SINGLE,
             ],
             [
                 'phrase' => 'Phrase 2 %1',
                 'file' => $this->_testFile,
-                'line' => $this->_stringsCount - 1,
+                'line' => $this->_stringsCount - 3,
                 'quote' => Phrase::QUOTE_DOUBLE
             ],
+            [
+                'phrase' => 'Field ',
+                'file' => $this->_testFile,
+                'line' => $this->_stringsCount - 2,
+                'quote' => Phrase::QUOTE_SINGLE
+            ],
+            [
+                'phrase' => ' is required.',
+                'file' => $this->_testFile,
+                'line' => $this->_stringsCount - 2,
+                'quote' => Phrase::QUOTE_SINGLE
+            ],
+            [
+                'phrase' => 'Welcome, %1!',
+                'file' => $this->_testFile,
+                'line' => $this->_stringsCount - 1,
+                'quote' => Phrase::QUOTE_SINGLE
+            ]
         ];
 
         $this->_adapter->parse($this->_testFile);

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/_files/email.html
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/_files/email.html
@@ -31,5 +31,9 @@
     <label data-bind="i18n: '\\\\ '"></label>
     <span><translate args="'This is test content in translate tag'" /></span>
     <span translate="'This is test content in translate attribute'"></span>
+    <a data-bind="attr: { title: $t('This is \' test \' data for attribute translation with single quotes'), href: '#'} "></a>
+    <a data-bind="attr: { title: $t('This is test data for attribute translation with a quote after\'\''), href: '#'} "></a>
+    <a data-bind="attr: { title: $t('This is test data for attribute translation with a quote after\' \' '), href: '#'} "></a>
+    <input type="text" data-bind="attr: { placeholder: $t('Attribute translation - Placeholder'), title: $t('Attribute translation - Title') }" />
 </body>
 </html>

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/_files/email.html
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/_files/email.html
@@ -21,6 +21,7 @@
         }}
     </span>
     <label data-bind="i18n: 'This is test data', attr: {for: 'more-test-data-'}"></label>
+    <label data-bind="I18N: 'This is test data with uppercase binding', attr: {for: 'more-test-data-'}"></label>
     <label data-bind="attr: {for: 'more-test-data-' + $parent.getCode()}"><span data-bind="i18n: 'This is test data at right side of attr'"></span></label>
     <label data-bind="i18n: 'This is \' test \' data', attr: {for: 'more-test-data-' + $parent.getCode()}"></label>
     <label data-bind="i18n: 'This is \" test \" data', attr: {for: 'more-test-data-' + $parent.getCode()}"></label>
@@ -30,7 +31,10 @@
     <label data-bind="i18n: '\''"></label>
     <label data-bind="i18n: '\\\\ '"></label>
     <span><translate args="'This is test content in translate tag'" /></span>
+    <span><TRANSLATE args="'This is test content in the uppercase translate tag'" /></span>
     <span translate="'This is test content in translate attribute'"></span>
+    <span TRANSLATE="'This is test content in uppercase translate attribute'"></span>
+    <a data-bind="attr: { title: $T('This is test data for invalid attribute translation'), href: '#'} "></a>
     <a data-bind="attr: { title: $t('This is \' test \' data for attribute translation with single quotes'), href: '#'} "></a>
     <a data-bind="attr: { title: $t('This is test data for attribute translation with a quote after\'\''), href: '#'} "></a>
     <a data-bind="attr: { title: $t('This is test data for attribute translation with a quote after\' \' '), href: '#'} "></a>

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/_files/file.js
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Parser/Adapter/_files/file.js
@@ -7,4 +7,6 @@
     $.mage.__('Phrase 1');
     $.mage.__('Phrase 1');
     $.mage.__("Phrase 2 %1");
+    let message = $t('Field ') + field + $t(' is required.');
+    let html = $t('Welcome, %1!').replace('%1', 'John Doe');
 });


### PR DESCRIPTION
### Description (*)

According to the official Magento 2 documentations, there is a way to translate HTML attributes, but this is not covered as well. Here is a text from the documentation:

> When a string is added as an attribute of an HTML element:

```html
<input type="text" data-bind="attr: {placeholder: $t('First Name')}" />
```

[Documentation -  Strings added in UI component templates](https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/translations/translate_theory.html)

This was of translating attributes does not seem to be used in the Magento 2 itself (if my search is correct). Though,
it is officially documented, is used by some vendors and it can be found in some Q&A on the Internet
(like here - [magento.stackexchange.com](https://magento.stackexchange.com/questions/181070/magento-2-translate-input-placeholder-attribute-string-in-knockout-html-templat))


### Related Pull Requests
https://github.com/magento/magento2/commit/48216f3e13d04b8755b70f8b9b1399d87a33ab91

### Fixed Issues (if relevant)
1. Fixes magento/magento2#11175 - i18n:collect-phrases -m can't find many important magento phrases

### Manual testing scenarios (*)
1. Add the following code to any Magento `.html` file, for example `app/code/Magento/Catalog/view/frontend/web/template/product/addtocart-button.html`

```html
<a data-bind="attr: { title: $t('This is \' test \' data for attribute translation with single quotes'), href: '#'} "></a>
<a data-bind="attr: { title: $t('This is test data for attribute translation with a quote after\'\''), href: '#'} "></a>
<a data-bind="attr: { title: $t('This is test data for attribute translation with a quote after\' \' '), href: '#'} "></a>
<input type="text" data-bind="attr: { placeholder: $t('Attribute translation - Placeholder'), title: $t('Attribute translation - Title') }" />
```

2. Run the command `php bin/magento i18n:collect-phrases app/code/Magento/Catalog/view/frontend/web/template/product/`

Expected result: Command output contains phrases in the `$t('Text')` translations that cat be then used in the i18n files.
i18n output example:
```text
"This is ' test ' data for attribute translation with single quotes","This is ' test ' data for attribute translation with single quotes"
"This is test data for attribute translation with a quote after''","This is test data for attribute translation with a quote after''"
"This is test data for attribute translation with a quote after' ' ","This is test data for attribute translation with a quote after' ' "
"This is "" test "" data with 'href' after translate","This is "" test "" data with 'href' after translate"
```

Actual result: The above phrases are not present in the output.

### Questions or comments

### Contribution checklist (*)
- [ ] Pull request has a meaningful description of its purpose
- [ ] All commits are accompanied by meaningful commit messages
- [ ] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] All automated tests passed successfully (all builds are green)

### Resolved issues:
1. [x] resolves magento/magento2#31873: Fix #11175 - i18n:collect-phrases -m can't find many important Magento phrases - added parsing of the attr translations via `$t('Text')`