### PR TITLE
Restore UNIQUE_CHECKS mysql variable to its original value when done …

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/OperationsExecutor.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/OperationsExecutor.php
@@ -132,10 +132,10 @@ class OperationsExecutor
     private function startSetupForAllConnections()
     {
         foreach ($this->sharding->getResources() as $resource) {
-            $this->resourceConnection->getConnection($resource)
-                ->startSetup();
-            $this->resourceConnection->getConnection($resource)
-                ->query('SET UNIQUE_CHECKS=0');
+            $connection = $this->resourceConnection->getConnection($resource);
+
+            $connection->startSetup();
+            $connection->query('SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0');
         }
     }
 
@@ -148,8 +148,10 @@ class OperationsExecutor
     private function endSetupForAllConnections()
     {
         foreach ($this->sharding->getResources() as $resource) {
-            $this->resourceConnection->getConnection($resource)
-                ->endSetup();
+            $connection = $this->resourceConnection->getConnection($resource);
+
+            $connection->query('SET UNIQUE_CHECKS=IF(@OLD_UNIQUE_CHECKS=0, 0, 1)');
+            $connection->endSetup();
         }
     }
 

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/Declaration/Schema/OperationsExecutorTest.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/Declaration/Schema/OperationsExecutorTest.php
@@ -160,7 +160,7 @@ class OperationsExecutorTest extends TestCase
         $connectionMock = $this->getMockBuilder(Mysql::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->resourceConnectionMock->expects(self::exactly(3))
+        $this->resourceConnectionMock->expects(self::exactly(2))
             ->method('getConnection')
             ->with('default')
             ->willReturn($connectionMock);


### PR DESCRIPTION
…with changing the database structure. This prevents potentially inserting duplicated values while manipulating data in the setup:upgrade command.

### Description (*)
See https://github.com/magento/magento2/issues/32283
When approved, please please please consider backporting this to Magento 2.3.7, this is too important to be ignored for 2.3 in my opinion.

According to Magento core devs I spoke to on Slack in the past few days, there is an underlying problem where connections should be closed and opened again between the schema manipulation and the data manipulation in order to reset these mysql variables. But that's not happening.
So this is only a workaround, but since the same workaround was [implemented for the `FOREIGN_KEY_CHECKS` and others](https://github.com/magento/magento2/blob/2.4.2/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php#L2941-L2966), it makes sense to also do this for `UNIQUE_CHECKS` until the root cause is found, since it's an easy fix which should not cause issues.

I have no intention to write automated tests for this change, I already spend more then 10 hours on dealing with the consequences of this issue and then an hour on finding an appropriate solution, I can't invest more time in adding automated tests, sorry!

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/magento2/issues/32283: Mysql UNIQUE_CHECKS is disabled for data manipulation while it should only be disabled for schema manipulations
2. Fixes https://github.com/magento/magento2/issues/28326: Attribute value was duplicated after upgrade magento from 2.1 to 2.3

### Manual testing scenarios (*)
1. In some random RecurringData setup script, add some debugging code to verify the value of the `UNIQUE_CHECKS` variable, the RecurringData script makes it easy to test. For example, in the [Magento\SalesSequence\Setup\RecurringData::install method](https://github.com/magento/magento2/blob/2.4.2/app/code/Magento/SalesSequence/Setup/RecurringData.php#L34-L37), add:
```php
        $connection = $setup->getConnection();
        var_dump('*** In RecurringData', $connection->query('SHOW VARIABLES LIKE "UNIQUE_CHECKS"')->fetch());
```
2. Run `bin/magento setup:upgrade`

Before this PR, it outputs:
```
string(20) "*** In RecurringData"
array(2) {
  ["Variable_name"]=>
  string(13) "unique_checks"
  ["Value"]=>
  string(3) "OFF"
}
```

After this PR, it outputs:
```
string(20) "*** In RecurringData"
array(2) {
  ["Variable_name"]=>
  string(13) "unique_checks"
  ["Value"]=>
  string(2) "ON"
}
```

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
