### PR TITLE
+ forcing lowercase in URL comparison

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/Category/CurrentUrlRewritesRegenerator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Category/CurrentUrlRewritesRegenerator.php
@@ -114,7 +114,7 @@ class CurrentUrlRewritesRegenerator
     {
         if ($category->getData('save_rewrites_history')) {
             $targetPath = $this->categoryUrlPathGenerator->getUrlPathWithSuffix($category, $storeId);
-            if ($url->getRequestPath() !== $targetPath) {
+            if (strtolower($url->getRequestPath()) !== strtolower($targetPath)) {
                 $generatedUrl = clone $this->urlRewritePrototype;
                 $generatedUrl->setEntityType(CategoryUrlRewriteGenerator::ENTITY_TYPE)
                     ->setEntityId($category->getEntityId())


### PR DESCRIPTION
### Description (*)
If using custom URL keys for categories, created from API or code, and if the URL key does not follow lowercase format, it will throw exception when trying to save category from Admin.
Reason is when saving from admin, it is automatically transformed in lowercase. 

This fix also forces a lowercase comparison in the generateForAutogenerated method (which is responsible for generating url redirects as I see) from Magento\CatalogUrlRewrite\Model\Category\CurrentUrlRewritesRegenerator class. Without this transformation, an existing URL can gets into the comparison and Unique constraint violation error will happen when trying save the URL in url_rewrite table.


### Manual testing scenarios (*)
Pre-conditions:
Magento CE 2.4.1 
PHP 7.4
Mysql 5.7.24

1 - Create custom category Url keys, in uppercase format, using API or code. 
2 - Regenerate URL rewrite.
3 - Try save any parent category from admin.

- Expected result: Category is saved
- Actual result: Category is not saved. Unique constraint violation happened.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)