### PR TITLE
Change from model save() to repository save() method

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Save.php
@@ -140,7 +140,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Product implements Http
 
                 $originalSku = $product->getSku();
                 $canSaveCustomOptions = $product->getCanSaveCustomOptions();
-                $product->save();
+                $this->productRepository->save($product);
                 $this->handleImageRemoveError($data, $product->getId());
                 $productId = $product->getEntityId();
                 $productAttributeSetId = $product->getAttributeSetId();


### PR DESCRIPTION
The product models `save()` method is deprecated. And for a good reason: Third party code are not supposed to make changes to models, resource models and collections, but only modify things through service contracts. In short, they should be depending on repositories (thus, repository interfaces). A common scenario that Magento has been pushing for years is to hook into repository methods by using extension attributes,and intercepting the repository methods with plugin methods like `afterSave()`. But when the product is saved via the Magento Admin Panel, the current controller saves information directly to the model, bypassing the repository and therefore bypassing any extension that is using extension attributes. The workaround that many devs are taking now is to intercept the model method `save()` instead, which is currently a necessary evil. This PR fixes this.

Currently tested in various environments without zero issues.


### Resolved issues:
1. [x] resolves magento/magento2#32265: Change from model save() to repository save() method