### PR TITLE
MC-40780: Moving category in hierarchy causes url_path to be incorrect when using different url keys in multiple storeviews

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminChangeSeoUrlKeyToDefaultValueWithoutRedirectActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminChangeSeoUrlKeyToDefaultValueWithoutRedirectActionGroup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminChangeSeoUrlKeyToDefaultValueWithoutRedirectActionGroup">
+        <annotations>
+            <description>Requires navigation to category creation/edit page. Selects 'Use Default Value' checkbox for the 'URL Key' with 'Create Permanent Redirect for old URL' unchecked.</description>
+        </annotations>
+
+        <conditionalClick selector="{{AdminCategorySEOSection.SectionHeader}}" dependentSelector="{{AdminCategorySEOSection.UrlKeyInput}}" visible="false" stepKey="clickOnSEOTab"/>
+        <waitForElementVisible selector="{{AdminCategorySEOSection.UrlKeyInput}}"  stepKey="waitForSEOTabOpened"/>
+        <clearField selector="{{AdminCategorySEOSection.UrlKeyInput}}" stepKey="clearUrlKeyField"/>
+        <uncheckOption selector="{{AdminCategorySEOSection.UrlKeyRedirectCheckbox}}" stepKey="uncheckRedirectCheckbox"/>
+        <checkOption selector="{{AdminCategorySEOSection.UrlKeyDefaultValueCheckbox}}" stepKey="checkUseDefaultValueCheckbox"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/CatalogUrlRewrite/Model/ResourceModel/Category/GetDefaultUrlKey.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/ResourceModel/Category/GetDefaultUrlKey.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogUrlRewrite\Model\ResourceModel\Category;
+
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Catalog\Model\Category;
+use Magento\Eav\Model\Config as EavConfig;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Select;
+use Magento\Framework\EntityManager\MetadataPool;
+use Magento\Store\Model\Store;
+
+/**
+ * Fetch category 'url_key' default value from the database.
+ */
+class GetDefaultUrlKey
+{
+    /**
+     * @var MetadataPool
+     */
+    private $metadataPool;
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var EavConfig
+     */
+    private $eavConfig;
+
+    /**
+     * @param MetadataPool $metadataPool
+     * @param ResourceConnection $resourceConnection
+     * @param EavConfig $eavConfig
+     */
+    public function __construct(
+        MetadataPool $metadataPool,
+        ResourceConnection $resourceConnection,
+        EavConfig $eavConfig
+    ) {
+        $this->metadataPool = $metadataPool;
+        $this->resourceConnection = $resourceConnection;
+        $this->eavConfig = $eavConfig;
+    }
+
+    /**
+     * Retrieve 'url_key' value for default store.
+     *
+     * @param int $categoryId
+     * @return string|null
+     */
+    public function execute(int $categoryId): ?string
+    {
+        $metadata = $this->metadataPool->getMetadata(CategoryInterface::class);
+        $entityTypeId = $this->eavConfig->getEntityType(Category::ENTITY)->getId();
+        $linkField = $metadata->getLinkField();
+        $whereConditions = [
+            'e.entity_type_id = ' . $entityTypeId,
+            "e.attribute_code = 'url_key'",
+            'c.' . $linkField . ' = ' . $categoryId,
+            'c.store_id = ' . Store::DEFAULT_STORE_ID,
+        ];
+        $connection = $this->resourceConnection->getConnection();
+        $select = $connection->select()
+            ->from(['c' => $this->resourceConnection->getTableName('catalog_category_entity_varchar')])
+            ->joinLeft(
+                ['e' => $this->resourceConnection->getTableName('eav_attribute')],
+                'e.attribute_id = c.attribute_id'
+            )
+            ->reset(Select::COLUMNS)
+            ->columns(['c.value'])
+            ->where(implode(' AND ', $whereConditions));
+
+        return $connection->fetchOne($select) ?: null;
+    }
+}

