### PR TITLE
Fixes 'unexpected token case' on massaction_extended template

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/templates/product/grid/massaction_extended.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/product/grid/massaction_extended.phtml
@@ -75,19 +75,19 @@ script;
         $scriptString .= <<<script
                 case 'selectAll':
                     return {$block->escapeJs($block->getJsObjectName())}.selectAll();
-                    break
+                    break;
                 case 'unselectAll':
                     return {$block->escapeJs($block->getJsObjectName())}.unselectAll();
-                    break
+                    break;
 script;
     endif;
     $scriptString .= <<<script
                 case 'selectVisible':
                     return {$block->escapeJs($block->getJsObjectName())}.selectVisible();
-                    break
+                    break;
                 case 'unselectVisible':
                     return {$block->escapeJs($block->getJsObjectName())}.unselectVisible();
-                    break
+                    break;
             }
             this.blur();
         });

--- a/app/code/Magento/Catalog/view/adminhtml/templates/product/grid/massaction_extended.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/product/grid/massaction_extended.phtml
@@ -42,22 +42,22 @@
     </div>
 
     <div class="mass-select-wrap">
-        <select id="<?= $block->escapeHtmlAttr($block->getHtmlId()) ?>-mass-select" data-menu="grid-mass-select">
-            <optgroup label="<?= $block->escapeHtmlAttr(__('Mass Actions')) ?>">
+        <select id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-mass-select" data-menu="grid-mass-select">
+            <optgroup label="<?= $escaper->escapeHtmlAttr(__('Mass Actions')) ?>">
                 <option disabled selected></option>
                 <?php if ($block->getUseSelectAll()):?>
                     <option value="selectAll">
-                        <?= $block->escapeHtml(__('Select All')) ?>
+                        <?= $escaper->escapeHtml(__('Select All')) ?>
                     </option>
                     <option value="unselectAll">
-                        <?= $block->escapeHtml(__('Unselect All')) ?>
+                        <?= $escaper->escapeHtml(__('Unselect All')) ?>
                     </option>
                 <?php endif; ?>
                 <option value="selectVisible">
-                    <?= $block->escapeHtml(__('Select Visible')) ?>
+                    <?= $escaper->escapeHtml(__('Select Visible')) ?>
                 </option>
                 <option value="unselectVisible">
-                    <?= $block->escapeHtml(__('Unselect Visible')) ?>
+                    <?= $escaper->escapeHtml(__('Unselect Visible')) ?>
                 </option>
             </optgroup>
         </select>
@@ -74,19 +74,19 @@ script;
     if ($block->getUseSelectAll()):
         $scriptString .= <<<script
                 case 'selectAll':
-                    return {$block->escapeJs($block->getJsObjectName())}.selectAll();
+                    return {$escaper->escapeJs($block->getJsObjectName())}.selectAll();
                     break;
                 case 'unselectAll':
-                    return {$block->escapeJs($block->getJsObjectName())}.unselectAll();
+                    return {$escaper->escapeJs($block->getJsObjectName())}.unselectAll();
                     break;
 script;
     endif;
     $scriptString .= <<<script
                 case 'selectVisible':
-                    return {$block->escapeJs($block->getJsObjectName())}.selectVisible();
+                    return {$escaper->escapeJs($block->getJsObjectName())}.selectVisible();
                     break;
                 case 'unselectVisible':
-                    return {$block->escapeJs($block->getJsObjectName())}.unselectVisible();
+                    return {$escaper->escapeJs($block->getJsObjectName())}.unselectVisible();
                     break;
             }
             this.blur();
@@ -95,7 +95,7 @@ script;
     });
 script;
     if (!$block->getParentBlock()->canDisplayContainer()):
-        $scriptString .= $block->escapeJs($block->getJsObjectName()) . ".setGridIds('" .
+        $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . ".setGridIds('" .
             /* @noEscape */ $block->getGridIdsJson() . "');";
     endif;
     ?>


### PR DESCRIPTION
### Description (*)
When using HTML minification the massaction_extended template (from the Magento_Catalog module) causes a javascript error ('unexpected token case'). Adding proper closing tags to the break statement fixes this.
Also removed deprecated escape calls.

### Steps for reproducing the issue
- Create a custom product grid using the app/code/Magento/Catalog/view/adminhtml/templates/product/grid/massaction_extended.phtml template
- Enable HTML minification using Cloudflare 
- Visit the page with the custom product grid

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
