### PR TITLE
MC-39186: ZIP code doesn't change unless other field is edited

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Address.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Address.php
@@ -122,4 +122,17 @@ class Address extends SalesResource implements OrderAddressResourceInterface
         }
         return $this;
     }
+
+    /**
+     * @inheritdoc
+     */
+    protected function isModified(\Magento\Framework\Model\AbstractModel $object)
+    {
+        $parentValue = parent::isModified($object);
+
+        $originalPostCode = $object->getOrigData("postcode");
+        $currentPostCode = $object->getDataByKey("postcode");
+
+        return $parentValue || ($originalPostCode !== $currentPostCode);
+    }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Fixed a bug where the postcode wouldn't save if you are trying to edit it. 

The issue is caused by a loose comparison when checking if the entity was modified before saving the entity. For the postcode ("60882." == "60882") evaluates to true which prevents a save, so a strict comparison solves the issue. 

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#30951

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. See magento/magento2#30951

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
