### PR TITLE
Fix AbstractCarrierInterface::collectRates signature

### DIFF
--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrierInterface.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrierInterface.php
@@ -25,7 +25,7 @@ interface AbstractCarrierInterface
      * Collect and get rates
      *
      * @param RateRequest $request
-     * @return \Magento\Framework\DataObject|bool|null
+     * @return \Magento\Shipping\Model\Rate\Result|bool|null
      * @api
      */
     public function collectRates(RateRequest $request);


### PR DESCRIPTION
### Description

As described in #28514, the method has the wrong phpdoc `@return` signature

### Fixed Issues

1. Fixes magento/magento2#28514

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
