### PR TITLE
ISSUE-20004: Refactoring minimum order amount including tax value in the calculate

### DIFF
--- a/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutCartSummarySection.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Section/CheckoutCartSummarySection.xml
@@ -22,6 +22,7 @@
         <element name="total" type="text" selector="//*[@id='cart-totals']//tr[@class='grand totals']//td//span[@class='price']"/>
         <element name="totalAmount" type="text" selector="//*[@id='cart-totals']//tr[@class='grand totals']//td//span[@class='price' and contains(text(), '{{amount}}')]" parameterized="true"/>
         <element name="proceedToCheckout" type="button" selector=".action.primary.checkout span" timeout="30"/>
+        <element name="proceedToCheckoutDisabled" type="button" selector=".action.primary.checkout.disabled" timeout="30"/>
         <element name="discountAmount" type="text" selector="td[data-th='Discount']"/>
         <element name="shippingHeading" type="button" selector="#block-shipping-heading" timeout="10"/>
         <element name="postcode" type="input" selector="input[name='postcode']" timeout="10"/>

--- a/app/code/Magento/Checkout/view/frontend/web/js/proceed-to-checkout.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/proceed-to-checkout.js
@@ -7,7 +7,7 @@ define([
     'jquery',
     'Magento_Customer/js/model/authentication-popup',
     'Magento_Customer/js/customer-data',
-    'Magento_Checkout/js/model/quote',
+    'Magento_Checkout/js/model/quote'
 ], function ($, authenticationPopup, customerData, quote) {
     'use strict';
 
@@ -27,17 +27,16 @@ define([
             location.href = config.checkoutUrl;
         });
 
-        quote.totals.subscribe(function(totals){
-           console.log(totals);
-           if (totals['is_minimum_order_amount']) {
-               $(element).prop( "disabled", false );
-               $(element).removeClass( "disabled");
-               return;
-           }
+        quote.totals.subscribe(function (totals) {
+            if (totals['is_minimum_order_amount']) {
+                $(element).prop('disabled', false);
+                $(element).removeClass('disabled');
 
-           $(element).prop( "disabled", true );
-           $(element).addClass( "disabled");
+                return;
+            }
 
+            $(element).prop('disabled', true);
+            $(element).addClass('disabled');
         });
     };
 });

--- a/app/code/Magento/Checkout/view/frontend/web/js/proceed-to-checkout.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/proceed-to-checkout.js
@@ -6,8 +6,9 @@
 define([
     'jquery',
     'Magento_Customer/js/model/authentication-popup',
-    'Magento_Customer/js/customer-data'
-], function ($, authenticationPopup, customerData) {
+    'Magento_Customer/js/customer-data',
+    'Magento_Checkout/js/model/quote',
+], function ($, authenticationPopup, customerData, quote) {
     'use strict';
 
     return function (config, element) {
@@ -26,5 +27,17 @@ define([
             location.href = config.checkoutUrl;
         });
 
+        quote.totals.subscribe(function(totals){
+           console.log(totals);
+           if (totals['is_minimum_order_amount']) {
+               $(element).prop( "disabled", false );
+               $(element).removeClass( "disabled");
+               return;
+           }
+
+           $(element).prop( "disabled", true );
+           $(element).addClass( "disabled");
+
+        });
     };
 });

--- a/app/code/Magento/Quote/Api/Data/TotalsInterface.php
+++ b/app/code/Magento/Quote/Api/Data/TotalsInterface.php
@@ -69,6 +69,8 @@ interface TotalsInterface extends \Magento\Framework\Api\ExtensibleDataInterface
 
     const KEY_ITEMS_QTY = 'items_qty';
 
+    const KEY_IS_MINIMUM_ORDER_AMOUNT = 'is_minimum_order_amount';
+
     /**#@-*/
 
     /**
@@ -475,6 +477,17 @@ interface TotalsInterface extends \Magento\Framework\Api\ExtensibleDataInterface
      * @return $this
      */
     public function setTotalSegments($totals = []);
+
+    /**
+     * @return bool
+     */
+    public function getIsMinimumOrderAmount();
+
+    /**
+     * @param bool $isMinimumAmount
+     * @return mixed
+     */
+    public function setIsMinimumOrderAmount(bool $isMinimumAmount);
 
     /**
      * Retrieve existing extension attributes object or create a new one.

--- a/app/code/Magento/Quote/Model/Cart/CartTotalRepository.php
+++ b/app/code/Magento/Quote/Model/Cart/CartTotalRepository.php
@@ -117,6 +117,8 @@ class CartTotalRepository implements CartTotalRepositoryInterface
         $quoteTotals->setItemsQty($quote->getItemsQty());
         $quoteTotals->setBaseCurrencyCode($quote->getBaseCurrencyCode());
         $quoteTotals->setQuoteCurrencyCode($quote->getQuoteCurrencyCode());
+        $isMinimumOrderAmount = $quote->validateMinimumAmount();
+        $quoteTotals->setIsMinimumOrderAmount($isMinimumOrderAmount);
         return $quoteTotals;
     }
 }

--- a/app/code/Magento/Quote/Model/Cart/Totals.php
+++ b/app/code/Magento/Quote/Model/Cart/Totals.php
@@ -575,6 +575,22 @@ class Totals extends AbstractExtensibleModel implements TotalsInterface
 
     /**
      * {@inheritdoc}
+     */
+    public function getIsMinimumOrderAmount()
+    {
+        return $this->getData(self::KEY_IS_MINIMUM_ORDER_AMOUNT);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setIsMinimumOrderAmount(bool $isMinimumAmount)
+    {
+        return $this->setData(self::KEY_IS_MINIMUM_ORDER_AMOUNT, $isMinimumAmount);
+    }
+
+    /**
+     * {@inheritdoc}
      *
      * @return \Magento\Quote\Api\Data\TotalsExtensionInterface|null
      */

--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -2298,6 +2298,8 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
             $storeId
         );
 
+        $this->collectTotals()->save();
+
         $addresses = $this->getAllAddresses();
 
         if (!$multishipping) {

--- a/app/code/Magento/Quote/Test/Unit/Model/Cart/CartTotalRepositoryTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Cart/CartTotalRepositoryTest.php
@@ -108,7 +108,8 @@ class CartTotalRepositoryTest extends TestCase
                     'getBillingAddress',
                     'getAllVisibleItems',
                     'getItemsQty',
-                    'collectTotals'
+                    'collectTotals',
+                    'validateMinimumAmount'
                 ]
             )
             ->disableOriginalConstructor()
