### PR TITLE
Js errors when date customer address attribute add to admin customer grid

### DIFF
--- a/app/code/Magento/Customer/view/adminhtml/ui_component/customer_listing.xml
+++ b/app/code/Magento/Customer/view/adminhtml/ui_component/customer_listing.xml
@@ -224,7 +224,6 @@
         </column>
         <column name="dob" class="Magento\Ui\Component\Listing\Columns\Date" component="Magento_Ui/js/grid/columns/date" sortOrder="170">
             <settings>
-                <timezone>false</timezone>
                 <dateFormat>MMM d, y</dateFormat>
                 <skipTimeZoneConversion>true</skipTimeZoneConversion>
                 <filter>dateRange</filter>

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
@@ -48,7 +48,7 @@ define([
 
             date = moment.utc(this._super());
 
-            if (!_.isUndefined(this.timezone)) {
+            if (!_.isUndefined(this.timezone) && typeof this.timezone === 'string') {
                 date = date.tz(this.timezone);
             }
 


### PR DESCRIPTION
### Description (*)

Steps to reproduce
- Create date address attribute with below settings.
```
- type:datetime
- input: date
- is_used_in_grid: 1
- is_visible_in_grid:1
```
- Go to admin customer grid
- Below js issues will show in browser.

```
knockout.js:3381 Uncaught TypeError: Unable to process binding "text: function(){return $col.getLabel($row()) }"
Message: Cannot read property 'isValid' of undefined
    at UiClass.getLabel (date.js:55)
    at UiClass.getLabel (wrapper.js:109)
    at text (eval at createBindingsStringEvaluator (knockout.js:2982), <anonymous>:3:69)
    at update (knockout.js:4659)
    at ko.dependentObservable.disposeWhenNodeIsRemoved (knockout.js:3373)
    at Function.evaluateImmediate_CallReadThenEndDependencyDetection (knockout.js:2173)
    at Function.evaluateImmediate_CallReadWithDependencyDetection (knockout.js:2140)
    at Function.evaluateImmediate (knockout.js:2101)
    at Object.ko.computed.ko.dependentObservable (knockout.js:1954)
    at knockout.js:3371`
```

`Moment Timezone has no data for false. See http://momentjs.com/timezone/docs/#/data-loading/.`

### Notes
- timezone tag type is strings
```
<column name="dob" ....
            <settings>
                <timezone>false</timezone>
```

- moment-timezone-with-data.js -> tz only support strings