### PR TITLE
MC-39508: Spreading multiple GraphQL fragments into CategoryTree causes Magento to throw

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Category/DepthCalculator.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Category/DepthCalculator.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\CatalogGraphQl\Model\Category;
 
+use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\FieldNode;
 use GraphQL\Language\AST\InlineFragmentNode;
 use GraphQL\Language\AST\NodeKind;
@@ -26,22 +27,35 @@ class DepthCalculator
      */
     public function calculate(ResolveInfo $resolveInfo, FieldNode $fieldNode) : int
     {
-        $selections = $fieldNode->selectionSet->selections ?? [];
+        return $this->calculateRecursive($resolveInfo, $fieldNode);
+    }
+
+    /**
+     * Calculate recursive the total depth of a category tree inside a GraphQL request
+     *
+     * @param ResolveInfo $resolveInfo
+     * @param Node $node
+     * @return int
+     */
+    private function calculateRecursive(ResolveInfo $resolveInfo, Node $node) : int
+    {
+        if ($node->kind === NodeKind::FRAGMENT_SPREAD) {
+            $selections = isset($resolveInfo->fragments[$node->name->value]) ?
+                $resolveInfo->fragments[$node->name->value]->selectionSet->selections : [];
+        } else {
+            $selections = $node->selectionSet->selections ?? [];
+        }
         $depth = count($selections) ? 1 : 0;
         $childrenDepth = [0];
-        foreach ($selections as $node) {
-            if (isset($node->alias) && null !== $node->alias) {
+        foreach ($selections as $subNode) {
+            if (isset($subNode->alias) && null !== $subNode->alias) {
                 continue;
             }
 
-            if ($node->kind ===  NodeKind::INLINE_FRAGMENT) {
-                $childrenDepth[] = $this->addInlineFragmentDepth($resolveInfo, $node);
-            } elseif ($node->kind === NodeKind::FRAGMENT_SPREAD && isset($resolveInfo->fragments[$node->name->value])) {
-                foreach ($resolveInfo->fragments[$node->name->value]->selectionSet->selections as $spreadNode) {
-                    $childrenDepth[] = $this->calculate($resolveInfo, $spreadNode);
-                }
+            if ($subNode->kind ===  NodeKind::INLINE_FRAGMENT) {
+                $childrenDepth[] = $this->addInlineFragmentDepth($resolveInfo, $subNode);
             } else {
-                $childrenDepth[] = $this->calculate($resolveInfo, $node);
+                $childrenDepth[] = $this->calculateRecursive($resolveInfo, $subNode);
             }
         }
 

--- a/app/code/Magento/CatalogGraphQl/Model/Category/DepthCalculator.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Category/DepthCalculator.php
@@ -7,9 +7,9 @@ declare(strict_types=1);
 
 namespace Magento\CatalogGraphQl\Model\Category;
 
-use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\FieldNode;
 use GraphQL\Language\AST\InlineFragmentNode;
+use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\NodeKind;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 
@@ -25,7 +25,7 @@ class DepthCalculator
      * @param FieldNode $fieldNode
      * @return int
      */
-    public function calculate(ResolveInfo $resolveInfo, FieldNode $fieldNode) : int
+    public function calculate(ResolveInfo $resolveInfo, FieldNode $fieldNode): int
     {
         return $this->calculateRecursive($resolveInfo, $fieldNode);
     }
@@ -37,7 +37,7 @@ class DepthCalculator
      * @param Node $node
      * @return int
      */
-    private function calculateRecursive(ResolveInfo $resolveInfo, Node $node) : int
+    private function calculateRecursive(ResolveInfo $resolveInfo, Node $node): int
     {
         if ($node->kind === NodeKind::FRAGMENT_SPREAD) {
             $selections = isset($resolveInfo->fragments[$node->name->value]) ?

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryListTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/CategoryListTest.php
@@ -848,7 +848,7 @@ QUERY;
      *
      * @magentoApiDataFixture Magento/Catalog/_files/categories.php
      */
-    public function testFilterCategoryRecursiveFragment() : void
+    public function testFilterCategoryRecursiveFragment(): void
     {
         $query = <<<'QUERY'
 query GetCategoryTree($filters: CategoryFilterInput!) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes https://github.com/magento/magento2/issues/31086

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
