### PR TITLE
Varnish cache adding top menu category ids to all page cache tags

### DIFF
--- a/app/code/Magento/PageCache/Model/Config.php
+++ b/app/code/Magento/PageCache/Model/Config.php
@@ -121,7 +121,7 @@ class Config
      */
     public function getType()
     {
-        return $this->_scopeConfig->getValue(self::XML_PAGECACHE_TYPE);
+        return (int)$this->_scopeConfig->getValue(self::XML_PAGECACHE_TYPE);
     }
 
     /**


### PR DESCRIPTION
### Description (*)
https://github.com/magento/magento2/blob/bf4cdad2b1d0436be831c1f5c89c1adc77bfd1fc/app/code/Magento/PageCache/Model/Layout/LayoutPlugin.php#L88

Magento is using type comparison for determining varnish cache is enabled or not. But it return false even if varnish is enabled.

This is because of following comparison; "2" === 2

Based on following code, I think it expected to skip adding tags for a top menu block
` $isEsiBlock = $block->getTtl() > 0;
                    if ($isVarnish && $isEsiBlock) {
                        continue;
                    }`

For Topmenu block we have TTL value, so that $isEsiBlock become true and with my fix $isVarnish will also become true.

### Fixed Issues (if relevant)



### Manual testing scenarios (*)

1. Enable varnish cache and make sure it is running
2. Open home page or any CMS page example: /about-us
3. Check Magento cache Tags.
4. Cache tags won't include top category IDs after merging this PR


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
