### PR TITLE
Newrelic api change

### DIFF
--- a/app/code/Magento/NewRelicReporting/Console/Command/DeployMarker.php
+++ b/app/code/Magento/NewRelicReporting/Console/Command/DeployMarker.php
@@ -62,6 +62,10 @@ class DeployMarker extends Command
                 'user',
                 InputArgument::OPTIONAL,
                 'Deployment User'
+            )->addArgument(
+                'revision',
+                InputArgument::OPTIONAL,
+                'Revision'
             );
         parent::configure();
     }
@@ -74,7 +78,8 @@ class DeployMarker extends Command
         $this->deploymentsFactory->create()->setDeployment(
             $input->getArgument('message'),
             $input->getArgument('change_log'),
-            $this->serviceShellUser->get($input->getArgument('user'))
+            $this->serviceShellUser->get($input->getArgument('user')),
+            $input->getArgument('revision')
         );
         $output->writeln('<info>NewRelic deployment information sent</info>');
     }

--- a/app/code/Magento/NewRelicReporting/Test/Unit/Model/Apm/DeploymentsTest.php
+++ b/app/code/Magento/NewRelicReporting/Test/Unit/Model/Apm/DeploymentsTest.php
@@ -59,7 +59,7 @@ class DeploymentsTest extends TestCase
             ->getMockForAbstractClass();
 
         $this->configMock = $this->getMockBuilder(Config::class)
