### PR TITLE
Fix setup wizard on php8-develop branch

### DIFF
--- a/setup/src/Zend/Mvc/Controller/LazyControllerAbstractFactory.php
+++ b/setup/src/Zend/Mvc/Controller/LazyControllerAbstractFactory.php
@@ -119,7 +119,7 @@ class LazyControllerAbstractFactory implements AbstractFactoryInterface
         }
 
         $parameters = array_map(
-            $this->resolveParameter($container->getServiceLocator(), $requestedName),
+            $this->resolveParameter($container, $requestedName),
             $reflectionParameters
         );
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
There is an issue in php8-develop branch with setup wizard not working after updating of laminas-servicemanager.
This PR fixes is

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Open setup wizard and wait for content to appear.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32551: Fix setup wizard on php8-develop branch