### PR TITLE
Prevent Category URL Rewrites generation when no Store Group assigned

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/Category/Plugin/Store/View.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Category/Plugin/Store/View.php
@@ -104,7 +104,10 @@ class View
         Store $object,
         Store $store
     ): Store {
-        if ($this->origStore->isObjectNew() || $this->origStore->dataHasChangedFor('group_id')) {
+        if (
+            $this->origStore->getData('group_id')
+            && ($this->origStore->isObjectNew() || $this->origStore->dataHasChangedFor('group_id'))
+        ) {
             $categoryRewriteUrls = $this->generateCategoryUrls(
                 (int)$this->origStore->getRootCategoryId(),
                 (int)$this->origStore->getId()

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Store/ViewTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Store/ViewTest.php
@@ -7,18 +7,18 @@ declare(strict_types=1);
 
 namespace Magento\CatalogUrlRewrite\Test\Unit\Model\Category\Plugin\Store;
 
-use Magento\Catalog\Model\ResourceModel\Category\Collection as CategoryCollection;
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\CategoryFactory;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ProductFactory;
+use Magento\Catalog\Model\ResourceModel\Category\Collection as CategoryCollection;
 use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\CatalogUrlRewrite\Model\Category\Plugin\Store\View as StoreViewPlugin;
 use Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGenerator;
 use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
 use Magento\Framework\Model\AbstractModel;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use Magento\Store\Model\ResourceModel\Store;
+use Magento\Store\Model\ResourceModel\Store as StoreResourceModel;
+use Magento\Store\Model\Store;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -28,11 +28,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ViewTest extends TestCase
 {
-    /**
-     * @var ObjectManager
-     */
-    private $objectManager;
-
     /**
      * @var StoreViewPlugin
      */
@@ -44,7 +39,7 @@ class ViewTest extends TestCase
     private $abstractModelMock;
 
     /**
-     * @var Store|MockObject
+     * @var StoreResourceModel|MockObject
      */
     private $subjectMock;
 
@@ -93,12 +88,11 @@ class ViewTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->objectManager = new ObjectManager($this);
         $this->abstractModelMock = $this->getMockBuilder(AbstractModel::class)
             ->disableOriginalConstructor()
             ->setMethods(['isObjectNew'])
             ->getMockForAbstractClass();
-        $this->subjectMock = $this->getMockBuilder(Store::class)
+        $this->subjectMock = $this->getMockBuilder(StoreResourceModel::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->urlPersistMock = $this->getMockBuilder(UrlPersistInterface::class)
@@ -131,15 +125,12 @@ class ViewTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods(['getCollection'])
             ->getMock();
-        $this->plugin = $this->objectManager->getObject(
-            StoreViewPlugin::class,
-            [
-                'urlPersist' => $this->urlPersistMock,
-                'categoryFactory' => $this->categoryFactoryMock,
-                'productFactory' => $this->productFactoryMock,
-                'categoryUrlRewriteGenerator' => $this->categoryUrlRewriteGeneratorMock,
-                'productUrlRewriteGenerator' => $this->productUrlRewriteGeneratorMock
-            ]
+        $this->plugin = new StoreViewPlugin(
+            $this->urlPersistMock,
+            $this->categoryFactoryMock,
+            $this->productFactoryMock,
+            $this->categoryUrlRewriteGeneratorMock,
+            $this->productUrlRewriteGeneratorMock
         );
     }
 
@@ -150,13 +141,19 @@ class ViewTest extends TestCase
      */
     public function testAfterSave(): void
     {
-        $origStoreMock = $this->getMockBuilder(\Magento\Store\Model\Store::class)
+        $origStoreMock = $this->getMockBuilder(Store::class)
             ->disableOriginalConstructor()
             ->getMock();
         $reflectionStore = new \ReflectionClass($this->plugin);
         $origStore = $reflectionStore->getProperty('origStore');
         $origStore->setAccessible(true);
         $origStore->setValue($this->plugin, $origStoreMock);
+
+        $origStoreMock->expects($this->atLeastOnce())
+            ->method('getData')
+            ->with('group_id')
+            ->willReturn('1');
+
         $origStoreMock->expects($this->atLeastOnce())
             ->method('isObjectNew')
             ->willReturn(true);
@@ -203,7 +200,54 @@ class ViewTest extends TestCase
 
         $this->assertSame(
             $this->subjectMock,
-            $this->plugin->afterSave($this->subjectMock, $this->subjectMock, $this->abstractModelMock)
+            $this->plugin->afterSave($this->subjectMock, $this->subjectMock)
+        );
+    }
+
+    public function testAfterSaveWhenNoGroupId()
+    {
+        $origStoreMock = $this->getMockBuilder(Store::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $reflectionStore = new \ReflectionClass($this->plugin);
+        $origStore = $reflectionStore->getProperty('origStore');
+        $origStore->setAccessible(true);
+        $origStore->setValue($this->plugin, $origStoreMock);
+
+        $origStoreMock->expects($this->atLeastOnce())
+            ->method('getData')
+            ->with('group_id')
+            ->willReturn(null);
+
+        $origStoreMock->expects($this->any())
+            ->method('isObjectNew')
+            ->willReturn(true);
+
+        $this->abstractModelMock->expects($this->any())
+            ->method('isObjectNew')
+            ->willReturn(true);
+        $categoryCollection = $this->getMockBuilder(CategoryCollection::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getIterator'])
+            ->getMock();
+        $categoryCollection->expects($this->any())
+            ->method('getIterator')
+            ->willReturn(new \ArrayIterator([]));
+        $this->categoryMock->expects($this->never())
+            ->method('getCategories');
+        $this->categoryFactoryMock->expects($this->never())->method('create');
+        $this->productFactoryMock->expects($this->never())->method('create');
+        $this->productMock->expects($this->never())->method('getCollection');
+        $this->productCollectionMock->expects($this->never())->method('addCategoryIds');
+        $this->productCollectionMock->expects($this->never())->method('addAttributeToSelect');
+        $this->productCollectionMock->expects($this->never())->method('addStoreFilter');
+
+        $this->productCollectionMock->expects($this->never())->method('getIterator');
+        $this->productUrlRewriteGeneratorMock->expects($this->never())->method('generate');
+
+        $this->assertSame(
+            $this->subjectMock,
+            $this->plugin->afterSave($this->subjectMock, $this->subjectMock)
         );
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
During creating new website, Store Group and Store view using `php bin/magento setup:upgrade` - we got the following issue:
exception was thrown while it was trying to create a new store view that later on will be assigned to Store group, and as result - later on we should generate URLs for this specific store.

This issue happened because, for some reason, we `$rootCategoryId` as 0 because we don't have any assigned Store Group:
https://github.com/magento/magento2/blob/95819f2b448c58edc38468efbfaa7b02a775f87b/app/code/Magento/Store/Model/Store.php#L1023-L1029

In this case, it was generating URL rewrites for Root categories, that the same URL keys.
Example:
```
-- Root Category 1 (used on Website 1)
---- Best Sellers (URL key is `best-sellers`)
---- ...
-- Root Category 2 (used on Website 2)
---- ...
---- Best Sellers (URL key is `best-sellers`)
---- ...
```

In this case, it will try to generate URL rewrites for Root Category 1 and all their children categories + URL rewrites for Root Category 2 and all it's children and will have a conflict due to the same URL key


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
1. Create 2 websites, category structure like this: 
```
-- Root Category 1 (used on Website 1)
---- Best Sellers (URL key is `best-sellers`)
---- ...
-- Root Category 2 (used on Website 2)
---- ...
---- Best Sellers (URL key is `best-sellers`)
---- ...
```
2. Dump websites/store groups/stores data to the config.php file using `php bin/magento app:config:dump scopes` command
3. Create DB dump
4. Create from the admin a new website, store group, store view, use Root Category 1 for it
5. Dump websites/store groups/stores data to the config.php file using `php bin/magento app:config:dump scopes` command
6. Apply dump from step 3
7. run `php bin/magento setup:upgrade`


**Expected result:**
✔ 3rd website, store group, store view should be created

**Actual result:**
❌ We have an exception `Import failed: URL key for specified store already exists.`
![image](https://user-images.githubusercontent.com/1873745/115357169-05086e80-a1c5-11eb-9e4c-9f41c0c2428a.png)


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32952: Prevent Category URL Rewrites generation when no Store Group assigned