### PR TITLE
MC-40031: [UX] Configurations are not preserved on form reload when new configurable product creation fails

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Validate.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Validate.php
@@ -13,7 +13,6 @@ use Magento\Catalog\Controller\Adminhtml\Product;
 use Magento\Framework\App\ObjectManager;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException;
-use Magento\Catalog\Model\Product as ProductModel;
 use Magento\CatalogUrlRewrite\Model\Product\Validator as ProductUrlRewriteValidator;
 
 /**
@@ -141,7 +140,7 @@ class Validate extends Product implements HttpPostActionInterface, HttpGetAction
             $resource->getAttribute('news_from_date')->setMaxValue($product->getNewsToDate());
             $resource->getAttribute('custom_design_from')->setMaxValue($product->getCustomDesignTo());
 
-            $this->validateUrlKeyUniqueness($product);
+            $this->productUrlRewriteValidator->validateUrlKey($product);
             $this->productValidator->validate($product, $this->getRequest(), $response);
         } catch (\Magento\Eav\Model\Entity\Attribute\Exception $e) {
             $response->setError(true);
@@ -165,32 +164,6 @@ class Validate extends Product implements HttpPostActionInterface, HttpGetAction
         }
 
         return $this->resultJsonFactory->create()->setData($response);
-    }
-
-    /**
-     * Validates Url Key uniqueness.
-     *
-     * @param ProductModel $product
-     * @throws UrlAlreadyExistsException
-     */
-    private function validateUrlKeyUniqueness(ProductModel $product): void
-    {
-        $conflictingUrlRewrites = $this->productUrlRewriteValidator->findUrlKeyConflicts($product);
-
-        if ($conflictingUrlRewrites) {
-            $data = [];
-
-            foreach ($conflictingUrlRewrites as $urlRewrite) {
-                $data[$urlRewrite->getUrlRewriteId()] = $urlRewrite->toArray();
-            }
-
-            throw new UrlAlreadyExistsException(
-                __('URL key for specified store already exists.'),
-                null,
-                0,
-                $data
-            );
-        }
     }
 
     /**

--- a/app/code/Magento/CatalogUrlRewrite/Model/Product/Validator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Product/Validator.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogUrlRewrite\Model\Product;
+
+use Magento\Catalog\Model\Product;
+use Magento\CatalogUrlRewrite\Model\ProductUrlPathGenerator;
+use Magento\UrlRewrite\Model\UrlFinderInterface;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
+use Magento\Store\Model\StoreManagerInterface;
+
+/**
+ * Url Rewrites Product validator.
+ */
+class Validator
+{
+    /**
+     * @var ProductUrlPathGenerator
+     */
+    private $productUrlPathGenerator;
+
+    /**
+     * @var UrlFinderInterface
+     */
+    private $urlFinder;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @param ProductUrlPathGenerator $productUrlPathGenerator
+     * @param UrlFinderInterface $urlFinder
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        ProductUrlPathGenerator $productUrlPathGenerator,
+        UrlFinderInterface $urlFinder,
+        StoreManagerInterface $storeManager
+    ) {
+        $this->productUrlPathGenerator = $productUrlPathGenerator;
+        $this->urlFinder = $urlFinder;
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * Find Url Key conflicts of a product.
+     *
+     * @param Product $product
+     * @return array Array of conflicting Url Keys.
+     */
+    public function findUrlKeyConflicts(Product $product): array
+    {
+        if (!$product->getUrlKey()) {
+            $urlKey = $this->productUrlPathGenerator->getUrlKey($product);
+            $product->setUrlKey($urlKey);
+        }
+
+        $stores = $this->storeManager->getStores();
+
+        $storeIdsToPathForSave = [];
+        $searchData = [
+            UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
+            UrlRewrite::REQUEST_PATH => []
+        ];
+
+        foreach ($stores as $store) {
+            if (!in_array($store->getWebsiteId(), $product->getWebsiteIds())) {
+                continue;
+            }
+
+            $urlPath = $this->productUrlPathGenerator->getUrlPathWithSuffix($product, $store->getId());
+            $storeIdsToPathForSave[$store->getId()] = $urlPath;
+            $searchData[UrlRewrite::REQUEST_PATH][] = $urlPath;
+        }
+
+        $urlRewrites = $this->urlFinder->findAllByData($searchData);
+        $conflicts = [];
+
+        foreach ($urlRewrites as $urlRewrite) {
+            if (in_array($urlRewrite->getRequestPath(), $storeIdsToPathForSave)
+                && isset($storeIdsToPathForSave[$urlRewrite->getStoreId()])
+                && $storeIdsToPathForSave[$urlRewrite->getStoreId()] == $urlRewrite->getRequestPath()
+                && $product->getId() != $urlRewrite->getEntityId()) {
+                $conflicts[] = $urlRewrite;
+            }
+        }
+
+        return $conflicts;
+    }
+}

