### PR TITLE
MFTF: Checkout With Minimum Order Amount Option Enabled Test

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/Data/ProductData.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Data/ProductData.xml
@@ -1432,4 +1432,18 @@
         <data key="name" unique="suffix">ProductWithSku24MB06-</data>
         <data key="sku" unique="suffix">24 MB06 </data>
     </entity>
+    <entity name="SimpleProduct50" type="product">
+        <data key="name" unique="suffix">Simple Product </data>
+        <data key="sku" unique="suffix">SimpleProduct</data>
+        <data key="urlKey" unique="suffix">simple-product-</data>
+        <data key="type_id">simple</data>
+        <data key="attribute_set_id">4</data>
+        <data key="price">50.00</data>
+        <data key="visibility">4</data>
+        <data key="status">1</data>
+        <data key="quantity">1000</data>
+        <data key="weight">1</data>
+        <requiredEntity type="product_extension_attribute">EavStockItem</requiredEntity>
+        <requiredEntity type="custom_attribute_array">CustomAttributeCategoryIds</requiredEntity>
+    </entity>
 </entities>

--- a/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontProceedToCheckoutButtonDisabledActionGroup.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/ActionGroup/AssertStorefrontProceedToCheckoutButtonDisabledActionGroup.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AssertStorefrontProceedToCheckoutButtonDisabledActionGroup">
+        <seeElement selector="{{CheckoutCartSummarySection.proceedToCheckoutDisabled}}" stepKey="assertCheckoutBtnDisabled"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutCartSummarySection.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutCartSummarySection.xml
@@ -37,5 +37,6 @@
         <element name="shippingPrice" type="text" selector="#co-shipping-method-form span .price"/>
         <element name="shippingMethodElementId" type="radio" selector="#s_method_{{carrierCode}}_{{methodCode}}" parameterized="true" timeout="30"/>
         <element name="estimateShippingAndTaxForm" type="block" selector="#shipping-zip-form"/>
+        <element name="proceedToCheckoutDisabled" type="button" selector=".action.primary.checkout.disabled" timeout="60"/>
     </section>
 </sections>

