### PR TITLE
Fixed assertDefinitionEqual column type test

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Declaration/ValidationRules/IncosistentReferenceDefinition.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Declaration/ValidationRules/IncosistentReferenceDefinition.php
@@ -40,7 +40,7 @@ class IncosistentReferenceDefinition implements ValidationInterface
          * Columns should have the same types
          */
         if ($column->getType() !== $referenceColumn->getType()) {
-            return true;
+            return false;
         }
 
         return $this->assertUnsigned($column, $referenceColumn) &&


### PR DESCRIPTION
Solves #32309

`Magento\Framework\Setup\Declaration\Schema\Declaration\ValidationRules\IncosistentReferenceDefinition` has a method `assertDefinitionEqual` that check foreign keys consistency.

The bug was : 

```
        if ($column->getType() !== $referenceColumn->getType()) {
            return true;
        }
```

If the type of foreign key and reference column, it should return false.

Note that the class is not named correctly `IncosistentReferenceDefinition` instead of `InconsistentReferenceDefinition`, but I did not fixed that since I'm not sure about your retrocompatibility policy regarding class name change.