### PR TITLE
Update di.xml

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -213,6 +213,7 @@
     <preference for="Magento\Framework\Interception\ConfigLoaderInterface" type="Magento\Framework\Interception\PluginListGenerator" />
     <preference for="Magento\Framework\Interception\ConfigWriterInterface" type="Magento\Framework\Interception\PluginListGenerator" />
     <type name="Magento\Framework\Model\ResourceModel\Db\TransactionManager" shared="false" />
+    <type name="Magento\Framework\HTTP\ClientInterface" shared="false" />
     <type name="Magento\Framework\Acl\Data\Cache">
         <arguments>
             <argument name="aclBuilder" xsi:type="object">Magento\Framework\Acl\Builder\Proxy</argument>


### PR DESCRIPTION


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The default implementation of the `Magento\Framework\HTTP\ClientInterface` is `Magento\Framework\HTTP\Client\Curl` which is a stateful class

When a `Magento\Framework\HTTP\Client\CurlFactory` is injected, there are no side effects because instances are not shared.

But when an instance of `Magento\Framework\HTTP\ClientInterface` is required (e.g., in the `Magento_InventoryDistanceBasedSourceSelection` module) through constructor-based dependency injection, this could have side effects, because a shared instance of a stateful class is used. 

If, for example, you set a curl timeout on that shared instance, that timeout will affect every class that uses the same instance.

This PR addresses this problem by setting a transient lifestyle to objects implementing `Magento\Framework\HTTP\ClientInterface` through the `shared="false"` property.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
