### PR TITLE
magento/magento2#30241: Stop catching exceptions and destroying them

### DIFF
--- a/app/code/Magento/Cms/Block/Adminhtml/Block/Edit/GenericButton.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Block/Edit/GenericButton.php
@@ -7,6 +7,7 @@ namespace Magento\Cms\Block\Adminhtml\Block\Edit;
 
 use Magento\Backend\Block\Widget\Context;
 use Magento\Cms\Api\BlockRepositoryInterface;
+use Psr\Log\LoggerInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
@@ -25,15 +26,23 @@ class GenericButton
     protected $blockRepository;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param Context $context
      * @param BlockRepositoryInterface $blockRepository
+     * @param LoggerInterface $logger
      */
     public function __construct(
         Context $context,
-        BlockRepositoryInterface $blockRepository
+        BlockRepositoryInterface $blockRepository,
+        LoggerInterface $logger
     ) {
         $this->context = $context;
         $this->blockRepository = $blockRepository;
+        $this->logger = $logger;
     }
 
     /**
@@ -48,6 +57,7 @@ class GenericButton
                 $this->context->getRequest()->getParam('block_id')
             )->getId();
         } catch (NoSuchEntityException $e) {
+            $this->logger->error($e);
         }
         return null;
     }

--- a/app/code/Magento/Cms/Block/Adminhtml/Page/Edit/GenericButton.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Page/Edit/GenericButton.php
@@ -7,6 +7,7 @@ namespace Magento\Cms\Block\Adminhtml\Page\Edit;
 
 use Magento\Backend\Block\Widget\Context;
 use Magento\Cms\Api\PageRepositoryInterface;
+use Psr\Log\LoggerInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 
 /**
@@ -25,15 +26,23 @@ class GenericButton
     protected $pageRepository;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param Context $context
      * @param PageRepositoryInterface $pageRepository
+     * @param LoggerInterface $logger
      */
     public function __construct(
         Context $context,
-        PageRepositoryInterface $pageRepository
+        PageRepositoryInterface $pageRepository,
+        LoggerInterface $logger
     ) {
         $this->context = $context;
         $this->pageRepository = $pageRepository;
+        $this->logger = $logger;
     }
 
     /**
@@ -48,6 +57,7 @@ class GenericButton
                 $this->context->getRequest()->getParam('page_id')
             )->getId();
         } catch (NoSuchEntityException $e) {
+            $this->logger->error($e);
         }
         return null;
     }

--- a/app/code/Magento/Cms/Block/BlockByIdentifier.php
+++ b/app/code/Magento/Cms/Block/BlockByIdentifier.php
@@ -16,6 +16,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\View\Element\AbstractBlock;
 use Magento\Framework\View\Element\Context;
 use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * This class is replacement of \Magento\Cms\Block\Block, that accepts only `string` identifier of CMS Block
@@ -45,9 +46,15 @@ class BlockByIdentifier extends AbstractBlock implements IdentityInterface
     private $cmsBlock;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param GetBlockByIdentifierInterface $blockByIdentifier
      * @param StoreManagerInterface $storeManager
      * @param FilterProvider $filterProvider
+     * @param LoggerInterface $logger
      * @param Context $context
      * @param array $data
      */
@@ -55,6 +62,7 @@ class BlockByIdentifier extends AbstractBlock implements IdentityInterface
         GetBlockByIdentifierInterface $blockByIdentifier,
         StoreManagerInterface $storeManager,
         FilterProvider $filterProvider,
