### PR TITLE
Don't redirect to PayPal with empty quote

### DIFF
--- a/app/code/Magento/Paypal/Controller/Transparent/RequestSecureToken.php
+++ b/app/code/Magento/Paypal/Controller/Transparent/RequestSecureToken.php
@@ -86,7 +86,7 @@ class RequestSecureToken extends \Magento\Framework\App\Action\Action implements
         /** @var Quote $quote */
         $quote = $this->sessionManager->getQuote();
 
-        if (!$quote || !$quote instanceof Quote) {
+        if (!$quote || !$quote instanceof Quote || $quote->getItemsCount() <= 0) {
             return $this->getErrorResponse();
         }
 


### PR DESCRIPTION
* https://community.magento.com/t5/Magento-2-x-Technical-Issues/PayPal-Payflow-extension-exploited-for-fraudulent-transactions/td-p/123002
* https://github.com/magento/magento2/issues/21870

We had a lot of POST requests to "/paypal/transparent/requestSecureToken/" from different IPs that have been redirected to PayPal by our Magento app. 

### Resolved issues:
1. [x] resolves magento/magento2#33355: Don't redirect to PayPal with empty quote