### PR TITLE
Load draggable and resizable jquery-ui chunks for dialog widget only if needed

### DIFF
--- a/lib/web/jquery/ui-modules/dialog.js
+++ b/lib/web/jquery/ui-modules/dialog.js
@@ -12,9 +12,7 @@
 define([
     'jquery',
     'jquery-ui-modules/button',
-    'jquery-ui-modules/draggable',
-    'jquery-ui-modules/position',
-    'jquery-ui-modules/resizable'
+    'jquery-ui-modules/position'
 ], function ($, undefined) {
 
     var sizeRelatedOptions = {
@@ -107,11 +105,22 @@ define([
             this._createTitlebar();
             this._createButtonPane();
 
-            if (this.options.draggable && $.fn.draggable) {
-                this._makeDraggable();
+            var widget = this;
+
+            if (this.options.draggable) {
+                require(['jquery-ui-modules/draggable'], function () {
+                    if($.fn.draggable) {
+                        widget._makeDraggable();
+                    }
+                });
             }
-            if (this.options.resizable && $.fn.resizable) {
-                this._makeResizable();
+
+            if (this.options.resizable) {
+                require(['jquery-ui-modules/resizable'], function () {
+                    if($.fn.resizable) {
+                        widget._makeResizable();
+                    }
+                });
             }
 
             this._isOpen = false;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
As in our shops we often struggle with huge javascript files, and quite a big amount of unused code, which lowers speed test results, I looked for some opportunity to remove not used code. Magento dropdownDialog widget (docs here: https://devdocs.magento.com/guides/v2.4/javascript-dev-guide/widgets/widget_dialog.html) is based on dialog widget.  In dialog widget, there are available options: draggable and resizable, but in dropdown they are set to false and even not mentioned in the documentation or covered in tests. Besides dropdownDialog, dialog widget is also used in inline translation functionality, but this functionality is not used by end-users in the shop. 

To decrease the amount of unnecessary code I added dependency only for dialog widget that really needs resizable and draggable jquery-ui chunks.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Check if an element that uses dropdown widget (for example minicart) works as expected
2. Enable inline translations and check if you can move and resize translation dialog

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32810: Load draggable and resizable jquery-ui chunks for dialog widget only if needed