### PR TITLE
- magento/magento2#33138: Rest API and Magento backend use different …

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
@@ -6,7 +6,6 @@
  */
 namespace Magento\Catalog\Model\Product\Attribute;
 
-use Laminas\Validator\Regex;
 use Magento\Catalog\Api\Data\EavAttributeInterface;
 use Magento\Eav\Model\Entity\Attribute;
 use Magento\Framework\Exception\InputException;
@@ -252,8 +251,10 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
             0,
             Attribute::ATTRIBUTE_CODE_MAX_LENGTH
         );
-        $validatorAttrCode = new Regex(['pattern' => '/^[a-z][a-z_0-9]{0,29}[a-z0-9]$/']);
-        if (!$validatorAttrCode->isValid($code)) {
+
+        try {
+            $this->validateCode($code);
+        } catch (InputException $e) {
             $code = 'attr_' . ($code ?: substr(hash('sha256', time()), 0, 8));
         }
 

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
@@ -57,6 +57,11 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
     protected $searchCriteriaBuilder;
 
     /**
+     * @var \Magento\Eav\Model\Validator\Attribute\Code
+     */
+    protected $attributeCodeValidator;
+
+    /**
      * @param \Magento\Catalog\Model\ResourceModel\Attribute $attributeResource
      * @param \Magento\Catalog\Helper\Product $productHelper
      * @param \Magento\Framework\Filter\FilterManager $filterManager
@@ -64,6 +69,7 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
      * @param \Magento\Eav\Model\Config $eavConfig
      * @param \Magento\Eav\Model\Adminhtml\System\Config\Source\Inputtype\ValidatorFactory $validatorFactory
      * @param \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder
+     * @param \Magento\Eav\Model\Validator\Attribute\Code $attributeCodeValidator
      */
     public function __construct(
         \Magento\Catalog\Model\ResourceModel\Attribute $attributeResource,
@@ -72,7 +78,8 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
         \Magento\Eav\Api\AttributeRepositoryInterface $eavAttributeRepository,
         \Magento\Eav\Model\Config $eavConfig,
         \Magento\Eav\Model\Adminhtml\System\Config\Source\Inputtype\ValidatorFactory $validatorFactory,
-        \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder
+        \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder,
+        \Magento\Eav\Model\Validator\Attribute\Code $attributeCodeValidator
     ) {
         $this->attributeResource = $attributeResource;
         $this->productHelper = $productHelper;
@@ -81,6 +88,7 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
         $this->eavConfig = $eavConfig;
         $this->inputtypeValidatorFactory = $validatorFactory;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->attributeCodeValidator = $attributeCodeValidator;
     }
 
     /**
@@ -261,10 +269,8 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
      */
     protected function validateCode($code)
     {
-        $validatorAttrCode = new Regex(
-            ['pattern' => '/^[a-z][a-z_0-9]{0,' . Attribute::ATTRIBUTE_CODE_MAX_LENGTH . '}$/']
-        );
-        if (!$validatorAttrCode->isValid($code)) {
+        $isValid = $this->attributeCodeValidator->isValid($code);
+        if (!$isValid) {
             throw InputException::invalidFieldValue('attribute_code', $code);
         }
     }

--- a/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
@@ -6,6 +6,7 @@
  */
 namespace Magento\Catalog\Model\Product\Attribute;
 
+use Laminas\Validator\Regex;
 use Magento\Catalog\Api\Data\EavAttributeInterface;
 use Magento\Eav\Model\Entity\Attribute;
 use Magento\Framework\Exception\InputException;
@@ -252,9 +253,8 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
             Attribute::ATTRIBUTE_CODE_MAX_LENGTH
         );
 
-        try {
-            $this->validateCode($code);
-        } catch (InputException $e) {
+        $validatorAttrCode = new Regex(['pattern' => '/^[a-z][a-z_0-9]{0,29}[a-z0-9]$/']);
+        if (!$validatorAttrCode->isValid($code)) {
             $code = 'attr_' . ($code ?: substr(hash('sha256', time()), 0, 8));
         }
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/RepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Attribute/RepositoryTest.php
@@ -20,6 +20,7 @@ use Magento\Eav\Api\Data\AttributeFrontendLabelInterface;
 use Magento\Eav\Model\Adminhtml\System\Config\Source\Inputtype\ValidatorFactory;
 use Magento\Eav\Model\Config;
 use Magento\Eav\Model\Entity\Attribute\FrontendLabel;
+use Magento\Eav\Model\Validator\Attribute\Code;
 use Magento\Framework\Api\SearchCriteria;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\SearchResultsInterface;
@@ -84,6 +85,11 @@ class RepositoryTest extends TestCase
     protected $searchResultMock;
 
     /**
+     * @var MockObject
+     */
+    protected $attributeCodeValidatorMock;
+
+    /**
      * @inheritdoc
      */
     protected function setUp(): void
@@ -111,6 +117,7 @@ class RepositoryTest extends TestCase
                     ['getItems', 'getSearchCriteria', 'getTotalCount', 'setItems', 'setSearchCriteria', 'setTotalCount']
                 )
                 ->getMockForAbstractClass();
+        $this->attributeCodeValidatorMock = $this->createMock(Code::class);
 
         $this->model = new Repository(
             $this->attributeResourceMock,
@@ -119,7 +126,8 @@ class RepositoryTest extends TestCase
             $this->eavAttributeRepositoryMock,
             $this->eavConfigMock,
             $this->validatorFactoryMock,
-            $this->searchCriteriaBuilderMock
+            $this->searchCriteriaBuilderMock,
+            $this->attributeCodeValidatorMock
         );
     }
 


### PR DESCRIPTION
…validation methods for attribute_code when creating new attributes

### Description (*)

When creating new product attributes through Rest-APIs 'rest/V1/products/attributes' endpoint, the validation is done through Magento\Catalog\Model\Product\Attribute\Repository::validateCode method.
The method validates against the regex "/^[a-z][a-z_0-9]{0,60}$/", which is hardcoded into the method.
When creating a new attribute through the Magento2 backend, this validation is done by Magento\Eav\Model\Validator\Attribute\Code::isValid, which uses a different regex: "/^[a-zA-Z]+[a-zA-Z0-9_]*$/u'"
The result is that attributes that are created through backend can have capital letters in the attribute code, while attributes created through Rest-API cannot.

Solution:

Using the Magento\Eav\Model\Validator\Attribute\Code::isValid method inside Magento\Catalog\Model\Product\Attribute\Repository::validateCode.
This way both kinds of creation methodologies for product attributes behave the same.
Furthermore, we increase code reuse and reduce badly duplicated code.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#33138

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Setup Rest-API and send a request to create a product attribute with an attribute code that has uppercase letters, e.g. "Test_Attribute2" (see sample script below)
2. Expect to get a success message.

Example script I have used to determine that the fix works:
```
BASE_URL='http://localhost/'
TOKEN=$(curl -X POST "${BASE_URL}index.php/rest/V1/integration/admin/token" \
-H "Content-Type:application/json" \
-d '{"username":"admin", "password":"password123"}')
TOKEN=$(echo $TOKEN | sed "s/\"//g");

curl -X POST "${BASE_URL}index.php/rest/V1/products/attributes" \
-H "authorization: Bearer ${TOKEN}" \
-H 'content-type: application/json' \
-d '{
 "attribute": {
   "attribute_code": "branding_Tester4",
   "default_frontend_label": "Testing",
   "frontend_input": "text"
 }
}'
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
