### PR TITLE
Fix activate widget tab no keep active after triggered save

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Tabs.php
+++ b/app/code/Magento/Backend/Block/Widget/Tabs.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Backend\Block\Widget;
 
 use Magento\Backend\Block\Widget\Tab\TabInterface;
@@ -129,7 +131,7 @@ class Tabs extends \Magento\Backend\Block\Widget
             }
         } elseif (is_string($tab)) {
             $this->_addTabByName($tab, $tabId);
-            
+
             if (!$this->_tabs[$tabId] instanceof TabInterface) {
                 unset($this->_tabs[$tabId]);
                 return $this;
@@ -137,7 +139,7 @@ class Tabs extends \Magento\Backend\Block\Widget
         } else {
             throw new \Exception(__('Please correct the tab configuration and try again.'));
         }
-        
+
         if ($this->_tabs[$tabId]->getUrl() === null) {
             $this->_tabs[$tabId]->setUrl('#');
         }
@@ -148,7 +150,7 @@ class Tabs extends \Magento\Backend\Block\Widget
 
         $this->_tabs[$tabId]->setId($tabId);
         $this->_tabs[$tabId]->setTabId($tabId);
-        
+
         if (true === $this->_tabs[$tabId]->getActive()) {
             $this->setActiveTab($tabId);
         }
@@ -241,7 +243,7 @@ class Tabs extends \Magento\Backend\Block\Widget
     protected function _beforeToHtml()
     {
         $this->_tabs = $this->reorderTabs();
-        
+
         if ($activeTab = $this->getRequest()->getParam('active_tab')) {
             $this->setActiveTab($activeTab);
         } elseif ($activeTabId = $this->_authSession->getActiveTabId()) {
@@ -252,11 +254,11 @@ class Tabs extends \Magento\Backend\Block\Widget
             /** @var TabInterface $tab */
             $this->_activeTab = (reset($this->_tabs))->getId();
         }
-        
+
         $this->assign('tabs', $this->_tabs);
         return parent::_beforeToHtml();
     }
-    
+
     /**
      * Reorder the tabs.
      *
@@ -267,7 +269,7 @@ class Tabs extends \Magento\Backend\Block\Widget
         $orderByIdentity = [];
         $orderByPosition = [];
         $position        = 100;
-    
+
         /**
          * Set the initial positions for each tab.
          *
@@ -276,10 +278,10 @@ class Tabs extends \Magento\Backend\Block\Widget
          */
         foreach ($this->_tabs as $key => $tab) {
             $tab->setPosition($position);
-    
+
             $orderByIdentity[$key]      = $tab;
             $orderByPosition[$position] = $tab;
-            
+
             $position += 100;
         }
 
@@ -343,7 +345,7 @@ class Tabs extends \Magento\Backend\Block\Widget
 
         return $ordered;
     }
-    
+
     /**
      * Get js object name
      *

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/tabs.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/tabs.phtml
@@ -8,14 +8,13 @@
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if (!empty($tabs)): ?>
-
-<div class="admin__page-nav" data-role="container" id="<?=  $block->escapeHtmlAttr($block->getId()) ?>">
+<div class="admin__page-nav" data-role="container" id="<?= $block->escapeHtmlAttr($block->getId()) ?>">
     <?php if ($block->getTitle()): ?>
         <div class="admin__page-nav-title" data-role="title" <?= /* @noEscape */ $block->getUiId('title') ?>>
             <strong><?= $block->escapeHtml($block->getTitle()) ?></strong>
             <span data-role="title-messages" class="admin__page-nav-title-messages"></span>
         </div>
-    <?php endif ?>
+    <?php endif; ?>
     <ul <?= /* @noEscape */ $block->getUiId('tab', $block->getId()) ?>
         class="<?= /* @noEscape */ $block->getIsHoriz() ? 'tabs-horiz' : 'tabs admin__page-nav-items' ?>">
         <?php foreach ($tabs as $_tab): ?>