@@ -137,6 +138,11 @@ class CartTotalRepositoryTest extends TestCase
         $this->totalsConverterMock = $this->createMock(
             TotalsConverter::class
         );
+
+        $this->totalsConverterMock = $this->createMock(
+            TotalsConverter::class
+        );
+
 
         $this->model = new CartTotalRepository(
             $this->totalsFactoryMock,
@@ -246,6 +252,10 @@ class CartTotalRepositoryTest extends TestCase
             ->method('setQuoteCurrencyCode')
             ->with(self::STUB_CURRENCY_CODE)
             ->willReturnSelf();
+
+        $this->quoteMock->expects($this->once())
+            ->method('validateMinimumAmount')
+            ->willReturn(true);
 
         $this->assertEquals($totalsMock, $this->model->get(self::STUB_CART_ID));
     }

--- a/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartTotalRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Quote/Api/CartTotalRepositoryTest.php
@@ -241,6 +241,7 @@ class CartTotalRepositoryTest extends WebapiAbstract
             Totals::KEY_QUOTE_CURRENCY_CODE => $quote->getQuoteCurrencyCode(),
             Totals::KEY_ITEMS_QTY => $quote->getItemsQty(),
             Totals::KEY_ITEMS => [$this->getQuoteItemTotalsData($quote)],
+            Totals::KEY_IS_MINIMUM_ORDER_AMOUNT => $quote->validateMinimumAmount()
         ];
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/Quote/Api/GuestCartTotalRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Quote/Api/GuestCartTotalRepositoryTest.php
@@ -87,6 +87,7 @@ class GuestCartTotalRepositoryTest extends WebapiAbstract
             Totals::KEY_QUOTE_CURRENCY_CODE => $quote->getQuoteCurrencyCode(),
             Totals::KEY_ITEMS_QTY => $quote->getItemsQty(),
             Totals::KEY_ITEMS => [$this->getQuoteItemTotalsData($quote)],
+            Totals::KEY_IS_MINIMUM_ORDER_AMOUNT => $quote->validateMinimumAmount()
         ];
 
         $requestData = ['cartId' => $cartId];


### PR DESCRIPTION
### Description (*)
It fixes the issue reported when the tax value was not taking account when minimum order amount was blocking the customer proceed to checkout even when the grant total of the cart was bigger than minimum order amount value.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#20004

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. see #20004 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
