### PR TITLE
Update di.xml to support MariaDB 10.5.x

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -1845,7 +1845,7 @@
             <argument name="supportedVersionPatterns" xsi:type="array">
                 <item name="MySQL-8" xsi:type="string">^8\.0\.</item>
                 <item name="MySQL-5.7" xsi:type="string">^5\.7\.</item>
-                <item name="MariaDB-(10.2-10.4)" xsi:type="string">^10\.[2-4]\.</item>
+                <item name="MariaDB-(10.2-10.5)" xsi:type="string">^10\.[2-5]\.</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Update di.xml to support MariaDB 10.5.x

### Description (*)

Magento seems to already support MariaDB 10.5, but not explicitly yet.

### Related Pull Requests

* Follow up of #31499 (no CLA was signed for that PR)

### Fixed Issues (if relevant)

1. Fixes magento/magento2#31109

### Manual testing scenarios (*)

Not sure what testing procedures Magento follows when a new db version is added.

1. Setup Magento on MariaDB 10.5
2. Run the application
3. Profit? 😄 

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
