### PR TITLE
Fix JS error on the create account page with multishipping

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
@@ -355,7 +355,7 @@ script;
                 "regionInputId": "#region",
                 "postcodeId": "#zip",
                 "form": "#form-validate",
-                "regionJson": <?= /* @noEscape */ $regionJson,
+                "regionJson": <?= /* @noEscape */ $regionJson ?>,
                 "defaultRegion": "<?= /* @noEscape */ $regionId ?>",
                 "countriesWithOptionalZip": <?= /* @noEscape */ $countriesWithOptionalZip ?>
             }

--- a/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
@@ -342,9 +342,9 @@ script;
 <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
 <?php if ($block->getShowAddressFields()): ?>
     <?php
-    $regionJson = /* @noEscape */ $directoryHelper->getRegionJson();
-    $regionId = (int) $formData->getRegionId();
-    $countriesWithOptionalZip = /* @noEscape */ $directoryHelper->getCountriesWithOptionalZip(true);
+    $regionJson = $directoryHelper->getRegionJson();
+    $regionId = (int)$formData->getRegionId();
+    $countriesWithOptionalZip = $directoryHelper->getCountriesWithOptionalZip(true);
     ?>
 <script type="text/x-magento-init">
     {
@@ -355,9 +355,9 @@ script;
                 "regionInputId": "#region",
                 "postcodeId": "#zip",
                 "form": "#form-validate",
-                "regionJson": {$regionJson},
-                "defaultRegion": "{$regionId}",
-                "countriesWithOptionalZip": {$countriesWithOptionalZip}
+                "regionJson": <?= /* @noEscape */ $regionJson,
+                "defaultRegion": "<?= /* @noEscape */ $regionId ?>",
+                "countriesWithOptionalZip": <?= /* @noEscape */ $countriesWithOptionalZip ?>
             }
         }
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
My PR fixes JS error that happened on the Create account page using multishipping checkout.
URL looks like this https://example.com/multishipping/checkout/addresses/

Covered in: https://github.com/magento/magento2/pull/32638

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes https://github.com/magento/magento2/issues/32629
2. Fixes https://github.com/magento/magento2/issues/32630
3. Fixes https://github.com/magento/magento2/issues/32632

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. As guest user add 2-3 products to cart
2. Shopping Cart
3. Click on Checkout with multiple addresses
4. Login page -> Click on Create an account button

**Expected result:**
There shouldn't be any JS errors

**Actual result:**
We have a JS error that causing multiple issues, listed in "fixed issues" section:
![image](https://user-images.githubusercontent.com/1873745/113128929-00cede00-9223-11eb-828e-cd97a751a87e.png)
![image](https://user-images.githubusercontent.com/1873745/113129057-24922400-9223-11eb-8e8a-76694bdd14da.png)

It was caused by an incorrect JSON file - in the source code we see the following code:
![image](https://user-images.githubusercontent.com/1873745/113128992-147a4480-9223-11eb-993e-7f2318c0435d.png)

**Note:** I don't think that MFTF tests will be effective here, as you still CAN create an account if you'll put all needed info correctly, while some JS part is broken on the page.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
