### PR TITLE
[MFTF] Check GoogleAnalytics rendering on the page.

### DIFF
--- a/app/code/Magento/GoogleAnalytics/Test/Mftf/ActionGroup/AdminEnableGoogleAnalyticsActionGroup.xml
+++ b/app/code/Magento/GoogleAnalytics/Test/Mftf/ActionGroup/AdminEnableGoogleAnalyticsActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminEnableGoogleAnalyticsActionGroup">
+        <annotations>
+            <description>Enable Google Analytics.</description>
+        </annotations>
+
+        <magentoCLI command="config:set google/analytics/active 1" stepKey="enableGoogleAnalytics"/>
+        <magentoCLI command="config:set google/analytics/account 12345678909876" stepKey="setGoogleAnalyticsAccount"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/GoogleAnalytics/Test/Mftf/Test/StorefrontCheckIsGoogleAnalyticsScriptPresentTest.xml
+++ b/app/code/Magento/GoogleAnalytics/Test/Mftf/Test/StorefrontCheckIsGoogleAnalyticsScriptPresentTest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontCheckIsGoogleAnalyticsScriptPresentTest">
+        <annotations>
+            <stories value="Check GoogleAnalytics rendering on the page."/>
+            <title value="Check GoogleAnalytics rendering on the page."/>
+            <description value="Check GoogleAnalytics rendering on the page."/>
+            <severity value="MINOR"/>
+        </annotations>
+
+        <actionGroup ref="AdminEnableGoogleAnalyticsActionGroup" stepKey="enableGoogleAnalytics"/>
+
+        <actionGroup ref="CliCacheCleanActionGroup" stepKey="cleanInvalidatedCaches">
+            <argument name="tags" value="config full_page"/>
+        </actionGroup>
+
+        <actionGroup ref="StorefrontOpenHomePageActionGroup" stepKey="openStoreFrontHomePage"/>
+
+        <seeInPageSource html="Magento_GoogleAnalytics/js/google-analytics" stepKey="seeAnalyticsInPageSource"/>
+    </test>
+</tests>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This test check if GoogleAnalytics was rendered on the pages

1. Enable GoogleAnalytics
2. Go to home page 
3. Assert is GoogleAnalytics script present in code source.

### Resolved issues:
1. [x] resolves magento/magento2#32764: [MFTF] Check GoogleAnalytics rendering on the page.