### PR TITLE
MFTF: Applying Coupon Codes With Enabled Captcha

### DIFF
--- a/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertStorefrontCaptchaVisibleOnShoppingCartApplyCouponCodeFormActionGroup.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/ActionGroup/AssertStorefrontCaptchaVisibleOnShoppingCartApplyCouponCodeFormActionGroup.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertStorefrontCaptchaVisibleOnShoppingCartApplyCouponCodeFormActionGroup">
+        <waitForElement selector="{{StorefrontSalesRuleCartCouponSection.couponHeader}}" time="30" stepKey="waitForCouponHeader"/>
+        <conditionalClick selector="{{StorefrontSalesRuleCartCouponSection.couponHeader}}" dependentSelector="{{StorefrontSalesRuleCartCouponSection.discountBlockActive}}" visible="false" stepKey="clickCouponHeader"/>
+        <waitForElementVisible selector="{{StorefrontSalesRuleCartCouponSection.couponField}}" stepKey="waitForCouponField"/>
+        <waitForElementVisible selector="{{StorefrontShoppingCartApplyDiscountCodeSection.captchaField}}" stepKey="waitToSeeCaptchaField"/>
+        <waitForElementVisible selector="{{StorefrontShoppingCartApplyDiscountCodeSection.captchaImg}}" stepKey="waitToSeeCaptchaImage"/>
+        <waitForElementVisible selector="{{StorefrontShoppingCartApplyDiscountCodeSection.captchaReload}}" stepKey="waitToSeeCaptchaReloadButton"/>
+        <reloadPage stepKey="refreshPage"/>
+        <waitForPageLoad stepKey="waitForPageReloaded"/>
+        <waitForElement selector="{{StorefrontSalesRuleCartCouponSection.couponHeader}}" time="30" stepKey="waitForCouponHeaderAfterReload"/>
+        <conditionalClick selector="{{StorefrontSalesRuleCartCouponSection.couponHeader}}" dependentSelector="{{StorefrontSalesRuleCartCouponSection.discountBlockActive}}" visible="false" stepKey="clickCouponHeaderAfterReload"/>
+        <waitForElementVisible selector="{{StorefrontSalesRuleCartCouponSection.couponField}}" stepKey="waitForCouponFieldAfterReload"/>
+        <waitForElementVisible selector="{{StorefrontShoppingCartApplyDiscountCodeSection.captchaField}}" stepKey="waitToSeeCaptchaFieldAfterPageReload"/>
+        <waitForElementVisible selector="{{StorefrontShoppingCartApplyDiscountCodeSection.captchaImg}}" stepKey="waitToSeeCaptchaImageAfterPageReload"/>
+        <waitForElementVisible selector="{{StorefrontShoppingCartApplyDiscountCodeSection.captchaReload}}" stepKey="waitToSeeCaptchaReloadButtonAfterPageReload"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Captcha/Test/Mftf/ActionGroup/StorefrontShoppingCartFillCaptchaFieldOnApplyDiscountFormActionGroup.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/ActionGroup/StorefrontShoppingCartFillCaptchaFieldOnApplyDiscountFormActionGroup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontShoppingCartFillCaptchaFieldOnApplyDiscountFormActionGroup">
+        <arguments>
+            <argument name="captcha" type="string"/>
+        </arguments>
+
+        <fillField userInput="{{captcha}}" selector="{{StorefrontShoppingCartApplyDiscountCodeSection.captchaField}}" stepKey="fillCaptchaField"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Captcha/Test/Mftf/Data/CaptchaConfigData.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/Data/CaptchaConfigData.xml
@@ -139,4 +139,10 @@
         <data key="label">ABCDEFGHJKMnpqrstuvwxyz23456789</data>
         <data key="value">ABCDEFGHJKMnpqrstuvwxyz23456789</data>
     </entity>
+    <entity name="StorefrontCaptchaOnApplyingCouponCodeFormsConfigData">
+        <data key="path">customer/captcha/forms</data>
+        <data key="scope_id">0</data>
+        <data key="label">Applying coupon code</data>
+        <data key="value">sales_rule_coupon_request</data>
+    </entity>
 </entities>

--- a/app/code/Magento/Captcha/Test/Mftf/Section/StorefrontShoppingCartApplyDiscountCodeSection.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/Section/StorefrontShoppingCartApplyDiscountCodeSection.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="StorefrontShoppingCartApplyDiscountCodeSection">
+        <element name="captchaField" type="input" selector="#discount-coupon-form input[name='captcha[sales_rule_coupon_request]']" />
+        <element name="captchaImg" type="block" selector="#discount-coupon-form img.captcha-img"/>
+        <element name="captchaReload" type="block" selector="#discount-coupon-form button.captcha-reload"/>
+    </section>
+</sections>

