### PR TITLE
Replace repetitive actions with Action Groups in AdminCreateVirtualProductFillingRequiredFieldsOnlyTest

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductFillingRequiredFieldsOnlyTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateVirtualProductFillingRequiredFieldsOnlyTest.xml
@@ -25,31 +25,54 @@
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
         </after>
 
-        <actionGroup ref="AdminProductCatalogPageOpenActionGroup" stepKey="openProductCatalogPage"/>
-        <comment userInput="Adding the comment to replace clickAddProductToggle action for preserving Backward Compatibility" stepKey="clickAddProductToggle"/>
-        <comment userInput="Adding the comment to replace clickAddProductToggle action for preserving Backward Compatibility" stepKey="waitForProductToggleToSelectProduct"/>
-        <actionGroup ref="AdminClickAddProductToggleAndSelectProductTypeActionGroup" stepKey="clickVirtualProduct">
+        <comment userInput="Adding the comment to replace clickAddProductToggle action for preserving Backward Compatibility"
+                 stepKey="openProductCatalogPage"/>
+        <comment userInput="Adding the comment to replace clickAddProductToggle action for preserving Backward Compatibility"
+                 stepKey="clickAddProductToggle"/>
+        <comment userInput="Adding the comment to replace clickAddProductToggle action for preserving Backward Compatibility"
+                 stepKey="waitForProductToggleToSelectProduct"/>
+        <actionGroup ref="AdminOpenNewProductFormPageActionGroup" stepKey="clickVirtualProduct">
             <argument name="productType" value="virtual"/>
         </actionGroup>
 
         <!-- Create virtual product with required fields only -->
-        <fillField selector="{{AdminProductFormSection.productName}}" userInput="{{virtualProductWithRequiredFields.name}}" stepKey="fillProductName"/>
-        <fillField selector="{{AdminProductFormSection.productSku}}" userInput="{{virtualProductWithRequiredFields.sku}}" stepKey="fillProductSku"/>
-        <fillField selector="{{AdminProductFormSection.productPrice}}" userInput="{{virtualProductWithRequiredFields.price}}" stepKey="fillProductPrice"/>
+        <actionGroup ref="FillProductNameAndSkuInProductFormActionGroup" stepKey="fillProductName">
+            <argument name="product" value="virtualProductWithRequiredFields"/>
+        </actionGroup>
+        <comment userInput="Adding the comment to replace clickAddProductToggle action for preserving Backward Compatibility"
+                 stepKey="fillProductSku"/>
+        <actionGroup ref="AdminFillProductPriceFieldAndPressEnterOnProductEditPageActionGroup" stepKey="fillProductPrice">
+            <argument name="price" value="{{virtualProductWithRequiredFields.price}}"/>
+        </actionGroup>
         <actionGroup ref="AdminProductFormSaveButtonClickActionGroup" stepKey="clickSaveButton"/>
 
         <!-- Verify we see success message -->
-        <see selector="{{AdminProductFormSection.successMessage}}" userInput="You saved the product." stepKey="seeAssertVirtualProductSuccessMessage"/>
+        <actionGroup ref="AssertMessageInAdminPanelActionGroup" stepKey="seeAssertVirtualProductSuccessMessage">
+            <argument name="message" value="You saved the product."/>
+        </actionGroup>
 
         <!-- Verify we see created virtual product(from the above step) on the product grid page -->
         <actionGroup ref="AdminProductCatalogPageOpenActionGroup" stepKey="openProductCatalogPage1"/>
-        <conditionalClick selector="{{AdminProductGridFilterSection.clearAll}}" dependentSelector="{{AdminProductGridFilterSection.clearAll}}" visible="true" stepKey="clickSelector"/>
-        <click selector="{{AdminProductGridFilterSection.filters}}" stepKey="clickFilter"/>
-        <fillField selector="{{AdminProductGridFilterSection.nameFilter}}" userInput="{{virtualProductWithRequiredFields.name}}" stepKey="fillProductName1"/>
-        <fillField selector="{{AdminProductGridFilterSection.skuFilter}}" userInput="{{virtualProductWithRequiredFields.sku}}" stepKey="fillVirtualProductSku"/>
-        <click selector="{{AdminProductGridFilterSection.applyFilters}}" stepKey="clickSearch2"/>
-        <waitForPageLoad stepKey="waitForProductSearch"/>
-        <seeInField selector="{{AdminProductGridFilterSection.nameFilter}}" userInput="{{virtualProductWithRequiredFields.name}}" stepKey="seeVirtualProductName"/>
-        <seeInField selector="{{AdminProductGridFilterSection.skuFilter}}" userInput="{{virtualProductWithRequiredFields.sku}}" stepKey="seeVirtualProductSku"/>
+        <comment userInput="Adding the comment to replace clickAddProductToggle action for preserving Backward Compatibility"
+                 stepKey="clickSelector"/>
+        <comment userInput="Adding the comment to replace clickAddProductToggle action for preserving Backward Compatibility"
+                 stepKey="clickFilter"/>
+        <comment userInput="Adding the comment to replace clickAddProductToggle action for preserving Backward Compatibility"
+                 stepKey="fillProductName1"/>
+        <comment userInput="Adding the comment to replace clickAddProductToggle action for preserving Backward Compatibility"
+                 stepKey="fillVirtualProductSku"/>
+        <actionGroup ref="FilterProductGridBySkuAndNameActionGroup" stepKey="clickSearch2">
+            <argument name="product" value="virtualProductWithRequiredFields"/>
+        </actionGroup>
+        <comment userInput="Adding the comment to replace clickAddProductToggle action for preserving Backward Compatibility"
+                 stepKey="waitForProductSearch"/>
+        <actionGroup ref="AssertAdminProductGridCellActionGroup" stepKey="seeVirtualProductName">
+            <argument name="column" value="Name"/>
+            <argument name="value" value="{{virtualProductWithRequiredFields.name}}"/>
+        </actionGroup>
+        <actionGroup ref="AssertAdminProductGridCellActionGroup" stepKey="seeVirtualProductSku">
+            <argument name="column" value="SKU"/>
+            <argument name="value" value="{{virtualProductWithRequiredFields.sku}}"/>
+        </actionGroup>
     </test>
 </tests>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The test is refactored according to the best practices followed by MFTF.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
Run the test in the local environment and verified that it run successfully

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32504: Replace repetitive actions with Action Groups in AdminCreateVirtualProductFillingRequiredFieldsOnlyTest