### PR TITLE
MQ Consumers: take maxIdleTime config setting into account even when …

### DIFF
--- a/lib/internal/Magento/Framework/MessageQueue/CallbackInvoker.php
+++ b/lib/internal/Magento/Framework/MessageQueue/CallbackInvoker.php
@@ -71,6 +71,7 @@ class CallbackInvoker implements CallbackInvokerInterface
     ) {
         $this->poisonPillVersion = $this->poisonPillRead->getLatestVersion();
         $sleep = (int) $sleep ?: 1;
+        $isMaxIdleTimeSet = $maxIdleTime !== null;
         $maxIdleTime = $maxIdleTime ? (int) $maxIdleTime : PHP_INT_MAX;
         for ($i = $maxNumberOfMessages; $i > 0; $i--) {
             $idleStartTime = microtime(true);
@@ -80,7 +81,7 @@ class CallbackInvoker implements CallbackInvokerInterface
                     break 2;
                 }
                 // phpcs:ignore Magento2.Functions.DiscouragedFunction
-            } while ($message === null && $this->isWaitingNextMessage() && (sleep($sleep) === 0));
+            } while ($message === null && $this->isWaitingNextMessage($isMaxIdleTimeSet) && (sleep($sleep) === 0));
 
             if ($message === null) {
                 break;
@@ -101,8 +102,12 @@ class CallbackInvoker implements CallbackInvokerInterface
      *
      * @return bool
      */
-    private function isWaitingNextMessage(): bool
+    private function isWaitingNextMessage(bool $isMaxIdleTimeSet): bool
     {
+        if ($isMaxIdleTimeSet) {
+            return true;
+        }
+
         return $this->deploymentConfig->get('queue/consumers_wait_for_messages', 1) === 1;
     }
 }


### PR DESCRIPTION
…the consumers_wait_for_messages setting is not active.

### Description (*)
When you specify the `maxIdleTime` configuration in the xml file of a specific consumer. And you have the global `consumers_wait_for_messages` setting set to `0`, then I would still expect the consumer to be running for the time specified in `maxIdleTime` even when no messages are in the queue.

### Related Pull Requests

### Fixed Issues (if relevant)
1. None that I could find

### Manual testing scenarios (*)
1. In your `env.php` file, have the following config:
```php
    'queue' => [
        'consumers_wait_for_messages' => 0,
        'only_spawn_when_message_available' => 1
    ],
```
2. In a custom consumer, or just some random default Magento consumer, specify this in the `queue_consumer.xml` file:
```xml
<consumer name="some_consumer_name"
              ...
              onlySpawnWhenMessageAvailable="0"
              maxIdleTime="50"/>
```
3. Flush caches
4. Run `bin/magento cron:run`

**Expected**:
When the Magento cron executes, a new consumer process should spawn and stay alive for 50 seconds when no messages are in the queue and then stop running.

**Actual**:
When the Magento cron executes, the consumer process is being kicked of but immediately kills itself again

### More information
You could wonder why I just don't want to set `consumers_wait_for_messages` to `1` and be done with it.

Well, here's the behavior I want for the consumer processes in a particular shop:
1. All the default Magento consumers, I want them to not start up when there are no messages in the queue
2. Only for certain specific custom consumers, I do want them to start up even when no messages are in the queue, and just sit there waiting for a specific amount of time just in case a message does come in so it can quickly handle it and not have to wait until the cronjob kicks in the next minute and only then spawns a consumer process.

Currently this seems not possible to achieve with any of the options we have right now.
This would allow for lower sustained memory usage on the server if we can achieve something like this. Only consumers which are important run and immediately respond to new messages when they appear in the queue and the consumers which are almost never used don't take up memory and only spawn when a message appears in their queue, handle the message(s) and then quickly kill themselves again.

Ideally we should be able to overwrite the `consumers_wait_for_messages` on a specific consumer, but I don't think that's possible right now (but feel free to correct me when I'm wrong) and is probably going to be a bit more complex to implement then the change proposed here.
Another approach would be to set a global `max_idle_time` variable which can be overwritten on a per consumer basis, but I think the global setting is also not possible right now?

### Questions or comments
I'm looking for some opinions if the changes in this PR makes sense or if we need to figure out another way be able to handle such scenario's.
I'm going to tag some people who I know have some experience with these consumer processes: @Neos2007, @nuzil, @adifucan, @AntonEvers

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
