### PR TITLE
#33094 Renamed confusing store select labels - Login As Customer

### DIFF
--- a/app/code/Magento/LoginAsCustomer/Test/Mftf/Section/AdminCustomerConfigSection.xml
+++ b/app/code/Magento/LoginAsCustomer/Test/Mftf/Section/AdminCustomerConfigSection.xml
@@ -13,6 +13,6 @@
         <element name="loginAsCustomerSettingsHead" type="text" selector="#login_as_customer_general-head" timeout="30"/>
         <element name="enableExtensionLabel" type="text" selector="//span[contains(text(),'Enable Extension') and contains(@data-config-scope,'[GLOBAL]')]" timeout="30"/>
         <element name="disablePageCacheLabel" type="text" selector="//span[contains(text(),'Disable Page Cache For Admin User') and contains(@data-config-scope,'[GLOBAL]')]" timeout="30"/>
-        <element name="storeViewToLoginToLabel" type="text" selector="//span[contains(text(),'Store View To Login To') and contains(@data-config-scope,'[GLOBAL]')]" timeout="30"/>
+        <element name="storeViewToLoginToLabel" type="text" selector="//span[contains(text(),'Store To Login To') and contains(@data-config-scope,'[GLOBAL]')]" timeout="30"/>
     </section>
 </sections>

--- a/app/code/Magento/LoginAsCustomerAdminUi/Controller/Adminhtml/Login/Login.php
+++ b/app/code/Magento/LoginAsCustomerAdminUi/Controller/Adminhtml/Login/Login.php
@@ -200,7 +200,7 @@ class Login extends Action implements HttpPostActionInterface
         if ($this->config->isStoreManualChoiceEnabled()) {
             $storeId = (int)$this->_request->getParam('store_id');
             if (empty($storeId)) {
-                $messages[] = __('Please select a Store View to login in.');
+                $messages[] = __('Please select a Store to login in.');
                 return $this->prepareJsonResult($messages);
             }
         } elseif ($this->share->isGlobalScope()) {

--- a/app/code/Magento/LoginAsCustomerAdminUi/etc/adminhtml/system.xml
+++ b/app/code/Magento/LoginAsCustomerAdminUi/etc/adminhtml/system.xml
@@ -19,7 +19,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="store_view_manual_choice_enabled" translate="label comment" type="select" sortOrder="40" showInDefault="1" canRestore="1">
-                    <label>Store View To Login To</label>
+                    <label>Store To Login To</label>
                     <source_model>Magento\LoginAsCustomerAdminUi\Model\Config\Source\StoreViewLogin</source_model>
                     <comment><![CDATA[
                             Use the "Manual Selection" option on a multi-website setup that has "Share Customer Accounts" enabled globally.

--- a/app/code/Magento/LoginAsCustomerAdminUi/view/adminhtml/web/js/confirmation-popup.js
+++ b/app/code/Magento/LoginAsCustomerAdminUi/view/adminhtml/web/js/confirmation-popup.js
@@ -36,7 +36,7 @@ define([
                         data: {
                             showStoreViewOptions: self.showStoreViewOptions,
                             storeViewOptions: self.storeViewOptions,
-                            label: $t('Store View')
+                            label: $t('Store')
                         }
                     }) + content;
             }


### PR DESCRIPTION

### Description (*)
Renamed confusing store select labels at admin login as customers related config and modal window


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#33094

### Manual testing scenarios (*)
1. Set Store View To Login To to Manual Selection in Stores -> Configuration -> Customers -> Login as Customer
2. Go to Customer edit page and click Login as Customer