+        LoggerInterface $logger,
         Context $context,
         array $data = []
     ) {
@@ -62,6 +70,7 @@ class BlockByIdentifier extends AbstractBlock implements IdentityInterface
         $this->blockByIdentifier = $blockByIdentifier;
         $this->storeManager = $storeManager;
         $this->filterProvider = $filterProvider;
+        $this->logger = $logger;
     }
 
     /**
@@ -166,8 +175,8 @@ class BlockByIdentifier extends AbstractBlock implements IdentityInterface
             if ($cmsBlock instanceof IdentityInterface) {
                 $identities = array_merge($identities, $cmsBlock->getIdentities());
             }
-            // phpcs:ignore Magento2.CodeAnalysis.EmptyBlock.DetectedCatch
         } catch (NoSuchEntityException $e) {
+            $this->logger->error($e);
         }
 
         return $identities;

--- a/app/code/Magento/Cms/Block/Widget/Block.php
+++ b/app/code/Magento/Cms/Block/Widget/Block.php
@@ -12,6 +12,7 @@ use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Cms\Model\Block as CmsBlock;
 use Magento\Widget\Block\BlockInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Cms Static Block Widget
@@ -45,20 +46,28 @@ class Block extends \Magento\Framework\View\Element\Template implements BlockInt
     private $block;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param \Magento\Cms\Model\Template\FilterProvider $filterProvider
      * @param \Magento\Cms\Model\BlockFactory $blockFactory
+     * @param LoggerInterface $logger
      * @param array $data
      */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
         \Magento\Cms\Model\Template\FilterProvider $filterProvider,
         \Magento\Cms\Model\BlockFactory $blockFactory,
+        LoggerInterface $logger,
         array $data = []
     ) {
         parent::__construct($context, $data);
         $this->_filterProvider = $filterProvider;
         $this->_blockFactory = $blockFactory;
+        $this->logger = $logger;
     }
 
     /**
@@ -88,6 +97,7 @@ class Block extends \Magento\Framework\View\Element\Template implements BlockInt
                     $this->_filterProvider->getBlockFilter()->setStoreId($storeId)->filter($block->getContent())
                 );
             } catch (NoSuchEntityException $e) {
+                $this->logger->error($e);
             }
         }
         unset(self::$_widgetUsageMap[$blockHash]);
@@ -133,6 +143,7 @@ class Block extends \Magento\Framework\View\Element\Template implements BlockInt
 
                 return $block;
             } catch (NoSuchEntityException $e) {
+                $this->logger->error($e);
             }
         }
 

--- a/app/code/Magento/Customer/Block/Address/Book.php
+++ b/app/code/Magento/Customer/Block/Address/Book.php
@@ -8,6 +8,7 @@ namespace Magento\Customer\Block\Address;
 use Magento\Customer\Api\AddressRepositoryInterface;
 use Magento\Customer\Model\Address\Mapper;
 use Magento\Customer\Block\Address\Grid as AddressesGrid;
+use Psr\Log\LoggerInterface;
 
 /**
  * Customer address book block
@@ -49,11 +50,17 @@ class Book extends \Magento\Framework\View\Element\Template
     private $addressesGrid;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param \Magento\Framework\View\Element\Template\Context $context
      * @param CustomerRepositoryInterface|null $customerRepository
      * @param AddressRepositoryInterface $addressRepository
      * @param \Magento\Customer\Helper\Session\CurrentCustomer $currentCustomer
      * @param \Magento\Customer\Model\Address\Config $addressConfig
+     * @param LoggerInterface $logger
      * @param Mapper $addressMapper
      * @param array $data
      * @param AddressesGrid|null $addressesGrid
@@ -65,6 +72,7 @@ class Book extends \Magento\Framework\View\Element\Template
         AddressRepositoryInterface $addressRepository,
         \Magento\Customer\Helper\Session\CurrentCustomer $currentCustomer,
         \Magento\Customer\Model\Address\Config $addressConfig,
+        LoggerInterface $logger,
         Mapper $addressMapper,
         array $data = [],
         Grid $addressesGrid = null
@@ -72,6 +80,7 @@ class Book extends \Magento\Framework\View\Element\Template
         $this->currentCustomer = $currentCustomer;
         $this->addressRepository = $addressRepository;
         $this->_addressConfig = $addressConfig;
+        $this->logger = $logger;
         $this->addressMapper = $addressMapper;
         $this->addressesGrid = $addressesGrid ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(AddressesGrid::class);
@@ -167,6 +176,7 @@ class Book extends \Magento\Framework\View\Element\Template
         try {
             $addresses = $this->addressesGrid->getAdditionalAddresses();
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            $this->logger->error($e);
         }
         return empty($addresses) ? false : $addresses;
     }
@@ -198,6 +208,7 @@ class Book extends \Magento\Framework\View\Element\Template
         try {
             $customer = $this->currentCustomer->getCustomer();
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            $this->logger->error($e);
         }
         return $customer;
     }

--- a/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/View/Cart.php
+++ b/app/code/Magento/Customer/Block/Adminhtml/Edit/Tab/View/Cart.php
@@ -7,6 +7,7 @@ namespace Magento\Customer\Block\Adminhtml\Edit\Tab\View;
 
 use Magento\Customer\Controller\RegistryConstants;
 use Magento\Directory\Model\Currency;
+use Psr\Log\LoggerInterface;
 
 /**
  * Adminhtml customer cart items grid block
@@ -46,12 +47,18 @@ class Cart extends \Magento\Backend\Block\Widget\Grid\Extended
     protected $quoteFactory;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Backend\Helper\Data $backendHelper
      * @param \Magento\Quote\Api\CartRepositoryInterface $quoteRepository
      * @param \Magento\Framework\Data\CollectionFactory $dataCollectionFactory
      * @param \Magento\Framework\Registry $coreRegistry
      * @param \Magento\Quote\Model\QuoteFactory $quoteFactory
+     * @param LoggerInterface $logger
      * @param array $data
      */
     public function __construct(
@@ -61,12 +68,14 @@ class Cart extends \Magento\Backend\Block\Widget\Grid\Extended
         \Magento\Framework\Data\CollectionFactory $dataCollectionFactory,
         \Magento\Framework\Registry $coreRegistry,
         \Magento\Quote\Model\QuoteFactory $quoteFactory,
+        LoggerInterface $logger,
         array $data = []
     ) {
         $this->_dataCollectionFactory = $dataCollectionFactory;
         $this->_coreRegistry = $coreRegistry;
         $this->quoteRepository = $quoteRepository;
         $this->quoteFactory = $quoteFactory;
+        $this->logger = $logger;
         parent::__construct($context, $backendHelper, $data);
     }
 
