### PR TITLE
fix Elastic Search interferes with the default sort order of products (changing newest first to oldest first)

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSetPositionInCategoryProductsGridActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSetPositionInCategoryProductsGridActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminSetProductPositionInCategoryProductsGirdActionGroup">
+        <arguments>
+            <argument name="positionInGrid" type="string"/>
+            <argument name="position" type="string"/>
+        </arguments>
+
+        <fillField selector="{{AdminCategoryProductsGridSection.positionField(positionInGrid)}}" userInput="{{position}}" stepKey="fillPositionOnCategory" />
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSetProductPositionInCategoryProductsGirdActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSetProductPositionInCategoryProductsGirdActionGroup.xml
@@ -14,6 +14,6 @@
             <argument name="position" type="string"/>
         </arguments>
 
-        <fillField selector="{{AdminCategoryProductsGridSection.positionField(positionInGrid)}}" userInput="{{position}}" stepKey="fillPositionOnCategory" />
+        <fillField selector="{{AdminCategoryProductsGridSection.rowPositionInput(positionInGrid)}}" userInput="{{position}}" stepKey="fillPositionOnCategory" />
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminCategoryProductsGridSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminCategoryProductsGridSection.xml
@@ -18,6 +18,6 @@
         <element name="productVisibility" type="select" selector="//*[@name='product[visibility]']"/>
         <element name="productSelectAll" type="checkbox" selector="input.admin__control-checkbox"/>
         <element name="productsGridEmpty" type="text" selector="#catalog_category_products_table .data-grid-tr-no-data .empty-text"/>
-        <element name="positionField" type="input" selector="//tbody/tr[{{var}}]//input[@name='position']" timeout="30" parameterized="true"/>
+        <element name="rowPositionInput" type="input" selector="//tbody/tr[{{var}}]//input[@name='position']" timeout="30" parameterized="true"/>
     </section>
 </sections>

--- a/app/code/Magento/Catalog/Test/Mftf/Section/AdminCategoryProductsGridSection.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Section/AdminCategoryProductsGridSection.xml
@@ -18,5 +18,6 @@
         <element name="productVisibility" type="select" selector="//*[@name='product[visibility]']"/>
         <element name="productSelectAll" type="checkbox" selector="input.admin__control-checkbox"/>
         <element name="productsGridEmpty" type="text" selector="#catalog_category_products_table .data-grid-tr-no-data .empty-text"/>
+        <element name="positionField" type="input" selector="//tbody/tr[{{var}}]//input[@name='position']" timeout="30" parameterized="true"/>
     </section>
 </sections>

--- a/app/code/Magento/CatalogSearch/Test/Mftf/Test/SearchEntityResultsTest/QuickSearchTwoProductsWithSameWeightTest.xml
+++ b/app/code/Magento/CatalogSearch/Test/Mftf/Test/SearchEntityResultsTest/QuickSearchTwoProductsWithSameWeightTest.xml
@@ -83,11 +83,11 @@
         </actionGroup>
         <actionGroup ref="StorefrontQuickSearchCheckProductNameInGridActionGroup" stepKey="assertProduct1Position">
             <argument name="productName" value="$product1.name$"/>
-            <argument name="index" value="1"/>
+            <argument name="index" value="2"/>
         </actionGroup>
         <actionGroup ref="StorefrontQuickSearchCheckProductNameInGridActionGroup" stepKey="assertProduct2Position">
             <argument name="productName" value="$product2.name$"/>
-            <argument name="index" value="2"/>
+            <argument name="index" value="1"/>
         </actionGroup>
     </test>
 </tests>

--- a/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Sort.php
+++ b/app/code/Magento/Elasticsearch/SearchAdapter/Query/Builder/Sort.php
@@ -20,15 +20,14 @@ class Sort
     /**
      * List of fields that need to skipp by default.
      */