--- a/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckoutWithEnabledMinimumOrderAmountOptionTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/StorefrontCheckoutWithEnabledMinimumOrderAmountOptionTest.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontCheckoutWithEnabledMinimumOrderAmountOptionTest">
+        <annotations>
+            <features value="Sales"/>
+            <stories value="Order Placement With Enabled Minimum Order Amount Option"/>
+            <title value="Minimum Order Amount Option Enabled for Checkout"/>
+            <description value="Customer should not be able to place an order with if minimum order amount was not reached"/>
+            <severity value="MAJOR"/>
+            <group value="checkout"/>
+        </annotations>
+        <before>
+            <magentoCLI command="config:set {{EnableMinimumOrderAmountConfigData.path}} {{EnableMinimumOrderAmountConfigData.value}}" stepKey="enableMinimumOrderAmount"/>
+            <magentoCLI command="config:set {{SetMinimumOrderAmount100ConfigData.path}} {{SetMinimumOrderAmount100ConfigData.value}}" stepKey="setMinimumOrderAmount100"/>
+            <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
+            <createData entity="SimpleSubCategory" stepKey="createCategory"/>
+            <createData entity="SimpleProduct50" stepKey="createProduct">
+                <requiredEntity createDataKey="createCategory"/>
+            </createData>
+            <actionGroup ref="CliCacheCleanActionGroup" stepKey="cleanInvalidatedCaches">
+                <argument name="tags" value="config full_page"/>
+            </actionGroup>
+        </before>
+        <after>
+            <magentoCLI command="config:set {{DisableMinimumOrderAmountConfigData.path}} {{DisableMinimumOrderAmountConfigData.value}}" stepKey="disableMinimumOrderAmount"/>
+            <magentoCLI command="config:set {{SetDefaultMinimumOrderAmountConfigData.path}} {{SetDefaultMinimumOrderAmountConfigData.value}}" stepKey="setMinimumOrderAmountDefaultValue"/>
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
+            <actionGroup ref="StorefrontCustomerLogoutActionGroup" stepKey="logoutCustomer"/>
+            <deleteData createDataKey="createCustomer" stepKey="deleteCustomer"/>
+            <actionGroup ref="CliCacheCleanActionGroup" stepKey="cleanInvalidatedCaches">
+                <argument name="tags" value="config full_page"/>
+            </actionGroup>
+        </after>
+
+        <actionGroup ref="LoginToStorefrontActionGroup" stepKey="loginToStorefrontAccount">
+            <argument name="Customer" value="$createCustomer$"/>
+        </actionGroup>
+        <actionGroup ref="OpenProductFromCategoryPageActionGroup" stepKey="openProductFromCategory">
+            <argument name="category" value="$createCategory$"/>
+            <argument name="product" value="$createProduct$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontAddProductToCartWithQtyActionGroup" stepKey="addProductToTheCart">
+            <argument name="productQty" value="1"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontCartPageOpenActionGroup" stepKey="navigateToCartPage"/>
+        <actionGroup ref="AssertMessageCustomerChangeAccountInfoActionGroup" stepKey="assertMessage">
+            <argument name="message" value="Minimum order amount is $100.00"/>
+            <argument name="messageType" value="notice"/>
+        </actionGroup>
+        <actionGroup ref="AssertStorefrontProceedToCheckoutButtonDisabledActionGroup" stepKey="assertCheckoutBtnDisabled"/>
+        <actionGroup ref="OpenProductFromCategoryPageActionGroup" stepKey="navigateToProductPage">
+            <argument name="category" value="$createCategory$"/>
+            <argument name="product" value="$createProduct$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontAddProductToCartWithQtyActionGroup" stepKey="addSecondProductToTheCart">
+            <argument name="productQty" value="1"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontCartPageOpenActionGroup" stepKey="openShoppingCartPage"/>
+        <actionGroup ref="StorefrontClickProceedToCheckoutActionGroup" stepKey="goToCheckout"/>
+        <actionGroup ref="CheckoutSelectFlatRateShippingMethodActionGroup" stepKey="selectFlatRate"/>
+        <actionGroup ref="StorefrontCheckoutForwardFromShippingStepActionGroup" stepKey="goToReview"/>
+        <actionGroup ref="CheckoutSelectCheckMoneyOrderPaymentActionGroup" stepKey="selectCheckMoneyOrder"/>
+        <actionGroup ref="CheckoutPlaceOrderActionGroup" stepKey="clickOnPlaceOrder">
+            <argument name="orderNumberMessage" value="CONST.successCheckoutOrderNumberMessage"/>
+            <argument name="emailYouMessage" value="CONST.successCheckoutEmailYouMessage"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/Sales/Test/Mftf/Data/SalesConfigData.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Data/SalesConfigData.xml
@@ -24,4 +24,20 @@
     <entity name="DisableMinimumOrderCheck" type="active">
         <data key="value">0</data>
     </entity>
+    <entity name="EnableMinimumOrderAmountConfigData">
+        <data key="path">sales/minimum_order/active</data>
+        <data key="value">1</data>
+    </entity>
+    <entity name="DisableMinimumOrderAmountConfigData">
+        <data key="path">sales/minimum_order/active</data>
+        <data key="value">0</data>
+    </entity>
+    <entity name="SetMinimumOrderAmount100ConfigData">
+        <data key="path">sales/minimum_order/amount</data>
+        <data key="value">100</data>
+    </entity>
+    <entity name="SetDefaultMinimumOrderAmountConfigData">
+        <data key="path">sales/minimum_order/amount</data>
+        <data key="value">0</data>
+    </entity>
 </entities>


### PR DESCRIPTION
This PR contains MFTF test for checkout with minimum order amount option enabled.

**Steps to reproduce:**

1 - Configure minimum order amount
2 - Add the product into shopping cart (minimum order amount is not reached)
3 - Add product into shopping cart second time, to reach minimum order amount
4 - Place order
5 - Perform Assertions

### Resolved issues:
1. [x] resolves magento/magento2#33460: MFTF: Checkout With Minimum Order Amount Option Enabled Test