### PR TITLE
Added password reset service email config. Using this config for gett…

### DIFF
--- a/app/code/Magento/Security/Model/Config.php
+++ b/app/code/Magento/Security/Model/Config.php
@@ -57,9 +57,9 @@ class Config implements ConfigInterface
     const XML_PATH_MIN_TIME_BETWEEN_PASSWORD_RESET_REQUESTS = 'min_time_between_password_reset_requests';
 
     /**
-     * Recipient email config path
+     * Configuration key to password reset service email
      */
-    const XML_PATH_EMAIL_RECIPIENT = 'contact/email/recipient_email';
+    const XML_PATH_PASSWORD_RESET_SERVICE_EMAIL = 'password_reset_service_email';
 
     /**
      * @var ScopeConfigInterface
@@ -93,7 +93,7 @@ class Config implements ConfigInterface
     public function getCustomerServiceEmail()
     {
         return $this->scopeConfig->getValue(
-            self::XML_PATH_EMAIL_RECIPIENT,
+            $this->getXmlPathPrefix() . self::XML_PATH_PASSWORD_RESET_SERVICE_EMAIL,
             StoreScopeInterface::SCOPE_STORE
         );
     }

--- a/app/code/Magento/Security/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/Security/Test/Unit/Model/ConfigTest.php
@@ -71,20 +71,36 @@ class ConfigTest extends TestCase
     /**
      * Test get customer service email
      * @return void
+     * @dataProvider dataProviderForGetCustomerServiceEmail
      */
-    public function testGetCustomerServiceEmail()
+    public function testGetCustomerServiceEmail($scope)
     {
         $email = 'test@example.com';
         $this->scopeConfigMock->expects($this->once())
             ->method('getValue')
             ->with(
-                Config::XML_PATH_EMAIL_RECIPIENT,
+                $this->getXmlPathPrefix($scope)
+                . Config::XML_PATH_PASSWORD_RESET_SERVICE_EMAIL,
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             )
             ->willReturn(
                 $email
             );
+        $this->scopeMock->expects($this->once())
+            ->method('getCurrentScope')
+            ->willReturn($scope);
         $this->assertEquals($email, $this->model->getCustomerServiceEmail());
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForGetCustomerServiceEmail()
+    {
+        return [
+            [Area::AREA_ADMINHTML],
+            [Area::AREA_FRONTEND]
+        ];
     }
 
     /**

--- a/app/code/Magento/Security/etc/adminhtml/system.xml
+++ b/app/code/Magento/Security/etc/adminhtml/system.xml
@@ -34,6 +34,11 @@
                         <field id="password_reset_protection_type" separator="," negative="1">0</field>
                     </depends>
                 </field>
+                <field id="password_reset_service_email" translate="label comment" type="text" sortOrder="9" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Password Reset Service Email</label>
+                    <comment>Service email address for password reset communication</comment>
+                    <validate>validate-email</validate>
+                </field>
             </group>
         </section>
         <section id="customer">
@@ -57,6 +62,11 @@
                     <depends>
                         <field id="password_reset_protection_type" separator="," negative="1">0</field>
                     </depends>
+                </field>
+                <field id="password_reset_service_email" translate="label comment" type="text" sortOrder="8" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Password Reset Service Email</label>
+                    <comment>Service email address for password reset communication</comment>
+                    <validate>validate-email</validate>
                 </field>
             </group>
         </section>

--- a/app/code/Magento/Security/etc/config.xml
+++ b/app/code/Magento/Security/etc/config.xml
@@ -14,6 +14,7 @@
                 <max_number_password_reset_requests>5</max_number_password_reset_requests>
                 <min_time_between_password_reset_requests>10</min_time_between_password_reset_requests>
                 <session_lifetime>900</session_lifetime>
+                <password_reset_service_email><![CDATA[hello@example.com]]></password_reset_service_email>
             </security>
         </admin>
         <customer>
@@ -21,6 +22,7 @@
                 <password_reset_protection_type>1</password_reset_protection_type>
                 <max_number_password_reset_requests>5</max_number_password_reset_requests>
                 <min_time_between_password_reset_requests>10</min_time_between_password_reset_requests>
+                <password_reset_service_email><![CDATA[hello@example.com]]></password_reset_service_email>
             </password>
         </customer>
     </default>


### PR DESCRIPTION
### Description (*)
I have created new following configs:
1. `Stores->Configuration->Customer->Customer Configuration->Password Options->Password Reset Service Email`. 
![1619519920005](https://user-images.githubusercontent.com/41998275/116228589-271e6580-a75e-11eb-916a-1c7479ec23a6.jpg)

This config allows change email in the  `We received too many requests for password resets. Please wait and try again later or contact hello@example.com` message. This message appears when customer requested few times password reset.
![1619520007499](https://user-images.githubusercontent.com/41998275/116228615-2ede0a00-a75e-11eb-9ad3-a26be5c0d54d.jpg)

2. `Stores->Configuration->Advanced->Admin->Security->Password Reset Service Email`. 
![1619530406555](https://user-images.githubusercontent.com/41998275/116251665-8b015800-a777-11eb-91f1-11dc2ea224ba.jpg)
This config allows change email in the  `We received too many requests for password resets. Please wait and try again later or contact hello@example.com` message. This message appears when admin user requested few times password reset.
![1619530334808](https://user-images.githubusercontent.com/41998275/116251728-9d7b9180-a777-11eb-82ca-a1fe0440e458.jpg)

I created a new configurations because I think it's a bad idea to use a configuration from the `Magento Contact` module.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#32837

### Manual testing scenarios (*)
**Scenario 1. Reset Customer password**
1. Change email in the config `Stores->Configuration->Customer->Customer Configuration->Password Options->Password Reset Service Email`. For example (`test@example.com`)
![1619520136713](https://user-images.githubusercontent.com/41998275/116228810-6ea4f180-a75e-11eb-87de-155dd3691d16.jpg)



2. On the password reset route (/customer/account/forgotpassword/) request a password reset multiple times. Assuming out-of-the-box configuration you will eventually get the error message that contain email from previous step:
`We received too many requests for password resets. Please wait and try again later or contact test@example.com`
![1619520112569](https://user-images.githubusercontent.com/41998275/116228816-72387880-a75e-11eb-9ace-f8d52f2d1ead.jpg)

**Scenario 2. Reset Admin password**
1. Change email in the config `Stores->Configuration->Customer->Customer Configuration->Password Options->Password Reset Service Email`. For example (`test1@example.com`)
![1619530444257](https://user-images.githubusercontent.com/41998275/116252015-dc114c00-a777-11eb-8747-d6a3b4f12cad.jpg)

2. On the password reset route (admin/auth/forgotpassword/) request a password reset multiple times. Assuming out-of-the-box configuration you will eventually get the error message that contain email from previous step:
`We received too many requests for password resets. Please wait and try again later or contact test1@example.com`
![1619530533123](https://user-images.githubusercontent.com/41998275/116252286-18dd4300-a778-11eb-8575-a1337aa2fa48.jpg)


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
