### PR TITLE
Fix syntax error in jQuery cookie when samesite option not set

### DIFF
--- a/lib/web/jquery/jquery.cookie.js
+++ b/lib/web/jquery/jquery.cookie.js
@@ -47,7 +47,7 @@
                 options.path    ? '; path=' + options.path : '',
                 options.domain  ? '; domain=' + options.domain : '',
                 options.secure  ? '; secure' : '',
-                options.samesite  ? '; samesite=' + options.samesite : 'lax',
+                options.samesite  ? '; samesite=' + options.samesite : '',
             ].join(''));
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
If the `samesite` option was not set, the cookie would be malformed due to a dangling `lax` being appended to it. For example calling `$.cookie('foo', 'bar', {domain: 'foobar.com'})` would call `document.cookie = foo=bar; domain=foobar.comlax;`

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Open browser dev tools.
2. Add the following logpoint to `lib/jquery/jquery.cookie.js` for debugging:
![image](https://user-images.githubusercontent.com/2262772/108958273-6c99b600-767b-11eb-9304-4d2411aaffb7.png)
3. Type `jQuery.cookie('foo', 'bar', {domain: 'foobar.com'})` to the dev tools console.
4. Notice that the cookie syntax is invalid.
![image](https://user-images.githubusercontent.com/2262772/108958411-9c48be00-767b-11eb-953a-131c4ee89cfd.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32297: Fix syntax error in jQuery cookie when samesite option not set