### PR TITLE
Made address street line translation dynamic

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/address/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/address/edit.phtml
@@ -75,12 +75,12 @@ $viewModel = $block->getViewModel();
                     <?php for ($_i = 1, $_n = $viewModel->addressGetStreetLines(); $_i < $_n; $_i++): ?>
                         <div class="field additional">
                             <label class="label" for="street_<?= /* @noEscape */ $_i + 1 ?>">
-                                <span><?= $escaper->escapeHtml(__('Street Address: Line %1', $_i + 1)) ?></span>
+                                <span><?= $escaper->escapeHtml(__(sprintf('Street Address: Line %s', $_i + 1))) ?></span>
                             </label>
                             <div class="control">
                                 <input type="text" name="street[]"
                                        value="<?= $escaper->escapeHtmlAttr($block->getStreetLine($_i + 1)) ?>"
-                                       title="<?= $escaper->escapeHtmlAttr(__('Street Address %1', $_i + 1)) ?>"
+                                       title="<?= $escaper->escapeHtmlAttr(__(sprintf('Street Address %s', $_i + 1))) ?>"
                                        id="street_<?= /* @noEscape */ $_i + 1 ?>"
                                        class="input-text
                                         <?= $escaper->escapeHtmlAttr($_streetValidationClassNotRequired) ?>">


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Currently, trying to add 'Street' above the first address line and 'House number' above the second address line is not possible because of the way the labels for the street lines are translated. In the current situation it is only possible to change the 'Street Address' text, which in most cases (at least, for us) is not what you want. 
![Screenshot 2021-03-04 at 14 36 41](https://user-images.githubusercontent.com/3921273/109972152-4b7a3a80-7cf7-11eb-9873-0292c0b7dfca.png)

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
-

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.  Go to Stores > Configuration > Customers > Customer Configuration > Name and address options 
2. Set the value of "Number of Lines in a Street Address" to at least 2
2. Create an account, login, and navigate to the customer account section
3. Open the address book and create a new address
4. See the two lines under "Street Address"

### Questions or comments
I am not sure if the proposed solution is the way-to-go. However, I feel like this issue should be pointed out. Any other solution to this problem are welcome.
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32372: Made address street line translation dynamic