-            ->setMethods(['getNewRelicApiUrl', 'getNewRelicApiKey', 'getNewRelicAppName', 'getNewRelicAppId'])
+            ->setMethods(['getNewRelicApiUrl', 'getNewRelicApiKey', 'getNewRelicAppId'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -110,10 +110,6 @@ class DeploymentsTest extends TestCase
             ->willReturn($data['api_key']);
 
         $this->configMock->expects($this->once())
-            ->method('getNewRelicAppName')
-            ->willReturn($data['app_name']);
-
-        $this->configMock->expects($this->once())
             ->method('getNewRelicAppId')
             ->willReturn($data['app_id']);
 
@@ -130,7 +126,7 @@ class DeploymentsTest extends TestCase
             ->method('create')
             ->willReturn($this->zendClientMock);
 
-        $this->assertIsString($this->model->setDeployment($data['description'], $data['change'], $data['user']));
+        $this->assertIsString($this->model->setDeployment($data['description'], $data['change'], $data['user'], $data['revision']));
     }
 
     /**
@@ -171,10 +167,6 @@ class DeploymentsTest extends TestCase
             ->willReturn($data['api_key']);
 
         $this->configMock->expects($this->once())
-            ->method('getNewRelicAppName')
-            ->willReturn($data['app_name']);
-
-        $this->configMock->expects($this->once())
             ->method('getNewRelicAppId')
             ->willReturn($data['app_id']);
 
@@ -191,7 +183,7 @@ class DeploymentsTest extends TestCase
             ->method('create')
             ->willReturn($this->zendClientMock);
 
-        $this->assertIsBool($this->model->setDeployment($data['description'], $data['change'], $data['user']));
+        $this->assertIsBool($this->model->setDeployment($data['description'], $data['change'], $data['user'], $data['revision']));
     }
 
     /**
@@ -230,10 +222,6 @@ class DeploymentsTest extends TestCase
             ->willReturn($data['api_key']);
 
         $this->configMock->expects($this->once())
-            ->method('getNewRelicAppName')
-            ->willReturn($data['app_name']);
-
-        $this->configMock->expects($this->once())
             ->method('getNewRelicAppId')
             ->willReturn($data['app_id']);
 
@@ -246,7 +234,7 @@ class DeploymentsTest extends TestCase
             ->method('create')
             ->willReturn($this->zendClientMock);
 
-        $this->assertIsBool($this->model->setDeployment($data['description'], $data['change'], $data['user']));
+        $this->assertIsBool($this->model->setDeployment($data['description'], $data['change'], $data['user'], $data['revision']));
     }
 
     /**
@@ -258,23 +246,26 @@ class DeploymentsTest extends TestCase
         $change = 'flush the cache username';
         $user = 'username';
         $uri = 'https://example.com/listener';
-        $selfUri = 'https://api.newrelic.com/deployments.xml';
+        $selfUri = 'https://api.newrelic.com/v2/applications/%s/deployments.json';
         $apiKey = '1234';
         $appName = 'app_name';
         $appId = 'application_id';
         $method = ZendClient::POST;
-        $headers = ['x-api-key' => $apiKey];
+        $headers = ['Api-Key' => $apiKey, 'Content-Type' => 'application/json'];
         $responseBody = 'Response body content';
         $statusOk = '200';
         $statusBad = '401';
+        $revision = 'f81d42327219e17b1427096c354e9b8209939d4dd586972f12f0352f8343b91b';
         $params = [
-            'deployment[app_name]'       => $appName,
-            'deployment[application_id]' => $appId,
-            'deployment[description]'    => $description,
-            'deployment[changelog]'      => $change,
-            'deployment[user]'           => $user
+            'deployment' => [
+                'description' => $description,
+                'changelog' => $change,
+                'user' => $user,
+                'revision' => $revision
+            ]
         ];
 
+        $selfUri = sprintf($selfUri, $appId);
         return ['description' => $description,
             'change' => $change,
             'user' => $user,
@@ -288,7 +279,8 @@ class DeploymentsTest extends TestCase
             'status_ok' => $statusOk,
             'status_bad' => $statusBad,
             'response_body' => $responseBody,
-            'params' => $params
+            'params' => $params,
+            'revision' => $revision
         ];
     }
 }

--- a/app/code/Magento/NewRelicReporting/composer.json
+++ b/app/code/Magento/NewRelicReporting/composer.json
@@ -1,25 +1,26 @@
 {
     "name": "magento/module-new-relic-reporting",
     "description": "N/A",
-    "config": {
-        "sort-packages": true
-    },
-    "require": {
-        "php": "~7.3.0||~7.4.0",
-        "magento/framework": "*",
-        "magento/magento-composer-installer": "*",
-        "magento/module-backend": "*",
-        "magento/module-catalog": "*",
-        "magento/module-config": "*",
-        "magento/module-configurable-product": "*",
-        "magento/module-customer": "*",
-        "magento/module-store": "*"
-    },
     "type": "magento2-module",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
     ],
+    "config": {
+        "sort-packages": true
+    },
+    "version": "100.4.1",
+    "require": {
+        "php": "~7.3.0||~7.4.0",
+        "magento/framework": "103.0.*",
+        "magento/magento-composer-installer": "*",
+        "magento/module-backend": "102.0.*",
+        "magento/module-catalog": "104.0.*",
+        "magento/module-config": "101.2.*",
+        "magento/module-configurable-product": "100.4.*",
+        "magento/module-customer": "103.0.*",
+        "magento/module-store": "101.1.*"
+    },
     "autoload": {
         "files": [
             "registration.php"
@@ -29,3 +30,4 @@
         }
     }
 }
+

--- a/app/code/Magento/NewRelicReporting/composer.json
+++ b/app/code/Magento/NewRelicReporting/composer.json
@@ -1,26 +1,25 @@
 {
     "name": "magento/module-new-relic-reporting",
     "description": "N/A",
+    "config": {
+        "sort-packages": true
+    },
+    "require": {
+        "php": "~7.3.0||~7.4.0",
+        "magento/framework": "*",
+        "magento/magento-composer-installer": "*",
+        "magento/module-backend": "*",
+        "magento/module-catalog": "*",
+        "magento/module-config": "*",
+        "magento/module-configurable-product": "*",
+        "magento/module-customer": "*",
+        "magento/module-store": "*"
+    },
     "type": "magento2-module",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
     ],
-    "config": {
-        "sort-packages": true
-    },
-    "version": "100.4.1",
-    "require": {
-        "php": "~7.3.0||~7.4.0",
-        "magento/framework": "103.0.*",
-        "magento/magento-composer-installer": "*",
-        "magento/module-backend": "102.0.*",
-        "magento/module-catalog": "104.0.*",
-        "magento/module-config": "101.2.*",
-        "magento/module-configurable-product": "100.4.*",
-        "magento/module-customer": "103.0.*",
-        "magento/module-store": "101.1.*"
-    },
     "autoload": {
         "files": [
             "registration.php"
@@ -30,4 +29,3 @@
         }
     }
 }
-

--- a/app/code/Magento/NewRelicReporting/etc/config.xml
+++ b/app/code/Magento/NewRelicReporting/etc/config.xml
@@ -10,7 +10,7 @@
         <newrelicreporting>
             <general>
                 <enable>0</enable>
-                <api_url>https://api.newrelic.com/deployments.xml</api_url>
+                <api_url>https://api.newrelic.com/v2/applications/%s/deployments.json</api_url>
                 <insights_api_url>https://insights-collector.newrelic.com/v1/accounts/%s/events</insights_api_url>
             </general>
             <cron>


### PR DESCRIPTION
### Description (*)

New Relic has an possibility to setup deployment markers. 
But this feature is not working anymore, cause NewRelic changed API some time ago and current implementation is useless.

I changed Modue to work with a new API.

More info:
https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/record-monitor-deployments/

### Fixed Issues (if relevant)
Fixed Deployment functionality for NewRelic module

### Manual testing scenarios (*)

1. Deployment marker can be sent manually from CMD: bin/magento newrelic:create:deploy-marker "Name" "Description" "Email", "Release"
2. Every time Cache flushed, marker is set

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32649: Newrelic api change