### PR TITLE
Inheriting from a class that doesn't exist#33334

### DIFF
--- a/app/code/Magento/Bundle/Pricing/Price/ConfiguredPrice.php
+++ b/app/code/Magento/Bundle/Pricing/Price/ConfiguredPrice.php
@@ -148,7 +148,7 @@ class ConfiguredPrice extends CatalogPrice\FinalPrice implements ConfiguredPrice
             $configuredOptionsAmount = $this->getConfiguredAmount()->getBaseAmount();
             return parent::getValue() +
                 $this->priceInfo
-                    ->getPrice(BundleDiscountPrice::PRICE_CODE)
+                    ->getPrice(self::PRICE_CODE)
                     ->calculateDiscount($configuredOptionsAmount);
         }
         return parent::getValue();

--- a/app/code/Magento/Bundle/Pricing/Price/ConfiguredPrice.php
+++ b/app/code/Magento/Bundle/Pricing/Price/ConfiguredPrice.php
@@ -48,6 +48,10 @@ class ConfiguredPrice extends CatalogPrice\FinalPrice implements ConfiguredPrice
      * @var ConfiguredPriceSelection
      */
     private $configuredPriceSelection;
+    /**
+     * @var \Magento\Bundle\Pricing\Price\DiscountCalculator
+     */
+    private $discountCalculator;
 
     /**
      * @param Product $saleableItem
@@ -63,6 +67,7 @@ class ConfiguredPrice extends CatalogPrice\FinalPrice implements ConfiguredPrice
         $quantity,
         BundleCalculatorInterface $calculator,
         PriceCurrencyInterface $priceCurrency,
+        DiscountCalculator $discountCalculator,
         ItemInterface $item = null,
         JsonSerializer $serializer = null,
         ConfiguredPriceSelection $configuredPriceSelection = null
@@ -73,6 +78,7 @@ class ConfiguredPrice extends CatalogPrice\FinalPrice implements ConfiguredPrice
         $this->configuredPriceSelection = $configuredPriceSelection
             ?: \Magento\Framework\App\ObjectManager::getInstance()
                 ->get(ConfiguredPriceSelection::class);
+        $this->discountCalculator = $discountCalculator;
         parent::__construct($saleableItem, $quantity, $calculator, $priceCurrency);
     }
 
@@ -146,10 +152,9 @@ class ConfiguredPrice extends CatalogPrice\FinalPrice implements ConfiguredPrice
     {
         if ($this->item) {
             $configuredOptionsAmount = $this->getConfiguredAmount()->getBaseAmount();
-            return parent::getValue() +
-                $this->priceInfo
-                    ->getPrice(self::PRICE_CODE)
-                    ->calculateDiscount($configuredOptionsAmount);
+            if (!empty($this->item->getProduct())) {
+                return parent::getValue() + $this->discountCalculator->calculateDiscount($this->item->getProduct(), $configuredOptionsAmount);
+            }
         }
         return parent::getValue();
     }

--- a/app/code/Magento/Bundle/Test/Unit/Pricing/Price/BundlePriceTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Pricing/Price/BundlePriceTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Bundle\Test\Unit\Pricing\Price;
+
+use Magento\Bundle\Pricing\Price\DiscountCalculator;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Configuration\Item\ItemInterface;
+use Magento\Catalog\Model\Product\Configuration\Item\Option\OptionInterface;
+use Magento\Catalog\Model\Product\Option;
+use Magento\Catalog\Model\Product\Option\Type\DefaultType;
+use Magento\Bundle\Pricing\Price\ConfiguredPrice;
+use Magento\Bundle\Pricing\Adjustment\Calculator;
+use Magento\Catalog\Pricing\Price\ConfiguredPriceSelection;
+use Magento\Framework\DataObject;
+use Magento\Framework\Pricing\Amount\AmountInterface;
+use Magento\Framework\Pricing\Price\PriceInterface;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Framework\Pricing\PriceInfo\Base;
+use Magento\Framework\Serialize\Serializer\Json;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test for \Magento\Bundle\Pricing\Price\ConfiguredPrice
+ */
+class BundlePriceTest extends TestCase
+{
+    /**
+     * @var float
+     */
+    protected $basePriceValue = 100.;
+
+    /**
+     * @var MockObject
+     */
+    protected $item;
+
+    /**
+     * @var MockObject
+     */
+    protected $product;
+
+    /**
+     * @var MockObject
+     */
+    protected $calculator;
+
+    /**
+     * @var MockObject
+     */
+    protected $priceInfo;
+
+    /**
+     * @var ConfiguredPrice
+     */
+    protected $model;
+
+    /**
+     * @var PriceCurrencyInterface|MockObject
+     */
+    protected $priceCurrencyMock;
+    /**
+     * @var Json|MockObject
+     */
+    private $jsonSerializerMock;
+    /**
+     * @var ConfiguredPriceSelection|MockObject
+     */
+    private $configuredPriceSelectionMock;
+    /**
+     * @var array
+     */
+    private $selectionPriceDataSampleData;
+    /**
+     * @var AmountInterface|MockObject
+     */
+    private $amountInterfaceMock;
+    /**
+     * @var DiscountCalculator|MockObject
+     */
+    private $discountCalculator;
+
+    /**
+     * Initialize base dependencies
+     */
+    protected function setUp(): void
+    {
+        $basePrice = $this->getMockForAbstractClass(PriceInterface::class);
+        $basePrice->expects($this->any())->method('getValue')->willReturn($this->basePriceValue);
+
+        $this->priceInfo = $this->createMock(Base::class);
+        $this->priceInfo->expects($this->any())->method('getPrice')->willReturn($basePrice);
+        $this->product = $this->getMockBuilder(Product::class)
+            ->setMethods(['getPriceInfo', 'getOptionById', 'getResource'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->product->expects($this->once())->method('getPriceInfo')->willReturn($this->priceInfo);
+
+        $this->item = $this->getMockBuilder(ItemInterface::class)
+            ->getMock();
+        $this->item->expects($this->any())->method('getProduct')->willReturn($this->product);
+
+        $this->priceCurrencyMock = $this->getMockForAbstractClass(PriceCurrencyInterface::class);
+
+        $this->jsonSerializerMock = $this->getMockBuilder(Json::class)
+            ->getMock();
+        $this->configuredPriceSelectionMock = $this->getMockBuilder(ConfiguredPriceSelection::class)
+            ->setMethods(['getSelectionPriceList'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->configuredPriceSelectionMock->expects($this->any())->method('getSelectionPriceList')
+            ->willReturn($this->prepareAndReturnSelectionPriceDataStub());
+        $this->amountInterfaceMock = $this->getMockBuilder(AmountInterface::class)->getMock();
+        $this->amountInterfaceMock->expects($this->any())->method('getBaseAmount')
+            ->willReturn(100.0);
+        $this->calculator = $this->getMockBuilder(Calculator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->calculator->expects($this->any())->method('calculateBundleAmount')
+            ->willReturn($this->amountInterfaceMock);
+        $this->discountCalculator = $this->getMockBuilder(DiscountCalculator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->discountCalculator->expects($this->any())->method('calculateDiscount')
+            ->willReturn(-5.0);
+        $this->model = new ConfiguredPrice($this->product, 1, $this->calculator, $this->priceCurrencyMock, $this->discountCalculator,null, $this->jsonSerializerMock, $this->configuredPriceSelectionMock);
+        $this->model->setItem($this->item);
+    }
+
+    private function prepareAndReturnSelectionPriceDataStub()
+    {
+        $first = new DataObject();
+        $first->setValue(2);
+        $first->setQuantity(1);
+        $second = new DataObject();
+        $second->setValue(3);
+        $second->setQuantity(1);
+        return [
+            $first,
+            $second
+        ];
+    }
+    /**
+     * Test of value getter
+     */
+    public function testGetValueMethod()
+    {
+        $valueFromMock = $this->model->getValue();
+        $this->assertEquals(95., $valueFromMock);
+    }
+}


### PR DESCRIPTION
- Changed PRICE_CODE constant from non-exist class to $this class
This class already have its own constant on 28 line.
const PRICE_CODE = self::CONFIGURED_PRICE_CODE;
The related issue https://github.com/magento/magento2/issues/33334
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The class that responsible for getting price value uses not valid constant.
I was remove incorrect constant and add the constant from this class that can be correctly overrided. 
### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#33334

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. On any properly created bundle product will be executed \Magento\Catalog\Pricing\Render\ConfiguredPriceBox because the 
\Magento\Catalog\Pricing\Price\ConfiguredPriceInterface::CONFIGURED_PRICE_CODE is in Magento\Bundle\Pricing\Price\Pool
2. The render mechanism will found the template app/code/Magento/Catalog/view/base/templates/product/price/configured_price.phtml that will get the class \Magento\Bundle\Pricing\Price\ConfiguredRegularPrice that inherits from \Magento\Bundle\Pricing\Price\ConfiguredPrice with the problem get value method
3. On line 18 of app/code/Magento/Catalog/view/base/templates/product/price/configured_price.phtml will be invoked code from \Magento\Bundle\Pricing\Price\ConfiguredPrice::getValue
4. If item was previously set using setItem the getValue code will throw exception
5. I change to self::PRICE_CODE and code no longer crash
### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
Comments:
The class that inherits this class already have the Unit test
\Magento\Catalog\Test\Unit\Pricing\Price\ConfiguredPriceTest but it.
Also i wrote unit for getValue method

Normally on frontend the code with error not invokes. It seems to be fallback.
This code may crash when unit tests executing

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
