### PR TITLE
#28318 - Fixed the issue when unsubscribe stock alert via GET request

### DIFF
--- a/app/code/Magento/ProductAlert/Controller/Unsubscribe/Stock.php
+++ b/app/code/Magento/ProductAlert/Controller/Unsubscribe/Stock.php
@@ -11,6 +11,7 @@ namespace Magento\ProductAlert\Controller\Unsubscribe;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Controller\Result\Redirect;
@@ -24,7 +25,7 @@ use Magento\Catalog\Api\Data\ProductInterface;
 /**
  * Unsubscribing from 'back in stock alert'.
  */
-class Stock extends UnsubscribeController implements HttpPostActionInterface
+class Stock extends UnsubscribeController implements HttpPostActionInterface, HttpGetActionInterface
 {
     /**
      * @var ProductRepositoryInterface


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Unsubscribe from stock alert via GET request wasn't working. I've added the HttpGetActionInterface to the class.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#28318

### Manual testing scenarios (*)
### Steps to reproduce (*)

- Set a product to out of stock
- Enable Product allerts for back in stock
- Log in to a frontend account
- go to the page of the product whith is out of stock
- click the link for product alerts
- run cron job catalog_product_alert
- open the product alert e-mail
- click on the unsubscribe link

### Expected result (*)

being unsubscribe from this product allert
message that you have be unsubscribed
### Actual result (*)

getting a 404 page

### Questions or comments


### Contribution checklist (*)
 - [ x] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
