### PR TITLE
ESI blocks should be internal links

### DIFF
--- a/app/code/Magento/PageCache/Observer/ProcessLayoutRenderElement.php
+++ b/app/code/Magento/PageCache/Observer/ProcessLayoutRenderElement.php
@@ -91,7 +91,8 @@ class ProcessLayoutRenderElement implements ObserverInterface
                 'blocks' => $this->jsonSerializer->serialize([$block->getNameInLayout()]),
                 'handles' => $this->base64jsonSerializer->serialize(
                     array_values(array_diff($handles, $pageSpecificHandles))
-                )
+                ),
+                '_type' => \Magento\Framework\UrlInterface::URL_TYPE_WEB
             ]
         );
         // Varnish does not support ESI over HTTPS must change to HTTP

--- a/app/code/Magento/PageCache/Test/Unit/Observer/ProcessLayoutRenderElementTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/Observer/ProcessLayoutRenderElementTest.php
@@ -136,8 +136,11 @@ class ProcessLayoutRenderElementTest extends TestCase
                     ->method('getUrl')
                     ->with(
                         'page_cache/block/esi',
-                        ['blocks' => '[null]',
-                            'handles' => 'WyJkZWZhdWx0IiwiY2F0YWxvZ19wcm9kdWN0X3ZpZXciXQ==']
+                        [
+                            'blocks' => '[null]',
+                            'handles' => 'WyJkZWZhdWx0IiwiY2F0YWxvZ19wcm9kdWN0X3ZpZXciXQ==',
+                            '_type' => \Magento\Framework\UrlInterface::URL_TYPE_WEB
+                        ]
                     )
                     ->willReturn(
                         'page_cache/block/wrapesi/with/handles/WyJkZWZhdWx0IiwiY2F0YWxvZ19wcm9kdWN0X3ZpZXciXQ=='


### PR DESCRIPTION
Use the Base URL instead of the Base link URL when creating ESI links. Should be an internal reference.

### Description (*)
Magento default uses the `link` type which resolves the `base_link_url` which works when public facing urls, but not for internal references such as Varnish ESI requests, this is why we should use the `base_url`.

The link URL can result in 302 redirects which makes it impossible to load the ESI blocks.

### Manual testing scenarios (*)
1. Create a Magento store with a different `link url` and `base url`
2. Enable Varnish caching
3. The ESI blocks will now link to the base url instead of link url, and thereby no longer generate a 302 redirect to the base url

### Questions or comments
We have a multistore setup where the internal base url which differs from the public facing link url.
After this setup, all ESI blocks where no longer loaded, and the access log was displaying 302 redirects to the "base_url"

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#33059: ESI blocks should be internal links