### PR TITLE
#19710 Magento 2.3 images cache generation generates wrong hash for s…

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
@@ -11,7 +11,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\View\ConfigInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Catalog\Model\Product\Image;
-use Magento\Theme\Model\Theme;
+use Magento\Framework\View\Design\ThemeInterface;
 
 /**
  * Builds parameters array used to build Image Asset
@@ -70,11 +70,12 @@ class ParamsBuilder
      *
      * @param array $imageArguments
      * @param int $scopeId
+     * @param ThemeInterface $theme
      * @return array
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    public function build(array $imageArguments, int $scopeId = null, /*Theme*/ $theme = null): array
+    public function build(array $imageArguments, int $scopeId = null, /*ThemeInterface*/ $theme = null): array
     {
         $miscParams = [
             'image_type' => $imageArguments['type'] ?? null,
@@ -92,9 +93,10 @@ class ParamsBuilder
      * Overwrite default values
      *
      * @param array $imageArguments
+     * @param ThemeInterface $theme
      * @return array
      */
-    private function overwriteDefaultValues(array $imageArguments, /*Theme*/ $theme = null): array
+    private function overwriteDefaultValues(array $imageArguments, /*ThemeInterface*/ $theme = null): array
     {
         $frame = $imageArguments['frame'] ?? $this->hasDefaultFrame($theme);
         $constrain = $imageArguments['constrain'] ?? $this->defaultConstrainOnly;
@@ -166,10 +168,12 @@ class ParamsBuilder
 
     /**
      * Get frame from product_image_white_borders
+     * 
+     * @param ThemeInterface $theme
      *
      * @return bool
      */
-    private function hasDefaultFrame(/*Theme*/ $theme = null): bool
+    private function hasDefaultFrame(/*ThemeInterface*/ $theme = null): bool
     {
         $viewConfigParams = ['area' => \Magento\Framework\App\Area::AREA_FRONTEND];
         if ($theme) {

--- a/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
@@ -74,7 +74,7 @@ class ParamsBuilder
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    public function build(array $imageArguments, int $scopeId = null, Theme $theme = null): array
+    public function build(array $imageArguments, int $scopeId = null, /*Theme*/ $theme = null): array
     {
         $miscParams = [
             'image_type' => $imageArguments['type'] ?? null,
@@ -94,7 +94,7 @@ class ParamsBuilder
      * @param array $imageArguments
      * @return array
      */
-    private function overwriteDefaultValues(array $imageArguments, Theme $theme = null): array
+    private function overwriteDefaultValues(array $imageArguments, /*Theme*/ $theme = null): array
     {
         $frame = $imageArguments['frame'] ?? $this->hasDefaultFrame($theme);
         $constrain = $imageArguments['constrain'] ?? $this->defaultConstrainOnly;
@@ -169,7 +169,7 @@ class ParamsBuilder
      *
      * @return bool
      */
-    private function hasDefaultFrame(Theme $theme = null): bool
+    private function hasDefaultFrame(/*Theme*/ $theme = null): bool
     {
         $viewConfigParams = ['area' => \Magento\Framework\App\Area::AREA_FRONTEND];
         if ($theme) {

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -250,7 +250,7 @@ class ImageResize
             $images = $config->getMediaEntities('Magento_Catalog', ImageHelper::MEDIA_TYPE_CONFIG_NODE);
             foreach ($images as $imageId => $imageData) {
                 foreach ($stores as $store) {
-                    $data = $this->paramsBuilder->build($imageData, (int) $store->getId());
+                    $data = $this->paramsBuilder->build($imageData, (int) $store->getId(), $theme);
                     $uniqIndex = $this->getUniqueImageIndex($data);
                     $data['id'] = $imageId;
                     $viewImages[$uniqIndex] = $data;

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -27,7 +27,7 @@ use Magento\Theme\Model\Config\Customization as ThemeCustomizationConfig;
 use Magento\Theme\Model\ResourceModel\Theme\Collection as ThemeCollection;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\MediaStorage\Helper\File\Storage\Database as FileStorageDatabase;
-use Magento\Theme\Model\Theme;
+use Magento\Framework\View\Design\ThemeInterface;
 
 /**
  * Image resize service.
@@ -239,7 +239,7 @@ class ImageResize
     {
         $viewImages = [];
         $stores = $this->storeManager->getStores(true);
-        /** @var Theme $theme */
+        /** @var ThemeInterface $theme */
         foreach ($themes as $theme) {
             $config = $this->viewConfig->getViewConfig(
                 [


### PR DESCRIPTION
Solves #19710 

Issue description : when "product_image_white_borders" is set to 0 in the `view.xml` of a theme, the generated resized images are not generated with the correct hash.
