### PR TITLE
MC-40702: Order currency is used instead of bas currency in the shipping label for form

### DIFF
--- a/app/code/Magento/Shipping/Block/Adminhtml/Order/Packaging.php
+++ b/app/code/Magento/Shipping/Block/Adminhtml/Order/Packaging.php
@@ -380,7 +380,7 @@ class Packaging extends \Magento\Backend\Block\Template
     public function getCustomValueCurrencyCode()
     {
         $orderInfo = $this->getShipment()->getOrder();
-        return $orderInfo->getBaseCurrency()->getCurrencyCode();
+        return $orderInfo->getOrderCurrency()->getCurrencyCode();
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Shipping/Block/Adminhtml/Order/AddToPackageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Shipping/Block/Adminhtml/Order/AddToPackageTest.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Shipping\Block\Adminhtml\Order;
 
 use Magento\Backend\Block\Template;
@@ -28,17 +30,78 @@ class AddToPackageTest extends TestCase
      */
     private $orderRepository;
 
-    /** @var ObjectManagerInterface */
+    /**
+     * @var ObjectManagerInterface
+     */
     private $objectManager;
 
-    /** @var Registry */
+    /**
+     * @var Registry
+     */
     private $registry;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->registry = $this->objectManager->get(Registry::class);
         $this->orderRepository = $this->objectManager->get(OrderRepositoryInterface::class);
+    }
+
+    /**
+     * Test that Packaging popup renders
+     *
+     * @magentoDataFixture Magento/Shipping/_files/shipping_with_carrier_data.php
+     */
+    public function testGetCommentsHtml(): void
+    {
+        $expectedNeedle = "packaging.setItemQtyCallback(function(itemId){
+            var item = $$('[name=\"shipment[items]['+itemId+']\"]')[0],
+                itemTitle = $('order_item_' + itemId + '_title');
+            if (!itemTitle && !item) {
+                return 0;
+            }
+            if (item && !isNaN(item.value)) {
+                return item.value;
+            }
+        });";
+        $this->assertStringContainsString($expectedNeedle, $this->getHtml());
+    }
+
+    /**
+     * Verify currency code on custom value field
+     *
+     * @magentoDataFixture Magento/Shipping/_files/shipping_with_carrier_data_different_currency_code.php
+     */
+    public function testGetCurrencyCodeCustomValue ()
+    {
+        $expectedCurrencyCode = '<span class="customs-value-currency">
+                                        FR                                    </span>';
+        $this->assertStringContainsString($expectedCurrencyCode, $this->getHtml());
+    }
+
+    /**
+     * Get html for packaging popup
+     *
+     * @return string
+     */
+    private function getHtml()
+    {
+        /** @var Template $block */
+        $block = $this->objectManager->get(Packaging::class);
+
+        $order = $this->getOrderByIncrementId('100000001');
+
+        /** @var ShipmentTrackInterface $track */
+        $shipment = $order->getShipmentsCollection()->getFirstItem();
+
+        $this->registry->register('current_shipment', $shipment);
+
+        $block->setTemplate('Magento_Shipping::order/packaging/popup.phtml');
+
+        return $block->toHtml();
     }
 
     /**
@@ -58,37 +121,5 @@ class AddToPackageTest extends TestCase
             ->getItems();
 
         return array_pop($items);
-    }
-
-    /**
-     * Test that Packaging popup renders
-     *
-     * @magentoDataFixture Magento/Shipping/_files/shipping_with_carrier_data.php
-     */
-    public function testGetCommentsHtml()
-    {
-        /** @var Template $block */
-        $block = $this->objectManager->get(Packaging::class);
-
-        $order = $this->getOrderByIncrementId('100000001');
-
-        /** @var ShipmentTrackInterface $track */
-        $shipment = $order->getShipmentsCollection()->getFirstItem();
-
-        $this->registry->register('current_shipment', $shipment);
-
-        $block->setTemplate('Magento_Shipping::order/packaging/popup.phtml');
-        $html = $block->toHtml();
-        $expectedNeedle = "packaging.setItemQtyCallback(function(itemId){
-            var item = $$('[name=\"shipment[items]['+itemId+']\"]')[0],
-                itemTitle = $('order_item_' + itemId + '_title');
-            if (!itemTitle && !item) {
-                return 0;
-            }
-            if (item && !isNaN(item.value)) {
-                return item.value;
-            }
-        });";
-        $this->assertStringContainsString($expectedNeedle, $html);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Shipping/Block/Adminhtml/Order/AddToPackageTest.php
+++ b/dev/tests/integration/testsuite/Magento/Shipping/Block/Adminhtml/Order/AddToPackageTest.php
@@ -77,9 +77,11 @@ class AddToPackageTest extends TestCase
      */
     public function testGetCurrencyCodeCustomValue ()
     {
-        $expectedCurrencyCode = '<span class="customs-value-currency">
-                                        FR                                    </span>';
-        $this->assertStringContainsString($expectedCurrencyCode, $this->getHtml());
+        $template = '/<span class="customs-value-currency">\s*?(?<currency>[A-Za-z]+)\s*?<\/span>/';
+        $matches = [];
+        preg_match($template, $this->getHtml(), $matches);
+        $currency = $matches['currency'] ?? null;
+        $this->assertEquals('FR',$currency );
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Shipping/_files/shipping_with_carrier_data_different_currency_code.php
+++ b/dev/tests/integration/testsuite/Magento/Shipping/_files/shipping_with_carrier_data_different_currency_code.php
@@ -20,7 +20,7 @@ $objectManager = Bootstrap::getObjectManager();
 /** @var Transaction $transaction */
 $transaction = $objectManager->get(Transaction::class);
 /** @var ProductRepositoryInterface $productRepository */
-$productRepository = $objectManager->create(ProductRepositoryInterface::class);
+$productRepository = $objectManager->get(ProductRepositoryInterface::class);
 $product = $productRepository->get('simple');
 /** @var Order $order */
 $order = $objectManager->get(OrderInterfaceFactory::class)->create()->loadByIncrementId('100000001');
@@ -42,7 +42,7 @@ foreach ($order->getItems() as $orderItem) {
 $tracking = [
     'carrier_code' => 'ups',
     'title' => 'United Parcel Service',
-    'number' => '987654321'
+    'number' => '987654321',
 ];
 
 $shipment = $objectManager->get(ShipmentFactory::class)->create($order, $shipmentItems, [$tracking]);

--- a/dev/tests/integration/testsuite/Magento/Shipping/_files/shipping_with_carrier_data_different_currency_code.php
+++ b/dev/tests/integration/testsuite/Magento/Shipping/_files/shipping_with_carrier_data_different_currency_code.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Sales\Api\Data\OrderInterfaceFactory;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\ShipmentFactory;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\Workaround\Override\Fixture\Resolver;
+use Magento\Framework\DB\Transaction;
+
+Resolver::getInstance()->requireDataFixture('Magento/Sales/_files/order_with_customer.php');
+
+$objectManager = Bootstrap::getObjectManager();
+/** @var Transaction $transaction */
+$transaction = $objectManager->get(Transaction::class);
+/** @var ProductRepositoryInterface $productRepository */
+$productRepository = $objectManager->create(ProductRepositoryInterface::class);
+$product = $productRepository->get('simple');
+/** @var Order $order */
+$order = $objectManager->get(OrderInterfaceFactory::class)->create()->loadByIncrementId('100000001');
+$order->setShippingDescription('UPS Next Day Air')
+    ->setShippingMethod('ups_11')
+    ->setOrderCurrencyCode('FR')
+    ->setShippingAmount(0)
+    ->setCouponCode('1234567890')
+    ->setDiscountDescription('1234567890');
+
+/** @var OrderRepositoryInterface $orderRepository */
+$orderRepository = $objectManager->create(OrderRepositoryInterface::class);
+$orderRepository->save($order);
+
+$shipmentItems = [];
+foreach ($order->getItems() as $orderItem) {
+    $shipmentItems[$orderItem->getId()] = $orderItem->getQtyOrdered();
+}
+$tracking = [
+    'carrier_code' => 'ups',
+    'title' => 'United Parcel Service',
+    'number' => '987654321'
+];
+
+$shipment = $objectManager->get(ShipmentFactory::class)->create($order, $shipmentItems, [$tracking]);
+$shipment->register();
+$transaction->addObject($shipment)->addObject($order)->save();

--- a/dev/tests/integration/testsuite/Magento/Shipping/_files/shipping_with_carrier_data_different_currency_code_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Shipping/_files/shipping_with_carrier_data_different_currency_code_rollback.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\TestFramework\Workaround\Override\Fixture\Resolver;
+
+Resolver::getInstance()->requireDataFixture('Magento/Sales/_files/order_with_customer_rollback.php');


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#31891

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See magento/magento2#31891

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