@@ -176,6 +185,7 @@ class Cart extends \Magento\Backend\Block\Widget\Grid\Extended
                 try {
                     $this->quote = $this->quoteRepository->getForCustomer($currentCustomerId, $storeIds);
                 } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+                    $this->logger->error($e);
                 }
             }
         }

--- a/app/code/Magento/Downloadable/Setup/Patch/Data/AddDownloadableHostsConfig.php
+++ b/app/code/Magento/Downloadable/Setup/Patch/Data/AddDownloadableHostsConfig.php
@@ -19,6 +19,7 @@ use Magento\Framework\Url\ScopeResolverInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
+use Psr\Log\LoggerInterface;
 
 /**
  * Adding base url as allowed downloadable domain.
@@ -57,6 +58,11 @@ class AddDownloadableHostsConfig implements DataPatchInterface
     private $whitelist = [];
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * AddDownloadableHostsConfig constructor.
      *
      * @param UriHandler $uriHandler
@@ -64,19 +70,22 @@ class AddDownloadableHostsConfig implements DataPatchInterface
      * @param ScopeConfigInterface $scopeConfig
      * @param DomainManager $domainManager
      * @param ModuleDataSetupInterface $moduleDataSetup
+     * @param LoggerInterface $logger
      */
     public function __construct(
         UriHandler $uriHandler,
         ScopeResolverInterface $scopeResolver,
         ScopeConfigInterface $scopeConfig,
         DomainManager $domainManager,
-        ModuleDataSetupInterface $moduleDataSetup
+        ModuleDataSetupInterface $moduleDataSetup,
+        LoggerInterface $logger
     ) {
         $this->uriHandler = $uriHandler;
         $this->scopeResolver = $scopeResolver;
         $this->scopeConfig = $scopeConfig;
         $this->domainManager = $domainManager;
         $this->moduleDataSetup = $moduleDataSetup;
+        $this->logger = $logger;
     }
 
     /**
@@ -165,7 +174,9 @@ class AddDownloadableHostsConfig implements DataPatchInterface
         try {
             $this->addHost($scope->getBaseUrl(UrlInterface::URL_TYPE_STATIC, false));
             $this->addHost($scope->getBaseUrl(UrlInterface::URL_TYPE_STATIC, true));
-        } catch (\UnexpectedValueException $e) {} //@codingStandardsIgnoreLine
+        } catch (\UnexpectedValueException $e) {
+            $this->logger->error($e);
+        }
 
         try {
             $website = $scope->getWebsite();

--- a/app/code/Magento/GiftMessage/Model/GiftMessageManager.php
+++ b/app/code/Magento/GiftMessage/Model/GiftMessageManager.php
@@ -6,6 +6,7 @@
 
 namespace Magento\GiftMessage\Model;
 
+use Psr\Log\LoggerInterface;
 use Magento\Framework\Exception\CouldNotSaveException;
 
 class GiftMessageManager
@@ -16,12 +17,20 @@ class GiftMessageManager
     protected $messageFactory;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param MessageFactory $messageFactory
+     * @param LoggerInterface $logger
      */
     public function __construct(
-        \Magento\GiftMessage\Model\MessageFactory $messageFactory
+        \Magento\GiftMessage\Model\MessageFactory $messageFactory,
+        LoggerInterface $logger
     ) {
         $this->messageFactory = $messageFactory;
+        $this->logger = $logger;
     }
 
     /**
@@ -67,6 +76,7 @@ class GiftMessageManager
                             $giftMessage->delete();
                             $entity->setGiftMessageId(0)->save();
                         } catch (\Exception $e) {
+                            $this->logger->error($e);
                         }
                     }
                     continue;
@@ -85,6 +95,7 @@ class GiftMessageManager
 
                     $entity->setGiftMessageId($giftMessage->getId())->save();
                 } catch (\Exception $e) {
+                    $this->logger->error($e);
                 }
             }
         }

--- a/app/code/Magento/ImportExport/Model/Import.php
+++ b/app/code/Magento/ImportExport/Model/Import.php
@@ -709,8 +709,8 @@ class Import extends AbstractModel
                 if (!$indexer->isScheduled()) {
                     $indexer->invalidate();
                 }
-                // phpcs:disable Magento2.CodeAnalysis.EmptyBlock.DetectedCatch
             } catch (\InvalidArgumentException $e) {
+                $this->_logger->error($e);
             }
         }
 

--- a/app/code/Magento/Integration/Model/OauthService.php
+++ b/app/code/Magento/Integration/Model/OauthService.php
@@ -150,6 +150,7 @@ class OauthService implements \Magento\Integration\Api\OauthServiceInterface
                 unset($existingToken);
             }
         } catch (\Exception $e) {
+            $this->_logger->error($e);
         }
         if (!isset($existingToken)) {
             $consumer = $this->_consumerFactory->create()->load($consumerId);

--- a/app/code/Magento/MediaStorage/Model/File/Storage/Synchronization.php
+++ b/app/code/Magento/MediaStorage/Model/File/Storage/Synchronization.php
@@ -10,6 +10,7 @@ use Magento\Framework\Filesystem\Directory\WriteInterface as DirectoryWrite;
 use Magento\Framework\Filesystem\File\WriteInterface;
 use Magento\MediaStorage\Service\ImageResize;
 use Magento\MediaStorage\Model\File\Storage\Database;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class Synchronization
@@ -31,15 +32,23 @@ class Synchronization
     protected $mediaDirectory;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param DatabaseFactory $storageFactory
      * @param DirectoryWrite $directory
+     * @param LoggerInterface $logger
      */
     public function __construct(
         DatabaseFactory $storageFactory,
-        DirectoryWrite $directory
+        DirectoryWrite $directory,
+        LoggerInterface $logger
     ) {
         $this->storageFactory = $storageFactory;
         $this->mediaDirectory = $directory;
+        $this->logger = $logger;
     }
 
     /**
@@ -56,6 +65,7 @@ class Synchronization
         try {
             $storage->loadByFilename($relativeFileName);
         } catch (\Exception $e) {
+            $this->logger->error($e);
         }
         if ($storage->getId()) {
             /** @var WriteInterface $file */

