### PR TITLE
When 'region_id' is '0' and region_id is required, the validation is not working

### DIFF
--- a/app/code/Magento/Customer/Model/Address/Validator/Country.php
+++ b/app/code/Magento/Customer/Model/Address/Validator/Country.php
@@ -108,7 +108,13 @@ class Country implements ValidatorInterface
             //If region is required for country and country doesn't provide regions list
             //region must be provided.
             $errors[] = __('"%fieldName" is required. Enter and try again.', ['fieldName' => 'region']);
-        } elseif ($allowedRegions && !\Zend_Validate::is($regionId, 'NotEmpty') && $isRegionRequired) {
+        } elseif (
+            $allowedRegions &&
+            !\Zend_Validate::is($regionId, 'NotEmpty', [
+                'type' => \Zend_Validate_NotEmpty::ZERO | \Zend_Validate_NotEmpty::INTEGER
+            ])
+            && $isRegionRequired
+        ) {
             //If country actually has regions and requires you to
             //select one then it must be selected.
             $errors[] = __('"%fieldName" is required. Enter and try again.', ['fieldName' => 'regionId']);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When 'region_id' is '0' and region_id is required, the validation is not working.
The Zend_Validate class needs to return false if:

- a string of '0' is given
- a integer of 0 is given

This PR adds those cases to the validation functionality.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Run app\code\Magento\Customer\Test\Unit\Model\Address\Validator\CountryTest.php tests with 'region_id' set to '0'

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
