### PR TITLE
33044 Fixed displaying of the custom option value in admin in order view

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/items/column/name.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/items/column/name.phtml
@@ -47,6 +47,7 @@ $catalogHelper = $block->getData('catalogHelper');
                                 require(['prototype'], function() {
 
 script;
+                            $scriptString .= "$('" . /* @noEscape */ $id . "').up().style.width='100%'" . PHP_EOL;
                             $scriptString .= "$('" . /* @noEscape */ $id . "').hide();" . PHP_EOL;
                             $scriptString .= "$('" . /* @noEscape */ $id .
                              "').up().observe('mouseover', function(){ $('" . /* @noEscape */ $id . "').show();});" .


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I determined that the code responsible for displaying the full text of the field works correctly, the problem was changing the overall dimensions of the "Items Ordered" table header, which causes the field to shift when hovering over which the full text should be displayed.
My solution is to automatically add fixed width for the field "custom option" if this field is present in the order.
I created a solution in the file ( app/code/Magento/Sales/view/adminhtml/templates/items/column/name.phtml ), I added this code to the script on the line 50:
( $scriptString .= "$('" . /* @noEscape */ $id . "').up().style.width='100%'" . PHP_EOL; )

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#33044

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create downloadable product in admin panel.
2. Create customizable option text field option.
3. On the product page enter more than 55 characters in the custom option text field.
<img width="539" alt="Screenshot 2021-06-30 at 11 57 03" src="https://user-images.githubusercontent.com/26867833/123932789-71100b80-d99a-11eb-8d28-f3ec8d97bc99.png">
4. Purchase this product as a registered user (if you want to see this field in your orders in 'My Account').

5. In the admin panel go to "Sales -> Orders -> choose your order" and check the custom options field.

https://user-images.githubusercontent.com/26867833/123937115-82f3ad80-d99e-11eb-8500-53c33f114ad5.mov

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#33403: 33044 Fixed displaying of the custom option value in admin in order view