--- a/app/code/Magento/Multishipping/Model/Checkout/Type/Multishipping.php
+++ b/app/code/Magento/Multishipping/Model/Checkout/Type/Multishipping.php
@@ -529,6 +529,7 @@ class Multishipping extends \Magento\Framework\DataObject
                 $address = $this->addressRepository->getById($addressId);
             // phpcs:ignore Magento2.CodeAnalysis.EmptyBlock
             } catch (\Exception $e) {
+                $this->logger->error($e);
             }
             if (isset($address)) {
                 if (!($quoteAddress = $this->getQuote()->getShippingAddressByCustomerAddressId($address->getId()))) {

--- a/app/code/Magento/Newsletter/Model/Subscriber.php
+++ b/app/code/Magento/Newsletter/Model/Subscriber.php
@@ -26,6 +26,7 @@ use Magento\Framework\Translate\Inline\StateInterface;
 use Magento\Newsletter\Helper\Data;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Subscriber model
@@ -160,6 +161,11 @@ class Subscriber extends AbstractModel
     private $subscriptionManager;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param Context $context
      * @param Registry $registry
      * @param Data $newsletterData
@@ -170,6 +176,7 @@ class Subscriber extends AbstractModel
      * @param CustomerRepositoryInterface $customerRepository
      * @param AccountManagementInterface $customerAccountManagement
      * @param StateInterface $inlineTranslation
+     * @param LoggerInterface $logger
      * @param AbstractResource|null $resource
      * @param AbstractDb|null $resourceCollection
      * @param array $data
@@ -190,6 +197,7 @@ class Subscriber extends AbstractModel
         CustomerRepositoryInterface $customerRepository,
         AccountManagementInterface $customerAccountManagement,
         StateInterface $inlineTranslation,
+        LoggerInterface $logger,
         AbstractResource $resource = null,
         AbstractDb $resourceCollection = null,
         array $data = [],
@@ -213,6 +221,7 @@ class Subscriber extends AbstractModel
         $this->customerRepository = $customerRepository;
         $this->customerAccountManagement = $customerAccountManagement;
         $this->inlineTranslation = $inlineTranslation;
+        $this->logger = $logger;
         $this->subscriptionManager = $subscriptionManager ?: ObjectManager::getInstance()
             ->get(SubscriptionManagerInterface::class);
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
@@ -638,6 +647,7 @@ class Subscriber extends AbstractModel
             }
             // phpcs:ignore Magento2.CodeAnalysis.EmptyBlock
         } catch (NoSuchEntityException $e) {
+            $this->logger->error($e);
         }
         return $this;
     }

