### PR TITLE
33589 fix array values in catalogsearch parameters

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/Advanced.php
+++ b/app/code/Magento/CatalogSearch/Model/Advanced.php
@@ -372,17 +372,15 @@ class Advanced extends \Magento\Framework\Model\AbstractModel
         $from = null;
         $to = null;
         if (is_array($value)) {
+            foreach ($value as $key => $element) {
+                if (is_array($element)) {
+                    $value[$key] = null;
+                }
+            }
             if (isset($value['from']) && isset($value['to'])) {
                 if (!empty($value['from']) || !empty($value['to'])) {
                     $from = '';
                     $to = '';
-
-                    foreach ($value as $key => $element) {
-                        if (is_array($element)) {
-                            $value[$key] = null;
-                        }
-                    }
-
 
                     if (isset($value['currency'])) {
                         /** @var $currencyModel Currency */

--- a/app/code/Magento/CatalogSearch/Model/Advanced.php
+++ b/app/code/Magento/CatalogSearch/Model/Advanced.php
@@ -212,7 +212,7 @@ class Advanced extends \Magento\Framework\Model\AbstractModel
             if ($attribute->getAttributeCode() == 'price') {
                 foreach ($value as $key => $element) {
                     if (is_array($element)) {
-                        $value[$key] = null;
+                        $value[$key] = 0;
                     }
                 }
 
@@ -374,7 +374,7 @@ class Advanced extends \Magento\Framework\Model\AbstractModel
         if (is_array($value)) {
             foreach ($value as $key => $element) {
                 if (is_array($element)) {
-                    $value[$key] = null;
+                    $value[$key] = '';
                 }
             }
             if (isset($value['from']) && isset($value['to'])) {

--- a/app/code/Magento/CatalogSearch/Model/Advanced.php
+++ b/app/code/Magento/CatalogSearch/Model/Advanced.php
@@ -368,6 +368,13 @@ class Advanced extends \Magento\Framework\Model\AbstractModel
                 if (!empty($value['from']) || !empty($value['to'])) {
                     $from = '';
                     $to = '';
+                    if (is_array($value['from'])) {
+                        $value['from'] = $this->getFirstArrayElement($value['from']);
+                    }
+                    if (is_array($value['to'])) {
+                        $value['to'] = $this->getFirstArrayElement($value['to']);
+                    }
+
                     if (isset($value['currency'])) {
                         /** @var $currencyModel Currency */
                         $currencyModel = $this->_currencyFactory->create()->load($value['currency']);
@@ -432,5 +439,17 @@ class Advanced extends \Magento\Framework\Model\AbstractModel
     public function getSearchCriterias()
     {
         return $this->_searchCriterias;
+    }
+
+    /**
+     * Return first value in array
+     *
+     * @param $value
+     *
+     * @return mixed
+     */
+    private function getFirstArrayElement($value)
+    {
+        return is_array($value) ? $this->getFirstArrayElement(array_shift($value)) : $value;
     }
 }

--- a/app/code/Magento/CatalogSearch/Model/Advanced.php
+++ b/app/code/Magento/CatalogSearch/Model/Advanced.php
@@ -210,6 +210,12 @@ class Advanced extends \Magento\Framework\Model\AbstractModel
             $this->addSearchCriteria($attribute, $preparedSearchValue);
 
             if ($attribute->getAttributeCode() == 'price') {
+                foreach ($value as $key => $element) {
+                    if (is_array($element)) {
+                        $value[$key] = null;
+                    }
+                }
+
                 $rate = 1;
                 $store = $this->_storeManager->getStore();
                 $currency = $store->getCurrentCurrencyCode();
@@ -351,13 +357,15 @@ class Advanced extends \Magento\Framework\Model\AbstractModel
     /**
      * Add data about search criteria to object state
      *
-     * @todo: Move this code to block
-     *
      * @param EntityAttribute $attribute
      * @param mixed $value
+     *
      * @return string|bool
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @throws LocalizedException
+     * @todo: Move this code to block
+     *
      */
     protected function getPreparedSearchCriteria($attribute, $value)
     {
@@ -368,12 +376,13 @@ class Advanced extends \Magento\Framework\Model\AbstractModel
                 if (!empty($value['from']) || !empty($value['to'])) {
                     $from = '';
                     $to = '';
-                    if (is_array($value['from'])) {
-                        $value['from'] = $this->getFirstArrayElement($value['from']);
+
+                    foreach ($value as $key => $element) {
+                        if (is_array($element)) {
+                            $value[$key] = null;
+                        }
                     }
-                    if (is_array($value['to'])) {
-                        $value['to'] = $this->getFirstArrayElement($value['to']);
-                    }
+
 
                     if (isset($value['currency'])) {
                         /** @var $currencyModel Currency */
@@ -439,17 +448,5 @@ class Advanced extends \Magento\Framework\Model\AbstractModel
     public function getSearchCriterias()
     {
         return $this->_searchCriterias;
-    }
-
-    /**
-     * Return first value in array
-     *
-     * @param $value
-     *
-     * @return mixed
-     */
-    private function getFirstArrayElement($value)
-    {
-        return is_array($value) ? $this->getFirstArrayElement(array_shift($value)) : $value;
     }
 }

--- a/app/code/Magento/CatalogSearch/view/frontend/templates/result.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/templates/result.phtml
@@ -4,7 +4,11 @@
  * See COPYING.txt for license details.
  */
 
-/** This changes need to valid applying filters and configuration before search process is started. */
+use Magento\CatalogSearch\Block\Result;
+
+/** These changes need to valid applying filters and configuration before search process is started. */
+
+/** @var $block  Result*/
 $productList = $block->getProductListHtml();
 ?>
 <?php if ($block->getResultCount()) : ?>

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/Advanced/ResultTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/Advanced/ResultTest.php
@@ -140,12 +140,12 @@ class ResultTest extends AbstractController
      * @magentoAppArea frontend
      * @magentoDataFixture Magento/CatalogSearch/_files/product_for_search.php
      * @magentoDataFixture Magento/CatalogSearch/_files/full_reindex.php
-     * @dataProvider searchParamsWithArrayDataProvider
+     * @dataProvider searchParamsInArrayDataProvider
      *
      * @param array $searchParams
      * @return void
      */
-    public function testExecuteWithArrayInParams(array $searchParams): void
+    public function testExecuteWithArrayInParam(array $searchParams): void
     {
         $this->getRequest()->setQuery(
             $this->_objectManager->create(
@@ -165,14 +165,14 @@ class ResultTest extends AbstractController
     }
 
     /**
-     * Data provider with arrays in param values
+     * Data provider with array in params values
      *
      * @return array
      */
-    public function searchParamsWithArrayDataProvider(): array
+    public function searchParamsInArrayDataProvider(): array
     {
         return [
-            'search_with_empty_arrays' => [
+            'search_with_from_param_is_array' => [
                 [
                     'name' => '',
                     'sku' => '',
@@ -181,6 +181,18 @@ class ResultTest extends AbstractController
                     'price' => [
                         'from' => [],
                         'to' => 1,
+                    ]
+                ]
+            ],
+            'search_with_to_param_is_array' => [
+                [
+                    'name' => '',
+                    'sku' => '',
+                    'description' => '',
+                    'short_description' => '',
+                    'price' => [
+                        'from' => 0,
+                        'to' => [],
                     ]
                 ]
             ],

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/Advanced/ResultTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/Advanced/ResultTest.php
@@ -135,6 +135,85 @@ class ResultTest extends AbstractController
     }
 
     /**
+     * Advanced search with array in price parameters
+     *
+     * @magentoAppArea frontend
+     * @magentoDataFixture Magento/CatalogSearch/_files/product_for_search.php
+     * @magentoDataFixture Magento/CatalogSearch/_files/full_reindex.php
+     * @dataProvider searchParamsWithArrayDataProvider
+     *
+     * @param array $searchParams
+     * @return void
+     */
+    public function testExecuteWithArrayInParams(array $searchParams): void
+    {
+        $this->getRequest()->setQuery(
+            $this->_objectManager->create(
+                Parameters::class,
+                [
+                    'values' => $searchParams
+                ]
+            )
+        );
+        $this->dispatch('catalogsearch/advanced/result');
+        $this->assertEquals(200, $this->getResponse()->getStatusCode());
+        $responseBody = $this->getResponse()->getBody();
+        $this->assertStringContainsString(
+            'We can\'t find any items matching these search criteria',
+            $responseBody
+        );
+    }
+
+    /**
+     * Data provider with arrays in param values
+     *
+     * @return array
+     */
+    public function searchParamsWithArrayDataProvider(): array
+    {
+        return [
+            'search_with_empty_arrays' => [
+                [
+                    'name' => '',
+                    'sku' => '',
+                    'description' => '',
+                    'short_description' => '',
+                    'price' => [
+                        'from' => [
+                            1
+                        ],
+                        'to' => 1,
+                    ]
+                ]
+            ],
+            'search_with_params_in_array' => [
+                [
+                    'name' => '',
+                    'sku' => '',
+                    'description' => '',
+                    'short_description' => '',
+                    'price' => [
+                        'from' => ['0' => 1],
+                        'to' => [1],
+                    ]
+                ]
+            ],
+            'search_with_params_in_array_in_array' => [
+                [
+                    'name' => '',
+                    'sku' => '',
+                    'description' => '',
+                    'short_description' => '',
+                    'price' => [
+                        ['from' => ['0' => 1]],
+                        ['to' => 1],
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
      * Data provider with strings for quick search.
      *
      * @return array

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/Advanced/ResultTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/Advanced/ResultTest.php
@@ -159,7 +159,7 @@ class ResultTest extends AbstractController
         $this->assertEquals(200, $this->getResponse()->getStatusCode());
         $responseBody = $this->getResponse()->getBody();
         $this->assertStringContainsString(
-            'We can\'t find any items matching these search criteria',
+            'We can&#039;t find any items matching these search criteria.',
             $responseBody
         );
     }
@@ -179,9 +179,7 @@ class ResultTest extends AbstractController
                     'description' => '',
                     'short_description' => '',
                     'price' => [
-                        'from' => [
-                            1
-                        ],
+                        'from' => [],
                         'to' => 1,
                     ]
                 ]
@@ -205,8 +203,8 @@ class ResultTest extends AbstractController
                     'description' => '',
                     'short_description' => '',
                     'price' => [
-                        ['from' => ['0' => 1]],
-                        ['to' => 1],
+                        'from' => ['0' => ['0' => 1]],
+                        'to' => 1,
                     ]
                 ]
             ]


### PR DESCRIPTION
### Description (*)
I changed a method that prepare values for advanced search. Model: `\Magento\CatalogSearch\Model\Advanced`

### Fixed Issues (if relevant)

1. Fixes magento/magento2#33589

### Manual testing scenarios (*)

1. Open page with parameters: `/catalogsearch/advanced/result/?price[from][]=1&price[to]=1`
For example: `htps://base_url/catalogsearch/advanced/result/?price[from][]=1&price[to]=1`

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
