### PR TITLE
Enhanced counter-label to show item or items

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
@@ -21,8 +21,7 @@
                 <!-- ko text: getCartParam('summary_count') --><!-- /ko -->
                 <!-- ko i18n: 'item' --><!-- /ko -->
             <!-- /ko -->
-                        <!-- ko if: getCartParam('summary_count') > 1 -->
-
+            <!-- ko if: getCartParam('summary_count') > 1 -->
                 <!-- ko text: getCartParam('summary_count') --><!-- /ko -->
                 <!-- ko i18n: 'items' --><!-- /ko -->
             <!-- /ko -->

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
@@ -17,7 +17,12 @@
                blockLoader: isLoading">
             <span class="counter-number"><!-- ko text: getCartParam('summary_count') --><!-- /ko --></span>
             <span class="counter-label">
-            <!-- ko if: getCartParam('summary_count') -->
+            <!-- ko if: getCartParam('summary_count') == 1 -->
+                <!-- ko text: getCartParam('summary_count') --><!-- /ko -->
+                <!-- ko i18n: 'item' --><!-- /ko -->
+            <!-- /ko -->
+                        <!-- ko if: getCartParam('summary_count') > 1 -->
+
                 <!-- ko text: getCartParam('summary_count') --><!-- /ko -->
                 <!-- ko i18n: 'items' --><!-- /ko -->
             <!-- /ko -->

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
@@ -17,13 +17,9 @@
                blockLoader: isLoading">
             <span class="counter-number"><!-- ko text: getCartParam('summary_count') --><!-- /ko --></span>
             <span class="counter-label">
-            <!-- ko if: getCartParam('summary_count') == 1 -->
+            <!-- ko if: getCartParam('summary_count') -->
                 <!-- ko text: getCartParam('summary_count') --><!-- /ko -->
-                <!-- ko i18n: 'item' --><!-- /ko -->
-            <!-- /ko -->
-            <!-- ko if: getCartParam('summary_count') > 1 -->
-                <!-- ko text: getCartParam('summary_count') --><!-- /ko -->
-                <!-- ko i18n: 'items' --><!-- /ko -->
+                <!-- ko i18n: getCartParam('summary_count') > 1 ? 'items' : 'item' --><!-- /ko -->
             <!-- /ko -->
             </span>
         </span>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Adding one item to your cart gives you 1 items in cart
![luma-2 4-develop-1-item](https://user-images.githubusercontent.com/22952492/114537287-b3a72f00-9c5a-11eb-86c2-265699e11319.png)

Adding more items in your cart it gives 2 items in cart
![luma-2 4-develop-2-items](https://user-images.githubusercontent.com/22952492/114537308-b86be300-9c5a-11eb-8069-8897af2d6b97.png)

Issue 29920(which is closed) didn't fix the counter label.

By enhancing the KO* code in minicart.phtml you can have 1 item or 2 items

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. magento/magento2/#29920

### Manual testing scenarios (*)
1. Add product to cart
2. Counter label shows items instead of item
3. Add another product to cart
4. Counter label shows items, which is good

### Questions or comments
In the vanilla Luma theme its not shown, but with custom templates, the label is used.