### PR TITLE
[MFTF] Add product to the Cart if Backorders are allowed on Product level and Product Qty<=0

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSetBackordersOnProductAdvancedInventoryActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSetBackordersOnProductAdvancedInventoryActionGroup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminSetBackordersOnProductAdvancedInventoryActionGroup">
+        <annotations>
+            <description>Deselects the "Use Config Settings" checkbox and set the "Backorders" select value to required</description>
+        </annotations>
+        <arguments>
+            <argument name="backorders" type="string" defaultValue="Allow Qty Below 0"/>
+        </arguments>
+        
+        <uncheckOption selector="{{AdminProductFormAdvancedInventorySection.useConfigSettingsForBackorders}}" stepKey="uncheckUseConfigSettings"/>
+        <selectOption selector="{{AdminProductFormAdvancedInventorySection.backorders}}" userInput="{{backorders}}" stepKey="fillBackordersy"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSetBackordersOnProductAdvancedInventoryActionGroup.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/ActionGroup/AdminSetBackordersOnProductAdvancedInventoryActionGroup.xml
@@ -17,6 +17,6 @@
         </arguments>
         
         <uncheckOption selector="{{AdminProductFormAdvancedInventorySection.useConfigSettingsForBackorders}}" stepKey="uncheckUseConfigSettings"/>
-        <selectOption selector="{{AdminProductFormAdvancedInventorySection.backorders}}" userInput="{{backorders}}" stepKey="fillBackordersy"/>
+        <selectOption selector="{{AdminProductFormAdvancedInventorySection.backorders}}" userInput="{{backorders}}" stepKey="fillBackorders"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontAddProductWithBackordersAllowedOnProductLevelToCartTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontAddProductWithBackordersAllowedOnProductLevelToCartTest.xml
@@ -28,7 +28,7 @@
             <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
         </after>
 
-        <actionGroup ref="NavigateToCreatedProductEditPageActionGroup" stepKey="openEditBundleProduct">
+        <actionGroup ref="NavigateToCreatedProductEditPageActionGroup" stepKey="openCreatedProductEditPage">
             <argument name="product" value="$$createProduct$$"/>
         </actionGroup>
         <actionGroup ref="AdminClickOnAdvancedInventoryLinkActionGroup" stepKey="clickOnAdvancedInventoryLink"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontAddProductWithBackordersAllowedOnProductLevelToCartTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontAddProductWithBackordersAllowedOnProductLevelToCartTest.xml
@@ -10,9 +10,12 @@
        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
     <test name="StorefrontAddProductWithBackordersAllowedOnProductLevelToCartTest">
         <annotations>
+            <features value="Catalog"/>
             <stories value="Manage inventory, backorders"/>
             <title value="Add Product to Cart, Backorders Allowed On Product Level"/>
+            <severity value="MAJOR"/>
             <description value="Customer should be able to add products to Cart if product qty less or equal 0 and Backorders are allowed on Product level"/>
+            <group value="catalog"/>
         </annotations>
 
         <before>
@@ -22,7 +25,6 @@
 
         <after>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
-            <actionGroup ref="CliCacheCleanActionGroup" stepKey="cleanInvalidatedCaches">
                 <argument name="tags" value="config full_page"/>
             </actionGroup>
             <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontAddProductWithBackordersAllowedOnProductLevelToCartTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontAddProductWithBackordersAllowedOnProductLevelToCartTest.xml
@@ -25,8 +25,6 @@
 
         <after>
             <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
-                <argument name="tags" value="config full_page"/>
-            </actionGroup>
             <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
         </after>
 

--- a/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontAddProductWithBackordersAllowedOnProductLevelToCartTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontAddProductWithBackordersAllowedOnProductLevelToCartTest.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontAddProductWithBackordersAllowedOnProductLevelToCartTest">
+        <annotations>
+            <stories value="Manage inventory, backorders"/>
+            <title value="Add Product to Cart, Backorders Allowed On Product Level"/>
+            <description value="Customer should be able to add products to Cart if product qty less or equal 0 and Backorders are allowed on Product level"/>
+        </annotations>
+
+        <before>
+            <createData entity="SimpleProductInStockQuantityZero" stepKey="createProduct"/>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+        </before>
+
+        <after>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
+            <actionGroup ref="CliCacheCleanActionGroup" stepKey="cleanInvalidatedCaches">
+                <argument name="tags" value="config full_page"/>
+            </actionGroup>
+            <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
+        </after>
+
+        <actionGroup ref="NavigateToCreatedProductEditPageActionGroup" stepKey="openEditBundleProduct">
+            <argument name="product" value="$$createProduct$$"/>
+        </actionGroup>
+        <actionGroup ref="AdminClickOnAdvancedInventoryLinkActionGroup" stepKey="clickOnAdvancedInventoryLink"/>
+        <actionGroup ref="AdminSetBackordersOnProductAdvancedInventoryActionGroup" stepKey="allowBackorders"/>
+        <actionGroup ref="AdminFillAdvancedInventoryQtyActionGroup" stepKey="fillProductQty">
+            <argument name="qty" value="-5"/>
+        </actionGroup>
+        <actionGroup ref="AdminSubmitAdvancedInventoryFormActionGroup" stepKey="clickDoneButton"/>
+        <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProduct"/>
+
+        <actionGroup ref="AddSimpleProductToCartActionGroup" stepKey="gotoAndAddProductToCart">
+            <argument name="product" value="$$createProduct$$"/>
+        </actionGroup>
+
+        <actionGroup ref="StorefrontCartPageOpenActionGroup" stepKey="gotoCart"/>
+        <actionGroup ref="AssertStorefrontCheckoutCartItemsActionGroup" stepKey="assertProductItemInCheckOutCart">
+            <argument name="productName" value="$$createProduct.name$$"/>
+            <argument name="productSku" value="$$createProduct.sku$$"/>
+            <argument name="productPrice" value="$$createProduct.price$$"/>
+            <argument name="subtotal" value="$$createProduct.price$$" />
+            <argument name="qty" value="1"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/app/code/Magento/CatalogInventory/Test/Mftf/Section/AdminProductFormAdvancedInventorySection.xml
+++ b/app/code/Magento/CatalogInventory/Test/Mftf/Section/AdminProductFormAdvancedInventorySection.xml
@@ -32,5 +32,7 @@
         <element name="minQtyConfigSetting" type="checkbox" selector="//input[@name='product[stock_data][use_config_min_qty]']" timeout="30"/>
         <element name="advancedInventoryModal" type="block" selector=".product_form_product_form_advanced_inventory_modal[data-role=modal]"/>
         <element name="maxiQtyAllowedInCartError" type="text" selector="[name='product[stock_data][max_sale_qty]'] + label.admin__field-error"/>
+        <element name="backorders" type="select" selector="//*[@name='product[stock_data][backorders]']"/>
+        <element name="useConfigSettingsForBackorders" type="checkbox" selector="//input[@name='product[stock_data][use_config_backorders]']"/>
     </section>
 </sections>


### PR DESCRIPTION
### Description (*)
This is to check if Product can be added to the Cart if Backorders are allowed on Product level and Product Qty<=0

### Manual testing scenarios (*)
1. Login as Admin
2. Open the Edit Product page->Advanced Inventory
3. Set the "Backorders" select value to "Allow Qty Below 0"
4. Set product Qty to <0
5. Save product
6. Open the Product on the Storefront
7. Click the "Add to Cart" button
8. Assert that the Product is in the Cart



### Resolved issues:
1. [x] resolves magento/magento2#33635: [MFTF] Add product to the Cart if Backorders are allowed on Product level and Product Qty<=0