--- a/app/code/Magento/Paypal/Model/Payflow/Service/Response/Handler/FraudHandler.php
+++ b/app/code/Magento/Paypal/Model/Payflow/Service/Response/Handler/FraudHandler.php
@@ -11,6 +11,7 @@ use Magento\Framework\Xml\Security;
 use Magento\Payment\Model\InfoInterface;
 use Magento\Paypal\Model\Info;
 use Magento\Paypal\Model\Payflowpro;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class FraudHandler
@@ -40,15 +41,22 @@ class FraudHandler implements HandlerInterface
     private $xmlSecurity;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * Constructor
      *
      * @param Info $paypalInfoManager
      * @param Security $xmlSecurity
+     * @param LoggerInterface $logger
      */
-    public function __construct(Info $paypalInfoManager, Security $xmlSecurity)
+    public function __construct(Info $paypalInfoManager, Security $xmlSecurity, LoggerInterface $logger)
     {
         $this->paypalInfoManager = $paypalInfoManager;
         $this->xmlSecurity = $xmlSecurity;
+        $this->logger = $logger;
     }
 
     /**
@@ -106,6 +114,7 @@ class FraudHandler implements HandlerInterface
                 $rules[(string)$rule->{'ruleDescription'}] = (string)$rule->{'triggeredMessage'};
             }
         } catch (\Exception $e) {
+            $this->logger->error($e);
         } finally {
             libxml_use_internal_errors(false);
         }

--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -18,6 +18,7 @@ use Magento\Quote\Model\Quote\Address\Total as AddressTotal;
 use Magento\Sales\Model\Status;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Framework\App\ObjectManager;
+use Psr\Log\LoggerInterface;
 
 /**
  * Quote model
@@ -368,6 +369,11 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
     private $allowedCountriesReader;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Api\ExtensionAttributesFactory $extensionFactory
@@ -405,6 +411,7 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
      * @param Quote\TotalsReader $totalsReader
      * @param ShippingFactory $shippingFactory
      * @param ShippingAssignmentFactory $shippingAssignmentFactory
+     * @param LoggerInterface $logger
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb|null $resourceCollection
      * @param array $data
@@ -450,6 +457,7 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
         Quote\TotalsReader $totalsReader,
         \Magento\Quote\Model\ShippingFactory $shippingFactory,
         \Magento\Quote\Model\ShippingAssignmentFactory $shippingAssignmentFactory,
+        LoggerInterface $logger,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = [],
@@ -489,6 +497,7 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
         $this->totalsReader = $totalsReader;
         $this->shippingFactory = $shippingFactory;
         $this->shippingAssignmentFactory = $shippingAssignmentFactory;
+        $this->logger = $logger;
         $this->orderIncrementIdChecker = $orderIncrementIdChecker ?: ObjectManager::getInstance()
             ->get(\Magento\Sales\Model\OrderIncrementIdChecker::class);
         $this->allowedCountriesReader = $allowedCountriesReader
@@ -950,6 +959,7 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
                     $defaultBillingAddress = $this->addressRepository->getById($customer->getDefaultBilling());
                     // phpcs:ignore Magento2.CodeAnalysis.EmptyBlock
                 } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+                    $this->logger->error($e);
                 }
                 if (isset($defaultBillingAddress)) {
                     /** @var \Magento\Quote\Model\Quote\Address $billingAddress */
