### PR TITLE
Support S3 compatible storage

### DIFF
--- a/app/code/Magento/AwsS3/Driver/AwsS3Factory.php
+++ b/app/code/Magento/AwsS3/Driver/AwsS3Factory.php
@@ -116,6 +116,10 @@ class AwsS3Factory implements DriverFactoryInterface
             $config['http_handler'] = $this->objectManager->create($config['http_handler'])($config);
         }
 
+        if (!empty($config['path_style'])) {
+            $config['use_path_style_endpoint'] = boolval($config['path_style']);
+        }
+
         $client = new S3Client($config);
         $adapter = new AwsS3V3Adapter($client, $config['bucket'], $prefix);
         $cache = $this->cacheInterfaceFactory->create(

--- a/app/code/Magento/AwsS3/Model/Config.php
+++ b/app/code/Magento/AwsS3/Model/Config.php
@@ -14,11 +14,13 @@ use Magento\Framework\App\DeploymentConfig;
  */
 class Config
 {
+    public const PATH_ENDPOINT = 'remote_storage/endpoint';
     public const PATH_REGION = 'remote_storage/region';
     public const PATH_BUCKET = 'remote_storage/bucket';
     public const PATH_ACCESS_KEY = 'remote_storage/access_key';
     public const PATH_SECRET_KEY = 'remote_storage/secret_key';
     public const PATH_PREFIX = 'remote_storage/prefix';
+    public const PATH_PATH_STYLE = 'remote_storage/path_style';
 
     /**
      * @var DeploymentConfig
@@ -31,6 +33,16 @@ class Config
     public function __construct(DeploymentConfig $config)
     {
         $this->config = $config;
+    }
+
+    /**
+     * Retrieves endpoint.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return (string)$this->config->get(self::PATH_ENDPOINT);
     }
 
     /**
@@ -81,5 +93,15 @@ class Config
     public function getPrefix(): string
     {
         return (string)$this->config->get(self::PATH_PREFIX, '');
+    }
+
+    /**
+     * Retrieves endpoint.
+     *
+     * @return string
+     */
+    public function getPathStyle(): string
+    {
+        return (string)$this->config->get(self::PATH_PATH_STYLE, '0');
     }
 }

--- a/app/code/Magento/RemoteStorage/Setup/ConfigOptionsList.php
+++ b/app/code/Magento/RemoteStorage/Setup/ConfigOptionsList.php
@@ -27,6 +27,8 @@ class ConfigOptionsList implements ConfigOptionsListInterface
     private const CONFIG_PATH__REMOTE_STORAGE_DRIVER = RemoteDriverPool::PATH_DRIVER;
     private const OPTION_REMOTE_STORAGE_PREFIX = 'remote-storage-prefix';
     private const CONFIG_PATH__REMOTE_STORAGE_PREFIX = RemoteDriverPool::PATH_PREFIX;
+    private const OPTION_REMOTE_STORAGE_ENDPOINT = 'remote-storage-endpoint';
+    private const CONFIG_PATH__REMOTE_STORAGE_ENDPOINT = RemoteDriverPool::PATH_CONFIG . '/endpoint';
     private const OPTION_REMOTE_STORAGE_BUCKET = 'remote-storage-bucket';
     private const CONFIG_PATH__REMOTE_STORAGE_BUCKET = RemoteDriverPool::PATH_CONFIG . '/bucket';
     private const OPTION_REMOTE_STORAGE_REGION = 'remote-storage-region';
@@ -35,6 +37,8 @@ class ConfigOptionsList implements ConfigOptionsListInterface
     private const CONFIG_PATH__REMOTE_STORAGE_ACCESS_KEY = RemoteDriverPool::PATH_CONFIG . '/credentials/key';
     private const OPTION_REMOTE_STORAGE_SECRET_KEY = 'remote-storage-secret';
     private const CONFIG_PATH__REMOTE_STORAGE_SECRET_KEY = RemoteDriverPool::PATH_CONFIG . '/credentials/secret';
+    private const OPTION_REMOTE_STORAGE_PATH_STYLE = 'remote-storage-path-style';
+    private const CONFIG_PATH__REMOTE_STORAGE_PATH_STYLE = RemoteDriverPool::PATH_CONFIG . '/path-style';
 
     /**
      * Map of option to config path relations.
@@ -43,10 +47,12 @@ class ConfigOptionsList implements ConfigOptionsListInterface
      */
     private static $map = [
         self::OPTION_REMOTE_STORAGE_PREFIX => self::CONFIG_PATH__REMOTE_STORAGE_PREFIX,
+        self::OPTION_REMOTE_STORAGE_ENDPOINT => self::CONFIG_PATH__REMOTE_STORAGE_ENDPOINT,
         self::OPTION_REMOTE_STORAGE_BUCKET => self::CONFIG_PATH__REMOTE_STORAGE_BUCKET,
         self::OPTION_REMOTE_STORAGE_REGION => self::CONFIG_PATH__REMOTE_STORAGE_REGION,
         self::OPTION_REMOTE_STORAGE_ACCESS_KEY => self::CONFIG_PATH__REMOTE_STORAGE_ACCESS_KEY,
-        self::OPTION_REMOTE_STORAGE_SECRET_KEY => self::CONFIG_PATH__REMOTE_STORAGE_SECRET_KEY
+        self::OPTION_REMOTE_STORAGE_SECRET_KEY => self::CONFIG_PATH__REMOTE_STORAGE_SECRET_KEY,
+        self::OPTION_REMOTE_STORAGE_PATH_STYLE => self::CONFIG_PATH__REMOTE_STORAGE_PATH_STYLE
     ];
 
     /**
@@ -90,6 +96,12 @@ class ConfigOptionsList implements ConfigOptionsListInterface
                 ''
             ),
             new TextConfigOption(
+                self::OPTION_REMOTE_STORAGE_ENDPOINT,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                self::CONFIG_PATH__REMOTE_STORAGE_ENDPOINT,
+                'Remote storage endpoint'
+            ),
+            new TextConfigOption(
                 self::OPTION_REMOTE_STORAGE_BUCKET,
                 TextConfigOption::FRONTEND_WIZARD_TEXT,
                 self::CONFIG_PATH__REMOTE_STORAGE_BUCKET,
@@ -114,6 +126,13 @@ class ConfigOptionsList implements ConfigOptionsListInterface
                 self::CONFIG_PATH__REMOTE_STORAGE_SECRET_KEY,
                 'Remote storage secret key',
                 ''
+            ),
+            new TextConfigOption(
+                self::OPTION_REMOTE_STORAGE_PATH_STYLE,
+                TextConfigOption::FRONTEND_WIZARD_PASSWORD,
+                self::CONFIG_PATH__REMOTE_STORAGE_PATH_STYLE,
+                'Remote storage path style',
+                '0'
             )
         ];
     }


### PR DESCRIPTION
### Description
This PR should allow users to configure the endpoint and path style for S3 compatible storage like Minio or services like Clever Cloud Cellar.

### Fixed Issues
Fixes magento/magento2#32114

### Manual testing scenarios

Start Minio with [Docker](https://docs.min.io/docs/minio-quickstart-guide.html) and create a bucket with [s3cmd](https://docs.min.io/docs/s3cmd-with-minio).

Setup Magento Remote storage:

```bash
bin/magento setup:config:set \
    --remote-storage-driver="aws-s3" \
    --remote-storage-endpoint="http://127.0.0.1:9000" \
    --remote-storage-region="us-east-1" \
    --remote-storage-bucket="magento-media" \
    --remote-storage-key="minioadmin" \
    --remote-storage-secret="minioadmin" \
    --no-interaction
```

Sync media folders:

```bash
bin/magento remote-storage:sync
```

### Comments
As `$config` seems to be directly passed to `S3Client`, I though it did not need any specific unit or integration tests.

A PR is waiting on the devdocs : https://github.com/magento/devdocs/pull/8914
