### PR TITLE
Fix broken reference problems at gallery blocks

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
+++ b/app/code/Magento/Catalog/view/frontend/layout/catalog_product_view.xml
@@ -118,7 +118,7 @@
                     </arguments>
                 </block>
                 <container name="skip_gallery_before.wrapper" htmlTag="div" htmlClass="action-skip-wrapper">
-                    <block class="Magento\Framework\View\Element\Template" before="product.info.media.image" name="skip_gallery_before" template="Magento_Theme::html/skip.phtml">
+                    <block class="Magento\Framework\View\Element\Template" name="skip_gallery_before" template="Magento_Theme::html/skip.phtml">
                         <arguments>
                             <argument name="target" xsi:type="string">gallery-next-area</argument>
                             <argument name="label" translate="true" xsi:type="string">Skip to the end of the images gallery</argument>
@@ -132,7 +132,7 @@
                     </arguments>
                 </block>
                 <container name="skip_gallery_after.wrapper" htmlTag="div" htmlClass="action-skip-wrapper">
-                    <block class="Magento\Framework\View\Element\Template" after="product.info.media.image" name="skip_gallery_after" template="Magento_Theme::html/skip.phtml">
+                    <block class="Magento\Framework\View\Element\Template" name="skip_gallery_after" template="Magento_Theme::html/skip.phtml">
                         <arguments>
                             <argument name="target" xsi:type="string">gallery-prev-area</argument>
                             <argument name="label" translate="true" xsi:type="string">Skip to the beginning of the images gallery</argument>


### PR DESCRIPTION
### Description
When open a product page system.log appended with 2 entries.
`[2021-04-07 08:05:14] main.INFO: Broken reference: the 'skip_gallery_before' tries to reorder itself towards 'product.info.media.image', but their parents are different: 'skip_gallery_before.wrapper' and 'product.info.media' respectively. [] []
[2021-04-07 08:05:14] main.INFO: Broken reference: the 'skip_gallery_after' tries to reorder itself towards 'product.info.media.image', but their parents are different: 'skip_gallery_after.wrapper' and 'product.info.media' respectively. [] []
`

### Fixed Issues
1. Fixes https://github.com/magento/magento2/issues/27216
