### PR TITLE
Update bundle price renderer docblock

### DIFF
--- a/app/code/Magento/Bundle/Block/Sales/Order/Items/Renderer.php
+++ b/app/code/Magento/Bundle/Block/Sales/Order/Items/Renderer.php
@@ -7,6 +7,9 @@ namespace Magento\Bundle\Block\Sales\Order\Items;
 
 use Magento\Catalog\Model\Product\Type\AbstractType;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Sales\Api\Data\CreditmemoItemInterface;
+use Magento\Sales\Api\Data\InvoiceItemInterface;
+use Magento\Sales\Api\Data\OrderItemInterface;
 
 /**
  * Order item render block
@@ -199,7 +202,7 @@ class Renderer extends \Magento\Sales\Block\Order\Item\Renderer\DefaultRenderer
     /**
      * Get the html for item price
      *
-     * @param OrderItem|InvoiceItem|CreditmemoItem $item
+     * @param OrderItemInterface|InvoiceItemInterface|CreditmemoItemInterface $item
      * @return string
      */
     public function getItemPrice($item)


### PR DESCRIPTION
### Description

PHPStan fails when using the original block:

```
 ------ --------------------------------------------------------------------------------------------------------------------- 
  Line   app/design/frontend/my/theme-x/Magento_Bundle/templates/email/order/items/creditmemo/default.phtml  
 ------ --------------------------------------------------------------------------------------------------------------------- 
  25     Parameter #1 $item of method                                                                                         
         Magento\Bundle\Block\Sales\Order\Items\Renderer::getItemPrice()                                                      
         expects                                                                                                              
         Magento\Bundle\Block\Sales\Order\Items\CreditmemoItem|Magento\Bundle\                                                
         Block\Sales\Order\Items\InvoiceItem|Magento\Bundle\Block\Sales\Order\                                                
         Items\OrderItem, Magento\Sales\Model\Order\Item given.                                                               
 ------ --------------------------------------------------------------------------------------------------------------------- 
```

default.phtml line 25:

```
<p class="item-price"><?= /* @noEscape */ $block->getItemPrice($item->getOrderItem()) ?></p>
```

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios

1. Configure PHPStan to run against your app/design files;
2. Have the following line on your app/design/frontend/my/theme-x/Magento_Bundle/templates/email/order/items/creditmemo/default.phtml file:

```
<p class="item-price"><?= /* @noEscape */ $block->getItemPrice($item->getOrderItem()) ?></p>
```

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31845: Update bundle price renderer docblock