### PR TITLE
Allow higher versions of phpstan to be installed (Magento 2.4 edition)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
         "pdepend/pdepend": "~2.7.1",
         "phpcompatibility/php-compatibility": "^9.3",
         "phpmd/phpmd": "^2.8.0",
-        "phpstan/phpstan": ">=0.12.3 <=0.12.23",
+        "phpstan/phpstan": "^0.12.3",
         "phpunit/phpunit": "^9",
         "sebastian/phpcpd": "~5.0.0",
         "squizlabs/php_codesniffer": "~3.5.4"

--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
         "pdepend/pdepend": "~2.7.1",
         "phpcompatibility/php-compatibility": "^9.3",
         "phpmd/phpmd": "^2.8.0",
-        "phpstan/phpstan": "^0.12.3",
+        "phpstan/phpstan": "^0.12.77",
         "phpunit/phpunit": "^9",
         "sebastian/phpcpd": "~5.0.0",
         "squizlabs/php_codesniffer": "~3.5.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9bc433740520119db84253a54d67a303",
+    "content-hash": "ab265fb0ee87c426d0df3cdf3efd110c",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -6837,6 +6837,20 @@
                 "parser",
                 "php"
             ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-25T17:44:05+00:00"
         },
         {
@@ -8817,20 +8831,20 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.23",
+            "version": "0.12.69",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "71e529efced79e055fa8318b692e7f7d03ea4e75"
+                "reference": "8f436ea35241da33487fd0d38b4bc3e6dfe30ea8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/71e529efced79e055fa8318b692e7f7d03ea4e75",
-                "reference": "71e529efced79e055fa8318b692e7f7d03ea4e75",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8f436ea35241da33487fd0d38b4bc3e6dfe30ea8",
+                "reference": "8f436ea35241da33487fd0d38b4bc3e6dfe30ea8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.1|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -8855,7 +8869,21 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2020-05-05T12:55:44+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-24T14:55:37+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab265fb0ee87c426d0df3cdf3efd110c",
+    "content-hash": "6c631d2ace73beffe81b609df6182026",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -8831,16 +8831,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.69",
+            "version": "0.12.77",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "8f436ea35241da33487fd0d38b4bc3e6dfe30ea8"
+                "reference": "1f10b8c8d118d01e7b492f9707999d456be5812c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8f436ea35241da33487fd0d38b4bc3e6dfe30ea8",
-                "reference": "8f436ea35241da33487fd0d38b4bc3e6dfe30ea8",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1f10b8c8d118d01e7b492f9707999d456be5812c",
+                "reference": "1f10b8c8d118d01e7b492f9707999d456be5812c",
                 "shasum": ""
             },
             "require": {
@@ -8883,7 +8883,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-24T14:55:37+00:00"
+            "time": "2021-02-17T16:22:19+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/dev/tests/static/framework/Magento/PhpStan/Formatters/FilteredErrorFormatter.php
+++ b/dev/tests/static/framework/Magento/PhpStan/Formatters/FilteredErrorFormatter.php
@@ -41,9 +41,11 @@ use PHPStan\Command\Output;
 class FilteredErrorFormatter implements ErrorFormatter
 {
     private const MUTE_ERROR_ANNOTATION = 'phpstan:ignore';
-
     private const NO_ERRORS = 0;
 
+    /**
+     * @var TableErrorFormatter
+     */
     private $tableErrorFormatter;
 
     /**
@@ -60,22 +62,18 @@ class FilteredErrorFormatter implements ErrorFormatter
     public function formatErrors(AnalysisResult $analysisResult, Output $output): int
     {
         if (!$analysisResult->hasErrors()) {
-            $style = $output->getStyle();
-            $style->success('No errors');
+            $output->getStyle()->success('No errors');
             return self::NO_ERRORS;
         }
 
-        $fileSpecificErrorsWithoutIgnoredErrors = $this->clearIgnoredErrors(
-            $analysisResult->getFileSpecificErrors()
-        );
-
         $clearedAnalysisResult = new AnalysisResult(
-            $fileSpecificErrorsWithoutIgnoredErrors,
+            $this->clearIgnoredErrors($analysisResult->getFileSpecificErrors()),
             $analysisResult->getNotFileSpecificErrors(),
+            $analysisResult->getInternalErrors(),
             $analysisResult->getWarnings(),
             $analysisResult->isDefaultLevelUsed(),
-            $analysisResult->hasInferrablePropertyTypesFromConstructor(),
-            $analysisResult->getProjectConfigFile()
+            $analysisResult->getProjectConfigFile(),
+            $analysisResult->isResultCacheSaved()
         );
 
         return $this->tableErrorFormatter->formatErrors($clearedAnalysisResult, $output);

--- a/dev/tests/static/framework/Magento/PhpStan/Formatters/FilteredErrorFormatter.php
+++ b/dev/tests/static/framework/Magento/PhpStan/Formatters/FilteredErrorFormatter.php
@@ -9,6 +9,7 @@ namespace Magento\PhpStan\Formatters;
 
 use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\ErrorFormatter\TableErrorFormatter;
+use PHPStan\Command\ErrorFormatter\ErrorFormatter;
 use PHPStan\Command\Output;
 
 /**
@@ -37,11 +38,21 @@ use PHPStan\Command\Output;
  *
  * @see \Magento\PhpStan\Formatters\Fixtures\ClassWithIgnoreAnnotation
  */
-class FilteredErrorFormatter extends TableErrorFormatter
+class FilteredErrorFormatter implements ErrorFormatter
 {
     private const MUTE_ERROR_ANNOTATION = 'phpstan:ignore';
 
     private const NO_ERRORS = 0;
+
+    private $tableErrorFormatter;
+
+    /**
+     * @param TableErrorFormatter $tableErrorFormatter
+     */
+    public function __construct(TableErrorFormatter $tableErrorFormatter)
+    {
+        $this->tableErrorFormatter = $tableErrorFormatter;
+    }
 
     /**
      * @inheritdoc
@@ -67,7 +78,7 @@ class FilteredErrorFormatter extends TableErrorFormatter
             $analysisResult->getProjectConfigFile()
         );
 
-        return parent::formatErrors($clearedAnalysisResult, $output);
+        return $this->tableErrorFormatter->formatErrors($clearedAnalysisResult, $output);
     }
 
     /**

--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon
@@ -9,11 +9,11 @@ parameters:
         - %rootDir%/../../../dev/tests/*/tmp/*
         - %rootDir%/../../../dev/tests/*/_generated/*
         - %rootDir%/../../../pub/*
-    autoload_directories:
+    scanDirectories:
         - %rootDir%/../../../dev/tests/static/framework/tests/unit/testsuite/Magento
         - %rootDir%/../../../dev/tests/integration/framework/tests/unit/testsuite/Magento
         - %rootDir%/../../../dev/tests/api-functional/_files/Magento
-    autoload_files:
+    bootstrapFiles:
             - %rootDir%/../../../dev/tests/static/framework/autoload.php
             - %rootDir%/../../../dev/tests/integration/framework/autoload.php
             - %rootDir%/../../../dev/tests/api-functional/framework/autoload.php
@@ -46,7 +46,4 @@ services:
     errorFormatter.filtered:
         class: Magento\PhpStan\Formatters\FilteredErrorFormatter
         arguments:
-            showTipsOfTheDay: false
-            checkThisOnly: false
-            inferPrivatePropertyTypeFromConstructor: true
-            checkMissingTypehints: %checkMissingTypehints%
+            tableErrorFormatter: @errorFormatter.table


### PR DESCRIPTION
(cherry picked from commit 075a1b20033909b1c70ac869470506005e4cc4d8)

### Description (*)
This is the exact same change as https://github.com/magento/magento2/pull/30581, but this one targets the `2.4-develop` branch and not the `php8-develop` branch.

My original intention was to introduce this change in the 2.4 codebase. However it was [changed](https://github.com/magento/magento2/pull/30581#event-4130290621) to the php8 branch because it fitted in that context as well. But I'm afraid that the php8 branch will not get merged soon enough in `2.4-develop` (or even not at all, they aren't sure yet), so I decided to create a second PR now targeting the branch I originally wanted to see this change in.

### Related Pull Requests

### Fixed Issues (if relevant)
1. Fixes bitExpert/phpstan-magento#42: Mismatch between requirements


### Manual testing scenarios (*)
1. Somehow, tell phpstan to run on the Magento 2 source code and it should run without problems (it might detect more/different issues, and that is expected)

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
