### PR TITLE
Mark interfaces as api url rewrite graphql wishlist 2.4

### DIFF
--- a/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite/CustomUrlLocatorInterface.php
+++ b/app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite/CustomUrlLocatorInterface.php
@@ -11,6 +11,8 @@ namespace Magento\UrlRewriteGraphQl\Model\Resolver\UrlRewrite;
  * Interface for resolution of custom URLs.
  *
  * It can be used, for example, to resolve '\' URL path to a 'Home' page.
+ *
+ * @api
  */
 interface CustomUrlLocatorInterface
 {

--- a/app/code/Magento/User/Model/Spi/NotificationExceptionInterface.php
+++ b/app/code/Magento/User/Model/Spi/NotificationExceptionInterface.php
@@ -10,6 +10,8 @@ namespace Magento\User\Model\Spi;
 
 /**
  * When a notification cannot be sent.
+ *
+ * @api
  */
 interface NotificationExceptionInterface extends \Throwable
 {

--- a/app/code/Magento/User/Model/Spi/NotificatorInterface.php
+++ b/app/code/Magento/User/Model/Spi/NotificatorInterface.php
@@ -12,6 +12,8 @@ use Magento\User\Api\Data\UserInterface;
 
 /**
  * Use to send out notifications about user related events.
+ *
+ * @api
  */
 interface NotificatorInterface
 {

--- a/app/code/Magento/Vault/Block/Customer/IconInterface.php
+++ b/app/code/Magento/Vault/Block/Customer/IconInterface.php
@@ -7,6 +7,8 @@ namespace Magento\Vault\Block\Customer;
 
 /**
  * Interface IconInterface
+ *
+ * @api
  */
 interface IconInterface
 {

--- a/app/code/Magento/Webapi/Controller/Rest/RequestProcessorInterface.php
+++ b/app/code/Magento/Webapi/Controller/Rest/RequestProcessorInterface.php
@@ -9,6 +9,8 @@ namespace Magento\Webapi\Controller\Rest;
 
 /**
  *  Request processor interface
+ *
+ * @api
  */
 interface RequestProcessorInterface
 {

--- a/app/code/Magento/Widget/Block/BlockInterface.php
+++ b/app/code/Magento/Widget/Block/BlockInterface.php
@@ -14,6 +14,7 @@ namespace Magento\Widget\Block;
 /**
  * Interface \Magento\Widget\Block\BlockInterface
  *
+ * @api
  */
 interface BlockInterface
 {

--- a/app/code/Magento/Wishlist/Controller/IndexInterface.php
+++ b/app/code/Magento/Wishlist/Controller/IndexInterface.php
@@ -11,6 +11,7 @@ use Magento\Catalog\Controller\Product\View\ViewInterface;
 /**
  * Interface \Magento\Wishlist\Controller\IndexInterface
  *
+ * @api
  */
 interface IndexInterface extends \Magento\Framework\App\ActionInterface, ViewInterface
 {

--- a/app/code/Magento/Wishlist/Controller/WishlistProviderInterface.php
+++ b/app/code/Magento/Wishlist/Controller/WishlistProviderInterface.php
@@ -9,6 +9,7 @@ namespace Magento\Wishlist\Controller;
 /**
  * Interface \Magento\Wishlist\Controller\WishlistProviderInterface
  *
+ * @api
  */
 interface WishlistProviderInterface
 {

--- a/app/code/Magento/Wishlist/Model/AuthenticationStateInterface.php
+++ b/app/code/Magento/Wishlist/Model/AuthenticationStateInterface.php
@@ -9,6 +9,7 @@ namespace Magento\Wishlist\Model;
 /**
  * Interface \Magento\Wishlist\Model\AuthenticationStateInterface
  *
+ * @api
  */
 interface AuthenticationStateInterface
 {

--- a/app/code/Magento/Wishlist/Model/ResourceModel/Item/Product/CollectionBuilderInterface.php
+++ b/app/code/Magento/Wishlist/Model/ResourceModel/Item/Product/CollectionBuilderInterface.php
@@ -12,6 +12,8 @@ use Magento\Wishlist\Model\ResourceModel\Item\Collection as WishlistItemCollecti
 
 /**
  * Wishlist items products collection builder
+ *
+ * @api
  */
 interface CollectionBuilderInterface
 {

--- a/app/code/Magento/Wishlist/Model/Wishlist/BuyRequest/BuyRequestDataProviderInterface.php
+++ b/app/code/Magento/Wishlist/Model/Wishlist/BuyRequest/BuyRequestDataProviderInterface.php
@@ -11,6 +11,8 @@ use Magento\Wishlist\Model\Wishlist\Data\WishlistItem;
 
 /**
  * Build buy request for adding products to wishlist
+ *
+ * @api
  */
 interface BuyRequestDataProviderInterface
 {

--- a/app/code/Magento/Wishlist/Model/Wishlist/Data/WishlistItem.php
+++ b/app/code/Magento/Wishlist/Model/Wishlist/Data/WishlistItem.php
@@ -9,6 +9,8 @@ namespace Magento\Wishlist\Model\Wishlist\Data;
 
 /**
  * DTO represents Wishlist Item data
+ *
+ * @api
  */
 class WishlistItem
 {

--- a/lib/internal/Magento/Framework/Webapi/Rest/Request.php
+++ b/lib/internal/Magento/Framework/Webapi/Rest/Request.php
@@ -15,8 +15,6 @@ use Magento\Framework\Phrase;
  * Class Request
  *
  * @api
- *
- * @package Magento\Framework\Webapi\Rest
  */
 class Request extends \Magento\Framework\Webapi\Request
 {

--- a/lib/internal/Magento/Framework/Webapi/Rest/Request.php
+++ b/lib/internal/Magento/Framework/Webapi/Rest/Request.php
@@ -11,6 +11,13 @@ namespace Magento\Framework\Webapi\Rest;
 use Magento\Framework\Api\SimpleDataObjectConverter;
 use Magento\Framework\Phrase;
 
+/**
+ * Class Request
+ *
+ * @api
+ *
+ * @package Magento\Framework\Webapi\Rest
+ */
 class Request extends \Magento\Framework\Webapi\Request
 {
     /**#@+


### PR DESCRIPTION
### Description (*)
Recreated PR  from https://github.com/magento/magento2/pull/32076

The following interfaces marked as API:

1. app/code/Magento/UrlRewriteGraphQl/Model/Resolver/UrlRewrite/CustomUrlLocatorInterface.php
2. app/code/Magento/User/Model/Spi/NotificationExceptionInterface.php
3. app/code/Magento/User/Model/Spi/NotificatorInterface.php
4. app/code/Magento/Vault/Block/Customer/IconInterface.php
5. app/code/Magento/Webapi/Controller/Rest/RequestProcessorInterface.php
6. app/code/Magento/Widget/Block/BlockInterface.php
7. app/code/Magento/Wishlist/Controller/IndexInterface.php
8. app/code/Magento/Wishlist/Controller/WishlistProviderInterface.php
9. app/code/Magento/Wishlist/Model/AuthenticationStateInterface.php
10. app/code/Magento/Wishlist/Model/ResourceModel/Item/Product/CollectionBuilderInterface.php
11. app/code/Magento/Wishlist/Model/Wishlist/BuyRequest/BuyRequestDataProviderInterface.php

### Fixed Issues (if relevant)

1. Fixes magento/magento2#32023

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
