### PR TITLE
Fix mage-messages cookie path

### DIFF
--- a/app/code/Magento/Theme/view/frontend/web/js/view/messages.js
+++ b/app/code/Magento/Theme/view/frontend/web/js/view/messages.js
@@ -41,7 +41,8 @@ define([
 
             $.mage.cookies.set('mage-messages', '', {
                 samesite: 'strict',
-                domain: ''
+                domain: '',
+                path: '/'
             });
         },
 


### PR DESCRIPTION
### Description (*)
Success and error messages are not displayed if Magento has its base url configured in a sub path.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#32219

### Manual testing scenarios (*)
1. Configure a base url with a sub path (example: https://magento.com/sub/)
2. Copy/paste `pub/index.php` to `pub/sub/index.php` on the server (and replace `/../app/bootstrap.php` by `/../../app/bootstrap.php` in the `pub/sub/index.php` file)
2. Go to the contact page (https://magento.com/sub/contact/ in our example)
3. Submit the contact form
4. The success message should display after sending the contact message (before this Pull Request, it is not displayed)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
