### PR TITLE
Set self closing tags for void elements

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Csp/CspUtilTest.php
+++ b/dev/tests/integration/testsuite/Magento/Csp/CspUtilTest.php
@@ -30,7 +30,7 @@ class CspUtilTest extends AbstractController
         $content = $this->getResponse()->getContent();
 
         $this->assertStringContainsString(
-            '<script src="http&#x3A;&#x2F;&#x2F;my.magento.com&#x2F;static&#x2F;script.js"/>',
+            '<script src="http&#x3A;&#x2F;&#x2F;my.magento.com&#x2F;static&#x2F;script.js"></script>',
             $content
         );
         $this->assertStringContainsString("<script>\n    let myVar = 1;\n</script>", $content);

--- a/dev/tests/integration/testsuite/Magento/Csp/Helper/InlineUtilTest.php
+++ b/dev/tests/integration/testsuite/Magento/Csp/Helper/InlineUtilTest.php
@@ -96,7 +96,7 @@ class InlineUtilTest extends TestCase
                 'script',
                 ['src' => 'http://magento.com/static/some-script.js'],
                 null,
-                '<script src="http&#x3A;&#x2F;&#x2F;magento.com&#x2F;static&#x2F;some-script.js"/>',
+                '<script src="http&#x3A;&#x2F;&#x2F;magento.com&#x2F;static&#x2F;some-script.js"></script>',
                 [new FetchPolicy('script-src', false, ['http://magento.com'])]
             ],
             'inline-script' => [
@@ -209,7 +209,7 @@ class InlineUtilTest extends TestCase
                 'iframe',
                 ['src' => 'http://magento.com/some-page'],
                 null,
-                '<iframe src="http&#x3A;&#x2F;&#x2F;magento.com&#x2F;some-page"/>',
+                '<iframe src="http&#x3A;&#x2F;&#x2F;magento.com&#x2F;some-page"></iframe>',
                 [new FetchPolicy('frame-src', false, ['http://magento.com'])]
             ],
             'remote-track' => [
@@ -230,21 +230,21 @@ class InlineUtilTest extends TestCase
                 'video',
                 ['src' => 'https://magento.com/static/video.mp4'],
                 null,
-                '<video src="https&#x3A;&#x2F;&#x2F;magento.com&#x2F;static&#x2F;video.mp4"/>',
+                '<video src="https&#x3A;&#x2F;&#x2F;magento.com&#x2F;static&#x2F;video.mp4"></video>',
                 [new FetchPolicy('media-src', false, ['https://magento.com'])]
             ],
             'remote-audio' => [
                 'audio',
                 ['src' => 'https://magento.com/static/audio.mp3'],
                 null,
-                '<audio src="https&#x3A;&#x2F;&#x2F;magento.com&#x2F;static&#x2F;audio.mp3"/>',
+                '<audio src="https&#x3A;&#x2F;&#x2F;magento.com&#x2F;static&#x2F;audio.mp3"></audio>',
                 [new FetchPolicy('media-src', false, ['https://magento.com'])]
             ],
             'remote-object' => [
                 'object',
                 ['data' => 'http://magento.com/static/flash.swf'],
                 null,
-                '<object data="http&#x3A;&#x2F;&#x2F;magento.com&#x2F;static&#x2F;flash.swf"/>',
+                '<object data="http&#x3A;&#x2F;&#x2F;magento.com&#x2F;static&#x2F;flash.swf"></object>',
                 [new FetchPolicy('object-src', false, ['http://magento.com'])]
             ],
             'remote-embed' => [
@@ -259,7 +259,7 @@ class InlineUtilTest extends TestCase
                 ['code' => 'SomeApplet.class', 'archive' => 'https://magento.com/applet/my-applet.jar'],
                 null,
                 '<applet code="SomeApplet.class" '
-                    . 'archive="https&#x3A;&#x2F;&#x2F;magento.com&#x2F;applet&#x2F;my-applet.jar"/>',
+                    . 'archive="https&#x3A;&#x2F;&#x2F;magento.com&#x2F;applet&#x2F;my-applet.jar"></applet>',
                 [new FetchPolicy('object-src', false, ['https://magento.com'])]
             ]
         ];
@@ -294,7 +294,7 @@ class InlineUtilTest extends TestCase
         $eventListener = $this->secureHtmlRenderer->renderEventListener('onclick', 'alert()');
 
         $this->assertEquals(
-            '<script src="https&#x3A;&#x2F;&#x2F;test.magento.com&#x2F;static&#x2F;script.js"/>',
+            '<script src="https&#x3A;&#x2F;&#x2F;test.magento.com&#x2F;static&#x2F;script.js"></script>',
             $scriptTag
         );
         $this->assertEquals(

--- a/dev/tests/integration/testsuite/Magento/Framework/View/Helper/SecureHtmlRendererTemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Helper/SecureHtmlRendererTemplateTest.php
@@ -33,7 +33,7 @@ class SecureHtmlRendererTemplateTest extends AbstractController
             $content
         );
         $this->assertStringContainsString(
-            '<script src="http&#x3A;&#x2F;&#x2F;my.magento.com&#x2F;static&#x2F;script.js"/>',
+            '<script src="http&#x3A;&#x2F;&#x2F;my.magento.com&#x2F;static&#x2F;script.js"></script>',
             $content
         );
         $this->assertStringContainsString(

--- a/lib/internal/Magento/Framework/View/Helper/SecureHtmlRender/HtmlRenderer.php
+++ b/lib/internal/Magento/Framework/View/Helper/SecureHtmlRender/HtmlRenderer.php
@@ -74,7 +74,7 @@ class HtmlRenderer
         }
 
         $html = '<' .$tagData->getTag() .$attributesHtml;
