### PR TITLE
Added missing web-token/jwt-framework dependency to magento/module-jwt-framework-adapter

### DIFF
--- a/app/code/Magento/JwtFrameworkAdapter/composer.json
+++ b/app/code/Magento/JwtFrameworkAdapter/composer.json
@@ -6,7 +6,8 @@
     },
     "require": {
         "php": "~7.3.0||~7.4.0",
-        "magento/framework": "*"
+        "magento/framework": "*",
+        "web-token/jwt-framework": "^v2.2.7"
     },
     "type": "magento2-module",
     "license": [


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The Magento_JwtFrameworkAdapter module introduces a new dependency on the web-token/jwt-framework package. The dependency is added to the product-level (global) composer.json file, but it's missing from the module itself. This PR addresses that and adds it.

### Related Pull Requests

### Fixed Issues (if relevant)
1. Fixes magento/magento2#32578

### Manual testing scenarios (*)
This is only about adding a dependency on module level that already exists on product level - no tests are required, only a reproduction of the issue linked above.
As a reference, check Magento_AwsS3 module's composer.json - notice that all its "league" dependencies are both there and in the global composer.json

### Questions or comments
The missing dependency needs to be in both global and module-level composer.json or else installations pulled from github wouldn't install it.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
