### PR TITLE
Update varnish6.vcl

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -164,7 +164,7 @@ sub vcl_backend_response {
 
     # cache only successfully responses and 404s
     if (beresp.status != 200 && beresp.status != 404) {
-        set beresp.ttl = 0s;
+        set beresp.ttl = 120s;
         set beresp.uncacheable = true;
         return (deliver);
     } elsif (beresp.http.Cache-Control ~ "private") {


### PR DESCRIPTION
This is Thijs from Varnish Software.

The `set beresp.ttl = 0s` should NEVER EVER be used. By setting the TTL to zero seconds, the object will not be stored in the *Hit-For-Miss* cache.

When the next request for this object is received, Varnish will assume the content is cacheable and will put the request on the waiting list. However, those requests can never be satisfied in parallel. This means every request for a resource that has a status code other than `200` or `404` will be processed serially.

If one of these requests has slow response times, it will slow the entire chain of requests down.

I understand that you want to cater for one-off HTTP 500 requests, because you're afraid they'll end up in the *Hit-For-Pass cache* for a long time. But this behavior has changed in Varnish 5: as of Varnish 5, *Hit-For-Pass* has been converted into *Hit-For-Miss*. 

This means that the object will be uncacheable until the *Hit-For-Miss* TTL expires, or until the next response is deemed cacheable.

My advice is to use the standard TTL as illustrated below:

```
if (beresp.status != 200 && beresp.status != 404) {
    set beresp.ttl = 120s;
    set beresp.uncacheable = true;
    return (deliver);
}
```

> Please also change this in `varnish5.vcl` and set the TTL to a lower value in `varnish4.vcl`.