### PR TITLE
Fix type error in ConfigureFedexDefaults.php (PHP 7.1 Compatibility)

### DIFF
--- a/app/code/Magento/Fedex/Setup/Patch/Data/ConfigureFedexDefaults.php
+++ b/app/code/Magento/Fedex/Setup/Patch/Data/ConfigureFedexDefaults.php
@@ -97,6 +97,7 @@ class ConfigureFedexDefaults implements DataPatchInterface, PatchVersionInterfac
             } elseif (stripos($mapOld['path'], 'free_method') !== false && isset($codes['method'][$mapOld['value']])) {
                 $mapNew = $codes['method'][$mapOld['value']];
             } elseif (stripos($mapOld['path'], 'allowed_methods') !== false) {
+                $mapNew = [];
                 foreach (explode(',', $mapOld['value']) as $shippingMethod) {
                     if (isset($codes['method'][$shippingMethod])) {
                         $mapNew[] = $codes['method'][$shippingMethod];


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This error happens to me on setup:install / setup:upgrade:
`PHP Fatal error:  Uncaught Error: [] operator not supported for strings in /srv/htdocs/foobar/htdocs/prod/releases/179/magento/vendor/magento/module-fedex/Setup/Patch/Data/ConfigureFedexDefaults.php:104`

This code path is not always executed because it depends on config values, so i guess thats why its not fixed/reported yet. 
On php7.1 the following change was introduced: "The empty index operator is not supported for strings anymore"


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable) 
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
