### PR TITLE
Allow shipment update emails to be disabled

### DIFF
--- a/app/code/Magento/Shipping/view/adminhtml/layout/adminhtml_order_shipment_view.xml
+++ b/app/code/Magento/Shipping/view/adminhtml/layout/adminhtml_order_shipment_view.xml
@@ -22,7 +22,11 @@
                         <block class="Magento\Sales\Block\Adminhtml\Items\Column\Name" name="column_name" template="Magento_Sales::items/column/name.phtml" group="column"/>
                         <block class="Magento\Framework\View\Element\Text\ListText" name="order_item_extra_info"/>
                     </block>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="Magento_Sales::order/comments/view.phtml"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\Comments\View" name="order_comments" template="Magento_Sales::order/comments/view.phtml">
+                        <action method="setParentType">
+                            <argument name="type" xsi:type="string">shipment</argument>
+                        </action>
+                    </block>
                     <block class="Magento\Shipping\Block\Adminhtml\Order\Tracking\View" name="shipment_tracking" template="Magento_Shipping::order/tracking/view.phtml"/>
                     <block class="Magento\Shipping\Block\Adminhtml\Order\Packaging" name="shipment_packaging" template="Magento_Shipping::order/packaging/popup.phtml"/>
                     <block class="Magento\Shipping\Block\Adminhtml\Order\Packaging" name="shipment_packed" template="Magento_Shipping::order/packaging/packed.phtml"/>


### PR DESCRIPTION
### Description

Already in place for invoices and creditmemos:

https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Sales/view/adminhtml/layout/sales_order_invoice_view.xml#L26-L30

https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Sales/view/adminhtml/layout/sales_order_creditmemo_view.xml#L25-L29

### Fixed Issues (if relevant)

1. Fixes magento/magento2#33165

### Manual testing scenarios

See #33165

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
