### PR TITLE
Guest order, include customer middle name, prefix and suffix

### DIFF
--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -390,11 +390,11 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
             $quote->setCustomerId(null);
             $quote->setCustomerEmail($quote->getBillingAddress()->getEmail());
             if ($quote->getCustomerFirstname() === null && $quote->getCustomerLastname() === null) {
+                $quote->setCustomerPrefix($quote->getBillingAddress()->getPrefix());
                 $quote->setCustomerFirstname($quote->getBillingAddress()->getFirstname());
+                $quote->setCustomerMiddlename($quote->getBillingAddress()->getMiddlename());
                 $quote->setCustomerLastname($quote->getBillingAddress()->getLastname());
-                if ($quote->getBillingAddress()->getMiddlename() === null) {
-                    $quote->setCustomerMiddlename($quote->getBillingAddress()->getMiddlename());
-                }
+                $quote->setCustomerSuffix($quote->getBillingAddress()->getSuffix());
             }
             $quote->setCustomerIsGuest(true);
             $groupId = $quote->getCustomer()->getGroupId() ?: GroupInterface::NOT_LOGGED_IN_ID;


### PR DESCRIPTION
### Description (*)
When a customer places a guest order and the quote has an empty first and last name Magento uses the name of the billing address to populate this quote data. But two years ago a bug was introduced that removed the middle name from a guest order. The issue we're currently having is that the middle name is not filled in the sales_order table anymore when a customer places an order as guest.

With this PR that issue is resolved and we also add the prefix and suffix of the billing address.

### Related Pull Requests
- None

### Fixed Issues (if relevant)
- Couldn't find any

### Manual testing scenarios (*)
1. Place an order as a guest customer with a prefix, middle name and or suffix.
2. Check the transactional email to see if the prefix, middle name and or suffix is shown in the heading of the email.

### Questions or comments
- None

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#33037: Guest order, include customer middle name, prefix and suffix