### PR TITLE
Separate cache_types from app/etc/config.php

### DIFF
--- a/lib/internal/Magento/Framework/App/Cache/State.php
+++ b/lib/internal/Magento/Framework/App/Cache/State.php
@@ -101,7 +101,7 @@ class State implements StateInterface
     public function persist()
     {
         $this->load();
-        $this->writer->saveConfig([ConfigFilePool::APP_ENV => [self::CACHE_KEY => $this->statuses]]);
+        $this->writer->saveConfig([ConfigFilePool::APP_CACHE => [self::CACHE_KEY => $this->statuses]]);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Config/File/ConfigFilePool.php
+++ b/lib/internal/Magento/Framework/Config/File/ConfigFilePool.php
@@ -13,6 +13,7 @@ namespace Magento\Framework\Config\File;
  */
 class ConfigFilePool
 {
+    const APP_CACHE = 'app_cache';
     const APP_CONFIG = 'app_config';
     const APP_ENV = 'app_env';
 
@@ -32,6 +33,7 @@ class ConfigFilePool
      * @var array
      */
     private $applicationConfigFiles = [
+        self::APP_CACHE => 'cache.php',
         self::APP_CONFIG => 'config.php',
         self::APP_ENV => 'env.php',
     ];

--- a/lib/internal/Magento/Framework/Config/Test/Unit/File/ConfigFilePoolTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/File/ConfigFilePoolTest.php
@@ -29,6 +29,7 @@ class ConfigFilePoolTest extends TestCase
     public function testGetPaths()
     {
         $expected['new_key'] = 'new_config.php';
+        $expected[ConfigFilePool::APP_CACHE] = 'cache.php';
         $expected[ConfigFilePool::APP_CONFIG] = 'config.php';
         $expected[ConfigFilePool::APP_ENV] = 'env.php';
 


### PR DESCRIPTION
### Description

When trying to run Magento in a read-only filesystem, ideally both `config.php` and `env.php` should be read-only as well, but that breaks the ability of turning on/off any cache type in using `php bin/magento cache:(disable|enable)`. This PR splits the `cache_types` key away from `config.php`, so system administrators can still guarantee that the `config.php` and all its values can't be changed during execution, but still allow the caches to be toggled by mounting `app/etc/cache.php` into a writable filesystem.

### Fixed Issues (if relevant)

1. Fixes #26292

### Manual testing scenarios

1. Deploy magento in a read-only filesystem;
2. Mount `app/etc/cache.php` in a writable filesystem (symbolic link works);
3. Use `php bin/magento cache:disable`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
