### PR TITLE
magento/magento2#28239: resize command does not process hidden images

### DIFF
--- a/app/code/Magento/MediaStorage/Console/Command/ImagesResizeCommand.php
+++ b/app/code/Magento/MediaStorage/Console/Command/ImagesResizeCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Command\Command;
-use Magento\Catalog\Model\ResourceModel\Product\Image as ProductImage;
+
 
 /**
  * Resizes product images according to theme view definitions.
@@ -56,11 +56,6 @@ class ImagesResizeCommand extends Command
     private $progressBarFactory;
 
     /**
-     * @var ProductImage
-     */
-    private $productImage;
-
-    /**
      * @var bool
      */
     private $skipHiddenImages = false;
@@ -70,22 +65,19 @@ class ImagesResizeCommand extends Command
      * @param ImageResize $imageResize
      * @param ImageResizeScheduler $imageResizeScheduler
      * @param ProgressBarFactory $progressBarFactory
-     * @param ProductImage $productImage
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
         State $appState,
         ImageResize $imageResize,
         ImageResizeScheduler $imageResizeScheduler,
-        ProgressBarFactory $progressBarFactory,
-        ProductImage $productImage
+        ProgressBarFactory $progressBarFactory
     ) {
         parent::__construct();
         $this->appState = $appState;
         $this->imageResize = $imageResize;
         $this->imageResizeScheduler = $imageResizeScheduler;
         $this->progressBarFactory = $progressBarFactory;
-        $this->productImage = $productImage;
     }
 
     /**

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -171,17 +171,18 @@ class ImageResize
      * Create resized images of different sizes from themes.
      *
      * @param array|null $themes
+     * @param bool $skipHiddenImages
      * @return Generator
      * @throws NotFoundException
      */
