### PR TITLE
#33204 - Fixed: Reset button not working in user/customer form at adminpanel

### DIFF
--- a/app/code/Magento/Search/Test/Mftf/Section/AdminSearchSynonymsNewSection.xml
+++ b/app/code/Magento/Search/Test/Mftf/Section/AdminSearchSynonymsNewSection.xml
@@ -10,7 +10,7 @@
           xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="AdminSearchSynonymsNewSection">
         <element name="save" type="button" selector="//button[@id='save']"/>
-        <element name="resetButton" type="button" selector="//button[@id='reset_ui_form']"/>
+        <element name="resetButton" type="button" selector="//button[@id='reset']"/>
         <element name="scope" type="select" selector="//select[@name='scope_id']"/>
         <element name="synonyms" type="textarea" selector="//textarea[@name='synonyms']"/>
         <element name="merge" type="checkbox" selector="//input[@name='mergeOnConflict']"/>

--- a/app/code/Magento/Search/Test/Mftf/Section/AdminSearchSynonymsNewSection.xml
+++ b/app/code/Magento/Search/Test/Mftf/Section/AdminSearchSynonymsNewSection.xml
@@ -10,7 +10,7 @@
           xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="AdminSearchSynonymsNewSection">
         <element name="save" type="button" selector="//button[@id='save']"/>
-        <element name="resetButton" type="button" selector="//button[@id='reset']"/>
+        <element name="resetButton" type="button" selector="//button[@id='reset_ui_form']"/>
         <element name="scope" type="select" selector="//select[@name='scope_id']"/>
         <element name="synonyms" type="textarea" selector="//textarea[@name='synonyms']"/>
         <element name="merge" type="checkbox" selector="//input[@name='mergeOnConflict']"/>

--- a/app/code/Magento/Ui/view/base/web/js/form/adapter/buttons.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/adapter/buttons.js
@@ -10,7 +10,7 @@ define(function () {
     'use strict';
 
     return {
-        'reset': '#reset',
+        'reset': '#reset_ui_form',
         'save': '#save',
         'saveAndContinue': '#save_and_continue'
     };


### PR DESCRIPTION
### Description (*)
This pull request contains the solution of the issue: #33204  -  "Reset" button in user form is not working. I have seen the same issue in customer edit form (Customers > All Customers > Edit customer page) as well. The solution applied in this pull request resolves both the issue as it is regarding reset button "id" which conflicts when there are two different forms (UI-component form and form created using block method) are used in the same page.

**Below is the explanation of the issue and applied solution:**
In Magento admin-forms, "Reset" button can be from either UI-components or using the block method. Both has difference in functionality however button "id" is same. Below are the two different "reset" button functions:

1. The reset button of UI-component form reloads page and sets intial values to form fields.
    - Associated file path: 
        - Magento/Ui/view/base/web/js/form/element/abstract.js (function name: reset)
        - Magento/Ui/view/base/web/js/form/adapter/buttons.js
          
2. The reset button of form which is created using the block method reloads and navigates to the main page.
    - Associated file path:
        - Magento/Backend/Block/Widget/Form/Container.php (line no: 105)

When any admin page contains both the forms (UI-component and block method), the "Reset" button doesn't work as its "id" is the same. I have changed the "id" of reset button in UI-component form to "reset_ui_form" which solves this issue.

### Related Pull Requests

### Fixed Issues (if relevant)
 1. Fixes magento/magento2#33204 - Reset button in User form doesn't work when 2FA enabled
 2. Fixes Reset button not working in customer edit page in admin panel.

### Manual testing scenarios (*)
 1. Enable two factor authentication module (Magento_TwoFactorAuth) and setup authentication. Login to admin panel and Navigate to Systems > Permissions > All Users. Select any user and open user edit form. Click on the Reset button and it will reload page.
 2. Navigate to Customers > All Customers > Edit customer page and click on reset button. It will reload page after applying this solution.
 3. In Customer/User edit form, Open other tabs in left section and click on reset button, It will reload page and navigate to first tab menu.

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
