### PR TITLE
Product images are being duplicated on import 

### DIFF
--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest.php
@@ -52,6 +52,8 @@ use Psr\Log\LoggerInterface;
  */
 class ProductTest extends \Magento\TestFramework\Indexer\TestCase
 {
+    private const LONG_FILE_NAME_IMAGE = 'magento_long_image_name_magento_long_image_name_magento_long_image_name.jpg';
+
     /**
      * @var \Magento\CatalogImportExport\Model\Import\Product
      */
@@ -1027,13 +1029,12 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
             )
         );
 
-        $this->importDataForMediaTest('import_media_additional_images.csv');
+        $this->importDataForMediaTest('import_media_additional_long_name_image.csv');
         $product->cleanModelCache();
         $product = $this->getProductBySku('simple_new');
         $items = array_values($product->getMediaGalleryImages()->getItems());
-        $images[] = ['file' => '/m/a/magento_additional_image_three.jpg', 'label' => ''];
-        $images[] = ['file' => '/m/a/magento_additional_image_four.jpg', 'label' => ''];
-        $this->assertCount(7, $items);
+        $images[] = ['file' => '/m/a/' . self::LONG_FILE_NAME_IMAGE, 'label' => ''];
+        $this->assertCount(6, $items);
         $this->assertEquals(
             $images,
             array_map(
@@ -1045,6 +1046,24 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
         );
     }
 
+    /**
+     * Test import twice and check that image will not be duplicate
+     *
+     * @magentoDataFixture mediaImportImageFixture
+     * @return void
+     */
+    public function testSaveMediaImageDuplicateImages(): void
+    {
+        $this->importDataForMediaTest('import_media.csv');
+        $imagesCount = count($this->getProductBySku('simple_new')->getMediaGalleryImages()->getItems());
+
+        // import the same file again
+        $this->importDataForMediaTest('import_media.csv');
+
+        $this->assertCount($imagesCount, $this->getProductBySku('simple_new')->getMediaGalleryImages()->getItems());
+    }
+    
+    
     /**
      * Test that errors occurred during importing images are logged.
      *
@@ -1086,6 +1105,10 @@ class ProductTest extends \Magento\TestFramework\Indexer\TestCase
             [
                 'source' => __DIR__ . '/../../../../Magento/Catalog/_files/magento_thumbnail.jpg',
                 'dest' => $dirPath . '/magento_thumbnail.jpg',
+            ],
+            [
+                'source' => __DIR__ . '/../../../../Magento/Catalog/_files/' . self::LONG_FILE_NAME_IMAGE,
+                'dest' => $dirPath . '/' . self::LONG_FILE_NAME_IMAGE,
             ],
             [
                 'source' => __DIR__ . '/_files/magento_additional_image_one.jpg',

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/import_media_additional_long_name_image.csv
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/import_media_additional_long_name_image.csv
@@ -1,0 +1,2 @@
+sku,additional_images
+simple_new,magento_long_image_name_magento_long_image_name_magento_long_image_name.jpg


### PR DESCRIPTION
Backport of PR #26713 to patch Magento 2.3.6 

Description
Built on top of #21146 and #21855.

This PR adds image deletion so after import product will have images specified in the CSV. New images will be added, existing will not be duplicated and images not mentioned in the CSV will be removed. This PR has been created for 2.4-develop branch and when approved I'll create backport for 2.3 branch.

Fixed Issues
#14398: Images Not Replaced via CSV Import
#21885: Product images are being duplicated on import

Manual testing scenarios (*)
Import product CSV using Add/Update method multiple times
Check if image duplication happens or not