### PR TITLE
Issue 29209 - Enforce order store locale in sales email address / order creation display

### DIFF
--- a/app/code/Magento/Customer/Block/Address/Renderer/DefaultRenderer.php
+++ b/app/code/Magento/Customer/Block/Address/Renderer/DefaultRenderer.php
@@ -143,11 +143,12 @@ class DefaultRenderer extends AbstractBlock implements RendererInterface
      *
      * @param array $addressAttributes
      * @param Format|null $format
+     * @param string|null $locale
      * @return string
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function renderArray($addressAttributes, $format = null)
+    public function renderArray($addressAttributes, $format = null, $locale = null)
     {
         switch ($this->getType()->getCode()) {
             case 'html':
@@ -174,7 +175,7 @@ class DefaultRenderer extends AbstractBlock implements RendererInterface
             if ($attributeCode == 'country_id' && isset($addressAttributes['country_id'])) {
                 $data['country'] = $this->_countryFactory->create()->loadByCode(
                     $addressAttributes['country_id']
-                )->getName();
+                )->getName($locale);
             } elseif ($attributeCode == 'region' && isset($addressAttributes['region'])) {
                 $data['region'] = (string)__($addressAttributes['region']);
             } elseif (isset($addressAttributes[$attributeCode])) {

--- a/app/code/Magento/Customer/Block/Address/Renderer/RendererInterface.php
+++ b/app/code/Magento/Customer/Block/Address/Renderer/RendererInterface.php
@@ -53,7 +53,8 @@ interface RendererInterface
      *
      * @param array $addressAttributes
      * @param Format|null $format
+     * @param string|null $locale
      * @return string
      */
-    public function renderArray($addressAttributes, $format = null);
+    public function renderArray($addressAttributes, $format = null, $locale = null);
 }

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -6,6 +6,7 @@
 namespace Magento\Sales\Model;
 
 use Magento\Config\Model\Config\Source\Nooptreq;
+use Magento\Directory\Helper\Data as DirectoryHelper;
 use Magento\Directory\Model\Currency;
 use Magento\Directory\Model\RegionFactory;
 use Magento\Framework\Api\AttributeValueFactory;
@@ -2052,7 +2053,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
             new \DateTime($this->getCreatedAt()),
             $format,
             $format,
-            $this->localeResolver->getDefaultLocale(),
+            $this->getLocale(),
             $this->timezone->getConfigTimezone('store', $this->getStore())
         );
     }
@@ -4584,6 +4585,20 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     public function setShippingMethod($shippingMethod)
     {
         return $this->setData('shipping_method', $shippingMethod);
+    }
+
+    /**
+     * Return the locale for the order's store
+     *
+     * @return string
+     */
+    private function getLocale(): string
+    {
+        return (string) $this->scopeConfig->getValue(
+            DirectoryHelper::XML_PATH_DEFAULT_LOCALE,
+            ScopeInterface::SCOPE_STORES,
+            $this->getStoreId()
+        );
     }
 
     /**

--- a/app/code/Magento/Sales/Model/Order/Address/Renderer.php
+++ b/app/code/Magento/Sales/Model/Order/Address/Renderer.php
@@ -7,8 +7,11 @@
 namespace Magento\Sales\Model\Order\Address;
 
 use Magento\Customer\Model\Address\Config as AddressConfig;
+use Magento\Directory\Helper\Data as DirectoryHelper;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Event\ManagerInterface as EventManager;
 use Magento\Sales\Model\Order\Address;
+use Magento\Store\Model\ScopeInterface;
 
 /**
  * Class Renderer used for formatting an order address
@@ -28,17 +31,25 @@ class Renderer
     protected $eventManager;
 
     /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
      * Constructor
      *
      * @param AddressConfig $addressConfig
      * @param EventManager $eventManager
+     * @param ScopeConfigInterface $scopeConfig
      */
     public function __construct(
         AddressConfig $addressConfig,
-        EventManager $eventManager
+        EventManager $eventManager,
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->addressConfig = $addressConfig;
         $this->eventManager = $eventManager;
+        $this->scopeConfig = $scopeConfig;
     }
 
     /**
@@ -56,6 +67,11 @@ class Renderer
             return null;
         }
         $this->eventManager->dispatch('customer_address_format', ['type' => $formatType, 'address' => $address]);
-        return $formatType->getRenderer()->renderArray($address->getData());
+        $locale = $this->scopeConfig->getValue(
+            DirectoryHelper::XML_PATH_DEFAULT_LOCALE,
+            ScopeInterface::SCOPE_STORES,
+            $address->getOrder()->getStoreId()
+        );
+        return $formatType->getRenderer()->renderArray($address->getData(), null, $locale);
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When an order is placed on the store front and sales emails are triggered from the admin, the locale of the order's store is not properly applied to the country (in billing or shipping address) or the formatted order creation date.

Example: Frontend store view is French and admin is in English. Order is placed using a US address. Original order email will say "États-Unis" for country and "28 janv. 2021 18:14:06" for order date. However, resending the order email from the admin says "United States" and "Jan 28, 2021, 6:14:06 PM".

This PR properly applies the locale of the order's store to order address country and formatted creation date.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#29209

### Manual testing scenarios (*)
1. Have the admin locale set to English.
2. Create a store view with locale set to French.
3. Create an order from the French store view with United States as the shipping / billing address country.
4. Confirm that the new order email has a French formatted date / time (Ex: 28 janv. 2021 18:14:06) and country is "États-Unis".
5. Log into admin, view the order, and click Send Email.
6. Confirm that the email matches the original and does NOT say "United States" or have a US-formatted date (Jan 28, 2021, 6:14:06 PM)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
