### PR TITLE
Resolving module:uninstall hanging without response

### DIFF
--- a/setup/src/Magento/Setup/Model/ModuleUninstaller.php
+++ b/setup/src/Magento/Setup/Model/ModuleUninstaller.php
@@ -7,6 +7,7 @@ namespace Magento\Setup\Model;
 
 use Magento\Framework\Setup\Patch\PatchApplier;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 
 /**
  * Class to uninstall a module component
@@ -94,6 +95,19 @@ class ModuleUninstaller
             $this->getPatchApplier()->revertDataPatches($module);
         }
     }
+    
+    /**
+     * Checks wether auth.json exists in the Magento root.
+     * @throws FileNotFoundException when auth.json is not found with a reference to the developer documentation.
+     */
+    private function failOnMissingAuthJson() 
+    {
+        $auth_json_path = BP . DIRECTORY_SEPARATOR . 'auth.json';
+        if (!file_exists($auth_json_path)) {
+            $error_message = sprintf('auth.json at %s could not be found. Refer to https://devdocs.magento.com/guides/v2.4/install-gde/prereq/dev_install.html#authentication-file how to install this file.', $auth_json_path);
+            throw new FileNotFoundException($error_message);
+        }
+    }
 
     /**
      * Run 'composer remove' to remove code
@@ -104,6 +118,7 @@ class ModuleUninstaller
      */
     public function uninstallCode(OutputInterface $output, array $modules)
     {
+        $this->failOnMissingAuthJson();
         $output->writeln('<info>Removing code from Magento codebase:</info>');
         $packages = [];
         /** @var \Magento\Framework\Module\PackageInfo $packageInfo */


### PR DESCRIPTION
This fix is based on https://github.com/magento/magento2/issues/3544

Basically, when Magento command `bin/magento module:uninstall Module_Name` is called it will hang indefinitely, even for half an hour. The only way to exit is to CTRL +C out of it.

I posted my research in this issue here: [https://blog.tschallacka.de/2021/05/binmagento-moduleuninstall-never.html](https://blog.tschallacka.de/2021/05/binmagento-moduleuninstall-never.html) but it boils down that when auth.json is not found in the Magento root dir, composer will prompt for the access keys to repo.magento.com, but as the output is contained in a BufferedOutput that doesn't output to STDOUT this isn't visible. 

My proposed fix, before initiating the uninstall via composer, check if auth.json exists in the root dir.  
When auth.json is not found, an FileNotFoundException is thrown, adding a reference to https://devdocs.magento.com/guides/v2.4/install-gde/prereq/dev_install.html#authentication-file so they can resolve the issue.

For testing have a module that registers a custom attribute that you remove with an uninstaller, with a missing auth.json in the Magento root directory.

```php
<?php namespace Test\Dummy\Setup;

use Magento\Catalog\Model\Product;
use Magento\Eav\Setup\EavSetupFactory;
use Magento\Framework\Setup\ModuleContextInterface;
use Magento\Framework\Setup\SchemaSetupInterface;
use Magento\Framework\Setup\UninstallInterface;
use Symfony\Component\Console\Output\ConsoleOutput;

class Uninstall implements UninstallInterface
{
    protected $eavSetupFactory;
    protected $output;

    public function __construct(EavSetupFactory $eavSetupFactory, ConsoleOutput $output)
    {
        $this->eavSetupFactory = $eavSetupFactory;
        $this->output = $output;
    }

    /**
     * @inheritDoc
     */
    public function uninstall(SchemaSetupInterface $setup, ModuleContextInterface $context)
    {
        $eavSetup = $this->eavSetupFactory->create();
        $this->output->writeln("Starting to remove the attributes for something.");
        $eavSetup->removeAttribute(Product::ENTITY, UpgradeData::SOME_ATTRIBUTE);
    }
}
```
### Description (*)
Added a private method [ModuleUninstaller::failOnMissingAuthJson()](https://github.com/magento/magento2/compare/2.4-develop...tschallacka:meaningfull-error-uninstall-missing-auth-json?expand=1#diff-56325d7bfdd2b20ff507ebf1cb2b5e9dafa52b433f3731f61f1f6fdad8e62d5fR103). 
This method tests whether auth.json exists in the Magento root dir. When it is not found it throws a meaningful error message with a reference to the developer documentation.

This method is called in [ModuleUninstaller::uninstallCode()](https://github.com/magento/magento2/compare/2.4-develop...tschallacka:meaningfull-error-uninstall-missing-auth-json?expand=1#diff-56325d7bfdd2b20ff507ebf1cb2b5e9dafa52b433f3731f61f1f6fdad8e62d5fR121)

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#3544

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Fresh install of magento
2. install https://github.com/tschallacka/mage2-dummy-test
3. run `bin/magento module:enable Test_Dummy && bin/magento setup:upgrade && bin/magento module:disable Test_Dummy && bin/magento module:uninstall Test_Dummy`
4. Type yes twice to the questions
5. Process will hang forever. After roughly 30-60 seconds, only when you type gibberish/hit enter a few times you'll get the output from an exception handler.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