--- a/app/code/Magento/Captcha/Test/Mftf/Test/StorefrontCaptchaOnApplyingCouponCodesFormsTest.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/Test/StorefrontCaptchaOnApplyingCouponCodesFormsTest.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontCaptchaOnApplyingCouponCodesFormsTest">
+        <annotations>
+            <features value="Captcha"/>
+            <stories value="Applying coupon codes with enabled captcha"/>
+            <title value="Captcha on applying coupon code forms"/>
+            <description value="Customer should be able apply coupon codes with enabled captcha"/>
+            <severity value="MINOR"/>
+            <group value="captcha"/>
+        </annotations>
+        <before>
+            <createData entity="SimpleSubCategory" stepKey="createCategory"/>
+            <createData entity="SimpleProduct" stepKey="createProduct">
+                <requiredEntity createDataKey="createCategory"/>
+            </createData>
+            <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
+            <createData entity="SalesRuleSpecificCouponWithFixedDiscount" stepKey="createCartPriceRule"/>
+            <createData entity="SimpleSalesRuleCoupon" stepKey="createCouponForCartPriceRule">
+                <requiredEntity createDataKey="createCartPriceRule"/>
+            </createData>
+            <magentoCLI command="config:set {{EnablePaymentBankTransferConfigData.path}} {{EnablePaymentBankTransferConfigData.value}}" stepKey="enableBankTransferPayment"/>
+            <magentoCLI command="config:set {{EnableFlatRateConfigData.path}} {{EnableFlatRateConfigData.value}}" stepKey="enableFlatRate"/>
+            <magentoCLI command="config:set {{StorefrontCustomerCaptchaLength3ConfigData.path}} {{StorefrontCustomerCaptchaLength3ConfigData.value}}" stepKey="setCaptchaLength"/>
+            <magentoCLI command="config:set {{StorefrontCustomerCaptchaSymbols1ConfigData.path}} {{StorefrontCustomerCaptchaSymbols1ConfigData.value}}" stepKey="setCaptchaSymbols"/>
+            <magentoCLI command="config:set {{StorefrontCaptchaOnApplyingCouponCodeFormsConfigData.path}} {{StorefrontCaptchaOnApplyingCouponCodeFormsConfigData.value}}" stepKey="enableCaptchaOnApplyingCouponsForms"/>
+            <magentoCLI command="config:set {{StorefrontCustomerCaptchaModeAlwaysConfigData.path}} {{StorefrontCustomerCaptchaModeAlwaysConfigData.value}}" stepKey="setCaptchaAlwaysVisible"/>
+            <actionGroup ref="CliCacheCleanActionGroup" stepKey="cleanInvalidatedCaches">
+                <argument name="tags" value="config full_page"/>
+            </actionGroup>
+        </before>
+        <after>
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
+            <deleteData createDataKey="createCartPriceRule" stepKey="deleteCartPriceRule"/>
+            <actionGroup ref="StorefrontCustomerLogoutActionGroup" stepKey="logoutCustomer"/>
+            <deleteData createDataKey="createCustomer" stepKey="deleteCustomer"/>
+            <magentoCLI command="config:set {{DisablePaymentBankTransferConfigData.path}} {{DisablePaymentBankTransferConfigData.value}}" stepKey="disableBankTransferPayment"/>
+            <magentoCLI command="config:set {{StorefrontCustomerCaptchaDefaultLengthConfigData.path}} {{StorefrontCustomerCaptchaDefaultLengthConfigData.value}}" stepKey="setDefaultCaptchaLength"/>
+            <magentoCLI command="config:set {{StorefrontCustomerCaptchaDefaultSymbolsConfigData.path}} {{StorefrontCustomerCaptchaDefaultSymbolsConfigData.value}}" stepKey="setDefaultCaptchaSymbols"/>
+            <magentoCLI command="config:set {{StorefrontCustomerCaptchaModeAfterFailConfigData.path}} {{StorefrontCustomerCaptchaModeAfterFailConfigData.value}}" stepKey="setCaptchaDefaultVisibility"/>
+            <magentoCLI command="config:set {{StorefrontCaptchaOnCustomerLoginConfigData.path}} {{StorefrontCaptchaOnCustomerLoginConfigData.value}},{{StorefrontCaptchaOnCustomerForgotPasswordConfigData.value}}" stepKey="enableCaptchaOnDefaultForms"/>
+            <actionGroup ref="CliCacheCleanActionGroup" stepKey="cleanInvalidatedCaches">
+                <argument name="tags" value="config full_page"/>
+            </actionGroup>
+        </after>
+
+        <actionGroup ref="LoginToStorefrontActionGroup" stepKey="loginToStorefrontAccount">
+            <argument name="Customer" value="$createCustomer$"/>
+        </actionGroup>
+        <actionGroup ref="OpenProductFromCategoryPageActionGroup" stepKey="openProductFromCategory">
+            <argument name="category" value="$createCategory$"/>
+            <argument name="product" value="$createProduct$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontAddProductToCartWithQtyActionGroup" stepKey="addProductToTheCart">
+            <argument name="productQty" value="1"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontCartPageOpenActionGroup" stepKey="navigateToShoppingCart"/>
+        <actionGroup ref="AssertStorefrontCaptchaVisibleOnShoppingCartApplyCouponCodeFormActionGroup" stepKey="assertCaptchaIsPresent"/>
+        <actionGroup ref="StorefrontShoppingCartFillCouponCodeFieldActionGroup" stepKey="fillDiscountField">
+            <argument name="discountCode" value="$$createCouponForCartPriceRule.code$$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontShoppingCartFillCaptchaFieldOnApplyDiscountFormActionGroup" stepKey="fillCaptchaWithIncorrectValues">
+            <argument name="captcha" value="{{WrongCaptcha.value}}"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontShoppingCartClickApplyDiscountButtonActionGroup" stepKey="clickApplyButton"/>
+        <actionGroup ref="AssertMessageCustomerChangeAccountInfoActionGroup" stepKey="assertErrorMessage">
+            <argument name="message" value="Incorrect CAPTCHA"/>
+            <argument name="messageType" value="error"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontShoppingCartFillCouponCodeFieldActionGroup" stepKey="fillDiscountCodeField">
+            <argument name="discountCode" value="$$createCouponForCartPriceRule.code$$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontShoppingCartFillCaptchaFieldOnApplyDiscountFormActionGroup" stepKey="fillCaptchaWithCorrectValues">
+            <argument name="captcha" value="{{PreconfiguredCaptcha.value}}"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontShoppingCartClickApplyDiscountButtonActionGroup" stepKey="clickApplyDiscountButton"/>
+        <actionGroup ref="AssertMessageCustomerChangeAccountInfoActionGroup" stepKey="assertSuccessMessage">
+            <argument name="message" value='You used coupon code "$$createCouponForCartPriceRule.code$$".'/>
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/StorefrontShoppingCartClickApplyDiscountButtonActionGroup.xml
+++ b/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/StorefrontShoppingCartClickApplyDiscountButtonActionGroup.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontShoppingCartClickApplyDiscountButtonActionGroup">
+        <conditionalClick selector="{{DiscountSection.DiscountTab}}" dependentSelector="{{DiscountSection.CouponInput}}" visible="false" stepKey="clickToAddDiscount"/>
+        <click selector="{{DiscountSection.ApplyCodeBtn}}" stepKey="clickToApplyDiscount"/>
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/StorefrontShoppingCartFillCouponCodeFieldActionGroup.xml
+++ b/app/code/Magento/SalesRule/Test/Mftf/ActionGroup/StorefrontShoppingCartFillCouponCodeFieldActionGroup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontShoppingCartFillCouponCodeFieldActionGroup">
+        <arguments>
+            <argument name="discountCode" type="string"/>
+        </arguments>
+        <conditionalClick selector="{{DiscountSection.DiscountTab}}" dependentSelector="{{DiscountSection.CouponInput}}" visible="false" stepKey="clickToAddDiscount"/>
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+        <fillField selector="{{DiscountSection.CouponInput}}" userInput="{{discountCode}}" stepKey="fillFieldDiscountCode"/>
+    </actionGroup>
+</actionGroups>


### PR DESCRIPTION
This PR contains MFTF test for applying coupon codes on shopping cart page with enabled captcha

**Steps to reproduce:**

1 - Enable captcha on Applying codes form
2 - Create product
3 - Create customer
4 - Login as customer
5 - Navigate to created product
6 - Add product into shopping cart
7 - Navigate to shopping cart
8 - Apply coupon code with incorrect captcha values
0 - Apply coupon code with correct captcha values
9 - Perform assertions