### PR TITLE
[Framework] Fixed getHeader for returning default value if requested missing

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/PhpEnvironment/Request.php
+++ b/lib/internal/Magento/Framework/HTTP/PhpEnvironment/Request.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Framework\HTTP\PhpEnvironment;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
@@ -25,7 +26,7 @@ class Request extends \Laminas\Http\PhpEnvironment\Request
     /**#@+
      * Protocols
      */
-    const SCHEME_HTTP  = 'http';
+    const SCHEME_HTTP = 'http';
     const SCHEME_HTTPS = 'https';
     /**#@-*/
 
@@ -123,7 +124,7 @@ class Request extends \Laminas\Http\PhpEnvironment\Request
                 $uri = UriFactory::factory($uri);
             }
             if ($uri->isValid()) {
-                $path  = $uri->getPath();
+                $path = $uri->getPath();
                 $query = $uri->getQuery();
                 if (!empty($query)) {
                     $path .= '?' . $query;
@@ -302,7 +303,7 @@ class Request extends \Laminas\Http\PhpEnvironment\Request
      */
     public function getParam($key, $default = null)
     {
-        $key = (string) $key;
+        $key = (string)$key;
         $keyName = (null !== ($alias = $this->getAlias($key))) ? $alias : $key;
         if (isset($this->params[$keyName])) {
             return $this->params[$keyName];
@@ -325,7 +326,7 @@ class Request extends \Laminas\Http\PhpEnvironment\Request
      */
     public function setParam($key, $value)
     {
-        $key = (string) $key;
+        $key = (string)$key;
         $keyName = (null !== ($alias = $this->getAlias($key))) ? $alias : $key;
         if ((null === $value) && isset($this->params[$keyName])) {
             unset($this->params[$keyName]);
@@ -696,7 +697,7 @@ class Request extends \Laminas\Http\PhpEnvironment\Request
         if ($header instanceof HeaderInterface) {
             return $header->getFieldValue();
         }
-        return  $header;
+        return $header;
     }
 
     /**
@@ -724,7 +725,7 @@ class Request extends \Laminas\Http\PhpEnvironment\Request
     /**
      * Get the client's IP addres
      *
-     * @param  boolean $checkProxy
+     * @param boolean $checkProxy
      * @return string
      */
     public function getClientIp($checkProxy = true)
@@ -795,7 +796,7 @@ class Request extends \Laminas\Http\PhpEnvironment\Request
     public function getBaseUrl()
     {
         $url = urldecode(parent::getBaseUrl());
-        $url = str_replace(['\\', '/' . DirectoryList::PUB .'/'], '/', $url);
+        $url = str_replace(['\\', '/' . DirectoryList::PUB . '/'], '/', $url);
         return $url;
     }
 

--- a/lib/internal/Magento/Framework/HTTP/PhpEnvironment/Request.php
+++ b/lib/internal/Magento/Framework/HTTP/PhpEnvironment/Request.php
@@ -696,7 +696,7 @@ class Request extends \Laminas\Http\PhpEnvironment\Request
         if ($header instanceof HeaderInterface) {
             return $header->getFieldValue();
         }
-        return false;
+        return  $header;
     }
 
     /**

--- a/lib/internal/Magento/Framework/HTTP/Test/Unit/PhpEnvironment/RequestTest.php
+++ b/lib/internal/Magento/Framework/HTTP/Test/Unit/PhpEnvironment/RequestTest.php
@@ -280,4 +280,24 @@ class RequestTest extends TestCase
 
         $this->assertEquals($default, $this->getModel()->getCookie($nullKey, $default));
     }
+
+    /**
+     * Get header with default value test
+     */
+    public function testGetHeaderWithDefaultValue()
+    {
+        $expectedValue = 'test-value';
+        $actualValue = $this->getModel()->getHeader('test-header', $expectedValue);
+        $this->assertEquals($expectedValue, $actualValue);
+    }
+
+    /**
+     * Get header without default value test
+     */
+    public function testGetHeaderWithoutDefaultValue()
+    {
+        $expectedValue = false;
+        $actualValue = $this->getModel()->getHeader('test-header');
+        $this->assertEquals($expectedValue, $actualValue);
+    }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
`getHeader` function allow to provider default value parameter, but this value never return back

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#32521

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create controller action class
2. Try to receive header value for missing header `$this->getRequest()->getHeader('test-header', 'test-value')`

### Expected result
`test-value` should be returned

### Actual result result
`false` returned

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32521: [Framework] Fixed getHeader for returning default value if requested missing