### PR TITLE
MFTF: Update Admin User Password

### DIFF
--- a/app/code/Magento/User/Test/Mftf/ActionGroup/AdminChangePasswordActionGroup.xml
+++ b/app/code/Magento/User/Test/Mftf/ActionGroup/AdminChangePasswordActionGroup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminChangePasswordActionGroup">
+        <arguments>
+            <argument name="user" defaultValue="NewAdminUser"/>
+        </arguments>
+        <fillField selector="{{AdminNewUserFormSection.password}}" userInput="{{user.password}}" stepKey="fillPassword"/>
+        <fillField selector="{{AdminNewUserFormSection.passwordConfirmation}}" userInput="{{user.password_confirmation}}" stepKey="fillPasswordConfirmation"/>
+        <fillField selector="{{AdminNewUserFormSection.currentPassword}}" userInput="{{user.current_password}}" stepKey="fillCurrentUserPassword"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/User/Test/Mftf/Data/UserData.xml
+++ b/app/code/Magento/User/Test/Mftf/Data/UserData.xml
@@ -182,5 +182,30 @@
     Please use "AdminDeleteUserViaCurlActionGroup".
     See how it works: app/code/Magento/User/Test/Mftf/ActionGroup/AdminDeleteUserViaCurlActionGroup.xml
 -->
-    <entity name="deleteUser" type="deleteUser" />
+    <entity name="deleteUser" type="deleteUser"/>
+    <entity name="AdminConstantUserName" type="user">
+        <data key="username">admin_constant</data>
+        <data key="firstname">John</data>
+        <data key="lastname">Doe</data>
+        <data key="email" unique="prefix">admin@example.com</data>
+        <data key="password">123123QA</data>
+        <data key="password_confirmation">123123QA</data>
+        <data key="current_password">{{_ENV.MAGENTO_ADMIN_PASSWORD}}</data>
+        <data key="role">Administrators</data>
+        <array key="roles">
+            <item>1</item>
+        </array>
+    </entity>
+    <entity name="AdminConstantUserNameUpdatedPassword" type="user">
+        <data key="username">admin_constant</data>
+        <data key="firstname">John</data>
+        <data key="lastname">Doe</data>
+        <data key="email" unique="prefix">admin@example.com</data>
+        <data key="password">123123UPD</data>
+        <data key="password_confirmation">123123UPD</data>
+        <data key="current_password">{{_ENV.MAGENTO_ADMIN_PASSWORD}}</data>
+        <array key="roles">
+            <item>1</item>
+        </array>
+    </entity>
 </entities>

--- a/app/code/Magento/User/Test/Mftf/Test/AdminUpdateUserPasswordTest.xml
+++ b/app/code/Magento/User/Test/Mftf/Test/AdminUpdateUserPasswordTest.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminUpdateUserPasswordTest">
+        <annotations>
+            <features value="User"/>
+            <title value="Update admin user password"/>
+            <stories value="Admin User Password Updating"/>
+            <description value="User should be able login with new password after it was updated by other Admin User"/>
+            <severity value="MAJOR"/>
+            <group value="user"/>
+        </annotations>
+
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="logIn"/>
+            <actionGroup ref="AdminOpenNewUserPageActionGroup" stepKey="navigateToNewUserPage"/>
+            <actionGroup ref="AdminFillNewUserFormRequiredFieldsActionGroup" stepKey="fillNewUserForm">
+                <argument name="user" value="AdminConstantUserName"/>
+            </actionGroup>
+            <actionGroup ref="AdminClickSaveButtonOnUserFormActionGroup" stepKey="saveNewUser"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logoutAsUpdatedUser"/>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsDefaultAdminUser"/>
+            <actionGroup ref="AdminDeleteCustomUserActionGroup" stepKey="deleteUpdatedUser">
+                <argument name="user" value="AdminConstantUserName"/>
+            </actionGroup>
+        </after>
+
+        <actionGroup ref="AdminOpenUserEditPageActionGroup" stepKey="openUserEditPage">
+            <argument name="user" value="AdminConstantUserName"/>
+        </actionGroup>
+        <actionGroup ref="AdminChangePasswordActionGroup" stepKey="changePassword">
+            <argument name="user" value="AdminConstantUserNameUpdatedPassword"/>
+        </actionGroup>
+        <actionGroup ref="AdminClickSaveButtonOnUserFormActionGroup" stepKey="saveUser"/>
+        <actionGroup ref="AssertMessageInAdminPanelActionGroup" stepKey="assertSuccessMessage">
+            <argument name="message" value="You saved the user."/>
+        </actionGroup>
+        <actionGroup ref="AdminLogoutActionGroup" stepKey="logOutFromAdminPanel"/>
+        <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsUpdatedUser">
+            <argument name="username" value="{{AdminConstantUserNameUpdatedPassword.username}}"/>
+            <argument name="password" value="{{AdminConstantUserNameUpdatedPassword.password}}"/>
+        </actionGroup>
+        <actionGroup ref="AssertAdminSuccessLoginActionGroup" stepKey="seeSuccessLoginMessage"/>
+    </test>
+</tests>


### PR DESCRIPTION
This PR contains a test for updating the password for admin user.
User should be able login with new password after it was updated by other Admin User

**Steps to reproduce:**

1 - Create Admin user

2 - Change the password for created user

3 - Login as created user with updated password

4 - Perform Assertions