### PR TITLE
32519 fix admin category products sort by name

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Category/Tab/Product.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Category/Tab/Product.php
@@ -120,6 +120,8 @@ class Product extends \Magento\Backend\Block\Widget\Grid\Extended
         $collection = $this->_productFactory->create()->getCollection()->addAttributeToSelect(
             'name'
         )->addAttributeToSelect(
+            'name '
+        )->addAttributeToSelect(
             'sku'
         )->addAttributeToSelect(
             'visibility'


### PR DESCRIPTION
### Description (*)
To fix issue [#32519](https://github.com/magento/magento2/issues/32519) I added new column to product Collection in app/code/Magento/Backend/Block/Widget/Grid.php. It helps to get string values in MySQL response.

### Fixed Issues (if relevant)
1. Fixes magento/magento2 [#32519](https://github.com/magento/magento2/issues/32519)

### Manual testing scenarios (*)
1. Open id admin panel some category with products.
2. Sort products in category by name.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
