### PR TITLE
Error messages are not shown in frontend

### DIFF
--- a/app/code/Magento/Theme/view/frontend/web/js/view/messages.js
+++ b/app/code/Magento/Theme/view/frontend/web/js/view/messages.js
@@ -8,12 +8,13 @@
  */
 define([
     'jquery',
+    'knockout',
     'uiComponent',
     'Magento_Customer/js/customer-data',
     'underscore',
     'escaper',
     'jquery/jquery-storageapi'
-], function ($, Component, customerData, _, escaper) {
+], function ($, ko, Component, customerData, _, escaper) {
     'use strict';
 
     return Component.extend({
@@ -30,9 +31,9 @@ define([
             this._super();
 
             this.cookieMessages = _.unique($.cookieStorage.get('mage-messages'), 'text');
-            this.messages = customerData.get('messages').extend({
+            this.messages = ko.observable({ ...customerData.get('messages').extend({
                 disposableCustomerData: 'messages'
-            });
+            })() });
 
             // Force to clean obsolete messages
             if (!_.isEmpty(this.messages().messages)) {

--- a/app/code/Magento/Theme/view/frontend/web/js/view/messages.js
+++ b/app/code/Magento/Theme/view/frontend/web/js/view/messages.js
@@ -31,9 +31,9 @@ define([
             this._super();
 
             this.cookieMessages = _.unique($.cookieStorage.get('mage-messages'), 'text');
-            this.messages = ko.observable({ ...customerData.get('messages').extend({
+            this.messages = ko.observable(Object.assign({}, customerData.get('messages').extend({
                 disposableCustomerData: 'messages'
-            })() });
+            })()));
 
             // Force to clean obsolete messages
             if (!_.isEmpty(this.messages().messages)) {


### PR DESCRIPTION
cloneObj = { ...obj }   this is equivalent to $classA = clone $classB; in php.


This snippet : 
```
            // Force to clean obsolete messages
            if (!_.isEmpty(this.messages().messages)) {
                customerData.set('messages', {});
            }
```

is clearing the variable "this.messages" because there is a memory reference between them, defined at line `this.messages = customerData.get('messages'). .....`


later on in Magento_Theme::messages.phtml 
```
    <!-- ko if: messages().messages && messages().messages.length > 0 -->
    <div aria-atomic="true" role="alert" class="messages" data-bind="foreach: {
        data: messages().messages, as: 'message'
    }">
        <div data-bind="attr: {
            class: 'message-' + message.type + ' ' + message.type + ' message',
            'data-ui-id': 'message-' + message.type
        }">
            <div data-bind="html: $parent.prepareMessageForHtml(message.text)"></div>
        </div>
    </div>
    <!-- /ko -->
```

This snippet will have empty values for "messages()" and it will never pass the IF statement