@@ -964,6 +974,7 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
                     $defaultShippingAddress = $this->addressRepository->getById($customer->getDefaultShipping());
                     // phpcs:ignore Magento2.CodeAnalysis.EmptyBlock
                 } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+                    $this->logger->error($e);
                 }
                 if (isset($defaultShippingAddress)) {
                     /** @var \Magento\Quote\Model\Quote\Address $shippingAddress */

--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -23,6 +23,7 @@ use Magento\Quote\Model\Quote\Payment\ToOrderPayment as ToOrderPaymentConverter;
 use Magento\Sales\Api\Data\OrderInterfaceFactory as OrderFactory;
 use Magento\Sales\Api\OrderManagementInterface as OrderManagement;
 use Magento\Store\Model\StoreManagerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class for managing quote
@@ -159,6 +160,11 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
     private $remoteAddress;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param EventManager $eventManager
      * @param SubmitQuoteValidator $submitQuoteValidator
      * @param OrderFactory $orderFactory
@@ -179,6 +185,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
      * @param \Magento\Customer\Model\Session $customerSession
      * @param \Magento\Customer\Api\AccountManagementInterface $accountManagement
      * @param QuoteFactory $quoteFactory
+     * @param LoggerInterface $logger
      * @param \Magento\Quote\Model\QuoteIdMaskFactory|null $quoteIdMaskFactory
      * @param \Magento\Customer\Api\AddressRepositoryInterface|null $addressRepository
      * @param \Magento\Framework\App\RequestInterface|null $request
@@ -206,6 +213,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
         \Magento\Customer\Model\Session $customerSession,
         \Magento\Customer\Api\AccountManagementInterface $accountManagement,
         \Magento\Quote\Model\QuoteFactory $quoteFactory,
+        LoggerInterface $logger,
         \Magento\Quote\Model\QuoteIdMaskFactory $quoteIdMaskFactory = null,
         \Magento\Customer\Api\AddressRepositoryInterface $addressRepository = null,
         \Magento\Framework\App\RequestInterface $request = null,
@@ -231,6 +239,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
         $this->accountManagement = $accountManagement;
         $this->customerSession = $customerSession;
         $this->quoteFactory = $quoteFactory;
+        $this->logger = $logger;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory ?: ObjectManager::getInstance()
             ->get(\Magento\Quote\Model\QuoteIdMaskFactory::class);
         $this->addressRepository = $addressRepository ?: ObjectManager::getInstance()
@@ -308,6 +317,7 @@ class QuoteManagement implements \Magento\Quote\Api\CartManagementInterface
 
         // phpcs:ignore Magento2.CodeAnalysis.EmptyBlock
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            $this->logger->error($e);
         }
 
         $quote->setCustomer($customer);

--- a/app/code/Magento/Quote/Observer/Backend/CustomerQuoteObserver.php
+++ b/app/code/Magento/Quote/Observer/Backend/CustomerQuoteObserver.php
@@ -10,6 +10,7 @@ use Magento\Customer\Model\Config\Share as ShareConfig;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class CustomerQuote
@@ -32,18 +33,26 @@ class CustomerQuoteObserver implements ObserverInterface
     protected $quoteRepository;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param StoreManagerInterface $storeManager
      * @param ShareConfig $config
      * @param CartRepositoryInterface $quoteRepository
