### PR TITLE
Fixed type error during creditmemo email item generation for grouped …

### DIFF
--- a/app/code/Magento/GroupedProduct/Test/Unit/Block/Order/Email/Items/Order/GroupedTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Block/Order/Email/Items/Order/GroupedTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\GroupedProduct\Test\Unit\Block\Order\Email\Items\Order\GroupedTest;
+
+class GroupedTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\GroupedProduct\Block\Order\Email\Items\Order\Grouped
+     */
+    protected $groupedBlock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Backend\Block\Template
+     */
+    protected $priceRenderBlock;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\View\Layout
+     */
+    protected $layoutMock;
+
+    /**
+     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     */
+    protected $objectManager;
+
+    /** @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Sales\Model\Order\Creditmemo\Item */
+    protected $creditMemoItemMock;
+
+    /**
+     * Initialize required data
+     */
+    protected function setUp()
+    {
+        $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+
+        $this->layoutMock = $this->getMockBuilder(\Magento\Framework\View\Layout::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getBlock'])
+            ->getMock();
+
+
+        $this->groupedBlock = $this->objectManager->getObject(
+            \Magento\GroupedProduct\Block\Order\Email\Items\Order\Grouped::class,
+            [
+                'context' => $this->objectManager->getObject(
+                    \Magento\Backend\Block\Template\Context::class,
+                    ['layout' => $this->layoutMock]
+                )
+            ]
+        );
+
+        $this->priceRenderBlock = $this->getMockBuilder(\Magento\Backend\Block\Template::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setItem', 'toHtml'])
+            ->getMock();
+
+
+        $this->creditMemoItemMock = $this->getMockBuilder(\Magento\Sales\Model\Order\Creditmemo\Item::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['__wakeup'])
+            ->getMock();
+    }
+
+    public function testGetItem()
+    {
+        $html = '$34.28';
+
+        $this->layoutMock->expects($this->once())
+            ->method('getBlock')
+            ->with('item_price')
+            ->will($this->returnValue($this->priceRenderBlock));
+
+        $this->priceRenderBlock->expects($this->once())
+            ->method('setItem')
+            ->with($this->creditMemoItemMock);
+
+        $this->priceRenderBlock->expects($this->once())
+            ->method('toHtml')
+            ->will($this->returnValue($html));
+
+        $this->assertEquals($html, $this->groupedBlock->getItemPrice($this->creditMemoItemMock));
+    }
+}

--- a/app/code/Magento/Sales/Block/Order/Email/Items/Order/DefaultOrder.php
+++ b/app/code/Magento/Sales/Block/Order/Email/Items/Order/DefaultOrder.php
@@ -7,6 +7,7 @@
 namespace Magento\Sales\Block\Order\Email\Items\Order;
 
 use Magento\Sales\Model\Order\Item as OrderItem;
+use Magento\Sales\Model\Order\Creditmemo\Item as CreditMemoItem;
 
 /**
  * Sales Order Email items default renderer
@@ -95,10 +96,10 @@ class DefaultOrder extends \Magento\Framework\View\Element\Template
     /**
      * Get the html for item price
      *
-     * @param OrderItem $item
+     * @param OrderItem|CreditMemoItem $item
      * @return string
      */
-    public function getItemPrice(OrderItem $item)
+    public function getItemPrice($item)
     {
         $block = $this->getLayout()->getBlock('item_price');
         $block->setItem($item);


### PR DESCRIPTION
…products

Fix for Creditmemo generation issue mentioned here #25617. 

The issue is producable with on environment with email server. As Magento test environments here doesn't have email server set up, it's not producable in those environments. 
![image](https://user-images.githubusercontent.com/1422426/105643314-314f7000-5ea0-11eb-99f9-1cf9b47af2ac.png)



<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

I've removed strict type from method and added Creditmemo Item Model into phpdoc. That's worked fine all order, invoice and creditmemo email. Also unit test has been implemented for related class that changes have been made.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2 #25617 

### Manual testing scenarios (*)

- Add grouped product to cart 
- Place order
- Login in admin section
- Create invoice for order
- Create credit memo for order
- In the credit memo section click 'Send Email'

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
