### PR TITLE
Fix for Export process running out of memory

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Export/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Export/Product.php
@@ -949,8 +949,9 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
             $productIds = array_keys($rawData);
             $stockItemRows = $this->prepareCatalogInventory($productIds);
 
+            $entityCollection = clone $this->_getEntityCollection();
             $this->rowCustomizer->prepareData(
-                $this->_prepareEntityCollection($this->_entityCollectionFactory->create()),
+                $entityCollection,
                 $productIds
             );
 


### PR DESCRIPTION
### Description (*)
When running a product export, the pagination and memory limit calculations are not used for the full process.
This causes the process to run out of memory, when you have a large catalog.


### Fixed Issues (if relevant)
1. Fixes magento/magento2#32492

### Manual testing scenarios (*)
#### Preconditions (*)
Can replicate on 2.3.5-p1, looking at the codebase this should be reproducible for any version beyond this.
1. Have a product catalog with a lot of products (>200K)
2. Have a php memory limit of 2G
3. ensure cron is running

#### Steps to reproduce (*)
1. Initiate a "product" export from the Admin. (System => Data Transfer - Export)

#### Expected result (*)
1. At some point the export file will be available.

#### Actual result (*)
1. File is never generated.
2. Running the consumer manually (with something like: `php bin/magento queue:consumers:start --single-thread --max-messages=100 -vvv -- exportProcessor`, causes an "Out Of Memory" exception)

### Questions or comments
I understand that memory_limit settings can be increased, however, I believe this issue is application-specific as great care has been taken to take into account the current `memory_limit` settings, see [here](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/CatalogImportExport/Model/Export/Product.php#L822). 
The bug is caused by this logic not being used/re-used correctly

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