+     * @param LoggerInterface $logger
      */
     public function __construct(
         StoreManagerInterface $storeManager,
         ShareConfig $config,
-        CartRepositoryInterface $quoteRepository
+        CartRepositoryInterface $quoteRepository,
+        LoggerInterface $logger
     ) {
         $this->storeManager = $storeManager;
         $this->config = $config;
         $this->quoteRepository = $quoteRepository;
+        $this->logger = $logger;
     }
 
     /**
@@ -76,6 +85,7 @@ class CustomerQuoteObserver implements ObserverInterface
                 }
             }
         } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            $this->logger->error($e);
         }
     }
 }

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
@@ -673,6 +673,7 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
             $this->filterXmlData($xml);
             $data = $xml->asXML();
         } catch (\Exception $e) {
+            $this->_logger->error($e);
         }
         return $data;
     }

--- a/app/code/Magento/Tax/Model/Calculation.php
+++ b/app/code/Magento/Tax/Model/Calculation.php
@@ -18,6 +18,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Store\Model\Store;
 use Magento\Tax\Api\TaxClassRepositoryInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Tax Calculation Model
@@ -189,6 +190,11 @@ class Calculation extends \Magento\Framework\Model\AbstractModel
     protected $taxClassRepository;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
@@ -206,6 +212,7 @@ class Calculation extends \Magento\Framework\Model\AbstractModel
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
      * @param FilterBuilder $filterBuilder
      * @param TaxClassRepositoryInterface $taxClassRepository
+     * @param LoggerInterface $logger
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
      * @param array $data
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -228,6 +235,7 @@ class Calculation extends \Magento\Framework\Model\AbstractModel
         SearchCriteriaBuilder $searchCriteriaBuilder,
         FilterBuilder $filterBuilder,
         TaxClassRepositoryInterface $taxClassRepository,
+        LoggerInterface $logger,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
@@ -245,6 +253,7 @@ class Calculation extends \Magento\Framework\Model\AbstractModel
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->filterBuilder = $filterBuilder;
         $this->taxClassRepository = $taxClassRepository;
+        $this->logger = $logger;
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
     }
 
@@ -530,11 +539,13 @@ class Calculation extends \Magento\Framework\Model\AbstractModel
                     try {
                         $defaultBilling = $this->customerAccountManagement->getDefaultBillingAddress($customerId);
                     } catch (NoSuchEntityException $e) {
+                        $this->logger->error($e);
                     }
 
                     try {
                         $defaultShipping = $this->customerAccountManagement->getDefaultShippingAddress($customerId);
                     } catch (NoSuchEntityException $e) {
+                        $this->logger->error($e);
                     }
 
                     if ($basedOn == 'billing' && isset($defaultBilling) && $defaultBilling->getCountryId()) {


### PR DESCRIPTION
- Add basic logging to all destroyed exceptions in .php files

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

I used this regex `\}[\s]+catch[\s]+\(.+\)[\s]*\{[\s]*\}` to find all files in the `app/code/Magento` directory with empty catch statements. I then added `Psr\Log\LoggerInterface` to the files and included a basic log statement to the catch statements: `$this->logger->error($e)`. 

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Band-aid fixes magento/magento2#30241

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Each logger that was added can be tested by throwing a custom exception and checking if the catch statement logs the error.

For example:

1. Enable `Allow Gift Messages` in Admin Panel
2. Add a throw new CouldNotSaveException(__("Show custom error.")); code to the /app/code/Magento/GiftMessage/Model/GiftMessageManager.php file
2. Add any Product to Cart
3. Type long name with different characters into From and To fields under Gift Options
4. Update
5. Check logs for output (there should be output)

### Questions or comments

I used `$this->logger->error()` as a safe option for all logging. I am not sure which files it would be better to use `$this->logger->warning()` or `$this->logger->critical()`. 

Removing generic `\Exception` catching  should be a separate issue and PR as mentioned here: https://github.com/magento/magento2/issues/30241#issuecomment-701362833

Unit tests failed because logger was added to constructor. The tests expect a specific number of arguments in the __construct().

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
