### PR TITLE
Magento_Backend store switcher: Use nowdoc instead of heredoc

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/templates/store/switcher.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/store/switcher.phtml
@@ -200,7 +200,7 @@ script;
                 setLocation(url);
 ';
     } else {
-        $scriptString .= <<<script
+        $scriptString .= <<<'script'
             jQuery('#preview_selected_store').val(scopeId);
             jQuery('#preview_form').submit();
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

The heredoc in [Magento/Backend/view/adminhtml/templates/store/switcher.phtml#L203-L216](https://github.com/magento/magento2/blob/896f0d6/app/code/Magento/Backend/view/adminhtml/templates/store/switcher.phtml#L203-L216) is not valid, because the embedded JavaScript contains `$this`, which happens to be a valid variable name in PHP, too. Consequently, PHP tries to replace its occurrences by the current class object which results in an error. This can be avoided by using nowdoc instead of heredoc, which is the aim of this PR.

In Magento core, the `is_using_iframe` flag is never set. As a consequence, the else-branch in  [Magento/Backend/view/adminhtml/templates/store/switcher.phtml#L203-L216](https://github.com/magento/magento2/blob/896f0d6/app/code/Magento/Backend/view/adminhtml/templates/store/switcher.phtml#L203-L216) is never called, so the error does not occur in a standard environment. However, we use Amasty's [*Improved Layered Navigation*](https://amasty.com/improved-layered-navigation-for-magento-2.html), which sets this flag to true for one of their backend configurations. The resulting error (in developer mode) looks as follows:

![Screenshot from 2021-02-23 08-32-05](https://user-images.githubusercontent.com/881988/108815654-16fad600-75b5-11eb-81f5-3975e93f6309.png)

### Related Pull Requests
<!-- related pull request placeholder -->

Two years ago, there was https://github.com/magento/magento2/pull/20656 to replace all heredoc by nowdoc, but it was closed.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

No separate issue created.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
For reproducing this error, it is not necessary to install Magento or the referenced Amasty extension at all. Simply paste the snippet into a fresh PHP file `test.php`:

```php
<?php
$test = <<<script
            jQuery('#preview_selected_store').val(scopeId);
            jQuery('#preview_form').submit();

            jQuery('.store-switcher .dropdown-menu li a').each(function() {
                var $this = jQuery(this);

                if ($this.data('role') === 'store-view-id' && $this.data('value') == scopeId) {
                    jQuery('#store-change-button').html($this.text());
                }
            });

            jQuery('#store-change-button').click();
script;
echo $test;
```

Calling the script via `php -f test.php` yields a similar error. Changing the first line to `<<<'script'` resolves this issue.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32262: Magento_Backend store switcher: Use nowdoc instead of heredoc