-    public function resizeFromThemes(array $themes = null): Generator
+    public function resizeFromThemes(array $themes = null, bool $skipHiddenImages = false): Generator
     {
-        $count = $this->productImage->getCountUsedProductImages();
+        $count = $this->getCountProductImages($skipHiddenImages);
         if (!$count) {
             throw new NotFoundException(__('Cannot resize images - product images not found'));
         }
 
-        $productImages = $this->productImage->getUsedProductImages();
+        $productImages = $this->getProductImages($skipHiddenImages);
         $viewImages = $this->getViewImages($themes ?? $this->getThemesInUse());
 
         foreach ($productImages as $image) {
@@ -208,6 +209,26 @@ class ImageResize
 
             yield ['filename' => $originalImageName, 'error' => (string) $error] => $count;
         }
+    }
+
+    /**
+     * @param bool $skipHiddenImages
+     * @return int
+     */
+    public function getCountProductImages(bool $skipHiddenImages = false): int
+    {
+        return $skipHiddenImages ?
+            $this->productImage->getCountUsedProductImages() : $this->productImage->getCountAllProductImages();
+    }
+
+    /**
+     * @param bool $skipHiddenImages
+     * @return Generator
+     */
+    public function getProductImages(bool $skipHiddenImages = false): \Generator
+    {
+        return $skipHiddenImages ?
+            $this->productImage->getUsedProductImages() : $this->productImage->getAllProductImages();
     }
 
     /**

--- a/app/code/Magento/MediaStorage/Test/Unit/Service/ImageResizeTest.php
+++ b/app/code/Magento/MediaStorage/Test/Unit/Service/ImageResizeTest.php
@@ -204,7 +204,6 @@ class ImageResizeTest extends TestCase
             ->willReturnOnConsecutiveCalls($this->testfilepath, $this->testImageHiddenfilepath);
         $this->mediaDirectoryMock->expects($this->any())
             ->method('getRelativePath')
-            ->willReturnOnConsecutiveCalls($this->testfilepath, $this->testImageHiddenfilepath)
             ->willReturnOnConsecutiveCalls($this->testfilepath, $this->testImageHiddenfilepath);
 
         $this->viewMock->expects($this->any())
@@ -418,13 +417,13 @@ class ImageResizeTest extends TestCase
             ->willReturn(false);
 
         $imageMock = $this->createMock(Image::class);
-        $this->imageFactoryMock->expects($this->any())
+        $this->imageFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($imageMock);
 
         $this->mediaDirectoryMock->expects($this->any())
             ->method('isFile')
-            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath])
+            ->with($this->testfilepath)
             ->willReturnOnConsecutiveCalls(
                 $this->returnValue(false),
                 $this->returnValue(true)
@@ -441,12 +440,12 @@ class ImageResizeTest extends TestCase
                 ['0' => []]
             );
 
-        $this->databaseMock->expects($this->any())
+        $this->databaseMock->expects($this->once())
             ->method('saveFileToFilesystem')
-            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath]);
-        $this->databaseMock->expects($this->any())
+            ->with($this->testfilepath);
+        $this->databaseMock->expects($this->once())
             ->method('saveFile')
-            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath]);
+            ->with($this->testfilepath);
 
         $this->service->resizeFromImageName($this->testfilename);
     }
@@ -489,7 +488,7 @@ class ImageResizeTest extends TestCase
 
         $this->mediaDirectoryMock->expects($this->any())
             ->method('isFile')
-            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath])
+            ->with($this->testfilepath)
             ->willReturnOnConsecutiveCalls(
                 $this->returnValue(false),
                 $this->returnValue(true)

--- a/app/code/Magento/MediaStorage/Test/Unit/Service/ImageResizeTest.php
+++ b/app/code/Magento/MediaStorage/Test/Unit/Service/ImageResizeTest.php
@@ -131,6 +131,11 @@ class ImageResizeTest extends TestCase
     private $storeManager;
 
     /**
+     * @var string
+     */
+    private $testImageHiddenfilepath;
+
+    /**
      * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
@@ -139,6 +144,8 @@ class ImageResizeTest extends TestCase
         $this->testfilename = "image.jpg";
         $this->testImageHiddenFilename = "image_hidden.jpg";
         $this->testfilepath = "/image.jpg";
+        $this->testImageHiddenfilepath = "/image_hidden.jpg";
+
 
         $this->appStateMock = $this->createMock(State::class);
         $this->imageConfigMock = $this->createMock(MediaConfig::class);
@@ -167,7 +174,7 @@ class ImageResizeTest extends TestCase
 
         $this->assetImageMock->expects($this->any())
             ->method('getPath')
-            ->willReturn($this->testfilepath);
+            ->willReturnOnConsecutiveCalls($this->testfilepath, $this->testImageHiddenfilepath);
         $this->assetImageFactoryMock->expects($this->any())
             ->method('create')
             ->willReturn($this->assetImageMock);
@@ -189,16 +196,16 @@ class ImageResizeTest extends TestCase
 
         $this->imageConfigMock->expects($this->any())
             ->method('getMediaPath')
-            ->with($this->testfilename)
-            ->willReturn($this->testfilepath);
+            ->withConsecutive([$this->testfilename], [$this->testImageHiddenFilename])
+            ->willReturnOnConsecutiveCalls($this->testfilepath, $this->testImageHiddenfilepath);
         $this->mediaDirectoryMock->expects($this->any())
             ->method('getAbsolutePath')
-            ->with($this->testfilepath)
-            ->willReturn($this->testfilepath);
+            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath])
+            ->willReturnOnConsecutiveCalls($this->testfilepath, $this->testImageHiddenfilepath);
         $this->mediaDirectoryMock->expects($this->any())
             ->method('getRelativePath')
-            ->with($this->testfilepath)
-            ->willReturn($this->testfilepath);
+            ->willReturnOnConsecutiveCalls($this->testfilepath, $this->testImageHiddenfilepath)
+            ->willReturnOnConsecutiveCalls($this->testfilepath, $this->testImageHiddenfilepath);
 
         $this->viewMock->expects($this->any())
             ->method('getMediaEntities')
@@ -255,7 +262,7 @@ class ImageResizeTest extends TestCase
             ->willReturn(false);
 
         $imageMock = $this->createMock(Image::class);
-        $this->imageFactoryMock->expects($this->once())
+        $this->imageFactoryMock->expects($this->any())
             ->method('create')
             ->willReturn($imageMock);
 
@@ -275,15 +282,15 @@ class ImageResizeTest extends TestCase
 
         $this->mediaDirectoryMock->expects($this->any())
             ->method('isFile')
-            ->with($this->testfilepath)
+            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath])
             ->willReturn(true);
 
-        $this->databaseMock->expects($this->once())
+        $this->databaseMock->expects($this->any())
             ->method('saveFileToFilesystem')
-            ->with($this->testfilepath);
-        $this->databaseMock->expects($this->once())
+            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath]);
+        $this->databaseMock->expects($this->any())
             ->method('saveFile')
-            ->with($this->testfilepath);
+            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath]);
 
         $generator = $this->service->resizeFromThemes(['test-theme'], true);
         while ($generator->valid()) {
@@ -304,7 +311,7 @@ class ImageResizeTest extends TestCase
             ->willReturn(false);
 
         $imageMock = $this->createMock(Image::class);
-        $this->imageFactoryMock->expects($this->once())
+        $this->imageFactoryMock->expects($this->any())
             ->method('create')
             ->willReturn($imageMock);
 
@@ -338,15 +345,15 @@ class ImageResizeTest extends TestCase
 
         $this->mediaDirectoryMock->expects($this->any())
             ->method('isFile')
-            ->with($this->testfilepath)
+            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath])
             ->willReturn(true);
 
-        $this->databaseMock->expects($this->once())
+        $this->databaseMock->expects($this->any())
             ->method('saveFileToFilesystem')
-            ->with($this->testfilepath);
-        $this->databaseMock->expects($this->once())
+            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath]);
+        $this->databaseMock->expects($this->any())
             ->method('saveFile')
-            ->with($this->testfilepath);
+            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath]);
 
         $this->assertEquals(2, $this->service->getCountProductImages());
         $this->assertEquals(1, $this->service->getCountProductImages(true));
@@ -370,7 +377,7 @@ class ImageResizeTest extends TestCase
             ->method('fileExists')
             ->willReturn(false);
 
-        $this->imageFactoryMock->expects($this->once())
+        $this->imageFactoryMock->expects($this->any())
             ->method('create')
             ->willThrowException(new \InvalidArgumentException('Unsupported image format.'));
 
@@ -390,7 +397,7 @@ class ImageResizeTest extends TestCase
 
         $this->mediaDirectoryMock->expects($this->any())
             ->method('isFile')
-            ->with($this->testfilepath)
+            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath])
             ->willReturn(true);
 
         $generator = $this->service->resizeFromThemes(['test-theme'], true);
@@ -411,13 +418,13 @@ class ImageResizeTest extends TestCase
             ->willReturn(false);
 
         $imageMock = $this->createMock(Image::class);
-        $this->imageFactoryMock->expects($this->once())
+        $this->imageFactoryMock->expects($this->any())
             ->method('create')
             ->willReturn($imageMock);
 
         $this->mediaDirectoryMock->expects($this->any())
             ->method('isFile')
-            ->with($this->testfilepath)
+            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath])
             ->willReturnOnConsecutiveCalls(
                 $this->returnValue(false),
                 $this->returnValue(true)
@@ -434,12 +441,12 @@ class ImageResizeTest extends TestCase
                 ['0' => []]
             );
 
-        $this->databaseMock->expects($this->once())
+        $this->databaseMock->expects($this->any())
             ->method('saveFileToFilesystem')
-            ->with($this->testfilepath);
-        $this->databaseMock->expects($this->once())
+            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath]);
+        $this->databaseMock->expects($this->any())
             ->method('saveFile')
-            ->with($this->testfilepath);
+            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath]);
 
         $this->service->resizeFromImageName($this->testfilename);
     }
@@ -482,7 +489,7 @@ class ImageResizeTest extends TestCase
 
         $this->mediaDirectoryMock->expects($this->any())
             ->method('isFile')
-            ->with($this->testfilepath)
+            ->withConsecutive([$this->testfilepath], [$this->testImageHiddenfilepath])
             ->willReturnOnConsecutiveCalls(
                 $this->returnValue(false),
                 $this->returnValue(true)


### PR DESCRIPTION
### Description (*)
- added new options --skip-hidden-images
- added new unit test

### Related Pull Requests
no

### Fixed Issues (if relevant)

1. Fixes magento/magento2#28239

### Manual testing scenarios (*)

1. View the product page, only Image 1 should be visible
2. pub/media/catalog/cache folder should contain resized Image 1's
3. pub/media/catalog/cache folder should contain resized Image 2's
4. Clear image cache
5. Run php bin/magento catalog:images:resize
6. pub/media/catalog/cache folder should contain resized Image 1's
7. pub/media/catalog/cache folder should contain resized Image 2's
8. Clear image cache
9. Run php bin/magento catalog:images:resize --skip-hidden-images
10. Image resize command processes 1 image, not 2
11. pub/media/catalog/cache folder should contain resized Image 1's
12. pub/media/catalog/cache folder does not contain resized Image 2's

### Questions or comments
no

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
