### PR TITLE
Do not trigger url rewrites re-generation for all store views

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/Category/Plugin/Store/Group.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Category/Plugin/Store/Group.php
@@ -92,6 +92,7 @@ class Group
         AbstractModel $group
     ) {
         if (!$group->isObjectNew()
+            && $group->getStoreIds()
             && ($group->dataHasChangedFor('website_id')
                 || $group->dataHasChangedFor('root_category_id'))
         ) {

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Store/GroupTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/Plugin/Store/GroupTest.php
@@ -88,9 +88,6 @@ class GroupTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods(['isObjectNew', 'dataHasChangedFor', 'getStoreIds'])
             ->getMockForAbstractClass();
-        $this->abstractModelMock->expects($this->any())
-            ->method('getStoreIds')
-            ->willReturn([]);
         $this->subjectMock = $this->getMockBuilder(Group::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -138,6 +135,9 @@ class GroupTest extends TestCase
         $this->abstractModelMock->expects($this->once())
             ->method('isObjectNew')
             ->willReturn(false);
+        $this->abstractModelMock->expects($this->any())
+            ->method('getStoreIds')
+            ->willReturn(['1']);
         $this->abstractModelMock->expects($this->once())
             ->method('dataHasChangedFor')
             ->with('website_id')
@@ -173,6 +173,36 @@ class GroupTest extends TestCase
             ->method('generate')
             ->with($this->productMock)
             ->willReturn([]);
+
+        $this->assertSame(
+            $this->subjectMock,
+            $this->plugin->afterSave($this->subjectMock, $this->subjectMock, $this->abstractModelMock)
+        );
+    }
+
+    public function testAfterSaveWithNoStoresAssigned()
+    {
+        $this->abstractModelMock->expects($this->once())
+            ->method('isObjectNew')
+            ->willReturn(false);
+        $this->abstractModelMock->expects($this->any())
+            ->method('getStoreIds')
+            ->willReturn([]);
+        $this->abstractModelMock->expects($this->any())
+            ->method('dataHasChangedFor')
+            ->with('website_id')
+            ->willReturn(true);
+        $this->storeManagerMock->expects($this->never())->method('reinitStores');
+        $this->categoryMock->expects($this->never())->method('getCategories');
+        $this->categoryFactoryMock->expects($this->never())->method('create');
+        $this->productFactoryMock->expects($this->never())->method('create');
+        $this->productMock->expects($this->never())->method('getCollection');
+        $this->productCollectionMock->expects($this->never())->method('addCategoryIds');
+        $this->productCollectionMock->expects($this->never())            ->method('addAttributeToSelect');
+        $this->productCollectionMock->expects($this->never())->method('addWebsiteFilter');
+        $iterator = new \ArrayIterator([$this->productMock]);
+        $this->productCollectionMock->expects($this->never())->method('getIterator');
+        $this->productUrlRewriteGeneratorMock->expects($this->never())->method('generate');
 
         $this->assertSame(
             $this->subjectMock,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
During creating a new website, Store Group and Store view using `php bin/magento setup:upgrade` - we noticed that some URL rewrites for categories on **different** stores were re-generated in DB, that's absolutely not obvious and for sure not expected behavior. Such behavior, especially for us changed URLs for some categories _w/o creating any redirect from old -> new URL_ (for some reason, we had incorrect url_path values in DB, that's another story). 
As a result of this issue - some advertised categories started returning 404 pages, and we basically started burning our money.

#### Root cause analyze
Investigation showed, that `app/code/Magento/CatalogUrlRewrite/Model/Category/Plugin/Store/Group.php` plugin was executed due to 2 step saving of group:
- at first, we just creating a new group
- later we're assigning it to a website
https://github.com/magento/magento2/blob/6729b6e01368248abc33300208eb292c95050203/app/code/Magento/Store/Model/Config/Importer/Processor/Create.php#L165-L195

As a store group still don't have any store IDs assigned (the store will be created on the next step) - `$group->getStoreIds()` returns an empty array, we're setting this value to the category and trying to generate URL rewrites
https://github.com/magento/magento2/blob/a2b93809864fa6dd645d44a5c818266459f53b95/app/code/Magento/CatalogUrlRewrite/Model/Category/Plugin/Store/Group.php#L155-L157

Then it goes to this method, which tries to fetch a list of store Ids:
https://github.com/magento/magento2/blob/c051134a4b2c837f798cc8f66b9ad4c208310363/app/code/Magento/CatalogUrlRewrite/Model/CategoryUrlRewriteGenerator.php#L116-L143

Here we don't have any saved `store_ids`, so it fetches the list of stores where this category used as a root.
https://github.com/magento/magento2/blob/68c7282c414916d5929528f472a3f064422aa12d/app/code/Magento/Catalog/Model/Category.php#L534-L570

As a result - we're re-generating category URL rewrites for **all store views with the same root category ID**. 
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
1. Install magento, so you'll have 1 website, 1 store group, 1 store view
2. Create some categories structure
3. Run `php bin/magento app:config:dump scopes` to dump all the stores data into the config.php
4. Create a DB dump
5. Go to Admin, and create a new website, store group and a store view (re-use the same root category for that)
6. Run `php bin/magento app:config:dump scopes` to dump all the stores data into the config.php, save the file
7. Apply the DB dump from the step 4 in order to emulate the case, when we didn't have 2nd website, store group, etc
8. Run `php bin/magento setup:upgrade` or `php bin/magento app:config:import` to create a new website, store group, store view 
9. Compare data in the `url_rewrites` table with a backup file for the store 1.

**Expected result:**
✔ URL rewrites for store 1 shouldn't be touched when we creating a new website / store group / store view

**Actual result:**
❌ URL rewrites for store 1 are re-generated when we creating a new website / store group / store view
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#32954: Do not trigger url rewrites re-generation for all store views