### PR TITLE
add coupon code to totals model

### DIFF
--- a/app/code/Magento/Sales/Block/Order/Totals.php
+++ b/app/code/Magento/Sales/Block/Order/Totals.php
@@ -6,6 +6,7 @@
 namespace Magento\Sales\Block\Order;
 
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Invoice;
 
 /**
  * Order totals.
@@ -126,8 +127,13 @@ class Totals extends \Magento\Framework\View\Element\Template
          * Add discount
          */
         if ((double)$this->getSource()->getDiscountAmount() != 0) {
-            if ($this->getSource()->getDiscountDescription()) {
-                $discountLabel = __('Discount (%1)', $source->getDiscountDescription());
+            if ($this->getSource() instanceof Invoice) {
+                $discountSource = $this->getSource()->getOrder();
+            } else {
+                $discountSource = $this->getSource();
+            }
+            if ($this->getSource()->getCouponCode()) {
+                $discountLabel = __('Discount (%1)', $discountSource->getCouponCode());
             } else {
                 $discountLabel = __('Discount');
             }
@@ -135,7 +141,7 @@ class Totals extends \Magento\Framework\View\Element\Template
                 [
                     'code' => 'discount',
                     'field' => 'discount_amount',
-                    'value' => $source->getDiscountAmount(),
+                    'value' => $discountSource->getDiscountAmount(),
                     'label' => $discountLabel,
                 ]
             );


### PR DESCRIPTION
### Description (*)
I changed \Magento\Sales\Block\Order\Totals class to add Coupon Code to order.total block

### Fixed Issues (if relevant)

1. Fixes magento/magento2#28432

### Manual testing scenarios (*)

1. Create new Cart Price Rule with long description and coupone code.
2. Create order on storefront.
3. Check coupon code in order view, invoice view, order print, invoice print

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