@@ -31,14 +30,14 @@
             <?php $_tabHref = $block->getTabUrl($_tab) == '#' ? '#' . $block->getTabId($_tab) . '_content' :
                 $block->getTabUrl($_tab) ?>
 
-            <li class="admin__page-nav-item no-display" id="<?= $block->escapeHtmlAttr($block->getTabId($_tab)) ?>"
+            <li class="admin__page-nav-item no-display" id="list_<?= $block->escapeHtmlAttr($block->getTabId($_tab)) ?>"
                 <?= /* @noEscape */ $block->getUiId('tab', 'item', $_tab->getId()) ?>>
-                <a href="<?=  $block->escapeUrl($_tabHref) ?>"
-                   id="<?=  $block->escapeHtmlAttr($block->getTabId($_tab)) ?>"
-                   name="<?=  $block->escapeHtmlAttr($block->getTabId($_tab, false)) ?>"
-                   title="<?=  $block->escapeHtmlAttr($block->getTabTitle($_tab)) ?>"
+                <a href="<?= $block->escapeUrl($_tabHref) ?>"
+                   id="<?= $block->escapeHtmlAttr($block->getTabId($_tab)) ?>"
+                   name="<?= $block->escapeHtmlAttr($block->getTabId($_tab, false)) ?>"
+                   title="<?= $block->escapeHtmlAttr($block->getTabTitle($_tab)) ?>"
                    class="admin__page-nav-link <?= $block->escapeHtmlAttr($_tabClass) ?>"
-                   data-tab-type="<?=  $block->escapeHtmlAttr($_tabType) ?>"
+                   data-tab-type="<?= $block->escapeHtmlAttr($_tabType) ?>"
                    <?= /* @noEscape */ $block->getUiId('tab', 'link', $_tab->getId()) ?>>
 
                    <span><?= $block->escapeHtml($block->getTabLabel($_tab)) ?></span>
@@ -68,13 +67,13 @@
                        </span>
                    </span>
                 </a>
-                <div id="<?=  $block->escapeHtmlAttr($block->getTabId($_tab)) ?>_content"
+                <div id="<?= $block->escapeHtmlAttr($block->getTabId($_tab)) ?>_content"
                     <?= /* @noEscape */ $block->getUiId('tab', 'content', $_tab->getId()) ?>>
                     <?= /* @noEscape */ $block->getTabContent($_tab) ?>
                 </div>
                 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
                     'display:none',
-                    'div#' . $block->escapeJs($block->getTabId($_tab)) . '_content'
+                    '#' . $block->escapeJs($block->getTabId($_tab)) . '_content'
                 ); ?>
             </li>
             <?php $scriptString = <<<script
@@ -83,12 +82,12 @@
 script;
             if ($block->getTabIsHidden($_tab)):
                 $scriptString .= <<<script
-        $('li.admin__page-nav-item#{$block->escapeJs($block->getTabId($_tab))}').css('display', 'none');
+        $('#list_{$block->escapeJs($block->getTabId($_tab))}').css('display', 'none');
 script;
             endif;
 
             $scriptString .= <<<script
-        $('li.admin__page-nav-item#{$block->escapeJs($block->getTabId($_tab))}').removeClass('no-display');
+        $('#list_{$block->escapeJs($block->getTabId($_tab))}').removeClass('no-display');
     })
 script;
             ?>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminClickCreateNewAttributeButtonActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminClickCreateNewAttributeButtonActionGroup.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminClickCreateNewAttributeButtonActionGroup">
