### PR TITLE
MC-40678: Cart page subtotal shows wrong when we back from multishipping

### DIFF
--- a/app/code/Magento/Multishipping/Model/Cart/Controller/CartPlugin.php
+++ b/app/code/Magento/Multishipping/Model/Cart/Controller/CartPlugin.php
@@ -73,7 +73,7 @@ class CartPlugin
     {
         /** @var Quote $quote */
         $quote = $this->checkoutSession->getQuote();
-        if ($quote->isMultipleShippingAddresses() && $this->isCheckoutComplete()) {
+        if ($quote->isMultipleShippingAddresses()) {
             $this->disableMultishipping->execute($quote);
             foreach ($quote->getAllShippingAddresses() as $address) {
                 $quote->removeAddress($address->getId());
@@ -90,16 +90,6 @@ class CartPlugin
             $quote->setTotalsCollectedFlag(false);
             $this->cartRepository->save($quote);
         }
-    }
-
-    /**
-     * Checks whether the checkout flow is complete
-     *
-     * @return bool
-     */
-    private function isCheckoutComplete() : bool
-    {
-        return (bool) ($this->checkoutSession->getStepData(State::STEP_SHIPPING)['is_complete'] ?? true);
     }
 
     /**

--- a/app/code/Magento/Multishipping/Test/Mftf/Test/StorefrontProcessMultishippingCheckoutWhenCartPageIsOpenedInAnotherTabTest.xml
+++ b/app/code/Magento/Multishipping/Test/Mftf/Test/StorefrontProcessMultishippingCheckoutWhenCartPageIsOpenedInAnotherTabTest.xml
@@ -85,6 +85,12 @@
         </actionGroup>
         <switchToNextTab stepKey="switchToNextTab"/>
         <!-- Click 'Continue to Billing Information' and 'Go to Review Your Order' -->
+        <actionGroup ref="StorefrontGoToBillingInformationActionGroup" stepKey="redirectToSelectAddressAfterReset"/>
+        <seeOptionIsSelected selector="{{StorefrontCheckoutShippingMultipleAddressesSection.selectedMultipleShippingAddress('1')}}" userInput="{{US_Address_NY.street[1]}}" stepKey="checkAddressIsReset"/>
+        <actionGroup ref="StorefrontCheckoutShippingSelectMultipleAddressesActionGroup" stepKey="selectMultipleAddressesAfterReset">
+            <argument name="firstAddress" value="{{UK_Not_Default_Address.street[0]}}"/>
+            <argument name="secondAddress" value="{{US_Address_NY.street[1]}}"/>
+        </actionGroup>
         <actionGroup ref="StorefrontGoToBillingInformationActionGroup" stepKey="goToBillingInformation"/>
         <see selector="{{ShipmentFormSection.shippingAddress}}" userInput="{{US_Address_NY.city}}" stepKey="seeBillingAddress"/>
         <waitForElementVisible selector="{{StorefrontMultipleShippingMethodSection.goToReviewYourOrderButton}}" stepKey="waitForGoToReviewYourOrderVisible" />


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#31889

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login as a customer
2. Add 2 simple products to the cart
3. Navigate to the cart page
4. Click checkout with multiple addresses
5. select for 2 products different addresses
6. click update Qty and Addresses
7. Go back to the cart page
Expected result:
See correct totals price in totals block
Multi-shipping deactivated and multiple addresses reset to a single one

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
