### PR TITLE
Fix incompatibility with laminas-escaper (2.7.1)

### DIFF
--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -291,7 +291,7 @@ class Escaper
      */
     public function encodeUrlParam($string)
     {
-        return $this->getEscaper()->escapeUrl($string);
+        return $this->getEscaper()->escapeUrl((string)$string);
     }
 
     /**
@@ -330,7 +330,7 @@ class Escaper
      */
     public function escapeCss($string)
     {
-        return $this->getEscaper()->escapeCss($string);
+        return $this->getEscaper()->escapeCss((string)$string);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -289,9 +289,9 @@ class Escaper
      * @return string
      * @since 101.0.0
      */
-    public function encodeUrlParam($string)
+    public function encodeUrlParam(string $string): string
     {
-        return $this->getEscaper()->escapeUrl((string)$string);
+        return $this->getEscaper()->escapeUrl($string);
     }
 
     /**
@@ -328,9 +328,9 @@ class Escaper
      * @return string
      * @since 101.0.0
      */
-    public function escapeCss($string)
+    public function escapeCss(string $string): string
     {
-        return $this->getEscaper()->escapeCss((string)$string);
+        return $this->getEscaper()->escapeCss($string);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -289,9 +289,9 @@ class Escaper
      * @return string
      * @since 101.0.0
      */
-    public function encodeUrlParam(string $string)
+    public function encodeUrlParam($string)
     {
-        return $this->getEscaper()->escapeUrl($string);
+        return $this->getEscaper()->escapeUrl((string)$string);
     }
 
     /**
@@ -328,9 +328,9 @@ class Escaper
      * @return string
      * @since 101.0.0
      */
-    public function escapeCss(string $string)
+    public function escapeCss($string)
     {
-        return $this->getEscaper()->escapeCss($string);
+        return $this->getEscaper()->escapeCss((string)$string);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -289,7 +289,7 @@ class Escaper
      * @return string
      * @since 101.0.0
      */
-    public function encodeUrlParam(string $string): string
+    public function encodeUrlParam(string $string)
     {
         return $this->getEscaper()->escapeUrl($string);
     }
@@ -328,7 +328,7 @@ class Escaper
      * @return string
      * @since 101.0.0
      */
-    public function escapeCss(string $string): string
+    public function escapeCss(string $string)
     {
         return $this->getEscaper()->escapeCss($string);
     }

--- a/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
@@ -365,6 +365,76 @@ class EscaperTest extends TestCase
     }
 
     /**
+     * @covers \Magento\Framework\Escaper::escapeCss
+     *
+     * @param string $data
+     * @param string $expected
+     * @return void
+     *
+     * @dataProvider escapeCssDataProvider
+     */
+    public function testEscapeCss($data, string $expected): void
+    {
+        $this->assertEquals($expected, $this->escaper->escapeCss($data));
+    }
+
+    /**
+     * @return array
+     */
+    public function escapeCssDataProvider(): array
+    {
+        return [
+            [
+                'data'     => 1,
+                'expected' => '1',
+            ],
+            [
+                'data'     => '*%string{foo}%::',
+                'expected' => '\2A \25 string\7B foo\7D \25 \3A \3A ',
+            ]
+        ];
+    }
+
+    /**
+     * @covers \Magento\Framework\Escaper::encodeUrlParam
+     *
+     * @param string $data
+     * @param string $expected
+     * @return void
+     *
+     * @dataProvider encodeUrlParamDataProvider
+     */
+    public function testEncodeUrlParam($data, string $expected): void
+    {
+        $this->assertEquals($expected, $this->escaper->encodeUrlParam($data));
+    }
+
+    /**
+     * @return array
+     */
+    public function encodeUrlParamDataProvider(): array
+    {
+        return [
+            [
+                'data'     => "a3==",
+                'expected' => "a3%3D%3D",
+            ],
+            [
+                'data'     => "example string",
+                'expected' => "example%20string",
+            ],
+            [
+                'data'     => 1,
+                'expected' => "1",
+            ],
+            [
+                'data'     => null,
+                'expected' => "",
+            ]
+        ];
+    }
+
+    /**
      * @return array
      */
     public function escapeUrlDataProvider(): array

--- a/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
@@ -385,6 +385,10 @@ class EscaperTest extends TestCase
     {
         return [
             [
+                'data'     => 1,
+                'expected' => '1',
+            ],
+            [
                 'data'     => '*%string{foo}%::',
                 'expected' => '\2A \25 string\7B foo\7D \25 \3A \3A ',
             ]
@@ -418,6 +422,14 @@ class EscaperTest extends TestCase
             [
                 'data'     => "example string",
                 'expected' => "example%20string",
+            ],
+            [
+                'data'     => 1,
+                'expected' => "1",
+            ],
+            [
+                'data'     => null,
+                'expected' => "",
             ]
         ];
     }

--- a/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
@@ -385,10 +385,6 @@ class EscaperTest extends TestCase
     {
         return [
             [
-                'data'     => 1,
-                'expected' => '1',
-            ],
-            [
                 'data'     => '*%string{foo}%::',
                 'expected' => '\2A \25 string\7B foo\7D \25 \3A \3A ',
             ]
@@ -422,14 +418,6 @@ class EscaperTest extends TestCase
             [
                 'data'     => "example string",
                 'expected' => "example%20string",
-            ],
-            [
-                'data'     => 1,
-                'expected' => "1",
-            ],
-            [
-                'data'     => null,
-                'expected' => "",
             ]
         ];
     }

--- a/lib/internal/Magento/Framework/Url/RouteParamsResolver.php
+++ b/lib/internal/Magento/Framework/Url/RouteParamsResolver.php
@@ -112,7 +112,7 @@ class RouteParamsResolver extends \Magento\Framework\DataObject implements Route
             } else {
                 $this->setRouteParam(
                     $this->getEscaper()->encodeUrlParam($key),
-                    $this->getEscaper()->encodeUrlParam($value)
+                    $this->getEscaper()->encodeUrlParam((string)$value)
                 );
             }
         }


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
laminas/laminas-escaper 2.7.1 use strict types and it breaks magento framework escaper

### Fixed Issues
1. Fixes magento/magento2#33346