### PR TITLE
magento/magento2#24442: Since Magento 2.3 the wysiwyg images are not loaded anymore from media storage database.

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSeeProductThumbnailInGridActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSeeProductThumbnailInGridActionGroup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminSeeProductThumbnailInGridActionGroup">
+        <annotations>
+            <description>See product thumbnail in admin product grid</description>
+        </annotations>
+        <arguments>
+            <argument name="pattern" type="string"/>
+        </arguments>
+
+        <waitForElement selector="{{AdminProductGridSection.firstProductRow}}" stepKey="waitForElement"/>
+        <seeElement selector="{{AdminProductGridSection.productThumbnailBySrc(pattern)}}" stepKey="seeImageInGrid"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontSeeProductImageOnCategoryPageActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontSeeProductImageOnCategoryPageActionGroup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontSeeProductImageOnCategoryPageActionGroup">
+        <annotations>
+            <description>See product image on category page</description>
+        </annotations>
+        <arguments>
+            <argument name="pattern" type="string"/>
+        </arguments>
+
+        <waitForElement selector="{{StorefrontCategoryMainSection.CategoryTitle}}" stepKey="waitForPage"/>
+        <seeElement selector="{{StorefrontCategoryProductSection.ProductImageBySrc(pattern)}}" stepKey="seeUploadedImage"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -314,18 +314,18 @@ class ImageResize
         $usingDbAsStorage = $this->fileStorageDatabase->checkDbUsage();
         $mediaStorageFilename = $this->mediaDirectory->getRelativePath($imageAssetPath);
 
-        $alreadyResized = $usingDbAsStorage ?
-            $this->fileStorageDatabase->fileExists($mediaStorageFilename) :
-            $this->mediaDirectory->isFile($imageAssetPath);
-
-        if (!$alreadyResized) {
-            $this->generateResizedImage(
-                $imageParams,
-                $originalImagePath,
-                $imageAssetPath,
-                $usingDbAsStorage,
-                $mediaStorageFilename
-            );
+        if (!$this->mediaDirectory->isFile($imageAssetPath)) {
+            if ($this->fileStorageDatabase->fileExists($mediaStorageFilename)) {
+                $this->fileStorageDatabase->saveFileToFilesystem($mediaStorageFilename);
+            } else {
+                $this->generateResizedImage(
+                    $imageParams,
+                    $originalImagePath,
+                    $imageAssetPath,
+                    $usingDbAsStorage,
+                    $mediaStorageFilename
+                );
+            }
         }
     }
 

--- a/app/code/Magento/MediaStorage/Test/Mftf/Data/DatabaseMediaStorageConfigData.xml
+++ b/app/code/Magento/MediaStorage/Test/Mftf/Data/DatabaseMediaStorageConfigData.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<entities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:DataGenerator/etc/dataProfileSchema.xsd">
+    <entity name="DatabaseSystemMediaStorage">
+        <data key="path">system/media_storage_configuration/media_storage</data>
+        <data key="scope_id">0</data>
+        <data key="value">1</data>
+    </entity>
+    <entity name="FilesystemSystemMediaStorage">
+        <data key="path">system/media_storage_configuration/media_storage</data>
+        <data key="scope_id">0</data>
+        <data key="value">0</data>
+    </entity>
+    <entity name="DefaultSetupSystemMediaDatabase">
+        <data key="path">system/media_storage_configuration/media_database</data>
+        <data key="scope_id">0</data>
+        <data key="value">default_setup</data>
+    </entity>
+</entities>

--- a/app/code/Magento/MediaStorage/Test/Mftf/Test/StorefrontDatabaseMediaStorageTest.xml
+++ b/app/code/Magento/MediaStorage/Test/Mftf/Test/StorefrontDatabaseMediaStorageTest.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontDatabaseMediaStorageTest">
+        <annotations>
+            <features value="MediaStorage"/>
+            <stories value="Database media storage"/>
+            <title value="Storefront database media storage test"/>
+            <description
+                value="Verify product image correctly resized if database media storage is enabled"/>
+            <severity value="CRITICAL"/>
+            <group value="MediaStorage"/>
+        </annotations>
+
+        <before>
+            <magentoCLI command="config:set {{DatabaseSystemMediaStorage.path}} {{DatabaseSystemMediaStorage.value}}"
+                        stepKey="enableDatabaseMediaStorage"/>
+            <magentoCLI
+                command="config:set {{DefaultSetupSystemMediaDatabase.path}} {{DefaultSetupSystemMediaDatabase.value}}"
+                stepKey="setDefaultMediaDatabase"/>
+            <createData entity="_defaultCategory" stepKey="createCategory"/>
+            <createData entity="_defaultProduct" stepKey="createProduct">
+                <requiredEntity createDataKey="createCategory"/>
+            </createData>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+        </before>
+
+        <after>
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="adminLogout"/>
+            <magentoCLI
+                command="config:set {{FilesystemSystemMediaStorage.path}} {{FilesystemSystemMediaStorage.value}}"
+                stepKey="disableDatabaseMediaStorage"/>
+        </after>
+
+        <!-- Add an Image to Product-->
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="openProductPage">
+            <argument name="productId" value="$$createProduct.id$$"/>
+        </actionGroup>
+        <actionGroup ref="AddProductImageActionGroup" stepKey="addImageForProduct"/>
+        <actionGroup ref="SaveProductFormActionGroup" stepKey="saveSimpleProduct"/>
+
+        <!-- Go to the admin grid and see the uploaded image -->
+        <actionGroup ref="AdminOpenProductIndexPageActionGroup" stepKey="goToProductIndex3"/>
+        <actionGroup ref="ResetProductGridToDefaultViewActionGroup" stepKey="resetProductGrid3"/>
+        <actionGroup ref="FilterProductGridBySkuActionGroup" stepKey="filterProductGridBySku3">
+            <argument name="product" value="$$createProduct$$"/>
+        </actionGroup>
+        <actionGroup ref="AdminSeeProductThumbnailInGridActionGroup" stepKey="seeProductThumbnailInGrid">
+            <argument name="pattern" value=".png"/>
+        </actionGroup>
+
+        <!-- Go to the category page and see the uploaded image -->
+        <actionGroup ref="StorefrontGoToCategoryPageActionGroup" stepKey="openCategoryPage">
+            <argument name="categoryName" value="$$createCategory.name$$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontSeeProductImageOnCategoryPageActionGroup" stepKey="seeProductImageInCategoryPage">
+            <argument name="pattern" value=".png"/>
+        </actionGroup>
+
+        <!-- Go to the product page and see the uploaded image -->
+        <actionGroup ref="StorefrontOpenProductPageActionGroup" stepKey="goToFirstProductPageSecondTime">
+            <argument name="productUrl" value="$$createProduct.custom_attributes[url_key]$$"/>
+        </actionGroup>
+        <actionGroup ref="AssertProductImageStorefrontProductPage2ActionGroup" stepKey="seeProductImageInProductPage">
+            <argument name="product" value="$$createProduct$$"/>
+            <argument name="image" value="ProductImage"/>
+        </actionGroup>
+    </test>
+</tests>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#24442: Since Magento 2.3 the wysiwyg images are not loaded anymore from media storage database.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See magento/magento2#24442: Since Magento 2.3 the wysiwyg images are not loaded anymore from media storage database.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
