### PR TITLE
Fixed console error in the customer grid

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/Ui/Component/ColumnFactoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Ui/Component/ColumnFactoryTest.php
@@ -181,7 +181,7 @@ class ColumnFactoryTest extends TestCase
                     'visible' => true,
                     'filter' => 'dateRange',
                     'component' => 'Magento_Ui/js/grid/columns/date',
-                    'timezone' => $expectedTimezone,
+                    'timeZone' => $expectedTimezone,
                     'dateFormat' => $expectedDateFormat,
                     'options' => [
                         'showsTime' => $showsTime

--- a/app/code/Magento/Catalog/Ui/Component/ColumnFactory.php
+++ b/app/code/Magento/Catalog/Ui/Component/ColumnFactory.php
@@ -136,7 +136,7 @@ class ColumnFactory
             : $this->timezone->getDefaultTimezone();
 
         return [
-            'timezone' => $timezone,
+            'timeZone' => $timezone,
             'dateFormat' => $dateFormat,
             'options' => ['showsTime' => $isDatetime],
         ];

--- a/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/columns/date.js
@@ -48,8 +48,8 @@ define([
 
             date = moment.utc(this._super());
 
-            if (!_.isUndefined(this.timezone)) {
-                date = date.tz(this.timezone);
+            if (!_.isUndefined(this.timeZone)) {
+                date = date.tz(this.timeZone);
             }
 
             date = date.isValid() && value[this.index] ?


### PR DESCRIPTION
### Description (*)

In the `app/code/Magento/Customer/view/adminhtml/ui_component/customer_listing.xml` for column `dob` is setting `timezone`. This setting is boolean.
![1624971918351](https://user-images.githubusercontent.com/41998275/123802362-e7a5fe00-d8f3-11eb-916a-0780ba4628a0.jpg)
Depend on this setting column component `app/code/Magento/Ui/Component/Listing/Columns/Date.php` renders date in the column
![1624972171236](https://user-images.githubusercontent.com/41998275/123802887-70249e80-d8f4-11eb-98bc-7207b52ee49b.jpg)

`timezone` settings renders in the component config json like string.
![1624972316151](https://user-images.githubusercontent.com/41998275/123803334-e0cbbb00-d8f4-11eb-91ac-f638e8fce31b.jpg)
And we get error in the `app/code/Magento/Ui/view/base/web/js/grid/columns/date.js` because `this.timezone` is not undefined and it equal to string `false` or (true depends on listing)
![1624972484545](https://user-images.githubusercontent.com/41998275/123803836-5041aa80-d8f5-11eb-91ee-dece87da767d.jpg)

This condition was added in the scope `MC-5233: DateTime product attributes support` and timezone only need for render product datetime attributes in the grid. 
This config adding in the `app/code/Magento/Catalog/Ui/Component/ColumnFactory.php`
![1624972849353](https://user-images.githubusercontent.com/41998275/123804541-fb526400-d8f5-11eb-81ec-0b48ab96f83a.jpg)
So we have one and the same setting is responsible for different purposes.
Therefore, it was decided to change the name for the product attribute settings


### Fixed Issues (if relevant)

1. Fixes magento/magento2#33091

### Manual testing scenarios (*)

1. Go to admin > Customers > All Customers
2. Open browser console
3. Open Columns settings
4. Click Date of Birth column


**Expected result**
There are no errors in browser console

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
