### PR TITLE
Add Ireland counties data

### DIFF
--- a/app/code/Magento/Directory/Setup/Patch/Data/AddDataForIreland.php
+++ b/app/code/Magento/Directory/Setup/Patch/Data/AddDataForIreland.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Directory\Setup\Patch\Data;
+
+use Magento\Directory\Setup\DataInstaller;
+use Magento\Directory\Setup\DataInstallerFactory;
+use Magento\Directory\Setup\Patch\Data\InitializeDirectoryData;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+/**
+ * Add Ireland States
+ */
+class AddDataForIreland implements DataPatchInterface
+{
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private $moduleDataSetup;
+
+    /**
+     * @var DataInstallerFactory
+     */
+    private $dataInstallerFactory;
+
+    /**
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     * @param DataInstallerFactory $dataInstallerFactory
+     */
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup,
+        DataInstallerFactory $dataInstallerFactory
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+        $this->dataInstallerFactory = $dataInstallerFactory;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function apply()
+    {
+        /** @var DataInstaller $dataInstaller */
+        $dataInstaller = $this->dataInstallerFactory->create();
+        $dataInstaller->addCountryRegions(
+            $this->moduleDataSetup->getConnection(),
+            $this->getDataForIreland()
+        );
+    }
+
+    /**
+     * Ireland states data.
+     *
+     * @return array
+     */
+    private function getDataForIreland()
+    {
+        return [
+            ['IE', 'CW', 'Carlow'],
+            ['IE', 'CN', 'Cavan'],
+            ['IE', 'CE', 'Clare'],
+            ['IE', 'CO', 'Cork'],
+            ['IE', 'DL', 'Donegal'],
+            ['IE', 'D', 'Dublin'],
+            ['IE', 'G', 'Galway'],
+            ['IE', 'KY', 'Kerry'],
+            ['IE', 'KE', 'Kildare'],
+            ['IE', 'KK', 'Kilkenny'],
+            ['IE', 'LS', 'Laois'],
+            ['IE', 'LM', 'Leitrim'],
+            ['IE', 'LK', 'Limerick'],
+            ['IE', 'LD', 'Longford'],
+            ['IE', 'LH', 'Louth'],
+            ['IE', 'MO', 'Mayo'],
+            ['IE', 'MH', 'Meath'],
+            ['IE', 'MN', 'Monaghan'],
+            ['IE', 'OY', 'Offaly'],
+            ['IE', 'RN', 'Roscommon'],
+            ['IE', 'SO', 'Sligo'],
+            ['IE', 'TA', 'Tipperary'],
+            ['IE', 'WD', 'Waterford'],
+            ['IE', 'WH', 'Westmeath'],
+            ['IE', 'WX', 'Wexford'],
+            ['IE', 'WW', 'Wicklow'],
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getDependencies()
+    {
+        return [
+            InitializeDirectoryData::class,
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR adds Ireland counties to Magento. So that Ireland based users can pick their county from a dropdown instead of having to type it on the input.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to Address Book
2. Add a new address, and select 'Ireland' as the country
3. You should now see the dropdown with the counties.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32459: Add Ireland counties data