--- a/app/code/Magento/CatalogUrlRewrite/Model/Product/Validator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Product/Validator.php
@@ -51,18 +51,13 @@ class Validator
     }
 
     /**
-     * Validate Url Key of a Product.
+     * Validate Url Key of a Product has no conflicts.
      *
      * @param Product $product
      * @throws UrlAlreadyExistsException
      */
-    public function validateUrlKey(Product $product): void
+    public function validateUrlKeyConflicts(Product $product): void
     {
-        if (!$product->getUrlKey()) {
-            $urlKey = $this->productUrlPathGenerator->getUrlKey($product);
-            $product->setUrlKey($urlKey);
-        }
-
         $stores = $this->storeManager->getStores();
 
         $storeIdsToPathForSave = [];

--- a/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/ValidateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Controller/Adminhtml/Product/ValidateTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Catalog\Controller\Adminhtml\Product;
+
+use Magento\TestFramework\TestCase\AbstractBackendController;
+use Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException;
+use Magento\Framework\App\Request\Http as HttpRequest;
+use Magento\Catalog\Model\Product\Type;
+
+/**
+ * @magentoAppArea adminhtml
+ */
+class ValidateTest extends AbstractBackendController
+{
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     */
+    public function testNotUniqueUrlKey()
+    {
+        $this->getRequest()
+            ->setMethod(HttpRequest::METHOD_POST);
+
+        $postData = [
+            'product' => [
+                'attribute_set_id' => '4',
+                'status' => '1',
+                'name' => 'Simple product',
+                'sku' => 'simple',
+                'type_id' => Type::TYPE_SIMPLE,
+                'quantity_and_stock_status' => [
+                    'qty' => '10',
+                    'is_in_stock' => '1',
+                ],
+                'website_ids' => [
+                    1 => '1',
+                ],
+                'price' => '100',
+            ],
+        ];
+
+        $this->getRequest()
+            ->setPostValue($postData);
+        $this->dispatch('backend/catalog/product/validate/');
+        $responseBody = $this->getResponse()
+            ->getBody();
+
+        $message = __('The value specified in the URL Key field would generate a URL that already exists.');
+        $additionalInfo = __('To resolve this conflict, you can either change the value of the URL Key field '
+            . '(located in the Search Engine Optimization section) to a unique value, or change the Request Path fields'
+            . ' in all locations listed below:');
+
+        $this->assertStringContainsString((string)$message, $responseBody);
+        $this->assertStringContainsString((string)$additionalInfo, $responseBody);
+    }
+}


### PR DESCRIPTION
### Description (*)
This is a usability issue.

### Fixed Issues (if relevant)
1. Fixes magento/magento2/issues/32102

### Manual testing scenarios (*)

1. Open backend
2. Go to products grid
3. Create configurable product with 1 attribute named "Configurable One"
4. Save product
5. Create new configurable product configuration basing on 5 attributes with only 2 variations each
6. Enter "Configurable One" as name
7. Configure variations qty and prices (enter different price and qty for each vatiation)
8. CLick Save

 **Actual**: Form is reloaded. Error is displayed:
_The value specified in the URL Key field would generate a URL that already exists._
The variations you configured have disappeared. Information that has to be entered manually and requires significant time is lost.

**Expected**: To be identified by UX team.
- Form is reloaded, configurations are preserved.
OR
- Form is not reloaded, AJAX validation includes URL Key check.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
