### PR TITLE
MFTF: Create a Customer with Enabled Email Confirmation Setting Test

### DIFF
--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickSendConfirmationLinkButtonActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontClickSendConfirmationLinkButtonActionGroup.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontClickSendConfirmationLinkButtonActionGroup">
+        <click selector="{{StorefrontSendConfirmationLinkSection.sendConfirmationLink}}" stepKey="clickSendConfirmationLinkBtn"/>
+        <waitForPageLoad stepKey="waitForPageLoad"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerClickAccountConfirmationSendingLinkActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerClickAccountConfirmationSendingLinkActionGroup.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontCustomerClickAccountConfirmationSendingLinkActionGroup">
+        <click selector="{{StorefrontCustomerMessagesSection.confirmLink}}" stepKey="clickHereLink"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerFillEmailFieldOnSendConfirmationLinkPageActionGroup.xml
+++ b/app/code/Magento/Customer/Test/Mftf/ActionGroup/StorefrontCustomerFillEmailFieldOnSendConfirmationLinkPageActionGroup.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontCustomerFillEmailFieldOnSendConfirmationLinkPageActionGroup">
+        <arguments>
+            <argument name="email" type="entity"/>
+        </arguments>
+        <fillField userInput="{{email}}" selector="{{StorefrontSendConfirmationLinkSection.emailField}}" stepKey="fillEmailField"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Customer/Test/Mftf/Data/CustomerConfigData.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Data/CustomerConfigData.xml
@@ -61,4 +61,14 @@
         <data key="label">Global</data>
         <data key="value">0</data>
     </entity>
+    <entity name="CustomerAccountConfirmationEnabled">
+        <data key="path">customer/create_account/confirm</data>
+        <data key="label">Yes</data>
+        <data key="value">1</data>
+    </entity>
+    <entity name="CustomerAccountConfirmationDisabled">
+        <data key="path">customer/create_account/confirm</data>
+        <data key="label">No</data>
+        <data key="value">0</data>
+    </entity>
 </entities>

--- a/app/code/Magento/Customer/Test/Mftf/Section/StorefrontCustomerMessagesSection.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Section/StorefrontCustomerMessagesSection.xml
@@ -11,5 +11,6 @@
     <section name="StorefrontCustomerMessagesSection">
         <element name="successMessage" type="text" selector=".message-success"/>
         <element name="errorMessage" type="text" selector=".message-error"/>
+        <element name="confirmLink" type="button" selector="//*[contains(@class,'message-success success message')]//*[text()='click here']"/>
     </section>
 </sections>

--- a/app/code/Magento/Customer/Test/Mftf/Section/StorefrontSendConfirmationLinkSection.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Section/StorefrontSendConfirmationLinkSection.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="StorefrontSendConfirmationLinkSection">
+        <element name="emailField" type="input" selector="#email_address.input-text"/>
+        <element name="sendConfirmationLink" type="button" selector=".action.send.primary"/>
+    </section>
+</sections>

--- a/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerSendConfirmationLinkTest.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Test/StorefrontCreateCustomerSendConfirmationLinkTest.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontCreateCustomerSendConfirmationLinkTest">
+        <annotations>
+            <features value="Customer"/>
+            <stories value="Create a Customer on Storefront with enabled Email Confirmation Setting"/>
+            <title value="Register a customer with enabled Email Confirmation Setting"/>
+            <description value="Customer should receive notification about account confirmation after registration and have possibility re-send confirmation link"/>
+            <severity value="MINOR"/>
+            <group value="customer"/>
+            <group value="create"/>
+        </annotations>
+        <before>
+            <magentoCLI command="config:set {{CustomerAccountConfirmationEnabled.path}} {{CustomerAccountConfirmationEnabled.value}}" stepKey="enableAccountConfirmation"/>
+            <actionGroup ref="CliCacheCleanActionGroup" stepKey="cleanInvalidatedCaches">
+                <argument name="tags" value="config full_page"/>
+            </actionGroup>
+        </before>
+        <after>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="LoginAsAdmin"/>
+            <actionGroup ref="DeleteCustomerByEmailActionGroup" stepKey="deleteCreatedCustomer">
+                <argument name="email" value="{{Simple_US_Customer.email}}"/>
+            </actionGroup>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
+            <magentoCLI command="config:set {{CustomerAccountConfirmationDisabled.path}} {{CustomerAccountConfirmationDisabled.value}}" stepKey="disableAccountConfirmation"/>
+            <actionGroup ref="CliCacheCleanActionGroup" stepKey="cleanInvalidatedCaches">
+                <argument name="tags" value="config full_page"/>
+            </actionGroup>
+        </after>
+
+        <actionGroup ref="StorefrontOpenCustomerAccountCreatePageActionGroup" stepKey="openCreateAccountPage"/>
+        <actionGroup ref="StorefrontFillCustomerAccountCreationFormActionGroup" stepKey="fillCreateAccountForm">
+            <argument name="customer" value="Simple_US_Customer"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontClickCreateAnAccountCustomerAccountCreationFormActionGroup" stepKey="submitCreateAccountForm"/>
+        <actionGroup ref="AssertMessageCustomerCreateAccountActionGroup" stepKey="seeSuccessMessage">
+            <argument name="messageType" value="success"/>
+            <argument name="message" value="You must confirm your account. Please check your email for the confirmation link or click here for a new link."/>
+        </actionGroup>
+        <actionGroup ref="StorefrontCustomerClickAccountConfirmationSendingLinkActionGroup" stepKey="clickTheConfirmationLinkSending"/>
+        <actionGroup ref="StorefrontCustomerFillEmailFieldOnSendConfirmationLinkPageActionGroup" stepKey="fillEmailField">
+            <argument name="email" value="Simple_US_Customer.email"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontClickSendConfirmationLinkButtonActionGroup" stepKey="clickSendConfirmationLinkBtn"/>
+        <actionGroup ref="AssertMessageCustomerCreateAccountActionGroup" stepKey="assertSuccessMessage">
+            <argument name="messageType" value="success"/>
+            <argument name="message" value="Please check your email for confirmation key."/>
+        </actionGroup>
+    </test>
+</tests>


### PR DESCRIPTION
This PR contains MFTF test for creating new customer on storefront with enabled Email Confirmation config

**Steps to reproduce:**

1 - Enable Email Confirmation config
2 - Create new customer on storefront
3 - Re-send confirmation link
4 - Perform assertions