--- a/app/code/Magento/CatalogUrlRewrite/Test/Mftf/Test/StorefrontCheckCategoryUrlPathForCustomStoreAfterChangingHierarchyTest.xml
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Mftf/Test/StorefrontCheckCategoryUrlPathForCustomStoreAfterChangingHierarchyTest.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontCheckCategoryUrlPathForCustomStoreAfterChangingHierarchyTest">
+        <annotations>
+            <features value="CatalogUrlRewrite"/>
+            <stories value="Url rewrites"/>
+            <title value="Checking category URL path for custom store after changing hierarchy"/>
+            <description value="Checks that category and its children have correct URL path for custom store after changing hierarchy"/>
+            <severity value="MAJOR"/>
+            <testCaseId value="MC-41615"/>
+            <useCaseId value="MC-40780"/>
+            <group value="catalog"/>
+            <group value="urlRewrite"/>
+        </annotations>
+        <before>
+            <!-- Create categories -->
+            <createData entity="_defaultCategory" stepKey="createCategory1"/>
+            <createData entity="SubCategoryWithParent" stepKey="createCategory2">
+                <requiredEntity createDataKey="createCategory1"/>
+            </createData>
+            <createData entity="_defaultCategory" stepKey="createCategory3"/>
+            <createData entity="_defaultCategory" stepKey="createCategory4"/>
+            <!-- Login as Admin -->
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <!-- Create "EN" Store View -->
+            <actionGroup ref="AdminCreateStoreViewActionGroup" stepKey="createEnStoreView">
+                <argument name="customStore" value="customStoreEN"/>
+            </actionGroup>
+        </before>
+        <after>
+            <!-- Delete categories -->
+            <deleteData createDataKey="createCategory4" stepKey="deleteCategory4"/>
+            <deleteData createDataKey="createCategory3" stepKey="deleteCategory3"/>
+            <deleteData createDataKey="createCategory2" stepKey="deleteCategory2"/>
+            <deleteData createDataKey="createCategory1" stepKey="deleteCategory1"/>
+            <actionGroup ref="AdminDeleteStoreViewActionGroup" stepKey="deleteEnStoreView">
+                <argument name="customStore" value="customStoreEN"/>
+            </actionGroup>
+            <!-- Clear grid filters -->
+            <actionGroup ref="ClearFiltersAdminDataGridActionGroup" stepKey="clearStoreFilters"/>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logoutFromAdmin"/>
+        </after>
+
+        <!-- Go to Category 1 edit page on "EN" store view -->
+        <actionGroup ref="SwitchCategoryStoreViewActionGroup" stepKey="goToCategory1PageOnEnStoreView">
+            <argument name="Store" value="customStoreEN.name"/>
+            <argument name="CatName" value="$createCategory1.name$"/>
+        </actionGroup>
+
+        <!-- Change Name and URL key for Category 1 -->
+        <actionGroup ref="AdminChangeCategoryNameOnStoreViewLevelActionGroup" stepKey="changeCategory1NameForEnStoreView">
+            <argument name="categoryName" value="EN 1"/>
+        </actionGroup>
+        <actionGroup ref="AdminChangeSeoUrlKeyForSubCategoryWithoutRedirectActionGroup" stepKey="changeCategory1UrlKeyForEnStoreView">
+            <argument name="value" value="en 1"/>
+        </actionGroup>
+
+        <!-- Change Name and URL key for Category 2 -->
+        <actionGroup ref="AdminCategoriesOpenCategoryActionGroup" stepKey="openCategory2EditPage">
+            <argument name="category" value="$createCategory2$"/>
+        </actionGroup>
+        <actionGroup ref="AdminChangeCategoryNameOnStoreViewLevelActionGroup" stepKey="changeCategory2NameForEnStoreView">
+            <argument name="categoryName" value="EN 2"/>
+        </actionGroup>
+        <actionGroup ref="AdminChangeSeoUrlKeyForSubCategoryWithoutRedirectActionGroup" stepKey="changeCategory2UrlKeyForEnStoreView">
+            <argument name="value" value="en 2"/>
+        </actionGroup>
+
+        <!-- Change Name and URL key for Category 3 -->
+        <actionGroup ref="AdminCategoriesOpenCategoryActionGroup" stepKey="openCategory3EditPage">
+            <argument name="category" value="$createCategory3$"/>
+        </actionGroup>
+        <actionGroup ref="AdminChangeCategoryNameOnStoreViewLevelActionGroup" stepKey="changeCategory3NameForEnStoreView">
+            <argument name="categoryName" value="EN 3"/>
+        </actionGroup>
+        <actionGroup ref="AdminChangeSeoUrlKeyForSubCategoryWithoutRedirectActionGroup" stepKey="changeCategory3UrlKeyForEnStoreView">
+            <argument name="value" value="en 3"/>
+        </actionGroup>
+
+        <!-- Change Name and URL key for Category 4 -->
+        <actionGroup ref="AdminCategoriesOpenCategoryActionGroup" stepKey="openCategory4EditPage">
+            <argument name="category" value="$createCategory4$"/>
+        </actionGroup>
+        <actionGroup ref="AdminChangeCategoryNameOnStoreViewLevelActionGroup" stepKey="changeCategory4NameForEnStoreView">
+            <argument name="categoryName" value="EN 4"/>
+        </actionGroup>
+        <actionGroup ref="AdminChangeSeoUrlKeyForSubCategoryWithoutRedirectActionGroup" stepKey="changeCategory4UrlKeyForEnStoreView">
+            <argument name="value" value="en 4"/>
+        </actionGroup>
+
+        <!-- Go to Home page on the Storefront -->
+        <actionGroup ref="StorefrontOpenHomePageActionGroup" stepKey="goToHomePage"/>
+        <!-- Switch store view to 'EN' -->
+        <actionGroup ref="StorefrontSwitchStoreViewActionGroup" stepKey="switchStoreViewToEn">
+            <argument name="storeView" value="customStoreEN"/>
+        </actionGroup>
+
+        <!-- Assert Category 2 URL path on the 'EN' store view -->
+        <actionGroup ref="StorefrontGoToSubCategoryPageActionGroup" stepKey="navigateToCategory2Page">
+            <argument name="categoryName" value="EN 1"/>
+            <argument name="subCategoryName" value="EN 2"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontAssertProperUrlIsShownActionGroup" stepKey="assertUrlPathForCategory2">
+            <argument name="urlPath" value="/en-1/en-2.html"/>
+        </actionGroup>
+
+        <!-- Go to Categories page on the Admin -->
+        <actionGroup ref="AdminOpenCategoryPageActionGroup" stepKey="goToAdminCategoriesPage"/>
+        <see userInput="All Store View" selector="{{AdminMainActionsSection.storeViewDropdown}}" stepKey="assertAllStoreView"/>
+
+        <!-- Move Category 2 to 'Default Category' -->
+        <actionGroup ref="MoveCategoryActionGroup" stepKey="moveCategory2ToDefaultCategory">
+            <argument name="childCategory" value="$createCategory2.name$"/>
+            <argument name="parentCategory" value="Default Category"/>
+        </actionGroup>
+        <!-- Move Category 4 to Category 3 -->
+        <actionGroup ref="MoveCategoryActionGroup" stepKey="moveCategory4ToCategory3">
+            <argument name="childCategory" value="$createCategory4.name$"/>
+            <argument name="parentCategory" value="$createCategory3.name$"/>
+        </actionGroup>
+
+        <!-- Create Category 5 -->
+        <actionGroup ref="AdminCategoriesOpenCategoryActionGroup" stepKey="navigateToCategory2EditPage">
+            <argument name="category" value="$createCategory2$"/>
+        </actionGroup>
+        <click selector="{{AdminCategorySidebarActionSection.AddSubcategoryButton}}" stepKey="clickToAddCategory5"/>
+        <checkOption selector="{{AdminCategoryBasicFieldSection.EnableCategory}}" stepKey="enableCategory5"/>
+        <fillField selector="{{AdminCategoryBasicFieldSection.CategoryNameInput}}" userInput="{{SimpleSubCategory.name}}" stepKey="fillCategory5Name"/>
+        <actionGroup ref="AdminSaveCategoryActionGroup" stepKey="saveCategory5"/>
+        <actionGroup ref="AssertAdminCategorySaveSuccessMessageActionGroup" stepKey="assertCategory5Saved"/>
+
+        <!-- Assert Category 5 URL path on the 'EN' store view -->
+        <actionGroup ref="StorefrontGoToSubCategoryPageActionGroup" stepKey="navigateToCategory5Page">
+            <argument name="categoryName" value="EN 2"/>
+            <argument name="subCategoryName" value="{{SimpleSubCategory.name}}"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontAssertProperUrlIsShownActionGroup" stepKey="assertUrlPathForCategory5">
+            <argument name="urlPath" value="en-2/{{SimpleSubCategory.name_lwr}}.html"/>
+        </actionGroup>
+
+        <!-- Go to Category 2 edit page on "EN" store view -->
+        <actionGroup ref="AdminOpenCategoryPageActionGroup" stepKey="goToAdminCategoryIndexPage"/>
+        <actionGroup ref="AdminCategoriesOpenCategoryActionGroup" stepKey="goToCategory2EditPage">
+            <argument name="category" value="$createCategory2$"/>
+        </actionGroup>
+        <actionGroup ref="AdminSwitchStoreViewActionGroup" stepKey="switchToDefaultStoreView">
+            <argument name="storeView" value="customStoreEN.name"/>
+        </actionGroup>
+
+        <!-- Change Category 2 URL key to default value -->
+        <actionGroup ref="AdminChangeSeoUrlKeyToDefaultValueWithoutRedirectActionGroup" stepKey="changeCategory2UrlKeyToDefaultValue"/>
+        <actionGroup ref="AdminSaveCategoryActionGroup" stepKey="saveCategory2"/>
+        <actionGroup ref="AssertAdminCategorySaveSuccessMessageActionGroup" stepKey="assertCategory2Saved"/>
+
+        <!-- Go to Home page on the Storefront -->
+        <actionGroup ref="StorefrontOpenHomePageActionGroup" stepKey="navigateToHomePage"/>
+        <!-- Assert Category 5 URL path on the 'EN' store view after change parent category -->
+        <actionGroup ref="StorefrontGoToSubCategoryPageActionGroup" stepKey="goToCategory5Page">
+            <argument name="categoryName" value="EN 2"/>
+            <argument name="subCategoryName" value="{{SimpleSubCategory.name}}"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontAssertProperUrlIsShownActionGroup" stepKey="assertUrlPathForCategory5AfterChangeParent">
+            <argument name="urlPath" value="$createCategory2.name_lwr$/{{SimpleSubCategory.name_lwr}}.html"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryUrlPathAutogeneratorObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryUrlPathAutogeneratorObserverTest.php
@@ -7,9 +7,11 @@ declare(strict_types=1);
 
 namespace Magento\CatalogUrlRewrite\Test\Unit\Observer;
 
