### PR TITLE
Fix 'unsafe-inline' error #33101

### DIFF
--- a/app/code/Magento/Csp/etc/config.xml
+++ b/app/code/Magento/Csp/etc/config.xml
@@ -106,7 +106,7 @@
                     <frame-ancestors>
                         <policy_id>frame-ancestors</policy_id>
                         <self>1</self>
-                        <inline>1</inline>
+                        <inline>0</inline>
                         <eval>0</eval>
                         <dynamic>0</dynamic>
                     </frame-ancestors>
@@ -217,7 +217,7 @@
                     <frame-ancestors>
                         <policy_id>frame-ancestors</policy_id>
                         <self>1</self>
-                        <inline>1</inline>
+                        <inline>0</inline>
                         <eval>0</eval>
                         <dynamic>0</dynamic>
                     </frame-ancestors>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes the "The Content-Security-Policy directive 'frame-ancestors' does not support the source expression ''unsafe-inline'" error that appears in the dev console in Google Chrome. Setting `inline` equal to `0` within the related `frame-ancestors` node resolves this error.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
1. Fixes magento/magento2#33101

### Manual testing scenarios (*)
1. After applying, reload the home page in Google Chrome and confirm the CSP error no longer displays.

### Questions or comments
N/A

### Contribution checklist (*)
 - [ x ] Pull request has a meaningful description of its purpose
 - [ x ] All commits are accompanied by meaningful commit messages
 - [ x ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ x ] All automated tests passed successfully (all builds are green)
