### PR TITLE
Fix issue 32257

### DIFF
--- a/app/code/Magento/Translation/Model/Inline/Parser.php
+++ b/app/code/Magento/Translation/Model/Inline/Parser.php
@@ -422,7 +422,7 @@ class Parser implements ParserInterface
                 [
                     'shown' => htmlspecialchars_decode($matches[1][0]),
                     'translated' => htmlspecialchars_decode($matches[2][0]),
-                    'original' => htmlspecialchars_decode($matches[3][0]),
+                    'original' => htmlspecialchars_decode($matches[4][0]),
                     'location' => htmlspecialchars_decode($locationCallback($matches, $options)),
                 ]
             );
@@ -682,9 +682,9 @@ class Parser implements ParserInterface
                 [
                     'shown' => $matches[1][0],
                     'translated' => $matches[2][0],
-                    'original' => $matches[3][0],
+                    'original' => $matches[4][0],
                     'location' => 'Text',
-                    'scope' => $matches[4][0],
+                    'scope' => $matches[5][0],
                 ],
                 JSON_HEX_QUOT
             );

--- a/lib/internal/Magento/Framework/Translate/Inline/ParserInterface.php
+++ b/lib/internal/Magento/Framework/Translate/Inline/ParserInterface.php
@@ -16,7 +16,7 @@ interface ParserInterface
     /**
      * Regular Expression for detected and replace translate
      */
-    const REGEXP_TOKEN = '\{\{\{(.*?)\}\}\{\{(.*?)\}\}\{\{(.*?)\}\}\{\{(.*?)\}\}\}';
+    const REGEXP_TOKEN = '\{\{\{(.*?)\}\}\{\{(.*?)\}\}\{\{(.*?)\}\}\{\{(.*?)\}\}\{\{(.*?)\}\}\}';
 
     /**
      * Parse and save edited translation


### PR DESCRIPTION
### Description (*)
This pull request fixes the issue https://github.com/magento/magento2/issues/32257 related to Translate Inline.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#32257 

### Manual testing scenarios (*)
See magento/magento2#32257 

### Questions or comments
The difference that in Magento2.4.2 when enable Translate inline e.g. Add to cart button (other elements too) start looking as 
```
<button type="button"
                            title="{{{Add to Cart2}}{{Add to Cart2}}{{Add to Cart2}}{{Add to Cart}}{{themeMagento/luma}}}"
                            class="action tocart primary">
                        <span>{{{Add to Cart2}}{{Add to Cart2}}{{Add to Cart2}}{{Add to Cart}}{{themeMagento/luma}}}</span>
                    </button>
```
And e.g. in previus Magento2.3.3 it was
```
<button type="button"
                            title="{{{Add to Cart2}}{{Add to Cart2}}{{Add to Cart}}{{themeMagento/luma}}}"
                            class="action tocart primary">
                        <span>{{{Add to Cart2}}{{Add to Cart2}}{{Add to Cart}}{{themeMagento/luma}}}</span>
                    </button>
```

And this is related to additional renderer in \Magento\Framework\Phrase\RendererInterface\Composite::render(), previously there was 3 renders:
Magento\Framework\Phrase\Renderer\Translate
Magento\Framework\Phrase\Renderer\Placeholde
Magento\Framework\Phrase\Renderer\Inline

And new renderer Magento\Framework\Phrase\Renderer\MessageFormatter was added and that leads to additional {{}} element, so need to change REGEXP_TOKEN

### Contribution checklist (*)
 - [+] Pull request has a meaningful description of its purpose
 - [+] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