-        if (in_array($tagData->getTag(), self::VOID_ELEMENTS)) {
+        if (isset(self::VOID_ELEMENTS_MAP[$tagData->getTag()])) {
             $html .= '/>';
         } else {
             $html .= '>' .$content .'</' .$tagData->getTag() .'>';

--- a/lib/internal/Magento/Framework/View/Helper/SecureHtmlRender/HtmlRenderer.php
+++ b/lib/internal/Magento/Framework/View/Helper/SecureHtmlRender/HtmlRenderer.php
@@ -19,23 +19,23 @@ class HtmlRenderer
      *
      * @var array
      */
-    private const VOID_ELEMENTS = [
-        'area',
-        'base',
-        'br',
-        'col',
-        'command',
-        'embed',
-        'hr',
-        'img',
-        'input',
-        'keygen',
-        'link',
-        'meta',
-        'param',
-        'source',
-        'track',
-        'wbr'
+    private const VOID_ELEMENTS_MAP = [
+        'area' => true,
+        'base' => true,
+        'br' => true,
+        'col' => true,
+        'command' => true,
+        'embed' => true,
+        'hr' => true,
+        'img' => true,
+        'input' => true,
+        'keygen' => true,
+        'link' => true,
+        'meta' => true,
+        'param' => true,
+        'source' => true,
+        'track' => true,
+        'wbr' => true,
     ];
 
     /**

--- a/lib/internal/Magento/Framework/View/Helper/SecureHtmlRender/HtmlRenderer.php
+++ b/lib/internal/Magento/Framework/View/Helper/SecureHtmlRender/HtmlRenderer.php
@@ -13,6 +13,31 @@ use Magento\Framework\Escaper;
  */
 class HtmlRenderer
 {
+
+    /**
+     * List of void elements which require a self-closing tag and don't allow content
+     *
+     * @var array
+     */
+    private const VOID_ELEMENTS = [
+        'area',
+        'base',
+        'br',
+        'col',
+        'command',
+        'embed',
+        'hr',
+        'img',
+        'input',
+        'keygen',
+        'link',
+        'meta',
+        'param',
+        'source',
+        'track',
+        'wbr'
+    ];
+
     /**
      * @var Escaper
      */
@@ -49,10 +74,10 @@ class HtmlRenderer
         }
 
         $html = '<' .$tagData->getTag() .$attributesHtml;
-        if ($content) {
-            $html .= '>' .$content .'</' .$tagData->getTag() .'>';
-        } else {
+        if (in_array($tagData->getTag(), self::VOID_ELEMENTS)) {
             $html .= '/>';
+        } else {
+            $html .= '>' .$content .'</' .$tagData->getTag() .'>';
         }
 
         return $html;

--- a/lib/internal/Magento/Framework/View/Test/Unit/Helper/SecureHtmlRenderer/HtmlRendererTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Helper/SecureHtmlRenderer/HtmlRendererTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\View\Test\Unit\Helper\SecureHtmlRenderer;
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRender\HtmlRenderer;
+use Magento\Framework\View\Helper\SecureHtmlRender\TagData;
+use PHPUnit\Framework\TestCase;
+
+class HtmlRendererTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->escaperMock = $this->createMock(Escaper::class);
+    }
+
+    /**
+     * @covers \Magento\Framework\View\Helper\SecureHtmlRender\HtmlRenderer::renderTag
+     */
+    public function testRenderTag()
+    {
+        $helper = new HtmlRenderer($this->escaperMock);
+
+        /** Test void element to have closing tag */
+        $tag = new TagData('hr', [], null, true);
+        $this->assertEquals(
+            "<hr/>",
+            $helper->renderTag($tag)
+        );
+
+        /** Test void element to never have content */
+        $tag = new TagData('hr', [], 'content', false);
+        $this->assertEquals(
+            "<hr/>",
+            $helper->renderTag($tag)
+        );
+
+        /** Test any non-void element to not have a closing tag and allow content */
+        $tags = new TagData('script', [], 'content', false);
+        $this->assertEquals(
+            "<script>content</script>",
+            $helper->renderTag($tags)
+        );
+    }
+}

--- a/lib/internal/Magento/Framework/View/Test/Unit/Helper/SecureHtmlRenderer/HtmlRendererTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Helper/SecureHtmlRenderer/HtmlRendererTest.php
@@ -43,6 +43,13 @@ class HtmlRendererTest extends TestCase
             $helper->renderTag($tag)
         );
 
+        /** Test any non-void element to not have a closing tag while not having content */
+        $tags = new TagData('script', [], null, false);
+        $this->assertEquals(
+            "<script></script>",
+            $helper->renderTag($tags)
+        );
+
         /** Test any non-void element to not have a closing tag and allow content */
         $tags = new TagData('script', [], 'content', false);
         $this->assertEquals(


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR adds a fix to prevent html tags to be rendered in a wrong way. If a tag doesn't have content it's always self-closing, adding a script tag without content will therefor not work. 

Tags like hr, br, input, img, etc. are forbidden to be closed - they must be self-closing and are not allowed to have content. 

This change checks if the element type is void to determine if the tag should be self-closing.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#32822

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
There's currently no steps you can take inside Magento to test this, as all present script tags have content. Adding a script tag without content (like <script/>, or what happens in many scenarios, <script src="script.js"/>) will trigger the issue.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
I have written a unit test to verify behaviour, please let me know if anything else is needed.
Related to this issue there might be the question wether it's a good practice to add external scripts this way - but this is not the function to validate this - this function should just take care of rendering the html tag.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
