### PR TITLE
Fixed notice if extension image is not found

### DIFF
--- a/lib/internal/Magento/Framework/File/Uploader.php
+++ b/lib/internal/Magento/Framework/File/Uploader.php
@@ -803,7 +803,7 @@ class Uploader
         $fileInfo = pathinfo($destinationFile);
         $index = 1;
         while ($fileExists($fileInfo['dirname'] . '/' . $fileInfo['basename'])) {
-            $fileInfo['basename'] = $fileInfo['filename'] . '_' . $index++ . '.' . $fileInfo['extension'];
+            $fileInfo['basename'] = (isset($fileInfo['extension'])) ? $fileInfo['filename'] . '_' . $index++ . '.' . $fileInfo['extension'] : $fileInfo['filename'] . '_' . $index++;
         }
 
         return $fileInfo['basename'];

--- a/lib/internal/Magento/Framework/File/Uploader.php
+++ b/lib/internal/Magento/Framework/File/Uploader.php
@@ -803,7 +803,7 @@ class Uploader
         $fileInfo = pathinfo($destinationFile);
         $index = 1;
         while ($fileExists($fileInfo['dirname'] . '/' . $fileInfo['basename'])) {
-            $fileInfo['basename'] = (isset($fileInfo['extension'])) ? $fileInfo['filename'] . '_' . $index++ . '.' . $fileInfo['extension'] : $fileInfo['filename'] . '_' . $index++;
+            $fileInfo['basename'] = $fileInfo['filename'] . '_' . $index++ . (isset($fileInfo['extension']) ? '.' . $fileInfo['extension'] : '');
         }
 
         return $fileInfo['basename'];


### PR DESCRIPTION
### Description (*)
If you add a vimeo video on product, we get an image without extension and you match this video to another product, you will get the following error: Notice : Undefined index: extension in/vendor/magento/framework/File/Uploader on line 802

### Manual testing scenarios (*)
1. Add a vimeo video on product
2. Add the same video on other product


![Capture d’écran 2021-06-16 à 14 35 27](https://user-images.githubusercontent.com/14790414/122228590-49a84180-ceb8-11eb-9278-74e0d62d7567.png)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)



### Resolved issues:
1. [x] resolves magento/magento2#33266: Fixed notice if extension image is not found