### PR TITLE
32911 fixed product import with url key with spaces

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -3019,7 +3019,7 @@ class Product extends AbstractEntity
     {
         if (!empty($rowData[self::URL_KEY])) {
             $urlKey = (string) $rowData[self::URL_KEY];
-            return trim(strtolower($urlKey));
+            return $this->productUrl->formatUrlKey($urlKey);
         }
 
         if (!empty($rowData[self::COL_NAME])

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_with_spaces_in_url_key.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_with_spaces_in_url_key.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/** @var $product \Magento\Catalog\Model\Product */
+$product = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(\Magento\Catalog\Model\Product::class);
+$product->setTypeId(\Magento\Catalog\Model\Product\Type::TYPE_SIMPLE)
+    ->setAttributeSetId(4)
+    ->setWebsiteIds([1])
+    ->setName('Simple Product')
+    ->setSku('simple1')
+    ->setPrice(10)
+    ->setDescription('Description with <b>html tag</b>')
+    ->setTaxClassId(2)
+    ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+    ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
+    ->setCategoryIds([2])
+    ->setStockData(['use_config_manage_stock' => 1, 'qty' => 100, 'is_qty_decimal' => 0, 'is_in_stock' => 1])
+    ->setUrlKey('url with spaces 1')
+    ->save();
+
+/** @var $product \Magento\Catalog\Model\Product */
+$product = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(\Magento\Catalog\Model\Product::class);
+$product->setTypeId(\Magento\Catalog\Model\Product\Type::TYPE_SIMPLE)
+    ->setAttributeSetId(4)
+    ->setWebsiteIds([1])
+    ->setName('Simple Product 2')
+    ->setSku('simple2')
+    ->setPrice(10)
+    ->setDescription('Description with <b>html tag</b>')
+    ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+    ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
+    ->setCategoryIds([2])
+    ->setStockData(['use_config_manage_stock' => 1, 'qty' => 100, 'is_qty_decimal' => 0, 'is_in_stock' => 1])
+    ->setUrlKey('url with spaces 2')
+    ->save();

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_with_spaces_in_url_key_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_with_spaces_in_url_key_rollback.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Framework\Exception\NoSuchEntityException;
+
+\Magento\TestFramework\Helper\Bootstrap::getInstance()->getInstance()->reinitialize();
+
+/** @var \Magento\Framework\Registry $registry */
+$registry = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(\Magento\Framework\Registry::class);
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+
+/** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+$productRepository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()
+    ->get(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+try {
+    $product = $productRepository->get('simple1', false, null, true);
+    $productRepository->delete($product);
+    $product = $productRepository->get('simple2', false, null, true);
+    $productRepository->delete($product);
+} catch (NoSuchEntityException $e) {
+}
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', false);

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest/ProductUrlKeyTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/ProductTest/ProductUrlKeyTest.php
@@ -213,9 +213,9 @@ class ProductUrlKeyTest extends ProductTestBase
     public function testAddUpdateProductWithInvalidUrlKeys() : void
     {
         $products = [
-            'simple1' => 'cuvée merlot-cabernet igp pays d\'oc frankrijk',
+            'simple1' => 'cuvee-merlot-cabernet-igp-pays-d-oc-frankrijk',
             'simple2' => 'normal-url',
-            'simple3' => 'some!wrong\'url'
+            'simple3' => 'some-wrong-url'
         ];
         // added by _files/products_to_import_with_invalid_url_keys.csv
         $this->importedProducts[] = 'simple3';
@@ -328,10 +328,10 @@ class ProductUrlKeyTest extends ProductTestBase
     {
         $productsCreatedByFixture = [
             'ukrainian-with-url-key' => 'nove-im-ja-pislja-importu-scho-stane-url-key',
-            'ukrainian-without-url-key' => 'новий url key після імпорту',
+            'ukrainian-without-url-key' => 'novij-url-key-pislja-importu',
         ];
         $productsImportedByCsv = [
-            'imported-ukrainian-with-url-key' => 'імпортований продукт',
+            'imported-ukrainian-with-url-key' => 'importovanij-produkt',
             'imported-ukrainian-without-url-key' => 'importovanij-produkt-bez-url-key',
         ];
         $productSkuMap = array_merge($productsCreatedByFixture, $productsImportedByCsv);
@@ -359,6 +359,44 @@ class ProductUrlKeyTest extends ProductTestBase
         /** @var ProductRepositoryInterface $productRepository */
         $productRepository = $this->objectManager->create(ProductRepositoryInterface::class);
         foreach ($productSkuMap as $productSku => $productUrlKey) {
+            $this->assertEquals($productUrlKey, $productRepository->get($productSku)->getUrlKey());
+        }
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/product_simple_with_spaces_in_url_key.php
+     * @magentoDbIsolation disabled
+     * @magentoAppIsolation enabled
+     * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function testImportWithSpacesInUrlKeys()
+    {
+        $products = [
+            'simple1' => 'url-with-spaces-1',
+            'simple2' => 'url-with-spaces-2'
+        ];
+        $filesystem = $this->objectManager->create(\Magento\Framework\Filesystem::class);
+        $directory = $filesystem->getDirectoryWrite(DirectoryList::ROOT);
+        $source = $this->objectManager->create(
+            \Magento\ImportExport\Model\Import\Source\Csv::class,
+            [
+                'file' => __DIR__ . '/../_files/products_to_import_with_spaces_in_url_keys.csv',
+                'directory' => $directory,
+            ]
+        );
+        $errors = $this->_model->setParameters(
+            ['behavior' => \Magento\ImportExport\Model\Import::BEHAVIOR_ADD_UPDATE, 'entity' => 'catalog_product']
+        )
+            ->setSource($source)
+            ->validateData();
+
+        $this->assertEquals($errors->getErrorsCount(), 0);
+        $this->_model->importData();
+
+        /** @var ProductRepositoryInterface $productRepository */
+        $productRepository = $this->objectManager->create(ProductRepositoryInterface::class);
+        foreach ($products as $productSku => $productUrlKey) {
             $this->assertEquals($productUrlKey, $productRepository->get($productSku)->getUrlKey());
         }
     }

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/products_to_import_with_spaces_in_url_keys.csv
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/products_to_import_with_spaces_in_url_keys.csv
@@ -1,0 +1,3 @@
+sku,product_type,store_view_code,name,price,attribute_set_code,url_key
+simple1,simple,,"simple 1",25,Default,"url with spaces 1"
+simple2,simple,,"simple 2",34,Default,"url with spaces 2"


### PR DESCRIPTION
### Description (*)
I changed \Magento\CatalogImportExport\Model\Import\Product class as suggested in [issue](https://github.com/magento/magento2/issues/32911) and add integration test.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#32911

### Manual testing scenarios (*)
1. Create a product with sku: ABC
2. Create import file 
```
"sku", "url_key"
"ABC", "Test ABC 1 2 3"
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
