### PR TITLE
MC-36818: Related Products, added as Scheduled Changes, remain on the Product Page on the Storefront after the End Date of the update.

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertRelatedProductOnProductPageActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/StorefrontAssertRelatedProductOnProductPageActionGroup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontAssertRelatedProductOnProductPageActionGroup">
+        <annotations>
+            <description>Validates that the provided Product Name is present on Product details page.</description>
+        </annotations>
+        <arguments>
+            <argument name="productName" type="string" defaultValue="{{_defaultProduct.name}}"/>
+        </arguments>
+
+        <waitForElementVisible selector="{{StorefrontProductRelatedProductsSection.relatedProductsListSectionText}}" stepKey="waitForRelatedProductsList"/>
+        <see selector="{{StorefrontProductRelatedProductsSection.relatedProductsListSectionText}}" userInput="{{productName}}" stepKey="seeRelatedProduct"/>
+    </actionGroup>
+</actionGroups>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
https://github.com/magento/partners-magento2ee/pull/470
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes partners-magento2ee#469

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