+        <annotations>
+            <description>Admin click button create new attribute at product attribute page</description>
+        </annotations>
+
+        <click selector="{{AdminProductAttributeGridSection.createNewAttributeBtn}}" stepKey="createNewAttribute"/>
+        <waitForPageLoad stepKey="waitForNewAttributeFormLoad"/>
+
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminVerifyStorefrontPropertiesTabActiveActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminVerifyStorefrontPropertiesTabActiveActionGroup.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminVerifyStorefrontPropertiesTabActiveActionGroup">
+        <annotations>
+            <description>Switch to storefront properties and expected this tab remain active after form saved and reloaded</description>
+        </annotations>
+
+        <!-- Verify properties storefront tab visible -->
+        <seeElement selector="{{StorefrontPropertiesSection.StoreFrontPropertiesTab}}" stepKey="seeTabAttributePropertiesVisible" />
+
+        <!-- Click on "Storefront Properties" tab on left menu -->
+        <click selector="{{StorefrontPropertiesSection.StoreFrontPropertiesTab}}" stepKey="clickStorefrontPropertiesTab"/>
+
+        <!-- Click on save continue -->
+        <click selector="{{AttributePropertiesSection.SaveAndEdit}}" stepKey="clickSave"/>
+
+        <!-- wait page reload done -->
+        <waitForPageLoad stepKey="waitForPageProductAttributeLoad"/>
+
+        <!-- Verify tab still active -->
+        <seeElement selector="//li[@id='list_product_attribute_tabs_front'][contains(@class, 'admin__page-nav-item ui-state-default ui-corner-top ui-tabs-active ui-state-active')]" stepKey="seeTabAttributePropertiesActive" />
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminVerifyStorefrontPropertiesTabStillActiveAfterSaveContinueEditTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminVerifyStorefrontPropertiesTabStillActiveAfterSaveContinueEditTest.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminVerifyStorefrontPropertiesTabStillActiveAfterSaveContinueEditTest">
+        <annotations>
+            <features value="Catalog"/>
+            <stories value="Verify tab active after save form product attribute"/>
+            <title value="Activate Tab no longer works on legacy tabs/forms"/>
+            <description value="Admin should be able visible previous tab active after save product attribute"/>
+            <severity value="AVERAGE"/>
+            <testCaseId value="MC-38658"/>
+            <group value="Catalog"/>
+        </annotations>
+
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="LoginAsAdmin"/>
+        </before>
+
+        <after>
+            <!-- Delete created attribute -->
+            <actionGroup ref="DeleteProductAttributeActionGroup" stepKey="deleteAttribute">
+                <argument name="ProductAttribute" value="productTextEditorAttribute"/>
+            </actionGroup>
+
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logoutAsAdmin"/>
+            <!-- Reindex invalidated indices after product attribute has been created/deleted -->
+            <magentoCron groups="index" stepKey="reindexInvalidatedIndices"/>
+        </after>
+
+        <!-- Go to Stores > Product, click "Add New Attribute" -->
+        <actionGroup ref="AdminOpenProductAttributePageActionGroup" stepKey="openProductAttributePage"/>
+        <actionGroup ref="AdminClickCreateNewAttributeButtonActionGroup" stepKey="clickAddNewAttributeButton"/>
+
+        <!-- Fill attribute label name -->
+        <actionGroup ref="AdminFillProductAttributePropertiesActionGroup" stepKey="fillAttributeProperties">
+            <argument name="attributeName" value="{{productTextEditorAttribute.attribute_code}}"/>
+            <argument name="attributeType" value="{{productTextEditorAttribute.frontend_input}}"/>
+        </actionGroup>
+
+        <actionGroup ref="AdminVerifyStorefrontPropertiesTabActiveActionGroup" stepKey="verifyStorefrontTabActive"/>
+
+    </test>
+</tests>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Clean html class tabs (eliminate duplicate id for list item and anchor) and make sure tab work correctly like before
After this patch tab current keep active after admin change config and save form. Reload page return correct previous tab state
![Screenshot from 2021-02-16 21-41-44](https://user-images.githubusercontent.com/1908873/108078224-ff48bc80-709f-11eb-9493-900621ffd3d3.png)


Before after save form reload and set active for very first tab

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#30166

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login admin
2. Go to Stores
3. Select Attributes in dropdown main menu
4. Go Edit Product attribute
5. Choose Storefront Properties tab (last tab)
6. Change some options in right content tab
7. Click` save and continue edit` and watch results

Expected results
When we selected tab ex: "Storefront Properties" and do some change in form. Then save. After page reload tab "Storefront" should keep active state instead

Actually results
The first tab active instead previous tab

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
CC: @bvboas hope this fix correct as your wish
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
