### PR TITLE
Replace jquery-ui blind and fade effects with jquery slide and fade effects

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -13,8 +13,7 @@ define([
     'jquery-ui-modules/widget',
     'mage/decorate',
     'mage/collapsible',
-    'mage/cookies',
-    'jquery-ui-modules/effect-fade'
+    'mage/cookies'
 ], function ($, authenticationPopup, customerData, alert, confirm, _) {
     'use strict';
 
@@ -145,7 +144,7 @@ define([
                 itemQty = elem.data('item-qty');
 
             if (this._isValidQty(itemQty, elem.val())) {
-                $('#update-cart-item-' + itemId).show('fade', 300);
+                $('#update-cart-item-' + itemId).fadeIn(300);
             } else if (elem.val() == 0) { //eslint-disable-line eqeqeq
                 this._hideItemButton(elem);
             } else {
@@ -185,7 +184,7 @@ define([
         _hideItemButton: function (elem) {
             var itemId = elem.data('cart-item');
 
-            $('#update-cart-item-' + itemId).hide('fade', 300);
+            $('#update-cart-item-' + itemId).fadeOut(300);
         },
 
         /**

--- a/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/sidebar.js
@@ -144,7 +144,7 @@ define([
                 itemQty = elem.data('item-qty');
 
             if (this._isValidQty(itemQty, elem.val())) {
-                $('#update-cart-item-' + itemId).fadeIn(300);
+                $('#update-cart-item-' + itemId).addClass('show');
             } else if (elem.val() == 0) { //eslint-disable-line eqeqeq
                 this._hideItemButton(elem);
             } else {
@@ -184,7 +184,7 @@ define([
         _hideItemButton: function (elem) {
             var itemId = elem.data('cart-item');
 
-            $('#update-cart-item-' + itemId).fadeOut(300);
+            $('#update-cart-item-' + itemId).removeClass('show');
         },
 
         /**

--- a/app/code/Magento/Checkout/view/frontend/web/template/minicart/item/default.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/minicart/item/default.html
@@ -88,8 +88,7 @@
                            'data-cart-item': item_id,
                            title: $t('Update')
                            }"
-                            class="update-cart-item"
-                            style="display: none">
+                            class="update-cart-item">
                         <span data-bind="i18n: 'Update'"></span>
                     </button>
                 </div>

--- a/app/code/Magento/Ui/view/frontend/web/js/view/messages.js
+++ b/app/code/Magento/Ui/view/frontend/web/js/view/messages.js
@@ -20,7 +20,7 @@ define([
             selector: '[data-role=checkout-messages]',
             isHidden: false,
             hideTimeout: 5000,
-            hideSpeed: 1500,
+            hideSpeed: 500,
             listens: {
                 isHidden: 'onHiddenChange'
             }

--- a/app/code/Magento/Ui/view/frontend/web/js/view/messages.js
+++ b/app/code/Magento/Ui/view/frontend/web/js/view/messages.js
@@ -10,8 +10,7 @@ define([
     'ko',
     'jquery',
     'uiComponent',
-    '../model/messageList',
-    'jquery-ui-modules/effect-blind'
+    '../model/messageList'
 ], function (ko, $, Component, globalMessages) {
     'use strict';
 
@@ -21,7 +20,7 @@ define([
             selector: '[data-role=checkout-messages]',
             isHidden: false,
             hideTimeout: 5000,
-            hideSpeed: 500,
+            hideSpeed: 1500,
             listens: {
                 isHidden: 'onHiddenChange'
             }
@@ -68,7 +67,7 @@ define([
             // Hide message block if needed
             if (isHidden) {
                 setTimeout(function () {
-                    $(this.selector).hide('blind', {}, this.hideSpeed);
+                    $(this.selector).slideUp(this.hideSpeed);
                 }.bind(this), this.hideTimeout);
             }
         }

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
@@ -353,11 +353,11 @@
 
         .update-cart-item {
             .lib-font-size(11);
-            margin-left: 5px;
-            vertical-align: top;
-            pointer-events: none;
-            opacity: 0;
             .lib-css(transition, @minicart-update-cart-item__transition);
+            margin-left: 5px;
+            opacity: 0;
+            pointer-events: none;
+            vertical-align: top;
 
             &.show {
                 display: inline-block;

--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/_minicart.less
@@ -11,6 +11,7 @@
 @minicart__padding-horizontal: @indent__base;
 
 @minicart-qty__height: 24px;
+@minicart-update-cart-item__transition: opacity .3s;
 
 //
 //  Common
@@ -354,6 +355,15 @@
             .lib-font-size(11);
             margin-left: 5px;
             vertical-align: top;
+            pointer-events: none;
+            opacity: 0;
+            .lib-css(transition, @minicart-update-cart-item__transition);
+
+            &.show {
+                display: inline-block;
+                opacity: 1;
+                pointer-events: initial;
+            }
         }
 
         .subtitle {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Jquery UI effects seem to be rarely used. I was able to find only 2 places - minicart quantity update button and some checkout error messages. Unfortunately as minicart and authentication popup are loaded on every page quite a big chunk of code is loaded. It seems to me that these places come from quite old times and can be replaced with jquery animations - slideUp of fadeIn/Out. I cannot see any difference in behavior after replacing them. The advantage is that jquery-ui effects are not loaded at all which can improve performance.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.

1. Fixes magento/magento2#<issue_number>-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Add any product to the cart. Open minicart. Change the quantity of the product. Check if the update button appears with fade effect.
2. Click "Update" and check if minicart quantity update button disappears wit fade effect
3. Disable guest checkout. Add any product to the cart and click "Go to checkout". provide wrong credentials. An error message should appear.
4. Wait for 15s. After this time error message should disappear with slide effect.
5. Got to payment step of onepage checkout. Provide wrong data for any payment method (like missing credit card number) and click the "Place order" button
6. Error message should appear. Wait for 15s. After this time error message should disappear with slide effect.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
