### PR TITLE
Fix generating a new image name even there is no new image to upload

### DIFF
--- a/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
+++ b/app/code/Magento/Catalog/Model/Category/Attribute/Backend/Image.php
@@ -155,7 +155,7 @@ class Image extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
         }
 
         if ($imageName = $this->getUploadedImageName($value)) {
-            if (!$this->fileResidesOutsideCategoryDir($value)) {
+            if ($this->isTmpFileAvailable($value) && !$this->fileResidesOutsideCategoryDir($value)) {
                 $imageName = $this->checkUniqueImageName($imageName);
             }
             $object->setData($this->additionalData . $attributeName, $value);


### PR DESCRIPTION


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
On category edit page, saving category without changing anything, changes category image name value in catalog_category_entity_varchar table.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Go to category edit page in dashboard
2. Add a new category image (ex: image.png) and click save
3. Go back to edit same category and click save without changing any attribute

### Expected

Not losing category image data and see image.png as category image attribute

### Actual Happens

Category image data in catalog_category_entity_varchar changes to image_1.png

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
