### PR TITLE
Catch php syntax errors (or other errors) in bin/magento and output the error instead of staying silent

### DIFF
--- a/bin/magento
+++ b/bin/magento
@@ -21,7 +21,7 @@ try {
     set_error_handler([$handler, 'handler']);
     $application = new Magento\Framework\Console\Cli('Magento CLI');
     $application->run();
-} catch (\Exception $e) {
+} catch (\Throwable $e) {
     while ($e) {
         echo $e->getMessage();
         echo $e->getTraceAsString();


### PR DESCRIPTION
### Description (*)
When a PHP error occurs somewhere in code that is executed by `bin/magento` it should output that error instead of staying silent

### Related Pull Requests

### Fixed Issues (if relevant)

### Manual testing scenarios (*)
**I'll update these steps with more concrete things, not much time at the moment to put a lot more info here, will try this weekend if I find more time**

1. Have a module installed in `app/code` which uses PHP 7.4 specific syntax which doesn't work on PHP 7.3
2. Run `bin/magento` using PHP 7.3

### Expected
1. Exit code other then 0
2. Explanation of the error

### Actual
1. Exit code other then 0 => correct!
2. Just silence, nothing else, this makes it extremely confusing why the command doesn't seem to do anything

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32786: Catch php syntax errors (or other errors) in bin/magento and output the error instead of staying silent