### PR TITLE
Take required product attributes into account when caching used products

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
@@ -1290,13 +1290,19 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
      */
     public function getUsedProducts($product, $requiredAttributeIds = null)
     {
-        if (!$product->hasData($this->_usedProducts)) {
-            $collection = $this->getConfiguredUsedProductCollection($product, false, $requiredAttributeIds);
+        $requiredAttributeIds = $requiredAttributeIds ?: [];
+        array_unshift($requiredAttributeIds, $product->getId());
+
+        $cacheKey = $this->getUsedProductsCacheKey($requiredAttributeIds);
+        if (!$product->hasData($this->_usedProducts) || !isset($product->getData($this->_usedProducts)[$cacheKey])) {
+            $collection = $this->getConfiguredUsedProductCollection($product, true, $requiredAttributeIds);
             $usedProducts = array_values($collection->getItems());
-            $product->setData($this->_usedProducts, $usedProducts);
+            $usedProductsCache = $product->getData($this->_usedProducts);
+            $usedProductsCache[$cacheKey] = $usedProducts;
+            $product->setData($this->_usedProducts, $usedProductsCache);
         }
 
-        return $product->getData($this->_usedProducts);
+        return $product->getData($this->_usedProducts)[$cacheKey];
     }
 
     /**

--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
@@ -1295,7 +1295,7 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType
 
         $cacheKey = $this->getUsedProductsCacheKey($requiredAttributeIds);
         if (!$product->hasData($this->_usedProducts) || !isset($product->getData($this->_usedProducts)[$cacheKey])) {
-            $collection = $this->getConfiguredUsedProductCollection($product, true, $requiredAttributeIds);
+            $collection = $this->getConfiguredUsedProductCollection($product, false, $requiredAttributeIds);
             $usedProducts = array_values($collection->getItems());
             $usedProductsCache = $product->getData($this->_usedProducts);
             $usedProductsCache[$cacheKey] = $usedProducts;

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/Type/ConfigurableTest.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Model/Product/Type/ConfigurableTest.php
@@ -284,6 +284,24 @@ class ConfigurableTest extends TestCase
     }
 
     /**
+     * @magentoAppIsolation enabled
+     * @magentoDataFixture Magento/ConfigurableProduct/_files/product_configurable_with_metadescription.php
+     */
+    public function testGetUsedProductsWithoutAndWithRequiredAttributes()
+    {
+        $products = $this->model->getUsedProducts($this->product);
+        foreach ($products as $product) {
+            self::assertNull($product->getData('meta_description'));
+        }
+
+        $requiredAttributeIds = [86];
+        $products = $this->model->getUsedProducts($this->product, $requiredAttributeIds);
+        foreach ($products as $product) {
+            self::assertNotNull($product->getData('meta_description'));
+        }
+    }
+
+    /**
      * Test getUsedProducts returns array with same indexes regardless collections was cache or not.
      *
      * @magentoAppIsolation enabled


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When calling `Magento\ConfigurableProduct\Model\Product\Type\Configurable::getUsedProducts()` with custom required attributes _after_ that method has already been called before, the collection doesn't load your custom defined attributes.

The caching plugin around this method, `Magento\ConfigurableProduct\Model\Plugin\Frontend\UsedProductsCache::aroundGetUsedProducts()` actually does take the passed required attributes into account, by generating a cache key, but once proceeded to the original method, this is lost again, when `$product->getData($this->_usedProducts)` already contains a product collection.

### Manual testing scenarios (*)
This can be confirmed by running the added integration test _without_ the changes I proposed, you'll see it will fail, because the `meta_description` attribute of the product will be `null` at all times.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32765: Take required product attributes into account when caching used products