-    private const DEFAULT_SKIPPED_FIELDS = [
-        'entity_id',
-    ];
+    private const DEFAULT_SKIPPED_FIELDS = [];
 
     /**
      * Default mapping for special fields.
      */
     private const DEFAULT_MAP = [
         'relevance' => '_score',
+        'entity_id' => '_id',
     ];
 
     /**

--- a/app/code/Magento/Elasticsearch/Test/Mftf/Test/StorefrontSortByPositionOnCategoryPageTest.xml
+++ b/app/code/Magento/Elasticsearch/Test/Mftf/Test/StorefrontSortByPositionOnCategoryPageTest.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontSortByPositionOnCategoryPageTest">
+        <annotations>
+            <features value="Search"/>
+            <stories value="Elasticsearch"/>
+            <title value="Sort by position when products have the same positions"/>
+            <description value="When two products have the same position user should be see newest product first using ElasticSearch"/>
+            <severity value="MAJOR"/>
+            <group value="SearchEngineElasticsearch" />
+        </annotations>
+        <before>
+            <createData entity="_defaultCategory" stepKey="createCategory"/>
+            <createData entity="ApiSimpleProduct" stepKey="createFirstProduct">
+                <field key="name">First simple product</field>
+                <requiredEntity createDataKey="createCategory"/>
+            </createData>
+            <createData entity="ApiSimpleProduct" stepKey="createSecondProduct">
+                <field key="name">Second simple product</field>
+                <requiredEntity createDataKey="createCategory"/>
+            </createData>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logoutOfAdmin"/>
+            <deleteData createDataKey="createFirstProduct" stepKey="deleteFirstProduct"/>
+            <deleteData createDataKey="createSecondProduct" stepKey="deleteSecondProduct"/>
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+        </after>
+
+        <actionGroup ref="AdminOpenCategoryPageActionGroup" stepKey="openAdminCategoryIndexPage"/>
+        <actionGroup ref="AdminExpandCategoryTreeActionGroup" stepKey="expandCategoryTree"/>
+        <actionGroup ref="AdminCategoriesOpenCategoryActionGroup" stepKey="openCategory">
+            <argument name="category" value="$$createCategory$$"/>
+        </actionGroup>
+        <actionGroup ref="AdminCategoryPageOpenProductsInCategorySectionActionGroup" stepKey="openProductsInCategorySection"/>
+        <actionGroup ref="AdminSetProductPositionInCategoryProductsGirdActionGroup" stepKey="setProductPositionForSecondProduct">
+            <argument name="positionInGrid" value="1"/>
+            <argument name="position" value="1"/>
+        </actionGroup>
+        <actionGroup ref="AdminSetProductPositionInCategoryProductsGirdActionGroup" stepKey="setProductPositionForFirstProduct">
+            <argument name="positionInGrid" value="2"/>
+            <argument name="position" value="1"/>
+        </actionGroup>
+        <actionGroup ref="AdminSaveCategoryActionGroup" stepKey="saveCategory"/>
+        <actionGroup ref="StorefrontNavigateCategoryPageActionGroup" stepKey="navigateToCategoryPageToResetFilter">
+            <argument name="category" value="$createCategory$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontCheckProductPositionActionGroup" stepKey="seeSecondProductFirstInList">
+            <argument name="position" value="1"/>
+            <argument name="productName" value="$$createSecondProduct.name$$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontCheckProductPositionActionGroup" stepKey="seeFirstProductLastInList">
+            <argument name="position" value="2"/>
+            <argument name="productName" value="$$createFirstProduct.name$$"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/Elasticsearch/Test/Unit/SearchAdapter/Query/Builder/SortTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/SearchAdapter/Query/Builder/SortTest.php
@@ -130,21 +130,42 @@ class SortTest extends TestCase
                 [
                     [
                         'field' => 'entity_id',
-                        'direction' => 'DESC'
+                        'direction' => 'ASC'
                     ]
                 ],
                 false,
                 false,
                 false,
-                null,
-                []
+                'entity_id',
+                [
+                    [
+                        '_id' => [
+                            'order' => 'asc'
+                        ]
+                    ]
+                ]
             ],
             [
                 [
                     [
                         'field' => 'entity_id',
                         'direction' => 'DESC'
-                    ],
+                    ]
+                ],
+                false,
+                false,
+                false,
+                'entity_id',
+                [
+                    [
+                        '_id' => [
+                            'order' => 'desc'
+                        ]
+                    ]
+                ]
+            ],
+            [
+                [
                     [
                         'field' => 'price',
                         'direction' => 'DESC'
@@ -165,10 +186,6 @@ class SortTest extends TestCase
             [
                 [
                     [
-                        'field' => 'entity_id',
-                        'direction' => 'DESC'
-                    ],
-                    [
                         'field' => 'price',
                         'direction' => 'DESC'
                     ],
@@ -187,10 +204,6 @@ class SortTest extends TestCase
             ],
             [
                 [
-                    [
-                        'field' => 'entity_id',
-                        'direction' => 'DESC'
-                    ],
                     [
                         'field' => 'name',
                         'direction' => 'DESC'
@@ -210,10 +223,6 @@ class SortTest extends TestCase
             ],
             [
                 [
-                    [
-                        'field' => 'entity_id',
-                        'direction' => 'DESC'
-                    ],
                     [
                         'field' => 'not_eav_attribute',
                         'direction' => 'DESC'

--- a/dev/tests/integration/testsuite/Magento/LayeredNavigation/Block/Navigation/Category/MultipleFiltersTest.php
+++ b/dev/tests/integration/testsuite/Magento/LayeredNavigation/Block/Navigation/Category/MultipleFiltersTest.php
@@ -71,7 +71,7 @@ class MultipleFiltersTest extends AbstractFiltersTest
                     ],
                 ],
                 'filters' => [],
-                'expected_products' => ['simple1000', 'simple1001', 'simple1002'],
+                'expected_products' => ['simple1002', 'simple1001', 'simple1000'],
             ],
             'applied_first_option_in_both_filters' => [
                 'products_data' => [
@@ -87,7 +87,7 @@ class MultipleFiltersTest extends AbstractFiltersTest
                     ],
                 ],
                 'filters' => ['test_configurable' => 'Option 1', 'dropdown_attribute' => 'Option 1'],
-                'expected_products' => ['simple1000', 'simple1001'],
+                'expected_products' => ['simple1001', 'simple1000'],
             ],
             'applied_mixed_options_in_filters' => [
                 'products_data' => [


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#31043

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
