### PR TITLE
Support for multiple store views per group

### DIFF
--- a/app/code/Magento/LoginAsCustomerAdminUi/Ui/Customer/Component/ConfirmationPopup/Options.php
+++ b/app/code/Magento/LoginAsCustomerAdminUi/Ui/Customer/Component/ConfirmationPopup/Options.php
@@ -199,14 +199,18 @@ class Options implements OptionSourceInterface
         /** @var Group $group */
         foreach ($groupCollection as $group) {
             if ($group->getWebsiteId() == $websiteId) {
-                $storeViewIds = $group->getStoreIds();
-                if (!empty($storeViewIds)) {
-                    $code = $group->getCode();
-                    $name = $this->sanitizeName($group->getName());
+                $storeViews = $group->getStores();
+                if (empty($storeViews)) {
+                    continue;
+                }
+
+                foreach ($storeViews as $storeView) {
+                    $code = $storeView->getCode();
+                    $name = $this->sanitizeName($storeView->getName());
                     $groups[$code]['label'] = str_repeat(' ', 4) . $name;
-                    $groups[$code]['value'] = array_values($storeViewIds)[0];
+                    $groups[$code]['value'] = $storeView->getId();
                     $groups[$code]['disabled'] = !$isGlobalScope && $customerWebsiteId !== $websiteId;
-                    $groups[$code]['selected'] = in_array($customerStoreId, $storeViewIds) ? true : false;
+                    $groups[$code]['selected'] = $customerStoreId === $storeView->getId();
                 }
             }
         }


### PR DESCRIPTION
### Description (*)
At the moment only the first storeview from the group is supported to use for customer login. This commit will add all store views to the select options.

### Manual testing scenarios (*)
1. Set `Store View To Login To` to `Manual Selection` in Stores -> Configuration -> Customers -> Login as Customer
2. A store view dropdown will appear in the customer view in the backend: 
![image](https://user-images.githubusercontent.com/2726055/118659506-aba85500-b7ed-11eb-9df4-4c618e87735d.png)
3. Without this pull request the drop down will only add the first store view to the dropdown: 
![image](https://user-images.githubusercontent.com/2726055/118659803-ed390000-b7ed-11eb-93c8-c9b62248694d.png)
4. After this pull request the drop down will have all the store views: 
![image](https://user-images.githubusercontent.com/2726055/118660054-21142580-b7ee-11eb-9fa8-0e1595132619.png)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#33035: Support for multiple store views per group