-use Magento\Catalog\Model\ResourceModel\Category;
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\ResourceModel\Category as CategoryResource;
 use Magento\CatalogUrlRewrite\Model\Category\ChildrenCategoriesProvider;
 use Magento\CatalogUrlRewrite\Model\CategoryUrlPathGenerator;
+use Magento\CatalogUrlRewrite\Model\ResourceModel\Category\GetDefaultUrlKey;
 use Magento\CatalogUrlRewrite\Observer\CategoryUrlPathAutogeneratorObserver;
 use Magento\CatalogUrlRewrite\Service\V1\StoreViewService;
 use Magento\Framework\Event\Observer;
@@ -20,6 +22,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Magento\Backend\Model\Validator\UrlKey\CompositeUrlKey;
 
+/**
+ * Unit tests for \Magento\CatalogUrlRewrite\Observer\CategoryUrlPathAutogeneratorObserver class.
+ */
 class CategoryUrlPathAutogeneratorObserverTest extends TestCase
 {
     /**
@@ -53,7 +58,7 @@ class CategoryUrlPathAutogeneratorObserverTest extends TestCase
     private $storeViewService;
 
     /**
-     * @var Category|MockObject
+     * @var CategoryResource|MockObject
      */
     private $categoryResource;
 
@@ -61,6 +66,11 @@ class CategoryUrlPathAutogeneratorObserverTest extends TestCase
      * @var CompositeUrlKey|MockObject
      */
     private $compositeUrlValidator;
+
+    /**
+     * @var GetDefaultUrlKey|MockObject
+     */
+    private $getDefaultUrlKey;
 
     /**
      * @inheritDoc
@@ -72,31 +82,34 @@ class CategoryUrlPathAutogeneratorObserverTest extends TestCase
             ->onlyMethods(['getEvent'])
             ->disableOriginalConstructor()
             ->getMock();
-        $this->categoryResource = $this->createMock(Category::class);
+        $this->categoryResource = $this->createMock(CategoryResource::class);
         $this->category = $this->createPartialMock(
-            \Magento\Catalog\Model\Category::class,
+            Category::class,
             [
                 'dataHasChangedFor',
                 'getResource',
                 'getStoreId',
-                'formatUrlKey'
+                'formatUrlKey',
+                'getId',
+                'hasChildren',
             ]
         );
         $this->category->expects($this->any())->method('getResource')->willReturn($this->categoryResource);
         $this->observer->expects($this->any())->method('getEvent')->willReturnSelf();
         $this->observer->expects($this->any())->method('getCategory')->willReturn($this->category);
-        $this->categoryUrlPathGenerator = $this->createMock(
-            CategoryUrlPathGenerator::class
-        );
-        $this->childrenCategoriesProvider = $this->createMock(
-            ChildrenCategoriesProvider::class
-        );
+        $this->categoryUrlPathGenerator = $this->createMock(CategoryUrlPathGenerator::class);
+        $this->childrenCategoriesProvider = $this->createMock(ChildrenCategoriesProvider::class);
 
         $this->storeViewService = $this->createMock(StoreViewService::class);
 
         $this->compositeUrlValidator = $this->getMockBuilder(CompositeUrlKey::class)
             ->disableOriginalConstructor()
-            ->setMethods(['validate'])
+            ->onlyMethods(['validate'])
+            ->getMock();
+
+        $this->getDefaultUrlKey = $this->getMockBuilder(GetDefaultUrlKey::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['execute'])
             ->getMock();
 
         $this->categoryUrlPathAutogeneratorObserver = (new ObjectManagerHelper($this))->getObject(
@@ -106,6 +119,7 @@ class CategoryUrlPathAutogeneratorObserverTest extends TestCase
                 'childrenCategoriesProvider' => $this->childrenCategoriesProvider,
                 'storeViewService' => $this->storeViewService,
                 'compositeUrlValidator' => $this->compositeUrlValidator,
+                'getDefaultUrlKey' => $this->getDefaultUrlKey,
             ]
         );
     }
@@ -145,16 +159,26 @@ class CategoryUrlPathAutogeneratorObserverTest extends TestCase
     }
 
     /**
-     * @param $isObjectNew
+     * @param bool $isObjectNew
+     * @param int $storeId
+     * @return void
      * @throws LocalizedException
      * @dataProvider shouldResetUrlPathAndUrlKeyIfUrlKeyIsUsingDefaultValueDataProvider
      */
-    public function testShouldResetUrlPathAndUrlKeyIfUrlKeyIsUsingDefaultValue($isObjectNew)
+    public function testShouldResetUrlPathAndUrlKeyIfUrlKeyIsUsingDefaultValue(bool $isObjectNew, int $storeId): void
     {
-        $categoryData = ['use_default' => ['url_key' => 1], 'url_key' => 'some_key', 'url_path' => 'some_path'];
+        $categoryData = [
+            'use_default' => ['url_key' => 1],
+            'url_key' => 'some_key',
+            'url_path' => 'some_path',
+        ];
         $this->category->setData($categoryData);
         $this->category->isObjectNew($isObjectNew);
         $this->category->expects($this->any())->method('formatUrlKey')->willReturn('formatted_key');
+        $this->category->expects($this->any())->method('getStoreId')->willReturn($storeId);
+        $this->category->expects($this->once())
+            ->method('hasChildren')
+            ->willReturn(false);
         $this->assertEquals($categoryData['url_key'], $this->category->getUrlKey());
         $this->assertEquals($categoryData['url_path'], $this->category->getUrlPath());
         $this->categoryUrlPathAutogeneratorObserver->execute($this->observer);
@@ -165,12 +189,81 @@ class CategoryUrlPathAutogeneratorObserverTest extends TestCase
     /**
      * @return array
      */
-    public function shouldResetUrlPathAndUrlKeyIfUrlKeyIsUsingDefaultValueDataProvider()
+    public function shouldResetUrlPathAndUrlKeyIfUrlKeyIsUsingDefaultValueDataProvider(): array
     {
         return [
-            [true],
-            [false],
+            [false, 0],
+            [false, 1],
+            [true, 1],
+            [true, 0],
         ];
+    }
+
+    /**
+     * @return void
+     */
+    public function testShouldUpdateUrlPathForChildrenIfUrlKeyIsUsingDefaultValueForSpecificStore(): void
+    {
+        $storeId = 1;
+        $categoryId = 1;
+        $categoryData = [
+            'use_default' => ['url_key' => 1],
+            'url_key' => null,
+            'url_path' => 'some_path',
+        ];
+
+        $this->category->setData($categoryData);
+        $this->category->isObjectNew(false);
+        $this->category->expects($this->any())
+            ->method('getStoreId')
+            ->willReturn($storeId);
+        $this->category->expects($this->once())
+            ->method('hasChildren')
+            ->willReturn(true);
+        $this->category->expects($this->exactly(2))
+            ->method('getId')
+            ->willReturn($categoryId);
+        $this->getDefaultUrlKey->expects($this->once())
+            ->method('execute')
+            ->with($categoryId)
+            ->willReturn('default_url_key');
+        $this->category->expects($this->once())
+            ->method('dataHasChangedFor')
+            ->with('url_path')
+            ->willReturn(true);
+
+        $childCategory = $this->getMockBuilder(Category::class)
+            ->onlyMethods(
+                [
+                    'getResource',
+                    'getStore',
+                    'getStoreId',
+                    'setStoreId',
+                ]
+            )
+            ->addMethods(
+                [
+                    'getUrlPath',
+                    'setUrlPath',
+                ]
+            )
+            ->disableOriginalConstructor()
+            ->getMock();
+        $childCategory->expects($this->any())
+            ->method('getResource')
+            ->willReturn($this->categoryResource);
+        $childCategory->expects($this->once())
+            ->method('setStoreId')
+            ->with($storeId)
+            ->willReturnSelf();
+
+        $this->childrenCategoriesProvider->expects($this->once())
+            ->method('getChildren')
+            ->willReturn([$childCategory]);
+
+        $this->categoryUrlPathAutogeneratorObserver->execute($this->observer);
+        $this->assertNull($this->category->getUrlKey());
+        $this->assertNull($this->category->getUrlPath());
     }
 
     /**
@@ -253,10 +346,10 @@ class CategoryUrlPathAutogeneratorObserverTest extends TestCase
         // only for specific store
         $this->category->expects($this->atLeastOnce())->method('getStoreId')->willReturn(1);
 
-        $childCategoryResource = $this->getMockBuilder(Category::class)
+        $childCategoryResource = $this->getMockBuilder(CategoryResource::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $childCategory = $this->getMockBuilder(\Magento\Catalog\Model\Category::class)
+        $childCategory = $this->getMockBuilder(Category::class)
             ->setMethods(
                 [
                     'getUrlPath',


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#16202

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
See magento/magento2#16202

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
