### PR TITLE
Add attributes for fonts preload

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Theme/layout/default_head_blocks.xml
+++ b/app/design/frontend/Magento/luma/Magento_Theme/layout/default_head_blocks.xml
@@ -8,10 +8,10 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
-        <font src="fonts/opensans/light/opensans-300.woff2"/>
-        <font src="fonts/opensans/regular/opensans-400.woff2"/>
-        <font src="fonts/opensans/semibold/opensans-600.woff2"/>
-        <font src="fonts/opensans/bold/opensans-700.woff2"/>
-        <font src="fonts/Luma-Icons.woff2"/>
+        <font src="fonts/opensans/light/opensans-300.woff2" type="font/woff2"/>
+        <font src="fonts/opensans/regular/opensans-400.woff2" type="font/woff2"/>
+        <font src="fonts/opensans/semibold/opensans-600.woff2" type="font/woff2"/>
+        <font src="fonts/opensans/bold/opensans-700.woff2" type="font/woff2"/>
+        <font src="fonts/Luma-Icons.woff2" type="font/woff2"/>
     </head>
 </page>

--- a/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
+++ b/lib/internal/Magento/Framework/View/Page/Config/Renderer.php
@@ -358,7 +358,7 @@ class Renderer implements RendererInterface
         }
 
         if ($this->canTypeBeFont($contentType)) {
-            return 'rel="preload" as="font" crossorigin="anonymous"';
+            return 'rel="preload" as="font" crossorigin="anonymous" ' . $attributes;
         }
 
         return $attributes;


### PR DESCRIPTION
<link> elements can accept a type attribute, which contains the MIME type of the resource the element points to. This is especially useful when preloading resources — the browser will use the type attribute value to work out if it supports that resource, and will only download it if so, ignoring it if not. For some browsers the preload request is not necessary if only woff is supported or future new formats.

Reference: 

- https://web.dev/optimize-lcp/#preload-important-resources
- https://www.w3.org/TR/preload/#early-fetch-of-critical-resources
- https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload#cors-enabled_fetches

```
<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
    <head>
        <font src="fonts/Luma-Icons.woff2" type="font/woff2" />
    </head>
</page>
```
Output:
```
<link rel="preload" as="font" crossorigin="anonymous"  type="font/woff2" href="..../Luma-Icons.woff2" />
```

Related to images preload: 
https://github.com/magento/magento2/pull/33196

Also, I assume that the preload will go on soon, like:
`<link rel="preload" name="OpenSans" as="font" weight="400" crossorigin="anonymous" type="font/woff2" href="OpenSans.woff2"/>` but that remains to be seen :-) 