### PR TITLE
32977 Fixed text area for Customizable Options on the Checkout Cart Page

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/default.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/default.phtml
@@ -48,7 +48,7 @@ $canApplyMsrp = $helper->isShowBeforeOrderConfirm($product) && $helper->isMinima
                             <dt><?= $block->escapeHtml($_option['label']) ?></dt>
                             <dd>
                                 <?php if (isset($_formatedOptionValue['full_view'])) :?>
-                                        <?= $block->escapeHtml($_formatedOptionValue['full_view']) ?>
+                                        <?= $block->escapeHtml($_formatedOptionValue['full_view'], ['span', 'a']) ?>
                                     <?php else :?>
                                     <?= $block->escapeHtml($_formatedOptionValue['value'], ['span', 'a']) ?>
                                 <?php endif; ?>

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_with_custom_option_text_area.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/product_simple_with_custom_option_text_area.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Catalog\Api\CategoryLinkManagementInterface;
+use Magento\Catalog\Api\Data\ProductCustomOptionInterface;
+use Magento\Catalog\Api\Data\ProductCustomOptionInterfaceFactory;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\Product\Type;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\TestFramework\Helper\Bootstrap;
+
+Bootstrap::getInstance()->reinitialize();
+
+/** @var \Magento\TestFramework\ObjectManager $objectManager */
+$objectManager = Bootstrap::getObjectManager();
+
+/** @var CategoryLinkManagementInterface $categoryLinkManagement */
+$categoryLinkManagement = $objectManager->create(CategoryLinkManagementInterface::class);
+
+/** @var $product Product */
+$product = $objectManager->create(Product::class);
+$product->isObjectNew(true);
+$product->setTypeId(Type::TYPE_SIMPLE)
+    ->setAttributeSetId(4)
+    ->setWebsiteIds([1])
+    ->setName('Simple Product')
+    ->setSku('simple_with_custom_option_text_area')
+    ->setPrice(10)
+    ->setWeight(1)
+    ->setShortDescription("Short description")
+    ->setTaxClassId(0)
+    ->setDescription('Description with <b>html tag</b>')
+    ->setMetaTitle('meta title')
+    ->setMetaKeyword('meta keyword')
+    ->setMetaDescription('meta description')
+    ->setVisibility(Visibility::VISIBILITY_BOTH)
+    ->setStatus(Status::STATUS_ENABLED)
+    ->setStockData(
+        [
+            'use_config_manage_stock' => 1,
+            'qty' => 100,
+            'is_qty_decimal' => 0,
+            'is_in_stock' => 1,
+        ]
+    )->setCanSaveCustomOptions(true)
+    ->setHasOptions(true);
+
+$oldOptions = [
+    [
+        'title' => 'area option',
+        'type' => 'area',
+        'is_require' => false,
+        'sort_order' => 1,
+        'price' => 20.0,
+        'price_type' => 'percent',
+        'sku' => 'sku_test',
+        'max_characters' => 350
+    ]
+];
+
+$options = [];
+
+/** @var ProductCustomOptionInterfaceFactory $customOptionFactory */
+$customOptionFactory = $objectManager->create(ProductCustomOptionInterfaceFactory::class);
+
+foreach ($oldOptions as $option) {
+    /** @var ProductCustomOptionInterface $option */
+    $option = $customOptionFactory->create(['data' => $option]);
+    $option->setProductSku($product->getSku());
+
+    $options[] = $option;
+}
+
+$product->setOptions($options);
+
+/** @var ProductRepositoryInterface $productRepositoryFactory */
+$productRepositoryFactory = $objectManager->create(ProductRepositoryInterface::class);
+$productRepositoryFactory->save($product);

--- a/dev/tests/integration/testsuite/Magento/Checkout/Block/Cart/Item/RendererTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Block/Cart/Item/RendererTest.php
@@ -113,8 +113,11 @@ class RendererTest extends TestCase
         $this->renderer->getLayout()->setBlock('checkout.item.price.row', $priceBlock);
         $html = $this->renderer->toHtml();
 
