### PR TITLE
Fixed issue #31891: Order currency is used instead of bas currency in the shipping label form

### DIFF
--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/grid.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/grid.phtml
@@ -88,7 +88,7 @@
                         <input type="text"
                                name="customs_value"
                                class="input-text admin__control-text <?= /* @noEscape */ $customsValueValidation ?>"
-                               value="<?= $block->escapeHtmlAttr($block->formatPrice($item->getPrice())) ?>"
+                               value="<?= $block->escapeHtmlAttr($block->formatPrice($_orderItem->getBasePrice())) ?>"
                                size="10">
                     </td>
                     <?php if (!$block->displayCustomsValue()): ?>


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I have used the base amount of the sales order item so that the base amount will be used in the frontend recalculation logic and issue #31891 will be resolved.
### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#31891

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
