### PR TITLE
33613 Simplify and speed up the SQL requests

### DIFF
--- a/app/code/Magento/Customer/Model/ResourceModel/Visitor.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/Visitor.php
@@ -75,23 +75,11 @@ class Visitor extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $cleanTime = $object->getCleanTime();
         $connection = $this->getConnection();
         $timeLimit = $this->dateTime->formatDate($this->date->gmtTimestamp() - $cleanTime);
-        while (true) {
-            $select = $connection->select()->from(
-                ['visitor_table' => $this->getTable('customer_visitor')],
-                ['visitor_id' => 'visitor_table.visitor_id']
-            )->where(
-                'visitor_table.last_visit_at < ?',
-                $timeLimit
-            )->limit(
-                100
-            );
-            $visitorIds = $connection->fetchCol($select);
-            if (!$visitorIds) {
-                break;
-            }
-            $condition = ['visitor_id IN (?)' => $visitorIds];
-            $connection->delete($this->getTable('customer_visitor'), $condition);
-        }
+        
+        $connection->delete(
+            $this->getTable('customer_visitor'),
+            ['last_visit_at < ?' => $timeLimit]
+        );
 
         return $this;
     }


### PR DESCRIPTION
I don't see a reason why need to run queries to get the ids to be removed first and not just send a delete SQL request for 'last_visit_at < ?' => $timeLimit

### Description (*)
Fix for https://github.com/magento/magento2/issues/33613


### Fixed Issues (if relevant)
https://github.com/magento/magento2/issues/33613

### Manual testing scenarios (*)
Wait until visitor_clean cron job will be executed and check if in the db table "customer_visitor" old records will be removed.