### PR TITLE
Fix missing video when advanced  js bundling used

### DIFF
--- a/app/code/Magento/ProductVideo/view/frontend/web/js/fotorama-add-video-events.js
+++ b/app/code/Magento/ProductVideo/view/frontend/web/js/fotorama-add-video-events.js
@@ -138,10 +138,9 @@ define([
          * @private
          */
         _create: function () {
-            $(this.element).on('gallery:loaded',  $.proxy(function () {
-                this.fotoramaItem = $(this.element).find('.fotorama-item');
-                this._initialize();
-            }, this));
+            $(this.element).data('gallery') ?
+                this._onGalleryLoaded() :
+                $(this.element).on('gallery:loaded', this._onGalleryLoaded.bind(this));
         },
 
         /**
@@ -169,6 +168,14 @@ define([
                 this._initFotoramaVideo();
                 this._attachFotoramaEvents();
             }
+        },
+
+        /**
+         * Callback which fired after gallery gets initialized.
+         */
+        _onGalleryLoaded: function () {
+            this.fotoramaItem = $(this.element).find('.fotorama-item');
+            this._initialize();
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes issue when a video is missing in the product gallery when advanced JS bundling is enabled and used.

This happened because the event `gallery:loaded` was already triggered before this code was executed.

In order to fix the issue I looked how with this event we working in different places, so I did same in this piece of code as well.
https://github.com/magento/magento2/blob/fbfac3e51730abe2b79c6072544bc9742fcf7606/app/code/Magento/ConfigurableProduct/view/frontend/web/js/configurable.js#L106-L108


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes https://github.com/magesuite/magesuite/issues/82

### Manual testing scenarios (*)
1. **Configure advanced JS bundling**, I used this one https://github.com/magesuite/magepack
2. Go to a product page that contains youtube or vimeo video
3. See gallery, try to find the video

**Actual result:** (before this PR)
❌ No video appeared, just image shown

**Expected result:** (after this PR)
✔ Video should appear in gallery

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32501: Fix missing video when advanced  js bundling used