### PR TITLE
MFTF: Print Packing Slips Without Created Shipment Test

### DIFF
--- a/app/code/Magento/Sales/Test/Mftf/Test/AdminSalesPrintPackingSlipsWithoutCreatedShipmentTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/AdminSalesPrintPackingSlipsWithoutCreatedShipmentTest.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminSalesPrintPackingSlipsWithoutCreatedShipmentTest">
+        <annotations>
+            <features value="sales"/>
+            <stories value="Printing Packing Slips Without Created Shipments"/>
+            <title value="Packing Slips Printing"/>
+            <description value="Admin should not be able print packing slips until shipment was not created"/>
+            <severity value="MINOR"/>
+            <group value="sales"/>
+        </annotations>
+        <before>
+            <createData entity="SimpleSubCategory" stepKey="createCategory"/>
+            <createData entity="SimpleProduct" stepKey="createProduct">
+                <requiredEntity createDataKey="createCategory"/>
+            </createData>
+            <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
+        </before>
+        <after>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="adminLogout"/>
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
+            <actionGroup ref="StorefrontCustomerLogoutActionGroup" stepKey="logoutCustomer"/>
+            <deleteData createDataKey="createCustomer" stepKey="deleteCustomer"/>
+        </after>
+
+        <actionGroup ref="LoginToStorefrontActionGroup" stepKey="loginToStorefrontAccount">
+            <argument name="Customer" value="$createCustomer$"/>
+        </actionGroup>
+        <actionGroup ref="OpenProductFromCategoryPageActionGroup" stepKey="openProductFromCategory">
+            <argument name="category" value="$createCategory$"/>
+            <argument name="product" value="$createProduct$"/>
+        </actionGroup>
+        <actionGroup ref="StorefrontAddProductToCartWithQtyActionGroup" stepKey="addProductToTheCart">
+            <argument name="productQty" value="1"/>
+        </actionGroup>
+        <actionGroup ref="GoToCheckoutFromMinicartActionGroup" stepKey="navigateToCheckout"/>
+        <actionGroup ref="CheckoutSelectFlatRateShippingMethodActionGroup" stepKey="selectFlatRate"/>
+        <actionGroup ref="StorefrontCheckoutForwardFromShippingStepActionGroup" stepKey="goToReview"/>
+        <actionGroup ref="CheckoutSelectCheckMoneyOrderPaymentActionGroup" stepKey="selectCheckMoneyOrder"/>
+        <actionGroup ref="CheckoutPlaceOrderActionGroup" stepKey="clickOnPlaceOrder">
+            <argument name="orderNumberMessage" value="CONST.successCheckoutOrderNumberMessage"/>
+            <argument name="emailYouMessage" value="CONST.successCheckoutEmailYouMessage"/>
+        </actionGroup>
+        <grabTextFrom selector="{{CheckoutSuccessMainSection.orderNumber22}}" stepKey="getOrderId"/>
+        <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+        <actionGroup ref="FilterOrderGridByIdActionGroup" stepKey="findCreatedOrderOnGrid">
+            <argument name="orderId" value="$getOrderId"/>
+        </actionGroup>
+        <actionGroup ref="AdminOrderActionOnGridActionGroup" stepKey="selectPrintPackingSlips">
+            <argument name="action" value="Print Packing Slips"/>
+            <argument name="orderId" value="$getOrderId"/>
+        </actionGroup>
+        <actionGroup ref="AssertMessageInAdminPanelActionGroup" stepKey="assertErrorMessage">
+            <argument name="message" value="There are no printable documents related to selected orders."/>
+            <argument name="messageType" value="error"/>
+        </actionGroup>
+    </test>
+</tests>


### PR DESCRIPTION
This PR contains a test for asserting error, when the admin prints packing slips without created shipment.

**Steps to reproduce**
1 - Place an order on FE
2- Navigate to Admin Order Grid
3 - Find placed order
4 - Print packing slips
5 - Perform Assertions

### Resolved issues:
1. [x] resolves magento/magento2#33345: MFTF: Print Packing Slips Without Created Shipment Test