### PR TITLE
Catch throwable errors during model save (rollback)

### DIFF
--- a/lib/internal/Magento/Framework/Model/ResourceModel/Db/AbstractDb.php
+++ b/lib/internal/Magento/Framework/Model/ResourceModel/Db/AbstractDb.php
@@ -389,7 +389,7 @@ abstract class AbstractDb extends AbstractResource
      * @param \Magento\Framework\Model\AbstractModel $object
      * @return $this
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-     * @throws \Exception
+     * @throws \Throwable
      * @throws AlreadyExistsException
      * @api
      */
@@ -429,7 +429,7 @@ abstract class AbstractDb extends AbstractResource
             $this->rollBack();
             $object->setHasDataChanges(true);
             throw new AlreadyExistsException(new Phrase('Unique constraint violation found'), $e);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->rollBack();
             $object->setHasDataChanges(true);
             throw $e;

--- a/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/AbstractDbTest.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/AbstractDbTest.php
@@ -616,4 +616,26 @@ class AbstractDbTest extends TestCase
 
         $model->save($object);
     }
+
+    public function testThrowableProcessingOnSave()
+    {
+        $connection = $this->getMockForAbstractClass(AdapterInterface::class);
+
+        /** @var AbstractDb|MockObject $model */
+        $model = $this->getMockBuilder(AbstractDb::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getConnection'])
+            ->getMockForAbstractClass();
+        $model->expects($this->any())->method('getConnection')->willReturn($connection);
+
+        /** @var AbstractModel|MockObject $object */
+        $object = $this->getMockBuilder(AbstractModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $object->expects($this->once())->method('hasDataChanges')->willReturn(true);
+        $object->expects($this->once())->method('beforeSave')->willThrowException(new \Error());
+
+        $model->save($object);
+    }
+
 }


### PR DESCRIPTION
### Description (*)
When you throw `Error` class (or some inherited class) in `beforeSave` method - Magento do not rollback started transaction correctly.

You can look at similar pull request for OpenMage project: https://github.com/OpenMage/magento-lts/pull/1483

`Exception implements Throwable` - so this change should be unbreakable

### Manual testing scenarios (*)
1. ` throw new Error('error from some specifiec reason');`


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32562: Catch throwable errors during model save (rollback)