-        $this->assertMatchesRegularExpression('/Test product simple with
+        $this->assertMatchesRegularExpression(<<<EOT
+/Test product simple with
 custom option text area
-with more 50 characters/', $html);
+with more 50 characters/
+EOT
+, $html);
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Checkout/Block/Cart/Item/RendererTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Block/Cart/Item/RendererTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Checkout\Block\Cart\Item;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Item;
+use PHPUnit\Framework\TestCase;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/**
+ * Class RendererTest
+ * @package Magento\Checkout\Block\Cart\Item
+ * @magentoAppArea frontend
+ */
+class RendererTest extends TestCase
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var mixed
+     */
+    private $renderer;
+
+    /**
+     * @var mixed
+     */
+    public $productRepository;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->renderer = $this->objectManager->get(Renderer::class);
+        $this->productRepository = $this->objectManager->get(ProductRepositoryInterface::class);
+    }
+
+    /**
+     * Gets quote by reserved order id.
+     *
+     * @param string $reservedOrderId
+     * @return Quote
+     */
+    private function getQuote($reservedOrderId)
+    {
+        /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+        $searchCriteriaBuilder = $this->objectManager->get(SearchCriteriaBuilder::class);
+        $searchCriteria = $searchCriteriaBuilder->addFilter('reserved_order_id', $reservedOrderId)
+            ->create();
+
+        /** @var CartRepositoryInterface $quoteRepository */
+        $quoteRepository = $this->objectManager->get(CartRepositoryInterface::class);
+
+        /** @var Quote[] $items */
+        $items = $quoteRepository->getList($searchCriteria)->getItems();
+
+        return $items[0];
+    }
+
+    /**
+     * Gets \Magento\Quote\Model\Quote\Item from \Magento\Quote\Model\Quote by product id
+     *
+     * @param Quote $quote
+     * @param string|int $productId
+     *
+     * @return Item|null
+     */
+    private function _getQuoteItemIdByProductId($quote, $productId)
+    {
+        /** @var $quoteItems Item[] */
+        $quoteItems = $quote->getAllItems();
+        foreach ($quoteItems as $quoteItem) {
+            if ($productId == $quoteItem->getProductId()) {
+                return $quoteItem;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @magentoDataFixture Magento/Checkout/_files/cart_with_simple_product_and_custom_option_text_area.php
+     */
+    public function testTextAreaCustomOption()
+    {
+        $quote = $this->getQuote('test_order_item_with_custom_option_text_area');
+
+        /** @var $product Product */
+        $product = $this->productRepository->get('simple_with_custom_option_text_area');
+
+        $quoteItem = $this->_getQuoteItemIdByProductId($quote, $product->getId());
+        $this->assertNotNull($quoteItem, 'Cannot get quote item for simple product with custom option text area');
+
+        $template = 'Magento_Checkout::cart/item/default.phtml';
+        $this->renderer->setTemplate($template);
+        $this->renderer->setItem($quoteItem);
+
+        $priceBlock = $this->objectManager->create(\Magento\Checkout\Block\Item\Price\Renderer::class);
+        $this->renderer->getLayout()->setBlock('checkout.item.price.unit', $priceBlock);
+        $this->renderer->getLayout()->setBlock('checkout.item.price.row', $priceBlock);
+        $html = $this->renderer->toHtml();
+
+        $this->assertMatchesRegularExpression('/Test product simple with
+custom option text area
+with more 50 characters/', $html);
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/cart_with_simple_product_and_custom_option_text_area.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/cart_with_simple_product_and_custom_option_text_area.php
@@ -29,9 +29,11 @@ foreach ($product->getOptions() as $option) {
             $value = key($option->getValues());
             break;
         default:
-            $value = 'Test product simple with
+            $value = <<<EOT
+            Test product simple with
 custom option text area
-with more 50 characters';
+with more 50 characters
+EOT;
             break;
     }
     $options[$option->getId()] = $value;

--- a/dev/tests/integration/testsuite/Magento/Checkout/_files/cart_with_simple_product_and_custom_option_text_area.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/_files/cart_with_simple_product_and_custom_option_text_area.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+use Magento\Catalog\Api\Data\ProductCustomOptionInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product\Option;
+use Magento\Checkout\Model\Session;
+use Magento\Framework\DataObject;
+use Magento\Quote\Model\Quote;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\Workaround\Override\Fixture\Resolver;
+
+Resolver::getInstance()->requireDataFixture('Magento/Catalog/_files/product_simple_with_custom_option_text_area.php');
+
+/** @var ProductRepositoryInterface $productRepository */
+$productRepository = Bootstrap::getObjectManager()
+    ->create(ProductRepositoryInterface::class);
+$product = $productRepository->get('simple_with_custom_option_text_area');
+
+$options = [];
+/** @var $option Option */
+foreach ($product->getOptions() as $option) {
+    switch ($option->getGroupByType()) {
+        case ProductCustomOptionInterface::OPTION_GROUP_SELECT:
+            $value = key($option->getValues());
+            break;
+        default:
+            $value = 'Test product simple with
+custom option text area
+with more 50 characters';
+            break;
+    }
+    $options[$option->getId()] = $value;
+}
+
+$requestInfo = new DataObject(['qty' => 1, 'options' => $options]);
+
+/** @var $cart \Magento\Checkout\Model\Cart */
+$quote = Bootstrap::getObjectManager()->create(Quote::class);
+$quote->setReservedOrderId('test_order_item_with_custom_option_text_area');
+$quote->addProduct($product, $requestInfo);
+$quote->save();
+
+/** @var $objectManager \Magento\TestFramework\ObjectManager */
+$objectManager = Bootstrap::getObjectManager();
+$objectManager->removeSharedInstance(Session::class);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I created a solution in the file ( Magento/Checkout/view/frontend/templates/cart/item/default.phtml ). 
For the correct display of the text, need to add one or more AllowedTags ( ['span', 'a'] ) to the function call 
( $block->escapeHtml($_formatedOptionValue['full_view'], ['span', 'a'] ) by analogy with 
( $block->escapeHtml($_formatedOptionValue['value'], ['span', 'a']) ). 
If this is not done, then the formation of the text will take place without the pregmach function called on line 117 of the file 
( lib/internal/Magento/Framework/Escaper.php ) which leads to incorrect display of text.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#32977

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a simple product in the admin panel.
2. Create two customizable options both with text area option with 350 characters allowed.
3. On the product page enter less than 55 characters in one text area and more than 55 in the other both with spaces and line breaks.
<img width="535" alt="Screenshot 2021-06-16 at 12 14 57" src="https://user-images.githubusercontent.com/26867833/122192919-bf061900-ce9c-11eb-83c7-212868a7a3dc.png">
4. Add the item to your cart and go to the cart page. You will see the correct text display.
<img width="919" alt="Screenshot 2021-06-16 at 12 19 21" src="https://user-images.githubusercontent.com/26867833/122193385-1c9a6580-ce9d-11eb-84ff-fe31b04ed3aa.png">


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)

