### PR TITLE
Mark Exceptions as API

### DIFF
--- a/app/code/Magento/Checkout/Api/Exception/PaymentProcessingRateLimitExceededException.php
+++ b/app/code/Magento/Checkout/Api/Exception/PaymentProcessingRateLimitExceededException.php
@@ -12,6 +12,8 @@ use Magento\Framework\Exception\LocalizedException;
 
 /**
  * Thrown when too many payment processing/saving requests have been initiated by a user.
+ *
+ * @api
  */
 class PaymentProcessingRateLimitExceededException extends LocalizedException
 {

--- a/app/code/Magento/SalesRule/Api/Exception/CodeRequestLimitException.php
+++ b/app/code/Magento/SalesRule/Api/Exception/CodeRequestLimitException.php
@@ -12,6 +12,8 @@ use Magento\Framework\Exception\LocalizedException;
 
 /**
  * Thrown when coupon codes requests limit is reached.
+ *
+ * @api
  */
 class CodeRequestLimitException extends LocalizedException
 {


### PR DESCRIPTION
### Description (*)
This is recreated PR (https://github.com/magento/magento2/pull/32085)

The follwoing Exceptions marked as API:

1. app/code/Magento/Checkout/Api/Exception/PaymentProcessingRateLimitExceededException.php
2. app/code/Magento/SalesRule/Api/Exception/CodeRequestLimitException.php

### Fixed Issues (if relevant)
1. Fixes magento/magento2#32039

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
